### PR TITLE
Change address method, simplify `nxstack`

### DIFF
--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -138,15 +138,15 @@ void LoadILLLagrange::loadData() {
   nDims = scanVarSpace.getSimpleExtentNdims();
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
-  if ((nDims != 2) || (dimsSize[1] != m_nScans))
+  if ((nDims != 2) || (dimsSize[1] != m_nScans)) // cppcheck-suppress containerOutOfBounds
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
+  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]); // cppcheck-suppress containerOutOfBounds
   scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]);
-  std::vector<double> scanVariableData(dimsSize[1]);
+  std::vector<double> monitorData(dimsSize[1]);      // cppcheck-suppress containerOutOfBounds
+  std::vector<double> scanVariableData(dimsSize[1]); // cppcheck-suppress containerOutOfBounds
   for (size_t i = 0; i < monitorData.size(); i++) {
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
+    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i]; // cppcheck-suppress containerOutOfBounds
     scanVariableData[i] = scanVarData[i];
   }
   scanVar.close();

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -231,14 +231,14 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
   nDims = scanVarSpace.getSimpleExtentNdims();
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
-  if ((nDims != 2) || (dimsSize[1] != numberOfScans))
+  if ((nDims != 2) || (dimsSize[1] != numberOfScans)) // cppcheck-suppress containerOutOfBounds
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
+  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]); // cppcheck-suppress containerOutOfBounds
   scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]);
+  std::vector<double> monitorData(dimsSize[1]); // cppcheck-suppress containerOutOfBounds
   for (size_t i = 0; i < monitorData.size(); i++)
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
+    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i]; // cppcheck-suppress containerOutOfBounds
 
   scanVar.close();
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -36,6 +36,32 @@ constexpr int NX_MAXADDRESSLEN = 1024;
 
 constexpr int NXMAXSTACK = 50;
 
+typedef int64_t hid_t;
+typedef uint64_t hsize_t;
+
+typedef struct __NexusFile5 {
+  struct iStack5 {
+    char irefn[1024];
+    hid_t iVref;
+    hsize_t iCurrentIDX;
+  } iStack5[NXMAXSTACK];
+  struct iStack5 iAtt5;
+  hid_t iFID;
+  hid_t iCurrentG;
+  hid_t iCurrentD;
+  hid_t iCurrentS;
+  hid_t iCurrentT;
+  hid_t iCurrentA;
+  int iNX;
+  int iNXID;
+  int iStackPtr;
+  char *iCurrentLGG;
+  char *iCurrentLD;
+  char name_ref[1024];
+  char name_tmp[1024];
+  char iAccess[2];
+} NexusFile5, *pNexusFile5;
+
 typedef void *NXhandle; /* really a pointer to a NexusFile structure */
 typedef char NXname[128];
 

--- a/Framework/Nexus/inc/MantidNexus/nxstack.h
+++ b/Framework/Nexus/inc/MantidNexus/nxstack.h
@@ -36,12 +36,9 @@ pFileStack makeFileStack();
 void killFileStack(pFileStack self);
 
 void pushFileStack(pFileStack self, pNexusFunction pDriv, const char *filename);
-void popFileStack(pFileStack self);
 
 pNexusFunction peekFileOnStack(pFileStack self);
 char *peekFilenameOnStack(pFileStack self);
-void peekIDOnStack(pFileStack self, NXlink *id);
-void setCloseID(pFileStack self, const NXlink &id);
 
 int fileStackDepth(pFileStack self);
 

--- a/Framework/Nexus/inc/MantidNexus/nxstack.h
+++ b/Framework/Nexus/inc/MantidNexus/nxstack.h
@@ -43,15 +43,11 @@ public:
 
   void resetValues(pNexusFunction pDriv, std::string const &filename);
 
-  pNexusFunction getFunctions() const { return pDriver; }
+  pNexusFunction const &getFunctions() const { return pDriver; }
 
-  std::string getFilename() const { return filename; }
+  std::string const &getFilename() const { return filename; }
 };
 
 typedef nxstack *pFileStack;
-
-pFileStack makeFileStack();
-
-void killFileStack(pFileStack self);
 
 #endif

--- a/Framework/Nexus/inc/MantidNexus/nxstack.h
+++ b/Framework/Nexus/inc/MantidNexus/nxstack.h
@@ -40,6 +40,4 @@ void pushFileStack(pFileStack self, pNexusFunction pDriv, const char *filename);
 pNexusFunction peekFileOnStack(pFileStack self);
 char *peekFilenameOnStack(pFileStack self);
 
-int fileStackDepth(pFileStack self);
-
 #endif

--- a/Framework/Nexus/inc/MantidNexus/nxstack.h
+++ b/Framework/Nexus/inc/MantidNexus/nxstack.h
@@ -29,15 +29,29 @@
 
 #include "MantidNexus/napi_internal.h"
 
-typedef struct __fileStack *pFileStack;
-#define MAXEXTERNALDEPTH 16
+class nxstack {
+private:
+  std::string filename;
+  pNexusFunction pDriver;
+
+public:
+  nxstack() = default;
+
+  nxstack(std::string const &filename) : filename(filename) {};
+
+  nxstack(pNexusFunction pDriv, std::string const &filename) : filename(filename), pDriver(pDriv) {};
+
+  void resetValues(pNexusFunction pDriv, std::string const &filename);
+
+  pNexusFunction getFunctions() const { return pDriver; }
+
+  std::string getFilename() const { return filename; }
+};
+
+typedef nxstack *pFileStack;
 
 pFileStack makeFileStack();
+
 void killFileStack(pFileStack self);
-
-void pushFileStack(pFileStack self, pNexusFunction pDriv, const char *filename);
-
-pNexusFunction peekFileOnStack(pFileStack self);
-char *peekFilenameOnStack(pFileStack self);
 
 #endif

--- a/Framework/Nexus/inc/MantidNexus/nxstack.h
+++ b/Framework/Nexus/inc/MantidNexus/nxstack.h
@@ -45,8 +45,4 @@ void setCloseID(pFileStack self, const NXlink &id);
 
 int fileStackDepth(pFileStack self);
 
-void pushAddress(pFileStack self, const char *name);
-void popAddress(pFileStack self);
-int buildAddress(pFileStack self, char *address, int addresslen);
-
 #endif

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -35,6 +35,8 @@
 #include "MantidNexus/napi_internal.h"
 #include "MantidNexus/nxstack.h"
 
+// cppcheck-suppress-begin [constVariablePointer, constParameterCallback, variableScope]
+
 // this has to be after the other napi includes
 #include "MantidNexus/napi5.h"
 
@@ -893,3 +895,5 @@ char *NXIformatNeXusTime() {
 }
 
 const char *NXgetversion() { return NEXUS_VERSION; }
+
+// cppcheck-suppress-end [constVariablePointer, constParameterCallback, variableScope]

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -35,7 +35,7 @@
 #include "MantidNexus/napi_internal.h"
 #include "MantidNexus/nxstack.h"
 
-// cppcheck-suppress-begin [constVariablePointer, constParameterCallback, variableScope]
+// cppcheck-suppress-begin [constVariablePointer]
 
 // this has to be after the other napi includes
 #include "MantidNexus/napi5.h"
@@ -896,4 +896,4 @@ char *NXIformatNeXusTime() {
 
 const char *NXgetversion() { return NEXUS_VERSION; }
 
-// cppcheck-suppress-end [constVariablePointer, constParameterCallback, variableScope]
+// cppcheck-suppress-end [constVariablePointer]

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -180,7 +180,7 @@ NXstatus NXreopen(NXhandle pOrigHandle, NXhandle &newHandle) {
   }
   fNewHandle = static_cast<NexusFunction *>(malloc(sizeof(NexusFunction)));
   memcpy(fNewHandle, fOrigHandle, sizeof(NexusFunction));
-  fNewHandle->nxreopen(fOrigHandle->pNexusData, &(fNewHandle->pNexusData));
+  fNewHandle->nxreopen(fOrigHandle->pNexusData, fNewHandle->pNexusData);
   newFileStack->resetValues(fNewHandle, origFileStack->getFilename());
   newHandle = newFileStack;
   return NXstatus::NX_OK;

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -908,10 +908,16 @@ NXstatus NXgetaddress(NXhandle fid, char *address, int addresslen) {
   pFileStack fileStack = NULL;
 
   fileStack = static_cast<pFileStack>(fid);
-  status = buildAddress(fileStack, address, addresslen);
-  if (status != 1) {
-    return NXstatus::NX_ERROR;
+  pNexusFile5 hfil = static_cast<pNexusFile5>(peekFileOnStack(fileStack)->pNexusData);
+  hid_t current;
+  if (hfil->iCurrentD != 0) {
+    current = hfil->iCurrentD;
+  } else if (hfil->iCurrentG != 0) {
+    current = hfil->iCurrentG;
+  } else {
+    current = hfil->iFID;
   }
+  H5Iget_name(current, address, addresslen);
   return NXstatus::NX_OK;
 }
 

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -229,19 +229,8 @@ NXstatus NXmakegroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
 /*------------------------------------------------------------------------*/
 
 NXstatus NXopengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
-  NXstatus status;
-  pFileStack fileStack;
-  pNexusFunction pFunc = NULL;
-
-  fileStack = static_cast<pFileStack>(fid);
-  pFunc = handleToNexusFunc(fid);
-
-  status = pFunc->nxopengroup(pFunc->pNexusData, name, nxclass);
-  if (status == NXstatus::NX_OK) {
-    pushAddress(fileStack, name);
-  }
-
-  return status;
+  pNexusFunction pFunc = handleToNexusFunc(fid);
+  return pFunc->nxopengroup(pFunc->pNexusData, name, nxclass);
 }
 
 /* ------------------------------------------------------------------- */
@@ -255,10 +244,6 @@ NXstatus NXclosegroup(NXhandle fid) {
   fileStack = static_cast<pFileStack>(fid);
   if (fileStackDepth(fileStack) == 0) {
     status = pFunc->nxclosegroup(pFunc->pNexusData);
-    if (status == NXstatus::NX_OK) {
-      popAddress(fileStack);
-    }
-    return status;
   } else {
     /* we have to check for leaving an external file */
     NXgetgroupID(fid, &currentID);
@@ -268,12 +253,9 @@ NXstatus NXclosegroup(NXhandle fid) {
       status = NXclosegroup(fid);
     } else {
       status = pFunc->nxclosegroup(pFunc->pNexusData);
-      if (status == NXstatus::NX_OK) {
-        popAddress(fileStack);
-      }
     }
-    return status;
   }
+  return status;
 }
 
 /* --------------------------------------------------------------------- */
@@ -294,19 +276,8 @@ NXstatus NXcompmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int
 /* --------------------------------------------------------------------- */
 
 NXstatus NXopendata(NXhandle fid, CONSTCHAR *name) {
-  NXstatus status;
-  pFileStack fileStack;
-  pNexusFunction pFunc = NULL;
-
-  fileStack = static_cast<pFileStack>(fid);
-  pFunc = handleToNexusFunc(fid);
-  status = pFunc->nxopendata(pFunc->pNexusData, name);
-
-  if (status == NXstatus::NX_OK) {
-    pushAddress(fileStack, name);
-  }
-
-  return status;
+  pNexusFunction pFunc = handleToNexusFunc(fid);
+  return pFunc->nxopendata(pFunc->pNexusData, name);
 }
 
 /* ----------------------------------------------------------------- */
@@ -321,10 +292,6 @@ NXstatus NXclosedata(NXhandle fid) {
 
   if (fileStackDepth(fileStack) == 0) {
     status = pFunc->nxclosedata(pFunc->pNexusData);
-    if (status == NXstatus::NX_OK) {
-      popAddress(fileStack);
-    }
-    return status;
   } else {
     /* we have to check for leaving an external file */
     NXgetdataID(fid, &currentID);
@@ -334,12 +301,9 @@ NXstatus NXclosedata(NXhandle fid) {
       status = NXclosedata(fid);
     } else {
       status = pFunc->nxclosedata(pFunc->pNexusData);
-      if (status == NXstatus::NX_OK) {
-        popAddress(fileStack);
-      }
     }
-    return status;
   }
+  return status;
 }
 
 /* ------------------------------------------------------------------- */
@@ -904,7 +868,6 @@ NXstatus NXIprintlink(NXhandle fid, NXlink const *link) {
 
 /*----------------------------------------------------------------------*/
 NXstatus NXgetaddress(NXhandle fid, char *address, int addresslen) {
-  int status;
   pFileStack fileStack = NULL;
 
   fileStack = static_cast<pFileStack>(fid);

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -821,7 +821,7 @@ NXstatus NXgetaddress(NXhandle fid, char *address, int addresslen) {
   pFileStack fileStack = NULL;
 
   fileStack = static_cast<pFileStack>(fid);
-  pNexusFile5 hfil = static_cast<pNexusFile5>(peekFileOnStack(fileStack)->pNexusData);
+  pNexusFile5 const hfil = static_cast<pNexusFile5>(peekFileOnStack(fileStack)->pNexusData);
   hid_t current;
   if (hfil->iCurrentD != 0) {
     current = hfil->iCurrentD;

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -441,9 +441,11 @@ NXstatus NX5close(NXhandle &fid) {
   NXI5KillDir(pFile);
   if (pFile->iCurrentLGG != NULL) {
     free(pFile->iCurrentLGG);
+    pFile->iCurrentLGG = NULL;
   }
   if (pFile->iCurrentLD != NULL) {
     free(pFile->iCurrentLD);
+    pFile->iCurrentLD = NULL;
   }
   free(pFile);
   fid = NULL;
@@ -573,6 +575,7 @@ NXstatus NX5opengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
   pFile->iCurrentD = 0;
   if (pFile->iCurrentLGG != NULL) {
     free(pFile->iCurrentLGG);
+    pFile->iCurrentLGG = NULL;
   }
   pFile->iCurrentLGG = strdup(name);
   NXI5KillDir(pFile);
@@ -915,6 +918,7 @@ NXstatus NX5opendata(NXhandle fid, CONSTCHAR *name) {
   }
   if (pFile->iCurrentLD != NULL) {
     free(pFile->iCurrentLD);
+    pFile->iCurrentLD = NULL;
   }
   pFile->iCurrentLD = strdup(name);
 

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -54,29 +54,6 @@
 
 extern void *NXpData;
 
-typedef struct __NexusFile5 {
-  struct iStack5 {
-    char irefn[1024];
-    hid_t iVref;
-    hsize_t iCurrentIDX;
-  } iStack5[NXMAXSTACK];
-  struct iStack5 iAtt5;
-  hid_t iFID;
-  hid_t iCurrentG;
-  hid_t iCurrentD;
-  hid_t iCurrentS;
-  hid_t iCurrentT;
-  hid_t iCurrentA;
-  int iNX;
-  int iNXID;
-  int iStackPtr;
-  char *iCurrentLGG;
-  char *iCurrentLD;
-  char name_ref[1024];
-  char name_tmp[1024];
-  char iAccess[2];
-} NexusFile5, *pNexusFile5;
-
 /* forward declaration of NX5closegroup in order to get rid of a nasty warning */
 
 NXstatus NX5closegroup(NXhandle fid);

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -23,7 +23,7 @@
 
 ----------------------------------------------------------------------------*/
 
-// cppcheck-suppress-begin
+// cppcheck-suppress-begin [constParameterCallback, variableScope]
 
 #include <string>
 #define H5Aiterate_vers 2
@@ -2287,4 +2287,4 @@ void NX5assignFunctions(pNexusFunction fHandle) {
   fHandle->nxgetnextattra = NX5getnextattra;
 }
 
-// cppcheck-suppress-end
+// cppcheck-suppress-end [constParameterCallback, variableScope]

--- a/Framework/Nexus/src/nxstack.cpp
+++ b/Framework/Nexus/src/nxstack.cpp
@@ -84,33 +84,3 @@ void setCloseID(pFileStack self, const NXlink &id) { self->fileStack[self->fileS
 /*----------------------------------------------------------------------*/
 int fileStackDepth(pFileStack self) { return self->fileStackPointer; }
 /*----------------------------------------------------------------------*/
-void pushAddress(pFileStack self, const char *name) {
-  if (self->addressPointer >= 0 && name == self->addressStack[self->addressPointer]) {
-    return;
-  }
-  self->addressPointer++;
-  self->addressStack.emplace_back(name);
-}
-/*-----------------------------------------------------------------------*/
-void popAddress(pFileStack self) {
-  self->addressPointer--;
-  if (self->addressPointer < -1) {
-    self->addressPointer = -1;
-  }
-  if (!self->addressStack.empty()) {
-    self->addressStack.pop_back();
-  }
-}
-/*-----------------------------------------------------------------------*/
-int buildAddress(pFileStack self, char *address, int addresslen) {
-  std::string totalAddress;
-  if (self->addressStack.empty()) {
-    totalAddress = "/";
-  }
-  for (std::string const &subaddress : self->addressStack) {
-    totalAddress += "/" + subaddress;
-  }
-  strncpy(address, totalAddress.c_str(), addresslen - 1);
-
-  return 1;
-}

--- a/Framework/Nexus/src/nxstack.cpp
+++ b/Framework/Nexus/src/nxstack.cpp
@@ -33,54 +33,29 @@
  Data definitions
 ---------------------------------------------------------------------*/
 
-typedef struct {
-  pNexusFunction pDriver;
-  NXlink closeID;
-  std::string filename;
-} fileStackEntry;
-
 typedef struct __fileStack {
-  int fileStackPointer;
-  std::vector<fileStackEntry> fileStack;
-  int addressPointer;
-  std::vector<std::string> addressStack;
+  pNexusFunction pDriver;
+  std::string filename;
 } fileStack;
+
 /*---------------------------------------------------------------------*/
 pFileStack makeFileStack() {
   pFileStack pNew = new fileStack;
-  pNew->fileStackPointer = -1;
-  pNew->addressPointer = -1;
   return pNew;
 }
 /*---------------------------------------------------------------------*/
 void killFileStack(pFileStack self) {
   if (self != NULL) {
-    free(self);
+    delete self;
   }
 }
 /*----------------------------------------------------------------------*/
 void pushFileStack(pFileStack self, pNexusFunction pDriv, const char *file) {
-  self->fileStackPointer++;
-  self->fileStack.emplace_back(pDriv, NXlink{"", NXentrytype::group}, std::string(file));
+  self->pDriver = pDriv;
+  self->filename = std::string(file);
 }
 /*----------------------------------------------------------------------*/
-void popFileStack(pFileStack self) {
-  self->fileStackPointer--;
-  if (self->fileStackPointer < -1) {
-    self->fileStackPointer = -1;
-  }
-  if (!self->fileStack.empty()) {
-    self->fileStack.pop_back();
-  }
-}
-/*----------------------------------------------------------------------*/
-pNexusFunction peekFileOnStack(pFileStack self) { return self->fileStack[self->fileStackPointer].pDriver; }
+pNexusFunction peekFileOnStack(pFileStack self) { return self->pDriver; }
 /*---------------------------------------------------------------------*/
-char *peekFilenameOnStack(pFileStack self) { return self->fileStack[self->fileStackPointer].filename.data(); }
-/*----------------------------------------------------------------------*/
-void peekIDOnStack(pFileStack self, NXlink *id) { *id = self->fileStack[self->fileStackPointer].closeID; }
-/*---------------------------------------------------------------------*/
-void setCloseID(pFileStack self, const NXlink &id) { self->fileStack[self->fileStackPointer].closeID = id; }
-/*----------------------------------------------------------------------*/
-int fileStackDepth(pFileStack self) { return self->fileStackPointer; }
+char *peekFilenameOnStack(pFileStack self) { return self->filename.data(); }
 /*----------------------------------------------------------------------*/

--- a/Framework/Nexus/src/nxstack.cpp
+++ b/Framework/Nexus/src/nxstack.cpp
@@ -29,33 +29,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-/*-----------------------------------------------------------------------
- Data definitions
----------------------------------------------------------------------*/
-
-typedef struct __fileStack {
-  pNexusFunction pDriver;
-  std::string filename;
-} fileStack;
-
-/*---------------------------------------------------------------------*/
-pFileStack makeFileStack() {
-  pFileStack pNew = new fileStack;
-  return pNew;
-}
-/*---------------------------------------------------------------------*/
-void killFileStack(pFileStack self) {
-  if (self != NULL) {
-    delete self;
-  }
-}
 /*----------------------------------------------------------------------*/
-void pushFileStack(pFileStack self, pNexusFunction pDriv, const char *file) {
-  self->pDriver = pDriv;
-  self->filename = std::string(file);
+void nxstack::resetValues(pNexusFunction pDriv, std::string const &file) {
+  this->pDriver = pDriv;
+  this->filename = file;
 }
-/*----------------------------------------------------------------------*/
-pNexusFunction peekFileOnStack(pFileStack self) { return self->pDriver; }
-/*---------------------------------------------------------------------*/
-char *peekFilenameOnStack(pFileStack self) { return self->filename.data(); }
 /*----------------------------------------------------------------------*/


### PR DESCRIPTION
Switch to using `hdf5`'s own internal tracking of paths from an object ID, rather than `nxstack`'s use of a string vector and concatenation to make the path.

This allows simplification of `nxstack`.

Refs #38332 and [EWM 11399](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11399)

#### Further detail of work

Using the `hdf5` path method requires moving the `NexusFIle5` definition so that it is visible to `napi.cpp`.  This will also help with upcoming work to change `NXhandle` from a `void *` to  `NexusFile5*`.

Some residual external file support was still leftover from PRs #39408  and #39412.  Removing this last bit allows further simplification of `nxstack` so that there is no longer any real "stack" at all.

This change exposed CppCheck warnings in `LoadILLLagrange` and `LoadILLSALSA`.  These errors always existed, but CppCheck was not able to see them until these simplifications.  Future work should figure out how to fix those issues, but for now they are being suppressed.

### To test:

This is a refactor.  Ensure all tests pass and code looks sensible.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
