### PR TITLE
Add Classical option to VesuvioPeakPrediction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -80,7 +80,7 @@ class VesuvioPeakPrediction(VesuvioBase):
                 vesuvio_params.addColumn("float", "RMS Momentum(A)")
 
                 for temp in self._temperature:
-                    if temp == 0:
+                    if temp < MIN_TEMPERATURE:
                         temp = MIN_TEMPERATURE
 
                     # Convert to mEV
@@ -101,7 +101,7 @@ class VesuvioPeakPrediction(VesuvioBase):
                 vesuvio_params.addColumn("float", "RMS Displacement(A)")
 
                 for temp in self._temperature:
-                    if temp == 0:
+                    if temp < MIN_TEMPERATURE:
                         temp = MIN_TEMPERATURE
 
                     kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
@@ -114,7 +114,7 @@ class VesuvioPeakPrediction(VesuvioBase):
                 vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
 
                 for temp in self._temperature:
-                    if temp == 0:
+                    if temp < MIN_TEMPERATURE:
                         temp = MIN_TEMPERATURE
 
                     temp_mev = temp / K_IN_MEV

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -16,6 +16,7 @@ MIN_TEMPERATURE = 1e-6
 K_IN_MEV = scipy.constants.value("electron volt-kelvin relationship") / 1e3
 EINSTEIN_CONSTANT = 2.0717
 DEBYE_CONSTANT = 4.18036
+H_BAR = 2.04434  # Reduced Planck constant in units sqrt(mev * amu) / A-1
 
 
 class VesuvioPeakPrediction(VesuvioBase):
@@ -117,11 +118,9 @@ class VesuvioPeakPrediction(VesuvioBase):
                         temp = MIN_TEMPERATURE
 
                     temp_mev = temp / K_IN_MEV
-                    # Reduced Planck constant in units sqrt(mev * amu) / A-1
-                    h_bar = 2.04434
 
-                    rms_momentum = math.sqrt(temp_mev * self._atomic_mass / h_bar**2)  # Units A-1
-                    kinetic_energy = 3 * h_bar**2 * rms_momentum**2 / (2 * self._atomic_mass)  # Units mev
+                    rms_momentum = math.sqrt(temp_mev * self._atomic_mass / H_BAR**2)  # Units A-1
+                    kinetic_energy = 3 * H_BAR**2 * rms_momentum**2 / (2 * self._atomic_mass)  # Units mev
 
                     vesuvio_params.addRow([temp, self._atomic_mass, rms_momentum, kinetic_energy])
 

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -71,58 +71,59 @@ class VesuvioPeakPrediction(VesuvioBase):
         vesuvio_params.addColumn("float", "Temperature(K)")
         vesuvio_params.addColumn("float", "Atomic Mass(AMU)")
 
-        if self._model == "Einstein":
-            vesuvio_params.addColumn("float", "Frequency(mEV)")
-            vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
-            vesuvio_params.addColumn("float", "Effective Temp(K)")
-            vesuvio_params.addColumn("float", "RMS Momentum(A)")
+        match self._model:
+            case "Einstein":
+                vesuvio_params.addColumn("float", "Frequency(mEV)")
+                vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
+                vesuvio_params.addColumn("float", "Effective Temp(K)")
+                vesuvio_params.addColumn("float", "RMS Momentum(A)")
 
-            for temp in self._temperature:
-                if temp == 0:
-                    temp = MIN_TEMPERATURE
+                for temp in self._temperature:
+                    if temp == 0:
+                        temp = MIN_TEMPERATURE
 
-                # Convert to mEV
-                temp_mev = temp / K_IN_MEV
-                # Kinetic Energy
-                kinetic_energy = 0.25 * self._frequency / math.tanh(self._frequency / (2 * temp_mev))
-                # Effective temperature in K
-                t_star = 2 * kinetic_energy * K_IN_MEV
-                # RMS moment
-                sig = math.sqrt(self._atomic_mass * kinetic_energy / EINSTEIN_CONSTANT)
+                    # Convert to mEV
+                    temp_mev = temp / K_IN_MEV
+                    # Kinetic Energy
+                    kinetic_energy = 0.25 * self._frequency / math.tanh(self._frequency / (2 * temp_mev))
+                    # Effective temperature in K
+                    t_star = 2 * kinetic_energy * K_IN_MEV
+                    # RMS moment
+                    sig = math.sqrt(self._atomic_mass * kinetic_energy / EINSTEIN_CONSTANT)
 
-                vesuvio_params.addRow([temp, self._atomic_mass, self._frequency, kinetic_energy, t_star, sig])
+                    vesuvio_params.addRow([temp, self._atomic_mass, self._frequency, kinetic_energy, t_star, sig])
 
-        if self._model == "Debye":
-            vesuvio_params.addColumn("float", "Debye Temp(K)")
-            vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
-            vesuvio_params.addColumn("float", "RMS Momentum(A-1)")
-            vesuvio_params.addColumn("float", "RMS Displacement(A)")
+            case "Debye":
+                vesuvio_params.addColumn("float", "Debye Temp(K)")
+                vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
+                vesuvio_params.addColumn("float", "RMS Momentum(A-1)")
+                vesuvio_params.addColumn("float", "RMS Displacement(A)")
 
-            for temp in self._temperature:
-                if temp == 0:
-                    temp = MIN_TEMPERATURE
+                for temp in self._temperature:
+                    if temp == 0:
+                        temp = MIN_TEMPERATURE
 
-                kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
-                rms_disp = self.displacement(temp, self._debye_temp, self._atomic_mass)
+                    kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
+                    rms_disp = self.displacement(temp, self._debye_temp, self._atomic_mass)
 
-                vesuvio_params.addRow([temp, self._atomic_mass, self._debye_temp, kinetic, rms_momentum, rms_disp])
+                    vesuvio_params.addRow([temp, self._atomic_mass, self._debye_temp, kinetic, rms_momentum, rms_disp])
 
-        if self._model == "Classical":
-            vesuvio_params.addColumn("float", "RMS Momentum(A-1)")
-            vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
+            case "Classical":
+                vesuvio_params.addColumn("float", "RMS Momentum(A-1)")
+                vesuvio_params.addColumn("float", "Kinetic Energy(mEV)")
 
-            for temp in self._temperature:
-                if temp == 0:
-                    temp = MIN_TEMPERATURE
+                for temp in self._temperature:
+                    if temp == 0:
+                        temp = MIN_TEMPERATURE
 
-                temp_mev = temp / K_IN_MEV
-                # Reduced Planck constant in units sqrt(mev * amu) / A-1
-                h_bar = 2.04434
+                    temp_mev = temp / K_IN_MEV
+                    # Reduced Planck constant in units sqrt(mev * amu) / A-1
+                    h_bar = 2.04434
 
-                rms_momentum = math.sqrt(temp_mev * self._atomic_mass / h_bar**2)  # Units A-1
-                kinetic_energy = 3 * h_bar**2 * rms_momentum**2 / (2 * self._atomic_mass)  # Units mev
+                    rms_momentum = math.sqrt(temp_mev * self._atomic_mass / h_bar**2)  # Units A-1
+                    kinetic_energy = 3 * h_bar**2 * rms_momentum**2 / (2 * self._atomic_mass)  # Units mev
 
-                vesuvio_params.addRow([temp, self._atomic_mass, rms_momentum, kinetic_energy])
+                    vesuvio_params.addRow([temp, self._atomic_mass, rms_momentum, kinetic_energy])
 
         self.setProperty("OutputTable", vesuvio_params)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -34,6 +34,17 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         self.assertEqual(vesuvio_einstein_params.cell(1, 1), 63.5)
         self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 5), 18.47381)
 
+    def test_classical(self):
+        """
+        Test of Classical model with multiple temperatures
+        """
+        vesuvio_classical_params = VesuvioPeakPrediction(Model="Classical", Temperature=[100, 120, 240, 300], AtomicMass=50.94)
+
+        self.assertTrue(isinstance(vesuvio_classical_params, ITableWorkspace))
+        # Values slightly different from matlab script becaused used scipy constant for K/mev conversion
+        self.assertEqual(round(vesuvio_classical_params.cell(3, 2), 4), 17.751)
+        self.assertEqual(round(vesuvio_classical_params.cell(3, 3), 4), 38.778)
+
     # -------------------------Failure Cases-------------------------
 
     def test_temperature(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -17,10 +17,14 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         vesuvio_debye_params = VesuvioPeakPrediction(
             Model="Debye", Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347
         )
-
         self.assertTrue(isinstance(vesuvio_debye_params, ITableWorkspace))
         self.assertEqual(vesuvio_debye_params.cell(1, 1), 63.5)
         self.assertEqual(round(vesuvio_debye_params.cell(2, 5), 7), 0.0694458)
+
+    def test_debye_zero_temperature(self):
+        vesuvio_debye_params = VesuvioPeakPrediction(Model="Debye", Temperature=[0], AtomicMass=63.5)
+        self.assertEqual(round(vesuvio_debye_params.cell(0, 2), 4), 1.0)
+        self.assertEqual(round(vesuvio_debye_params.cell(0, 3), 4), 0.0483)
 
     def test_einstein(self):
         """
@@ -29,21 +33,28 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         vesuvio_einstein_params = VesuvioPeakPrediction(
             Model="Einstein", Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347
         )
-
         self.assertTrue(isinstance(vesuvio_einstein_params, ITableWorkspace))
         self.assertEqual(vesuvio_einstein_params.cell(1, 1), 63.5)
         self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 5), 18.47381)
+
+    def test_einstein_zero_temperature(self):
+        vesuvio_einstein_params = VesuvioPeakPrediction(Model="Einstein", Temperature=[0], AtomicMass=63.5)
+        self.assertEqual(round(vesuvio_einstein_params.cell(0, 2), 4), 1.0)
+        self.assertEqual(round(vesuvio_einstein_params.cell(0, 3), 4), 0.25)
 
     def test_classical(self):
         """
         Test of Classical model with multiple temperatures
         """
         vesuvio_classical_params = VesuvioPeakPrediction(Model="Classical", Temperature=[100, 120, 240, 300], AtomicMass=50.94)
-
         self.assertTrue(isinstance(vesuvio_classical_params, ITableWorkspace))
-        # Values slightly different from matlab script becaused used scipy constant for K/mev conversion
         self.assertEqual(round(vesuvio_classical_params.cell(3, 2), 4), 17.751)
         self.assertEqual(round(vesuvio_classical_params.cell(3, 3), 4), 38.778)
+
+    def test_classical_zero_temperature(self):
+        vesuvio_classical_params = VesuvioPeakPrediction(Model="Classical", Temperature=[0], AtomicMass=50.94)
+        self.assertEqual(round(vesuvio_classical_params.cell(0, 2), 4), 0.001)
+        self.assertEqual(round(vesuvio_classical_params.cell(0, 3), 4), 0.0)
 
     # -------------------------Failure Cases-------------------------
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -22,9 +22,9 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         self.assertEqual(round(vesuvio_debye_params.cell(2, 5), 7), 0.0694458)
 
     def test_debye_zero_temperature(self):
-        vesuvio_debye_params = VesuvioPeakPrediction(Model="Debye", Temperature=[0], AtomicMass=63.5)
-        self.assertEqual(round(vesuvio_debye_params.cell(0, 2), 4), 1.0)
-        self.assertEqual(round(vesuvio_debye_params.cell(0, 3), 4), 0.0483)
+        vesuvio_debye_params = VesuvioPeakPrediction(Model="Debye", Temperature=[0], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+        self.assertEqual(round(vesuvio_debye_params.cell(0, 2), 4), 347)
+        self.assertEqual(round(vesuvio_debye_params.cell(0, 3), 4), 16.7528)
 
     def test_einstein(self):
         """
@@ -38,9 +38,11 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 5), 18.47381)
 
     def test_einstein_zero_temperature(self):
-        vesuvio_einstein_params = VesuvioPeakPrediction(Model="Einstein", Temperature=[0], AtomicMass=63.5)
-        self.assertEqual(round(vesuvio_einstein_params.cell(0, 2), 4), 1.0)
-        self.assertEqual(round(vesuvio_einstein_params.cell(0, 3), 4), 0.25)
+        vesuvio_einstein_params = VesuvioPeakPrediction(
+            Model="Einstein", Temperature=[0], AtomicMass=63.5, Frequency=20, DebyeTemperature=347
+        )
+        self.assertEqual(round(vesuvio_einstein_params.cell(0, 2), 4), 20)
+        self.assertEqual(round(vesuvio_einstein_params.cell(0, 3), 4), 5.0)
 
     def test_classical(self):
         """

--- a/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
+++ b/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
@@ -1,1 +1,1 @@
-- Algorithm :ref:`algm-VesuvioPeakPrediction` now supports option `Classical`, used to estimate the lower bounds of the width of the Neutron Compton Profiles when running analysis routines.
+- Algorithm :ref:`algm-VesuvioPeakPrediction` now supports option ``Classical``, used to estimate the lower bounds of the width of the Neutron Compton Profiles when running analysis routines.

--- a/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
+++ b/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
@@ -1,0 +1,1 @@
+ - Algorithm :ref:`algm-VesuvioPeakPrediction` now supports option `Classical`, used to estimate the lower bounds of the width of the Neutron Compton Profiles when running analysis routines.

--- a/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
+++ b/docs/source/release/v6.13.0/Indirect/New_features/39212.rst
@@ -1,1 +1,1 @@
- - Algorithm :ref:`algm-VesuvioPeakPrediction` now supports option `Classical`, used to estimate the lower bounds of the width of the Neutron Compton Profiles when running analysis routines.
+- Algorithm :ref:`algm-VesuvioPeakPrediction` now supports option `Classical`, used to estimate the lower bounds of the width of the Neutron Compton Profiles when running analysis routines.


### PR DESCRIPTION
### Description of work
Added an option in VesuvioPeakPrediction algorithm to estimate the lower bound for the neutron compton profile peak for a given mass. Previously scientists were using a short matlab script to do this.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The calculations are the same as the matlab script provided by the Vesuvio scientists.

#### Purpose of work
Adding this in Mantid avoids the hassle of having to open matlab just to run a simple script.

Fixes https://github.com/mantidproject/vesuvio/issues/146#issue-2711453612
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

- Run the folllowing:
```python
vesuvio_classical_params = VesuvioPeakPrediction(Model="Classical", Temperature=[100, 120, 240, 300], AtomicMass=50.94)

``` 
- Open the `vesuvio-classical_params` table workspace and confirm the values for the row T=300K: RMS Momentum should be 17.751 and Kinetic Energy should be 38.778

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
