### PR TITLE
Update cov cmake and docs

### DIFF
--- a/buildconfig/CMake/Coverage.cmake
+++ b/buildconfig/CMake/Coverage.cmake
@@ -29,7 +29,11 @@ function(coverage_setup _COVERAGE_SRCS _coverage_UPLOAD)
 
   # Remove each of these files littered across build dir
   foreach(_EXT in LISTS *.gcda *.gcno *.gcov)
-    add_custom_command(TARGET coverage_clean COMMAND find "${PROJECT_BINARY_DIR}" -iname "${_EXT}" -type f -delete)
+    add_custom_command(
+      TARGET coverage_clean
+      POST_BUILD
+      COMMAND find "${PROJECT_BINARY_DIR}" -iname "${_EXT}" -type f -delete
+    )
   endforeach()
 
   add_custom_target(
@@ -41,6 +45,8 @@ function(coverage_setup _COVERAGE_SRCS _coverage_UPLOAD)
       --exclude-throw-branches --xml "${COV_CPP_XML_DIR}/Cobertura.xml"
       # The file format will take x.html and turn it into x.Framework.Kernel.y.cpp.html so set x to mantid
       --html --html-details -o "${COV_CPP_HTML_DIR}/mantid.html"
+      # Work around a bug in gcov tool: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080
+      --gcov-ignore-parse-errors=suspicious_hits.warn
       # Run in the binary dir
       "${CMAKE_BINARY_DIR}"
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"

--- a/dev-docs/source/CodeCoverage.rst
+++ b/dev-docs/source/CodeCoverage.rst
@@ -16,6 +16,13 @@ GCC and LLVM have tooling built in to allow a developer to view the code coverag
 
 This will work for native C++ code and any code executed via Python, as the instrumentation is compiled into the binary output. Gcovr will also filter out any non-project code automatically.
 
+Coverage on Conda
+#################
+
+Since the move to `conda`, `GCC` is installed through the conda package `gxx_linux-64`. This conda package does NOT include `gcov`, required to assess code coverage. `gcov` is not currently available on `conda`, so you will need to ensure that `gcov` can be instead found on your system, and that this version of `gcov` is the same version as the `GCC` compiler we install using `conda`. If this is not the case, errors will be raised during the generation of coverage data.
+
+As `gcov` is packaged with `GCC`, you will need to install `GCC` on your system. You can typically do this using the `apt` package manager. If an appropriate version of `GCC` is not available for your OS you will unfortunately have to build it from source: https://gcc.gnu.org/wiki/InstallingGCC
+
 C++ Specific Notes
 ##################
 
@@ -31,7 +38,7 @@ Setup
     cmake /path/to/src -DCOVERAGE=ON
     ninja # or make
 
-- Install gcovr
+- Install gcovr (already included in mantid-developer environments)
 
   .. code-block:: shell
 
@@ -51,6 +58,8 @@ The following targets are available to make/ninja:
 HTML output is written into: `<build_dir>/coverage/<lang>/html`
 
 Where `<lang>` is either `cpp` or `python`.
+
+Note: If errors are thrown on certain directories during automatic report production, you may have more luck specifying individual directories manually.
 
 Producing a coverage report manually
 ####################################


### PR DESCRIPTION
### Description of work

This PR fixes a couple of issues with the use of `coverage`, and update docs with guidance following the move to conda.

Including a build event option is now a requirement of `add_custom_command`: https://cmake.org/cmake/help/latest/command/add_custom_command.html#build-events.
Use of `POST_BUILD` retains the legacy behaviour
```
CMake Warning (dev) at buildconfig/CMake/Coverage.cmake:32 (add_custom_command):
  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
  POST_BUILD to preserve backward compatibility
```

The following error is output during coverage generation:
```
(WARNING) - Thread-1 (worker) - Exception during parsing:
        SuspiciousHits: Got suspicious hit value in gcov line 'branch  0 taken 89850893380' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file.
```
As per the message, the `--gcov-ignore-parse-errors=suspcious_hits.warn` option as been included to fix this.

### To test:

This PR doesn't effect the functionality of mantid.

If you want to test coverage you can follow the documentation, though be warned that compilation and running tests with coverage on takes a while, you will want to do it on a remote machine.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
