### PR TITLE
Optimize the addTies function by implementing a single sort operation after all ties are added

### DIFF
--- a/Framework/API/inc/MantidAPI/FunctionParameterDecorator.h
+++ b/Framework/API/inc/MantidAPI/FunctionParameterDecorator.h
@@ -113,6 +113,8 @@ public:
   void removeConstraint(const std::string &parName) override;
   /// Set parameters of decorated function to satisfy constraints.
   void setUpForFit() override;
+  /// Add ties to the decorated function.
+  void addTies(const std::string &ties, bool isDefault = false) override;
 
 protected:
   /// Does nothing.

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -731,6 +731,12 @@ private:
   bool m_isRegistered{false};
   /// The function used to calculate the step size
   std::function<double(const double)> m_stepSizeFunction;
+
+  // Creates and processes a single tie, handling constant expressions and validation
+  std::unique_ptr<ParameterTie> createAndProcessTie(const std::string &parName, const std::string &expr,
+                                                    bool isDefault);
+  // Insert a new tie to the correct position
+  std::pair<std::size_t, std::string> insertTie(std::unique_ptr<ParameterTie> tie);
 };
 
 /// shared pointer to the function base class

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -348,9 +348,7 @@ void FunctionFactoryImpl::addTies(const IFunction_sptr &fun, const Expression &e
   if (expr.name() == "=") {
     addTie(fun, expr);
   } else if (expr.name() == ",") {
-    for (const auto &constraint : expr) {
-      addTie(fun, constraint);
-    }
+    fun->addTies(expr.str());
   }
 }
 

--- a/Framework/API/src/FunctionParameterDecorator.cpp
+++ b/Framework/API/src/FunctionParameterDecorator.cpp
@@ -270,6 +270,12 @@ void FunctionParameterDecorator::setUpForFit() {
   m_wrappedFunction->setUpForFit();
 }
 
+void FunctionParameterDecorator::addTies(const std::string &ties, bool isDefault) {
+  throwIfNoFunctionSet();
+
+  m_wrappedFunction->addTies(ties, isDefault);
+}
+
 /// Throws std::runtime_error when m_wrappedFunction is not set.
 void FunctionParameterDecorator::throwIfNoFunctionSet() const {
   if (!m_wrappedFunction) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -106,12 +106,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:579
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:889
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IEventWorkspace.cpp:58
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:263
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:313
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:325
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:1159
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:1607
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:1650
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:50
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:85
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:92

--- a/docs/source/release/v6.13.0/Framework/Fit_Functions/New_features/38962.rst
+++ b/docs/source/release/v6.13.0/Framework/Fit_Functions/New_features/38962.rst
@@ -1,0 +1,1 @@
+- Optimize the addTies function by implementing a single sort operation after all ties are added, rather than sorting the ties after each individual addition


### PR DESCRIPTION
### Description of work
This PR optimises the `addTies` function in the interface of all fitting functions `IFunction`. Previously, the function sorted the ties each time a new tie was added. This PR changes the behaviour by sorting all ties after they're completely added, and if sorting fails, it reverses all changes. This implementation has created a significant performance boost, as shown in the graph below comparing old and new implementations. I know there's duplicate code in the implementation, but when I tried to refactor the function, it became more complicated, so I went back to this simpler version with minimal changes. Since this is core code used throughout the codebase, keeping changes small is safer. I've also added a unit test that covers all cases. 

![image](https://github.com/user-attachments/assets/db9cd276-6cb0-4b63-aafa-aea375b65714)

Fixes #38962

### To test:
1- Run this script
```
from mantid.simpleapi import *
from mantid.api import MultiDomainFunction, FunctionFactory
from mantid.fitfunctions import FunctionWrapper
                          

comp_func = CompositeFunction(Gaussian(Height=1, Sigma=0.3, PeakCentre=3), FunctionWrapper("FlatBackground"), NumDeriv=True)
ws = CreateSampleWorkspace(OutputWorkspace='ws', Function='User Defined', UserDefinedFunction=str(comp_func), XUnit='DeltaE', 
                           XMax=7, BinWidth=0.1, NumBanks=1, BankPixelWidth=2)

func = MultiDomainFunction()        
md_fit_kwargs = {}
for ispec in range(ws.getNumberHistograms()):
    func.add(comp_func.function)
    func.setDomainIndex(ispec,ispec)
    key_suffix = f"_{ispec}" if ispec > 0 else ""
    md_fit_kwargs["InputWorkspace" + key_suffix] = ws.name()
    md_fit_kwargs["StartX" + key_suffix] = 0.1
    md_fit_kwargs["EndX" + key_suffix] = 6.8
    md_fit_kwargs["WorkspaceIndex" + key_suffix] = ispec

add_ties = True
if add_ties:
    ties = []
    for idom in range(1, ws.getNumberHistograms()):
        for ifunc in range(func[0].nFunctions()):
            for ipar in range(func[0][ifunc].nParams()):
                par = func[0][ifunc].getParamName(ipar)
                ties.append(f"f{idom}.f{ifunc}.{par}=f0.f{ifunc}.{par}")
    func_str = f"{str(func)};ties=({','.join(ties)})"
else:
    func_str = str(func)
    
out = Fit(Function=func_str, Output='ws', StoreInADS=True, CreateOutput=True, OutputCompositeMembers=True,
          **md_fit_kwargs)
```

2- Increase the number of spectra and check the performance of the script compared to an older version of Mantid 
```
ws = CreateSampleWorkspace(OutputWorkspace='ws', Function='User Defined', UserDefinedFunction=str(comp_func), XUnit='DeltaE', 
                           XMax=7, BinWidth=0.1, NumBanks=25, BankPixelWidth=2)
```
3- You should notice a significant performance improvement compared with the previous version
4- Test the fitting engine by following the Mantid basic course (especially adding ties and constraints section): https://docs.mantidproject.org/nightly/tutorials/mantid_basic_course/fitting_data/index.html#fitting-data


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
