### PR TITLE
Use a Relative Tolerance in SXD System Test

### DIFF
--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -196,7 +196,7 @@ class SXDIntegrateData1DProfile(systemtesting.MantidSystemTest):
 
     def validate(self):
         intens_over_sigma = [0.0, 0.0, 27.47, 131.576, 0.0]
-        self.assertTrue(np.allclose(self.integrated_peaks.column("Intens/SigInt"), intens_over_sigma, atol=1e-2))
+        np.testing.assert_allclose(self.integrated_peaks.column("Intens/SigInt"), intens_over_sigma, rtol=1e-2)
 
 
 def _load_data_and_add_peaks(sxd, runno):


### PR DESCRIPTION
### Description of work

#### Summary of work
The values in the test are pretty large, so a relative tolerance is more appropriate here anyway. Also it makes the test pass on macOS, which is holding up the nightly.

#### Purpose of work
Test newly introduced at code freeze so a test on macOS slipped through the net. Particularly with fitting macOS tends to be finicky. 

*There is no associated issue.*

#### Further detail of work
The change also makes use of `np.testing.assert_allclose` rather than an an `assertTrue` (thanks @warunawickramasingha for finding that function). This returns a really helpful error message so would be good to use elsewhere when we're making numpy comparisons (particularly for fitting). 

### To test:
1. Run the system test on every OS `./systemtest -R SXDIntegrateData1DProfile`
2. Check the status of the build_packages_from_branch and ensure the systests pass on everything: [![Build Status](https://builds.mantidproject.org/job/build_packages_from_branch/1119/badge/icon)](https://builds.mantidproject.org/job/build_packages_from_branch/1119/)


*This does not require release notes* because **it only affects tests, and was introduced this release anyway.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
