### PR TITLE
Fix cppcheck suppressions in LoadILLSALSA and LoadILLLagrange

### DIFF
--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -136,13 +136,13 @@ void LoadILLLagrange::loadData() {
   H5::DataSpace scanVarSpace = scanVar.getSpace();
 
   nDims = scanVarSpace.getSimpleExtentNdims();
+  if (nDims != 2)
+    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
+
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
-  if (dimsSize.size() < nDims)
-    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
-
-  if ((nDims != 2) || (dimsSize[1] != m_nScans))
+  if (imsSize[1] != m_nScans)
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
   std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -136,22 +136,25 @@ void LoadILLLagrange::loadData() {
   H5::DataSpace scanVarSpace = scanVar.getSpace();
 
   nDims = scanVarSpace.getSimpleExtentNdims();
-  if (nDims != 2)
+  std::vector<double> monitorData;
+  std::vector<double> scanVariableData;
+  if (nDims != 2) {
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
+  } else {
+    dimsSize = std::vector<hsize_t>(nDims);
+    scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
-  dimsSize = std::vector<hsize_t>(nDims);
-  scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
+    if (dimsSize[1] != m_nScans)
+      throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  if (imsSize[1] != m_nScans)
-    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
-
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
-  scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]);
-  std::vector<double> scanVariableData(dimsSize[1]);
-  for (size_t i = 0; i < monitorData.size(); i++) {
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
-    scanVariableData[i] = scanVarData[i];
+    std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
+    scanVar.read(scanVarData.data(), scanVar.getDataType());
+    monitorData.resize(dimsSize[1]);
+    scanVariableData.resize(dimsSize[1]);
+    for (size_t i = 0; i < monitorData.size(); i++) {
+      monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
+      scanVariableData[i] = scanVarData[i];
+    }
   }
   scanVar.close();
 

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -138,10 +138,10 @@ void LoadILLLagrange::loadData() {
   nDims = scanVarSpace.getSimpleExtentNdims();
   std::vector<double> monitorData;
   std::vector<double> scanVariableData;
-  if (nDims != 2) {
+  dimsSize.resize(nDims);
+  if (dimsSize.size() != 2) {
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
   } else {
-    dimsSize = std::vector<hsize_t>(nDims);
     scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
     if (dimsSize[1] != m_nScans)

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -138,15 +138,19 @@ void LoadILLLagrange::loadData() {
   nDims = scanVarSpace.getSimpleExtentNdims();
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
-  if ((nDims != 2) || (dimsSize[1] != m_nScans)) // cppcheck-suppress containerOutOfBounds
+
+  if (dimsSize.size() < nDims)
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]); // cppcheck-suppress containerOutOfBounds
+  if ((nDims != 2) || (dimsSize[1] != m_nScans))
+    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
+
+  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
   scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]);      // cppcheck-suppress containerOutOfBounds
-  std::vector<double> scanVariableData(dimsSize[1]); // cppcheck-suppress containerOutOfBounds
+  std::vector<double> monitorData(dimsSize[1]);
+  std::vector<double> scanVariableData(dimsSize[1]);
   for (size_t i = 0; i < monitorData.size(); i++) {
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i]; // cppcheck-suppress containerOutOfBounds
+    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
     scanVariableData[i] = scanVarData[i];
   }
   scanVar.close();

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -231,14 +231,18 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
   nDims = scanVarSpace.getSimpleExtentNdims();
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
-  if ((nDims != 2) || (dimsSize[1] != numberOfScans)) // cppcheck-suppress containerOutOfBounds
+
+  if (dimsSize.size() < nDims)
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]); // cppcheck-suppress containerOutOfBounds
+  if ((nDims != 2) || (dimsSize[1] != numberOfScans))
+    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
+
+  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
   scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]); // cppcheck-suppress containerOutOfBounds
+  std::vector<double> monitorData(dimsSize[1]);
   for (size_t i = 0; i < monitorData.size(); i++)
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i]; // cppcheck-suppress containerOutOfBounds
+    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
 
   scanVar.close();
 

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -229,13 +229,12 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
   H5::DataSpace scanVarSpace = scanVar.getSpace();
 
   nDims = scanVarSpace.getSimpleExtentNdims();
+  if (nDims != 2)
+    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
   dimsSize = std::vector<hsize_t>(nDims);
   scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
-  if (dimsSize.size() < nDims)
-    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
-
-  if ((nDims != 2) || (dimsSize[1] != numberOfScans))
+  if (dimsSize[1] != numberOfScans)
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
   std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -229,20 +229,22 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
   H5::DataSpace scanVarSpace = scanVar.getSpace();
 
   nDims = scanVarSpace.getSimpleExtentNdims();
-  if (nDims != 2)
+  std::vector<double> monitorData;
+  if (nDims != 2) {
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
-  dimsSize = std::vector<hsize_t>(nDims);
-  scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
+  } else {
+    dimsSize = std::vector<hsize_t>(nDims);
+    scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
-  if (dimsSize[1] != numberOfScans)
-    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
+    if (dimsSize[1] != numberOfScans)
+      throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
 
-  std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
-  scanVar.read(scanVarData.data(), scanVar.getDataType());
-  std::vector<double> monitorData(dimsSize[1]);
-  for (size_t i = 0; i < monitorData.size(); i++)
-    monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
-
+    std::vector<double> scanVarData(dimsSize[0] * dimsSize[1]);
+    scanVar.read(scanVarData.data(), scanVar.getDataType());
+    monitorData.resize(dimsSize[1]);
+    for (size_t i = 0; i < monitorData.size(); i++)
+      monitorData[i] = scanVarData[monitorIndex * dimsSize[1] + i];
+  }
   scanVar.close();
 
   // fill the workspace

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -207,7 +207,7 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
   H5::DataSpace scanVarNamesSpace = scanVarNames.getSpace();
 
   nDims = scanVarNamesSpace.getSimpleExtentNdims();
-  dimsSize = std::vector<hsize_t>(nDims);
+  dimsSize.resize(nDims);
   scanVarNamesSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
   std::vector<char *> rdata(dimsSize[0]);
@@ -230,10 +230,10 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
 
   nDims = scanVarSpace.getSimpleExtentNdims();
   std::vector<double> monitorData;
-  if (nDims != 2) {
+  dimsSize.resize(nDims);
+  if (dimsSize.size() < 2) {
     throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
   } else {
-    dimsSize = std::vector<hsize_t>(nDims);
     scanVarSpace.getSimpleExtentDims(dimsSize.data(), nullptr);
 
     if (dimsSize[1] != numberOfScans)


### PR DESCRIPTION
### Description of work

#### Summary of work

With ongoing Nexus refactor work, CppCheck noticed these lines in these algorithms and complained about an out-of-bounds issue.  This is apparently because it doesn't recognize that `dimsSize().size()` should be at least as big as `nDims`.

Hopefully the added check will convince CppCheck

Refs #38332 

#### Further detail of work

Adds the check
``` cpp
if (dimsSize.size() < nDims)
    throw std::runtime_error("Scanned variables are not formatted properly. Check you nexus file.");
```

The error message is a copy of the pre-existing one.

### To test:

Make sure CppCheck passes.

Make sure all tests pass.  It's possible a negative test somewhere down the line may unexpectedly fail.  The error message was re-used to prevent this as much as possible.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
