### PR TITLE
Refactor `SaveNexusProcessedTest` for `FileRegistry`

### DIFF
--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -1029,8 +1029,8 @@ public:
     SaveNexusProcessed saveAlg;
     saveAlg.initialize();
     TS_ASSERT_THROWS_NOTHING(saveAlg.setPropertyValue("InputWorkspace", "gws2"));
-    std::string file = "namesdoesntmatterasitshouldntsaveanyway.nxs";
-    TS_ASSERT_THROWS_NOTHING(saveAlg.setPropertyValue("Filename", file));
+    FileResource file("namesdoesntmatterasitshouldntsaveanyway.nxs", !clearfiles);
+    TS_ASSERT_THROWS_NOTHING(saveAlg.setPropertyValue("Filename", file.fullPath()));
     TS_ASSERT_THROWS(saveAlg.execute(), const std::runtime_error &);
     TS_ASSERT(!saveAlg.isExecuted());
   }

--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -30,8 +30,6 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NeXusFile.hpp"
-#include <Poco/File.h>
-#include <Poco/Path.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -64,8 +62,7 @@ public:
   SaveNexusProcessedTest() {
     // clearfiles - make true for SVN as dont want to leave on build server.
     // Unless the file "KEEP_NXS_FILES" exists, then clear up nxs files
-    Poco::File file("KEEP_NXS_FILES");
-    clearfiles = !file.exists();
+    clearfiles = !std::filesystem::exists("KEEP_NXS_FILES");
   }
 
   void setUp() override {}
@@ -128,18 +125,18 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", outputFile));
     std::string fullOutputFile = alg.getPropertyValue("Filename");
     TS_ASSERT_DIFFERS(fullOutputFile, outputFile);
-    if (Poco::File(fullOutputFile).exists())
-      Poco::File(fullOutputFile).remove();
+    if (std::filesystem::exists(fullOutputFile))
+      std::filesystem::remove(fullOutputFile);
 
     // execute, check path exists
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
-    TS_ASSERT(Poco::File(fullOutputFile).exists())
+    TS_ASSERT(std::filesystem::exists(fullOutputFile))
 
-    if (Poco::File(fullOutputFile).exists())
-      Poco::File(fullOutputFile).remove();
-    if (Poco::File(outputFile).exists())
-      Poco::File(outputFile).remove();
+    if (std::filesystem::exists(fullOutputFile))
+      std::filesystem::remove(fullOutputFile);
+    if (std::filesystem::exists(outputFile))
+      std::filesystem::remove(outputFile);
   }
 
   void testExecOnLoadraw() {

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
@@ -24,6 +24,7 @@ public:
   void setDebugMode(bool mode);
   std::string fullPath() const;
   ~FileResource();
+  bool exists();
 
 private:
   bool m_debugMode;

--- a/Framework/TestHelpers/src/FileResource.cpp
+++ b/Framework/TestHelpers/src/FileResource.cpp
@@ -31,6 +31,14 @@ FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debu
   }
 }
 
+bool FileResource::exists() {
+  if (std::filesystem::is_regular_file(m_full_path)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 void FileResource::setDebugMode(bool mode) { m_debugMode = mode; }
 std::string FileResource::fullPath() const { return m_full_path.generic_string(); }
 


### PR DESCRIPTION
### Description of work

#### Summary of work

The `SaveNexusProcessedTest` was refactored to rely on `FileRegistry` to resolve paths and delete temp files, instead of using `Poco`.

Because `FileRegistry` will always give a full path, and additional test was added to ensure the algorithm will work without a full path.

#### Purpose of work

While working on NeXus takeover, `SaveNexusProcessedTest` had some errors which seemed to be related to files not being properly cleared.  The test suite was setup to manually delete temp files with `Poco`.  Using `FileRegistry` is a safer alternative, to remove any doubt.

Related to Issue #38332 

#### Further detail of work

Made the changes described above removing `Poco` for manual file deletion.

Also added an `exists()` method to `FileRegistry` to cut down `Poco` calls even further.

### To test:

The tests should still work.  Check the logic of the extra test to make sure it proves what it is supposed to.

Check the build server and make sure no files were left in the temp folder.

*This does not require release notes* because it does not impact user experience*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
