### PR TITLE
Ensure proton charge returned consistently across datasets with period data

### DIFF
--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -28,7 +28,8 @@ using namespace Kernel;
 using Mantid::Types::Core::DateAndTime;
 
 namespace {
-/// helper struct for addable properties
+/// static logger object
+Kernel::Logger g_log("Run");
 
 auto addPeriodSeries = [](Property *left, const Property *right) {
   auto *leftAP = dynamic_cast<ArrayProperty<double> *>(left);
@@ -39,6 +40,8 @@ auto addPeriodSeries = [](Property *left, const Property *right) {
   const auto &leftVec = leftAP->operator()();
   const auto &rightVec = rightAP->operator()();
   if (leftVec.size() != rightVec.size()) {
+    g_log.warning(
+        "Summing runs with differing number of periods. Proton charge logs will retain values from LHS operand.");
     return;
   }
   std::vector<double> resVec;
@@ -49,6 +52,7 @@ auto addPeriodSeries = [](Property *left, const Property *right) {
   *leftAP = resVec;
 };
 
+/// helper struct for addable properties
 struct addableProperty {
 public:
   using func = std::function<void(Property *, const Property *)>;
@@ -71,6 +75,7 @@ const std::vector<addableProperty> ADDABLE{addableProperty("tot_prtn_chrg"),
                                            addableProperty("monitor4_counts"),
                                            addableProperty("monitor5_counts"),
                                            addableProperty("proton_charge_by_period", addPeriodSeries)};
+
 /// Name of the goniometer log when saved to a NeXus file
 const char *GONIOMETER_LOG_NAME = "goniometer";
 const char *GONIOMETERS_LOG_NAME = "goniometers";
@@ -79,9 +84,6 @@ const char *HISTO_BINS_LOG_NAME = "processed_histogram_bins";
 const char *PEAK_RADIUS_GROUP = "peak_radius";
 const char *INNER_BKG_RADIUS_GROUP = "inner_bkg_radius";
 const char *OUTER_BKG_RADIUS_GROUP = "outer_bkg_radius";
-
-/// static logger object
-Kernel::Logger g_log("Run");
 } // namespace
 
 Run::Run() {

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -46,7 +46,7 @@ auto addPeriodSeries = [](Property *left, const Property *right) {
   }
   std::vector<double> resVec;
   resVec.reserve(leftVec.size());
-  for (int i = 0; i < leftVec.size(); i++) {
+  for (size_t i = 0; i < leftVec.size(); i++) {
     resVec.push_back(leftVec[i] + rightVec[i]);
   }
   *leftAP = resVec;

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -32,8 +32,8 @@ namespace {
 Kernel::Logger g_log("Run");
 
 auto addPeriodSeries = [](Property *left, const Property *right) {
-  auto *leftAP = dynamic_cast<ArrayProperty<double> *>(left);
-  const auto *rightAP = dynamic_cast<const ArrayProperty<double> *>(right);
+  auto *leftAP = dynamic_cast<PropertyWithValue<std::vector<double>> *>(left);
+  const auto *rightAP = dynamic_cast<const PropertyWithValue<std::vector<double>> *>(right);
   if (!leftAP || !rightAP) {
     throw std::runtime_error("Expected ArrayProperty<double> for both inputs.");
   }

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -384,7 +384,7 @@ void Run::integrateProtonCharge(const std::string &logname) const {
     const_cast<Run *>(this)->setProtonCharge(total);
     // Mark gd_prtn_chrg as filtered as this method accounts for period filtering
     if (m_manager->existsProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME)) {
-      m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, false);
+      m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, 0);
     }
 
   } else {
@@ -936,6 +936,12 @@ void Run::loadNexusCommon(::NeXus::File *file, const std::string &nameClass) {
     double charge;
     file->readData("proton_charge", charge);
     this->setProtonCharge(charge);
+  } else if (nameClass == "proton_charge_by_period") {
+    file->openGroup(nameClass, "NXlog");
+    std::vector<double> values;
+    file->readData("value", values);
+    file->closeGroup();
+    this->addProperty("proton_charge_by_period", values, true);
   }
 }
 

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -308,7 +308,7 @@ double Run::getProtonCharge() const {
   if (!m_manager->existsProperty(PROTON_CHARGE_LOG_NAME)) {
     integrateProtonCharge();
   } else if (m_manager->existsProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME) &&
-             m_manager->getProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME)) {
+             m_manager->getProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME).operator int()) {
     const std::vector<double> &protonChargeByPeriod = m_manager->getProperty("proton_charge_by_period");
     const int currentPeriod = m_manager->getProperty("current_period");
     m_manager->setProperty(PROTON_CHARGE_LOG_NAME, protonChargeByPeriod[currentPeriod - 1]);

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -312,7 +312,7 @@ double Run::getProtonCharge() const {
     const std::vector<double> &protonChargeByPeriod = m_manager->getProperty("proton_charge_by_period");
     const int currentPeriod = m_manager->getProperty("current_period");
     m_manager->setProperty(PROTON_CHARGE_LOG_NAME, protonChargeByPeriod[currentPeriod - 1]);
-    m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, false);
+    m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, 0);
   }
 
   if (m_manager->existsProperty(PROTON_CHARGE_LOG_NAME)) {

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -606,13 +606,6 @@ void LoadNexusLogs::execLoader() {
 
   if (!workspace->run().hasProperty(workspace->run().getProtonChargeLogName())) {
     try {
-      // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
-      if (workspace->run().hasProperty("proton_charge_by_period") &&
-          workspace->run().getPropertyValueAsType<int>("nperiods") > 1) {
-        Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
-            new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
-        workspace->mutableRun().addProperty(pChargeUnfiltered, true);
-      }
       // Try pulling proton charge from the main proton_charge entry
       file.openData("proton_charge");
       std::vector<double> values;
@@ -633,6 +626,12 @@ void LoadNexusLogs::execLoader() {
         // Ignore not found property error.
       }
     }
+  }
+  // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
+  if (workspace->run().hasProperty("proton_charge_by_period")) {
+    Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
+        new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
+    workspace->mutableRun().addProperty(pChargeUnfiltered, true);
   }
 
   if (!allow_list.empty()) {

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -607,7 +607,8 @@ void LoadNexusLogs::execLoader() {
   if (!workspace->run().hasProperty(workspace->run().getProtonChargeLogName())) {
     try {
       // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
-      if (workspace->run().hasProperty("proton_charge_by_period")) {
+      if (workspace->run().hasProperty("proton_charge_by_period") &&
+          std::stoi(workspace->run().getProperty("nperiods")->value()) > 1) {
         Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
             new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
         workspace->mutableRun().addProperty(pChargeUnfiltered, true);

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -608,7 +608,7 @@ void LoadNexusLogs::execLoader() {
     try {
       // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
       if (workspace->run().hasProperty("proton_charge_by_period") &&
-          std::stoi(workspace->run().getProperty("nperiods")->value()) > 1) {
+          workspace->run().getPropertyValueAsType<int>("nperiods") > 1) {
         Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
             new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
         workspace->mutableRun().addProperty(pChargeUnfiltered, true);

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -629,8 +629,8 @@ void LoadNexusLogs::execLoader() {
   }
   // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
   if (workspace->run().hasProperty("proton_charge_by_period")) {
-    Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
-        new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
+    Kernel::PropertyWithValue<int> *pChargeUnfiltered =
+        new Kernel::PropertyWithValue<int>(workspace->run().getProtonChargeUnfilteredName(), 1);
     workspace->mutableRun().addProperty(pChargeUnfiltered, true);
   }
 

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -113,7 +113,7 @@ public:
     TS_ASSERT_EQUALS(mon_ws->y(0)[3], 0.);
 
     const std::vector<Property *> &logs = mon_ws->run().getLogData();
-    TS_ASSERT_EQUALS(logs.size(), 50);
+    TS_ASSERT_EQUALS(logs.size(), 51);
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(mon_ws->run().getLogData("icp_event"));
@@ -187,7 +187,7 @@ public:
     TS_ASSERT(ws->getSpectrum(1234).hasDetectorID(1235));
 
     const std::vector<Property *> &logs = ws->run().getLogData();
-    TS_ASSERT_EQUALS(logs.size(), 50);
+    TS_ASSERT_EQUALS(logs.size(), 51);
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(ws->run().getLogData("icp_event"));
@@ -402,7 +402,7 @@ public:
     ld.setPropertyValue("SpectrumMin", "10");
     ld.setPropertyValue("SpectrumMax", "20");
     //      ld.setPropertyValue("SpectrumList","29,30,31");
-    ld.setPropertyValue("EntryNumber", "5");
+    ld.setPropertyValue("EntryNumber", "1");
     TS_ASSERT_THROWS_NOTHING(ld.execute());
     TS_ASSERT(ld.isExecuted());
 
@@ -561,7 +561,7 @@ public:
     TS_ASSERT(ws->getSpectrum(1234 - 2).hasDetectorID(1235));
 
     const std::vector<Property *> &logs = ws->run().getLogData();
-    TS_ASSERT_EQUALS(logs.size(), 50);
+    TS_ASSERT_EQUALS(logs.size(), 51);
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(ws->run().getLogData("icp_event"));

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -230,7 +230,7 @@ public:
     auto run = testWS->run();
     run.addProperty("current_period", 1, true);
 
-    TSM_ASSERT("Confirm dataset has 1 period", run.getPropertyValueAsType<int>("nperiods"), 1)
+    TSM_ASSERT("Confirm dataset has 1 period", run.getPropertyValueAsType<int>("nperiods"), 1);
 
     const bool hasGdPrtnChrgUnfiltered = run.hasProperty("gd_prtn_chrg_unfiltered");
     TSM_ASSERT("Confirm does not have gd_prtn_chrg_unfiltered as nperiods < 1", !hasGdPrtnChrgUnfiltered);

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -230,7 +230,7 @@ public:
     auto run = testWS->run();
     run.addProperty("current_period", 1, true);
 
-    TSM_ASSERT("Confirm dataset has 1 period", run.getPropertyValueAsType<int>("nperiods"), 1);
+    TSM_ASSERT("Confirm dataset has 1 period", run.getPropertyValueAsType<int>("nperiods") == 1);
 
     const bool hasGdPrtnChrgUnfiltered = run.hasProperty("gd_prtn_chrg_unfiltered");
     TSM_ASSERT("Confirm does not have gd_prtn_chrg_unfiltered as nperiods < 1", !hasGdPrtnChrgUnfiltered);

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -209,11 +209,11 @@ public:
     const bool hasGdPrtnChrgUnfiltered = run.hasProperty("gd_prtn_chrg_unfiltered");
     TSM_ASSERT("Should have period_log now we have run LoadNexusLogs", hasGdPrtnChrgUnfiltered);
 
-    bool gdPrtnChrgUnfiltered = run.getPropertyValueAsType<bool>("gd_prtn_chrg_unfiltered");
+    int gdPrtnChrgUnfiltered = run.getPropertyValueAsType<int>("gd_prtn_chrg_unfiltered");
     TSM_ASSERT("Value of gd_prtn_chrg_unfiltered true until getProtonCharge called", gdPrtnChrgUnfiltered);
 
     run.getProtonCharge();
-    gdPrtnChrgUnfiltered = run.getPropertyValueAsType<bool>("gd_prtn_chrg_unfiltered");
+    gdPrtnChrgUnfiltered = run.getPropertyValueAsType<int>("gd_prtn_chrg_unfiltered");
     TSM_ASSERT("Value of gd_prtn_chrg_unfiltered false following getProtonCharge call", !gdPrtnChrgUnfiltered);
   }
 

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -88,8 +88,9 @@ public:
     const API::Run &run = testWS->run();
     const std::vector<Property *> &logs = run.getLogData();
     TS_ASSERT_EQUALS(logs.size(),
-                     36); // 34 logs in file + 1 synthetic nperiods log
+                     37); // 34 logs in file + 1 synthetic nperiods log
                           // + 1 proton_charge_by_period log
+                          // + 1 gd_prtn_chrg_unfiltered log
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(run.getLogData("icp_event"));

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -216,26 +216,6 @@ public:
     TSM_ASSERT("Value of gd_prtn_chrg_unfiltered false following getProtonCharge call", !gdPrtnChrgUnfiltered);
   }
 
-  void test_gd_prtn_chrg_unfiltered_added_for_period_dataset_n_equal_1() {
-
-    auto testWS = createTestWorkspace();
-
-    LoadNexusLogs loader;
-    loader.setChild(true);
-    loader.initialize();
-    loader.setProperty("Workspace", testWS);
-    loader.setPropertyValue("Filename", "LOQ49886.nxs");
-    loader.execute();
-
-    auto run = testWS->run();
-    run.addProperty("current_period", 1, true);
-
-    TSM_ASSERT("Confirm dataset has 1 period", run.getPropertyValueAsType<int>("nperiods") == 1);
-
-    const bool hasGdPrtnChrgUnfiltered = run.hasProperty("gd_prtn_chrg_unfiltered");
-    TSM_ASSERT("Confirm does not have gd_prtn_chrg_unfiltered as nperiods < 1", !hasGdPrtnChrgUnfiltered);
-  }
-
   void test_extract_run_title_from_event_nexus() {
 
     auto testWS = createTestWorkspace();

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
@@ -96,7 +96,6 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
     _MERGED_WS_NAME = "original"
     _CALIBRATED_WS_NAME = "result"
     _NEXUS_SUFFIX = ".nxs"
-    _PROTON_CHRG_LOG = "proton_charge_by_period"
     _REAR_DET_Z_LOG = "Rear_Det_Z"
     _FRONT_DET_Z_LOG = "Front_Det_Z"
     _BEAM_STOPPER_STRIP_POSITION = 260
@@ -396,8 +395,7 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
         return ws_list
 
     def _get_proton_charge(self, ws) -> float:
-        proton_charge = ws.getRun()[self._PROTON_CHRG_LOG].value
-        return proton_charge[0] if type(proton_charge) is np.ndarray else proton_charge
+        return ws.getRun().getProtonCharge()
 
     def _crop_and_scale_workspace(self, ws, start_pixel: int, end_pixel: int, uamphr_to_rescale: float):
         scaled_ws_name = ws.name() + self._SCALED_WS_SUFFIX

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -40,13 +40,13 @@ class RunTest(unittest.TestCase):
 
     def test_proton_charge_accounts_for_period_filtering(self):
         run = self._run
-        run.addProperty("gd_prtn_chrg_unfiltered", True, True)
+        run.addProperty("gd_prtn_chrg_unfiltered", 1, True)
         run.addProperty("proton_charge_by_period", [6.0, 4.05], True)
         run.addProperty("current_period", 1, True)
         charge = run.getProtonCharge()
         self.assertAlmostEqual(charge, 6.0)
 
-        run.addProperty("gd_prtn_chrg_unfiltered", True, True)
+        run.addProperty("gd_prtn_chrg_unfiltered", 1, True)
         run.addProperty("current_period", 2, True)
         charge = run.getProtonCharge()
         self.assertAlmostEqual(charge, 4.05)

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
@@ -1,1 +1,1 @@
-- ``getProtonCharge`` method of ``Run`` object now consistently returns a period filtered log value when called on multi-period NeXus files.
+- ``getProtonCharge`` method of ``Run`` object now correctly returns a period filtered log value when called on multi-period NeXus files. Some inconsistencies remain when adding runs that consist of different periods, please see `this issue <https://github.com/mantidproject/mantid/issues/39336>`_ for more information.

--- a/docs/source/release/v6.13.0/Reflectometry/New_features/37768.rst
+++ b/docs/source/release/v6.13.0/Reflectometry/New_features/37768.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-PolarizationEfficienciesWildes` algorithm now propagates errors correctly using the taylor series method (first order). A new helper class has been introduced to do this using the Eigen ``autodiff`` module to calculate partials.

--- a/docs/source/release/v6.13.0/SANS/New_features/39002.rst
+++ b/docs/source/release/v6.13.0/SANS/New_features/39002.rst
@@ -1,0 +1,1 @@
+- Changes have been made to ``SANSadd2`` and ``CreateSANSWavelengthPixelAdjustment`` to enable the summing of LOQ event mode data, and allow for the use of the new LOQ IDF.

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -27,7 +27,7 @@ class SampleLogsModelTest(unittest.TestCase):
         self.assertEqual(log.size(), 4)
 
         log_names = model.get_log_names()
-        self.assertEqual(len(log_names), 46)
+        self.assertEqual(len(log_names), 47)
         self.assertIn("w", log_names)
 
         values = model.get_log_display_values("w")
@@ -80,7 +80,7 @@ class SampleLogsModelTest(unittest.TestCase):
         model = SampleLogsModel(ws)
 
         log_names = model.get_log_names()
-        self.assertEqual(len(log_names), 140)
+        self.assertEqual(len(log_names), 141)
         self.assertIn("raw_uah_log", log_names)
         self.assertIn("current_period", log_names)
         self.assertIn("period", log_names)
@@ -138,7 +138,7 @@ class SampleLogsModelTest(unittest.TestCase):
 
         model = SampleLogsModel(ws)
         log_names = model.get_log_names()
-        self.assertEqual(len(log_names), 48)
+        self.assertEqual(len(log_names), 49)
         invalid_logs = model.get_logs_with_invalid_data()
         self.assertEqual(2, len(invalid_logs.keys()))
         self.assertIn("cryo_temp1", invalid_logs.keys())

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -49,7 +49,7 @@ class SampleLogsModelTest(unittest.TestCase):
         self.assertEqual(itemModel.horizontalHeaderItem(1).text(), "Type")
         self.assertEqual(itemModel.horizontalHeaderItem(2).text(), "Value")
         self.assertEqual(itemModel.horizontalHeaderItem(3).text(), "Units")
-        self.assertEqual(itemModel.rowCount(), 46)
+        self.assertEqual(itemModel.rowCount(), 47)
         self.assertEqual(itemModel.item(0, 0).text(), "C6_MASTER_FREQUENCY")
         self.assertEqual(itemModel.item(0, 1).text(), "float series")
         self.assertEqual(itemModel.item(0, 2).text(), "50.0 (2 entries)")


### PR DESCRIPTION
### Description of work

#### Summary of work

A bug was introduced in #39029. For any dataset that has period data, the log `proton_charge_by_period` is used to return the proton charge for the current period.

When runs are added. the `proton_charge_by_period` log is not summed; An erroneous proton charge is therefore subsequently returned.

To resolve this, this PR enables the elementwise addition of the `proton_charge_by_period` log during run addition.

Using a bool property was causing warnings to be raised during workspace save, as bool properties are not supported. The unfiltered flag has therefore been changed to an int.

Also, the check that flags for period data filtering has been moved outside of ` if (!workspace->run().hasProperty(workspace->run().getProtonChargeLogName()))` to account for datasets that come pre-loaded with this log (vesuvio).

This PR fixes a number of the more prelevant issues, but leaves some inconsistencies. An issue to fix these issues in an upcoming has been raised:
https://github.com/mantidproject/mantid/issues/39336

Some release notes have been added which I owed to other PRs.

### To test:

Run the following script:
```
from mantid.simpleapi import *

ws_mar1 = Load(Filename='MAR30565.nxs')
ws_mar2 = Load(Filename='MAR30566.nxs')
wssum_mar = Plus(LHSWorkspace=ws_mar1, RHSWorkspace=ws_mar2)
print(ws_mar1.getRun().getProtonCharge())
print(ws_mar2.getRun().getProtonCharge())
print(wssum_mar.getRun().getProtonCharge())

ws_ves1 = Load(Filename='VESUVIO00054091.nxs')
ws_ves2 = Load(Filename='VESUVIO00054092.nxs')
wssum_ves = Plus(LHSWorkspace=ws_ves1[0], RHSWorkspace=ws_ves2[0])
print(ws_ves1[0].getRun().getProtonCharge())
print(ws_ves2[0].getRun().getProtonCharge())
print(wssum_ves.getRun().getProtonCharge())

ws_pref1 = Load(Filename='POLREF00045018.nxs')
ws_pref2 = Load(Filename='POLREF00045019.nxs')
wssum_pref = Plus(LHSWorkspace=ws_pref1[0], RHSWorkspace=ws_pref2[0])
print(ws_pref1[0].getRun().getProtonCharge())
print(ws_pref2[0].getRun().getProtonCharge())
print(wssum_pref.getRun().getProtonCharge())
```

Expected Output:
```
386.2809143066406
250.0518341064453
636.3327484130859

15.014394760131836
15.013330459594727
30.027725219726562

19.597339630126953
19.55563735961914
39.152976989746094

```

Previous Output:
```
386.2809143066406
250.0518341064453
386.2809143066406

90.05866241455078
90.05770111083984
180.11636352539062

19.597339630126953
19.55563735961914
19.597339630126953
```

Fixes #39312

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
