### PR TITLE
Revert "Add ARM option to building packages on Jenkins"

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "osx-default",
-      "description": "Inherited by all macOS configurations",
+      "description": "Inherited by all OSX configurations",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_FIND_FRAMEWORK": "LAST",
@@ -46,18 +46,11 @@
     },
     {
       "name": "osx-64-ci",
-      "description": "Build options for a CI build on macOS",
+      "description": "Build options for a CI build on OSX",
       "inherits": [
         "osx-default",
         "ci-default",
         "conda"
-      ]
-    },
-    {
-      "name": "osx-arm64-ci",
-      "description": "Build options for a CI build on an Arm macOS machine",
-      "inherits": [
-        "osx-64-ci"
       ]
     },
     {
@@ -114,7 +107,7 @@
     },
     {
       "name": "osx",
-      "description": "Default build options for a developer macOS build",
+      "description": "Default build options for a developer OSX build",
       "inherits": [
         "unix-debug",
         "osx-default",

--- a/Framework/Algorithms/test/AddSampleLogTest.h
+++ b/Framework/Algorithms/test/AddSampleLogTest.h
@@ -263,11 +263,11 @@ public:
     // check the center angles from downstream
     // V3D::angle returns radians
     const Mantid::Kernel::V3D downstream(0, 0, 1);
-    TS_ASSERT_DELTA(westPosGood.angle(downstream) * 180 / M_PI, abs(det_arc1), 1e-12);
-    TS_ASSERT_DELTA(eastPosGood.angle(downstream) * 180 / M_PI, abs(det_arc2), 1e-12);
+    TS_ASSERT_EQUALS(westPosGood.angle(downstream) * 180 / M_PI, abs(det_arc1));
+    TS_ASSERT_EQUALS(eastPosGood.angle(downstream) * 180 / M_PI, abs(det_arc2));
 
     // check the center distance - detector is 0.5m + det_lin motor
-    TS_ASSERT_DELTA(westPosGood.distance(ORIGIN), 0.5 + det_lin1, 1e-12);
-    TS_ASSERT_DELTA(eastPosGood.distance(ORIGIN), 0.5 + det_lin2, 1e-12);
+    TS_ASSERT_EQUALS(westPosGood.distance(ORIGIN), 0.5 + det_lin1);
+    TS_ASSERT_EQUALS(eastPosGood.distance(ORIGIN), 0.5 + det_lin2);
   }
 };

--- a/Framework/Algorithms/test/GetDetectorOffsetsTest.h
+++ b/Framework/Algorithms/test/GetDetectorOffsetsTest.h
@@ -561,8 +561,6 @@ public:
 
   // Verify that detectors which fail during peak fitting are masked.
   void testExecFailuresAreMasked() {
-// Peak fitting gives different results on ARM
-#ifndef __aarch64__
     const std::string uniquePrefix = "test_EFAM";
     const std::string outputWSName(uniquePrefix + "_offsets");
 
@@ -605,14 +603,11 @@ public:
 
     AnalysisDataService::Instance().remove(outputWSName);
     AnalysisDataService::Instance().remove(maskWSName);
-#endif
   }
 
   // Verify that detectors masked in the output include both those masked in the input, and also those that fail during
   // peak fitting.
   void testExecMasksAreCombined() {
-// Peak fitting gives different results on ARM
-#ifndef __aarch64__
     const std::string uniquePrefix = "test_EFAM";
     const std::string outputWSName(uniquePrefix + "_offsets");
 
@@ -661,7 +656,6 @@ public:
 
     AnalysisDataService::Instance().remove(outputWSName);
     AnalysisDataService::Instance().remove(maskWSName);
-#endif
   }
 
   /**
@@ -669,8 +663,6 @@ public:
    * values.
    */
   void testExecMasksAreConsistentWithDetectorFlags() {
-// Peak fitting gives different results on ARM
-#ifndef __aarch64__
     const std::string uniquePrefix = "test_EFAM";
     const std::string outputWSName(uniquePrefix + "_offsets");
 
@@ -722,7 +714,6 @@ public:
 
     AnalysisDataService::Instance().remove(outputWSName);
     AnalysisDataService::Instance().remove(maskWSName);
-#endif
   }
 };
 

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -401,8 +401,8 @@ public:
     // Check that xmin and xmax have been caclulated correctly.
     TS_ASSERT_EQUALS(nBinsToBinTo, X.size());
     // Added 1 nanosecond to start time
-    TS_ASSERT_DELTA(pulseTimeMin + double(step) / 2 - 1.e-9, X.front(), 1e-12);
-    TS_ASSERT_DELTA(pulseTimeMax - double(step) / 2 - 1.e-9, X.back(), 1e-12);
+    TS_ASSERT_EQUALS(pulseTimeMin + double(step) / 2 - 1.e-9, X.front());
+    TS_ASSERT_EQUALS(pulseTimeMax - double(step) / 2 - 1.e-9, X.back());
   }
 
   /*
@@ -450,8 +450,8 @@ public:
 
     // Check that xmin and xmax have been caclulated correctly.
     TS_ASSERT_EQUALS(nBinsToBinTo + 1, X.size());
-    TS_ASSERT_DELTA(pulseTimeMin, X.front(), 1e-12);
-    TS_ASSERT_DELTA(pulseTimeMax, X.back(), 1e-12);
+    TS_ASSERT_EQUALS(pulseTimeMin, X.front());
+    TS_ASSERT_EQUALS(pulseTimeMax, X.back());
 
     auto &Y = outWS->y(0);
     TS_ASSERT_EQUALS(nBinsToBinTo, Y.size());

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -613,7 +613,7 @@ public:
     IFunction_sptr out = fit.getProperty("Function");
     TS_ASSERT_DELTA(out->getParameter("A"), 1000, 30.0);
     TS_ASSERT_DELTA(out->getParameter("B"), 26, 0.1);
-    TS_ASSERT_DELTA(out->getParameter("C"), 7.7, 0.2);
+    TS_ASSERT_DELTA(out->getParameter("C"), 7.7, 0.1);
     TS_ASSERT_DELTA(out->getParameter("D"), 0, 0.1);
   }
 

--- a/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtMDTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtMDTest.h
@@ -284,7 +284,7 @@ public:
 
   void test_BSpline_fit_uniform_finer() {
     double startx = -3.14;
-    double endx = 3.139;
+    double endx = 3.14;
 
     std::shared_ptr<BSpline> bsp = std::make_shared<BSpline>();
     bsp->setAttributeValue("Order", 3);
@@ -337,7 +337,7 @@ public:
   void test_BSpline_derivative() {
 
     double startx = -3.14;
-    double endx = 3.139;
+    double endx = 3.14;
 
     std::shared_ptr<BSpline> bsp = std::make_shared<BSpline>();
     bsp->setAttributeValue("Order", 3);
@@ -361,7 +361,7 @@ public:
   void test_BSpline_derivative_2() {
 
     double startx = -3.14;
-    double endx = 3.139;
+    double endx = 3.14;
 
     std::shared_ptr<BSpline> bsp = std::make_shared<BSpline>();
     bsp->setAttributeValue("Order", 4);
@@ -385,7 +385,7 @@ public:
   void test_BSpline_derivative_3() {
 
     double startx = -3.14;
-    double endx = 3.139;
+    double endx = 3.14;
 
     std::shared_ptr<BSpline> bsp = std::make_shared<BSpline>();
     bsp->setAttributeValue("Order", 5);

--- a/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
@@ -288,8 +288,6 @@ public:
   }
 
   void test_cannot_reach_tolerance() {
-// Different error code on ARM
-#ifndef __aarch64__
     API::FunctionDomain1D_sptr domain(new API::FunctionDomain1DVector(0.0, 1.0, 10));
     API::FunctionValues mockData(*domain);
     UserFunction dataMaker;
@@ -312,6 +310,5 @@ public:
     TS_ASSERT(!s.minimize());
 
     TS_ASSERT_EQUALS(s.getError(), "Changes in function value are too small");
-#endif
   }
 };

--- a/Framework/CurveFitting/test/Functions/ComptonScatteringCountRateTest.h
+++ b/Framework/CurveFitting/test/Functions/ComptonScatteringCountRateTest.h
@@ -188,7 +188,7 @@ public:
     TS_ASSERT_DELTA(func->getParameter("f1.Width"), 10.0, 1e-8);
     TS_ASSERT_DELTA(func->getParameter("f1.Intensity"), 0.5 * intensity0, 1e-8);
     TS_ASSERT_DELTA(func->getParameter("f2.A0"), 0.35708376, 1e-8);
-    TS_ASSERT_DELTA(func->getParameter("f2.A1"), 0.99989358, 1e-6);
+    TS_ASSERT_DELTA(func->getParameter("f2.A1"), 0.99989358, 1e-8);
   }
 
 private:

--- a/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
@@ -68,10 +68,20 @@ public:
     FunctionValues values(domain);
 
     TS_ASSERT_THROWS_NOTHING(func->function(domain, values));
+
+// The intel compiler doesn't get quite to the precision
+// of the other platforms
+#if defined(__INTEL_COMPILER)
     const double tol(1e-6);
+    TS_ASSERT_DELTA(0.104894, values.getCalculated(0), tol);
+    TS_ASSERT_DELTA(0.104489, values.getCalculated(1), tol);
+    TS_ASSERT_DELTA(0.102977, values.getCalculated(2), tol);
+#else
+    const double tol(1e-10);
     TS_ASSERT_DELTA(0.1048941000, values.getCalculated(0), tol);
     TS_ASSERT_DELTA(0.1044889285, values.getCalculated(1), tol);
     TS_ASSERT_DELTA(0.1029765223, values.getCalculated(2), tol);
+#endif
   }
 
 private:

--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -209,9 +209,9 @@ public:
     for (size_t row = 0; row < 10; ++row) {
       for (size_t col = 0; col < 21; ++col) {
         double val = static_cast<double>(col);
-        TS_ASSERT_DELTA(outputWS->y(row)[col], 3. * (val + 1), 1e-12)
-        TS_ASSERT_DELTA(outputWS->x(row)[col], 1. + 0.2 * val, 1e-12)
-        TS_ASSERT_DELTA(outputWS->e(row)[col], sqrt(3. * (val + 1)), 1e-12)
+        TS_ASSERT_EQUALS(outputWS->y(row)[col], 3. * (val + 1))
+        TS_ASSERT_EQUALS(outputWS->x(row)[col], 1. + 0.2 * val)
+        TS_ASSERT_EQUALS(outputWS->e(row)[col], sqrt(3. * (val + 1)))
       }
     }
 

--- a/Framework/Geometry/src/Math/PolygonEdge.cpp
+++ b/Framework/Geometry/src/Math/PolygonEdge.cpp
@@ -49,10 +49,10 @@ PointClassification classify(const V2D &pt, const PolygonEdge &edge) {
   const V2D &a = edge.direction();
   const V2D b = p2 - edge.start();
   double sa = a.X() * b.Y() - b.X() * a.Y();
-  if (sa > EPSILON) {
+  if (sa > 0.0) {
     return OnLeft;
   }
-  if (sa < -EPSILON) {
+  if (sa < 0.0) {
     return OnRight;
   }
   if ((a.X() * b.X() < 0.0) || (a.Y() * b.Y() < 0.0)) {
@@ -81,7 +81,7 @@ PointClassification classify(const V2D &pt, const PolygonEdge &edge) {
 PolygonEdge::Orientation orientation(const PolygonEdge &focusEdge, const PolygonEdge &refEdge, double &t) {
   V2D normalToRef((refEdge.end().Y() - refEdge.start().Y()), (refEdge.start().X() - refEdge.end().X()));
   double denom = normalToRef.scalar_prod(focusEdge.direction());
-  if (std::abs(denom) < EPSILON) {
+  if (Kernel::equals(denom, 0.0)) {
     PointClassification edgeClass = classify(focusEdge.start(), refEdge);
     if (edgeClass == OnLeft || edgeClass == OnRight) {
       return PolygonEdge::Parallel;

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -55,7 +55,7 @@ std::string convert_units_check_range(const Unit &aUnit, std::vector<double> &sa
     error_mess = "conversion: " + aUnit.unitID() + " Time range is  zero (tof_left==tof_rignt)";
     return error_mess;
   }
-  if (tof1 * (1 + epsilon1) < tof_min || tof2 * (1 + epsilon1) < tof_min) {
+  if (tof1 < tof_min || tof2 < tof_min) {
     error_mess = "conversion: " + aUnit.unitID() + " min time range is smaller then minimal conversion time";
     return error_mess;
   }
@@ -796,7 +796,7 @@ public:
   void testdSpacingPerpendicularRange() {
     std::vector<double> sample, rezult;
 
-    std::string err_mess = convert_units_check_range(dp, sample, rezult, FLT_EPSILON);
+    std::string err_mess = convert_units_check_range(dp, sample, rezult);
     TSM_ASSERT(" ERROR:" + err_mess, err_mess.size() == 0);
 
     for (size_t i = 0; i < sample.size(); i++) {

--- a/Framework/MDAlgorithms/test/EvaluateMDFunctionTest.h
+++ b/Framework/MDAlgorithms/test/EvaluateMDFunctionTest.h
@@ -60,7 +60,7 @@ public:
         auto x = v[0];
         auto y = v[1];
         auto f = ws->getSignalAt(linearIndex);
-        TS_ASSERT_DELTA(f, x + y, 1e-7);
+        TS_ASSERT_DELTA(f, x + y, 1e-15);
       }
 
     // Remove workspace from the data service.

--- a/Framework/Muon/test/CalculateMuonAsymmetryTest.h
+++ b/Framework/Muon/test/CalculateMuonAsymmetryTest.h
@@ -297,8 +297,6 @@ public:
   }
 
   void test_simultaneous_fit_with_double_pulse_mode_enabled() {
-// Different results on ARM
-#ifndef __aarch64__
     genData();
     // need the 2 here to get multi func
     std::vector<std::string> wsNames = {"ws1", "ws2"};
@@ -337,7 +335,6 @@ public:
       TS_ASSERT_DELTA(outWS->e(0)[100], 0.0015, delta);
     }
     clearADS();
-#endif
   }
 };
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -9,12 +9,8 @@ import numpy as np
 from mantid.simpleapi import BayesQuasi, CreateWorkspace, DeleteWorkspace, Load
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from plugins.algorithms.WorkflowAlgorithms.BayesQuasi import _calculate_eisf
-import platform
-
-SHOULD_SKIP = "arm" in platform.machine()
 
 
-@unittest.skipIf(SHOULD_SKIP, "Skipping tests on ARM architecture")
 class BayesQuasiTest(unittest.TestCase):
     _res_ws = None
     _sample_ws = None
@@ -202,26 +198,25 @@ class BayesQuasiTest(unittest.TestCase):
         @param prob Probability workspace from BayesQuasi
         @param group Group workspace of fitted spectra from BayesQuasi
         """
-        significant_digits = 3
 
         # Test values of result
-        np.testing.assert_approx_equal(result.dataY(0)[0], 153.471, significant=significant_digits)
-        np.testing.assert_approx_equal(result.dataY(1)[0], 1785.06, significant=significant_digits)
-        np.testing.assert_approx_equal(result.dataY(2)[0], 0.0588549, significant=significant_digits)
-        np.testing.assert_approx_equal(result.dataY(3)[0], 0.0791689, significant=significant_digits)
+        self.assertAlmostEqual(result.dataY(0)[0], 153.471, delta=1e-3)
+        self.assertAlmostEqual(result.dataY(1)[0], 1785.06, delta=1e-2)
+        self.assertAlmostEqual(result.dataY(2)[0], 0.0588549, delta=1e-4)
+        self.assertAlmostEqual(result.dataY(3)[0], 0.0791689, delta=1e-4)
 
         # Test values of probability
-        np.testing.assert_approx_equal(probability.dataY(0)[0], -74887.1, significant=significant_digits)
-        np.testing.assert_approx_equal(probability.dataY(1)[0], -407.593, significant=significant_digits)
-        np.testing.assert_approx_equal(probability.dataY(2)[0], -0.480316, significant=2)
+        self.assertAlmostEqual(probability.dataY(0)[0], -74887.1, delta=1e-1)
+        self.assertAlmostEqual(probability.dataY(1)[0], -407.593, delta=1e-2)
+        self.assertAlmostEqual(probability.dataY(2)[0], -0.480316, delta=1e-2)
 
         # Test values of group
         sub_ws = group.getItem(0)
-        np.testing.assert_approx_equal(sub_ws.dataY(0)[0], 0.652046, significant=significant_digits)
-        np.testing.assert_approx_equal(sub_ws.dataY(1)[0], 0.48846, significant=significant_digits)
-        np.testing.assert_approx_equal(sub_ws.dataY(2)[0], -0.163586, significant=significant_digits)
-        np.testing.assert_approx_equal(sub_ws.dataY(3)[0], 0.414406, significant=significant_digits)
-        np.testing.assert_approx_equal(sub_ws.dataY(4)[0], -0.23764, significant=significant_digits)
+        self.assertAlmostEqual(sub_ws.dataY(0)[0], 0.652046, delta=1e-4)
+        self.assertAlmostEqual(sub_ws.dataY(1)[0], 0.48846, delta=1e-4)
+        self.assertAlmostEqual(sub_ws.dataY(2)[0], -0.163586, delta=1e-4)
+        self.assertAlmostEqual(sub_ws.dataY(3)[0], 0.414406, delta=1e-4)
+        self.assertAlmostEqual(sub_ws.dataY(4)[0], -0.23764, delta=1e-4)
 
     def _validate_QSe_shape(self, result, group):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7AbsoluteCrossSectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7AbsoluteCrossSectionsTest.py
@@ -7,12 +7,8 @@
 import unittest
 from mantid.api import WorkspaceGroup, MatrixWorkspace
 from mantid.simpleapi import Load, config, mtd, D7AbsoluteCrossSections, GroupWorkspaces
-import platform
-
-SHOULD_SKIP = "arm" in platform.machine()
 
 
-@unittest.skipIf(SHOULD_SKIP, "Skipping tests on ARM architecture")
 class D7AbsoluteCrossSectionsTest(unittest.TestCase):
     _facility = None
     _instrument = None

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLAutoProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLAutoProcessTest.py
@@ -8,12 +8,8 @@
 import unittest
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from mantid.simpleapi import config, mtd, DirectILLAutoProcess
-import platform
-
-SHOULD_SKIP = "arm" in platform.machine()
 
 
-@unittest.skipIf(SHOULD_SKIP, "Skipping tests on ARM architecture")
 class DirectILLAutoProcessTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
@@ -8,12 +8,8 @@
 import unittest
 from mantid.simpleapi import SANSILLAutoProcess, config, mtd
 from mantid.api import WorkspaceGroup, MatrixWorkspace
-import platform
-
-SHOULD_SKIP = "arm" in platform.machine()
 
 
-@unittest.skipIf(SHOULD_SKIP, "Skipping tests on ARM architecture")
 class SANSILLAutoProcessTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegrationTest.py
@@ -9,12 +9,8 @@ import unittest
 from mantid.api import mtd, MatrixWorkspace, WorkspaceGroup
 from mantid.kernel import config
 from mantid.simpleapi import SANSILLIntegration, SANSILLReduction
-import platform
-
-SHOULD_SKIP = "arm" in platform.machine()
 
 
-@unittest.skipIf(SHOULD_SKIP, "Skipping tests on ARM architecture")
 class SANSILLIntegrationTest(unittest.TestCase):
     _facility = None
 

--- a/Framework/SINQ/test/PoldiSpectrumDomainFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumDomainFunctionTest.h
@@ -118,7 +118,7 @@ public:
                                       4.32910692237627, 0.746498624291666, 0.102391587633906}};
 
     for (size_t i = 0; i < reference.size(); ++i) {
-      TS_ASSERT_DELTA(values[479 + i] / reference[i], 1.0, 1e-11);
+      TS_ASSERT_DELTA(values[479 + i] / reference[i], 1.0, 1e-14);
     }
   }
 
@@ -147,7 +147,7 @@ public:
                                       4.32910692237627, 0.746498624291666, 0.102391587633906}};
 
     for (size_t i = 0; i < reference.size(); ++i) {
-      TS_ASSERT_DELTA((jacobian.get(479 + i, 0)) / (reference[i] / 679.59369981039407842726), 1.0, 1e-11);
+      TS_ASSERT_DELTA((jacobian.get(479 + i, 0)) / (reference[i] / 679.59369981039407842726), 1.0, 1e-14);
     }
   }
 

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -152,7 +152,7 @@ public:
                                       4.32910692237627, 0.746498624291666, 0.102391587633906}};
 
     for (size_t i = 0; i < reference.size(); ++i) {
-      TS_ASSERT_DELTA(values[479 + i] / reference[i], 1.0, 1e-11);
+      TS_ASSERT_DELTA(values[479 + i] / reference[i], 1.0, 1e-12);
     }
   }
 

--- a/Testing/SystemTests/tests/framework/ConvertMultipleRunsToSingleCrystalMDTest.py
+++ b/Testing/SystemTests/tests/framework/ConvertMultipleRunsToSingleCrystalMDTest.py
@@ -4,16 +4,11 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import platform
 import systemtesting
 from mantid.simpleapi import ConvertMultipleRunsToSingleCrystalMD, Load, AlgorithmManager, SaveMD
 
 
 class ConvertMultipleRunsToSingleCrystalMDQSampleTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return ["CORELLI_29782.nxs", "CORELLI_29792.nxs"]
 
@@ -51,10 +46,6 @@ class ConvertMultipleRunsToSingleCrystalMDQSampleTest(systemtesting.MantidSystem
 
 
 class ConvertMultipleRunsToSingleCrystalMDHKLTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return ["CORELLI_29782.nxs", "CORELLI_29792.nxs", "SingleCrystalDiffuseReduction_UB.mat"]
 

--- a/Testing/SystemTests/tests/framework/Diffraction_Workflow_Test.py
+++ b/Testing/SystemTests/tests/framework/Diffraction_Workflow_Test.py
@@ -10,7 +10,6 @@ System test that loads TOPAZ single-crystal data,
 and runs Diffraction Workflow.
 """
 
-import platform
 import systemtesting
 import numpy
 import os
@@ -34,10 +33,6 @@ from mantid.api import FileFinder
 
 
 class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def cleanup(self):
         Files = ["TOPAZ_3132.hkl", "TOPAZ_3132FFT.hkl"]
         for filename in Files:

--- a/Testing/SystemTests/tests/framework/FindSatellitePeaksTest.py
+++ b/Testing/SystemTests/tests/framework/FindSatellitePeaksTest.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.simpleapi import FindSatellitePeaks, Load
 import systemtesting
-import platform
 
 
 def load_files():
@@ -17,10 +16,6 @@ def load_files():
 
 
 class FindSatellitePeaksTestFixedNumQ(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return ["WISH_md_small.nxs", "WISH_peak_hkl_small.nxs", "WISH_peak_hkl_frac_small.nxs"]
 
@@ -45,10 +40,6 @@ class FindSatellitePeaksTestFixedNumQ(systemtesting.MantidSystemTest):
 
 
 class FindSatellitePeaksTestAutoFindQ(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return ["WISH_md_small.nxs", "WISH_peak_hkl_small.nxs", "WISH_peak_hkl_frac_small.nxs"]
 

--- a/Testing/SystemTests/tests/framework/HB3AWorkflowTests.py
+++ b/Testing/SystemTests/tests/framework/HB3AWorkflowTests.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=no-init,too-few-public-methods
 # ruff: noqa: E741  # Ambiguous variable name
-import platform
 import numpy as np
 import systemtesting
 from mantid.simpleapi import (
@@ -45,13 +44,11 @@ class SingleFileFindPeaksIntegrate(systemtesting.MantidSystemTest):
 
         peaks = mtd[ws_name + "_integrated"]
 
-        absolute_tolerance = 1e-6 if "arm" in platform.machine() else 1e-7
-
         self.assertEqual(peaks.getNumberPeaks(), 15)
         ol = peaks.sample().getOrientedLattice()
         self.assertDelta(ol.a(), 5.231258554, 1.0e-7)
         self.assertDelta(ol.b(), 5.257701834, 1.0e-7)
-        self.assertDelta(ol.c(), 19.67041036, absolute_tolerance)
+        self.assertDelta(ol.c(), 19.67041036, 1.0e-7)
         self.assertEqual(ol.alpha(), 90)
         self.assertEqual(ol.beta(), 90)
         self.assertEqual(ol.gamma(), 90)
@@ -99,13 +96,11 @@ class SingleFilePredictPeaksUBFromFindPeaksIntegrate(systemtesting.MantidSystemT
 
         peaks = mtd[ws_name + "_integrated"]
 
-        absolute_tolerance = 1e-6 if "arm" in platform.machine() else 1e-7
-
         self.assertEqual(peaks.getNumberPeaks(), 114)
         ol = peaks.sample().getOrientedLattice()
         self.assertDelta(ol.a(), 5.231258554, 1.0e-7)
         self.assertDelta(ol.b(), 5.257701834, 1.0e-7)
-        self.assertDelta(ol.c(), 19.67041036, absolute_tolerance)
+        self.assertDelta(ol.c(), 19.67041036, 1.0e-7)
         self.assertEqual(ol.alpha(), 90)
         self.assertEqual(ol.beta(), 90)
         self.assertEqual(ol.gamma(), 90)
@@ -133,12 +128,10 @@ class MultiFileFindPeaksIntegrate(systemtesting.MantidSystemTest):
 
         self.assertEqual(peaks.getItem(0).getNumberPeaks() + peaks.getItem(1).getNumberPeaks(), integrated.getNumberPeaks())
 
-        absolute_tolerance = 1e-6 if "arm" in platform.machine() else 1e-7
-
         ol = integrated.sample().getOrientedLattice()
         self.assertDelta(ol.a(), 5.261051697, 1.0e-7)
         self.assertDelta(ol.b(), 5.224167511, 1.0e-7)
-        self.assertDelta(ol.c(), 19.689643636, absolute_tolerance)
+        self.assertDelta(ol.c(), 19.689643636, 1.0e-7)
         self.assertEqual(ol.alpha(), 90)
         self.assertEqual(ol.beta(), 90)
         self.assertEqual(ol.gamma(), 90)
@@ -244,13 +237,11 @@ class MultiFilePredictPeaksUBFromFindPeaksIntegrate(systemtesting.MantidSystemTe
         self.assertEqual(integrated.getNumberPeaks(), 191)
         self.assertEqual(peaks.getItem(0).getNumberPeaks() + peaks.getItem(1).getNumberPeaks(), integrated.getNumberPeaks())
 
-        absolute_tolerance = 1e-6 if "arm" in platform.machine() else 1e-7
-
         # should be the same as from MultiFileFindPeaksIntegrate test
         ol = integrated.sample().getOrientedLattice()
         self.assertDelta(ol.a(), 5.261051697, 1.0e-7)
         self.assertDelta(ol.b(), 5.224167511, 1.0e-7)
-        self.assertDelta(ol.c(), 19.689643636, absolute_tolerance)
+        self.assertDelta(ol.c(), 19.689643636, 1.0e-7)
         self.assertEqual(ol.alpha(), 90)
         self.assertEqual(ol.beta(), 90)
         self.assertEqual(ol.gamma(), 90)

--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -20,7 +20,6 @@ from mantid.simpleapi import (
     Subtract,
     Load,
 )
-import platform
 import systemtesting
 from testhelpers import assertRaisesNothing, create_algorithm
 
@@ -182,10 +181,6 @@ class IN5_Tube_Background(systemtesting.MantidSystemTest):
 
 
 class IN5_Mask_Non_Overlapping_Bins(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def validate(self):
         self.tolerance = 1e-7
         self.nanEqual = True

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2D_GDW20_4m_cycle_22_02.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2D_GDW20_4m_cycle_22_02.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import platform
+
 import systemtesting
 from ISIS.SANS.isis_sans_system_test import ISISSansSystemTest
 
@@ -44,10 +44,6 @@ class SANS2D_GDW20_4m_22_02_2D_M3(systemtesting.MantidSystemTest):
 
 @ISISSansSystemTest(SANSInstrument.SANS2D)
 class SANS2D_GDW20_4m_22_02_2D_M4(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredMemoryMB(self):
         return 2000
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
@@ -52,10 +52,6 @@ class CreateVanadiumNoSolidAngleTest(systemtesting.MantidSystemTest):
     calibration_results = None
     existing_config = config["datasearch.directories"]
 
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return _gen_required_files()
 
@@ -81,10 +77,6 @@ class CreateVanadiumNoSolidAngleNoEmptySubtractionTest(systemtesting.MantidSyste
     calibration_results = None
     existing_config = config["datasearch.directories"]
 
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return _gen_required_files()
 
@@ -109,10 +101,6 @@ class CreateVanadiumNoSolidAngleNoEmptySubtractionTest(systemtesting.MantidSyste
 class FocusNoSolidAngleTest(systemtesting.MantidSystemTest):
     focus_results = None
     existing_config = config["datasearch.directories"]
-
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
 
     def requiredFiles(self):
         return _gen_required_files()

--- a/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
+++ b/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
@@ -43,7 +43,6 @@ from Diffraction.wish.wishSX import WishSX
 from mantid import config
 import numpy as np
 import os
-import platform
 from SaveReflections import num_modulation_vectors
 
 
@@ -246,10 +245,6 @@ class WISHNormaliseDataAndCreateMDWorkspaceTest(MantidSystemTest):
     This tests the loading and normalisation of data, incl. correction for detector efficiency using vanadium and
     creation of MD workspace
     """
-
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
 
     def cleanup(self):
         ADS.clear()

--- a/Testing/SystemTests/tests/framework/MDNormBackgroundHYSPECTest.py
+++ b/Testing/SystemTests/tests/framework/MDNormBackgroundHYSPECTest.py
@@ -28,7 +28,6 @@ from mantid.simpleapi import (
     SetGoniometer,
     SetUB,
 )
-import platform
 import systemtesting
 
 # Define symmetry operation
@@ -39,10 +38,6 @@ LOG_VALUE_STEP = 1
 
 
 class MDNormBackgroundHYSPECTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     @staticmethod
     def prepare_single_exp_info_background(input_md_name, output_md_name, target_qframe="Q_lab"):
         if target_qframe not in ["Q_sample", "Q_lab"]:

--- a/Testing/SystemTests/tests/framework/MDNormCORELLITest.py
+++ b/Testing/SystemTests/tests/framework/MDNormCORELLITest.py
@@ -23,15 +23,10 @@ from mantid.simpleapi import (
     RecalculateTrajectoriesExtents,
     SetGoniometer,
 )
-import platform
 import systemtesting
 
 
 class MDNormCORELLITest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return [
             "CORELLI_29782.nxs",

--- a/Testing/SystemTests/tests/framework/POLDIFitPeaks2DTest.py
+++ b/Testing/SystemTests/tests/framework/POLDIFitPeaks2DTest.py
@@ -106,7 +106,7 @@ class POLDIFitPeaks2DTest(systemtesting.MantidSystemTest):
                 indices = np.nonzero(yDataRef)
                 maxDifference = np.abs(np.max((yDataCalc[indices] - yDataRef[indices]) / yDataCalc[indices]))
 
-                np.testing.assert_allclose(xDataCalc, xDataRef, atol=1e-7)
+                self.assertTrue(np.all(xDataCalc == xDataRef))
                 self.assertLessThan(maxDifference, 0.07)
 
 

--- a/Testing/SystemTests/tests/framework/ReduceOneSCD_Run.py
+++ b/Testing/SystemTests/tests/framework/ReduceOneSCD_Run.py
@@ -20,7 +20,7 @@
 #
 #
 import time
-import platform
+
 import systemtesting
 
 import os
@@ -54,10 +54,6 @@ class ReduceOneSCD_Run(systemtesting.MantidSystemTest):
     output_directory = ""
     run_conventional_matrix_file = ""
     qconvention = config["Q.convention"]
-
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
 
     def setUp(self):
         # Make this test use crystallography convention

--- a/Testing/SystemTests/tests/framework/ReflectometryISISCalculatePolEffTest.py
+++ b/Testing/SystemTests/tests/framework/ReflectometryISISCalculatePolEffTest.py
@@ -8,7 +8,6 @@
 from systemtesting import MantidSystemTest
 from abc import abstractmethod, ABCMeta
 from mantid.simpleapi import ReflectometryISISCalculatePolEff, Load
-import platform
 
 
 class ReflectometryISISCalculatePolEffTestBase(MantidSystemTest, metaclass=ABCMeta):
@@ -111,10 +110,6 @@ class ReflectometryISISCalculatePolEffAllCorrectionsTest(ReflectometryISISCalcul
     reference_file = "ReflectometryISISCalculatePolEffAllCorrections.nxs"
     all_corrections = True
     include_mag_runs = True
-
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
 
     def __init__(self):
         super(ReflectometryISISCalculatePolEffAllCorrectionsTest, self).__init__()

--- a/Testing/SystemTests/tests/framework/SingleCrystalDiffuseReductionTest.py
+++ b/Testing/SystemTests/tests/framework/SingleCrystalDiffuseReductionTest.py
@@ -4,16 +4,11 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import platform
 import systemtesting
 from mantid.simpleapi import SingleCrystalDiffuseReduction, Load, AlgorithmManager, SaveMD
 
 
 class SingleCrystalDiffuseTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
-
     def requiredFiles(self):
         return [
             "CORELLI_29782.nxs",

--- a/buildconfig/Jenkins/Conda/build-and-publish-devsite.sh
+++ b/buildconfig/Jenkins/Conda/build-and-publish-devsite.sh
@@ -28,7 +28,7 @@ fi
 ###############################################################################
 # Mamba
 ###############################################################################
-setup_mamba $WORKSPACE/mambaforge "devsite" false ""
+setup_mamba $WORKSPACE/mambaforge "devsite"
 mamba install --yes sphinx sphinx_bootstrap_theme
 
 ###############################################################################

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -64,21 +64,6 @@ CLEAN_BUILD=false
 CLEAN_EXTERNAL_PROJECTS=false
 EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 
-# This removes '-ci' from the end of the cmake preset to get the target platform
-# We check that it's not e.g. cppcheck or doxygen
-PLATFORM="${CMAKE_PRESET%-ci}"
-allowed_platforms=("win-64" "linux-64" "osx-64" "osx-arm64")
-is_allowed=false
-for item in "${allowed_platforms[@]}"; do
-    if [ "$PLATFORM" == "$item" ]; then
-        is_allowed=true
-        break
-    fi
-done
-if [ "$is_allowed" == false ]; then
-    PLATFORM=""
-fi
-
 # Handle flag inputs
 while [ ! $# -eq 0 ]
 do
@@ -126,8 +111,8 @@ fi
 git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "" $CLEAN_BUILD $PLATFORM
-create_and_activate_mantid_developer_env $WORKSPACE $PLATFORM
+setup_mamba $WORKSPACE/mambaforge "" $CLEAN_BUILD
+create_and_activate_mantid_developer_env $WORKSPACE
 
 # Check whether this is an incremental build that only changes rst files
 if [ -d $BUILD_DIR ]; then

--- a/buildconfig/Jenkins/Conda/conda-pre-commit
+++ b/buildconfig/Jenkins/Conda/conda-pre-commit
@@ -26,7 +26,7 @@ GIT_SHA=$2
 JOB_TYPE=$3
 
 # Mamba
-setup_mamba $SOURCE_DIR/mambaforge "pre-commit" false ""
+setup_mamba $SOURCE_DIR/mambaforge "pre-commit"
 # rstcheck fails with exit code -11 with Python 3.13
 mamba install --yes pre-commit python=3.12
 

--- a/buildconfig/Jenkins/Conda/cppcheck.sh
+++ b/buildconfig/Jenkins/Conda/cppcheck.sh
@@ -31,7 +31,7 @@ if $SCRIPT_DIR/../check_for_changes cpp; then
 fi
 
 # Setup conda environment
-setup_mamba $WORKSPACE/mambaforge "" false ""
+setup_mamba $WORKSPACE/mambaforge
 create_and_activate_mantid_developer_env $WORKSPACE
 
 ###############################################################################

--- a/buildconfig/Jenkins/Conda/delete-old-packages.sh
+++ b/buildconfig/Jenkins/Conda/delete-old-packages.sh
@@ -69,7 +69,7 @@ function delete_package() {
 ###
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "deletion-anaconda" false ""
+setup_mamba $WORKSPACE/mambaforge "deletion-anaconda"
 mamba install --yes curl jq
 
 for name in "$@"; do

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -24,7 +24,7 @@ shift 1
 cd $WORKSPACE
 
 # Setup Mamba. Create and activate environment
-setup_mamba $WORKSPACE/mambaforge "" true ""
+setup_mamba $WORKSPACE/mambaforge "" true
 create_and_activate_mantid_developer_env $WORKSPACE
 
 # Create the build directory if it doesn't exist

--- a/buildconfig/Jenkins/Conda/mamba-utils
+++ b/buildconfig/Jenkins/Conda/mamba-utils
@@ -9,18 +9,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   1. Install prefix
 #   2. Optional. If provided, the name of an environment to create and activate
 #   3. Optional. If true is specified any existing mamba installation is removed
-#   4. Optional. Target platform, e.g. linux-64
 setup_mamba () {
   local install_prefix=$1
   local env_name=$2
-  local clean=$3
-  local platform=$4
+  local clean=false
+  if [ $# -eq 3 ]; then
+    clean=$3
+  fi
   $SCRIPT_DIR/download-and-install-mambaforge $install_prefix $clean
   source $install_prefix/etc/profile.d/conda.sh
   source $install_prefix/etc/profile.d/mamba.sh
 
   if [ -n "$env_name" ]; then
-    create_and_activate_env "$env_name" "$platform"
+    create_and_activate_env "$env_name"
   fi
 }
 
@@ -28,16 +29,23 @@ setup_mamba () {
 # create and activate a mamba environment
 # Args:
 #   1. Name of environment.
-#   2. Optional platform, e.g. linux-64
+#   2. Optional environment file
 create_and_activate_env() {
-  local env_name=$1
-  local conda_subdir_str=$2
-  CONDA_SUBDIR=$conda_subdir_str mamba create --yes --name $env_name
-  mamba activate $env_name
-
-  if [[ -n "$conda_subdir_str" ]]; then
-    conda config --env --set subdir "$conda_subdir_str"
+  #on ARM MAC OS, create x64 env rather than default ARM env.
+  if [[ $OSTYPE == 'darwin'* && $(uname -p) == 'arm' ]]; then
+    local conda_subdir_str="osx-64"
+  else
+    local conda_subdir_str=""
   fi
+
+  local env_name=$1
+  local env_file=$2
+  if [ -z "$env_file" ]; then
+    CONDA_SUBDIR=$conda_subdir_str mamba create --yes --name $env_name
+  else
+    CONDA_SUBDIR=$conda_subdir_str mamba env create --force --name $env_name --file $env_file
+  fi
+  mamba activate $env_name
 }
 
 # Build the mantid-developer metapackage from source and
@@ -45,17 +53,22 @@ create_and_activate_env() {
 # Args:
 #   1. Path to pass to the package-conda script for building
 #      the mantid-developer metapackage.
-#   2. Optional platform, e.g. linux-64
 create_and_activate_mantid_developer_env() {
   local packaging_dir=$1
   if [[ -z "$packaging_dir" ]]; then
     echo "A path is required for building the mantid-developer metapackage."
     exit 1
   fi
-  shift
-  local platform=$1
 
-  $SCRIPT_DIR/package-conda "$packaging_dir" --build-mantid-developer --platform "$platform"
-  create_and_activate_env mantid-developer "$platform"
+  $SCRIPT_DIR/package-conda "$packaging_dir" --build-mantid-developer
+  create_and_activate_env mantid-developer
+
+  # We currently only build the mantid-developer metapackage for osx-64
+  # so we need to make sure we set the subdir if we're running on an ARM machine.
+  # This should be removed once we start creating developer packages for ARM machine.
+  if [[ $OSTYPE == 'darwin'* && $(uname -p) == 'arm' ]]; then
+    conda config --env --set subdir osx-64
+  fi
+
   mamba install -c "$packaging_dir"/conda-bld mantid-developer --yes
 }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -39,7 +39,7 @@ switch(GIT_BRANCH) {
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'unstable'
-    PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64']
+    PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'osx-64']
     break
 }
 
@@ -198,28 +198,6 @@ pipeline {
             }
           }
         }
-        stage('build and test: osx-arm64') {
-          when {
-            beforeAgent true
-            beforeOptions true
-              anyOf {
-                expression { env.BUILD_DEVEL == 'all' }
-                expression { env.BUILD_DEVEL == 'osx-arm64' }
-            }
-          }
-          agent { label 'osx-arm64' }
-          options { timestamps () }
-          steps {
-            checkoutSource("${GIT_SHA}")
-            build_and_test('osx-arm64')
-          }
-          post {
-            always {
-              archive_test_logs()
-              publish_test_reports()
-            }
-          }
-        }
         stage('package conda: linux-64') {
           when {
             beforeAgent true
@@ -316,38 +294,6 @@ pipeline {
             }
           }
         }
-        stage('package conda: osx-arm64') {
-          when {
-            beforeAgent true
-            beforeOptions true
-            anyOf {
-              expression { env.BUILD_PACKAGE == 'osx-arm64' }
-              expression { env.BUILD_PACKAGE == 'all' }
-            }
-          }
-          agent { label 'osx-arm64' }
-          options {
-              timestamps ()
-              retry(3)
-          }
-          steps {
-            // Clean up conda-bld before we start to avoid any
-            // confusion with old packages
-            dir('conda-bld') {
-              deleteDir()
-            }
-            checkoutSource("${GIT_SHA}")
-            // Build the base set of packages (ones not required for mantidworkbench)
-            // in parallel
-            package_conda('osx-arm64', 'base')
-            archive_conda_packages('osx-arm64')
-          }
-          post {
-            always {
-              archive_env_logs('osx-arm64')
-            }
-          }
-        }
       }
     }
     stage('Package workbench') {
@@ -355,7 +301,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'linux-64', 'win-64', 'osx-64', 'osx-arm64'
+            values 'linux-64', 'win-64', 'osx-64'
           }
         }
         stages {
@@ -390,7 +336,7 @@ pipeline {
 
               package_conda("${PLATFORM}", "workbench")
               archive_conda_packages("${PLATFORM}")
-              package_standalone("${PLATFORM}")
+              package_standalone()
               archive_standalone_package("${PLATFORM}")
             }
             post {
@@ -619,7 +565,7 @@ def package_conda_options(platform, base_or_workbench) {
     }
   }
 
-  package_options = "${package_flags} --git-tag ${GIT_TAG} --platform ${platform}"
+  package_options = "${package_flags} --git-tag ${GIT_TAG}"
   return package_options.trim()
 }
 
@@ -644,23 +590,23 @@ def generate_git_tag() {
   return git_tag
 }
 
-def package_standalone(platform) {
+def package_standalone() {
   packagescript_path = "${CISCRIPT_DIR}/package-standalone"
   if(isUnix()) {
-    sh "${packagescript_path} ${WORKSPACE} ${package_standalone_options(platform)}"
+    sh "${packagescript_path} ${WORKSPACE} ${package_standalone_options()}"
   } else {
     workspace_unix_style = toUnixStylePath("${WORKSPACE}")
     bat "\"${WIN_BASH}\" -ex -c \"${packagescript_path} ${workspace_unix_style}\
-      ${package_standalone_options(platform)}\""
+      ${package_standalone_options()}\""
   }
 }
 
-def package_standalone_options(platform) {
+def package_standalone_options() {
   package_options = ""
   if(PACKAGE_SUFFIX.trim() != '') {
     package_options += " --package-suffix ${PACKAGE_SUFFIX}"
   }
-  return package_options.trim() + " --platform ${platform}"
+  return package_options.trim()
 }
 
 // Determine whether this build should be marked as a prerelease on GitHub.

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -23,7 +23,6 @@
 #   --build-docs: build the HTML/Qthelp documentation
 #   --build-workbench: build the workbench package using conda-build (this will implicitly build qt and mantid)
 #   --git-tag: specify a tag for a release or nightly version
-#   --platform: target architecture, e.g. linux-64
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
 start_time=$(date +%s)
@@ -56,7 +55,6 @@ ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
 ENABLE_BUILD_DOCS=false
 BUILD_WORKBENCH_WITH_DOCS=true
-PLATFORM=""
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -74,9 +72,6 @@ do
         --git-tag)
             GIT_TAG="$2"
             shift ;;
-        --platform)
-            PLATFORM="$2"
-            shift ;;
         *)
             echo "Argument not accepted: $1"
             exit 1
@@ -87,7 +82,7 @@ done
 
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "" true $PLATFORM
+setup_mamba $WORKSPACE/mambaforge "" true
 mamba activate base
 mamba install --yes boa conda-verify versioningit
 
@@ -127,11 +122,9 @@ EXTRA_BUILD_OPTIONS="--debug "
 if [[ $OSTYPE == "msys" ]]; then
     # Do not use build id as it makes the path too long (>260 chars) for CMake (Legacy Windows API issue)
     EXTRA_BUILD_OPTIONS+="--no-build-id"
-elif [[ $PLATFORM == "osx-64" ]]; then
+elif [[ $OSTYPE == 'darwin'* ]]; then
     EXTRA_BUILD_OPTIONS+="-m ./osx_64.yaml"
 fi
-
-export CONDA_SUBDIR=$PLATFORM
 
 # Run conda build.
 if [[ $ENABLE_BUILD_MANTID_DEVELOPER == true ]]; then

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -18,7 +18,6 @@
 #
 # Possible parameters:
 #   --package-suffix: An optional suffix to pass to the standalone package step.
-#   --platform: Target platform, e.g. linux-64
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
@@ -45,15 +44,11 @@ fi
 
 # Parse options
 STANDALONE_PACKAGE_SUFFIX=
-PLATFORM=""
 while [ ! $# -eq 0 ]
 do
     case "$1" in
         --package-suffix)
             STANDALONE_PACKAGE_SUFFIX="$2"
-            shift ;;
-        --platform)
-            PLATFORM="$2"
             shift ;;
         *)
             echo "Argument not accepted: $1"
@@ -64,7 +59,7 @@ do
 done
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "" true $PLATFORM
+setup_mamba $WORKSPACE/mambaforge "" true
 mamba activate base
 mamba install --yes conda-index
 
@@ -82,15 +77,11 @@ PACKAGING_ARGS="-c ${LOCAL_CHANNEL}"
 if [ -n "${STANDALONE_PACKAGE_SUFFIX}" ]; then
     PACKAGING_ARGS="${PACKAGING_ARGS} -s ${STANDALONE_PACKAGE_SUFFIX}"
 fi
-
 if [[ $OSTYPE == 'msys'* ]]; then
     rm -fr *.exe
     ${PACKAGING_SCRIPTS_DIR}/win/create_package.sh $PACKAGING_ARGS
 elif [[ $OSTYPE == 'darwin'* ]]; then
     rm -fr *.dmg
-    if [ -n "${PLATFORM}" ]; then
-        PACKAGING_ARGS="${PACKAGING_ARGS} -p ${PLATFORM}"
-    fi
     ${PACKAGING_SCRIPTS_DIR}/osx/create_bundle.sh $PACKAGING_ARGS
 else
     rm -fr *.tar.xz

--- a/buildconfig/Jenkins/Conda/publish-to-anaconda
+++ b/buildconfig/Jenkins/Conda/publish-to-anaconda
@@ -22,7 +22,7 @@ LABEL=$4
 shift 4
 
 # Setup Mamba
-setup_mamba $WORKSPACE/mambaforge "publish-anaconda" false ""
+setup_mamba $WORKSPACE/mambaforge "publish-anaconda"
 mamba install --yes anaconda-client
 
 for package in "$@"

--- a/buildconfig/Jenkins/Conda/publish-to-github
+++ b/buildconfig/Jenkins/Conda/publish-to-github
@@ -40,7 +40,7 @@ github_release_cmd() {
 }
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge publish-gh false ""
+setup_mamba $WORKSPACE/mambaforge publish-gh
 mamba install --yes gh
 
 # Create a release and attach the given assets.

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -11,7 +11,7 @@ GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
 . source/buildconfig/Jenkins/Conda/mamba-utils
 
 # Install conda and environment
-setup_mamba $WORKSPACE/mambaforge "docs-build" true ""
+setup_mamba $WORKSPACE/mambaforge "docs-build" true
 mamba install -c ${CONDA_LABEL} --yes mantid-developer mantidqt rsync
 
 # Configure a clean build directory

--- a/conda/recipes/archive_env_logs.sh
+++ b/conda/recipes/archive_env_logs.sh
@@ -4,14 +4,21 @@ build_prefix=$1
 prefix=$2
 package_name=$3
 
-log_directory=../../$target_platform/env_logs
+platform=$(uname)
+if [ "$platform" == Linux ] ; then
+  platform_dir=linux-64
+elif [ "$platform" == Darwin ] ; then
+  platform_dir=osx-64
+else
+  platform_dir=none
+fi
 
-mkdir -p $log_directory
+mkdir -p ../../$platform_dir/env_logs
 source ../../../mambaforge/etc/profile.d/conda.sh
 
 #Just for first package (mantid), archive the package-conda environment
 if [ "$package_name" == mantid ] ; then
-  conda list --explicit --prefix ../../../mambaforge/envs/package-conda > $log_directory/package-conda_environment.txt 2>&1 || echo "Failed to write package-conda conda list output to file"
+  conda list --explicit --prefix ../../../mambaforge/envs/package-conda > ../../$platform_dir/env_logs/package-conda_environment.txt 2>&1 || echo "Failed to write package-conda conda list output to file"
 fi
-conda list --explicit --prefix "$build_prefix" > $log_directory/"${package_name}"_build_environment.txt 2>&1 || echo "Failed to write build conda list output to file"
-conda list --explicit --prefix "$prefix" > $log_directory/"${package_name}"_host_environment.txt 2>&1 || echo "Failed to write host conda list output to file"
+conda list --explicit --prefix "$build_prefix" > ../../$platform_dir/env_logs/"${package_name}"_build_environment.txt 2>&1 || echo "Failed to write build conda list output to file"
+conda list --explicit --prefix "$prefix" > ../../$platform_dir/env_logs/"${package_name}"_host_environment.txt 2>&1 || echo "Failed to write host conda list output to file"

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -49,8 +49,7 @@ graphviz:
 
 # this must match the version in the developer dependencies
 jemalloc:
-  - 5.2.0 # [linux]
-  - 5.2.* # [osx]
+  - 5.2.0
 
 jsoncpp:
   - '>=1.9.4,<2'

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -136,22 +136,17 @@ function usage() {
   echo "Options:"
   echo "  -c Optional Conda channel overriding the default mantid"
   echo "  -s Optional Add a suffix to the output mantid file, has to be Unstable, or Nightly or not used"
-  echo "  -p Target platform, e.g. osx-64 or osx-arm64"
+  echo
   exit $exitcode
 }
 
 ## Script begin
 # Optional arguments
 conda_channel=mantid
-platform=""
 suffix=
 while [ ! $# -eq 0 ]
 do
   case "$1" in
-    -p)
-        platform="$2"
-        shift
-        ;;
     -c)
         conda_channel="$2"
         shift
@@ -215,7 +210,7 @@ if [[ "$suffix" == "Unstable" ]] || [[ "$suffix" == "Nightly" ]]; then
 fi
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
-CONDA_SUBDIR="$platform" "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
+CONDA_SUBDIR=osx-64 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
   --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
   mantidworkbench \
   jq  # used for processing the version string
@@ -242,6 +237,6 @@ create_plist "$bundle_contents" "$bundle_name" "$bundle_icon" "$version"
 # `create-dmg` returns error code by default due to lack of signing - this is suppressed using a command list.
 # Failure of the following `mv` command likely signifies `create-dmg` error.
 export PATH=$PATH:/opt/homebrew/bin/
-version_name="$bundle_name"-"$platform"-"$version"
+version_name="$bundle_name"-"$version"
 create-dmg "$BUILD_DIR"/"$bundle_dirname" || true
 mv "${bundle_name} ${version}.dmg" "${version_name}.dmg"

--- a/scripts/test/DirectPropertyManagerTest.py
+++ b/scripts/test/DirectPropertyManagerTest.py
@@ -761,7 +761,8 @@ class DirectPropertyManagerTest(unittest.TestCase):
 
         allEi = PropertyManager.incident_energy.getAllEiList()
 
-        np.testing.assert_allclose([allEi[0], allEi[1]], [8.8, 15.8], rtol=2e-2)
+        self.assertAlmostEqual(allEi[0], 8.8, 1)
+        self.assertAlmostEqual(allEi[1], 15.8, 1)
 
     def test_ignore_complex_defailts_changes_fom_instrument(self):
         ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, NumEvents=10)


### PR DESCRIPTION
The nightly failed to build on ARM Mac due to a problem with resolving dependencies. It only affects the ARM Mac package and may be a result of upgrading to Python 3.11 yesterday (see #39283). By reverting this PR we can build and publish the nightly for the other operating systems. This is required for developers to rebase their PRs. Without rebasing PRs will fail due to using an older Python version.

Reverts mantidproject/mantid#38990