### PR TITLE
Handle import errors when simpleapi modules are imported without matplotlib installed

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -50,10 +50,16 @@ from mantid.kernel.funcinspect import (
 
 # register matplotlib projection
 try:
-    from mantid import plots  # noqa
-    from mantid.plots._compatability import plotSpectrum, plotBin  # noqa
+    from mantid import plots
+    from mantid.plots._compatability import plotSpectrum, plotBin
 except ImportError:
-    pass  # matplotlib is unavailable
+
+    def notSupported(*args, **kwargs):
+        raise ModuleNotFoundError("Plotting is not supported by default. Please install matplotlib to enable plotting.")
+
+    plots = notSupported
+    plotSpectrum = notSupported
+    plotBin = notSupported
 
 from mantid.kernel._aliases import *
 from mantid.api._aliases import *


### PR DESCRIPTION
### Description of work
This PR handles an exception that occurs when you try to use an algorithm that requires matplotlib. By default, matplotlib is not installed when you install the Mantid Python library. This will lead to import errors when attempting to access a module in the Framework, as some of the algorithms use matplotlib. The solution here is to add dummy functions that will raise an exception when called. This will delay the exception handling from compile time to run time. Additionally, I added a user prompt to notify the user to install matplotlib if they wish to use these algorithms.

Fixes #39396. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:
1- Build Mantid
2- In the conda environment, uninstall matplotlib "pip uninstall matplotlib"
3- Run the following Python commands in the Python shell:
```
from mantid.simpleapi import plotSpectrum
plotSpectrum()
```
4- This will raise an exception and notify the user to install matplotlib
5- Make sure other modules that doesn't depend on matplotlib works fine, for example run:
```
from mantid.api import FrameworkManager
FrameworkManager.Instance()
```
6- It should work fine without errors as the FrameworkManager doesn't require matplotlib


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
