### PR TITLE
Replace boost::optional from MantidQtWidgets and sip files with std::optional

### DIFF
--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -800,8 +800,8 @@ public:
     Cell deadCell() const;
 
     std::vector<MantidQt::MantidWidgets::Batch::RowLocation> selectedRowLocations() const;
-    boost::optional<std::vector<std::vector<Row>>> selectedSubtrees() const;
-    boost::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> selectedSubtreeRoots() const;
+    std::optional<std::vector<std::vector<Row>>> selectedSubtrees() const;
+    std::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> selectedSubtreeRoots() const;
 };
 
 class Cell {

--- a/qt/python/mantidqt/sip/vector.sip
+++ b/qt/python/mantidqt/sip/vector.sip
@@ -39,10 +39,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy);
   } else {
-    auto cppValue = pythonListToVector<TYPE>(sipPy, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+    auto cppValue = pythonListToVector<TYPE>(sipPy, [&](PyObject* pyItem) -> std::optional<TYPE> {
       if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
         PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-        return boost::none;
+        return std::nullopt;
       } else {
         int state;
         auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -58,11 +58,11 @@ template<TYPE>
 };
 
 template<TYPE>
-%MappedType boost::optional<std::vector<TYPE>>
+%MappedType std::optional<std::vector<TYPE>>
 {
 %TypeHeaderCode
 #include <vector>
-#include <boost/optional.hpp>
+#include <optional>
 %End
 
 %ConvertFromTypeCode
@@ -79,11 +79,11 @@ template<TYPE>
       // Check if type is compatible
       return isIterable(sipPy) || sipPy == Py_None;
     } else {
-      auto cppValue = pythonObjectToOptional<std::vector<TYPE>>(sipPy, [&](PyObject* pythonList) -> boost::optional<std::vector<TYPE>> {
-        return pythonListToVector<TYPE>(pythonList, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+      auto cppValue = pythonObjectToOptional<std::vector<TYPE>>(sipPy, [&](PyObject* pythonList) -> std::optional<std::vector<TYPE>> {
+        return pythonListToVector<TYPE>(pythonList, [&](PyObject* pyItem) -> std::optional<TYPE> {
           if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
             PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-            return boost::none;
+            return std::nullopt;
           } else {
             int state;
             auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -119,10 +119,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<double>(sipPy, [&](PyObject* pyItem) -> boost::optional<double> {
+    auto cppValue = pythonListToVector<double>(sipPy, [&](PyObject* pyItem) -> std::optional<double> {
       if (!PyNumber_Check(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not a number");
-        return boost::none;
+        return std::nullopt;
       } else {
         return PyFloat_AsDouble(pyItem);
       }
@@ -153,10 +153,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<int>(sipPy, [&](PyObject* pyItem) -> boost::optional<int> {
+    auto cppValue = pythonListToVector<int>(sipPy, [&](PyObject* pyItem) -> std::optional<int> {
       if (!INT_CHECK(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not an int");
-        return boost::none;
+        return std::nullopt;
       } else {
         return static_cast<int>(TO_LONG(pyItem));
       }
@@ -188,10 +188,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<unsigned int>(sipPy, [&](PyObject* pyItem) -> boost::optional<unsigned int> {
+    auto cppValue = pythonListToVector<unsigned int>(sipPy, [&](PyObject* pyItem) -> std::optional<unsigned int> {
       if (!INT_CHECK(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not an int");
-        return boost::none;
+        return std::nullopt;
       } else {
         return static_cast<unsigned int>(TO_LONG(pyItem));
       }
@@ -221,7 +221,7 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<std::string>(sipPy, [&](PyObject* pyItem) -> boost::optional<std::string> {
+    auto cppValue = pythonListToVector<std::string>(sipPy, [&](PyObject* pyItem) -> std::optional<std::string> {
       auto maybeValue = pythonStringToStdString(pyItem);
       return typeErrorIfNoneElseValue(maybeValue, "object in iterable is not a string.");
     });
@@ -256,11 +256,11 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy);
   } else {
-    auto cppValue = pythonListToVector<std::vector<TYPE>>(sipPy, [&](PyObject* pyItem) -> boost::optional<std::vector<TYPE>> {
-      return pythonListToVector<TYPE>(pyItem, [&](PyObject* pyInnerItem) -> boost::optional<TYPE> {
+    auto cppValue = pythonListToVector<std::vector<TYPE>>(sipPy, [&](PyObject* pyItem) -> std::optional<std::vector<TYPE>> {
+      return pythonListToVector<TYPE>(pyItem, [&](PyObject* pyInnerItem) -> std::optional<TYPE> {
         if (!sipCanConvertToType(pyInnerItem, sipType_TYPE, SIP_NOT_NONE)) {
           PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to the damn TYPE");
-          return boost::none;
+          return std::nullopt;
         } else {
           int state;
           auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -280,7 +280,7 @@ template<TYPE>
 // ****************************************************
 
 template<TYPE>
-%MappedType boost::optional<std::vector<std::vector<TYPE>>>
+%MappedType std::optional<std::vector<std::vector<TYPE>>>
 {
 %TypeHeaderCode
 #include <vector>
@@ -306,12 +306,12 @@ template<TYPE>
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
     auto cppValue = pythonObjectToOptional<std::vector<std::vector<TYPE>>>(sipPy,
-        [&](PyObject* pythonList) -> boost::optional<std::vector<std::vector<TYPE>>> {
-          return pythonListToVector<std::vector<TYPE>>(pythonList, [&](PyObject* pythonInnerList) -> boost::optional<std::vector<TYPE>> {
-            return pythonListToVector<TYPE>(pythonInnerList, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+        [&](PyObject* pythonList) -> std::optional<std::vector<std::vector<TYPE>>> {
+          return pythonListToVector<std::vector<TYPE>>(pythonList, [&](PyObject* pythonInnerList) -> std::optional<std::vector<TYPE>> {
+            return pythonListToVector<TYPE>(pythonInnerList, [&](PyObject* pyItem) -> std::optional<TYPE> {
               if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
                 PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-                return boost::none;
+                return std::nullopt;
               } else {
                 int state;
                 auto* cppItemPtr = reinterpret_cast<TYPE*>(

--- a/qt/python/mantidqt/sip/vector.sip.h
+++ b/qt/python/mantidqt/sip/vector.sip.h
@@ -5,8 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidPythonInterface/core/VersionCompat.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -18,24 +18,24 @@ bool isIterable(PyObject *iterable) {
 }
 
 template <typename T>
-boost::optional<T> typeErrorIfNoneElseValue(boost::optional<T> const &maybeValue, std::string const &errorMessage) {
-  if (!maybeValue.is_initialized())
+std::optional<T> typeErrorIfNoneElseValue(std::optional<T> const &maybeValue, std::string const &errorMessage) {
+  if (!maybeValue.has_value())
     PyErr_SetString(PyExc_TypeError, errorMessage.c_str());
   return maybeValue;
 }
 
 template <typename T, typename ConversionFunction>
-boost::optional<boost::optional<T>> pythonObjectToOptional(PyObject *object, ConversionFunction pyObjectAsValue) {
+std::optional<std::optional<T>> pythonObjectToOptional(PyObject *object, ConversionFunction pyObjectAsValue) {
   if (object == Py_None)
-    return boost::none;
+    return std::nullopt;
   else
     return pyObjectAsValue(object);
 }
 
 template <typename T, typename ConversionFunction>
-PyObject *optionalToPyObject(boost::optional<T> const &item, ConversionFunction valueAsPyObject) {
-  if (item.is_initialized()) {
-    return valueAsPyObject(item.get());
+PyObject *optionalToPyObject(std::optional<T> const &item, ConversionFunction valueAsPyObject) {
+  if (item.has_value()) {
+    return valueAsPyObject(item.value());
   } else {
     return Py_None;
   }
@@ -62,7 +62,7 @@ PyObject *vectorToPythonList(std::vector<T> const &vector, ConversionFunction it
 }
 
 template <typename T, typename ConversionFunction>
-boost::optional<std::vector<T>> pythonListToVector(PyObject *pythonList, ConversionFunction pyObjectToItem) {
+std::optional<std::vector<T>> pythonListToVector(PyObject *pythonList, ConversionFunction pyObjectToItem) {
   auto length = static_cast<int>(PyObject_Size(pythonList));
   PyObject *iterator = PyObject_GetIter(pythonList);
   if (iterator != nullptr) {
@@ -71,26 +71,25 @@ boost::optional<std::vector<T>> pythonListToVector(PyObject *pythonList, Convers
     PyObject *pythonItem = nullptr;
     while ((pythonItem = PyIter_Next(iterator))) {
       auto item = pyObjectToItem(pythonItem);
-      if (item.is_initialized())
-        cppVector.emplace_back(std::move(item.get()));
+      if (item.has_value())
+        cppVector.emplace_back(std::move(item.value()));
       else {
         Py_DECREF(pythonItem);
         Py_DECREF(iterator);
-        return boost::none;
+        return std::nullopt;
       }
       Py_DECREF(pythonItem);
     }
     Py_DECREF(iterator);
     return cppVector;
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-template <typename T>
-int transferToSip(boost::optional<T> const &cppValue, T **sipCppPtr, int *sipIsErr, int sipState) {
-  if (cppValue.is_initialized()) {
-    auto heapValue = ::std::make_unique<T>(std::move(cppValue.get()));
+template <typename T> int transferToSip(std::optional<T> const &cppValue, T **sipCppPtr, int *sipIsErr, int sipState) {
+  if (cppValue.has_value()) {
+    auto heapValue = ::std::make_unique<T>(std::move(cppValue.value()));
     *sipCppPtr = heapValue.release();
     return sipState;
   } else {
@@ -99,20 +98,20 @@ int transferToSip(boost::optional<T> const &cppValue, T **sipCppPtr, int *sipIsE
   }
 }
 
-template <typename T> boost::optional<T> asOptional(int *sipIsErr, T *sipCppPtr) {
+template <typename T> std::optional<T> asOptional(int *sipIsErr, T *sipCppPtr) {
   if (*sipIsErr)
-    return boost::none;
+    return std::nullopt;
   else
     return *sipCppPtr;
 }
 
-inline boost::optional<std::string> pythonStringToStdString(PyObject *pyString) {
+inline std::optional<std::string> pythonStringToStdString(PyObject *pyString) {
   if (PyBytes_Check(pyString)) {
     return std::string(PyBytes_AsString(pyString));
   } else if (STR_CHECK(pyString)) {
     return std::string(TO_CSTRING(pyString));
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -19,10 +19,10 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 namespace { // unnamed
 
-Clipboard initializeClipboard(const boost::optional<std::vector<MantidWidgets::Batch::Subtree>> &subTrees,
-                              const boost::optional<std::vector<MantidWidgets::Batch::RowLocation>> &subtreeRoots) {
-  return subTrees.is_initialized() && subtreeRoots.is_initialized() ? Clipboard(subTrees.get(), subtreeRoots.get())
-                                                                    : Clipboard();
+Clipboard initializeClipboard(const std::optional<std::vector<MantidWidgets::Batch::Subtree>> &subTrees,
+                              const std::optional<std::vector<MantidWidgets::Batch::RowLocation>> &subtreeRoots) {
+  return subTrees.has_value() && subtreeRoots.has_value() ? Clipboard(subTrees.value(), subtreeRoots.value())
+                                                          : Clipboard();
 }
 
 void clearStateStyling(MantidWidgets::Batch::Cell &cell) {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/ExtractSubtrees.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/ExtractSubtrees.h
@@ -14,7 +14,7 @@ developer.mantidproject.org/BatchWidget/index.html
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 #include "MantidQtWidgets/Common/DllOption.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 namespace MantidQt {
@@ -25,7 +25,7 @@ class EXPORT_OPT_MANTIDQT_COMMON ExtractSubtrees {
 public:
   using RandomAccessRowIterator = std::vector<Row>::iterator;
   using RandomAccessConstRowIterator = std::vector<Row>::const_iterator;
-  boost::optional<std::vector<Subtree>> operator()(std::vector<Row> region) const;
+  std::optional<std::vector<Subtree>> operator()(std::vector<Row> region) const;
 
 private:
   RandomAccessConstRowIterator findEndOfSubtree(RandomAccessConstRowIterator subtreeBegin,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/FindSubtreeRoots.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/FindSubtreeRoots.h
@@ -12,7 +12,7 @@ developer.mantidproject.org/BatchWidget/index.html
 #include "MantidQtWidgets/Common/Batch/AssertOrThrow.h"
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/DllOption.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 namespace MantidQt {
@@ -21,7 +21,7 @@ namespace Batch {
 
 class EXPORT_OPT_MANTIDQT_COMMON FindSubtreeRoots {
 public:
-  boost::optional<std::vector<RowLocation>> operator()(std::vector<RowLocation> region);
+  std::optional<std::vector<RowLocation>> operator()(std::vector<RowLocation> region);
 
 private:
   void removeIfDepthNotEqualTo(std::vector<RowLocation> &region, int expectedDepth) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/IJobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/IJobTreeView.h
@@ -13,7 +13,7 @@
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 #include "MantidQtWidgets/Common/DllOption.h"
 #include "MantidQtWidgets/Common/HintStrategy.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -81,8 +81,8 @@ public:
   virtual void collapseAll() = 0;
 
   virtual std::vector<RowLocation> selectedRowLocations() const = 0;
-  virtual boost::optional<std::vector<Subtree>> selectedSubtrees() const = 0;
-  virtual boost::optional<std::vector<RowLocation>> selectedSubtreeRoots() const = 0;
+  virtual std::optional<std::vector<Subtree>> selectedSubtrees() const = 0;
+  virtual std::optional<std::vector<RowLocation>> selectedSubtreeRoots() const = 0;
   virtual int currentColumn() const = 0;
   virtual Cell deadCell() const = 0;
   virtual ~IJobTreeView() = default;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
@@ -18,7 +18,7 @@ developer.mantidproject.org/BatchWidget/index.html
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/Batch/RowLocationAdapter.h"
 #include "MantidQtWidgets/Common/DllOption.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QTreeView>
 
@@ -74,8 +74,8 @@ public:
 
   QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
   std::vector<RowLocation> selectedRowLocations() const override;
-  boost::optional<std::vector<Subtree>> selectedSubtrees() const override;
-  boost::optional<std::vector<RowLocation>> selectedSubtreeRoots() const override;
+  std::optional<std::vector<Subtree>> selectedSubtrees() const override;
+  std::optional<std::vector<RowLocation>> selectedSubtreeRoots() const override;
 
   bool hasNoSelectedDescendants(QModelIndex const &index) const;
   void appendAllUnselectedDescendants(QModelIndexList &selectedRows, QModelIndex const &index) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/MockJobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/MockJobTreeView.h
@@ -67,8 +67,8 @@ public:
   }
 
   MOCK_CONST_METHOD0(selectedRowLocations, std::vector<RowLocation>());
-  MOCK_CONST_METHOD0(selectedSubtrees, boost::optional<std::vector<Subtree>>());
-  MOCK_CONST_METHOD0(selectedSubtreeRoots, boost::optional<std::vector<RowLocation>>());
+  MOCK_CONST_METHOD0(selectedSubtrees, std::optional<std::vector<Subtree>>());
+  MOCK_CONST_METHOD0(selectedSubtreeRoots, std::optional<std::vector<RowLocation>>());
   MOCK_CONST_METHOD0(currentColumn, int());
   MOCK_CONST_METHOD0(deadCell, Cell());
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/RowLocationAdapter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/RowLocationAdapter.h
@@ -23,7 +23,7 @@ public:
   RowLocationAdapter(QStandardItemModel const &model);
 
   RowLocation atIndex(QModelIndexForMainModel const &index) const;
-  boost::optional<QModelIndexForMainModel> indexIfExistsAt(RowLocation const &location, int column = 0) const;
+  std::optional<QModelIndexForMainModel> indexIfExistsAt(RowLocation const &location, int column = 0) const;
   QModelIndexForMainModel indexAt(RowLocation const &location, int column = 0) const;
 
 private:

--- a/qt/widgets/common/src/Batch/ExtractSubtrees.cpp
+++ b/qt/widgets/common/src/Batch/ExtractSubtrees.cpp
@@ -44,7 +44,7 @@ std::vector<Subtree> ExtractSubtrees::makeSubtreesFromRows(std::vector<Row> cons
 
 RowLocation rowToRowLocation(Row const &row) { return row.location(); }
 
-auto ExtractSubtrees::operator()(std::vector<Row> region) const -> boost::optional<std::vector<Subtree>> {
+auto ExtractSubtrees::operator()(std::vector<Row> region) const -> std::optional<std::vector<Subtree>> {
   std::sort(region.begin(), region.end());
   if (!region.empty()) {
     auto subtreeRootDepth = rowToRowLocation(region[0]).depth();
@@ -54,7 +54,7 @@ auto ExtractSubtrees::operator()(std::vector<Row> region) const -> boost::option
     if (allSubtreeRootsShareAParentAndAllSubtreeNodesAreConnected(subtreeRootDepth, rowLocationBegin, rowLocationEnd))
       return makeSubtreesFromRows(region, subtreeRootDepth);
     else
-      return boost::none;
+      return std::nullopt;
   } else {
     return std::vector<Subtree>();
   }

--- a/qt/widgets/common/src/Batch/FindSubtreeRoots.cpp
+++ b/qt/widgets/common/src/Batch/FindSubtreeRoots.cpp
@@ -10,7 +10,7 @@
 
 namespace MantidQt::MantidWidgets::Batch {
 
-auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> boost::optional<std::vector<RowLocation>> {
+auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> std::optional<std::vector<RowLocation>> {
   std::sort(region.begin(), region.end());
   if (!region.empty()) {
     auto subtreeRootDepth = region[0].depth();
@@ -18,7 +18,7 @@ auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> boost::opt
       removeIfDepthNotEqualTo(region, subtreeRootDepth);
       return region;
     } else {
-      return boost::none;
+      return std::nullopt;
     }
   } else {
     return std::vector<RowLocation>();

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -87,7 +87,7 @@ bool JobTreeView::edit(const QModelIndex &index, EditTrigger trigger, QEvent *ev
 
 Cell JobTreeView::deadCell() const { return g_deadCell; }
 
-boost::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
+std::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
   auto selected = selectedRowLocations();
   std::sort(selected.begin(), selected.end());
 
@@ -101,7 +101,7 @@ boost::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
   return extractSubtrees(selectedRows);
 }
 
-boost::optional<std::vector<RowLocation>> JobTreeView::selectedSubtreeRoots() const {
+std::optional<std::vector<RowLocation>> JobTreeView::selectedSubtreeRoots() const {
   auto findSubtreeRoots = FindSubtreeRoots();
   return findSubtreeRoots(selectedRowLocations());
 }
@@ -553,8 +553,8 @@ QModelIndex JobTreeView::applyNavigationResult(QtTreeCursorNavigationResult cons
     // `notifyRowInserted` hence we have to assume they did and try to get the
     // index again.
     auto maybeIndexOfNewRow = rowLocation().indexIfExistsAt(newRowLocation);
-    if (maybeIndexOfNewRow.is_initialized()) {
-      return expanded(mapToFilteredModel(maybeIndexOfNewRow.get())).untyped();
+    if (maybeIndexOfNewRow.has_value()) {
+      return expanded(mapToFilteredModel(maybeIndexOfNewRow.value())).untyped();
     } else {
       return QModelIndex();
     }

--- a/qt/widgets/common/src/Batch/RowLocationAdapter.cpp
+++ b/qt/widgets/common/src/Batch/RowLocationAdapter.cpp
@@ -31,8 +31,8 @@ QModelIndex RowLocationAdapter::walkFromRootToParentIndexOf(RowLocation const &l
   return parentIndex;
 }
 
-boost::optional<QModelIndexForMainModel> RowLocationAdapter::indexIfExistsAt(RowLocation const &location,
-                                                                             int column) const {
+std::optional<QModelIndexForMainModel> RowLocationAdapter::indexIfExistsAt(RowLocation const &location,
+                                                                           int column) const {
   if (location.isRoot()) {
     return fromMainModel(QModelIndex(), m_model);
   } else {
@@ -41,14 +41,14 @@ boost::optional<QModelIndexForMainModel> RowLocationAdapter::indexIfExistsAt(Row
     if (m_model.hasIndex(row, column, parentIndex))
       return fromMainModel(m_model.index(row, column, parentIndex), m_model);
     else
-      return boost::none;
+      return std::nullopt;
   }
 }
 
 QModelIndexForMainModel RowLocationAdapter::indexAt(RowLocation const &location, int column) const {
   auto maybeIndex = indexIfExistsAt(location, column);
-  if (maybeIndex.is_initialized())
-    return maybeIndex.get();
+  if (maybeIndex.has_value())
+    return maybeIndex.value();
   else {
     throw std::runtime_error("indexAt: Attempted to get model index for "
                              "row location which does not exist.");

--- a/qt/widgets/common/test/Batch/ExtractSubtreesTest.h
+++ b/qt/widgets/common/test/Batch/ExtractSubtreesTest.h
@@ -34,7 +34,7 @@ public:
   void testForSingleLocation() {
     auto extractSubtrees = ExtractSubtrees();
     auto region = std::vector<Row>({Row(RowLocation({1}), cells("Root"))});
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
 
     // clang-format off
     auto expectedSubtrees =
@@ -63,7 +63,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -81,7 +81,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -108,7 +108,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -135,7 +135,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -149,7 +149,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!extractSubtrees(region).is_initialized());
+    TS_ASSERT(!extractSubtrees(region).has_value());
   }
 
   void testFailsForLevelGapBetweenSubtrees() {
@@ -165,7 +165,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!extractSubtrees(region).is_initialized());
+    TS_ASSERT(!extractSubtrees(region).has_value());
   }
 
   void testForRealisticTree() {
@@ -212,7 +212,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -231,7 +231,7 @@ public:
     // clang-format on
 
     auto subtrees = extractSubtrees(region);
-    TS_ASSERT(!subtrees.is_initialized())
+    TS_ASSERT(!subtrees.has_value())
   }
 
   void testFailsForDeepRoot() {
@@ -249,7 +249,7 @@ public:
     // clang-format on
 
     auto subtrees = extractSubtrees(region);
-    TS_ASSERT(!subtrees.is_initialized())
+    TS_ASSERT(!subtrees.has_value())
   }
 
   void testFailsForDeepRootImmediatelyAfterFirstRoot() {
@@ -262,7 +262,7 @@ public:
     // clang-format on
 
     auto roots = extractSubtrees(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForShallowRootImmediatelyAfterFirstRoot() {
@@ -275,6 +275,6 @@ public:
     // clang-format on
 
     auto roots = extractSubtrees(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 };

--- a/qt/widgets/common/test/Batch/FindSubtreeRootsTest.h
+++ b/qt/widgets/common/test/Batch/FindSubtreeRootsTest.h
@@ -32,8 +32,8 @@ public:
 
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testTwoSiblingsResultsInTwoRoots() {
@@ -48,8 +48,8 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testParentAndChildResultsInParent() {
@@ -59,8 +59,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testParentWithChildAndSiblingResultsInParentAndSibling() {
@@ -76,8 +76,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1}), RowLocation({2})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFindsRootOfNonTrivialTree() {
@@ -94,8 +94,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFailsForLevelGap() {
@@ -108,7 +108,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!findSubtreeRoots(region).is_initialized());
+    TS_ASSERT(!findSubtreeRoots(region).has_value());
   }
 
   void testForRealisticTree() {
@@ -140,8 +140,8 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFailsForShallowRoot() {
@@ -159,7 +159,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDeepRoot() {
@@ -177,7 +177,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDeepRootImmediatelyAfterFirstRoot() {
@@ -190,7 +190,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForShallowRootImmediatelyAfterFirstRoot() {
@@ -203,7 +203,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDisconnectedRoots() {
@@ -216,7 +216,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testForDocumentationFailTree() {
@@ -233,6 +233,6 @@ public:
     });
     // clang-format on
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 };


### PR DESCRIPTION
### Description of work

Replaced `boost::optional` with `std::optional` in `MantidQtWidgets` and the related sip files.

There are still some instances left in the code base, but this was the scope of the issue.

Fixes #39253


### To test:

CI tests and code review

*This does not require release notes* because **internal change**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
