### PR TITLE
Add docs about customizing log format

### DIFF
--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -146,7 +146,7 @@ functionality within Mantid will not be explained here. For those who want more 
 `POCO logging classes <https://pocoproject.org/docs/package-Foundation.Logging.html>`_ and the
 `Log4J logging module <https://logging.apache.org/log4j/>`_ that it closely emulates.
 There are several comments in the properties file itself that explain the configuration we provide by default.
-However there are some obvious areas thatyou may want to alter and those properties are detailed below.
+However there are some obvious areas that you may want to alter and those properties are detailed below.
 Information on how to customize the logging system can be found in the
 `POCO documentation <https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders>`_.
 

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -141,31 +141,38 @@ Directory Properties
 Logging Properties
 ******************
 
-The details of configuring the logging functionality within Mantid will not be explained here. For those who want more
-details look into the `POCO logging classes <https://pocoproject.org/docs/package-Foundation.Logging.html>`_ and the
-`Log4J logging module <https://logging.apache.org/log4j/>`_ that it closely emulates. There are several comments in the
-properties file itself that explain the configuration we provide by default.  However there are some obvious areas that
-you may want to alter and those properties are detailed below.
+Mantid uses the `POCO <https://pocoproject.org/>`_ C++ libraries for logging. The details of configuring the logging
+functionality within Mantid will not be explained here. For those who want more details look into the
+`POCO logging classes <https://pocoproject.org/docs/package-Foundation.Logging.html>`_ and the
+`Log4J logging module <https://logging.apache.org/log4j/>`_ that it closely emulates.
+There are several comments in the properties file itself that explain the configuration we provide by default.
+However there are some obvious areas thatyou may want to alter and those properties are detailed below.
+Information on how to customize the logging system can be found in the
+`POCO documentation <https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders>`_.
 
-+-------------------------------------------------+---------------------------------------------------+-----------------------------+
-|Property                                         |Description                                        |Example value                |
-+=================================================+===================================================+=============================+
-| ``logging.loggers.root.level``                  |Defines the level of messages to be output         | ``debug``, ``information``, |
-|                                                 |by the system.                                     | ``notice``, ``warning``,    |
-|                                                 |The default is information, but                    | ``error``, ``critical``     |
-|                                                 |this can be lowered to debug for more detailed     | or ``fatal``                |
-|                                                 |feedback.                                          |                             |
-+-------------------------------------------------+---------------------------------------------------+-----------------------------+
-| ``logging.channels.consoleChannel.class``       | Select where log messages appear.                 | ``ConsoleChannel``,         |
-|                                                 | ``ConsoleChannel`` writes to stdlog.              | ``StdoutChannel``,          |
-|                                                 | ``StdoutChannel`` writes to stdout and can be     | ``PythonStdoutChannel``, or |
-|                                                 | redirected using pipes.                           | ``PythonLoggingChannel``    |
-|                                                 | ``PythonStdoutChannel`` writes to stdout through  |                             |
-|                                                 | python and is visible in jupyter notebooks.       |                             |
-|                                                 | ``PythonLoggingChannel`` sends messages to a      |                             |
-|                                                 | logger called ``'Mantid'`` from the ``logging``   |                             |
-|                                                 | framework of Python's standard library.           |                             |
-+-------------------------------------------------+---------------------------------------------------+-----------------------------+
+
++-------------------------------------------------+---------------------------------------------------+-------------------------------------+
+|Property                                         |Description                                        |Example value                        |
++=================================================+===================================================+=====================================+
+| ``logging.loggers.root.level``                  |Defines the level of messages to be output         | ``debug``, ``information``,         |
+|                                                 |by the system.                                     | ``notice``, ``warning``,            |
+|                                                 |The default is information, but                    | ``error``, ``critical``             |
+|                                                 |this can be lowered to debug for more detailed     | or ``fatal``                        |
+|                                                 |feedback.                                          |                                     |
++-------------------------------------------------+---------------------------------------------------+-------------------------------------+
+| ``logging.channels.consoleChannel.class``       | Select where log messages appear.                 | ``ConsoleChannel``,                 |
+|                                                 | ``ConsoleChannel`` writes to stdlog.              | ``StdoutChannel``,                  |
+|                                                 | ``StdoutChannel`` writes to stdout and can be     | ``PythonStdoutChannel``, or         |
+|                                                 | redirected using pipes.                           | ``PythonLoggingChannel``            |
+|                                                 | ``PythonStdoutChannel`` writes to stdout through  |                                     |
+|                                                 | python and is visible in jupyter notebooks.       |                                     |
+|                                                 | ``PythonLoggingChannel`` sends messages to a      |                                     |
+|                                                 | logger called ``'Mantid'`` from the ``logging``   |                                     |
+|                                                 | framework of Python's standard library.           |                                     |
++-------------------------------------------------+---------------------------------------------------+-------------------------------------+
+| ``logging.formatters.f1.pattern``               | The format of the log messages.                   | ``[%H:%M:%S][%q] %s %U:%u - %t``    |
+|                                                 | The default is ``%s-[%p] %t``.                    |                                     |
++-------------------------------------------------+---------------------------------------------------+-------------------------------------+
 
 The logging priority levels for the file logging and console logging can also be adjusted in python using the command:
 

--- a/docs/source/tutorials/extending_mantid_with_python/python_algorithms/05_logging.rst
+++ b/docs/source/tutorials/extending_mantid_with_python/python_algorithms/05_logging.rst
@@ -19,6 +19,9 @@ There are several levels of logging available, ordered in terms of increasing pr
 
 Any log message that is sent at a priority level above or equal to the value set in the properties file will appear in the appropriate location, i.e. Messages Box, log file.
 
+Additionally, the log message format can be customized by setting the **logging.formatters.f1.pattern** key in the :ref:`properties file <Properties File>`.
+Detailed information about valid log format placeholders can be found in the `POCO documentation <https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders>`_.
+
 Within a Python algorithm the log can be accessed using ``self.log()`` which is a configured instance of the :class:`~mantid.kernel.Logger`.
 To post a message, simply choose a priority level and call a function that has that name with the message as an argument
 

--- a/tools/DefaultConfigFiles/Mantid.user.properties
+++ b/tools/DefaultConfigFiles/Mantid.user.properties
@@ -60,6 +60,11 @@ Q.convention = Inelastic
 ## Valid values are: error, warning, notice, information, debug
 #logging.loggers.root.level=information
 
+## Uncomment to change the logging format
+## For valid placeholders, see:
+## https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders
+# logging.formatters.f1.pattern = %s - [%p] %t
+
 ##
 ## MantidWorkbench
 ##


### PR DESCRIPTION
### Description of work

#### Summary of work

Adds some documentation on how to customize log format. Update default mantid user properties file to include this field. 

#### Purpose of work

*There is no associated issue.*

### To test:

No testing required

*This does not require release notes* because the source code is unmodified; purely documentation changes. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
