### PR TITLE
alter NXcanSASTest to generate random file names

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -516,7 +516,8 @@ set(TEST_FILES
     LoadMuonNexusV2Test.h
     LoadNGEMTest.h
     LoadNXSPETest.h
-    LoadNXcanSASPerformanceTest.h
+    LoadNXcanSASPerformanceTest1D.h
+    LoadNXcanSASPerformanceTest2D.h
     LoadNXcanSASTest.h
     LoadNexusLogsTest.h
     LoadNexusMonitorsTest.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -516,6 +516,7 @@ set(TEST_FILES
     LoadMuonNexusV2Test.h
     LoadNGEMTest.h
     LoadNXSPETest.h
+    LoadNXcanSASPerformanceTest.h
     LoadNXcanSASTest.h
     LoadNexusLogsTest.h
     LoadNexusMonitorsTest.h

--- a/Framework/DataHandling/test/LoadNXcanSASPerformanceTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASPerformanceTest.h
@@ -1,0 +1,112 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include <utility>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/LoadNXcanSAS.h"
+#include "MantidDataHandling/NXcanSASDefinitions.h"
+#include "MantidKernel/Unit.h"
+#include "MantidKernel/VectorHelper.h"
+#include "NXcanSASTestHelper.h"
+
+using Mantid::DataHandling::NXcanSAS::LoadNXcanSAS;
+using namespace NXcanSASTestHelper;
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+using namespace Mantid::DataHandling::NXcanSAS;
+
+class ILoadNXcanSASPerformanceTest {
+public:
+  virtual void test_execute() = 0;
+  void setUp() {
+    setupUniqueParams();
+    setupParamsAndAlg();
+  }
+  void tearDown() {
+    AnalysisDataService::Instance().clear();
+    removeFile(m_parameters.filePath());
+  }
+
+protected:
+  LoadNXcanSAS alg;
+  NXcanSASTestParameters m_parameters;
+
+  void save_no_assert(const MatrixWorkspace_sptr &ws, NXcanSASTestParameters &parameters) {
+    auto saveAlg = AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
+    saveAlg->initialize();
+    saveAlg->setProperty("Filename", parameters.filePath());
+    saveAlg->setProperty("InputWorkspace", ws);
+    saveAlg->setProperty("RadiationSource", parameters.radiationSource);
+    if (!parameters.detectors.empty()) {
+      std::string detectorsAsString = concatenateStringVector(parameters.detectors);
+      saveAlg->setProperty("DetectorNames", detectorsAsString);
+    }
+    saveAlg->execute();
+  }
+
+  void setupParamsAndAlg() {
+    m_parameters.detectors.emplace_back("front-detector");
+    m_parameters.detectors.emplace_back("rear-detector");
+    m_parameters.invalidDetectors = false;
+
+    const std::string outWsName = "loadNXcanSASTestOutputWorkspace";
+    alg.initialize();
+    alg.setPropertyValue("Filename", m_parameters.filePath());
+    alg.setProperty("LoadTransmission", true);
+    alg.setPropertyValue("OutputWorkspace", outWsName);
+  }
+
+  virtual void setupUniqueParams() = 0;
+};
+
+class LoadNXcanSASPerformanceTest1D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
+public:
+  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
+  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
+  void test_execute() override { alg.execute(); }
+
+  static LoadNXcanSASPerformanceTest1D *createSuite() { return new LoadNXcanSASPerformanceTest1D(); }
+  static void destroySuite(LoadNXcanSASPerformanceTest1D *suite) { delete suite; }
+  void setupUniqueParams() override {
+    m_parameters.hasDx = true;
+
+    const auto ws = provide1DWorkspace(m_parameters);
+    setXValuesOn1DWorkspace(ws, m_parameters.xmin, m_parameters.xmax);
+    m_parameters.idf = getIDFfromWorkspace(ws);
+
+    save_no_assert(ws, m_parameters);
+  }
+};
+
+class LoadNXcanSASPerformanceTest2D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
+public:
+  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
+  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
+  void test_execute() override { alg.execute(); }
+
+  static LoadNXcanSASPerformanceTest2D *createSuite() { return new LoadNXcanSASPerformanceTest2D(); }
+  static void destroySuite(LoadNXcanSASPerformanceTest2D *suite) { delete suite; }
+  void setupUniqueParams() override {
+    m_parameters.is2dData = true;
+
+    const auto ws = provide2DWorkspace(m_parameters);
+    set2DValues(ws);
+    m_parameters.idf = getIDFfromWorkspace(ws);
+
+    save_no_assert(ws, m_parameters);
+  }
+};

--- a/Framework/DataHandling/test/LoadNXcanSASPerformanceTest1D.h
+++ b/Framework/DataHandling/test/LoadNXcanSASPerformanceTest1D.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "LoadNXcanSASPerformanceTestBase.h"
+#include <cxxtest/TestSuite.h>
+
+class LoadNXcanSASPerformanceTest1D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
+public:
+  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
+  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
+  void test_execute() override { alg.execute(); }
+
+  static LoadNXcanSASPerformanceTest1D *createSuite() { return new LoadNXcanSASPerformanceTest1D(); }
+  static void destroySuite(LoadNXcanSASPerformanceTest1D *suite) { delete suite; }
+  void setupUniqueParams() override {
+    m_parameters.hasDx = true;
+
+    const auto ws = provide1DWorkspace(m_parameters);
+    setXValuesOn1DWorkspace(ws, m_parameters.xmin, m_parameters.xmax);
+    m_parameters.idf = getIDFfromWorkspace(ws);
+
+    save_no_assert(ws, m_parameters);
+  }
+};

--- a/Framework/DataHandling/test/LoadNXcanSASPerformanceTest2D.h
+++ b/Framework/DataHandling/test/LoadNXcanSASPerformanceTest2D.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "LoadNXcanSASPerformanceTestBase.h"
+#include <cxxtest/TestSuite.h>
+
+class LoadNXcanSASPerformanceTest2D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
+public:
+  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
+  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
+  void test_execute() override { alg.execute(); }
+
+  static LoadNXcanSASPerformanceTest2D *createSuite() { return new LoadNXcanSASPerformanceTest2D(); }
+  static void destroySuite(LoadNXcanSASPerformanceTest2D *suite) { delete suite; }
+  void setupUniqueParams() override {
+    m_parameters.is2dData = true;
+
+    const auto ws = provide2DWorkspace(m_parameters);
+    set2DValues(ws);
+    m_parameters.idf = getIDFfromWorkspace(ws);
+
+    save_no_assert(ws, m_parameters);
+  }
+};

--- a/Framework/DataHandling/test/LoadNXcanSASPerformanceTestBase.h
+++ b/Framework/DataHandling/test/LoadNXcanSASPerformanceTestBase.h
@@ -8,25 +8,14 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include <utility>
-
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/Run.h"
-#include "MantidAPI/Sample.h"
-#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadNXcanSAS.h"
-#include "MantidDataHandling/NXcanSASDefinitions.h"
-#include "MantidKernel/Unit.h"
-#include "MantidKernel/VectorHelper.h"
 #include "NXcanSASTestHelper.h"
 
-using Mantid::DataHandling::NXcanSAS::LoadNXcanSAS;
 using namespace NXcanSASTestHelper;
 using namespace Mantid::API;
-using namespace Mantid::Kernel;
 using namespace Mantid::DataHandling::NXcanSAS;
 
 class ILoadNXcanSASPerformanceTest {
@@ -71,42 +60,4 @@ protected:
   }
 
   virtual void setupUniqueParams() = 0;
-};
-
-class LoadNXcanSASPerformanceTest1D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
-public:
-  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
-  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
-  void test_execute() override { alg.execute(); }
-
-  static LoadNXcanSASPerformanceTest1D *createSuite() { return new LoadNXcanSASPerformanceTest1D(); }
-  static void destroySuite(LoadNXcanSASPerformanceTest1D *suite) { delete suite; }
-  void setupUniqueParams() override {
-    m_parameters.hasDx = true;
-
-    const auto ws = provide1DWorkspace(m_parameters);
-    setXValuesOn1DWorkspace(ws, m_parameters.xmin, m_parameters.xmax);
-    m_parameters.idf = getIDFfromWorkspace(ws);
-
-    save_no_assert(ws, m_parameters);
-  }
-};
-
-class LoadNXcanSASPerformanceTest2D : public ILoadNXcanSASPerformanceTest, public CxxTest::TestSuite {
-public:
-  void setUp() override { ILoadNXcanSASPerformanceTest::setUp(); }
-  void tearDown() override { ILoadNXcanSASPerformanceTest::tearDown(); }
-  void test_execute() override { alg.execute(); }
-
-  static LoadNXcanSASPerformanceTest2D *createSuite() { return new LoadNXcanSASPerformanceTest2D(); }
-  static void destroySuite(LoadNXcanSASPerformanceTest2D *suite) { delete suite; }
-  void setupUniqueParams() override {
-    m_parameters.is2dData = true;
-
-    const auto ws = provide2DWorkspace(m_parameters);
-    set2DValues(ws);
-    m_parameters.idf = getIDFfromWorkspace(ws);
-
-    save_no_assert(ws, m_parameters);
-  }
 };

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -111,6 +111,7 @@ public:
     m_parameters.invalidDetectors = false;
     m_parameters.hasDx = false;
     m_parameters.loadTransmission = true;
+    m_parameters.filePath = generateRandomFilename();
 
     const auto ws = provide1DWorkspace(m_parameters);
     setXValuesOn1DWorkspace(ws, m_parameters.xmin, m_parameters.xmax);
@@ -142,9 +143,9 @@ public:
     m_parameters.detectors.emplace_back("front-detector");
     m_parameters.detectors.emplace_back("rear-detector");
     m_parameters.invalidDetectors = false;
-
     m_parameters.is2dData = true;
     m_parameters.hasDx = false;
+    m_parameters.filePath = generateRandomFilename();
 
     const auto ws = provide2DWorkspace(m_parameters);
     set2DValues(ws);
@@ -270,7 +271,11 @@ private:
   NXcanSASTestParameters m_parameters;
 
   Workspace_sptr load_file_no_issues() const {
+    if (m_parameters.filePath.empty()) {
+      throw std::runtime_error("Error in test - no file path set in parameters");
+    }
     LoadNXcanSAS alg;
+
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", m_parameters.filePath));
@@ -294,9 +299,9 @@ private:
 
     const std::string saveAlgName = m_parameters.isPolarized ? "SavePolarizedNXcanSAS" : "SaveNXcanSAS";
     const auto saveAlg = AlgorithmManager::Instance().createUnmanaged(saveAlgName);
-    std::string filePath = generate_random_filename();
+    m_parameters.filePath = generateRandomFilename();
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", filePath);
+    saveAlg->setProperty("Filename", m_parameters.filePath);
 
     if (m_parameters.isPolarized) {
       saveAlg->setProperty("InputWorkspace", std::dynamic_pointer_cast<WorkspaceGroup>(workspace));
@@ -560,7 +565,7 @@ private:
     parameters1D.detectors.emplace_back("rear-detector");
     parameters1D.invalidDetectors = false;
     parameters1D.hasDx = true;
-    parameters1D.filePath = generate_random_filename();
+    parameters1D.filePath = generateRandomFilename();
 
     const auto ws = provide1DWorkspace(parameters1D);
     setXValuesOn1DWorkspace(ws, parameters1D.xmin, parameters1D.xmax);
@@ -585,7 +590,7 @@ private:
     parameters2D.detectors.emplace_back("rear-detector");
     parameters2D.invalidDetectors = false;
     parameters2D.is2dData = true;
-    parameters2D.filePath = generate_random_filename();
+    parameters2D.filePath = generateRandomFilename();
 
     const auto ws = provide2DWorkspace(parameters2D);
     set2DValues(ws);

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -64,7 +64,7 @@ public:
   void setUp() override { m_parameters = NXcanSASTestParameters(); }
   void tearDown() override {
     m_ads.clear();
-    removeFile(m_parameters.filename);
+    removeFile(m_parameters.filePath);
   }
 
   void test_that_1D_workspace_with_Q_resolution_can_be_loaded() {
@@ -132,7 +132,7 @@ public:
   }
 
   void test_that_legacy_transmissions_saved_as_histograms_are_loaded() {
-    m_parameters.filename = "NXcanSAS-histo-lambda.h5";
+    m_parameters.filePath = "NXcanSAS-histo-lambda.h5";
 
     const auto wsOut = std::dynamic_pointer_cast<MatrixWorkspace>(load_file_no_issues());
     TS_ASSERT(!wsOut->isHistogramData());
@@ -273,7 +273,7 @@ private:
     LoadNXcanSAS alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", m_parameters.filename));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", m_parameters.filePath));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LoadTransmission", m_parameters.loadTransmission));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_parameters.loadedWSName));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
@@ -294,8 +294,9 @@ private:
 
     const std::string saveAlgName = m_parameters.isPolarized ? "SavePolarizedNXcanSAS" : "SaveNXcanSAS";
     const auto saveAlg = AlgorithmManager::Instance().createUnmanaged(saveAlgName);
+    std::string filePath = generate_random_filename();
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", m_parameters.filename);
+    saveAlg->setProperty("Filename", filePath);
 
     if (m_parameters.isPolarized) {
       saveAlg->setProperty("InputWorkspace", std::dynamic_pointer_cast<WorkspaceGroup>(workspace));
@@ -525,8 +526,8 @@ public:
 
   ~LoadNXcanSASTestPerformance() {
     AnalysisDataService::Instance().clear();
-    removeFile(parameters1D.filename);
-    removeFile(parameters2D.filename);
+    removeFile(parameters1D.filePath);
+    removeFile(parameters2D.filePath);
   }
 
   void test_execute_1D() { alg1D.execute(); }
@@ -542,7 +543,7 @@ private:
   void save_no_assert(const MatrixWorkspace_sptr &ws, NXcanSASTestParameters &parameters) {
     auto saveAlg = AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", parameters.filename);
+    saveAlg->setProperty("Filename", parameters.filePath);
     saveAlg->setProperty("InputWorkspace", ws);
     saveAlg->setProperty("RadiationSource", parameters.radiationSource);
     if (!parameters.detectors.empty()) {
@@ -554,11 +555,12 @@ private:
   }
 
   void setup_1D() {
-    removeFile(parameters1D.filename);
+    removeFile(parameters1D.filePath);
     parameters1D.detectors.emplace_back("front-detector");
     parameters1D.detectors.emplace_back("rear-detector");
     parameters1D.invalidDetectors = false;
     parameters1D.hasDx = true;
+    parameters1D.filePath = generate_random_filename();
 
     const auto ws = provide1DWorkspace(parameters1D);
     setXValuesOn1DWorkspace(ws, parameters1D.xmin, parameters1D.xmax);
@@ -569,7 +571,7 @@ private:
     const std::string outWsName = "loadNXcanSASTestOutputWorkspace";
 
     alg1D.initialize();
-    alg1D.setPropertyValue("Filename", parameters1D.filename);
+    alg1D.setPropertyValue("Filename", parameters1D.filePath);
 
     alg1D.setProperty("LoadTransmission", true);
 
@@ -577,13 +579,13 @@ private:
   }
 
   void setup_2D() {
-    removeFile(parameters2D.filename);
+    removeFile(parameters2D.filePath);
 
     parameters2D.detectors.emplace_back("front-detector");
     parameters2D.detectors.emplace_back("rear-detector");
     parameters2D.invalidDetectors = false;
-
     parameters2D.is2dData = true;
+    parameters2D.filePath = generate_random_filename();
 
     const auto ws = provide2DWorkspace(parameters2D);
     set2DValues(ws);
@@ -593,7 +595,7 @@ private:
     save_no_assert(ws, parameters2D);
 
     alg2D.initialize();
-    alg2D.setPropertyValue("Filename", parameters2D.filename);
+    alg2D.setPropertyValue("Filename", parameters2D.filePath);
 
     alg2D.setProperty("LoadTransmission", true);
 

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -64,7 +64,7 @@ public:
   void setUp() override { m_parameters = NXcanSASTestParameters(); }
   void tearDown() override {
     m_ads.clear();
-    removeFile(m_parameters.filePath);
+    removeFile(m_parameters.filePath());
   }
 
   void test_that_1D_workspace_with_Q_resolution_can_be_loaded() {
@@ -111,7 +111,6 @@ public:
     m_parameters.invalidDetectors = false;
     m_parameters.hasDx = false;
     m_parameters.loadTransmission = true;
-    m_parameters.filePath = generateRandomFilename();
 
     const auto ws = provide1DWorkspace(m_parameters);
     setXValuesOn1DWorkspace(ws, m_parameters.xmin, m_parameters.xmax);
@@ -133,8 +132,7 @@ public:
   }
 
   void test_that_legacy_transmissions_saved_as_histograms_are_loaded() {
-    m_parameters.filePath = "NXcanSAS-histo-lambda.h5";
-
+    m_parameters.overwriteFilePath("NXcanSAS-histo-lambda.h5");
     const auto wsOut = std::dynamic_pointer_cast<MatrixWorkspace>(load_file_no_issues());
     TS_ASSERT(!wsOut->isHistogramData());
   }
@@ -145,7 +143,6 @@ public:
     m_parameters.invalidDetectors = false;
     m_parameters.is2dData = true;
     m_parameters.hasDx = false;
-    m_parameters.filePath = generateRandomFilename();
 
     const auto ws = provide2DWorkspace(m_parameters);
     set2DValues(ws);
@@ -270,15 +267,12 @@ private:
   AnalysisDataServiceImpl &m_ads;
   NXcanSASTestParameters m_parameters;
 
-  Workspace_sptr load_file_no_issues() const {
-    if (m_parameters.filePath.empty()) {
-      throw std::runtime_error("Error in test - no file path set in parameters");
-    }
+  Workspace_sptr load_file_no_issues() {
     LoadNXcanSAS alg;
 
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", m_parameters.filePath));
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", m_parameters.filePath()));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LoadTransmission", m_parameters.loadTransmission));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_parameters.loadedWSName));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
@@ -299,9 +293,8 @@ private:
 
     const std::string saveAlgName = m_parameters.isPolarized ? "SavePolarizedNXcanSAS" : "SaveNXcanSAS";
     const auto saveAlg = AlgorithmManager::Instance().createUnmanaged(saveAlgName);
-    m_parameters.filePath = generateRandomFilename();
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", m_parameters.filePath);
+    saveAlg->setProperty("Filename", m_parameters.filePath());
 
     if (m_parameters.isPolarized) {
       saveAlg->setProperty("InputWorkspace", std::dynamic_pointer_cast<WorkspaceGroup>(workspace));
@@ -515,95 +508,5 @@ private:
       compareLogTo(wsOut, sasSampleEMFieldDirectionRotation, "3");
       do_assert_load(wsPoint, wsOut);
     }
-  }
-};
-
-class LoadNXcanSASTestPerformance : public CxxTest::TestSuite {
-public:
-  static LoadNXcanSASTestPerformance *createSuite() { return new LoadNXcanSASTestPerformance(); }
-
-  static void destroySuite(LoadNXcanSASTestPerformance *suite) { delete suite; }
-
-  LoadNXcanSASTestPerformance() {
-    setup_1D();
-    setup_2D();
-  }
-
-  ~LoadNXcanSASTestPerformance() {
-    AnalysisDataService::Instance().clear();
-    removeFile(parameters1D.filePath);
-    removeFile(parameters2D.filePath);
-  }
-
-  void test_execute_1D() { alg1D.execute(); }
-
-  void test_execute_2D() { alg2D.execute(); }
-
-private:
-  LoadNXcanSAS alg1D;
-  LoadNXcanSAS alg2D;
-  NXcanSASTestParameters parameters1D;
-  NXcanSASTestParameters parameters2D;
-
-  void save_no_assert(const MatrixWorkspace_sptr &ws, NXcanSASTestParameters &parameters) {
-    auto saveAlg = AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
-    saveAlg->initialize();
-    saveAlg->setProperty("Filename", parameters.filePath);
-    saveAlg->setProperty("InputWorkspace", ws);
-    saveAlg->setProperty("RadiationSource", parameters.radiationSource);
-    if (!parameters.detectors.empty()) {
-      std::string detectorsAsString = concatenateStringVector(parameters.detectors);
-      saveAlg->setProperty("DetectorNames", detectorsAsString);
-    }
-
-    saveAlg->execute();
-  }
-
-  void setup_1D() {
-    removeFile(parameters1D.filePath);
-    parameters1D.detectors.emplace_back("front-detector");
-    parameters1D.detectors.emplace_back("rear-detector");
-    parameters1D.invalidDetectors = false;
-    parameters1D.hasDx = true;
-    parameters1D.filePath = generateRandomFilename();
-
-    const auto ws = provide1DWorkspace(parameters1D);
-    setXValuesOn1DWorkspace(ws, parameters1D.xmin, parameters1D.xmax);
-    parameters1D.idf = getIDFfromWorkspace(ws);
-
-    save_no_assert(ws, parameters1D);
-
-    const std::string outWsName = "loadNXcanSASTestOutputWorkspace";
-
-    alg1D.initialize();
-    alg1D.setPropertyValue("Filename", parameters1D.filePath);
-
-    alg1D.setProperty("LoadTransmission", true);
-
-    alg1D.setPropertyValue("OutputWorkspace", outWsName);
-  }
-
-  void setup_2D() {
-    removeFile(parameters2D.filePath);
-
-    parameters2D.detectors.emplace_back("front-detector");
-    parameters2D.detectors.emplace_back("rear-detector");
-    parameters2D.invalidDetectors = false;
-    parameters2D.is2dData = true;
-    parameters2D.filePath = generateRandomFilename();
-
-    const auto ws = provide2DWorkspace(parameters2D);
-    set2DValues(ws);
-    const std::string outWsName = "loadNXcanSASTestOutputWorkspace";
-    parameters2D.idf = getIDFfromWorkspace(ws);
-
-    save_no_assert(ws, parameters2D);
-
-    alg2D.initialize();
-    alg2D.setPropertyValue("Filename", parameters2D.filePath);
-
-    alg2D.setProperty("LoadTransmission", true);
-
-    alg2D.setPropertyValue("OutputWorkspace", outWsName);
   }
 };

--- a/Framework/DataHandling/test/NXcanSASFileTest.h
+++ b/Framework/DataHandling/test/NXcanSASFileTest.h
@@ -412,8 +412,12 @@ protected:
   }
 
   void do_assert(const NXcanSASTestParameters &parameters) {
-    const auto filename = parameters.filename;
-    H5::H5File file(filename, H5F_ACC_RDONLY, H5Util::defaultFileAcc());
+    const auto filePath = parameters.filePath;
+    if (filePath.empty()) {
+      throw std::runtime_error("Error in test - no file path set in parameters");
+    }
+
+    H5::H5File file(filePath, H5F_ACC_RDONLY, H5Util::defaultFileAcc());
 
     // Check sasentry
     const auto entry = file.openGroup(sasEntryGroupName + sasEntryDefaultSuffix);

--- a/Framework/DataHandling/test/NXcanSASFileTest.h
+++ b/Framework/DataHandling/test/NXcanSASFileTest.h
@@ -411,13 +411,8 @@ protected:
     assertDataSpacesMatch(std::make_pair(tDataSet, lambdaDataSet), std::make_pair("Transmission signal", "Wavelength"));
   }
 
-  void do_assert(const NXcanSASTestParameters &parameters) {
-    const auto filePath = parameters.filePath;
-    if (filePath.empty()) {
-      throw std::runtime_error("Error in test - no file path set in parameters");
-    }
-
-    H5::H5File file(filePath, H5F_ACC_RDONLY, H5Util::defaultFileAcc());
+  void do_assert(NXcanSASTestParameters &parameters) {
+    H5::H5File file(parameters.filePath(), H5F_ACC_RDONLY, H5Util::defaultFileAcc());
 
     // Check sasentry
     const auto entry = file.openGroup(sasEntryGroupName + sasEntryDefaultSuffix);

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -15,10 +15,10 @@
 #include "MantidDataHandling/NXcanSASDefinitions.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/Strings.h"
 #include "MantidKernel/UnitFactory.h"
 
 #include <filesystem>
-#include <random>
 
 namespace {
 // Create a histogram from a workspace and return it
@@ -291,19 +291,8 @@ void removeFile(const std::string &filename) {
 }
 
 std::string generateRandomFilename(std::size_t length, const std::string &suffix) {
-  const char charset[] = "0123456789"
-                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                         "abcdefghijklmnopqrstuvwxyz";
-  static std::mt19937 rng{std::random_device{}()};
-  static std::uniform_int_distribution<> dist(0, sizeof(charset) - 2); // -2 to skip null terminator
-
-  std::string name;
-  name.reserve(length);
-  for (std::size_t i = 0; i < length; ++i) {
-    name += charset[dist(rng)];
-  }
-  std::filesystem::path filepath;
-  filepath = std::filesystem::temp_directory_path() / (name + suffix);
+  const auto &name = Mantid::Kernel::Strings::randomString(length);
+  std::filesystem::path filepath = std::filesystem::temp_directory_path() / (name + suffix);
   return filepath.string();
 }
 

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -18,6 +18,7 @@
 #include "MantidKernel/UnitFactory.h"
 
 #include <filesystem>
+#include <random>
 
 namespace {
 // Create a histogram from a workspace and return it
@@ -288,4 +289,22 @@ void removeFile(const std::string &filename) {
     std::filesystem::remove(path);
   }
 }
+
+std::string generate_random_filename(std::size_t length, const std::string &suffix) {
+  const char charset[] = "0123456789"
+                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                         "abcdefghijklmnopqrstuvwxyz";
+  static std::mt19937 rng{std::random_device{}()};
+  static std::uniform_int_distribution<> dist(0, sizeof(charset) - 2); // -2 to skip null terminator
+
+  std::string tempDir = std::filesystem::temp_directory_path().string();
+  std::string name;
+  name.reserve(tempDir.size() + length);
+  name += tempDir;
+  for (std::size_t i = 0; i < length; ++i) {
+    name += charset[dist(rng)];
+  }
+  return name + suffix;
+}
+
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -296,4 +296,11 @@ std::string generateRandomFilename(std::size_t length, const std::string &suffix
   return filepath.string();
 }
 
+const std::string &NXcanSASTestParameters::filePath() {
+  if (m_filePath.empty()) {
+    m_filePath = generateRandomFilename();
+  }
+  return m_filePath;
+}
+
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -290,21 +290,21 @@ void removeFile(const std::string &filename) {
   }
 }
 
-std::string generate_random_filename(std::size_t length, const std::string &suffix) {
+std::string generateRandomFilename(std::size_t length, const std::string &suffix) {
   const char charset[] = "0123456789"
                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                          "abcdefghijklmnopqrstuvwxyz";
   static std::mt19937 rng{std::random_device{}()};
   static std::uniform_int_distribution<> dist(0, sizeof(charset) - 2); // -2 to skip null terminator
 
-  std::string tempDir = std::filesystem::temp_directory_path().string();
   std::string name;
-  name.reserve(tempDir.size() + length);
-  name += tempDir;
+  name.reserve(length);
   for (std::size_t i = 0; i < length; ++i) {
     name += charset[dist(rng)];
   }
-  return name + suffix;
+  std::filesystem::path filepath;
+  filepath = std::filesystem::temp_directory_path() / (name + suffix);
+  return filepath.string();
 }
 
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -58,7 +58,7 @@ struct NXcanSASTestParameters {
   double magneticFieldStrength{1};
   double scaledBgSubScaleFactor{};
 
-  std::string filename{(std::filesystem::temp_directory_path() / "testFile.h5").string()};
+  std::string filePath;
   std::string runNumber{"1234"};
   std::string userFile{"my_user_file"};
   std::string workspaceTitle{"sample_workspace"};
@@ -133,4 +133,6 @@ Mantid::API::MatrixWorkspace_sptr provide2DWorkspace(const NXcanSASTestParameter
 void set2DValues(const Mantid::API::MatrixWorkspace_sptr &ws, double value = 0);
 
 void removeFile(const std::string &filename);
+
+std::string generate_random_filename(std::size_t length = 12, const std::string &suffix = ".h5");
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -39,7 +39,13 @@ struct TransmissionTestParameters {
   bool usesTransmission{false};
 };
 
-struct NXcanSASTestParameters {
+std::string generateRandomFilename(std::size_t length = 12, const std::string &suffix = ".h5");
+
+class NXcanSASTestParameters {
+private:
+  std::string m_filePath;
+
+public:
   NXcanSASTestParameters() = default;
 
   int polWorkspaceNumber{4};
@@ -58,7 +64,6 @@ struct NXcanSASTestParameters {
   double magneticFieldStrength{1};
   double scaledBgSubScaleFactor{};
 
-  std::string filePath;
   std::string runNumber{"1234"};
   std::string userFile{"my_user_file"};
   std::string workspaceTitle{"sample_workspace"};
@@ -99,6 +104,15 @@ struct NXcanSASTestParameters {
   bool hasBgSub{false};
   bool isHistogram{false};
   bool loadTransmission{false};
+
+  void overwriteFilePath(const std::string &inputFilePath) { m_filePath = inputFilePath; }
+
+  const std::string &filePath() {
+    if (m_filePath.empty()) {
+      m_filePath = generateRandomFilename();
+    }
+    return m_filePath;
+  }
 };
 
 std::string concatenateStringVector(const std::vector<std::string> &stringVector);
@@ -133,6 +147,4 @@ Mantid::API::MatrixWorkspace_sptr provide2DWorkspace(const NXcanSASTestParameter
 void set2DValues(const Mantid::API::MatrixWorkspace_sptr &ws, double value = 0);
 
 void removeFile(const std::string &filename);
-
-std::string generateRandomFilename(std::size_t length = 12, const std::string &suffix = ".h5");
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -134,5 +134,5 @@ void set2DValues(const Mantid::API::MatrixWorkspace_sptr &ws, double value = 0);
 
 void removeFile(const std::string &filename);
 
-std::string generate_random_filename(std::size_t length = 12, const std::string &suffix = ".h5");
+std::string generateRandomFilename(std::size_t length = 12, const std::string &suffix = ".h5");
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -107,12 +107,7 @@ public:
 
   void overwriteFilePath(const std::string &inputFilePath) { m_filePath = inputFilePath; }
 
-  const std::string &filePath() {
-    if (m_filePath.empty()) {
-      m_filePath = generateRandomFilename();
-    }
-    return m_filePath;
-  }
+  const std::string &filePath();
 };
 
 std::string concatenateStringVector(const std::vector<std::string> &stringVector);

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -378,7 +378,7 @@ private:
                            const Mantid::API::MatrixWorkspace_sptr &transmissionCan = nullptr) {
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
     saveAlg->initialize();
-    parameters.filePath = generate_random_filename();
+    parameters.filePath = generateRandomFilename();
 
     saveAlg->setProperty("Filename", parameters.filePath);
     saveAlg->setProperty("InputWorkspace", workspace);

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -21,6 +21,7 @@
 #include "NXcanSASTestHelper.h"
 
 #include <filesystem>
+#include <random>
 
 using Mantid::DataHandling::SaveNXcanSAS;
 using namespace Mantid::DataHandling::NXcanSAS;
@@ -90,7 +91,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_can_run_numbers_included_if_can_transmission_property_is_set() {
@@ -119,7 +120,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_can_and_sample_runs_included_if_both_transmission_properties_are_set() {
@@ -151,7 +152,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_1D_workspace_without_transmissions_is_saved_correctly() {
@@ -174,7 +175,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_sample_bgsub_values_included_if_properties_are_set() {
@@ -203,7 +204,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_unknown_detector_names_are_not_saved() {
@@ -227,7 +228,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_1D_workspace_without_transmissions_and_without_xerror_is_saved_correctly() {
@@ -252,7 +253,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_1D_workspace_with_point_transmissions_is_saved_correctly() {
@@ -293,7 +294,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_2D_workspace_is_saved_correctly() {
@@ -318,7 +319,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
   void test_that_group_workspaces_are_saved_correctly_in_individual_files() {
@@ -333,14 +334,14 @@ public:
 
     for (auto const &suffix : parameters.expectedGroupSuffices) {
       // Assert
-      auto tmpFilename = parameters.filename;
-      parameters.filename.insert(tmpFilename.size() - 3, suffix);
-      TS_ASSERT(!std::filesystem::is_empty(parameters.filename));
+      auto tmpFilePath = parameters.filePath;
+      parameters.filePath.insert(tmpFilePath.size() - 3, suffix);
+      TS_ASSERT(!std::filesystem::is_empty(parameters.filePath));
       do_assert(parameters);
 
       // clean files
-      removeFile(parameters.filename);
-      parameters.filename = tmpFilename;
+      removeFile(parameters.filePath);
+      parameters.filePath = tmpFilePath;
     }
     // Clean ads
     ads.clear();
@@ -349,7 +350,6 @@ public:
   void test_that_2D_workspace_histogram_is_saved_correctly() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -370,16 +370,18 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    removeFile(parameters.filePath);
   }
 
 private:
-  void save_file_no_issues(const Mantid::API::Workspace_sptr &workspace, const NXcanSASTestParameters &parameters,
+  void save_file_no_issues(const Mantid::API::Workspace_sptr &workspace, NXcanSASTestParameters &parameters,
                            const Mantid::API::MatrixWorkspace_sptr &transmission = nullptr,
                            const Mantid::API::MatrixWorkspace_sptr &transmissionCan = nullptr) {
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", parameters.filename);
+    parameters.filePath = generate_random_filename();
+
+    saveAlg->setProperty("Filename", parameters.filePath);
     saveAlg->setProperty("InputWorkspace", workspace);
     saveAlg->setProperty("RadiationSource", parameters.radiationSource);
     saveAlg->setProperty("Geometry", parameters.geometry);

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -331,16 +331,16 @@ public:
     // Act
     save_file_no_issues(std::dynamic_pointer_cast<Mantid::API::Workspace>(ws_group), parameters);
 
+    const auto origFilePath = parameters.filePath();
     for (auto const &suffix : parameters.expectedGroupSuffices) {
       // Assert
-      const auto &origFilePath = parameters.filePath();
       auto newFilePath = origFilePath;
-      parameters.overwriteFilePath(newFilePath.insert(newFilePath.size() - 3, suffix));
+      newFilePath.insert(newFilePath.size() - 3, suffix);
+      parameters.overwriteFilePath(newFilePath);
       do_assert(parameters);
 
       // clean files
       removeFile(parameters.filePath());
-      parameters.overwriteFilePath(origFilePath);
     }
     // Clean ads
     ads.clear();

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -21,7 +21,6 @@
 #include "NXcanSASTestHelper.h"
 
 #include <filesystem>
-#include <random>
 
 using Mantid::DataHandling::SaveNXcanSAS;
 using namespace Mantid::DataHandling::NXcanSAS;

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -90,7 +90,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_can_run_numbers_included_if_can_transmission_property_is_set() {
@@ -119,7 +119,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_can_and_sample_runs_included_if_both_transmission_properties_are_set() {
@@ -151,7 +151,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_1D_workspace_without_transmissions_is_saved_correctly() {
@@ -174,7 +174,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_sample_bgsub_values_included_if_properties_are_set() {
@@ -203,7 +203,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_unknown_detector_names_are_not_saved() {
@@ -227,7 +227,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_1D_workspace_without_transmissions_and_without_xerror_is_saved_correctly() {
@@ -252,7 +252,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_1D_workspace_with_point_transmissions_is_saved_correctly() {
@@ -293,7 +293,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_2D_workspace_is_saved_correctly() {
@@ -318,7 +318,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
   void test_that_group_workspaces_are_saved_correctly_in_individual_files() {
@@ -333,14 +333,14 @@ public:
 
     for (auto const &suffix : parameters.expectedGroupSuffices) {
       // Assert
-      auto tmpFilePath = parameters.filePath;
-      parameters.filePath.insert(tmpFilePath.size() - 3, suffix);
-      TS_ASSERT(!std::filesystem::is_empty(parameters.filePath));
+      const auto &origFilePath = parameters.filePath();
+      auto newFilePath = origFilePath;
+      parameters.overwriteFilePath(newFilePath.insert(newFilePath.size() - 3, suffix));
       do_assert(parameters);
 
       // clean files
-      removeFile(parameters.filePath);
-      parameters.filePath = tmpFilePath;
+      removeFile(parameters.filePath());
+      parameters.overwriteFilePath(origFilePath);
     }
     // Clean ads
     ads.clear();
@@ -369,7 +369,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filePath);
+    removeFile(parameters.filePath());
   }
 
 private:
@@ -378,9 +378,8 @@ private:
                            const Mantid::API::MatrixWorkspace_sptr &transmissionCan = nullptr) {
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SaveNXcanSAS");
     saveAlg->initialize();
-    parameters.filePath = generateRandomFilename();
 
-    saveAlg->setProperty("Filename", parameters.filePath);
+    saveAlg->setProperty("Filename", parameters.filePath());
     saveAlg->setProperty("InputWorkspace", workspace);
     saveAlg->setProperty("RadiationSource", parameters.radiationSource);
     saveAlg->setProperty("Geometry", parameters.geometry);

--- a/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
+++ b/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
@@ -35,11 +35,12 @@ public:
   static void destroySuite(SavePolarizedNXcanSASTest *suite) { delete suite; }
   void setUp() override {
     m_parameters = NXcanSASTestParameters();
+    m_parameters.filePath = generate_random_filename();
     setPolarizedParameters(m_parameters);
   }
   void tearDown() override {
     m_ads.clear();
-    removeFile(m_parameters.filename);
+    removeFile(m_parameters.filePath);
   }
 
   void test_algorithm_saves_with_no_issue_for_1D_test_data_full_polarization() {
@@ -53,7 +54,7 @@ public:
 
     const auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SavePolarizedNXcanSAS");
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", m_parameters.filename);
+    saveAlg->setProperty("Filename", m_parameters.filePath);
     saveAlg->setProperty("InputWorkspace", ws);
 
     TSM_ASSERT_THROWS("Incompatible workspace", saveAlg->execute(), const std::runtime_error &);
@@ -151,7 +152,7 @@ public:
         assertSavedFileFormat(savePolAlg);
 
         // clean
-        removeFile(m_parameters.filename);
+        removeFile(m_parameters.filePath);
         m_ads.clear();
       }
     }
@@ -185,7 +186,7 @@ public:
 
       // clean
       m_ads.clear();
-      removeFile(m_parameters.filename);
+      removeFile(m_parameters.filePath);
     }
   }
 
@@ -196,7 +197,7 @@ private:
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SavePolarizedNXcanSAS");
     saveAlg->initialize();
 
-    saveAlg->setProperty("Filename", m_parameters.filename);
+    saveAlg->setProperty("Filename", m_parameters.filePath);
     saveAlg->setProperty("InputWorkspace", workspace);
 
     // Standard Metadata

--- a/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
+++ b/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
@@ -35,7 +35,7 @@ public:
   static void destroySuite(SavePolarizedNXcanSASTest *suite) { delete suite; }
   void setUp() override {
     m_parameters = NXcanSASTestParameters();
-    m_parameters.filePath = generate_random_filename();
+    m_parameters.filePath = generateRandomFilename();
     setPolarizedParameters(m_parameters);
   }
   void tearDown() override {

--- a/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
+++ b/Framework/DataHandling/test/SavePolarizedNXcanSASTest.h
@@ -35,12 +35,11 @@ public:
   static void destroySuite(SavePolarizedNXcanSASTest *suite) { delete suite; }
   void setUp() override {
     m_parameters = NXcanSASTestParameters();
-    m_parameters.filePath = generateRandomFilename();
     setPolarizedParameters(m_parameters);
   }
   void tearDown() override {
     m_ads.clear();
-    removeFile(m_parameters.filePath);
+    removeFile(m_parameters.filePath());
   }
 
   void test_algorithm_saves_with_no_issue_for_1D_test_data_full_polarization() {
@@ -54,7 +53,7 @@ public:
 
     const auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SavePolarizedNXcanSAS");
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", m_parameters.filePath);
+    saveAlg->setProperty("Filename", m_parameters.filePath());
     saveAlg->setProperty("InputWorkspace", ws);
 
     TSM_ASSERT_THROWS("Incompatible workspace", saveAlg->execute(), const std::runtime_error &);
@@ -152,7 +151,7 @@ public:
         assertSavedFileFormat(savePolAlg);
 
         // clean
-        removeFile(m_parameters.filePath);
+        removeFile(m_parameters.filePath());
         m_ads.clear();
       }
     }
@@ -186,7 +185,7 @@ public:
 
       // clean
       m_ads.clear();
-      removeFile(m_parameters.filePath);
+      removeFile(m_parameters.filePath());
     }
   }
 
@@ -197,7 +196,7 @@ private:
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("SavePolarizedNXcanSAS");
     saveAlg->initialize();
 
-    saveAlg->setProperty("Filename", m_parameters.filePath);
+    saveAlg->setProperty("Filename", m_parameters.filePath());
     saveAlg->setProperty("InputWorkspace", workspace);
 
     // Standard Metadata


### PR DESCRIPTION
### Description of work

Generate random file names for NXcanSASTests.

I'm not optimistic this will fix all the failures, but it will help make any initial failure than causes test files to stick around more obvious.

Try to generate test file names as close as possible to file creation to reduce the probably slim likelihood of a Time-Of-Check to Time-Of-Use attack...

### To test:

Tests pass

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
