### PR TITLE
Add upper bounds for muparser dependency

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -55,8 +55,9 @@ jsoncpp:
 libglu:
   - '>=9.0'
 
+#v2.8.5 caused seg faults on Mantid conda versions and large numbers of tests failing
 muparser:
-  - '>=2.3.2'
+  - '>=2.3.2, <2.3.5'
 
 # We follow conda-forge and build with the lowest supported version of numpy for forward compatibility.
 numpy:
@@ -67,6 +68,7 @@ matplotlib:
 
 mslice:
   - '2.11.0'
+
 
 ninja:
   - '>=1.10.2'

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -62,6 +62,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - jemalloc {{ jemalloc }}  # [osx or linux]
     - lib3mf  # [win]
+    - muparser {{ muparser }}
     - {{ pin_compatible("numpy", upper_bound="2.2") }}
     - occt {{ occt }}
     - pycifrw


### PR DESCRIPTION
### Description of work

#### Summary of work
Added an upper pin to `muparser` to avoid `v2.3.5`.


#### Purpose of work
Version `2.3.5` of `muparser` caused the conda version of Mantid to fail to open on Linux machines (including IDAaaS). It also seems to have been failing 700+ tests on Linux.

*There is no associated issue.*


#### Further detail of work
As `muparser` already has a lower pin much of the infratructure was in place so only a small change was required.

### To test:

Tests should pass. 

*This does not require release notes* because **it is a dependency pin**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
