### PR TITLE
Handle out of bounds error in nthIterval of FilteredTimeSeriesProperty

### DIFF
--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -413,7 +413,7 @@ Kernel::TimeROI *FilteredTimeSeriesProperty<TYPE>::intersectFilterWithOther(cons
   auto roi = new TimeROI(*m_filter.get());
   if (other && (!other->useAll()))
     roi->update_or_replace_intersection(*other);
-  return std::move(roi);
+  return roi;
 }
 
 template <typename TYPE> const Kernel::TimeROI &FilteredTimeSeriesProperty<TYPE>::getTimeROI() const {

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -154,7 +154,15 @@ template <typename TYPE> TimeInterval FilteredTimeSeriesProperty<TYPE>::nthInter
     deltaT = TimeSeriesProperty<TYPE>::nthInterval(n);
   } else {
     this->applyFilter();
-    deltaT = this->m_filterIntervals[std::size_t(n)];
+    // Throw exception if out of bounds
+    if (n >= this->m_filterIntervals.size()) {
+      const std::string error("nthInterval(): FilteredTimeSeriesProperty '" + this->name() + "' interval " +
+                              std ::to_string(n) + " does not exist");
+      g_log.debug(error);
+      throw std::runtime_error(error);
+    } else {
+      deltaT = this->m_filterIntervals[std::size_t(n)];
+    }
   }
 
   return deltaT;

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -155,9 +155,9 @@ template <typename TYPE> TimeInterval FilteredTimeSeriesProperty<TYPE>::nthInter
   } else {
     this->applyFilter();
     // Throw exception if out of bounds
-    if (n >= this->m_filterIntervals.size()) {
+    if (n >= static_cast<int>(this->m_filterIntervals.size())) {
       const std::string error("nthInterval(): FilteredTimeSeriesProperty '" + this->name() + "' interval " +
-                              std ::to_string(n) + " does not exist");
+                              std::to_string(n) + " does not exist");
       g_log.debug(error);
       throw std::runtime_error(error);
     } else {

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -155,14 +155,13 @@ template <typename TYPE> TimeInterval FilteredTimeSeriesProperty<TYPE>::nthInter
   } else {
     this->applyFilter();
     // Throw exception if out of bounds
-    if (n >= static_cast<int>(this->m_filterIntervals.size())) {
+    if (n < 0 || n >= static_cast<int>(this->m_filterIntervals.size())) {
       const std::string error("nthInterval(): FilteredTimeSeriesProperty '" + this->name() + "' interval " +
                               std::to_string(n) + " does not exist");
       g_log.debug(error);
       throw std::runtime_error(error);
-    } else {
-      deltaT = this->m_filterIntervals[std::size_t(n)];
     }
+    deltaT = this->m_filterIntervals[std::size_t(n)];
   }
 
   return deltaT;

--- a/Framework/Kernel/test/LogFilterTest.h
+++ b/Framework/Kernel/test/LogFilterTest.h
@@ -57,6 +57,12 @@ public:
     TS_ASSERT_EQUALS(p->nthInterval(4).end_str(),
                      "2007-Nov-30 16:17:50"); // nth interval changed to use
                                               // previous interval now.
+
+    // test out of bounds check given filter applied
+    auto testFilter = createTestFilter(1);
+    LogFilter flt(p);
+    flt.addFilter(*testFilter);
+    TS_ASSERT_THROWS(flt.data()->nthInterval(5), const std::runtime_error &);
   }
 
   void testFilterWithTrueAtStart() {

--- a/Framework/Kernel/test/LogFilterTest.h
+++ b/Framework/Kernel/test/LogFilterTest.h
@@ -62,7 +62,10 @@ public:
     auto testFilter = createTestFilter(1);
     LogFilter flt(p);
     flt.addFilter(*testFilter);
-    TS_ASSERT_THROWS(flt.data()->nthInterval(5), const std::runtime_error &);
+    TS_ASSERT_THROWS_EQUALS(flt.data()->nthInterval(5), const std::runtime_error &e, std::string(e.what()),
+                            "nthInterval(): FilteredTimeSeriesProperty 'test' interval 5 does not exist");
+    TS_ASSERT_THROWS_EQUALS(flt.data()->nthInterval(-1), const std::runtime_error &e, std::string(e.what()),
+                            "nthInterval(): FilteredTimeSeriesProperty 'test' interval -1 does not exist");
   }
 
   void testFilterWithTrueAtStart() {

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
@@ -1,1 +1,1 @@
-- Handled out of bounds error possible when using get ``nthTime`` and ``nthInterval`` methods of a ``FilteredTimeSeriesProperty``. This occurred when the argument ``n`` was specified to be greater than the maximum index of the time filter intervals present.
+- Handled out of bounds error possible when using ``nthTime`` and ``nthInterval`` methods of a ``FilteredTimeSeriesProperty``. This occurred when the argument ``n`` was specified as an invalid index of the time filter intervals vector.

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
@@ -1,1 +1,1 @@
-- Handled out of bounds error possible when using get `nthTime` and `nthInterval` methods of a `FilteredTimeSeriesProperty`. This occurred when the argument `n` was specified to be greater than the maximum index of the time filter intervals present.
+- Handled out of bounds error possible when using get ``nthTime`` and ``nthInterval`` methods of a ``FilteredTimeSeriesProperty``. This occurred when the argument ``n`` was specified to be greater than the maximum index of the time filter intervals present.

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39238.rst
@@ -1,0 +1,1 @@
+- Handled out of bounds error possible when using get `nthTime` and `nthInterval` methods of a `FilteredTimeSeriesProperty`. This occurred when the argument `n` was specified to be greater than the maximum index of the time filter intervals present.


### PR DESCRIPTION
### Description of work

Reported by a user, possible to provide an `n` argument to `nthTime` or `nthInterval` method of a `FilteredTimeSeriesProperty` and get an out of bounds error.

This PR adds bounds checking.

### To test:

Ensure instrument is `HIFI` and data archive access is available.

Ensure error is handled when running the following script:
```
from mantid.simpleapi import *

wstuple=LoadMuonNexus(filename="196907")
ws=wstuple[0]
log=ws.getRun().getLogData("Field_Main")
log.nthTime(109)
```

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
