### PR TITLE
disable Croshair in 3D plots

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. THe crosshair button is disabled (invisible) in titled plots.
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.

--- a/docs/source/release/v6.13.0/Workbench/New_features/39286.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39286.rst
@@ -1,0 +1,1 @@
+- The crosshair button is disabled (invisible) in 3D plots, which include surface plot, wireframe plot and mesh plot.

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -20,7 +20,8 @@ from mantidqt.plotting import functions
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from mantid.plots.plotfunctions import plot
-from mantid.simpleapi import CreateSampleWorkspace, CreateMDHistoWorkspace, Load
+from mantid.simpleapi import CreateSampleWorkspace, CreateMDHistoWorkspace, Load, mtd
+import mantid.simpleapi as msa
 
 
 @start_qapplication
@@ -149,6 +150,28 @@ class ToolBarTest(unittest.TestCase):
         axes.contour(data, levels=np.linspace(10, 60, 6), colors="yellow", alpha=0.5)
         # crosshair button should be visible because this is a contour plot
         self.assertTrue(self._is_crosshair_button_visible(fig))
+        self.assertFalse(self._is_crosshair_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_hidden_for_3d_surface_plots(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        data = Load("MUSR00015189.nxs")
+        data = mtd["data_1"]  # Extract individual workspace from group
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
+        ax.plot_surface(data, cmap="viridis")
+        # crosshair button should be hidden
+        self.assertFalse(self._is_crosshair_button_visible(fig))
+        self.assertFalse(self._is_crosshair_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_hidden_for_3d_wireframe_plots(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        msa.config.setFacility("SNS")
+        data = Load("MAR11060.nxs")
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
+        ax.plot_wireframe(data)
+        # crosshair button should be hidden
+        self.assertFalse(self._is_crosshair_button_visible(fig))
         self.assertFalse(self._is_crosshair_button_checked(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -20,7 +20,8 @@ from mantidqt.plotting import functions
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from mantid.plots.plotfunctions import plot
-from mantid.simpleapi import CreateSampleWorkspace, CreateMDHistoWorkspace, Load, mtd
+from mantid.simpleapi import CreateSampleWorkspace, CreateMDHistoWorkspace, Load, mtd, LoadSampleShape
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 import mantid.simpleapi as msa
 
 
@@ -170,6 +171,23 @@ class ToolBarTest(unittest.TestCase):
         data = Load("MAR11060.nxs")
         fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
         ax.plot_wireframe(data)
+        # crosshair button should be hidden
+        self.assertFalse(self._is_crosshair_button_visible(fig))
+        self.assertFalse(self._is_crosshair_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_hidden_for_3d_mesh_plots(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        ws = CreateSampleWorkspace()
+        ws = LoadSampleShape(ws, "tube.stl")
+        sample = ws.sample()
+        shape = sample.getShape()
+        mesh = shape.getMesh()
+        mesh_polygon = Poly3DCollection(mesh, facecolors=["g"], edgecolors=["b"], alpha=0.5, linewidths=0.1)
+        fig, axes = plt.subplots(subplot_kw={"projection": "mantid3d"})
+        axes.add_collection3d(mesh_polygon)
+        axes.set_mesh_axes_equal(mesh)
+
         # crosshair button should be hidden
         self.assertFalse(self._is_crosshair_button_visible(fig))
         self.assertFalse(self._is_crosshair_button_checked(fig))

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -234,8 +234,10 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
             self.set_fit_enabled(False)
             self.set_superplot_enabled(False)
 
-        # disable crosshair in tiled plots but keep it enabled in color contour plot
-        if len(fig.get_axes()) > 1 and figure_type(fig) not in [FigureType.Contour]:
+        # disable crosshair in tiled plots, 3D plots but keep it enabled in color contour plot
+        if (len(fig.get_axes()) > 1 and figure_type(fig) not in [FigureType.Contour]) or (
+            figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]
+        ):
             self.set_crosshair_enabled(False)
 
         for ax in fig.get_axes():


### PR DESCRIPTION
### Description of work
EWM [10076](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10076) 

This PR disables crosshair functions in 3D plots by hiding the crosshair button from users.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

To test, consider three scenarios labeled as mantid 3D plotting options: surface, wireframe and mesh. In each scenarios, users should not see the crosshair button and changing axes or any other options should not crash mantid. Make sure testers set facility to SNS first.

Scenario 1 - Surface plot:
Run the following code:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

data = Load('MUSR00015189.nxs')
data = mtd['data_1'] # Extract individual workspace from group

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(data)
plt.show()
 
```
![image](https://github.com/user-attachments/assets/1b63d054-c626-491f-a802-953e78942118)

Scenario 2 - Wireframe plot:

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

data = Load('MAR11060.nxs')

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_wireframe(data, color='#1f77b4')
plt.show()
```
![image](https://github.com/user-attachments/assets/49687b66-909a-44cc-bb79-47a1e6f107af)

Scenario 3 - Mesh plot:

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mpl_toolkits.mplot3d.art3d import Poly3DCollection
from mantid.api import AnalysisDataService as ADS

# load sample shape mesh file for a workspace
ws = CreateSampleWorkspace()
# alternatively: ws = Load('filepath') or ws = ADS.retrieve('ws')
ws = LoadSampleShape(ws, "tube.stl")

# get shape and mesh vertices
sample = ws.sample()
shape = sample.getShape()
mesh = shape.getMesh()

# Create 3D Polygon and set facecolor
mesh_polygon = Poly3DCollection(mesh, facecolors = ['g'], edgecolors = ['b'], alpha = 0.5, linewidths=0.1)

fig, axes = plt.subplots(subplot_kw={'projection':'mantid3d'})
axes.add_collection3d(mesh_polygon)

axes.set_mesh_axes_equal(mesh)
axes.set_title('Sample Shape: Tube')
axes.set_xlabel('X / m')
axes.set_ylabel('Y / m')
axes.set_zlabel('Z / m')

plt.show()
```
![image](https://github.com/user-attachments/assets/bffcad28-4dff-4e1c-b770-73463c44ec36)

None of the plots should give user the option of enabling crosshair(button hidden).

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
