### PR TITLE
Fix XDataConverter for ragged workspaces

### DIFF
--- a/Framework/Algorithms/src/XDataConverter.cpp
+++ b/Framework/Algorithms/src/XDataConverter.cpp
@@ -54,8 +54,12 @@ void XDataConverter::exec() {
     return;
   }
 
+  const bool ragged = inputWS->isRaggedWorkspace();
+
   const auto numSpectra = static_cast<int>(inputWS->getNumberHistograms());
-  const size_t numYValues = getNewYSize(inputWS);
+  size_t numYValues{1};
+  if (!ragged)
+    numYValues = getNewYSize(inputWS);
   const size_t numXValues = getNewXSize(numYValues);
   m_sharedX = API::WorkspaceHelpers::sharedXData(inputWS);
   // Create the new workspace
@@ -73,6 +77,9 @@ void XDataConverter::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < int(numSpectra); ++i) {
     PARALLEL_START_INTERRUPT_REGION
+
+    if (ragged)
+      outputWS->resizeHistogram(i, inputWS->histogramSize(i));
 
     // Copy over the Y and E data
     outputWS->setSharedY(i, inputWS->sharedY(i));

--- a/Framework/Algorithms/test/ConvertToPointDataTest.h
+++ b/Framework/Algorithms/test/ConvertToPointDataTest.h
@@ -18,6 +18,9 @@ using Mantid::API::IAlgorithm_sptr;
 using Mantid::API::MatrixWorkspace;
 using Mantid::API::MatrixWorkspace_sptr;
 using Mantid::DataObjects::Workspace2D_sptr;
+using Mantid::HistogramData::BinEdges;
+using Mantid::HistogramData::Counts;
+using Mantid::HistogramData::Histogram;
 
 class ConvertToPointDataTest : public CxxTest::TestSuite {
 
@@ -155,6 +158,46 @@ public:
         TS_ASSERT_DELTA(dx[j], xErrors[j], 1E-16);
       }
     }
+  }
+
+  void test_ragged() {
+    // create ragged workspace
+    Workspace2D_sptr raggedWS = WorkspaceCreationHelper::create2DWorkspace(2, 1);
+
+    // create and replace histograms with ragged ones
+    raggedWS->setHistogram(0, Histogram(BinEdges{100., 200., 300., 400.}, Counts{1., 2., 3.}));
+    raggedWS->setHistogram(1, Histogram(BinEdges{200., 400., 600.}, Counts{4., 5.}));
+
+    // quick check of the input workspace
+    TS_ASSERT(raggedWS->isRaggedWorkspace());
+    TS_ASSERT(raggedWS->isHistogramData())
+    TS_ASSERT_EQUALS(raggedWS->getNumberHistograms(), 2);
+
+    MatrixWorkspace_sptr outputWS = runAlgorithm(raggedWS);
+    TS_ASSERT(outputWS)
+    TS_ASSERT(!outputWS->isHistogramData())  // output is a points workspace
+    TS_ASSERT(outputWS->isRaggedWorkspace()) // output is a ragged workspace
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 2);
+
+    // check the data
+    const Mantid::MantidVec &Y0 = outputWS->readY(0);
+    const Mantid::MantidVec &X0 = outputWS->readX(0);
+    const Mantid::MantidVec &Y1 = outputWS->readY(1);
+    const Mantid::MantidVec &X1 = outputWS->readX(1);
+    TS_ASSERT_EQUALS(Y0.size(), 3);
+    TS_ASSERT_EQUALS(X0.size(), 3);
+    TS_ASSERT_EQUALS(Y1.size(), 2);
+    TS_ASSERT_EQUALS(X1.size(), 2);
+    TS_ASSERT_EQUALS(X0[0], 150.);
+    TS_ASSERT_EQUALS(X0[1], 250.);
+    TS_ASSERT_EQUALS(X0[2], 350.);
+    TS_ASSERT_EQUALS(X1[0], 300.);
+    TS_ASSERT_EQUALS(X1[1], 500.);
+    TS_ASSERT_EQUALS(Y0[0], 1.);
+    TS_ASSERT_EQUALS(Y0[1], 2.);
+    TS_ASSERT_EQUALS(Y0[2], 3.);
+    TS_ASSERT_EQUALS(Y1[0], 4.);
+    TS_ASSERT_EQUALS(Y1[1], 5.);
   }
 
 private:

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -890,7 +890,7 @@ public:
    * This test is disabled because it requires changes to ConvertToHistogram which requires changes to it's parent
    * XDataConverter. Maybe this could be combined with previous test
    */
-  void xtest_ragged_Workspace2D_centers() {
+  void test_ragged_Workspace2D_centers() {
     const std::string outname("raggedWSout_edges");
     constexpr bool bin_edges(false);
 

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39304.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39304.rst
@@ -1,0 +1,1 @@
+- Fixed :ref:`ConvertUnits <algm-ConvertUnits>` when input workspace is a :ref:`ragged workspaces <Ragged_Workspace>` with point data.


### PR DESCRIPTION
### Description of work

This fixes `ConvertToPointData` and `ConvertToHistogram` for ragged workspaces which in turn fixes `ConvertUnits` when the input workspace is a ragged pointdata workspace. This is following on from #38551.

Before this fix you would just get the following error

```
ConvertToHistogram-[Error] ConvertToHistogram: Histogram: size mismatch of data.
```

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [8867: ConvertUnits for ragged workspaces with distribution=true and point data](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8867)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You can test `ConvertToPointData` and `ConvertToHistogram` now works with ragged workspaces

```python
ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=2)
ws=RebinRagged(ws, XMin=(100,200,300,400), XMax=(5000,15000,10000,5000), Delta=100)
points = ConvertToPointData(ws)
hist = ConvertToHistogram(points)
CompareWorkspaces(ws, hist)
```

and that `ConvertUnits` now works with a ragged pointdata workspace

```python
ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=2)
ConvertToDistribution(ws)
points = ConvertToPointData(ws)
points=RebinRagged(points, XMin=(100,200,300,400), XMax=(5000,15000,10000,5000), Delta=100)
out = ConvertUnits(points,Target="Wavelength")
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
