### PR TITLE
Remove NXinquirefile from nexus api

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/napi.h
+++ b/Framework/Nexus/inc/MantidNexus/napi.h
@@ -115,7 +115,6 @@
 #define NXsameID MANGLE(nxisameid)
 #define NXinitgroupdir MANGLE(nxiinitgroupdir)
 #define NXinitattrdir MANGLE(nxiinitattrdir)
-#define NXinquirefile MANGLE(nxiinquirefile)
 #define NXgetversion MANGLE(nxigetversion)
 
 /*
@@ -525,17 +524,6 @@ MANTID_NEXUS_DLL NXstatus NXinitgroupdir(NXhandle handle);
 MANTID_NEXUS_DLL NXstatus NXinitattrdir(NXhandle handle);
 
 /**
- * Inquire the filename of the currently open file. FilenameBufferLength of the file name
- * will be copied into the filename buffer.
- * \param handle A NeXus file handle as initialized by NXopen.
- * \param filename The buffer to hold the filename.
- * \param  filenameBufferLength The length of the filename buffer.
- * \return NX_OK on success, NX_ERROR in the case of an error.
- * \ingroup c_metadata
- */
-MANTID_NEXUS_DLL NXstatus NXinquirefile(NXhandle handle, char *filename, int filenameBufferLength);
-
-/**
  * Utility function which allocates a suitably sized memory area for the dataset characteristics specified.
  * \param data A pointer to a pointer which will be initialized with a pointer to a suitably sized memory area.
  * \param rank the rank of the data.
@@ -580,11 +568,6 @@ MANTID_NEXUS_DLL NXstatus NXIprintlink(NXhandle fid, NXlink const *link);
  * \param datatype A pointer to an integer which be set to the NeXus data type code for this dataset.
  * \return NX_OK on success, NX_ERROR in the case of an error.
  * \ingroup c_metadata
- */
-MANTID_NEXUS_DLL NXstatus NXgetrawinfo(NXhandle handle, int *rank, int dimension[], NXnumtype *datatype);
-
-/**
- * @copydoc NXgetrawinfo
  */
 MANTID_NEXUS_DLL NXstatus NXgetrawinfo64(NXhandle handle, int *rank, int64_t dimension[], NXnumtype *datatype);
 

--- a/Framework/Nexus/inc/MantidNexus/napi_internal.h
+++ b/Framework/Nexus/inc/MantidNexus/napi_internal.h
@@ -65,7 +65,6 @@ typedef struct {
   NXstatus (*nxinitgroupdir)(NXhandle handle);
   NXstatus (*nxinitattrdir)(NXhandle handle);
   NXstatus (*nxprintlink)(NXhandle handle, NXlink const *link);
-  NXstatus (*nxnativeinquirefile)(NXhandle handle, char *externalfile, const int filenamelength);
 
   NXaccess access_mode;
 } NexusFunction, *pNexusFunction;

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -652,37 +652,6 @@ NXstatus NXinitgroupdir(NXhandle fid) {
   return pFunc->nxinitgroupdir(pFunc->pNexusData);
 }
 
-/*----------------------------------------------------------------------*/
-NXstatus NXinquirefile(NXhandle handle, char *filename, int filenameBufferLength) {
-  pFileStack fileStack;
-
-  pNexusFunction pFunc = handleToNexusFunc(handle);
-  if (pFunc->nxnativeinquirefile != NULL) {
-
-    NXstatus status = pFunc->nxnativeinquirefile(pFunc->pNexusData, filename, filenameBufferLength);
-    if (status != NXstatus::NX_OK) {
-      return NXstatus::NX_ERROR;
-    } else {
-      return NXstatus::NX_OK;
-    }
-  }
-
-  fileStack = static_cast<pFileStack>(handle);
-  char const *pPtr = NULL;
-  pPtr = peekFilenameOnStack(fileStack);
-  if (pPtr != NULL) {
-    auto length = strlen(pPtr);
-    if (length > static_cast<size_t>(filenameBufferLength)) {
-      length = static_cast<size_t>(filenameBufferLength - 1);
-    }
-    memset(filename, 0, static_cast<size_t>(filenameBufferLength));
-    memcpy(filename, pPtr, length);
-    return NXstatus::NX_OK;
-  } else {
-    return NXstatus::NX_ERROR;
-  }
-}
-
 /*------------------------------------------------------------------------
   Implementation of NXopenaddress
   --------------------------------------------------------------------------*/

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -2123,28 +2123,6 @@ NXstatus NX5getgroupID(NXhandle fileid, NXlink *sRes) {
 
 /* ------------------------------------------------------------------- */
 
-NXstatus NX5nativeinquirefile(NXhandle fileid, char *externalfile, const int filenamelen) {
-  hid_t openthing;
-
-  const pNexusFile5 pFile = NXI5assert(fileid);
-  if (pFile->iCurrentD > 0) {
-    openthing = pFile->iCurrentD;
-  } else if (pFile->iCurrentG > 0) {
-    openthing = pFile->iCurrentG;
-  } else {
-    openthing = pFile->iFID;
-  }
-
-  // Check for failure again
-  if (H5Fget_name(openthing, externalfile, static_cast<size_t>(filenamelen)) < 0) {
-    NXReportError("ERROR: retrieving file name");
-    return NXstatus::NX_ERROR;
-  }
-  return NXstatus::NX_OK;
-}
-
-/* ------------------------------------------------------------------- */
-
 NXstatus NX5sameID(NXhandle fileid, NXlink const *pFirstID, NXlink const *pSecondID) {
   NXI5assert(fileid);
   if (pFirstID->targetAddress == pSecondID->targetAddress) {
@@ -2327,6 +2305,5 @@ void NX5assignFunctions(pNexusFunction fHandle) {
   fHandle->nxinitgroupdir = NX5initgroupdir;
   fHandle->nxinitattrdir = NX5initattrdir;
   fHandle->nxprintlink = NX5printlink;
-  fHandle->nxnativeinquirefile = NX5nativeinquirefile;
   fHandle->nxgetnextattra = NX5getnextattra;
 }

--- a/Framework/Nexus/test/napi_test.cpp
+++ b/Framework/Nexus/test/napi_test.cpp
@@ -45,10 +45,6 @@ using NexusNapiTest::write_dmc02;
   if ((status) != NXstatus::NX_OK)                                                                                     \
     ON_ERROR(msg);
 
-namespace { // anonymous namespace
-std::string relativePathOf(const std::string &filename) { return std::filesystem::path(filename).filename().string(); }
-} // anonymous namespace
-
 int main(int argc, char *argv[]) {
   std::cout << "determining file type" << std::endl;
   std::string nxFile;
@@ -226,9 +222,6 @@ int main(int argc, char *argv[]) {
   // read test
   std::cout << "Read/Write to read \"" << nxFile << "\"" << std::endl;
   ASSERT_NO_ERROR(NXopen(nxFile.c_str(), NXACC_RDWR, &fileid), "Failed to open \"" << nxFile << "\" for read/write");
-  char filename[256];
-  ASSERT_NO_ERROR(NXinquirefile(fileid, filename, 256), "");
-  std::cout << "NXinquirefile found: " << relativePathOf(filename) << std::endl;
   NXgetattrinfo(fileid, &i);
   if (i > 0) {
     std::cout << "Number of global attributes: " << i << std::endl;

--- a/Framework/Nexus/test/napi_test_cpp.cpp
+++ b/Framework/Nexus/test/napi_test_cpp.cpp
@@ -376,7 +376,6 @@ int testLoadPath(const string &filename) {
   if (getenv("NX_LOAD_PATH") != NULL) {
     Mantid::Nexus::File file(filename);
     cout << "Success loading NeXus file from path" << endl;
-    // cout << file.inquireFile() << endl; // DEBUG print
     return TEST_SUCCEED;
   } else {
     cout << "NX_LOAD_PATH variable not defined. Skipping testLoadPath\n";


### PR DESCRIPTION
Since nexus is relying on hdf5 internals for the functionality of linking to data in external files, this does not need to exist in the nexus api layer.

This also removes a function declaration where the implementation was previously removed.

Refs #38332 and [EWM11399](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11399)

### To test:

Removing unused functions are fun! The builds pass means that the methods were correctly removed.

*This does not require release notes* because it removes unused internal functions.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
