### PR TITLE
Allow SetGoniometer algorithm to take optional matrix as string

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SetGoniometer.h
+++ b/Framework/Crystal/inc/MantidCrystal/SetGoniometer.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidCrystal/DllConfig.h"
+#include "MantidKernel/Matrix.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -39,6 +40,7 @@ private:
   void init() override;
   /// Run the algorithm
   void exec() override;
+  Kernel::DblMatrix parseMatrixString(std::string gonMat);
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/SetGoniometer.h
+++ b/Framework/Crystal/inc/MantidCrystal/SetGoniometer.h
@@ -40,7 +40,7 @@ private:
   void init() override;
   /// Run the algorithm
   void exec() override;
-  Kernel::DblMatrix parseMatrixString(std::string gonMat);
+  std::map<std::string, std::string> validateInputs() override;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -76,7 +76,6 @@ std::map<std::string, std::string> SetGoniometer::validateInputs() {
     for (size_t i = 0; i < NUM_AXES; i++) {
       std::ostringstream propName;
       propName << "Axis" << i;
-      std::string axisDesc = getPropertyValue(propName.str());
       if (!isDefault(propName.str())) {
         issues[propName.str()] = "Can't provide a goniometer axis if a matrix string has also been provided";
       }

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -103,11 +103,11 @@ void SetGoniometer::exec() {
     ei = infos->getExperimentInfo(0);
   }
 
-  std::string gonioDefined = getPropertyValue("Goniometers");
   // Create the goniometer
   Goniometer gon;
 
   if (isDefault("GoniometerMatrix")) {
+    std::string gonioDefined = getPropertyValue("Goniometers");
     if (gonioDefined == "Universal")
       gon.makeUniversalGoniometer();
     else

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -48,9 +48,6 @@ void SetGoniometer::init() {
                   "Set the axes and motor names according to goniometers that "
                   "we define in the code (Universal defined for SNS)");
 
-  declareProperty(std::make_unique<ArrayProperty<double>>("GoniometerMatrix", std::move(zeroes), threeVthree),
-                  "Directly set the goniometer rotation matrix. Input should be in the form of a flattened 3x3 matrix");
-
   std::string axisHelp = ": name, x,y,z, 1/-1 (1 for ccw, -1 for cw rotation). "
                          "A number of degrees can be used instead of name. "
                          "Leave blank for no axis";
@@ -59,11 +56,18 @@ void SetGoniometer::init() {
     propName << "Axis" << i;
     declareProperty(std::make_unique<PropertyWithValue<std::string>>(propName.str(), "", Direction::Input),
                     propName.str() + axisHelp);
-    setPropertySettings(propName.str(), std::make_unique<EnabledWhenProperty>("GoniometerMatrix", IS_DEFAULT));
   }
   declareProperty("Average", true,
                   "Use the average value of the log, if false a separate "
                   "goniometer will be created for each value in the logs");
+
+  declareProperty(std::make_unique<ArrayProperty<double>>("GoniometerMatrix", std::move(zeroes), threeVthree),
+                  "Directly set the goniometer rotation matrix. Input should be in the form of a flattened 3x3 matrix");
+  for (size_t i = 0; i < NUM_AXES; i++) {
+    std::ostringstream propName;
+    propName << "Axis" << i;
+    setPropertySettings(propName.str(), std::make_unique<EnabledWhenProperty>("GoniometerMatrix", IS_DEFAULT));
+  }
 }
 
 std::map<std::string, std::string> SetGoniometer::validateInputs() {

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -12,7 +12,6 @@
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
-#include "MantidKernel/Matrix.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -70,10 +70,10 @@ std::map<std::string, std::string> SetGoniometer::validateInputs() {
   const Kernel::DblMatrix GMatrix(Gvec);
 
   // if a Goniometer Matrix is supplied, check it is a valid rotation
-  if (not isDefault("GoniometerMatrix")) {
+  if (!isDefault("GoniometerMatrix")) {
     try {
       bool isRot = GMatrix.isRotation();
-      if (not isRot) {
+      if (!isRot) {
         issues["GoniometerMatrix"] = "Supplied Goniometer Matrix is not a proper rotation";
       }
     } catch (std::invalid_argument &) {

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -70,13 +70,13 @@ std::map<std::string, std::string> SetGoniometer::validateInputs() {
 
   // if a Goniometer Matrix is supplied, check it is a valid rotation
   if (!isDefault("GoniometerMatrix")) {
-    try {
+    if (GMatrix.numRows() == GMatrix.numCols()) {
       bool isRot = GMatrix.isRotation();
       if (!isRot) {
         issues["GoniometerMatrix"] = "Supplied Goniometer Matrix is not a proper rotation";
       }
-    } catch (std::invalid_argument &) {
-      // this should not be thrown because of the input validator
+    } else {
+      // this should not be reached because of the input validator
       issues["GoniometerMatrix"] = "Supplied Goniometer Matrix is not a proper rotation: Matrix is not Square";
     }
   }

--- a/Framework/Crystal/test/SetGoniometerTest.h
+++ b/Framework/Crystal/test/SetGoniometerTest.h
@@ -70,7 +70,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Workspace", "SetGoniometerTest_ws"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GoniometerMatrix", "-1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GoniometerMatrix", gonMat))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 

--- a/Framework/Crystal/test/SetGoniometerTest.h
+++ b/Framework/Crystal/test/SetGoniometerTest.h
@@ -171,6 +171,17 @@ public:
     refMat[1][2] = 1.0;
     refMat[2][2] = 0.0;
     TS_ASSERT_EQUALS(gon.getR().equals(refMat), true);
+
+    // Check this is equivalent to setting R directly
+
+    Workspace2D_sptr ws_set = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+    AnalysisDataService::Instance().addOrReplace("SetGoniometerStringTestSetDirectly_ws", ws);
+
+    Goniometer setGon = ws_set->mutableRun().getGoniometer();
+    setGon.setR(refMat);
+
+    TS_ASSERT_EQUALS(gon.getR().equals(setGon.getR()), true);
+
     AnalysisDataService::Instance().remove("SetGoniometerStringTest_ws");
   }
 

--- a/Framework/Crystal/test/SetGoniometerTest.h
+++ b/Framework/Crystal/test/SetGoniometerTest.h
@@ -57,7 +57,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Workspace", "SetGoniometerTest_ws"));
     // set only 8 values for the matrix
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GoniometerMatrix", "-1.0,0.0,0.0,0.0,0.0,1.0,0.0,1.0"));
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error &);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT_EQUALS(alg.isExecuted(), false);
   }
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
@@ -60,6 +60,12 @@ public:
   Goniometer(const Kernel::DblMatrix &rot);
   // Copy Constructor
   Goniometer(const Goniometer &other);
+  // Copy assignment Constructor
+  Goniometer &operator=(const Goniometer &other);
+  // Move constructor
+  Goniometer(Goniometer &&other) noexcept;
+  // Move assignment Constructor
+  Goniometer &operator=(Goniometer &&other) noexcept;
   // Default destructor
   virtual ~Goniometer() = default;
   // Return rotation matrix

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
@@ -58,6 +58,8 @@ public:
   Goniometer();
   // Constructor from a rotation matrix
   Goniometer(const Kernel::DblMatrix &rot);
+  // Copy Constructor
+  Goniometer(const Goniometer &other);
   // Default destructor
   virtual ~Goniometer() = default;
   // Return rotation matrix

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -75,6 +75,9 @@ Goniometer::Goniometer(const DblMatrix &rot) {
     throw std::invalid_argument("rot is not a rotation matrix");
 }
 
+/// Add an explicit copy constructor
+Goniometer::Goniometer(const Goniometer &other) : R(other.R), motors(other.motors), initFromR(other.initFromR) {}
+
 /// Return global rotation matrix
 /// @return R :: 3x3 rotation matrix
 const Kernel::DblMatrix &Goniometer::getR() const { return R; }

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -78,6 +78,30 @@ Goniometer::Goniometer(const DblMatrix &rot) {
 /// Add an explicit copy constructor
 Goniometer::Goniometer(const Goniometer &other) : R(other.R), motors(other.motors), initFromR(other.initFromR) {}
 
+/// Copy assigment constructor
+Goniometer &Goniometer::operator=(const Goniometer &other) {
+  if (this != &other) {
+    R = other.R;
+    motors = other.motors;
+    initFromR = other.initFromR;
+  }
+  return *this;
+}
+
+// Move constructor
+Goniometer::Goniometer(Goniometer &&other) noexcept
+    : R(std::move(other.R)), motors(std::move(other.motors)), initFromR(other.initFromR) {}
+
+// Move assignment operator
+Goniometer &Goniometer::operator=(Goniometer &&other) noexcept {
+  if (this != &other) {
+    R = std::move(other.R);
+    motors = std::move(other.motors);
+    initFromR = other.initFromR;
+  }
+  return *this;
+}
+
 /// Return global rotation matrix
 /// @return R :: 3x3 rotation matrix
 const Kernel::DblMatrix &Goniometer::getR() const { return R; }

--- a/docs/source/algorithms/SetGoniometer-v1.rst
+++ b/docs/source/algorithms/SetGoniometer-v1.rst
@@ -127,15 +127,15 @@ Output:
    SetGoniometer(ws, GoniometerMatrix = "0.0,0.0,1.0,1.0,0.0,0.0,0.0,1.0,0.0")
 
    print('Goniometer rotation matrix =', ws.run().getGoniometer().getR())
-   print('Goniometer rotation matrix matches target: ', ws.run().getGoniometer().getR() == target_matrix)
+   print('Goniometer rotation matrix matches target: ', np.all(ws.run().getGoniometer().getR() == target_matrix))
 
 Output:
 
 .. testoutput:: GoniometerStringExample
 
    Goniometer rotation matrix = [[0. 0. 1.]
-                                 [1. 0. 0.]
-                                 [0. 1. 0.]]
+    [1. 0. 0.]
+    [0. 1. 0.]]
    Goniometer rotation matrix matches target:  True
 
 **Example: WISH goniometer**

--- a/docs/source/algorithms/SetGoniometer-v1.rst
+++ b/docs/source/algorithms/SetGoniometer-v1.rst
@@ -123,8 +123,8 @@ Output:
         DataX=[0., 1.],
         DataY=[1., 2., 3.,4.],
         NSpec=4)
-   target_matrix = np.array(([0.0,0.0,1.0],[1.0,0.0,0.0],[0.0,0.0,1.0]))
-   SetGoniometer(ws, GoniometerMatrix = "0.0,0.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0")
+   target_matrix = np.array(([0.0,0.0,1.0],[1.0,0.0,0.0],[0.0,1.0,0.0]))
+   SetGoniometer(ws, GoniometerMatrix = "0.0,0.0,1.0,1.0,0.0,0.0,0.0,1.0,0.0")
 
    print('Goniometer rotation matrix =', ws.run().getGoniometer().getR())
    print('Goniometer rotation matrix matches target: ', ws.run().getGoniometer().getR() == target_matrix)

--- a/docs/source/algorithms/SetGoniometer-v1.rst
+++ b/docs/source/algorithms/SetGoniometer-v1.rst
@@ -34,6 +34,10 @@ will be created for each value in the log. When multiple log axes are
 defined they must have the same length and are assumed to be all the
 same time series.
 
+Alternatively, a rotation matrix can be passed directly using the GoniometerMatrix parameter.
+This parameter expects the matrix as a flattened (row major), comma separated string.
+If this parameter is set, all other inputs will be ignored.
+
 The "Universal" goniometer at SNS is equivalent to Axis0 tied to the
 "omega" log pointing vertically upward, Axis1 tied to "chi" log,
 pointing along the beam, and Axis2 tied to "phi", pointing vertically
@@ -110,6 +114,29 @@ Output:
    18 omega = 4.6
    19 omega = 4.8
    20 omega = 5.0
+
+**Example - set goniometer matrix directly**
+
+.. testcode:: GoniometerStringExample
+
+   ws = CreateWorkspace(
+        DataX=[0., 1.],
+        DataY=[1., 2., 3.,4.],
+        NSpec=4)
+   target_matrix = np.array(([0.0,0.0,1.0],[1.0,0.0,0.0],[0.0,0.0,1.0]))
+   SetGoniometer(ws, GoniometerMatrix = "0.0,0.0,1.0,1.0,0.0,0.0,0.0,0.0,1.0")
+
+   print('Goniometer rotation matrix =', ws.run().getGoniometer().getR())
+   print('Goniometer rotation matrix matches target: ', ws.run().getGoniometer().getR() == target_matrix)
+
+Output:
+
+.. testoutput:: GoniometerStringExample
+
+   Goniometer rotation matrix = [[0. 0. 1.]
+                                 [1. 0. 0.]
+                                 [0. 1. 0.]]
+   Goniometer rotation matrix matches target:  True
 
 **Example: WISH goniometer**
 

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39219.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39219.rst
@@ -1,0 +1,1 @@
+- In :ref:`algm-SetGoniometer`, you can now directly pass a comma separated string of 9 values corresponding to the (row major) flattened rotation matrix.


### PR DESCRIPTION
### Description of work

#### Summary of work
New input parameter for `SetGoniometer` which allows the desired rotation matrix to be passed directly as a flattened, comma separated string of values.

#### Purpose of work
Currently, if you already know the rotation matrix of your goniometer, and you want to set the value on the workspace your options are: 
- Do some extra work to decompose into an euler vector/ series of euler angles and apply via `SetGoniometer`
- use `ws.getRun().getGoniometer().setR(rot_mat)`, which doesn't properly track in workspace history


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

Play around with this script, validate that `Show Sample Shape` gives the same orientations: 
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from scipy.spatial.transform import Rotation

# create a workspace
ws = CreateWorkspace(
        DataX=[0., 1.],
        DataY=[1., 2., 3.,4.],
        NSpec=4)

# add a sample for visualising
sample_shape = f"""
<cylinder id="A">
  <centre-of-bottom-base x="0" y="0" z="0.05" />
  <axis x="0" y="0" z="-1" />
  <radius val="0.1" />
  <height val="0.1" />
</cylinder>
"""

# create second comparison workspace
ws2 = CloneWorkspace(ws)

# pick some rotation angles (or define a rotation separately)
angs = (90, 90, 0)
theta, chi, phi = angs

# apply these rotations to ws
SetGoniometer("ws", Axis0 = f"{theta},0,1,0,1", 
                    Axis1 = f"{chi},  0,0,1,1",  
                    Axis2 = f"{phi},  0,1,0,1")
SetSample('ws', Geometry={'Shape': 'CSG', 'Value': sample_shape})

# independently calculate the resultant rotation matrix
r = Rotation.from_euler("YZY", angs, degrees=True).as_matrix()

# flatten
fr = r.reshape((-1))
# convert to comma separated string
mat_str = ",".join([str(x) for x in fr])

# set goniometer with string
SetGoniometer("ws2", GoniometerMatrix=mat_str)
SetSample('ws2', Geometry={'Shape': 'CSG', 'Value': sample_shape})

# check that the goniometer matrix is equal to r and ws
print(ws2.getRun().getGoniometer().getR(),
        np.all(ws2.getRun().getGoniometer().getR() == r),
        np.all(np.abs(ws2.getRun().getGoniometer().getR()-ws.getRun().getGoniometer().getR())< 0.0001))
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
