### PR TITLE
Fix crash in Muon results table

### DIFF
--- a/docs/source/release/v6.13.0/Muon/Muon_Analysis/Bugfixes/39263.rst
+++ b/docs/source/release/v6.13.0/Muon/Muon_Analysis/Bugfixes/39263.rst
@@ -1,0 +1,2 @@
+- Fix a crash ocurring in the :ref:`Results Tab <muon_results_tab-ref>` of the :ref:`Muon Analysis <Muon_Analysis-ref>` interface when an integer time series was added as a log in the results table.
+- Allow the `current_period` sample log from the selected fitted workspace to be added to the :ref:`results table <muon_results_tab-ref>`.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -259,13 +259,13 @@ class ResultsTabModel(object):
         table = WorkspaceFactory.Instance().createTable()
         table.addColumn("str", "workspace_name", TableColumnType.NoType.value)
 
-        def create_wkps_name_list(wksp_name):
+        def create_ws_name_list(selected_ws_name):
             """Creates a list with all the workspaces used in the fit and puts the current workspace
             in the first position of the list."""
             all_names = [ws_name for fit in all_fits for ws_name in fit.input_workspaces]
-            if all_names[0] != wksp_name:
-                all_names.pop(all_names.index(wksp_name))
-                all_names.insert(0, wksp_name)
+            if all_names[0] != selected_ws_name:
+                all_names.pop(all_names.index(selected_ws_name))
+                all_names.insert(0, selected_ws_name)
             return all_names
 
         def is_str_convertible_to_float(prop_value):
@@ -275,33 +275,33 @@ class ResultsTabModel(object):
             except ValueError:
                 return False
 
-        def add_log_table_columns(wksp_name, log_name, table):
-            all_names = create_wkps_name_list(wksp_name)
-            for name in all_names:
-                run = ads.Instance().retrieve(name).run()
-                if not run.hasProperty(log_name):
+        def add_log_table_columns(selected_ws_name, target_log_name, target_table):
+            all_names = create_ws_name_list(selected_ws_name)
+            for ws_name in all_names:
+                run = ads.Instance().retrieve(ws_name).run()
+                if not run.hasProperty(target_log_name):
                     continue
-                prop = run.getProperty(log_name)
+                prop = run.getProperty(target_log_name)
                 if isinstance(prop, TO_FLOAT_COLUMNS):
-                    table.addColumn("float", log_name, TableColumnType.X.value)
-                    table.addColumn("float", _error_column_name(log_name), TableColumnType.XErr.value)
+                    target_table.addColumn("float", target_log_name, TableColumnType.X.value)
+                    target_table.addColumn("float", _error_column_name(target_log_name), TableColumnType.XErr.value)
                     break
                 elif isinstance(prop, StringPropertyWithValue):
                     if is_str_convertible_to_float(prop.value):
-                        table.addColumn("float", log_name, TableColumnType.X.value)
-                        table.addColumn("float", _error_column_name(log_name), TableColumnType.XErr.value)
+                        target_table.addColumn("float", target_log_name, TableColumnType.X.value)
+                        target_table.addColumn("float", _error_column_name(target_log_name), TableColumnType.XErr.value)
                     else:
-                        table.addColumn("str", log_name, TableColumnType.X.value)
+                        target_table.addColumn("str", target_log_name, TableColumnType.X.value)
                     break
-            return table
+            return target_table
 
         for log_name in log_selection:
-            wksp_name = all_fits[0].input_workspaces[0]
+            sel_ws_name = all_fits[0].input_workspaces[0]
             if log_name in ["run_start", "run_end"]:
                 table.addColumn("str", log_name, TableColumnType.X.value)
                 table.addColumn("float", log_name + "_seconds", TableColumnType.X.value)
             else:
-                table = add_log_table_columns(wksp_name, log_name, table)
+                table = add_log_table_columns(sel_ws_name, log_name, table)
 
         # assume all fit functions are the same in fit_selection and take
         # the parameter names from the first fit.


### PR DESCRIPTION
### Description of work
This PR fixes a crash when retrieving certain logs form the muon results table in the Muon Analysis Interface. 
Check #39263
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
There's a certain set of allowed logs that can go into the results table. These logs are mostly time series, but can also be strings or numbers. If these logs are time series, they are averaged. Additionally, logs that are not time series, are attempted to be converted to float. If the selected log is not available in a given selected fitted workspace, there was a recursive call to all the workspaces used in the fit, until the log was found.  At some point the log named `periods` appears to have been changed for some Muon instruments, and now is in the form of an integer time series, which can't be detected by this function, therefore the call to this function gets trapped in an infinite loop that crashes Mantid.
Two things have been done in this PR: 
- Fix the crash, all the logs that can be converted to a float or averaged to a float are checked against their mantid types ( ie. IntTimePropertiySeries, FloatTimePropertySeries, ..) . All the fitted workspaces are stored in a list and the list is iterated in a for loop to check against these ws if it is not available in the selected fit ws, avoiding recursive calls.
- As per required from the scientist that submitted the error report, I have added the log `current_period` to the set of allowed logs into the results table.

Fixes #39263. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:** James Lord

### To test:

 - Follows #39263 crash instructions, no crash should be happening. 
 - Additionally, try to select all the allowed logs in the results table and export it to the ads. There should be no crashes. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
