### PR TITLE
Add additional tests to NexusClasses.

### DIFF
--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusException.h"
 #include "test_helper.h"
 #include <cxxtest/TestSuite.h>
 #include <filesystem>
@@ -31,12 +32,14 @@ public:
     // check NXChar
     auto definition = root.openNXChar("entry/definition"); // relative address
     definition.load();
-    TS_ASSERT_EQUALS(std::string(definition(), definition.dim0()), "NXsnsevent");
+    TS_ASSERT_EQUALS(std::string(definition()), "NXsnsevent");
     // and from getString
     TS_ASSERT_EQUALS(root.getString("entry/definition"), "NXsnsevent");
 
     TS_ASSERT(!entry.containsGroup("bank91_events")); // there aren't that many groups
     TS_ASSERT(entry.containsGroup("bank19_events"));
+
+    TS_ASSERT_THROWS(entry.openNXGroup("bank91_events"), const Mantid::Nexus::Exception &); // next call should be fine
 
     auto bank19 = entry.openNXGroup("bank19_events");
     TS_ASSERT_EQUALS(bank19.name(), "bank19_events");
@@ -52,6 +55,18 @@ public:
     TS_ASSERT_DELTA(time_of_flight[0], 16681.5, .01);
     TS_ASSERT_DELTA(time_of_flight[255], 958.1, .01);
     TS_ASSERT_THROWS_ANYTHING(time_of_flight[256]); // out of bounds
+
+    TS_ASSERT_THROWS(bank19.openNXFloat("timeofflight"), const Mantid::Nexus::Exception &); // next call should be fine
+
+    // load detector ids without letting previous data go out of scope
+    auto detid = bank19.openNXDataSet<uint32_t>("event_id"); // type does not have a convenience function
+    TS_ASSERT_EQUALS(detid.dim0(), 256);                     // same as number of time-of-flight
+    TS_ASSERT_EQUALS(detid.attributes.n(), 1);
+    TS_ASSERT_EQUALS(detid.attributes("target"), "/entry/instrument/bank19/event_id");
+    detid.load();
+    TS_ASSERT_EQUALS(detid[0], 37252);
+    TS_ASSERT_EQUALS(detid[255], 37272);
+    TS_ASSERT_THROWS_ANYTHING(detid[256]); // out of bounds
 
     auto duration = root.openNXFloat("/entry/duration"); // absolute address
     TS_ASSERT_EQUALS(duration.attributes.n(), 1);


### PR DESCRIPTION
These changes are copied from #39213

> Add another test of opening data without letting previous go out of scope. Add two more tests to make sure failures recover well.

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Ref #38332

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

If the CI passes we should be good.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

*This does not require release notes* because we are just adding more tests.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
