### PR TITLE
Add 'FullBinsOnly' parameter to 'DiffractionFocussing2'

### DIFF
--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -69,6 +69,7 @@ void DiffractionFocussing2::init() {
   declareProperty(std::make_unique<ArrayProperty<double>>("Delta"),
                   "Step parameters for rebin, positive values are constant step-size, negative are logorithmic. One "
                   "value for each output specta or single value which is common to all");
+  declareProperty("FullBinsOnly", false, "Omit the final bin if it's width is smaller than the step size");
 }
 
 std::map<std::string, std::string> DiffractionFocussing2::validateInputs() {
@@ -737,6 +738,8 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
 
   nGroups = groups.size(); // Number of unique groups
 
+  const bool fullBinsOnly = getProperty("FullBinsOnly");
+
   // only now can we check that the length of rebin parameters are correct
   std::vector<double> xmins = getProperty("DMin");
   std::vector<double> xmaxs = getProperty("DMax");
@@ -763,11 +766,12 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
   if (numDelta == 1)
     deltas.resize(nGroups, deltas[0]);
 
-  // Iterator over all groups to create the new X vectors
+  // Iterate over all groups to create the new X vectors
   size_t i = 0;
   for (auto group : groups) {
     HistogramData::BinEdges xnew(0);
-    static_cast<void>(VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew.mutableRawData()));
+    static_cast<void>(VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew.mutableRawData(),
+                                                              true, fullBinsOnly));
     group2xvector[group] = xnew; // Register this vector in the map
     group2xstep[group] = deltas[i];
     i++;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -164,7 +164,7 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CropWorkspa
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp:176
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp:54
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing.cpp:116
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:826
+containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:830
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:348
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:364
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EQSANSTofStructure.cpp:71

--- a/docs/source/algorithms/DiffractionFocussing-v2.rst
+++ b/docs/source/algorithms/DiffractionFocussing-v2.rst
@@ -63,6 +63,9 @@ one value overall, it is used for all of the spectra. The ``Delta``
 parameter is required and can either be a single number which is
 common to all, or one number per spectra. Positive values are
 interpreted as constant step-size. Negative are logarithmic.
+An optional boolean parameter ``FullBinsOnly`` may be set to indicate
+that final bins with width smaller than the step-size should be omitted
+from the output spectra.
 
 Usage
 -----

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39289.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39289.rst
@@ -1,0 +1,1 @@
+- :ref:`DiffractionFocussing <algm-DiffractionFocussing-v2>` has a new optional boolean parameter ``FullBinsOnly``.  When set, final bins of width less than the step-size are omitted from the output spectra.


### PR DESCRIPTION
### Description of work
When applying the `DiffractionFocussing` algorithm, it is possible for each spectrum to have distinct `DMin`, `DMax`, and `Delta` parameters.  In the course of the algorithm's application, sometimes this results in a final bin that has a width smaller than the step size `Delta`.  Often, this will cause problems in downstream algorithms.  By setting the `FullBinsOnly` parameter, such final bins are _omitted_ from the output spectrum.

#### Summary of work

This commit includes the following changes:

  * Add 'FullBinsOnly' parameter to the `DiffractionFocussing2` algorithm;

  * Add unit tests to verify the function of the new parameter.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


Fixes [EWM story #9124](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9124)

### To test:
New unit tests are provided to test both the _application_ of the new parameter, `FullBinsOnly=True`, and to verify that the same test setup does _not_ omit the final bin when `FullBinsOnly=False` (which is the _default_ value).

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
