### PR TITLE
Make changes to enable use of new LOQ IDF with event mode data

### DIFF
--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -97,7 +97,7 @@ def add_runs(  # noqa: C901
                 userEntry, defType, inst, ADD_FILES_SUM_TEMPORARY, rawTypes, period
             )
 
-            is_not_allowed_instrument = inst.upper() not in {"SANS2D", "LARMOR", "ZOOM"}
+            is_not_allowed_instrument = inst.upper() not in {"SANS2D", "LARMOR", "ZOOM", "LOQ"}
             if is_not_allowed_instrument and isFirstDataSetEvent:
                 error = "Adding event data not supported for " + inst + " for now"
                 print(error)

--- a/scripts/SANS/sans/algorithm_detail/CreateSANSWavelengthPixelAdjustment.py
+++ b/scripts/SANS/sans/algorithm_detail/CreateSANSWavelengthPixelAdjustment.py
@@ -147,7 +147,7 @@ class CreateSANSWavelengthPixelAdjustment(object):
 
             # Add an instrument to the workspace
             instrument_name = "LoadInstrument"
-            instrument_options = {"Workspace": output_workspace, "Filename": idf_path, "RewriteSpectraMap": False}
+            instrument_options = {"Workspace": output_workspace, "Filename": idf_path, "RewriteSpectraMap": True}
             instrument_alg = create_unmanaged_algorithm(instrument_name, **instrument_options)
             instrument_alg.execute()
 


### PR DESCRIPTION
### Description of work

#### Summary of work

As prescribed by Rob Dalgliesh, this change enables the use of the new LOQ IDF with event mode data.

This change has been made to the versions of mantid installed in the LOQ cabin, and has been in use for a couple of weeks.

It is important that this change goes into 6.13 to enable the use of the new LOQ IDF. Testing of the new IDF and LOQ Event mode will continue into the next release.

I have raised an issue to increase automated testing in this area and to put together a new LOQ demo for event mode: https://github.com/mantidproject/mantid/issues/39366

Fixes #39002

Will add release note as part of: #39322 

### To test:

With access to the ISIS data archive:
- On the `ISIS` sans GUI, navigate to `Sum Runs` in the left hand menu.
- Sum a number of runs, prior to and following the LOQ switch to event mode. For example:
  - 113314, 113316 (both event)
  - 111110, 111111 (both histo)
  - 111110, 113314 (mix)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
