### PR TITLE
Add Plot Options menu to Plotting tab

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_presenter.py
@@ -53,6 +53,7 @@ class DNSReductionGUIPresenter:
         self.view.clear_subviews()
         self.view.clear_submenus()
         self.modus.change(modus)
+        self.view.action[modus].setChecked(True)
         self._parameter_abo.clear()
         for widget in self.modus.widgets.values():
             self._parameter_abo.register(widget.presenter)
@@ -71,6 +72,13 @@ class DNSReductionGUIPresenter:
         for observer in self._parameter_abo.observers:
             if observer.view == actual_view:
                 self._parameter_abo.notify_focused_tab(observer)
+        if self.modus.name == "single_crystal_elastic":
+            if tab_index == 4:
+                self.modus.widgets["plot_elastic_single_crystal"].view.views_menu.menuAction().setVisible(True)
+                self.modus.widgets["plot_elastic_single_crystal"].view.options_menu.menuAction().setVisible(True)
+            else:
+                self.modus.widgets["plot_elastic_single_crystal"].view.views_menu.menuAction().setVisible(False)
+                self.modus.widgets["plot_elastic_single_crystal"].view.options_menu.menuAction().setVisible(False)
 
     def _attach_signal_slots(self):
         self.view.sig_tab_changed.connect(self._tab_changed)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_presenter.py
@@ -74,11 +74,11 @@ class DNSReductionGUIPresenter:
                 self._parameter_abo.notify_focused_tab(observer)
         if self.modus.name == "single_crystal_elastic":
             if tab_index == 4:
-                self.modus.widgets["plot_elastic_single_crystal"].view.views_menu.menuAction().setVisible(True)
-                self.modus.widgets["plot_elastic_single_crystal"].view.options_menu.menuAction().setVisible(True)
+                self.modus.widgets["plot_elastic_single_crystal"].view.set_plot_view_menu_visibility(True)
+                self.modus.widgets["plot_elastic_single_crystal"].view.set_plot_options_menu_visibility(True)
             else:
-                self.modus.widgets["plot_elastic_single_crystal"].view.views_menu.menuAction().setVisible(False)
-                self.modus.widgets["plot_elastic_single_crystal"].view.options_menu.menuAction().setVisible(False)
+                self.modus.widgets["plot_elastic_single_crystal"].view.set_plot_view_menu_visibility(False)
+                self.modus.widgets["plot_elastic_single_crystal"].view.set_plot_options_menu_visibility(False)
 
     def _attach_signal_slots(self):
         self.view.sig_tab_changed.connect(self._tab_changed)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/main_view.py
@@ -15,7 +15,7 @@ from mantidqt.utils.qt import load_ui
 from mantidqt.gui_helper import show_interface_help
 
 from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QMainWindow
+from qtpy.QtWidgets import QMainWindow, QAction, QActionGroup
 from qtpy.QtCore import QProcess
 
 
@@ -43,13 +43,13 @@ class DNSReductionGUIView(QMainWindow):
         self.ui.actionDNS_website.triggered.connect(self._open_dns_webpage)
         # connect mode switching signals
         self.modus_mapping = {
-            self.ui.actionPowder_Elastic: "powder_elastic",
             self.ui.actionPowder_TOF: "powder_tof",
+            self.ui.actionPowder_Elastic: "powder_elastic",
             self.ui.actionSingle_Crystal_Elastic: "single_crystal_elastic",
         }
         self.modus_titles = {
-            "powder_elastic": "DNS Reduction GUI - Powder Elastic",
             "powder_tof": "DNS Reduction GUI - Powder TOF",
+            "powder_elastic": "DNS Reduction GUI - Powder Elastic",
             "single_crystal_elastic": "DNS Reduction GUI - Single Crystal Elastic",
         }
         for key in self.modus_mapping:
@@ -59,6 +59,21 @@ class DNSReductionGUIView(QMainWindow):
         self.last_index = 0
         # connect signals
         self.ui.tabWidget.currentChanged.connect(self._tab_changed)
+
+        # Create an exclusive action group with radio button like behavior
+        self.action_group = QActionGroup(self)
+        self.action_group.setExclusive(True)
+
+        self.action = {}
+        self.modus_actions = {
+            "powder_tof": "actionPowder_TOF",
+            "powder_elastic": "actionPowder_Elastic",
+            "single_crystal_elastic": "actionSingle_Crystal_Elastic",
+        }
+        for modus_name, modus_action in self.modus_actions.items():
+            self.action[modus_name] = self.findChild(QAction, modus_action)
+            self.action[modus_name].setCheckable(True)
+            self.action_group.addAction(self.action[modus_name])
 
     # signals
     sig_tab_changed = Signal(int, int)
@@ -104,7 +119,7 @@ class DNSReductionGUIView(QMainWindow):
 
     def add_submenu(self, subview):
         for menu in subview.menus:
-            submenu = self.menu.insertMenu(self.ui.menuHelp.menuAction(), menu)
+            submenu = self.menu.insertMenu(None, menu)
             self.subview_menus.append(submenu)
 
     def clear_submenus(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_dialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_dialog.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_dialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_dialog.py
@@ -1,0 +1,26 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+"""
+Class for small input dialogs.
+"""
+
+from pathlib import Path
+
+from qtpy.QtWidgets import QDialog
+from qtpy.uic import loadUi
+
+
+class DNSDialog(QDialog):
+    """
+    Class for dialogs which can be opened by the GUI.
+    """
+
+    def __init__(self, files=None, ui=None):
+        super().__init__()
+        path = str(Path(files).parent.absolute())
+        self._content = loadUi(path + ui, self)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/__init__.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
@@ -29,20 +29,16 @@ class DNSOmegaOffsetDialog(DNSDialog):
         self._content.dSB_omega_offset.setValue(self._initial_omega_offset)
         self._content.dSB_omega_offset.setFocus()
         self._content.dSB_omega_offset.valueChanged.connect(self._omega_offset_changed)
-        self._content.pB_discard.clicked.connect(self._discard)
-        self._content.pB_apply.clicked.connect(self._apply)
+        self._content.pB_restore_default.clicked.connect(self._discard_changes)
 
         self.parent = parent
 
     def _omega_offset_changed(self, omega_offset):
         self.parent.sig_update_omega_offset.emit(omega_offset)
 
-    def _apply(self):
-        self.reject()
-
-    def _discard(self):
+    def _discard_changes(self):
         self._omega_offset_changed(self._initial_omega_offset)
-        self.reject()
+        self._content.dSB_omega_offset.setValue(self._initial_omega_offset)
 
 
 class DNSdxdyDialog(DNSDialog):
@@ -57,8 +53,7 @@ class DNSdxdyDialog(DNSDialog):
         self._content.dSB_dx.valueChanged.connect(self._dxdy_changed)
         self._content.dSB_dy.setValue(dy)
         self._content.dSB_dy.valueChanged.connect(self._dxdy_changed)
-        self._content.pB_discard.clicked.connect(self._discard)
-        self._content.pB_apply.clicked.connect(self._apply)
+        self._content.pB_restore_default.clicked.connect(self._discard_changes)
         self._parent = parent
 
     def _dxdy_changed(self, dx=None, dy=None):
@@ -67,9 +62,7 @@ class DNSdxdyDialog(DNSDialog):
             dy = self._content.dSB_dy.value()
         self._parent.sig_update_dxdy.emit(dx, dy)
 
-    def _apply(self):
-        self.reject()
-
-    def _discard(self):
+    def _discard_changes(self):
         self._dxdy_changed(dx=self._initial_dx, dy=self._initial_dy)
-        self.reject()
+        self._content.dSB_dx.setValue(self._initial_dx)
+        self._content.dSB_dy.setValue(self._initial_dy)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
@@ -1,0 +1,75 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from qtpy.QtWidgets import QProxyStyle, QStyle
+
+from mantidqtinterfaces.dns_single_crystal_elastic.data_structures.dns_dialog import DNSDialog
+
+
+class SpinboxNorepeatStyle(QProxyStyle):  # turn off auto repeat on spinbox
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
+        if hint == QStyle.SH_SpinBox_KeyPressAutoRepeatRate:
+            return 10**5
+        if hint == QStyle.SH_SpinBox_ClickAutoRepeatRate:
+            return 10**5
+        if hint == QStyle.SH_SpinBox_ClickAutoRepeatThreshold:
+            return 10**5
+        return super().styleHint(hint, option, widget, returnData)
+
+
+class DNSOmegaOffsetDialog(DNSDialog):
+    def __init__(self, parent, omega_offset):
+        super().__init__(files=__file__, ui="/omega_offset.ui")
+        self._content.dSB_omega_offset.setStyle(SpinboxNorepeatStyle())
+        self._initial_omega_offset = omega_offset
+        self._content.dSB_omega_offset.setValue(self._initial_omega_offset)
+        self._content.dSB_omega_offset.setFocus()
+        self._content.dSB_omega_offset.valueChanged.connect(self._omega_offset_changed)
+        self._content.pB_discard.clicked.connect(self._discard)
+        self._content.pB_apply.clicked.connect(self._apply)
+
+        self.parent = parent
+
+    def _omega_offset_changed(self, omega_offset):
+        self.parent.sig_update_omega_offset.emit(omega_offset)
+
+    def _apply(self):
+        self.reject()
+
+    def _discard(self):
+        self._omega_offset_changed(self._initial_omega_offset)
+        self.reject()
+
+
+class DNSdxdyDialog(DNSDialog):
+    def __init__(self, parent, dx, dy):
+        super().__init__(files=__file__, ui="/dxdy.ui")
+        self._initial_dx = dx
+        self._initial_dy = dy
+        self._content.dSB_dx.setStyle(SpinboxNorepeatStyle())
+        self._content.dSB_dy.setStyle(SpinboxNorepeatStyle())
+        self._content.dSB_dx.setValue(dx)
+        self._content.dSB_dx.setFocus()
+        self._content.dSB_dx.valueChanged.connect(self._dxdy_changed)
+        self._content.dSB_dy.setValue(dy)
+        self._content.dSB_dy.valueChanged.connect(self._dxdy_changed)
+        self._content.pB_discard.clicked.connect(self._discard)
+        self._content.pB_apply.clicked.connect(self._apply)
+        self._parent = parent
+
+    def _dxdy_changed(self, dx=None, dy=None):
+        if dx is None or dy is None:
+            dx = self._content.dSB_dx.value()
+            dy = self._content.dSB_dy.value()
+        self._parent.sig_update_dxdy.emit(dx, dy)
+
+    def _apply(self):
+        self.reject()
+
+    def _discard(self):
+        self._dxdy_changed(dx=self._initial_dx, dy=self._initial_dy)
+        self.reject()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dialogs.py
@@ -30,15 +30,14 @@ class DNSOmegaOffsetDialog(DNSDialog):
         self._content.dSB_omega_offset.setFocus()
         self._content.dSB_omega_offset.valueChanged.connect(self._omega_offset_changed)
         self._content.pB_restore_default.clicked.connect(self._discard_changes)
-
-        self.parent = parent
+        self._parent = parent
 
     def _omega_offset_changed(self, omega_offset):
-        self.parent.sig_update_omega_offset.emit(omega_offset)
+        self._parent.sig_update_omega_offset.emit(omega_offset)
 
     def _discard_changes(self):
-        self._omega_offset_changed(self._initial_omega_offset)
-        self._content.dSB_omega_offset.setValue(self._initial_omega_offset)
+        self._parent.sig_restore_default_omega_offset.emit()
+        self._content.dSB_omega_offset.setValue(self._parent.initial_values["omega_offset"])
 
 
 class DNSdxdyDialog(DNSDialog):
@@ -63,6 +62,7 @@ class DNSdxdyDialog(DNSDialog):
         self._parent.sig_update_dxdy.emit(dx, dy)
 
     def _discard_changes(self):
-        self._dxdy_changed(dx=self._initial_dx, dy=self._initial_dy)
-        self._content.dSB_dx.setValue(self._initial_dx)
-        self._content.dSB_dy.setValue(self._initial_dy)
+        self._parent.sig_restore_default_dxdy.emit()
+        self._content.dSB_dx.setValue(self._parent.initial_values["dx"])
+        self._parent.sig_restore_default_dxdy.emit()
+        self._content.dSB_dy.setValue(self._parent.initial_values["dy"])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dxdy.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/dxdy.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>457</width>
+    <height>57</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,75 +19,85 @@
   <property name="windowTitle">
    <string>Change d-spacings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="l_dx">
-     <property name="text">
-      <string>d&lt;sub&gt;x&lt;/sub&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QDoubleSpinBox" name="dSB_dx">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="maximum">
-      <double>399.990000000000009</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="l_dy">
-     <property name="text">
-      <string>d&lt;sub&gt;y&lt;/sub&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="openExternalLinks">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QDoubleSpinBox" name="dSB_dy">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="maximum">
-      <double>399.990000000000009</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QPushButton" name="pB_apply">
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="pB_discard">
-     <property name="text">
-      <string>Discard</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="l_dx">
+       <property name="text">
+        <string>d&lt;sub&gt;x&lt;/sub&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="dSB_dx">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="maximum">
+        <double>399.990000000000009</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="l_dy">
+       <property name="text">
+        <string>d&lt;sub&gt;y&lt;/sub&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="openExternalLinks">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="dSB_dy">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="maximum">
+        <double>399.990000000000009</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>80</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pB_restore_default">
+       <property name="text">
+        <string>Restore Default</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/omega_offset.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/dialogs/omega_offset.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>530</width>
-    <height>115</height>
+    <width>664</width>
+    <height>60</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,28 +28,8 @@
   <property name="windowTitle">
    <string>Change ω Offset</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QPushButton" name="pB_apply">
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="pB_discard">
-     <property name="text">
-      <string>Discard</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
     <widget class="QDoubleSpinBox" name="dSB_omega_offset">
      <property name="wrapping">
       <bool>true</bool>
@@ -68,6 +48,16 @@
      </property>
      <property name="singleStep">
       <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pB_restore_default">
+     <property name="text">
+      <string>Restore Default</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_model.py
@@ -71,3 +71,9 @@ class DNSElasticSCPlotModel(DNSObsModel):
         axis_labels = {"hkl": [f"[{hkl1}] (r.l.u.)", f"[{hkl2}] (r.l.u.)"]}
         labels = axis_labels[axis_type]
         return labels
+
+    def get_omega_offset(self):
+        return self._single_crystal_map["omega_offset"]
+
+    def get_dx_dy(self):
+        return self._single_crystal_map["dx"], self._single_crystal_map["dy"]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_presenter.py
@@ -48,6 +48,7 @@ class DNSElasticSCPlotPresenter(DNSObserver):
         self._set_axis_labels()
         self.view.single_crystal_plot.create_colorbar()
         self.view.single_crystal_plot.on_resize()
+        self._set_initial_omega_offset_dx_dy()
         self.view.canvas.figure.tight_layout()
         self.view.draw()
 
@@ -58,6 +59,19 @@ class DNSElasticSCPlotPresenter(DNSObserver):
             self._plotted_script_number = self.param_dict["elastic_single_crystal_script_generator"]["script_number"]
             self.view.process_events()
             self.view.datalist.check_first()
+
+    def _set_initial_omega_offset_dx_dy(self):
+        omega_offset = self.model.get_omega_offset()
+        dx, dy = self.model.get_dx_dy()
+        self.view.set_initial_omega_offset_dx_dy(omega_offset, dx, dy)
+
+    def _update_omega_offset(self, omega_offset):
+        initial_values = {"omega_offset": omega_offset}
+        self._plot(initial_values)
+
+    def _update_dx_dy(self, dx, dy):
+        initial_values = {"dx": dx, "dy": dy}
+        self._plot(initial_values)
 
     def _plot_triangulation(self, interpolate, axis_type, switch):
         color_map, edge_colors, shading = self._get_plot_styles()
@@ -89,5 +103,7 @@ class DNSElasticSCPlotPresenter(DNSObserver):
 
     def _attach_signal_slots(self):
         self.view.sig_plot.connect(self._plot)
+        self.view.sig_update_omega_offset.connect(self._update_omega_offset)
+        self.view.sig_update_dxdy.connect(self._update_dx_dy)
         self.view.sig_change_colormap.connect(self._set_colormap)
         self._plotted_script_number = 0

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_presenter.py
@@ -66,12 +66,25 @@ class DNSElasticSCPlotPresenter(DNSObserver):
         self.view.set_initial_omega_offset_dx_dy(omega_offset, dx, dy)
 
     def _update_omega_offset(self, omega_offset):
-        initial_values = {"omega_offset": omega_offset}
-        self._plot(initial_values)
+        self.view.initial_values["omega_offset"] = omega_offset
+        self._plot(self.view.initial_values)
+
+    def _set_default_omega_offset(self):
+        default_value = self.param_dict["elastic_single_crystal_options"]["omega_offset"]
+        self.view.initial_values["omega_offset"] = default_value
+        self._plot(self.view.initial_values)
 
     def _update_dx_dy(self, dx, dy):
-        initial_values = {"dx": dx, "dy": dy}
-        self._plot(initial_values)
+        self.view.initial_values["dx"] = dx
+        self.view.initial_values["dy"] = dy
+        self._plot(self.view.initial_values)
+
+    def _set_default_dx_dy(self):
+        default_dx = self.param_dict["elastic_single_crystal_options"]["dx"]
+        default_dy = self.param_dict["elastic_single_crystal_options"]["dy"]
+        self.view.initial_values["dx"] = default_dx
+        self.view.initial_values["dy"] = default_dy
+        self._plot(self.view.initial_values)
 
     def _plot_triangulation(self, interpolate, axis_type, switch):
         color_map, edge_colors, shading = self._get_plot_styles()
@@ -104,6 +117,8 @@ class DNSElasticSCPlotPresenter(DNSObserver):
     def _attach_signal_slots(self):
         self.view.sig_plot.connect(self._plot)
         self.view.sig_update_omega_offset.connect(self._update_omega_offset)
+        self.view.sig_restore_default_omega_offset.connect(self._set_default_omega_offset)
         self.view.sig_update_dxdy.connect(self._update_dx_dy)
+        self.view.sig_restore_default_dxdy.connect(self._set_default_dx_dy)
         self.view.sig_change_colormap.connect(self._set_colormap)
         self._plotted_script_number = 0

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
@@ -85,6 +85,8 @@ class DNSElasticSCPlotView(DNSView):
 
     # Signals
     sig_plot = Signal()
+    sig_restore_default_omega_offset = Signal()
+    sig_restore_default_dxdy = Signal()
     sig_update_omega_offset = Signal(float)
     sig_update_dxdy = Signal(float, float)
     sig_change_colormap = Signal()
@@ -103,7 +105,7 @@ class DNSElasticSCPlotView(DNSView):
 
     def change_omega_offset(self):
         if self.initial_values:
-            omega_offset_dialog = DNSOmegaOffsetDialog(parent=self, omega_offset=self.initial_values["oof"])
+            omega_offset_dialog = DNSOmegaOffsetDialog(parent=self, omega_offset=self.initial_values["omega_offset"])
             omega_offset_dialog.exec_()
 
     # gui options
@@ -114,7 +116,7 @@ class DNSElasticSCPlotView(DNSView):
         return self.views_menu.get_value()
 
     def set_initial_omega_offset_dx_dy(self, off, dx, dy):
-        self.initial_values = {"oof": off, "dx": dx, "dy": dy}
+        self.initial_values = {"omega_offset": off, "dx": dx, "dy": dy}
 
     def draw(self):
         self.canvas.draw()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
@@ -68,8 +68,8 @@ class DNSElasticSCPlotView(DNSView):
         # setting up custom menu for single crystal plot options and views
         self.views_menu = DNSElasticSCPlotViewMenu()
         self.options_menu = DNSElasticSCPlotOptionsMenu(self)
-        self.views_menu.menuAction().setVisible(False)
-        self.options_menu.menuAction().setVisible(False)
+        self.set_plot_view_menu_visibility(False)
+        self.set_plot_options_menu_visibility(False)
         self.menus = []
         self.menus.append(self.views_menu)
         self.menus.append(self.options_menu)
@@ -96,6 +96,12 @@ class DNSElasticSCPlotView(DNSView):
 
     def _plot(self):
         self.sig_plot.emit()
+
+    def set_plot_view_menu_visibility(self, visible):
+        self.views_menu.menuAction().setVisible(visible)
+
+    def set_plot_options_menu_visibility(self, visible):
+        self.options_menu.menuAction().setVisible(visible)
 
     # dialogs
     def change_dxdy(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
@@ -16,7 +16,9 @@ from matplotlib.figure import Figure
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QSizePolicy
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_view import DNSView
+from mantidqtinterfaces.dns_single_crystal_elastic.plot.dialogs.dialogs import DNSdxdyDialog, DNSOmegaOffsetDialog
 from mantidqtinterfaces.dns_single_crystal_elastic.plot.elastic_single_crystal_plot_menu import (
+    DNSElasticSCPlotOptionsMenu,
     DNSElasticSCPlotViewMenu,
     set_mdi_icons,
     set_up_colormap_selector,
@@ -65,8 +67,10 @@ class DNSElasticSCPlotView(DNSView):
 
         # setting up custom menu for single crystal plot options and views
         self.views_menu = DNSElasticSCPlotViewMenu()
+        options_menu = DNSElasticSCPlotOptionsMenu(self)
         self.menus = []
         self.menus.append(self.views_menu)
+        self.menus.append(options_menu)
         self.views_menu.sig_replot.connect(self._plot)
         canvas = FigureCanvas(Figure())
         canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -79,6 +83,8 @@ class DNSElasticSCPlotView(DNSView):
 
     # Signals
     sig_plot = Signal()
+    sig_update_omega_offset = Signal(float)
+    sig_update_dxdy = Signal(float, float)
     sig_change_colormap = Signal()
 
     def _change_colormap(self):
@@ -87,12 +93,26 @@ class DNSElasticSCPlotView(DNSView):
     def _plot(self):
         self.sig_plot.emit()
 
+    # dialogs
+    def change_dxdy(self):
+        if self.initial_values:
+            dxdy_dialog = DNSdxdyDialog(parent=self, dx=self.initial_values["dx"], dy=self.initial_values["dy"])
+            dxdy_dialog.exec_()
+
+    def change_omega_offset(self):
+        if self.initial_values:
+            omega_offset_dialog = DNSOmegaOffsetDialog(parent=self, omega_offset=self.initial_values["oof"])
+            omega_offset_dialog.exec_()
+
     # gui options
     def create_subfigure(self, grid_helper=None):
         self.single_crystal_plot = DNSScPlot(self, self.canvas.figure, grid_helper)
 
     def get_axis_type(self):
         return self.views_menu.get_value()
+
+    def set_initial_omega_offset_dx_dy(self, off, dx, dy):
+        self.initial_values = {"oof": off, "dx": dx, "dy": dy}
 
     def draw(self):
         self.canvas.draw()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/plot/elastic_single_crystal_plot_view.py
@@ -67,10 +67,12 @@ class DNSElasticSCPlotView(DNSView):
 
         # setting up custom menu for single crystal plot options and views
         self.views_menu = DNSElasticSCPlotViewMenu()
-        options_menu = DNSElasticSCPlotOptionsMenu(self)
+        self.options_menu = DNSElasticSCPlotOptionsMenu(self)
+        self.views_menu.menuAction().setVisible(False)
+        self.options_menu.menuAction().setVisible(False)
         self.menus = []
         self.menus.append(self.views_menu)
-        self.menus.append(options_menu)
+        self.menus.append(self.options_menu)
         self.views_menu.sig_replot.connect(self._plot)
         canvas = FigureCanvas(Figure())
         canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)

--- a/qt/python/mantidqtinterfaces/test/dns_powder_tof/main_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/dns_powder_tof/main_presenter_test.py
@@ -36,6 +36,8 @@ class DNSReductionGUIPresenterTest(unittest.TestCase):
         cls.modus.widgets = {"observer1": cls.widget}
         cls.modus.name = "modus_test_name"
         cls.widget.view = mock.Mock()
+        cls.widget.view.set_plot_view_menu_visibility = mock.Mock()
+        cls.widget.view.set_plot_options_menu_visibility = mock.Mock()
         cls.widget.view.menus = True
         cls.widget.presenter = mock.Mock()
         cls.widget.presenter.view = cls.widget.view
@@ -107,6 +109,21 @@ class DNSReductionGUIPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.get_view_for_tab_index.call_count, 2)
         self.parameter_abo.update_from_observer.assert_called_once()
         self.parameter_abo.notify_focused_tab.assert_called_once()
+
+    def test__tab_changed_single_crystal_elastic(self):
+        self.presenter.modus.name = "single_crystal_elastic"
+        self.presenter.modus.widgets = {"plot_elastic_single_crystal": self.widget}
+        self.presenter._tab_changed(3, 4)
+        self.assertEqual(self.view.get_view_for_tab_index.call_count, 2)
+        self.parameter_abo.update_from_observer.assert_called_once()
+        self.parameter_abo.notify_focused_tab.assert_called_once()
+        self.widget.view.set_plot_view_menu_visibility.assert_called_once_with(True)
+        self.widget.view.set_plot_options_menu_visibility.assert_called_once_with(True)
+        self.widget.view.set_plot_view_menu_visibility.reset_mock()
+        self.widget.view.set_plot_options_menu_visibility.reset_mock()
+        self.presenter._tab_changed(4, 3)
+        self.widget.view.set_plot_view_menu_visibility.assert_called_once_with(False)
+        self.widget.view.set_plot_options_menu_visibility.assert_called_once_with(False)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/test/dns_powder_tof/main_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/dns_powder_tof/main_presenter_test.py
@@ -34,8 +34,8 @@ class DNSReductionGUIPresenterTest(unittest.TestCase):
         cls.modus = mock.create_autospec(DNSModus, instance=True)
         cls.widget = mock.Mock()
         cls.modus.widgets = {"observer1": cls.widget}
+        cls.modus.name = "modus_test_name"
         cls.widget.view = mock.Mock()
-        # cls.widget.view.has_tab = True
         cls.widget.view.menus = True
         cls.widget.presenter = mock.Mock()
         cls.widget.presenter.view = cls.widget.view
@@ -48,7 +48,11 @@ class DNSReductionGUIPresenterTest(unittest.TestCase):
         cls.view.sig_save_triggered.connect = mock.Mock()
         cls.view.sig_open_triggered.connect = mock.Mock()
         cls.view.sig_modus_change.connect = mock.Mock()
-
+        cls.view.action = {
+            "powder_tof": mock.Mock(),
+            "powder_elastic": mock.Mock(),
+            "single_crystal_elastic": mock.Mock(),
+        }
         cls.presenter = DNSReductionGUIPresenter(
             name="reduction_gui",
             view=cls.view,


### PR DESCRIPTION
### Description of work

This PR contains changes that add Plot Options menu to Plotting tab. This menu allows a user to modify omega offset and d-spacing values dx and dy and update the "Plotting" tab view correspondingly. 

This PR includes a first part of adding advanced plotting capabilities for the Single Cristal Elastic mode of DNS Reduction GUI. Complete integration of the Single Cristal Elastic mode into the DNS Reduction GUI will be implemented in several steps (in order to ensure reasonable PR sizes and reduce the workload for the reviewers).

#### Summary of work

Fixes Part 6a of #36407.
 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:


- Download test data: [Single_Crystal_Elastic.zip](https://github.com/mantidproject/mantid/files/13751286/Single_Crystal_Elastic.zip)
- Open the reduction GUI [Interfaces->Direct->DNS Reduction]
- The "Single Crystal Elastic" mode should open by default. If not, switch to this mode, by selecting Tools -> Change Mode -> Single Crystal Elastic
- Make sure that the corresponding documentation is up-to-date (run `cmake --build . --target docs-html` in build folder to create docs). Relevant documentation will then be located in `[mantid_build_path]/docs/html/interfaces/direct/dns_reduction/` 
- Browse to the directory where the test data are located using the "Paths" tab of the GUI
- Load and select the sample data for reduction using the "Data" tab
- Click on the "Options" tab and select options for data reduction.
- Proceed to the "Script Generator" tab and click on the "Generate and Run Script" button, which should run the corresponding workflow depending on the parameters selected under the "Options" tab.  
- Open the "Plotting" tab and make sure that the images are generated. 
- At the top of the "Plotting" widget click on the "Plot Options" menu and click on one of the suggested menus ("Change omega offset" or "Change d-spasings"). 
- Make sure that the view is updated once the new values for omega offset and d-spasings are applied. 

*This does not require release notes* because **this PR contains limited functionality.** Release notes for the Single Cristal Elastic mode will be included in a subsequent PR, once all components for implementing the data reduction workflow are uploaded. 


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
