### PR TITLE
Remove GSL error code workaround

### DIFF
--- a/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
@@ -309,6 +309,6 @@ public:
     s.initialize(costFun);
     TS_ASSERT(!s.minimize());
 
-    TS_ASSERT_EQUALS(s.getError(), "Changes in function value are too small");
+    TS_ASSERT_DIFFERS(s.getError(), "success");
   }
 };

--- a/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39215.rst
+++ b/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39215.rst
@@ -1,0 +1,1 @@
+- Improved error handling in the Levenberg Marquardt minimization algorithm, where a failed solve could incorrectly be reported as a success.


### PR DESCRIPTION
The error` GSL_ENOPROG` is an error code indicating that the solver has stopped, but we were trying to force it to carry on. One potential problem is that if we do that, and the step size is within tolerance, then later on in the method we will report a success, (incorrectly).

I've also changed the test to handle the case where the error code could be different, which is what happens on ARM. The solver stops for a different reason to x86_64.

This is required for #38990.

*There is no associated issue.*

### To test:

Test fitting

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
