### PR TITLE
Update CreatePoleFigureTable to take an axes transformation matrix and to select readout column

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
@@ -2,7 +2,14 @@
 import numpy as np
 from mantid.kernel import V3D
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, ITableWorkspaceProperty, PythonAlgorithm, PropertyMode
-from mantid.kernel import Direction, FloatBoundedValidator, FloatArrayProperty, FloatArrayLengthValidator
+from mantid.kernel import (
+    Direction,
+    FloatBoundedValidator,
+    FloatArrayProperty,
+    FloatArrayLengthValidator,
+    PropertyCriterion,
+    EnabledWhenProperty,
+)
 from mantid.geometry import ReflectionGenerator, CrystalStructure
 from typing import Optional
 
@@ -81,6 +88,12 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
             "This can be overridden by providing a flattened axes transform matrix, "
             "which transforms X and Z to the desired initial vectors",
         )
+        # disable properties which don't apply when there is no peak parameter workspace
+        self.setPropertySettings("ReadoutColumn", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
+        self.setPropertySettings("Chi2Threshold", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
+        self.setPropertySettings("PeakPositionThreshold", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
+        # disable properties which don't apply when there is no reflection
+        self.setPropertySettings("ApplyScatteringPowerCorrection", EnabledWhenProperty("Reflection", PropertyCriterion.IsNotDefault))
 
     def validateInputs(self):
         issues = dict()

--- a/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
@@ -96,12 +96,12 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         x0_thresh = self.getProperty("PeakPositionThreshold").value
         readout_column = self.getProperty("ReadoutColumn").value
         # if the chi2_threshold is set to allow all peaks, no chi2 column is needed
-        self.no_chi2_needed = chi2_thresh < 1e-6
+        self.no_chi2_needed = np.allclose(chi2_thresh, 0)
         # if the x0_threshold is set to allow all peaks, no x0 column is needed
-        self.no_x0_needed = x0_thresh < 1e-6
+        self.no_x0_needed = np.allclose(x0_thresh, 0)
 
         ax_trans = np.asarray(self.getProperty("AxesTransform").value).reshape((3, 3))
-        if np.abs(np.abs(np.linalg.det(ax_trans)) - 1) > 1e-6:
+        if np.allclose(np.abs(np.linalg.det(ax_trans)), 1):
             issues["AxesTransform"] = (
                 "Algorithm currently expects axes transforms to volume-preserving, as such the determinant must equal 1 (or -1)"
             )
@@ -117,13 +117,17 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
                 except RuntimeError:
                     issues["PeakParameterWorkspace"] = f"PeakParameterWorkspace must have column: '{col_name}'"
 
-            # if peak parameter ws is given, expect these columns
+            # if peak parameter ws is given, expect these columns:
+
+            # the specified readout column
             check_col(readout_column)
 
             if not self.no_x0_needed:
+                # x0, if needed
                 check_col("X0")
 
             if not self.no_chi2_needed:
+                # chi2, if needed
                 check_col("chi2")
 
         if not self.getProperty("Reflection").isDefault:

--- a/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
@@ -34,6 +34,12 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
             doc="Output workspace containing the table of alphas, betas and intensities.",
         )
         self.declareProperty(
+            "ReadoutColumn",
+            defaultValue="I",
+            direction=Direction.Input,
+            doc="The column from the Peak Parameter Workspace which should be used for populating the final column in the output table",
+        )
+        self.declareProperty(
             FloatArrayProperty("Reflection", [0, 0, 0], FloatArrayLengthValidator(3), direction=Direction.Input),
             doc="Reflection number for peak being fit. If given, algorithm will attempt to use the CrystalStructure on "
             "the InputWorkspace to adjust intensity for scattering power.",
@@ -66,6 +72,15 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
             FloatArrayProperty("ScatteringVolumePosition", [0.0, 0.0, 0.0], FloatArrayLengthValidator(3), direction=Direction.Input),
             doc="Position where the diffraction vectors should be calculated from, defaults as the origin",
         )
+        self.declareProperty(
+            FloatArrayProperty(
+                "AxesTransform", [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], FloatArrayLengthValidator(9), direction=Direction.Input
+            ),
+            doc="Algorithm assumes the initial orientation of the sample has the "
+            "two in plane axes of the pole figure aligned with X and Z of the laboratory frame. "
+            "This can be overridden by providing a flattened axes transform matrix, "
+            "which transforms X and Z to the desired initial vectors",
+        )
 
     def validateInputs(self):
         issues = dict()
@@ -79,10 +94,18 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         peak_ws = self.getProperty("PeakParameterWorkspace").value
         chi2_thresh = self.getProperty("Chi2Threshold").value
         x0_thresh = self.getProperty("PeakPositionThreshold").value
+        readout_column = self.getProperty("ReadoutColumn").value
         # if the chi2_threshold is set to allow all peaks, no chi2 column is needed
         self.no_chi2_needed = chi2_thresh < 1e-6
         # if the x0_threshold is set to allow all peaks, no x0 column is needed
         self.no_x0_needed = x0_thresh < 1e-6
+
+        ax_trans = np.asarray(self.getProperty("AxesTransform").value).reshape((3, 3))
+        if np.abs(np.abs(np.linalg.det(ax_trans)) - 1) > 1e-6:
+            issues["AxesTransform"] = (
+                "Algorithm currently expects axes transforms to volume-preserving, as such the determinant must equal 1 (or -1)"
+            )
+
         if peak_ws:
             # check num rows in table matches num spectra in ws
             if peak_ws.rowCount() != ws.getNumberHistograms():
@@ -95,7 +118,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
                     issues["PeakParameterWorkspace"] = f"PeakParameterWorkspace must have column: '{col_name}'"
 
             # if peak parameter ws is given, expect these columns
-            check_col("I")
+            check_col(readout_column)
 
             if not self.no_x0_needed:
                 check_col("X0")
@@ -119,12 +142,14 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         # get inputs
         ws = self.getProperty("InputWorkspace").value
         peak_param_ws = self.getProperty("PeakParameterWorkspace").value
+        readout_column = self.getProperty("ReadoutColumn").value
         hkl = self.getProperty("Reflection").value
         hkl_is_set = not self.getProperty("Reflection").isDefault
         chi_thresh = self.getProperty("Chi2Threshold").value
         x0_thresh = self.getProperty("PeakPositionThreshold").value
         apply_scatt_corr = self.getProperty("ApplyScatteringPowerCorrection").value
         sample_pos = np.asarray(self.getProperty("ScatteringVolumePosition").value)
+        ax_trans = np.asarray(self.getProperty("AxesTransform").value).reshape((3, 3))
 
         # generate a detector table to get detector positions
         det_table = self.exec_child_alg(
@@ -139,7 +164,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         qi = sample_pos - source_pos
 
         # get the rotation matrix of the sample
-        rot_mat = ws.run().getGoniometer().getR()
+        rot_mat = ws.run().getGoniometer().getR() @ ax_trans
 
         # matrix to put detectors in sample frame
         to_pole_view = np.linalg.inv(rot_mat)
@@ -167,7 +192,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
 
         if peak_param_ws:
             # assume that the peak_param_ws has only the peak of interest fitted
-            intensities = np.asarray(peak_param_ws.column("I"))
+            intensities = np.asarray(peak_param_ws.column(readout_column))
             use_default_intensity = False
             if not self.no_x0_needed:
                 x0s = np.asarray(peak_param_ws.column("X0"))
@@ -190,7 +215,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         table_ws = self.exec_child_alg("CreateEmptyTableWorkspace", OutputWorkspace="_tmp")
         table_ws.addColumn(type="double", name="Alpha", plottype=2)
         table_ws.addColumn(type="double", name="Beta", plottype=2)
-        table_ws.addColumn(type="double", name="Intensity", plottype=2)
+        table_ws.addColumn(type="double", name=readout_column, plottype=2)
 
         # check which spectra meet inclusion thresholds
         valid_spec_mask = self._thresh_criteria_mask(ab_arr.shape[0], chi_thresh, x0_thresh, chi2, x0s, peak)
@@ -199,7 +224,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
                 # amend intensity for any scattering correction
                 intensity = intensities[spec_index] / scat_power if not use_default_intensity else default_intensity
                 # add data to table
-                table_ws.addRow({"Alpha": ab_arr[spec_index, 0], "Beta": ab_arr[spec_index, 1], "Intensity": intensity})
+                table_ws.addRow({"Alpha": ab_arr[spec_index, 0], "Beta": ab_arr[spec_index, 1], readout_column: intensity})
 
         self.setProperty("OutputWorkspace", table_ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
@@ -101,7 +101,7 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
         self.no_x0_needed = np.allclose(x0_thresh, 0)
 
         ax_trans = np.asarray(self.getProperty("AxesTransform").value).reshape((3, 3))
-        if np.allclose(np.abs(np.linalg.det(ax_trans)), 1):
+        if not np.allclose(np.abs(np.linalg.det(ax_trans)), 1):
             issues["AxesTransform"] = (
                 "Algorithm currently expects axes transforms to volume-preserving, as such the determinant must equal 1 (or -1)"
             )

--- a/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreatePoleFigureTableWorkspace.py
@@ -89,9 +89,9 @@ class CreatePoleFigureTableWorkspace(PythonAlgorithm):
             "which transforms X and Z to the desired initial vectors",
         )
         # disable properties which don't apply when there is no peak parameter workspace
-        self.setPropertySettings("ReadoutColumn", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
-        self.setPropertySettings("Chi2Threshold", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
-        self.setPropertySettings("PeakPositionThreshold", EnabledWhenProperty("PeaksParameterWorkspace", PropertyCriterion.IsNotDefault))
+        self.setPropertySettings("ReadoutColumn", EnabledWhenProperty("PeakParameterWorkspace", PropertyCriterion.IsNotDefault))
+        self.setPropertySettings("Chi2Threshold", EnabledWhenProperty("PeakParameterWorkspace", PropertyCriterion.IsNotDefault))
+        self.setPropertySettings("PeakPositionThreshold", EnabledWhenProperty("PeakParameterWorkspace", PropertyCriterion.IsNotDefault))
         # disable properties which don't apply when there is no reflection
         self.setPropertySettings("ApplyScatteringPowerCorrection", EnabledWhenProperty("Reflection", PropertyCriterion.IsNotDefault))
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
@@ -65,6 +65,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             val = 1.0 + (i / 10)
             peak_param_table.addRow([val, 3.14 + (i / 100), i])  # 3.14 hkl (1,1,1) dSpacing
 
+        self.default_alphas = np.deg2rad(np.array((-42.5, -45, -47.5, -54.74)))
+        self.default_betas = np.deg2rad(np.array((90, 90, 90, 60)))
+
     def tearDown(self):
         AnalysisDataService.clear()
 
@@ -94,11 +97,11 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # det 1 along X axis, det 0 is 5 degrees towards +Z
         # det 1 Q is at -45 degrees from X axis (it points towards -Z)
         # det 0 Q is at -42.5 degrees
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2])
 
         # beta
         # both det 0 and det 1 are in plane, beta = 90 degrees from Y
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
@@ -113,10 +116,10 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((42.5, 45))))
+        self.eval_arrays(outws.column("Alpha"), -self.default_alphas[:2])
 
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
@@ -131,10 +134,10 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-137.5, -135))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2] - 90)
 
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
@@ -149,10 +152,28 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2])
 
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
+
+        # intensity
+        # det 0 has 1.0, det 1 has 1.1
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_providing_identity_does_nothing(self):
+        # negative normal directions are always inverted so expect the same result
+        ax_transform = np.array(((1, 0, 0), (0, 1, 0), (0, 0, 1))).reshape(-1)
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", AxesTransform=ax_transform
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2])
+
+        # beta
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
@@ -169,10 +190,10 @@ class CreatePoleFigureTableTest(unittest.TestCase):
 
         # alpha
         print(outws.column("Alpha"))
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((2.5, 0))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2] + 45)
 
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
@@ -188,11 +209,11 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # det 1 along X axis, det 0 is 5 degrees towards +Z
         # det 1 Q is at -45 degrees from X axis (it points towards -Z)
         # det 0 Q is at -42.5 degrees
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2])
 
         # beta
         # both det 0 and det 1 are in plane, beta = 90 degrees from Y
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
 
         # final column should be chi2
         # det 0 has 0, det 1 has 1
@@ -209,9 +230,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # det 1 along X axis, det 0 is 5 degrees towards +Z
         # det 1 Q is at -45 degrees from X axis (it points towards -Z)
         # det 0 Q is at -42.5 degrees
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((2.5, 0, -2.5, -9.74))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas + 45)
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity
         self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
@@ -224,9 +245,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # alpha
         # det 0 Q is (1/sqrt2,0,1/sqrt2) but det 3 Q is (0.5,0.5,1/sqrt2)
         # det 3 alpha is -54.74 degs
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45, -47.5, -54.74))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas)
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity
         self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
@@ -244,9 +265,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # alpha
         # det 0 Q is (1/sqrt2,0,1/sqrt2) but det 3 Q is (0.5,0.5,1/sqrt2)
         # det 3 alpha is -54.74 degs
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45, -47.5, -54.74))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas)
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity
         scat_power = 13.58
         self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)) / scat_power)
@@ -263,9 +284,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 1)  # only det 0 should be within range
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5,))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:1])
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:1])
         # intensity
         scat_power = 13.58
         self.eval_arrays(outws.column("I"), np.array((1.0,)) / scat_power)
@@ -283,9 +304,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 1)  # only det 0 should be within range
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5,))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:1])
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:1])
         # intensity
         self.eval_arrays(outws.column("I"), np.array((1.0,)))
 
@@ -301,9 +322,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 1)  # det 0 and 1 should be in pos thresh but only det 0 in chi2 thresh
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5,))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:1])
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[:1])
         # intensity
         scat_power = 13.58
         self.eval_arrays(outws.column("I"), np.array((1.0,)) / scat_power)
@@ -319,19 +340,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 2)  # x0s are [3.14, 3.15, 3.16, 3.17] mean is 3.155
 
         # alpha
-        self.eval_arrays(
-            outws.column("Alpha"),
-            np.deg2rad(
-                np.array(
-                    (
-                        -45,
-                        -47.5,
-                    )
-                )
-            ),
-        )
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[1:3])
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas[1:3])
         # intensity
         self.eval_arrays(outws.column("I"), np.array((1.1, 1.2)))
 
@@ -340,9 +351,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             InputWorkspace="ws", OutputWorkspace="outws", Reflection=(1, 1, 1), ApplyScatteringPowerCorrection=True
         )
         self.assertEqual(outws.rowCount(), 4)
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45, -47.5, -54.74))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas)
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity should not be corrected for scattering power even though flag is true (as it is by default)
         self.eval_arrays(outws.column("I"), np.array((1.0, 1.0, 1.0, 1.0)))
 
@@ -421,9 +432,9 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # alpha
         # det 0 Q is (1/sqrt2,0,1/sqrt2) but det 3 Q is (0.5,0.5,1/sqrt2)
         # det 3 alpha is -54.74 degs
-        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45, -47.5, -54.74))))
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas)
         # beta
-        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
+        self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity
         self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
@@ -134,7 +134,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
 
         # alpha
-        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2] - 90)
+        self.eval_arrays(outws.column("Alpha"), -(self.default_alphas[:2] + np.pi))
 
         # beta
         self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
@@ -190,7 +190,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
 
         # alpha
         print(outws.column("Alpha"))
-        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2] + 45)
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas[:2] + (np.pi / 4))
 
         # beta
         self.eval_arrays(outws.column("Beta"), self.default_betas[:2])
@@ -230,7 +230,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # det 1 along X axis, det 0 is 5 degrees towards +Z
         # det 1 Q is at -45 degrees from X axis (it points towards -Z)
         # det 0 Q is at -42.5 degrees
-        self.eval_arrays(outws.column("Alpha"), self.default_alphas + 45)
+        self.eval_arrays(outws.column("Alpha"), self.default_alphas + (np.pi / 4))
         # beta
         self.eval_arrays(outws.column("Beta"), self.default_betas)
         # intensity

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
@@ -71,7 +71,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
     def eval_arrays(self, arr1, arr2, thresh=0.005):
         self.assertTrue(np.all(np.abs(arr1 - arr2) < thresh))
 
-    def setup_missing_column(self, column_name):
+    def setup_missing_column(self, column_name, readout="I"):
         # override PeakParameter Table
         peak_param_table = AnalysisDataService.retrieve("PeakParameterWS")
         peak_param_table.removeColumn(column_name)
@@ -81,6 +81,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         alg.setProperty("InputWorkspace", AnalysisDataService.retrieve("ws"))
         alg.setProperty("PeakParameterWorkspace", peak_param_table)
         alg.setProperty("OutputWorkspace", "outws")
+        alg.setProperty("ReadoutColumn", readout)
         issues = alg.validateInputs()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["PeakParameterWorkspace"], f"PeakParameterWorkspace must have column: '{column_name}'")
@@ -101,7 +102,101 @@ class CreatePoleFigureTableTest(unittest.TestCase):
 
         # intensity
         # det 0 has 1.0, det 1 has 1.1
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_flipping_td_negates_alphas(self):
+        # alpha is taken from rd, if td is inverted the q vectors are now at -alpha rather than alpha
+        ax_transform = np.array(((1, 0, 0), (0, 1, 0), (0, 0, -1))).reshape(-1)
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", AxesTransform=ax_transform
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((42.5, 45))))
+
+        # beta
+        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+
+        # intensity
+        # det 0 has 1.0, det 1 has 1.1
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_flipping_rd_adds_pi_to_alphas(self):
+        # alpha is taken from rd, if rd is inverted the q vectors are now at alpha +/- pi rather than alpha
+        ax_transform = np.array(((-1, 0, 0), (0, 1, 0), (0, 0, 1))).reshape(-1)
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", AxesTransform=ax_transform
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-137.5, -135))))
+
+        # beta
+        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+
+        # intensity
+        # det 0 has 1.0, det 1 has 1.1
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_flipping_nd_does_nothing(self):
+        # negative normal directions are always inverted so expect the same result
+        ax_transform = np.array(((1, 0, 0), (0, -1, 0), (0, 0, 1))).reshape(-1)
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", AxesTransform=ax_transform
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45))))
+
+        # beta
+        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+
+        # intensity
+        # det 0 has 1.0, det 1 has 1.1
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_rotating_rd_and_td_pi_by_4_about_nd_adds_pi_by_4_to_alphas(self):
+        # alpha is taken from rd, if rd and td are rotated pi/4 about nd, the Q vectors are rotated pi/4 relative to rd
+        ir2 = 1 / np.sqrt(2)
+        ax_transform = np.array(((ir2, 0, ir2), (0, 1, 0), (-ir2, 0, ir2))).reshape(-1)
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", AxesTransform=ax_transform
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        print(outws.column("Alpha"))
+        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((2.5, 0))))
+
+        # beta
+        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+
+        # intensity
+        # det 0 has 1.0, det 1 has 1.1
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1)))
+
+    def test_alg_with_different_readout_column(self):
+        outws = CreatePoleFigureTableWorkspace(
+            InputWorkspace="ws", PeakParameterWorkspace="PeakParameterWS", OutputWorkspace="outws", ReadoutColumn="chi2"
+        )
+        self.assertEqual(outws.rowCount(), 2)  # default args should have only chi2 < 2 (det 0 and det 1)
+
+        # alpha
+        # det 1 along X axis, det 0 is 5 degrees towards +Z
+        # det 1 Q is at -45 degrees from X axis (it points towards -Z)
+        # det 0 Q is at -42.5 degrees
+        self.eval_arrays(outws.column("Alpha"), np.deg2rad(np.array((-42.5, -45))))
+
+        # beta
+        # both det 0 and det 1 are in plane, beta = 90 degrees from Y
+        self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
+
+        # final column should be chi2
+        # det 0 has 0, det 1 has 1
+        self.eval_arrays(outws.column("chi2"), np.array((0.0, 1.0)))
 
     def test_alg_with_goniometer_applied(self):
         # ws 2 is rotated 45 degrees away from +Z
@@ -118,7 +213,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1, 1.2, 1.3)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
     def test_alg_with_chi_thresh(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -133,7 +228,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1, 1.2, 1.3)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
     def test_alg_with_hkl(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -154,7 +249,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
         # intensity
         scat_power = 13.58
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1, 1.2, 1.3)) / scat_power)
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)) / scat_power)
 
     def test_alg_with_hkl_and_pos_thresh(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -173,7 +268,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
         # intensity
         scat_power = 13.58
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0,)) / scat_power)
+        self.eval_arrays(outws.column("I"), np.array((1.0,)) / scat_power)
 
     def test_alg_with_hkl_and_pos_thresh_not_adjust_for_scatt_power_if_flag_false(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -192,7 +287,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0,)))
+        self.eval_arrays(outws.column("I"), np.array((1.0,)))
 
     def test_alg_with_hkl_and_pos_thresh_and_chi_thresh(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -211,7 +306,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90,))))
         # intensity
         scat_power = 13.58
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0,)) / scat_power)
+        self.eval_arrays(outws.column("I"), np.array((1.0,)) / scat_power)
 
     def test_alg_with_no_hkl_that_pos_thresh_applied_from_mean_x0(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -238,7 +333,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.1, 1.2)))
+        self.eval_arrays(outws.column("I"), np.array((1.1, 1.2)))
 
     def test_if_no_peak_param_table_default_intensity_used(self):
         outws = CreatePoleFigureTableWorkspace(
@@ -249,7 +344,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
         # intensity should not be corrected for scattering power even though flag is true (as it is by default)
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.0, 1.0, 1.0)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.0, 1.0, 1.0)))
 
     def test_chi2_not_required_if_threshold_is_set_to_zero(self):
         peak_param_table = AnalysisDataService.retrieve("PeakParameterWS")
@@ -330,7 +425,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 60))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1, 1.2, 1.3)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
     def test_offset_shape_fully_illuminated(self):
         sample_offset = [0.075, 0.0, 0.0]
@@ -354,7 +449,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         # beta
         self.eval_arrays(outws.column("Beta"), np.deg2rad(np.array((90, 90, 90, 59.13))))
         # intensity
-        self.eval_arrays(outws.column("Intensity"), np.array((1.0, 1.1, 1.2, 1.3)))
+        self.eval_arrays(outws.column("I"), np.array((1.0, 1.1, 1.2, 1.3)))
 
     # failure cases
     def test_error_if_num_spectra_does_not_match_param_ws_rows(self):
@@ -374,8 +469,8 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             issues["PeakParameterWorkspace"], "PeakParameterWorkspace must have same number of rows as Input Workspace has spectra"
         )
 
-    def test_error_if_no_intensity_on_peak_parameter_workspace(self):
-        self.setup_missing_column("I")
+    def test_error_if_no_intensity_on_peak_parameter_workspace_and_that_is_readout(self):
+        self.setup_missing_column("I", "I")
 
     def test_error_if_no_x0_on_peak_parameter_workspace(self):
         self.setup_missing_column("X0")
@@ -417,6 +512,20 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         issues = alg.validateInputs()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "If reflection is specified: InputWorkspace sample must have a CrystalStructure")
+
+    def test_error_if_bad_transform_matrix_given(self):
+        alg = _init_alg(
+            InputWorkspace=AnalysisDataService.retrieve("ws"),
+            PeakParameterWorkspace=AnalysisDataService.retrieve("PeakParameterWS"),
+            OutputWorkspace="outws",
+            AxesTransform=np.ones(9),
+        )
+        issues = alg.validateInputs()
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(
+            issues["AxesTransform"],
+            "Algorithm currently expects axes transforms to volume-preserving, as such the determinant must equal 1 (or -1)",
+        )
 
     def test_error_if_hkl_cannot_be_parsed(self):
         alg = _init_alg(


### PR DESCRIPTION
### Description of work

#### Summary of work
Two minor changes to create pole figure algorithm, the alg can now take a flattened 3x3 axes transform matrix as an argument and the column of the parameter table that gets added to the final table can now be specified

#### Purpose of work
After discussion with the project stake holders these are two features that they really wanted.
The first allows the sample to be set in the lab frame with an alternative initial orientation to having the RD along X and the TD along Z.
The second allows creation of alternative pole figures showing, for example, strain (by plotting X0 rather than I)

### To test:

You can edit the following script to change the ax_trans or readout column and the change should be reflected correctly in the table

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid.geometry import CrystalStructure
from scipy.spatial.transform import Rotation

# create a workspace
ws = CreateWorkspace(
    DataX=[0., 1.],
    DataY=[1., 2., 3.,4.],
    NSpec=4)


# set the instrument to have a detector at 2theta
EditInstrumentGeometry(Workspace='ws', 
                       PrimaryFlightPath = 50, L2=[50,50,50,50], Polar=[85, 90, 95, 90],
                       Azimuthal= [0,0,0,45], DetectorIDs = [0,1,2,3])
                   
# set a crystal structure    
xtal = CrystalStructure("5.431 5.431 5.431", "F d -3 m", "Si 0 0 0 1.0 0.05")

# declare a reflection of interest
hkl = "(1,1,1)"

# define a sample shape
sample_shape = f"""
<cylinder id="A">
  <centre-of-bottom-base x="0" y="0" z="0.05" />
  <axis x="0" y="0" z="-1" />
  <radius val="0.1" />
  <height val="0.1" />
</cylinder>
"""

# apply a generic rotation, set the sample and crystal structure
SetGoniometer("ws", Axis0="45,0,1,0,1")
SetSample('ws', Geometry={'Shape': 'CSG', 'Value': sample_shape})
ws.sample().setCrystalStructure(xtal)

# Create an example PeakParameter Table
peak_param_table = CreateEmptyTableWorkspace(OutputWorkspace = "PeakParameterWS")
for col in ("I", "X0", "chi2"):
    peak_param_table.addColumn("double", col)
for i in range(4):
    val = 1.0 + (i / 10)
    peak_param_table.addRow([val, 3.14+(i/100), i]) # 3.14 hkl (1,1,1) dSpacing

# create axes transform

ax_trans = Rotation.from_euler("Y", [0], degrees = True).as_matrix().reshape(-1) # still identity
    
    
# run alg
CreatePoleFigureTableWorkspace(InputWorkspace = "ws", 
                                       PeakParameterWorkspace = "PeakParameterWS", 
                                       OutputWorkspace = "outWS",
                                       PeakPositionThreshold = 0.0,
                                       Chi2Threshold = 0.0,
                                       ReadoutColumn = "I",
                                       AxesTransform = ax_trans)
```
*This does not require release notes* because **the algorithm is not yet in a release of mantid so the initial PR release notes should be fine**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
