### PR TITLE
Add upper bounds for muparser dependency

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -55,8 +55,9 @@ jsoncpp:
 libglu:
   - '>=9.0'
 
+#v2.8.5 caused seg faults on Mantid conda versions and large numbers of tests failing
 muparser:
-  - '>=2.3.2'
+  - '>=2.3.2, <2.3.5'
 
 # We follow conda-forge and build with the lowest supported version of numpy for forward compatibility.
 numpy:
@@ -67,6 +68,7 @@ matplotlib:
 
 mslice:
   - '2.11.0'
+
 
 ninja:
   - '>=1.10.2'

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -62,6 +62,7 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - jemalloc {{ jemalloc }}  # [osx or linux]
     - lib3mf  # [win]
+    - muparser {{ muparser }}
     - {{ pin_compatible("numpy", upper_bound="2.2") }}
     - occt {{ occt }}
     - pycifrw


### PR DESCRIPTION
This is a sibling of #39311 into `ornl-next`