### PR TITLE
Move post-link.bat functionality to python for Windows conda installs

### DIFF
--- a/conda/recipes/mantidworkbench/post-link.bat
+++ b/conda/recipes/mantidworkbench/post-link.bat
@@ -1,1 +1,0 @@
-conda env config vars set QT_PLUGIN_PATH=%PREFIX%\Library\plugins

--- a/conda/recipes/mantidworkbench/pre-unlink.bat
+++ b/conda/recipes/mantidworkbench/pre-unlink.bat
@@ -1,1 +1,0 @@
-conda env config vars unset QT_PLUGIN_PATH

--- a/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
+++ b/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+import os
 import subprocess
 import sys
 
@@ -18,6 +19,10 @@ def launch(args=None):
         command = ["launch_mantidworkbench"] + args[1:]
         subprocess.run(command)
     else:
+        if sys.platform.startswith("win"):
+            # Windows conda installs require us to set the QT_PLUGIN_PATH variable.
+            if "CONDA_PREFIX" in os.environ:
+                os.environ["QT_PLUGIN_PATH"] = f"{os.environ.get('CONDA_PREFIX')}\\Library\\plugins"
         main(args[1:])
 
 


### PR DESCRIPTION
### Description of work
Move logic to set `QT_PLUGIN_PATH` from `post-link.bat` to Python. This will make Conda installs on Windows more robust.

#### Summary of work
The `post-link.bat` file included in the `mantidworkbench` conda recipe was added to set `QT_PLUGIN_PATH` to avoid the following error that prevents workbench from launching:
```
qt.qpa.plugin: Could not find the Qt platform plugin "windows" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
For some conda installs on Windows it was necessary to deactivate and reactivate the environment so that the `post-link.bat` takes effect. Not sure why. It has also been necessary to pin conda in [the past](https://github.com/mantidproject/mantid/pull/38140) when we were unable to install `mantidworkbench` to create the standalone package. Here we move the logic to Python, which avoids the need for the additional scripts in the conda recipe. This aligns with the recommendation that such scripts should [be avoided whenever possible](https://docs.conda.io/projects/conda-build/en/stable/resources/link-scripts.html).

Fixes #38997

### To test:
1. Install the standalone Windows from [here](https://builds.mantidproject.org/job/build_packages_from_branch/1100/) package and check that it launches
2. Install the conda package and check that it launches:
`conda install thomashampson/label/qt_plugin_path_test::mantidworkbench -c mantid`


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
