### PR TITLE
disable crosshair in titled plot

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,0 +1,1 @@
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. THe crosshair button is disabled (invisible) in titled plots.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -232,6 +232,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_waterfall_conversion.connect(self.update_toolbar_waterfall_plot)
             self.toolbar.sig_change_line_collection_colour_triggered.connect(self.change_line_collection_colour)
             self.toolbar.sig_hide_plot_triggered.connect(self.hide_plot)
+            self.toolbar.sig_crosshair_toggle_triggered.connect(self.crosshair_toggle)
             self.toolbar.setFloatable(False)
             tbs_height = self.toolbar.sizeHint().height()
         else:
@@ -602,6 +603,41 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         for line in lines:
             line.remove()
             ax.add_line(line)
+
+    def crosshair_toggle(self, on):
+        cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
+        if not on:
+            self.canvas.mpl_disconnect(cid)
+
+    def crosshair(self, event):
+        axes = self.canvas.figure.gca()
+
+        # create a crosshair made from horizontal and verticle lines.
+        self.horizontal_line = axes.axhline(color="r", lw=1.0, ls="-")
+        self.vertical_line = axes.axvline(color="r", lw=1.0, ls="-")
+
+        def set_cross_hair_visible(visible):
+            need_redraw = self.horizontal_line.get_visible() != visible
+            self.horizontal_line.set_visible(visible)
+            self.vertical_line.set_visible(visible)
+            return need_redraw
+
+        # if event is out-of-bound we update
+        if not event.inaxes:
+            need_redraw = set_cross_hair_visible(False)
+            if need_redraw:
+                axes.figure.canvas.draw()
+
+        else:
+            set_cross_hair_visible(True)
+            x, y = event.xdata, event.ydata
+            self.horizontal_line.set_ydata([y])
+            self.vertical_line.set_xdata([x])
+            self.canvas.draw()
+
+        # after update we remove
+        self.horizontal_line.remove()
+        self.vertical_line.remove()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description of work
This PR re-introduces crosshair into mantidworkbench plotting module. EWM [10075](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10075).
To address part of the issue found during smoking test, the crosshair is automatically disabled in titled plots, enabled in contour plots. There will be a following PR to also disable this in 3D plots to address EWM 10076.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Testing is easy, check 3 things: 1. crosshair is enabled in general single axis plots. 2. check it's disabled in tiled plots. 3. check it's enabled in contour plots.

To test crosshair is enabled in single-axis plot, either load any data you have or do:

```
plt.plot([1,2,3], [3,2,1])
plt.show()

``` 
check crosshair can be enabled and works properly.
![image](https://github.com/user-attachments/assets/d1395cc9-6a79-40d2-bb7c-16d155e51c77)

To test crosshair is disabled in titled plots, do:
```
fig, ax = plt.subplots(2,2)
ax[0,0].plot([1,2,3],[3,2,1])
ax[0,1].plot([1,2,3],[1,2,3])
plt.show()
```
the crosshair button should be hidden from user now.
![image](https://github.com/user-attachments/assets/9b9ba415-346a-4cf6-8c4e-9e3f188d473d)
.

Finally, to test the crosshair is enabled in contour plots, do:
```
data = Load('SANSLOQCan2D.nxs')

fig, axes = plt.subplots(subplot_kw={'projection':'mantid'})

# IMPORTANT to set origin to lower
c = axes.imshow(data, origin = 'lower', cmap='viridis', aspect='auto')

# Overlay contours
axes.contour(data, levels=np.linspace(10, 60, 6), colors='yellow', alpha=0.5)
axes.set_title('SANSLOQCan2D.nxs')
cbar=fig.colorbar(c)
cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
fig.tight_layout()

fig.show()

```
crosshair button is back and can be enabled.
![image](https://github.com/user-attachments/assets/b37eb08f-6e64-4b65-8a71-63e94972b819)

In all three scenarios, changing axes scale from linear to log should not cause anything to crash.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
