### PR TITLE
Specify exact python on launch

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import argparse
+import os
 import subprocess
 import sys
 
@@ -66,7 +67,7 @@ def start(options: argparse.ArgumentParser):
         # this is already the default on Windows/macOS.
         # This will mean the relevant 'atexit' code will execute in the child process, and therefore the
         # FrameworkManager and UsageService will be shutdown as expected.
-        launch_command = f"python {wp.__file__}"
+        launch_command = f"./python {wp.__file__}"
         if options.script:
             launch_command += f" {options.script}"
         if options.execute:
@@ -74,11 +75,13 @@ def start(options: argparse.ArgumentParser):
         if options.quit:
             launch_command += " --quit"
 
+        launch_directory = os.environ["MANTIDPATH"]
+
         if not is_windows():
             # preexec_fn is not supported on Windows
-            workbench_process = subprocess.Popen(launch_command, shell=True, preexec_fn=setup_core_dump_files)
+            workbench_process = subprocess.Popen(launch_command, shell=True, cwd=launch_directory, preexec_fn=setup_core_dump_files)
         else:
-            workbench_process = subprocess.Popen(launch_command, shell=True)
+            workbench_process = subprocess.Popen(launch_command, shell=True, cwd=launch_directory)
 
         workbench_pid = str(workbench_process.pid)
         workbench_process.wait()

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import argparse
-import os
 import subprocess
 import sys
 
@@ -67,7 +66,7 @@ def start(options: argparse.ArgumentParser):
         # this is already the default on Windows/macOS.
         # This will mean the relevant 'atexit' code will execute in the child process, and therefore the
         # FrameworkManager and UsageService will be shutdown as expected.
-        launch_command = f"./python {wp.__file__}"
+        launch_command = f"{sys.executable} {wp.__file__}"
         if options.script:
             launch_command += f" {options.script}"
         if options.execute:
@@ -75,13 +74,11 @@ def start(options: argparse.ArgumentParser):
         if options.quit:
             launch_command += " --quit"
 
-        launch_directory = os.environ["MANTIDPATH"]
-
         if not is_windows():
             # preexec_fn is not supported on Windows
-            workbench_process = subprocess.Popen(launch_command, shell=True, cwd=launch_directory, preexec_fn=setup_core_dump_files)
+            workbench_process = subprocess.Popen(launch_command, shell=True, preexec_fn=setup_core_dump_files)
         else:
-            workbench_process = subprocess.Popen(launch_command, shell=True, cwd=launch_directory)
+            workbench_process = subprocess.Popen(launch_command, shell=True)
 
         workbench_pid = str(workbench_process.pid)
         workbench_process.wait()

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/run_pystack.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/run_pystack.py
@@ -30,7 +30,7 @@ def retrieve_thread_traces_from_coredump_file(workbench_pid: str) -> bytes:
     try:
         core_dumps_path = _get_core_dumps_dir()
     except ValueError as e:
-        log.error(str(e))
+        log.warning(str(e))
         return b""
 
     # Get most recent dump file.


### PR DESCRIPTION
### Description of work

A recent change to how workbench launches seem to have broken the linux stand-alone launch.

The problem was that workbench now launches using a a `python ` command, we don't add the stand-alone bin directory to the PATH so when launching it would either use the wrong python or not launch at all.

This pr changes the command to use the specific python binary found within the bin folder.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Test stand-alone launchers launch

https://builds.mantidproject.org/job/build_packages_from_branch/1091/

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
