### PR TITLE
Fixed a flaky crash in fitting tab of engineering diffraction GUI when deleting a bulk of runs in ADS

### DIFF
--- a/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38667.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38667.rst
@@ -1,0 +1,1 @@
+- Fixed a flaky crash in :ref:`Fitting tab <ui engineering fitting>` of :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` seen when deleting multiple workspaces in the ADS. This also fixed an issue of clearing the whole plot in the same tab when deleting workspaces in the ADS.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -135,7 +135,6 @@ class FittingDataPresenter(object):
         workspaces_to_be_plotted = self.plotted.copy()
         if clear_plotted:
             self.plotted.clear()
-
         self._remove_all_table_rows()
         self.row_numbers.clear()
         self.all_plots_removed_notifier.notify_subscribers()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -17,7 +17,6 @@ class FittingDataPresenter(object):
         self.view = view
         self.worker = None
         self.iplot = []
-
         self.row_numbers = TwoWayRowDict()  # {ws_name: table_row} and {table_row: ws_name}
         self.plotted = set()  # List of plotted workspace names
 
@@ -61,11 +60,13 @@ class FittingDataPresenter(object):
             self._start_load_worker(filenames)
 
     def remove_workspace(self, ws_name):
+        self.plotted.discard(ws_name)
         if ws_name in self.model.get_all_workspace_names():
+            if ws_name in self.model.get_loaded_workspaces():
+                self.row_numbers.pop(ws_name)
             self.model.remove_workspace(ws_name)
             # plot_presenter will already be notified of ws being removed via its own ADS observer
-            self.plotted.discard(ws_name)
-            self._repopulate_table()
+            self._repopulate_table(False)
         elif ws_name in self.model.get_all_log_workspaces_names():
             self.model.update_sample_log_workspace_group()
 
@@ -132,7 +133,6 @@ class FittingDataPresenter(object):
         Will also handle any workspaces that need to be plotted.
         """
         workspaces_to_be_plotted = self.plotted.copy()
-
         if clear_plotted:
             self.plotted.clear()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
@@ -7,7 +7,7 @@
 import unittest
 
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, call, ANY
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.data_handling import data_model, data_presenter, data_view
 
 dir_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.data_handling"
@@ -500,6 +500,44 @@ class FittingDataPresenterTest(unittest.TestCase):
         calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
         self.view.set_table_column.assert_has_calls(calls, any_order=False)
         self.presenter._update_plotted_ws_with_sub_state.assert_called_once_with("WS_Name2", True)
+
+    @patch(dir_path + ".data_presenter.FittingDataPresenter._repopulate_table")
+    def test_remove_loaded_workspace(self, mock_repopulate_table):
+        model_dict = {"name1": self.ws1, "name2": self.ws2}
+        self.model.get_loaded_workspaces.return_value = model_dict
+        self.model.get_all_workspace_names.return_value = ["name1", "name2", "name1_bg", "name1_bg"]
+        self.presenter.plotted = {"name1_bg", "name2_bg"}
+        self.presenter.row_numbers = {"name1": 0, "name2": 1}
+        self.presenter.plot_removed_notifier = mock.MagicMock()
+        self.presenter.all_plots_removed_notifier = mock.MagicMock()
+
+        self.presenter.remove_workspace("name1")
+
+        self.model.remove_workspace.assert_called_once_with("name1")
+        self.assertEqual({"name2": 1}, self.presenter.row_numbers)
+        mock_repopulate_table.assert_called_once_with(False)
+        self.model.update_sample_log_workspace_group.assert_not_called()
+
+    def test_remove_bg_workspace(self):
+        self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
+        self.model.get_all_workspace_names.return_value = ["name1", "name2", "name1_bg", "name1_bg"]
+        self.model.get_sample_log_from_ws.side_effect = lambda _, log: "runnumb" if log == "run_number" else "bank"
+        self.model.get_active_ws_name.side_effect = lambda name: name + "_bg"
+        self.presenter.plotted = {"name1_bg", "name2_bg"}
+        self.presenter.row_numbers = {"name1": 0, "name2": 1}
+        self.presenter.plot_removed_notifier = mock.MagicMock()
+        self.presenter.all_plots_removed_notifier = mock.MagicMock()
+
+        self.presenter.remove_workspace("name1_bg")
+
+        self.model.remove_workspace.assert_called_once_with("name1_bg")
+        self.assertEqual({"name1": 0, "name2": 1}, self.presenter.row_numbers)
+        self.model.update_sample_log_workspace_group.assert_not_called()
+        self.assertEqual(self.presenter.plotted, {"name2_bg"})
+        self.view.remove_all.assert_called_once()
+        self.presenter.all_plots_removed_notifier.notify_subscribers.assert_called_once()
+        expected_calls = [call("runnumb", "bank", False, ANY, ANY, ANY, ANY), call("runnumb", "bank", True, ANY, ANY, ANY, ANY)]
+        self.view.add_table_row.assert_has_calls(expected_calls, any_order=False)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
@@ -7,6 +7,7 @@
 from mantid.api import AnalysisDataServiceObserver
 from functools import wraps
 import sys
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 def _catch_exceptions(func):
@@ -30,10 +31,15 @@ def _catch_exceptions(func):
 class FittingADSObserver(AnalysisDataServiceObserver):
     def __init__(self, delete_callback, clear_callback, replace_callback, rename_callback):
         super(FittingADSObserver, self).__init__()
-        self.delete_callback = delete_callback
-        self.clear_callback = clear_callback
-        self.replace_callback = replace_callback
-        self.rename_callback = rename_callback
+        # self.delete_callback = delete_callback
+        # self.clear_callback = clear_callback
+        # self.replace_callback = replace_callback
+        # self.rename_callback = rename_callback
+
+        self.replace_callback = QAppThreadCall(replace_callback, blocking=False)
+        self.rename_callback = QAppThreadCall(rename_callback, blocking=False)
+        self.clear_callback = QAppThreadCall(clear_callback, blocking=False)
+        self.delete_callback = QAppThreadCall(delete_callback, blocking=False)
 
         self.observeDelete(True)
         self.observeRename(True)
@@ -73,6 +79,7 @@ class FittingADSObserver(AnalysisDataServiceObserver):
         :param name: The name of the workspace.
         :param workspace: A reference to the new workspace
         """
+        # self.replace_callback(name, workspace)
         self.replace_callback(name, workspace)
 
     def unsubscribe(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
@@ -73,7 +73,6 @@ class FittingADSObserver(AnalysisDataServiceObserver):
         :param name: The name of the workspace.
         :param workspace: A reference to the new workspace
         """
-        # self.replace_callback(name, workspace)
         self.replace_callback(name, workspace)
 
     def unsubscribe(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
@@ -7,7 +7,6 @@
 from mantid.api import AnalysisDataServiceObserver
 from functools import wraps
 import sys
-from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 def _catch_exceptions(func):
@@ -31,15 +30,10 @@ def _catch_exceptions(func):
 class FittingADSObserver(AnalysisDataServiceObserver):
     def __init__(self, delete_callback, clear_callback, replace_callback, rename_callback):
         super(FittingADSObserver, self).__init__()
-        # self.delete_callback = delete_callback
-        # self.clear_callback = clear_callback
-        # self.replace_callback = replace_callback
-        # self.rename_callback = rename_callback
-
-        self.replace_callback = QAppThreadCall(replace_callback, blocking=False)
-        self.rename_callback = QAppThreadCall(rename_callback, blocking=False)
-        self.clear_callback = QAppThreadCall(clear_callback, blocking=False)
-        self.delete_callback = QAppThreadCall(delete_callback, blocking=False)
+        self.delete_callback = delete_callback
+        self.clear_callback = clear_callback
+        self.replace_callback = replace_callback
+        self.rename_callback = rename_callback
 
         self.observeDelete(True)
         self.observeRename(True)


### PR DESCRIPTION
### Description of work
Fixed a crash in the fitting tab of the Engineering diffraction GUI that was observed when deleting a number of workspaces in the ADS. 

#### Summary of work
During debugging it was noted that the crash happens when receiving callbacks asynchronously into the `FittingDataPresenter.remove_workspace` from ADS to handle deleting workspaces and consequently `FittingDataPresenter._handle_table_cell_changed` getting triggered due to `FittingDataView.add_table_row` as a part of repopulating the table via `FittingDataPresenter._repopulate_table`. The root cause was `FittingDataPresenter.row_numbers` and 
`FittingDataPresenter.model._data_workspaces` were becoming out of sync due to data races.


Fixes #38667. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
1. Follow [Test 4](https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#id8) upto step 3 
2. Load a number of focused files into the Fitting tab having `Add to plot` ticked.
3. Select a chunk (half or more) workspaces in the ADS and click delete.
4. Nothing should crash, and the plots shown in the fitting tab need to reflect the undeleted runs present in the ADS as well as in the `Run Selection` table of the fitting tab.
5. For the remaining rows in the table, make sure the ticks in the `Plot` and `Subtract BG` columns are in sync with what is being plotted even after the workspace deletion in ADS.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
