### PR TITLE
Quasielasticbayes pinning - ornl-next

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -126,6 +126,11 @@ qscintilla2:
 qtpy:
   - '>=2.4,!=2.4.2'
 
+# We must pin this because it is known to be particularly unstable (especially in system tests).
+# 0.3.0 is the first version that supports Python > 3.10.
+quasielasticbayes:
+  - 0.3.0
+
 tbb:
   - 2021
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -127,9 +127,10 @@ qtpy:
   - '>=2.4,!=2.4.2'
 
 # We must pin this because it is known to be particularly unstable (especially in system tests).
-# 0.3.0 is the first version that supports Python > 3.10.
+# 0.3.0 is the first version that supports Python > 3.10, but it currently breaks BayesQuasi in the
+# standalone.
 quasielasticbayes:
-  - 0.3.0
+  - '<0.3.0'
 
 tbb:
   - 2021

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - qtconsole {{ qtconsole }}
     - qtpy {{ qtpy }}
     - qt-gtk-platformtheme # [linux]
-    - quasielasticbayes
+    - quasielasticbayes {{ quasielasticbayes }}
     - requests>=2.25.1
     - scipy {{ scipy }}
     - setuptools

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -75,7 +75,7 @@ requirements:
     - libglu {{ libglu }}  # [linux]
     - joblib
     - orsopy {{ orsopy }}
-    - quasielasticbayes
+    - quasielasticbayes {{ quasielasticbayes }}
     - zlib
 
   run_constrained:


### PR DESCRIPTION
This pulls all of the quasielasticbayes pinning work into `ornl-next`
* #39179
* #39200
