### PR TITLE
NeXus File uses NexusDescriptor

### DIFF
--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -256,18 +256,16 @@ void getWordsInString(const std::string &words4, std::string &w1, std::string &w
  * @param file :: previously opened NXS file.
  */
 void WorkspaceHistory::loadNexus(::NeXus::File *file) {
-  // Warn but continue if the group does not exist.
-  try {
+  if (file->hasGroup("process", "NXprocess")) {
     file->openGroup("process", "NXprocess");
-  } catch (std::exception &) {
+    loadNestedHistory(file);
+    file->closeGroup();
+  } else {
+    // Warn but continue if the group does not exist.
     g_log.warning() << "Error opening the algorithm history field 'process'. "
                        "Workspace will have no history."
                     << "\n";
-    return;
   }
-
-  loadNestedHistory(file);
-  file->closeGroup();
 }
 
 /** Load every algorithm history object at this point in the hierarchy.

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -700,14 +700,9 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
     file.getDataCoerce(duration);
     if (duration.size() == 1) {
       // get the units
-      std::vector<::NeXus::AttrInfo> infos = file.getAttrInfos();
       std::string units;
-      for (auto it = infos.begin(); it != infos.end(); ++it) {
-        // cppcheck-suppress useStlAlgorithm
-        if (it->name == "units") {
-          units = file.getStrAttr(*it);
-          break;
-        }
+      if (file.hasAttr("units")) {
+        file.getAttr<std::string>("units", units);
       }
 
       // set the property

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -130,11 +130,7 @@ void LoadHelper::addNexusFieldsToWsRun(::NeXus::File &filehandle, API::Run &runD
   // follows
   std::string entryNameActual(entryName);
   if (entryName.empty()) {
-    try {
-      const auto entryNameAndClass = filehandle.getNextEntry();
-      entryNameActual = entryNameAndClass.first;
-    } catch (const ::NeXus::Exception &) { /* ignore */
-    }
+    entryNameActual = filehandle.getTopLevelEntryName();
   }
 
   // open the group and parse down

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -286,29 +286,28 @@ std::unique_ptr<Kernel::Property> createTimeSeriesValidityFilter(::NeXus::File &
   // Now the validity of the values
   // this should be a match int array to the data values (or times)
   // If not present assume all data is valid
-  try {
+  if (file.hasData("value_valid")) {
     file.openData("value_valid");
-
-    // Now the validity data
-    ::NeXus::Info info = file.getInfo();
-    // Check the size
-    if (size_t(info.dims[0]) != times.size()) {
-      throw ::NeXus::Exception("Invalid value entry for validity data");
-    }
-    if (file.isDataInt()) // Int type
-    {
-      try {
-        file.getDataCoerce(values);
-        file.closeData();
-      } catch (::NeXus::Exception &) {
-        throw;
+    try {
+      // Now the validity data
+      ::NeXus::Info info = file.getInfo();
+      // Check the size
+      if (size_t(info.dims[0]) != times.size()) {
+        throw ::NeXus::Exception("Invalid value entry for validity data");
       }
-    } else {
-      throw ::NeXus::Exception("Invalid value type for validity data. Only int is supported");
-    }
-  } catch (::NeXus::Exception &ex) {
-    std::string error_msg = ex.what();
-    if (error_msg != "NXopendata(value_valid) failed") {
+      if (file.isDataInt()) // Int type
+      {
+        try {
+          file.getDataCoerce(values);
+          file.closeData();
+        } catch (::NeXus::Exception &) {
+          throw;
+        }
+      } else {
+        throw ::NeXus::Exception("Invalid value type for validity data. Only int is supported");
+      }
+    } catch (std::exception const &ex) {
+      std::string error_msg = ex.what();
       log.warning() << error_msg << "\n";
       file.closeData();
       // no data found

--- a/Framework/DataHandling/test/LoadNexusProcessed2Test.h
+++ b/Framework/DataHandling/test/LoadNexusProcessed2Test.h
@@ -297,4 +297,19 @@ public:
     // input. i.e. No geometry
     TS_ASSERT(!wsOut->detectorInfo().isEquivalent(wsIn->detectorInfo()));
   }
+
+  void test_non_hdf5_file() {
+    const std::string filename("WISH00043350.mat");
+    try {
+      auto wsOut = do_load_v2(filename);
+      TS_FAIL("Should not be able to load corrupt file: " + filename);
+    } catch (const std::invalid_argument &e) {
+      const std::string front("Cannot open file ");
+      const std::string back(filename + " using HDF5");
+
+      const std::string msg = e.what();
+      TS_ASSERT(msg.starts_with(front));
+      TS_ASSERT(msg.ends_with(back));
+    }
+  }
 };

--- a/Framework/DataHandling/test/LoadNexusProcessed2Test.h
+++ b/Framework/DataHandling/test/LoadNexusProcessed2Test.h
@@ -304,12 +304,10 @@ public:
       auto wsOut = do_load_v2(filename);
       TS_FAIL("Should not be able to load corrupt file: " + filename);
     } catch (const std::invalid_argument &e) {
-      const std::string front("Cannot open file ");
-      const std::string back(filename + " using HDF5");
+      const std::string expected("ERROR: Kernel::NexusDescriptor couldn't open hdf5 file");
 
       const std::string msg = e.what();
-      TS_ASSERT(msg.starts_with(front));
-      TS_ASSERT(msg.ends_with(back));
+      TS_ASSERT(msg.starts_with(expected));
     }
   }
 };

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
@@ -43,11 +43,13 @@ private:
    */
   Mantid::Nexus::NexusDescriptor m_descriptor;
 
-public:
   /**
    * \return A pair of the next entry available in a listing.
+   * NOTE: this is to be deleted in 6.14.  do NOT make public
    */
   Entry getNextEntry();
+
+public:
   /**
    * \return Information about the next attribute.
    */

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
@@ -121,6 +121,10 @@ public:
   /** Flush the file. */
   void flush();
 
+  bool hasPath(std::string const &);
+  bool hasGroup(std::string const &, std::string const &);
+  bool hasData(std::string const &);
+
   /**
    * Create a new group.
    *
@@ -510,6 +514,12 @@ public:
    */
   template <typename NumT> void getSlab(NumT *data, const DimSizeVector &start, const DimSizeVector &size);
 
+  /** Return the string name of the top-level entry
+   *
+   * \return a string with the name (not abs path) of the top-level entry
+   */
+  std::string getTopLevelEntryName();
+
   /**
    * \return Information about all attributes on the data that is currently open.
    */
@@ -571,6 +581,10 @@ public:
    * \returns true if we are currently in an open dataset else false
    */
   bool isDataSetOpen();
+
+private:
+  std::string formAbsolutePath(std::string const &);
+  void registerEntry(std::string const &, std::string const &);
 };
 
 /**

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
@@ -2,6 +2,7 @@
 
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexus/NeXusFile_fwd.h"
+#include "MantidNexus/NexusDescriptor.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -35,6 +36,8 @@ private:
   std::shared_ptr<NXhandle> m_pfile_id;
   /** should be close handle on exit */
   bool m_close_handle;
+  /** nexus descriptor to track the file tree */
+  Mantid::Nexus::NexusDescriptor m_descriptor;
 
 public:
   /**

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile.hpp
@@ -36,7 +36,11 @@ private:
   std::shared_ptr<NXhandle> m_pfile_id;
   /** should be close handle on exit */
   bool m_close_handle;
-  /** nexus descriptor to track the file tree */
+  /** nexus descriptor to track the file tree
+   * NOTE: in file write, the following cannot be relied upon:
+   * - hasRootAttr
+   * - firstEntryNameType
+   */
   Mantid::Nexus::NexusDescriptor m_descriptor;
 
 public:

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
@@ -28,7 +28,7 @@ typedef const char CONSTCHAR;
  */
 constexpr int NXACCMASK_REMOVEFLAGS = (0x7); /* bit mask to remove higher flag options */
 
-constexpr int NX_UNLIMITED = -1; // cppcheck-suppress syntaxError
+constexpr int NX_UNLIMITED = -1;
 
 constexpr int NX_MAXRANK = 32;
 constexpr int NX_MAXNAMELEN = 64;

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
@@ -28,7 +28,7 @@ typedef const char CONSTCHAR;
  */
 constexpr int NXACCMASK_REMOVEFLAGS = (0x7); /* bit mask to remove higher flag options */
 
-constexpr int NX_UNLIMITED = -1;
+constexpr int NX_UNLIMITED = -1; // cppcheck-suppress: syntaxError
 
 constexpr int NX_MAXRANK = 32;
 constexpr int NX_MAXNAMELEN = 64;

--- a/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NeXusFile_fwd.h
@@ -28,7 +28,7 @@ typedef const char CONSTCHAR;
  */
 constexpr int NXACCMASK_REMOVEFLAGS = (0x7); /* bit mask to remove higher flag options */
 
-constexpr int NX_UNLIMITED = -1; // cppcheck-suppress: syntaxError
+constexpr int NX_UNLIMITED = -1; // cppcheck-suppress syntaxError
 
 constexpr int NX_MAXRANK = 32;
 constexpr int NX_MAXNAMELEN = 64;

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -8,13 +8,14 @@
 
 #include "MantidNexus/DllConfig.h"
 
-#include "MantidNexus/NeXusFile_fwd.h"
-
 #include <map>
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+// from NeXusFile_fwd.h
+typedef int NXaccess;
 
 namespace Mantid {
 namespace Nexus {

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -26,7 +26,7 @@ public:
    */
   NexusDescriptor(std::string filename);
 
-  NexusDescriptor() = delete;
+  NexusDescriptor() = default;
 
   NexusDescriptor &operator=(NexusDescriptor const &nd) = default;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -26,7 +26,7 @@ public:
    */
   NexusDescriptor(std::string filename);
 
-  NexusDescriptor() = default;
+  NexusDescriptor() = delete;
 
   NexusDescriptor &operator=(NexusDescriptor const &nd) = default;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -91,6 +91,13 @@ public:
    */
   std::vector<std::string> allPathsOfType(const std::string &type) const;
 
+  /**
+   * @param level A string specifying the parent path
+   * @return path A map of strings giving names within parent (mapped to class type)
+   * e.g. group1 : NXentry, group2 : NXentry, data : NXdata
+   */
+  std::map<std::string, std::string> allPathsAtLevel(const std::string &level) const;
+
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(const std::string &classType) const;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -8,6 +8,8 @@
 
 #include "MantidNexus/DllConfig.h"
 
+#include "MantidNexus/NeXusFile_fwd.h"
+
 #include <map>
 #include <set>
 #include <string>
@@ -25,6 +27,8 @@ public:
    * @param filename input HDF5 Nexus file name
    */
   NexusDescriptor(std::string filename);
+
+  NexusDescriptor(std::string filename, NXaccess access);
 
   NexusDescriptor() = delete;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -109,6 +109,8 @@ public:
    */
   void addEntry(const std::string &entryName, const std::string &groupClass);
 
+  void addRootAttr(const std::string &name);
+
 private:
   /**
    * Sets m_allEntries, called in HDF5 constructor.

--- a/Framework/Nexus/src/NeXusFile.cpp
+++ b/Framework/Nexus/src/NeXusFile.cpp
@@ -88,12 +88,12 @@ template <> MANTID_NEXUS_DLL NXnumtype getType(string const) { return NXnumtype:
 namespace NeXus {
 
 File::File(const string &filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor() {
+    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename) {
   this->initOpenFile(m_filename, m_access);
 }
 
 File::File(const char *filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor() {
+    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename) {
   this->initOpenFile(m_filename, m_access);
 }
 

--- a/Framework/Nexus/src/NeXusFile.cpp
+++ b/Framework/Nexus/src/NeXusFile.cpp
@@ -88,12 +88,12 @@ template <> MANTID_NEXUS_DLL NXnumtype getType(string const) { return NXnumtype:
 namespace NeXus {
 
 File::File(const string &filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename) {
+    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename, m_access) {
   this->initOpenFile(m_filename, m_access);
 }
 
 File::File(const char *filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename) {
+    : m_filename(filename), m_access(access), m_close_handle(true), m_descriptor(m_filename, m_access) {
   this->initOpenFile(m_filename, m_access);
 }
 

--- a/Framework/Nexus/src/NeXusFile.cpp
+++ b/Framework/Nexus/src/NeXusFile.cpp
@@ -29,10 +29,7 @@ using std::vector;
 
 namespace { // anonymous namespace to keep it in the file
 
-std::string const group_class_spec("NX_class");
-std::string const target_attr_name("target");
 std::string const scientific_data_set("SDS");
-constexpr int default_deflate_level(6);
 
 template <typename NumT> static string toString(const vector<NumT> &data) {
   stringstream result;

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -160,15 +160,7 @@ void NXClass::readAllInfo() {
   }
 }
 
-bool NXClass::isValid(const std::string &path) const {
-  try {
-    m_fileID->openGroupPath(path);
-    m_fileID->closeGroup();
-    return true;
-  } catch (::NeXus::Exception const &) {
-    return false;
-  }
-}
+bool NXClass::isValid(const std::string &path) const { return m_fileID->hasPath(path); }
 
 void NXClass::open() {
   m_fileID->openGroupPath(m_path);

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -115,6 +115,11 @@ std::map<std::string, std::set<std::string>> NexusDescriptor::initAllEntries() {
 
   // if the file exists read it
   if (std::filesystem::exists(m_filename)) {
+    // if the file exists but cannot be opened, throw invalid
+    // NOTE must be std::invalid_argument for NXRoot to properly interpret
+    if (!H5::H5File::isAccessible(m_filename, Mantid::NeXus::H5Util::defaultFileAcc())) {
+      throw std::invalid_argument("Cannot open file " + m_filename + " using HDF5");
+    }
 
     H5::H5File fileID(m_filename, H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
     H5::Group groupID = fileID.openGroup("/");

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -166,6 +166,25 @@ std::vector<std::string> NexusDescriptor::allPathsOfType(const std::string &type
   return result;
 }
 
+std::map<std::string, std::string> NexusDescriptor::allPathsAtLevel(const std::string &level) const {
+  std::map<std::string, std::string> result;
+  for (auto itClass = m_allEntries.cbegin(); itClass != m_allEntries.cend(); itClass++) {
+    for (auto itEntry = itClass->second.cbegin(); itEntry != itClass->second.cend(); itEntry++) {
+      if (itEntry->size() <= level.size()) {
+        continue;
+      }
+      if (itEntry->starts_with(level)) {
+        int offset = (level == "/" ? 0 : 1);
+        std::string path = itEntry->substr(level.size() + offset, itEntry->find("/", level.size() + offset));
+        if (itEntry->ends_with(path)) {
+          result[path] = itClass->first;
+        }
+      }
+    }
+  }
+  return result;
+}
+
 bool NexusDescriptor::classTypeExists(const std::string &classType) const { return m_allEntries.contains(classType); }
 
 std::string NexusDescriptor::classTypeForName(std::string const &entryName) const {

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -110,18 +110,13 @@ void NexusDescriptor::addEntry(const std::string &entryName, const std::string &
 
 // PRIVATE
 std::map<std::string, std::set<std::string>> NexusDescriptor::initAllEntries() {
-  H5::FileAccPropList access_plist;
-  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
 
   std::map<std::string, std::set<std::string>> allEntries;
 
   // if the file exists read it
   if (std::filesystem::exists(m_filename)) {
-    if (!H5::H5File::isAccessible(m_filename, access_plist)) {
-      throw std::runtime_error("REALLY BAD");
-    }
 
-    H5::H5File fileID(m_filename, H5F_ACC_RDONLY, H5::FileCreatPropList::DEFAULT, access_plist);
+    H5::H5File fileID(m_filename, H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
     H5::Group groupID = fileID.openGroup("/");
 
     // get root attributes

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -81,6 +81,9 @@ bool NexusDescriptor::hasRootAttr(const std::string &name) const { return (m_roo
 const std::map<std::string, std::set<std::string>> &NexusDescriptor::getAllEntries() const noexcept {
   return m_allEntries;
 }
+
+void NexusDescriptor::addRootAttr(const std::string &name) { m_rootAttrs.insert(name); }
+
 void NexusDescriptor::addEntry(const std::string &entryName, const std::string &groupClass) {
   // simple checks
   if (entryName.empty())

--- a/Framework/Nexus/src/nxstack.cpp
+++ b/Framework/Nexus/src/nxstack.cpp
@@ -85,6 +85,9 @@ void setCloseID(pFileStack self, const NXlink &id) { self->fileStack[self->fileS
 int fileStackDepth(pFileStack self) { return self->fileStackPointer; }
 /*----------------------------------------------------------------------*/
 void pushPath(pFileStack self, const char *name) {
+  if (self->pathPointer >= 0 && name == self->pathStack[self->pathPointer]) {
+    return;
+  }
   self->pathPointer++;
   self->pathStack.emplace_back(name);
 }

--- a/Framework/Nexus/test/NeXusFileTest.h
+++ b/Framework/Nexus/test/NeXusFileTest.h
@@ -81,6 +81,19 @@ public:
     TS_ASSERT(std::filesystem::exists(filename));
   }
 
+  void test_fail_open() {
+    // test opening a file that exists, but is unreadable
+    std::string filename = getFullPath("Test_characterizations_char.txt");
+    TS_ASSERT_THROWS_ANYTHING(NeXus::File file(filename, NXACC_READ));
+
+    // test opening an empty file
+    FileResource resource("fake_empty_file.nxs.h5");
+    std::ofstream file(resource.fullPath());
+    file << "mock";
+    file.close();
+    TS_ASSERT_THROWS_ANYTHING(NeXus::File file(resource.fullPath(), NXACC_READ));
+  }
+
   void test_flush() {
     cout << "\ntest flush\n";
     // make sure flush works

--- a/Framework/Nexus/test/NeXusFileTest.h
+++ b/Framework/Nexus/test/NeXusFileTest.h
@@ -94,6 +94,20 @@ public:
     TS_ASSERT_THROWS_ANYTHING(NeXus::File file(resource.fullPath(), NXACC_READ));
   }
 
+  void test_clear_on_create() {
+    // create an empty file
+    FileResource resource("fake_empty_file.nxs.h5");
+    std::ofstream file(resource.fullPath());
+    file << "mock";
+    file.close();
+
+    // this file cannot be opened for read
+    TS_ASSERT_THROWS_ANYTHING(NeXus::File file(resource.fullPath(), NXACC_READ));
+
+    // but no issue if opened for create
+    TS_ASSERT_THROWS_NOTHING(NeXus::File file(resource.fullPath(), NXACC_CREATE5));
+  }
+
   void test_flush() {
     cout << "\ntest flush\n";
     // make sure flush works

--- a/Framework/Nexus/test/NexusDescriptorTest.h
+++ b/Framework/Nexus/test/NexusDescriptorTest.h
@@ -10,6 +10,7 @@
 #include "MantidNexus/NexusDescriptor.h"
 
 #include <filesystem>
+#include <fstream>
 
 #include <cstddef> // std::size_t
 
@@ -92,6 +93,18 @@ public:
     // test hasRootAttr
     TS_ASSERT(nexusHDF5Descriptor.hasRootAttr("file_name"));
     TS_ASSERT(!nexusHDF5Descriptor.hasRootAttr("not_attr"));
+  }
+
+  void test_fails_bad_file() {
+    // test opening a file that exists, but is unreadable
+    std::string filename = getFullPath("Test_characterizations_char.txt");
+    TS_ASSERT_THROWS(Mantid::Nexus::NexusDescriptor nd(filename), std::invalid_argument const &);
+
+    filename = "fake_empty_file.nxs.h5";
+    std::ofstream file(filename);
+    file << "mock";
+    file.close();
+    TS_ASSERT_THROWS(Mantid::Nexus::NexusDescriptor nd(filename), std::invalid_argument const &);
   }
 
   void test_AddEntry() {

--- a/Framework/Nexus/test/NexusDescriptorTest.h
+++ b/Framework/Nexus/test/NexusDescriptorTest.h
@@ -117,4 +117,61 @@ public:
     TS_ASSERT_THROWS_NOTHING(nexusHDF5Descriptor.addEntry("/entry/DASlogs/OmikronRequest", "NXlog"));
     TS_ASSERT_EQUALS(nexusHDF5Descriptor.isEntry("/entry/DASlogs/OmikronRequest", "NXlog"), true);
   }
+
+  void test_allPathsAtLevel() {
+
+    typedef std::pair<std::string, std::string> Entry;
+    typedef std::map<std::string, std::string> Entries;
+
+    // setup a recursive group tree
+    std::vector<Entry> tree{Entry{"/entry1", "NXentry"},
+                            Entry{"/entry1/layer2a", "NXentry"},
+                            Entry{"/entry1/layer2a/layer3a", "NXentry"},
+                            Entry{"/entry1/layer2a/layer3b", "NXentry"},
+                            Entry{"/entry1/layer2a/data1_vec_1", "SDS"},
+                            Entry{"/entry1/layer2b", "NXentry"},
+                            Entry{"/entry1/layer2b/layer3a", "NXentry"},
+                            Entry{"/entry1/layer2b/layer3b", "NXentry"},
+                            Entry{"/entry2", "NXentry"},
+                            Entry{"/entry2/layer2c", "NXentry"},
+                            Entry{"/entry2/layer2c/layer3c", "NXentry"}};
+
+    std::string nonexistent("not_a_real_file.egg");
+    Mantid::Nexus::NexusDescriptor nd(nonexistent);
+    for (auto it = tree.begin(); it != tree.end(); it++) {
+      nd.addEntry(it->first, it->second);
+    }
+
+    // at root level, should be entry1, entry2
+    Entries actual = nd.allPathsAtLevel("/");
+    Entries expected = {Entry{"entry1", "NXentry"}, Entry{"entry2", "NXentry"}};
+    for (auto it = expected.begin(); it != expected.end(); it++) {
+      TS_ASSERT_EQUALS(actual.count(it->first), 1);
+      TS_ASSERT_EQUALS(it->second, actual[it->first]);
+    }
+
+    // within entry1, should be layer2a, layer2b
+    actual = nd.allPathsAtLevel("/entry1");
+    expected = Entries({Entry{"layer2a", "NXentry"}, Entry{"layer2b", "NXentry"}});
+    for (auto it = expected.begin(); it != expected.end(); it++) {
+      TS_ASSERT_EQUALS(actual.count(it->first), 1);
+      TS_ASSERT_EQUALS(it->second, actual[it->first]);
+    }
+
+    // within entry1/layer2a, should be layer3a, layer3b, data1
+    actual = nd.allPathsAtLevel("/entry1/layer2a");
+    expected = Entries({Entry{"layer3a", "NXentry"}, Entry{"layer3b", "NXentry"}, Entry{"data1_vec_1", "SDS"}});
+    for (auto it = expected.begin(); it != expected.end(); it++) {
+      TS_ASSERT_EQUALS(actual.count(it->first), 1);
+      TS_ASSERT_EQUALS(it->second, actual[it->first]);
+    }
+
+    // within entry2/layer2c, should be layer3c
+    actual = nd.allPathsAtLevel("/entry2/layer2c");
+    expected = Entries({Entry{"layer3c", "NXentry"}});
+    for (auto it = expected.begin(); it != expected.end(); it++) {
+      TS_ASSERT_EQUALS(actual.count(it->first), 1);
+      TS_ASSERT_EQUALS(it->second, actual[it->first]);
+    }
+  }
 };


### PR DESCRIPTION
### Description of work

#### Summary of work

This adds a `NexusDescriptor` object inside of `NeXusFile` to track the file tree.  This means user code can check if a group or dataset exists in a file without having to touch disk.

#### Purpose of work

It is not going to be possible to finish PR #39213 before code freeze and release 6.13.  This was seen as one marginal improvement that can be implemented in time for code freeze.

Part of #38332

#### Further detail of work

A few algorithms in DataHandling were updated to use `hasGroup`/`hasData`/`hasPath` methods, which make use of the `NexusDescriptor`.  These could be useful as illustrations of the use of the new methods.

### To test:

This is a refactor.  Make sure all tests pass.

Would also be helpful to practice loading an object

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
