### PR TITLE
Goniometer can't be set by a rotation matrix with small numerical inaccuracy

### DIFF
--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -65,14 +65,14 @@ Goniometer::Goniometer() : R(3, 3, true), initFromR(false) {}
 /// @param rot :: DblMatrix matrix that is going to be the internal rotation
 /// matrix of the goniometer. Cannot push additional axes
 Goniometer::Goniometer(const DblMatrix &rot) {
-  DblMatrix ide(3, 3), rtr(3, 3);
-  rtr = rot.Tprime() * rot;
-  ide.identityMatrix();
-  if (rtr == ide) {
+  bool isRot = rot.isRotation(); // this can also throw if matrix is invalid rotation, but that is fine
+  if (!isRot) {
+    // constructor should fail if the matrix is invalid
+    throw std::invalid_argument("rot has not been evaluated to be a valid rotation matrix");
+  } else {
     R = rot;
     initFromR = true;
-  } else
-    throw std::invalid_argument("rot is not a rotation matrix");
+  }
 }
 
 /// Add an explicit copy constructor

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -69,10 +69,9 @@ Goniometer::Goniometer(const DblMatrix &rot) {
   if (!isRot) {
     // constructor should fail if the matrix is invalid
     throw std::invalid_argument("rot has not been evaluated to be a valid rotation matrix");
-  } else {
-    R = rot;
-    initFromR = true;
   }
+  R = rot;
+  initFromR = true;
 }
 
 /// Add an explicit copy constructor

--- a/Framework/Geometry/test/GoniometerTest.h
+++ b/Framework/Geometry/test/GoniometerTest.h
@@ -65,7 +65,6 @@ public:
     TS_ASSERT_THROWS_ANYTHING(G.pushAxis("Axis2", 0., 0., 1., 30));
     TS_ASSERT_EQUALS(M, G2.getR());
   }
-
   void testSense() {
     Goniometer G1, G2, G3;
     TS_ASSERT_THROWS_NOTHING(G1.pushAxis("Axis1", 0., 1., 0., 30));
@@ -280,5 +279,21 @@ public:
     Goniometer b(rotation_y);
     TS_ASSERT_DIFFERS(a, b);
     TS_ASSERT(!(a == b));
+  }
+
+  void test_setting_goniometer_when_matrix_has_small_numerical_inprecision() {
+    DblMatrix rotMat(3, 3, false);
+    rotMat[0][0] = -4.054652e-01;
+    rotMat[1][0] = -5.793048e-01;
+    rotMat[2][0] = 7.071096e-01;
+    rotMat[0][1] = 4.056876e-01;
+    rotMat[1][1] = 5.791560e-01;
+    rotMat[2][1] = 7.071039e-01;
+    rotMat[0][2] = -8.191554e-01;
+    rotMat[1][2] = 5.735716e-01;
+    rotMat[2][2] = 1.892000e-04;
+    Goniometer G(rotMat);
+    TS_ASSERT(G.isDefined());
+    TS_ASSERT_EQUALS(G.getR().equals(rotMat), true);
   }
 };


### PR DESCRIPTION
### Description of work

#### Summary of work
Updated the code so when a Goniometer is constructed from a matrix, it uses the internal `isRotation` method to check if it is a valid rotation matrix rather than the custom check that was present

#### Purpose of work
Before, it would perform the same check as `isRotation` but without any tolerance for numerical inaccuracy.

Fixes #39357

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
I think I have basically just added a tolerance to the check that `M@M^-1 == I` but by using the built in `isRotation` to keep consistent threshold values.

I've added a test as well

### To test:
You can try running the test script on `main` branch to verify that it fails (I've done that in the linked issue)

Now re-running the issue script:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace()


# rotational matrix with numerical inprecision
mat = np.array([[-4.054652e-01, -5.793048e-01,  7.071096e-01],
 [ 4.056876e-01,  5.791560e-01,  7.071039e-01],
 [-8.191554e-01,  5.735716e-01,  1.892000e-04]])

# validate determinant is essentially 1
print(mat, np.linalg.det(mat)-1 < 1e-5, )


# validate transpose is essentially inverse (M@M^-1 == I)
print((mat@mat.T)-np.eye(3))

# should let you set goniometer with this matrix
SetGoniometer(ws, GoniometerMatrix = mat.reshape(-1))
```
should give no error message

*This does not require release notes* because **this functionality has not been exposed within a previous release**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
