### PR TITLE
Add SavePolarizedNXCanSAS to SANSSave

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -16,6 +16,10 @@ from sans.common.general_functions import get_detector_names_from_instrument
 from sans.common.constant_containers import SANSInstrument_string_as_key_NoInstrument
 from sans.common.enums import SaveType
 
+FILE_FORMAT_DOC_SUFFIX = (
+    "Note that if file formats of the same type, e.g. .xml are chosen, then the file format is appended to the file name."
+)
+
 
 class SANSSave(DataProcessorAlgorithm):
     def category(self):
@@ -50,54 +54,49 @@ class SANSSave(DataProcessorAlgorithm):
             "Nexus",
             False,
             direction=Direction.Input,
-            doc="Save as nexus format. "
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as nexus format. " + FILE_FORMAT_DOC_SUFFIX,
         )
         self.declareProperty(
             "CanSAS",
             False,
             direction=Direction.Input,
-            doc="Save as CanSAS xml format."
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as CanSAS xml format. " + FILE_FORMAT_DOC_SUFFIX,
         )
         self.declareProperty(
             "NXcanSAS",
             False,
             direction=Direction.Input,
-            doc="Save as NXcanSAS format."
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as NXcanSAS format. " + FILE_FORMAT_DOC_SUFFIX,
+        )
+        self.declareProperty(
+            "PolarizedNXcanSAS",
+            False,
+            direction=Direction.Input,
+            doc="Save in PolarizedNXcanSAS format. " + FILE_FORMAT_DOC_SUFFIX,
         )
         self.declareProperty(
             "NistQxy",
             False,
             direction=Direction.Input,
-            doc="Save as Nist Qxy format."
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as Nist Qxy format. " + FILE_FORMAT_DOC_SUFFIX,
         )
         self.declareProperty(
             "RKH",
             False,
             direction=Direction.Input,
-            doc="Save as RKH format."
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as RKH format. " + FILE_FORMAT_DOC_SUFFIX,
         )
         self.declareProperty(
             "CSV",
             False,
             direction=Direction.Input,
-            doc="Save as CSV format."
-            "Note that if file formats of the same type, e.g. .xml are chosen, then the "
-            "file format is appended to the file name.",
+            doc="Save as CSV format. " + FILE_FORMAT_DOC_SUFFIX,
         )
 
         self.setPropertyGroup("Nexus", "FileFormats")
         self.setPropertyGroup("CanSAS", "FileFormats")
         self.setPropertyGroup("NXCanSAS", "FileFormats")
+        self.setPropertyGroup("PolarizedNXcanSAS", "FileFormats")
         self.setPropertyGroup("NistQxy", "FileFormats")
         self.setPropertyGroup("RKH", "FileFormats")
         self.setPropertyGroup("CSV", "FileFormats")
@@ -239,6 +238,7 @@ class SANSSave(DataProcessorAlgorithm):
             errors.update({"Nexus": "At least one data format needs to be specified."})
             errors.update({"CanSAS": "At least one data format needs to be specified."})
             errors.update({"NXcanSAS": "At least one data format needs to be specified."})
+            errors.update({"PolarizedNXcanSAS": "At least one data format needs to be specified"})
             errors.update({"NistQxy": "At least one data format needs to be specified."})
             errors.update({"RKH": "At least one data format needs to be specified."})
             errors.update({"CSV": "At least one data format needs to be specified."})
@@ -252,8 +252,8 @@ class SANSSave(DataProcessorAlgorithm):
                     " only. This requires all axes to be numeric."
                 }
             )
-        polarization_props = self.getProperty("PolarizationProps").value
-        if len(polarization_props) > 0:
+        if self.getProperty("PolarizedNXcanSAS"):
+            polarization_props = self.getProperty("PolarizationProps").value
             # TODO: Get these directly from the algorithm.
             mandatory_props = [
                 "InputSpinStates",
@@ -275,6 +275,7 @@ class SANSSave(DataProcessorAlgorithm):
         self._check_file_types(file_types, "Nexus", SaveType.NEXUS)
         self._check_file_types(file_types, "CanSAS", SaveType.CAN_SAS)
         self._check_file_types(file_types, "NXcanSAS", SaveType.NX_CAN_SAS)
+        self._check_file_types(file_types, "PolarizedNXcanSAS", SaveType.POL_NX_CAN_SAS)
         self._check_file_types(file_types, "NistQxy", SaveType.NIST_QXY)
         self._check_file_types(file_types, "RKH", SaveType.RKH)
         self._check_file_types(file_types, "CSV", SaveType.CSV)
@@ -288,6 +289,9 @@ class SANSSave(DataProcessorAlgorithm):
 
         # SaveNXcanSAS clashes with SaveNexusProcessed
         self.add_file_format_with_appended_name_requirement(file_formats, SaveType.NX_CAN_SAS, file_types, [])
+
+        # SavePolarizedNXcanSAS clashes with SaveNXcanSAS
+        self.add_file_format_with_appended_name_requirement(file_formats, SaveType.POL_NX_CAN_SAS, file_types, [SaveType.NX_CAN_SAS])
 
         # SaveNISTDAT clashes with SaveRKH, both can save to .dat
         self.add_file_format_with_appended_name_requirement(file_formats, SaveType.NIST_QXY, file_types, [SaveType.RKH])

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -110,7 +110,7 @@ class SANSSave(DataProcessorAlgorithm):
 
         self.setPropertyGroup("Nexus", "FileFormats")
         self.setPropertyGroup("CanSAS", "FileFormats")
-        self.setPropertyGroup("NXCanSAS", "FileFormats")
+        self.setPropertyGroup("NXcanSAS", "FileFormats")
         self.setPropertyGroup("PolarizedNXcanSAS", "FileFormats")
         self.setPropertyGroup("NistQxy", "FileFormats")
         self.setPropertyGroup("RKH", "FileFormats")
@@ -312,11 +312,11 @@ class SANSSave(DataProcessorAlgorithm):
     def _validate_pol_props(self, errors):
         polarization_props = self.getProperty("PolarizationProps").value
         if not polarization_props:
-            errors.update({"PolarizationProps": "PolarizationProps must be set to use SavePolarizedNXCanSAS."})
+            errors.update({"PolarizationProps": "PolarizationProps must be set to use SavePolarizedNXcanSAS."})
             return
         if "InputSpinStates" not in polarization_props.keys():
             errors.update(
-                {"PolarizationProps": "Missing property for SavePolarizedNXCanSAS. These properties are missing: InputSpinStates."}
+                {"PolarizationProps": "Missing property for SavePolarizedNXcanSAS. These properties are missing: InputSpinStates."}
             )
 
     def _get_file_formats(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -314,7 +314,6 @@ class SANSSave(DataProcessorAlgorithm):
         if not polarization_props:
             errors.update({"PolarizationProps": "PolarizationProps must be set to use SavePolarizedNXCanSAS."})
             return errors
-        # TODO: Get these directly from the algorithm.
         mandatory_props = [
             "InputSpinStates",
             "PolarizerComponentName",

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -261,14 +261,16 @@ class SANSSave(DataProcessorAlgorithm):
         workspace = self.getProperty("InputWorkspace").value
         if isinstance(workspace, WorkspaceGroup):
             return self._validate_group(errors, workspace)
+        if self.getProperty("PolarizedNXcanSAS").value:
+            errors.update({"InputWorkspace": "Must be a workspace group to save using PolarizedNXcanSAS"})
+            return errors
         return self._validate_workspace(errors, workspace)
 
     def _validate_group(self, errors, input_workspace):
-        if not self.getProperty("PolarizedNXcanSAS").value:
-            errors.update({"InputWorkspace": "Only PolarizedNXcanSAS is compatible with group workspaces."})
-            return
         for i in range(0, input_workspace.getNumberOfEntries()):
             self._validate_workspace(errors, input_workspace.getItem(i))
+        if self.getProperty("PolarizedNXcanSAS").value:
+            self._validate_pol_props(errors)
         return errors
 
     def _validate_workspace(self, errors, input_workspace):
@@ -298,8 +300,6 @@ class SANSSave(DataProcessorAlgorithm):
                     " only. This requires all axes to be numeric."
                 }
             )
-        if self.getProperty("PolarizedNXcanSAS").value:
-            self._validate_pol_props(errors)
         return errors
 
     def _validate_pol_props(self, errors):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -314,18 +314,9 @@ class SANSSave(DataProcessorAlgorithm):
         if not polarization_props:
             errors.update({"PolarizationProps": "PolarizationProps must be set to use SavePolarizedNXCanSAS."})
             return
-        mandatory_props = [
-            "InputSpinStates",
-            "PolarizerComponentName",
-            "AnalyzerComponentName",
-            "FlipperComponentNames",
-            "MagneticFieldStrengthLogName",
-            "MagneticFieldDirection",
-        ]
-        if not all(prop in polarization_props.keys() for prop in mandatory_props):
-            missing_props = set(mandatory_props) - set(polarization_props.keys())
+        if "InputSpinStates" not in polarization_props.keys():
             errors.update(
-                {"PolarizationProps": f"Missing property for SavePolarizedNXCanSAS. These properties are missing: {missing_props}"}
+                {"PolarizationProps": "Missing property for SavePolarizedNXCanSAS. These properties are missing: InputSpinStates."}
             )
 
     def _get_file_formats(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -313,7 +313,7 @@ class SANSSave(DataProcessorAlgorithm):
         polarization_props = self.getProperty("PolarizationProps").value
         if not polarization_props:
             errors.update({"PolarizationProps": "PolarizationProps must be set to use SavePolarizedNXCanSAS."})
-            return errors
+            return
         mandatory_props = [
             "InputSpinStates",
             "PolarizerComponentName",

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -271,6 +271,13 @@ class SANSSave(DataProcessorAlgorithm):
             self._validate_workspace(errors, input_workspace.getItem(i))
         if self.getProperty("PolarizedNXcanSAS").value:
             self._validate_pol_props(errors)
+        if (
+            self.getProperty("CanSAS").value
+            or self.getProperty("NistQxy").value
+            or self.getProperty("RKH").value
+            or self.getProperty("CSV").value
+        ):
+            errors.update({"InputWorkspace": "Cannot be a workspace group when saving using CanSAS, NistQxy, RKH, or CSV"})
         return errors
 
     def _validate_workspace(self, errors, input_workspace):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -142,6 +142,27 @@ class SANSSave(DataProcessorAlgorithm):
             direction=Direction.Input,
             doc="The scale factor the BackgroundSubtractionWorkspace is multiplied by before subtraction. Can be blank.",
         )
+        self.declareProperty(
+            "PolarizationProperties",
+            dict(),
+            direction=Direction.Input,
+            doc="A dictionary of properties to values for all of the metadata used in a polarized reduction. Supported "
+            "properties are:\n"
+            "InputSpinStates (str),\n"
+            "PolarizerComponentName (str),\n"
+            "AnalyzerComponentName (str),\n"
+            "FlipperComponentNames (str, comma separated list),\n"
+            "MagneticFieldStrengthLogName (str),\n"
+            "MagneticFieldDirection (str, comma separated list of axes),\n"
+            "PolarizationTransmissionWorkspaces (dict, component name -> workspace name),\n"
+            "PolarizationEfficiencyWorkspaces (dict, component name -> workspace name),\n"
+            "PolarizationEmptyCellWorkspaces (dict, component name -> workspace name),\n"
+            "ElectricFieldStrengthLogName (str),\n"
+            "ElectricFieldDirection (str, comma separated list of axes),\n"
+            "InitialCellPolarizations (dict, component name -> value (str)),\n"
+            "InitialCellPolarizationErrorWorkspaces (dict, component name -> value (str)),\n"
+            "GasPressure (dict, component name -> value (float))\n",
+        )
 
     def PyExec(self):
         use_zero_error_free = self.getProperty("UseZeroErrorFree").value

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -288,6 +288,14 @@ class SANSSaveTest(unittest.TestCase):
         # Act
         SANSSave(workspace, file_name, PolarizedNXcanSAS=True, PolarizationProps=pol_props)
 
+        expected_files = [
+            file_name + "00.h5",
+            file_name + "01.h5",
+        ]
+        for pol_file in expected_files:
+            self._assert_that_file_exists(pol_file)
+            self._remove_file(pol_file)
+
     def test_group_workspaces_handled_by_non_pol_alg(self):
         # Arrange
         workspace = self._get_sample_group_workspace(True)

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -13,7 +13,7 @@ import systemtesting
 
 from sans.common.general_functions import create_unmanaged_algorithm
 from sans.common.constants import EMPTY_NAME
-from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, SANSSave
+from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, SANSSave, ConvertSpectrumAxis, CreateSimulationWorkspace
 
 
 # -----------------------------------------------
@@ -258,6 +258,27 @@ class SANSSaveTest(unittest.TestCase):
                     PolarizedNXCanSAS=True,
                     PolarizationProps=one_removed,
                 )
+
+    def test_polarizer_algorithm_executed(self):
+        # Arrange
+        workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
+        workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
+        workspace_list = [workspace_0, workspace_1]
+        workspace = GroupWorkspaces(workspace_list)
+        workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)
+
+        file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
+        pol_props = {
+            "InputSpinStates": "+10,-10",
+            "PolarizerComponentName": "a",
+            "AnalyzerComponentName": "b",
+            "FlipperComponentNames": "c,d,e",
+            "MagneticFieldStrengthLogName": "f",
+            "MagneticFieldDirection": "1,2,3",
+        }
+
+        # Act
+        SANSSave(workspace, file_name, PolarizedNXcanSAS=True, PolarizationProps=pol_props)
 
 
 class SANSSaveRunnerTest(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -254,28 +254,19 @@ class SANSSaveTest(unittest.TestCase):
 
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
         pol_props = {
-            "InputSpinStates": "0,1",
-            "PolarizerComponentName": "a",
-            "AnalyzerComponentName": "b",
-            "FlipperComponentNames": ["c", "d", "e"],
-            "MagneticFieldStrengthLogName": "f",
-            "MagneticFieldDirection": "g,h,i",
+            "InputSpinStatez": "0,1",
         }
-        for i in range(0, len(pol_props)):
-            one_removed = pol_props.copy()
-            one_removed.pop(list(one_removed.keys())[i])
-            with self.assertRaisesRegex(
-                RuntimeError,
-                f".*PolarizationProps: Missing property for SavePolarizedNXCanSAS. "
-                f"These properties are missing: {{'{list(pol_props.keys())[i]}'}}",
-            ):
-                # Act
-                SANSSave(
-                    InputWorkspace=workspace,
-                    Filename=file_name,
-                    PolarizedNXCanSAS=True,
-                    PolarizationProps=one_removed,
-                )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            ".*PolarizationProps: Missing property for SavePolarizedNXCanSAS. These properties are missing: InputSpinStates",
+        ):
+            # Act
+            SANSSave(
+                InputWorkspace=workspace,
+                Filename=file_name,
+                PolarizedNXCanSAS=True,
+                PolarizationProps=pol_props,
+            )
 
     def test_polarizer_algorithm_executed(self):
         # Arrange

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -66,7 +66,7 @@ class SANSSaveTest(unittest.TestCase):
             "UseZeroErrorFree": False,
             "Nexus": False,
             "CanSAS": False,
-            "NXCanSAS": True,
+            "NXcanSAS": True,
             "NistQxy": False,
             "RKH": False,
             "CSV": False,
@@ -92,7 +92,7 @@ class SANSSaveTest(unittest.TestCase):
             "UseZeroErrorFree": use_zero_errors_free,
             "Nexus": True,
             "CanSAS": True,
-            "NXCanSAS": True,
+            "NXcanSAS": True,
             "NistQxy": True,
             "RKH": True,
             "CSV": True,
@@ -132,7 +132,7 @@ class SANSSaveTest(unittest.TestCase):
             "UseZeroErrorFree": use_zero_errors_free,
             "Nexus": False,
             "CanSAS": False,
-            "NXCanSAS": False,
+            "NXcanSAS": False,
             "NistQxy": True,
             "RKH": False,
             "CSV": False,
@@ -159,7 +159,7 @@ class SANSSaveTest(unittest.TestCase):
             "UseZeroErrorFree": use_zero_errors_free,
             "Nexus": False,
             "CanSAS": False,
-            "NXCanSAS": False,
+            "NXcanSAS": False,
             "NistQxy": False,
             "RKH": False,
             "CSV": False,
@@ -186,7 +186,7 @@ class SANSSaveTest(unittest.TestCase):
             "UseZeroErrorFree": use_zero_errors_free,
             "Nexus": True,
             "CanSAS": False,
-            "NXCanSAS": False,
+            "NXcanSAS": False,
             "NistQxy": False,
             "RKH": False,
             "CSV": False,
@@ -223,12 +223,12 @@ class SANSSaveTest(unittest.TestCase):
         save_options = {
             "InputWorkspace": workspace,
             "Filename": file_name,
-            "PolarizedNXCanSAS": True,
+            "PolarizedNXcanSAS": True,
         }
         save_alg = create_unmanaged_algorithm(save_name, **save_options)
         save_alg.setRethrows(True)
         # Act
-        self.assertRaisesRegex(RuntimeError, "PolarizationProps must be set to use SavePolarizedNXCanSAS.", save_alg.execute)
+        self.assertRaisesRegex(RuntimeError, "PolarizationProps must be set to use SavePolarizedNXcanSAS.", save_alg.execute)
 
     def test_workspace_must_be_group_to_use_polarized_nx_can_sas(self):
         # Arrange
@@ -238,7 +238,7 @@ class SANSSaveTest(unittest.TestCase):
         save_options = {
             "InputWorkspace": workspace,
             "Filename": file_name,
-            "PolarizedNXCanSAS": True,
+            "PolarizedNXcanSAS": True,
         }
         save_alg = create_unmanaged_algorithm(save_name, **save_options)
         save_alg.setRethrows(True)
@@ -258,13 +258,13 @@ class SANSSaveTest(unittest.TestCase):
         }
         with self.assertRaisesRegex(
             RuntimeError,
-            ".*PolarizationProps: Missing property for SavePolarizedNXCanSAS. These properties are missing: InputSpinStates",
+            ".*PolarizationProps: Missing property for SavePolarizedNXcanSAS. These properties are missing: InputSpinStates",
         ):
             # Act
             SANSSave(
                 InputWorkspace=workspace,
                 Filename=file_name,
-                PolarizedNXCanSAS=True,
+                PolarizedNXcanSAS=True,
                 PolarizationProps=pol_props,
             )
 

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -13,7 +13,7 @@ import systemtesting
 
 from sans.common.general_functions import create_unmanaged_algorithm
 from sans.common.constants import EMPTY_NAME
-from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, SANSSave, ConvertSpectrumAxis, CreateSimulationWorkspace
+from mantid.simpleapi import GroupWorkspaces, SANSSave, ConvertSpectrumAxis, CreateSimulationWorkspace
 
 
 # -----------------------------------------------
@@ -46,6 +46,16 @@ class SANSSaveTest(unittest.TestCase):
             errors[0] = 0.0
             errors[14] = 0.0
             errors[45] = 0.0
+        return workspace
+
+    @staticmethod
+    def _get_sample_group_workspace(convert_spectrum=False):
+        workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
+        workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
+        workspace_list = [workspace_0, workspace_1]
+        workspace = GroupWorkspaces(workspace_list)
+        if convert_spectrum:
+            workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)
         return workspace
 
     def _assert_that_file_exists(self, file_name):
@@ -214,10 +224,7 @@ class SANSSaveTest(unittest.TestCase):
 
     def test_polarization_props_must_be_set_when_polarized_nx_can_sas_set(self):
         # Arrange
-        workspace_0 = CreateSampleWorkspace()
-        workspace_1 = CreateSampleWorkspace()
-        workspace_list = [workspace_0, workspace_1]
-        workspace = GroupWorkspaces(workspace_list)
+        workspace = self._get_sample_group_workspace(False)
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
         save_name = "SANSSave"
         save_options = {
@@ -247,10 +254,7 @@ class SANSSaveTest(unittest.TestCase):
 
     def test_polarization_props_throws_when_any_mandatory_properties_unset(self):
         # Arrange
-        workspace_0 = CreateSampleWorkspace()
-        workspace_1 = CreateSampleWorkspace()
-        workspace_list = [workspace_0, workspace_1]
-        workspace = GroupWorkspaces(workspace_list)
+        workspace = self._get_sample_group_workspace(False)
 
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
         pol_props = {
@@ -270,12 +274,7 @@ class SANSSaveTest(unittest.TestCase):
 
     def test_polarizer_algorithm_executed(self):
         # Arrange
-        workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_list = [workspace_0, workspace_1]
-        workspace = GroupWorkspaces(workspace_list)
-        workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)
-
+        workspace = self._get_sample_group_workspace(True)
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
         pol_props = {
             "InputSpinStates": "+10,-10",
@@ -291,12 +290,7 @@ class SANSSaveTest(unittest.TestCase):
 
     def test_group_workspaces_handled_by_non_pol_alg(self):
         # Arrange
-        workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_list = [workspace_0, workspace_1]
-        workspace = GroupWorkspaces(workspace_list)
-        workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)
-
+        workspace = self._get_sample_group_workspace(True)
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
 
         # Act
@@ -304,11 +298,7 @@ class SANSSaveTest(unittest.TestCase):
 
     def test_group_workspaces_throw_for_incompatible_alg(self):
         # Arrange
-        workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
-        workspace_list = [workspace_0, workspace_1]
-        workspace = GroupWorkspaces(workspace_list)
-        workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)
+        workspace = self._get_sample_group_workspace(True)
 
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
 

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSSaveTest.py
@@ -258,7 +258,7 @@ class SANSSaveTest(unittest.TestCase):
 
         file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
         pol_props = {
-            "InputSpinStatez": "0,1",
+            "InvalidPropName": "0,1",
         }
         with self.assertRaisesRegex(
             RuntimeError,

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -29,7 +29,7 @@ Improvements
 - The **diagnostic** page icon has been changed from a question mark to a stethoscope, to distinguish it from the **Help** page icon. The **Export Table** button now has an icon. There have been minor icon changes elsewhere on the interface.
 - Sample thickness, height, and width can be read from a batch file. These parameters are also included in the batch file generated from exporting the table.
 - The beam centre HAB/LAB update checkboxes are automatically deselected if you select LAB/HAB as the reduction mode, respectively.
-- The run numbers for sample transmission, sample direct, can scatter, and can direct workspaces are now added to NXCanSAS and CanSAS files.
+- The run numbers for sample transmission, sample direct, can scatter, and can direct workspaces are now added to NXcanSAS and CanSAS files.
 
 
 Bug Fixes

--- a/docs/source/release/v5.1.0/sans.rst
+++ b/docs/source/release/v5.1.0/sans.rst
@@ -12,7 +12,7 @@ New
 ###
 
 - A new algorithm :ref:`SANSILLParameterScan <algm-SANSILLParameterScan>` added, used to treat data from ILL's D16 on omega scan mode.
-- :ref:`SaveCanSAS1D <algm-SaveCanSAS1D>` and :ref:`SaveNXCanSAS <algm-SaveNXCanSAS>` now include the batch
+- :ref:`SaveCanSAS1D <algm-SaveCanSAS1D>` and :ref:`SaveNXcanSAS <algm-SaveNXcanSAS>` now include the batch
   file name in their metadata if one was used to produce the output.
 
 Improvements

--- a/docs/source/release/v6.13.0/SANS/New_features/38523.rst
+++ b/docs/source/release/v6.13.0/SANS/New_features/38523.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-SANSSave` now supports the new :ref:`algm-SavePolarizedNXcanSAS` algorithm.

--- a/docs/source/release/v6.9.0/sans.rst
+++ b/docs/source/release/v6.9.0/sans.rst
@@ -7,7 +7,7 @@ SANS Changes
 
 New Features
 ------------
-- Metadata indicating the subtracted workspace and the scale factor is now saved to CanSAS1D and NXCanSAS subtracted
+- Metadata indicating the subtracted workspace and the scale factor is now saved to CanSAS1D and NXcanSAS subtracted
   output files when a :ref:`ISIS_SANS_scaled_background-ref` has been performed. This information is located in
   ``SASprocess``.
 - All beam centre settings can now be left uncommented in the TOML file. The appropriate beam centre values will now be

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -27,7 +27,7 @@ def save_to_file(workspace, file_format, file_name, additional_properties, addit
     :param file_name: the file name.
     :param additional_properties: a dict of additional save algorithm inputs
             e.g. Transmission and TransmissionCan for SaveCanSAS1D-v2
-    :param additional_run_numbers: a dict of workspace type to run number. Used in SaveNXCanSAS only.
+    :param additional_run_numbers: a dict of workspace type to run number. Used in SaveNXcanSAS only.
     :return:
     """
     save_options = {"InputWorkspace": workspace}

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -48,36 +48,37 @@ def get_save_strategy(file_format_bundle, file_name, save_options, additional_pr
     :return: a handle to a save algorithm
     """
     file_format = file_format_bundle.file_format
-    if file_format is SaveType.NEXUS:
-        file_name = get_file_name(file_format_bundle, file_name, "", ".nxs")
-        save_name = "SaveNexusProcessed"
-    elif file_format is SaveType.CAN_SAS:
-        file_name = get_file_name(file_format_bundle, file_name, "", ".xml")
-        save_name = "SaveCanSAS1D"
-        save_options.update(additional_properties)
-        save_options.update(additional_run_numbers)
-    elif file_format is SaveType.NX_CAN_SAS:
-        file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".h5")
-        save_name = "SaveNXcanSAS"
-        save_options.update(additional_properties)
-        save_options.update(additional_run_numbers)
-    elif file_format is SaveType.POL_NX_CAN_SAS:
-        file_name = get_file_name(file_format_bundle, file_name, "_polnxcansas", ".h5")
-        save_name = "SavePolarizedNXcanSAS"
-        save_options.update(additional_properties)
-        save_options.update(additional_run_numbers)
-    elif file_format is SaveType.NIST_QXY:
-        file_name = get_file_name(file_format_bundle, file_name, "_nistqxy", ".dat")
-        save_name = "SaveNISTDAT"
-    elif file_format is SaveType.RKH:
-        file_name = get_file_name(file_format_bundle, file_name, "", ".txt")
-        save_name = "SaveRKH"
-        save_options.update({"Append": False})
-    elif file_format is SaveType.CSV:
-        file_name = get_file_name(file_format_bundle, file_name, "", ".csv")
-        save_name = "SaveCSV"
-    else:
-        raise RuntimeError("SaveWorkspace: The requested data {0} format is currently not supported.".format(file_format))
+    match file_format:
+        case SaveType.NEXUS:
+            file_name = get_file_name(file_format_bundle, file_name, "", ".nxs")
+            save_name = "SaveNexusProcessed"
+        case SaveType.CAN_SAS:
+            file_name = get_file_name(file_format_bundle, file_name, "", ".xml")
+            save_name = "SaveCanSAS1D"
+            save_options.update(additional_properties)
+            save_options.update(additional_run_numbers)
+        case SaveType.NX_CAN_SAS:
+            file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".h5")
+            save_name = "SaveNXcanSAS"
+            save_options.update(additional_properties)
+            save_options.update(additional_run_numbers)
+        case SaveType.POL_NX_CAN_SAS:
+            file_name = get_file_name(file_format_bundle, file_name, "_polnxcansas", ".h5")
+            save_name = "SavePolarizedNXcanSAS"
+            save_options.update(additional_properties)
+            save_options.update(additional_run_numbers)
+        case SaveType.NIST_QXY:
+            file_name = get_file_name(file_format_bundle, file_name, "_nistqxy", ".dat")
+            save_name = "SaveNISTDAT"
+        case SaveType.RKH:
+            file_name = get_file_name(file_format_bundle, file_name, "", ".txt")
+            save_name = "SaveRKH"
+            save_options.update({"Append": False})
+        case SaveType.CSV:
+            file_name = get_file_name(file_format_bundle, file_name, "", ".csv")
+            save_name = "SaveCSV"
+        case _:
+            raise RuntimeError("SaveWorkspace: The requested data {0} format is currently not supported.".format(file_format))
     save_options.update({"Filename": file_name})
     return create_unmanaged_algorithm(save_name, **save_options)
 

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -61,6 +61,11 @@ def get_save_strategy(file_format_bundle, file_name, save_options, additional_pr
         save_name = "SaveNXcanSAS"
         save_options.update(additional_properties)
         save_options.update(additional_run_numbers)
+    elif file_format is SaveType.POL_NX_CAN_SAS:
+        file_name = get_file_name(file_format_bundle, file_name, "_polnxcansas", ".h5")
+        save_name = "SavePolarizedNXcanSAS"
+        save_options.update(additional_properties)
+        save_options.update(additional_run_numbers)
     elif file_format is SaveType.NIST_QXY:
         file_name = get_file_name(file_format_bundle, file_name, "_nistqxy", ".dat")
         save_name = "SaveNISTDAT"

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -532,7 +532,7 @@ def set_save(
                     save_algs.append(SaveType.CAN_SAS)
                 case "SaveCSV":
                     save_algs.append(SaveType.CSV)
-                case "SaveNXCanSAS":
+                case "SaveNXcanSAS":
                     save_algs.append(SaveType.NX_CAN_SAS)
                 case _:
                     raise RuntimeError(f"The save format {key} is not known")

--- a/scripts/SANS/sans/common/enums.py
+++ b/scripts/SANS/sans/common/enums.py
@@ -200,6 +200,7 @@ class SaveType(Enum):
     NIST_QXY = "NistQxy"
     NO_TYPE = "NoType"
     NX_CAN_SAS = "NXcanSAS"
+    POL_NX_CAN_SAS = "PolarizedNXcanSAS"
     RKH = "RKH"
 
 


### PR DESCRIPTION
### Description of work

#### Summary of work
Allows SANSSave (the SANS workflow algorithm for saving out reduced workspaces in a variety of formats) to make use of the new SavePolarizedNXCanSAS algorithm when the reduced output workspaces are in the polarized form. 

Part of the Polarized SANS Epic.

Fixes #38523 


#### Further detail of work
The algorithm now has an additional "PolarizationProps" property, which allows the passing of a dictionary containing all of the mandatory properties required for SavePolarizedNXCanSAS. 

The algorithm has also been adjusted to allow for the explicit passing of Workspace Groups. Groups are now processed as-is rather than attempting to process them one-by-one. Additional validation has been added to ensure that only algorithms that support such workspaces are allowed to be selected when calling the algorithm, and that workspaces explicitly are groups when calling for SavePolarizedNXCanSAS. 

### To test:

Use this script as a start, then have a play and try to break it.
```python
workspace_0 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
workspace_1 = CreateSimulationWorkspace(Instrument="LARMOR", BinParams="1,10,1000", UnitX="MomentumTransfer")
workspace_list = [workspace_0, workspace_1]
workspace = GroupWorkspaces(workspace_list)
workspace = ConvertSpectrumAxis(InputWorkspace=workspace, Target="ElasticQ", EFixed=1)

file_name = os.path.join(mantid.config.getString("defaultsave.directory"), "sample_sans_save_file")
pol_props = {
    "InputSpinStates": "+10,-10",
    "PolarizerComponentName": "a",
    "AnalyzerComponentName": "b",
    "FlipperComponentNames": "c, d, e",
    "MagneticFieldStrengthLogName": "f",
    "MagneticFieldDirection": "1,2,3",
}

# Act
SANSSave(workspace, file_name, NXcanSAS=True, PolarizedNXCanSAS=True, PolarizationProps=pol_props)
```

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
