### PR TITLE
Apply Polarized Properties in ISIS SANS User File V2 to Reduction Workspaces for Saving

### DIFF
--- a/docs/source/release/v6.13.0/SANS/New_features/38525.rst
+++ b/docs/source/release/v6.13.0/SANS/New_features/38525.rst
@@ -1,0 +1,3 @@
+- ISIS SANS Batch Reductions (such as those performed by ``WavRangeReduction`` from the
+  :ref:`ISIS Command Interface <ScriptingSANSReductions>`) can now make use of polarization
+  properties defined in the V2 User File to save using :ref:`algm-SavePolarizedNXcanSAS`.

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1731,6 +1731,8 @@ def save_workspace_to_file(
         save_options.update({"CanSAS": True})
     if SaveType.NX_CAN_SAS in file_formats:
         save_options.update({"NXcanSAS": True})
+    if SaveType.POL_NX_CAN_SAS in file_formats:
+        save_options.update({"PolarizedNXcanSAS": True})
     if SaveType.NIST_QXY in file_formats:
         save_options.update({"NistQxy": True})
     if SaveType.RKH in file_formats:

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1411,9 +1411,9 @@ def _add_polarization_metadata_if_relevant(polarization_state, metadata: dict[st
     pol_props = {}
     if polarization_state.spin_configuration:
         pol_props["InputSpinStates"] = str(polarization_state.spin_configuration)
-    if polarization_state.polarizer is not None and polarization_state.polarizer.idf_component_name:
+    if polarization_state.polarizer is not None:
         pol_props["PolarizerComponentName"] = str(polarization_state.polarizer.idf_component_name)
-    if polarization_state.analyzer is not None and polarization_state.analyzer.idf_component_name:
+    if polarization_state.analyzer is not None:
         pol_props["AnalyzerComponentName"] = str(polarization_state.analyzer.idf_component_name)
     flipper_component_names = []
     for flipper in polarization_state.flippers:
@@ -1450,6 +1450,17 @@ def _apply_polarization_component_adjustments(polarization_state, ws):
                 alg.execute()
 
     def _move_pol_component(location_x, location_y, location_z, idf_pos, idf_name):
+        """
+        The position of polarizers, analyzers and flippers in polarized experiments can be moved
+        on an experiment to experiment basis. This means their position may be defined in the
+        user file rather than constantly updating the IDF. This methods performs that move to match
+        the user file for the supplied component.
+        :param location_x: The new X location.
+        :param location_y: The new Y location.
+        :param location_z: The new Z location.
+        :param idf_pos: The old component position from the workspace's Instrument object.
+        :param idf_name: The name defined in the IDF of the component to move.
+        """
         location = {
             CanonicalCoordinates.X: location_x if location_x is not None else idf_pos.getX(),
             CanonicalCoordinates.Y: location_y if location_y is not None else idf_pos.getY(),
@@ -1475,9 +1486,9 @@ def _apply_polarization_component_adjustments(polarization_state, ws):
             parameter_map["gas_pressure"] = component_state.gas_pressure
         _update_component_parameters(idf_name, parameter_map)
 
-    if polarization_state.polarizer.idf_component_name:
+    if polarization_state.polarizer:
         _update_component_properties(polarization_state.polarizer)
-    if polarization_state.analyzer.idf_component_name:
+    if polarization_state.analyzer:
         _update_component_properties(polarization_state.analyzer)
     for flipper in polarization_state.flippers:
         _update_component_properties(flipper)

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1373,7 +1373,14 @@ def _add_scaled_background_metadata_if_relevant(bg_state, ws_name: str, metadata
 def _move_polarization_components(polarization_state, ws_name: str):
     def _move_component(component_state):
         idf_name = component_state.idf_component_name
-        idf_pos = ws.getInstrument().getComponentByName(idf_name).getPos()
+        component = ws.getInstrument().getComponentByName(idf_name)
+        if component is None:
+            raise AttributeError(
+                f'The name "{idf_name}" is not present in the Instrument Definition File for {ws.getInstrument().getName()}. '
+                f'Please ensure any "idf_component_name" fields in the User File match an existing entry in the IDF for the '
+                f"component you wish to override."
+            )
+        idf_pos = component.getPos()
         location = {
             CanonicalCoordinates.X: component_state.location_x if component_state.location_x is not None else idf_pos.getX(),
             CanonicalCoordinates.Y: component_state.location_y if component_state.location_y is not None else idf_pos.getY(),

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -534,6 +534,8 @@ def set_save(
                     save_algs.append(SaveType.CSV)
                 case "SaveNXcanSAS":
                     save_algs.append(SaveType.NX_CAN_SAS)
+                case "SavePolarizedNXcanSAS":
+                    save_algs.append(SaveType.POL_NX_CAN_SAS)
                 case _:
                     raise RuntimeError(f"The save format {key} is not known")
 

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
@@ -53,10 +53,10 @@ class TomlV2ParserImpl(TomlV1ParserImpl):
         self.polarization.electric_field = self._parse_field(self.get_val("electric_field", polarization_dict))
         self.polarization.validate()
 
-    def _parse_component(self, component_dict: dict) -> StateComponent:
-        component_state = StateComponent()
+    def _parse_component(self, component_dict: dict) -> StateComponent | None:
         if component_dict is None:
-            return component_state
+            return None
+        component_state = StateComponent()
         component_state.idf_component_name = self.get_val("idf_component_name", component_dict)
         component_state.device_name = self.get_val("device_name", component_dict)
         component_state.device_type = self.get_val("device_type", component_dict)
@@ -69,9 +69,9 @@ class TomlV2ParserImpl(TomlV1ParserImpl):
         component_state.efficiency = self.get_val("efficiency", component_dict)
         return component_state
 
-    def _parse_filter(self, filter_dict: dict) -> StateFilter:
+    def _parse_filter(self, filter_dict: dict) -> StateFilter | None:
         if filter_dict is None:
-            return StateFilter()
+            return None
         filter_state = StateFilter.construct_from_component(self._parse_component(filter_dict))
         filter_state.cell_length = self.get_val("cell_length", filter_dict)
         filter_state.gas_pressure = self.get_val("gas_pressure", filter_dict)
@@ -79,10 +79,10 @@ class TomlV2ParserImpl(TomlV1ParserImpl):
         filter_state.initial_polarization = self.get_val("initial_polarization", filter_dict)
         return filter_state
 
-    def _parse_field(self, field_dict: dict) -> StateField:
+    def _parse_field(self, field_dict: dict) -> StateField | None:
         field_state = StateField()
         if field_dict is None:
-            return field_state
+            return None
         field_state.sample_strength_log = self.get_val("sample_strength_log", field_dict)
         direction_dict = self.get_val("sample_direction", field_dict)
         if direction_dict:

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -1065,8 +1065,7 @@ class ParsedDictConverter(IStateParser):
         return state
 
     def get_state_polarization(self) -> StatePolarization:
-        # The polarization settings are not supported for the legacy txt user file format. Return a blank object.
-        return StatePolarization()
+        return self._all_states.polarization if self._all_states else StatePolarization()
 
     def _set_single_entry(self, state_obj, attr_name, tag, apply_to_value=None):
         """

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -521,7 +521,15 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         filename = "fileName"
         additional_run_numbers = {}
         additional_metadata = {}
-        file_types = [SaveType.NEXUS, SaveType.CAN_SAS, SaveType.NX_CAN_SAS, SaveType.NIST_QXY, SaveType.RKH, SaveType.CSV]
+        file_types = [
+            SaveType.NEXUS,
+            SaveType.CAN_SAS,
+            SaveType.NX_CAN_SAS,
+            SaveType.POL_NX_CAN_SAS,
+            SaveType.NIST_QXY,
+            SaveType.RKH,
+            SaveType.CSV,
+        ]
 
         save_workspace_to_file(ws_name, file_types, filename, additional_run_numbers, additional_metadata)
 
@@ -533,6 +541,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             "Nexus": True,
             "CanSAS": True,
             "NXcanSAS": True,
+            "PolarizedNXcanSAS": True,
             "NistQxy": True,
             "RKH": True,
             "CSV": True,

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -151,12 +151,14 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_polarizer.device_type = "He3"
         mock_polarizer.cell_length = 0.3
         mock_polarizer.gas_pressure = 5
+        mock_analyzer = mock.MagicMock()
+        mock_analyzer.idf_component_name = None
         mock_mag_field = mock.MagicMock()
         mock_mag_field.sample_strength_log = "str_log_name"
         mock_mag_field.sample_direction_log = "dir_log_name"
         mock_mag_field.sample_direction_a = None
         mock_polarization_state.polarizer = mock_polarizer
-        mock_polarization_state.analyzer = None
+        mock_polarization_state.analyzer = mock_analyzer
         mock_polarization_state.flippers = []
         mock_polarization_state.magnetic_field = mock_mag_field
         mock_ws = mock.MagicMock()
@@ -395,17 +397,17 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         )
 
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService")
-    @mock.patch("sans.algorithm_detail.batch_execution.save_workspace_to_file")
+    @mock.patch("sans.algorithm_detail.batch_execution.save_group_to_file")
     @mock.patch("sans.algorithm_detail.batch_execution.get_all_names_to_save")
-    @mock.patch("sans.algorithm_detail.batch_execution._add_polarization_metadata_if_relevant")
-    def test_save_to_file_applies_polarization_metadata(self, mock_pol_meta, mock_names_func, _, mock_ads):
+    def test_save_to_file_uses_save_by_group_for_pol_nx_can_sas(self, mock_names_func, mock_save_group, mock_ads):
         reduction_package, _ = self._create_saving_reduction_package()
+        reduction_package.state.save.file_format = [SaveType.POL_NX_CAN_SAS]
         mock_names_func.return_value = ["polarization_ws"]
         mock_ws = mock.MagicMock()
         mock_ads.retrieve.return_value = mock_ws
 
         save_to_file([reduction_package], False, {}, {})
-        self.assertEqual(mock_pol_meta.call_count, 1)
+        self.assertEqual(mock_save_group.call_count, 1)
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     @mock.patch("sans.algorithm_detail.batch_execution.move_component")

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -151,14 +151,12 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_polarizer.device_type = "He3"
         mock_polarizer.cell_length = 0.3
         mock_polarizer.gas_pressure = 5
-        mock_analyzer = mock.MagicMock()
-        mock_analyzer.idf_component_name = None
         mock_mag_field = mock.MagicMock()
         mock_mag_field.sample_strength_log = "str_log_name"
         mock_mag_field.sample_direction_log = "dir_log_name"
         mock_mag_field.sample_direction_a = None
         mock_polarization_state.polarizer = mock_polarizer
-        mock_polarization_state.analyzer = mock_analyzer
+        mock_polarization_state.analyzer = None
         mock_polarization_state.flippers = []
         mock_polarization_state.magnetic_field = mock_mag_field
         mock_ws = mock.MagicMock()

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -23,7 +23,7 @@ from sans.algorithm_detail.batch_execution import (
     check_for_background_workspace_in_ads,
     group_bgsub_if_required,
     save_to_file,
-    _move_polarization_components,
+    _apply_polarization_component_adjustments,
 )
 from sans.common.enums import SaveType, ReductionMode
 from sans.common.constants import SCALED_BGSUB_SUFFIX
@@ -146,6 +146,9 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_polarizer.location_x = 1.2
         mock_polarizer.location_y = 3.4
         mock_polarizer.location_z = 5.6
+        mock_polarizer.device_type = "He3"
+        mock_polarizer.cell_length = 0.3
+        mock_polarizer.gas_pressure = 5
         mock_polarization_state.polarizer = mock_polarizer
         mock_polarization_state.analyzer = None
         mock_polarization_state.flippers = []
@@ -356,7 +359,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         }
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
-    @mock.patch("sans.algorithm_detail.batch_execution._move_polarization_components")
+    @mock.patch("sans.algorithm_detail.batch_execution._apply_polarization_component_adjustments")
     @mock.patch("sans.algorithm_detail.batch_execution.get_all_names_to_save")
     @mock.patch("sans.algorithm_detail.batch_execution.save_workspace_to_file")
     def test_that_non_subtracted_save_to_file_does_not_include_metadata_in_options(self, mock_save_func, mock_names_func, _):
@@ -366,7 +369,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         save_to_file([reduction_package], False, {}, {})
         mock_save_func.assert_called_with("unsubbed_ws", file_formats_mock, "unsubbed_ws", {}, {})
 
-    @mock.patch("sans.algorithm_detail.batch_execution._move_polarization_components")
+    @mock.patch("sans.algorithm_detail.batch_execution._apply_polarization_component_adjustments")
     @mock.patch("sans.algorithm_detail.batch_execution.get_all_names_to_save")
     @mock.patch("sans.algorithm_detail.batch_execution.save_workspace_to_file")
     def test_that_subtracted_save_to_file_includes_metadata_in_options(self, mock_save_func, mock_names_func, _):
@@ -385,7 +388,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService")
     @mock.patch("sans.algorithm_detail.batch_execution.save_workspace_to_file")
     @mock.patch("sans.algorithm_detail.batch_execution.get_all_names_to_save")
-    @mock.patch("sans.algorithm_detail.batch_execution._move_polarization_components")
+    @mock.patch("sans.algorithm_detail.batch_execution._apply_polarization_component_adjustments")
     def test_save_to_file_moves_polarization_components(self, move_mock, mock_names_func, _, mock_ads):
         reduction_package, _ = self._create_saving_reduction_package()
         mock_names_func.return_value = ["polarization_ws"]
@@ -395,13 +398,14 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         save_to_file([reduction_package], False, {}, {})
         self.assertEqual(move_mock.call_count, 1)
 
+    @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     @mock.patch("sans.algorithm_detail.batch_execution.move_component")
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService")
-    def test_move_polarization_components_uses_state_first(self, mock_ads, mock_move):
+    def test_apply_polarization_component_adjustments_uses_state_first(self, mock_ads, mock_move, mock_alg_manager):
         mock_polarization_state, mock_ws = self._create_move_objects()
         mock_ads.retrieve.return_value = mock_ws
 
-        _move_polarization_components(mock_polarization_state, "mock_ws_name")
+        _apply_polarization_component_adjustments(mock_polarization_state, "mock_ws_name")
         self.assertEqual(mock_move.call_count, 1)
         mock_move.assert_called_with(mock_ws, mock.ANY, "mocked_polarizer", False)
         # For some reason assert_called_with doesn't like doing the dict comparison, so do it ourselves.
@@ -409,24 +413,43 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             set(mock_move.call_args.args[1].values()),
             set({CanonicalCoordinates.X: 1.2, CanonicalCoordinates.Y: 3.4, CanonicalCoordinates.Z: 5.6}.values()),
         )
+        mock_alg_manager.assert_called_with(
+            "SetInstrumentParameter",
+            Workspace=mock_ws,
+            ComponentName="mocked_polarizer",
+            ParameterName="gas_pressure",
+            ParameterType="Number",
+            Value=5,
+        )
 
+    @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     @mock.patch("sans.algorithm_detail.batch_execution.move_component")
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService")
-    def test_move_polarization_components_uses_idf_if_state_not_present(self, mock_ads, mock_move):
+    def test_apply_polarization_component_adjustments_uses_idf_if_state_not_present(self, mock_ads, mock_move, mock_alg_manager):
         mock_polarization_state, mock_ws = self._create_move_objects()
         mock_ads.retrieve.return_value = mock_ws
         mock_polarization_state.polarizer.location_x = None
         mock_polarization_state.polarizer.location_z = None
+        mock_polarization_state.polarizer.gas_pressure = None
+        mock_polarization_state.polarizer.cell_length = None
         mock_ws.getInstrument.return_value.getComponentByName.return_value.getPos.return_value.getX = mock.Mock(return_value=9.8)
         mock_ws.getInstrument.return_value.getComponentByName.return_value.getPos.return_value.getY = mock.Mock(return_value=7.6)
         mock_ws.getInstrument.return_value.getComponentByName.return_value.getPos.return_value.getZ = mock.Mock(return_value=5.4)
         mock_ads.retrieve.return_value = mock_ws
 
-        _move_polarization_components(mock_polarization_state, "mock_ws_name")
+        _apply_polarization_component_adjustments(mock_polarization_state, "mock_ws_name")
         mock_move.assert_any_call(mock_ws, mock.ANY, "mocked_polarizer", False)
         self.assertEqual(
             set(mock_move.call_args.args[1].values()),
             set({CanonicalCoordinates.X: 9.8, CanonicalCoordinates.Y: 3.4, CanonicalCoordinates.Z: 5.4}.values()),
+        )
+        mock_alg_manager.assert_called_with(
+            "SetInstrumentParameter",
+            Workspace=mock_ws,
+            ComponentName="mocked_polarizer",
+            ParameterName="device_type",
+            ParameterType="String",
+            Value="He3",
         )
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")


### PR DESCRIPTION
### Description of work

#### Summary of work
Make the connection between the changes made with the introduction of SANS TOML V2 and SavePolarizedNXcanSAS. Ensure metadata provided by the new polarisation-supporting user files is correctly applied to output workspaces and to the algorithm directly. 

Fixes #38525

#### Further detail of work

Adds a new branch to the saving process in the SANS reduction: 

- Checks if the user intends to save using SavePolarizedNXcanSAS (implying a polarised experiment)
- Adjusts the position and parameters of the polarisation components defined in the IDF according to entries in the user/mask file. 
- Collates any additional polarisation-related metadata defined in the user file into `additional_metadata`. 
- Selects the group workspace that should be saved from the set of reduction packages (of which there would normally be one package per workspace within a group for a given run)
- Passes this group workspace and metadata to SavePolarizedNXcanSAS 
- Resumes the normal saving process as before. 

### To test:
1. Contact me for required files. Put them somewhere accessible through the Mantid User Directories. 
2. Set your default save location somewhere sensible.
3. Run this script
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from sans.command_interface.ISISCommandInterface import *

ZOOM()
MaskFile('USER_ZOOM_Su_8m_3Dmagnet_245H_large_BEAMSTOP.toml')

AssignSample('22717')
WavRangeReduction(2.2, 10, saveAlgs={'SavePolarizedNXcanSAS': 'nxs'}, combineDet='rear')
```
4. Use an HDF viewer (https://myhdf5.hdfgroup.org/) to check the outputted file contains the metadata defined in the user file (for instance, the provided file should have `rotation_angle`, `azimuthal_angle`, and polar_angle` under `sassample`). 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
