### PR TITLE
Add time integer series test for Export Results Table in Muon Analysis Interface

### DIFF
--- a/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -260,13 +260,21 @@ class ResultsTabModelTest(unittest.TestCase):
     def test_create_results_table_with_logs_selected(self):
         workspace = CreateWorkspace([0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5])
         workspace.mutableRun().addProperty("run_start", "1970-01-01T00:00:01 to 1970-01-01T00:00:01", True)
+        # Float Time Series
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:00:00", Value=100)
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:30:00", Value=65)
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:50:00", Value=100.2)
+        # Integer Time Series
+        AddTimeSeriesLog(workspace, Name="periods", Time="2010-01-01T00:00:00", Type="int", Value=1)
+        AddTimeSeriesLog(workspace, Name="periods", Time="2010-01-01T00:30:00", Type="int", Value=2)
+        AddTimeSeriesLog(workspace, Name="periods", Time="2010-01-01T00:50:00", Type="int", Value=3)
+
         workspace.mutableRun().addProperty("sample_magn_field", 2, True)
-        _, model = create_test_model(("ws1",), "func1", self.parameters, [StaticWorkspaceWrapper("ws1", workspace)], self.logs)
+
+        log_names = [*self.log_names, "periods"]
+        _, model = create_test_model(("ws1",), "func1", self.parameters, [StaticWorkspaceWrapper("ws1", workspace)])
         selected_results = [("ws1", 0)]
-        table = model.create_results_table(self.log_names, selected_results)
+        table = model.create_results_table(log_names, selected_results)
 
         # workspace_name => no error col as its a string
         # sample_temp => time series and will have non-zero error
@@ -279,6 +287,8 @@ class ResultsTabModelTest(unittest.TestCase):
             "sample_tempError",
             "sample_magn_field",
             "sample_magn_fieldError",
+            "periods",
+            "periodsError",
             "f0.Height",
             "f0.HeightError",
             "f0.PeakCentre",
@@ -301,6 +311,8 @@ class ResultsTabModelTest(unittest.TestCase):
             TableColumnType.XErr,
             TableColumnType.X,
             TableColumnType.XErr,
+            TableColumnType.X,
+            TableColumnType.XErr,
             TableColumnType.Y,
             TableColumnType.YErr,
             TableColumnType.Y,
@@ -315,7 +327,7 @@ class ResultsTabModelTest(unittest.TestCase):
             TableColumnType.YErr,
             TableColumnType.Y,
         )
-        avg_log_values = "1970-01-01T00:00:01 to 1970-01-01T00:00:01", 1, 90.057, 2.0
+        avg_log_values = "1970-01-01T00:00:01 to 1970-01-01T00:00:01", 1, 90.057, 2.0, 1.857
         expected_content = [
             (
                 "ws1_Parameters",
@@ -325,6 +337,8 @@ class ResultsTabModelTest(unittest.TestCase):
                 15.848,
                 avg_log_values[3],
                 0.0,
+                avg_log_values[4],
+                0.8329,
                 self.f0_height[0],
                 self.f0_height[1],
                 self.f0_centre[0],


### PR DESCRIPTION
This PR is a small leftover bit from  #39338. We add a test that checks that adding an integer time series log (The offending log causing the crash in #39338 ) is working properly now. 

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [#39354](https://github.com/mantidproject/mantid/issues/39354). <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

- All tests should pass. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
