### PR TITLE
Relax BayesQuasiTest system test for consistency across Linux versions

### DIFF
--- a/Testing/SystemTests/tests/framework/BayesQuasiTest.py
+++ b/Testing/SystemTests/tests/framework/BayesQuasiTest.py
@@ -65,9 +65,9 @@ class BayesQuasiTest(MantidSystemTest):
         # fit, which is overparameterised, and therefore unstable between different Linux OS.
         max_spectrum_index = 10
 
-        # Beyond q = 1.7, the statistics become low enough so that the fit becomes too unstable
+        # Beyond q = 1.6, the statistics become low enough so that the fit becomes too unstable
         # for a meaningful system test.
-        max_q = 1.7
+        max_q = 1.6
 
         Load(Filename="irs26176_graphite002_QLr_Result.nxs", OutputWorkspace="bayesquasi_reference")
         CropWorkspace(

--- a/Testing/SystemTests/tests/framework/BayesQuasiTest.py
+++ b/Testing/SystemTests/tests/framework/BayesQuasiTest.py
@@ -8,12 +8,13 @@
 
 from sys import platform
 from systemtesting import MantidSystemTest
-from mantid.simpleapi import BayesQuasi, Load
+from mantid.simpleapi import BayesQuasi, CropWorkspace, Load
 
 
 class BayesQuasiTest(MantidSystemTest):
     _sample_name = "irs26176_graphite002_red"
     _resolution_name = "irs26173_graphite002_res"
+    _reference_result_file_name = "irs26176_graphite002_QLr_Result.nxs"
 
     def skipTests(self):
         return platform == "darwin"
@@ -35,10 +36,51 @@ class BayesQuasiTest(MantidSystemTest):
         )
 
     def validate(self):
+        if platform == "linux":
+            return self._validate_linux()
+
         self.tolerance = 1e-10
+
         return (
             "irs26176_graphite002_QLr_Result",
-            "irs26176_graphite002_QLr_Result.nxs",
+            self._reference_result_file_name,
             "irs26176_graphite002_QLr_Prob",
             "irs26176_graphite002_QLr_Prob.nxs",
         )
+
+    def validateMethod(self):
+        if platform == "linux":
+            return "ValidateWorkspaceToWorkspace"
+
+        return "WorkspaceToNeXus"
+
+    def _validate_linux(self):
+        # With the crop below applied, this is the smallest relative tolerance that can be consistently applied
+        # on all three of CentOS7, Rocky8, Alma9.
+        self.tolerance = 1e-3
+        self.tolerance_is_rel_err = True
+
+        # The first 11 spectra in the result workspace correspond to fit parameters used
+        # when fitting with one or two peaks. Anything beyond that comes from the three peak
+        # fit, which is overparameterised, and therefore unstable between different Linux OS.
+        max_spectrum_index = 10
+
+        # Beyond q = 1.7, the statistics become low enough so that the fit becomes too unstable
+        # for a meaningful system test.
+        max_q = 1.7
+
+        Load(Filename="irs26176_graphite002_QLr_Result.nxs", OutputWorkspace="bayesquasi_reference")
+        CropWorkspace(
+            InputWorkspace="bayesquasi_reference",
+            OutputWorkspace="bayesquasi_reference_cropped",
+            XMax=max_q,
+            EndWorkspaceIndex=max_spectrum_index,
+        )
+        CropWorkspace(
+            InputWorkspace="irs26176_graphite002_QLr_Result",
+            OutputWorkspace="bayesquasi_result_cropped",
+            XMax=max_q,
+            EndWorkspaceIndex=max_spectrum_index,
+        )
+
+        return "bayesquasi_result_cropped", "bayesquasi_reference_cropped"


### PR DESCRIPTION
### Description of work
Relax the BayesQuasiTest system test passing criteria for Linux so that it performs consistently across different Linux versions (CentOS7, Rocky8, Alma9).

#### Purpose of work
System test was failing on AlmaLinux9.

*There is no associated issue.*

#### Further detail of work
After speaking with a BayesQuasi expert, we decided to do the following to allow the system test to pass on Linux:
- Restrict comparison to the fits where one and two Lorentzian peaks are used. The three peak fit is overparameterising the problem, and leads to instability across different OS. The indirect Bayes fitting interface only displays the fit results for one and two peaks, so this is consistent with that.
- Restrict comparison to q < 1.6. Above this, the statistics drop significantly which leads to unstable results across different OS.
- Set a relative tolerance of 1e-3, which is the smallest order of magnitude that allowed the test to pass on RockyLinux8 when comparing with the original dataset after the two above conditions are applied.
Below is a plot showing the values of the fit parameters when using one and two Lorentzian functions. You can see that the results are very stable at lower q, and start to vary at higher q. This is magnified by the log scale on the y-axis. Solid lines are from the reference dataset, dashed lines from the Alma9 run.
![image](https://github.com/user-attachments/assets/14e9db4d-f257-4fb0-bdb8-a0105eaf4d21)
![image](https://github.com/user-attachments/assets/46c1419c-a3e3-421c-a38d-2675819d459f)



### To test:
Verify that BayesQuasiTest system test ran successfully on this PR's plinux job and in this build on Alma9:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/238/

*This does not require release notes* because **it's an update to a system test**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
