### PR TITLE
Fix error on sample log plot resize

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/Bugfixes/39247.rst
+++ b/docs/source/release/v6.13.0/Workbench/Bugfixes/39247.rst
@@ -1,0 +1,1 @@
+- Minimizing the sample log plot on the ``SampleLogs`` widget so that it is not visible no longer throws an error.

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -48,3 +48,11 @@ class SampleLogsViewTest(unittest.TestCase, QtWidgetFinder):
         assert pres.view.isVisible()
         DeleteWorkspace("new_name")
         assert not pres.view.isVisible()
+
+    def test_minimum_canvas_size(self):
+        ws = CreateSampleWorkspace()
+        pres = SampleLogs(ws)
+        pres.view.show_plot_and_stats(True)
+        pres.view.canvas.resize(-1, -1)
+        self.assertEqual(0, pres.view.canvas.width())
+        self.assertEqual(0, pres.view.canvas.height())

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
     QFrame,
     QSpacerItem,
 )
-from qtpy.QtCore import QItemSelectionModel, Qt, Signal
+from qtpy.QtCore import QItemSelectionModel, Qt, Signal, QSize
 from mantidqt.widgets.observers.observing_view import ObservingView
 from mantidqt.MPLwidgets import FigureCanvas
 from mantid.api import Workspace
@@ -123,6 +123,7 @@ class SampleLogsView(QSplitter, ObservingView):
         self.fig = Figure()
         self.canvas = FigureCanvas(self.fig)
         self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.canvas.setMinimumSize(QSize(0, 0))
         self.canvas.mpl_connect("button_press_event", self.presenter.plot_clicked)
         self.ax = self.fig.add_subplot(111, projection="mantid")
         layout_right.addWidget(self.canvas)
@@ -169,7 +170,7 @@ class SampleLogsView(QSplitter, ObservingView):
         self.table.selectionModel().selectionChanged.connect(self.presenter.update)
 
     def show_plot_and_stats(self, show_plot_and_stats):
-        """sets wether the plot and stats section should be visible"""
+        """sets whether the plot and stats section should be visible"""
         if self.frame_right.isVisible() != show_plot_and_stats:
             # the desired state is nor the current state
             self.setUpdatesEnabled(False)


### PR DESCRIPTION
### Description of work

Adds a minimum size to the `SampleLogsView` canvas. This prevents it being set to a negative size when resized, avoiding an error.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #39247

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Refer to instructions on issue.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
