### PR TITLE
Edit v6.13.0 SANS Release Notes

### DIFF
--- a/docs/source/release/v6.13.0/reflectometry.rst
+++ b/docs/source/release/v6.13.0/reflectometry.rst
@@ -17,6 +17,9 @@ New Features
 -  When a workspace is loaded on the ISIS Reflectometry GUI :ref:`Reduction Preview <refl_preview>` tab, region selectors are now added to the slice viewer plot to display any ROIs from matching experiment settings.
 - The :ref:`algm-PolarizationEfficienciesWildes` algorithm now propagates errors correctly using the taylor series method (first order). A new helper class has been introduced to do this using the Eigen ``autodiff`` module to calculate partials.
 - The :ref:`algm-SaveNXcanSAS` algorithm can also accept compatible Workspace Groups as input.
+- A new :ref:`algm-ReflectometryISISCalculatePolEff` algorithm has been added. This algorithm provides a convenient
+  wrapper for the :ref:`algm-ReflectometryISISCreateTransmission`, :ref:`algm-PolarizationEfficienciesWildes` and
+  :ref:`algm-JoinISISPolarizationEfficiencies` algorithms.
 
 Bugfixes
 --------

--- a/docs/source/release/v6.13.0/sans.rst
+++ b/docs/source/release/v6.13.0/sans.rst
@@ -7,22 +7,28 @@ SANS Changes
 
 New Features
 ------------
-- :ref:`algm-SANSSave` now supports the new :ref:`algm-SavePolarizedNXcanSAS` algorithm.
-- :ref:`algm-LoadNXcanSAS` can now load polarized NXcanSAS data.
-- Changes have been made to ``SANSadd2`` and ``CreateSANSWavelengthPixelAdjustment`` to enable the summing of LOQ event mode data, and allow for the use of the new LOQ IDF.
-- ISIS SANS Batch Reductions (such as those performed by ``WavRangeReduction`` from the
-  :ref:`ISIS Command Interface <ScriptingSANSReductions>`) can now make use of polarization
-  properties defined in the V2 User File to save using :ref:`algm-SavePolarizedNXcanSAS`.
-- Polarization options have been added the :ref:`sans_toml_v1-ref` format.
-  As a result, the most up-to-date version of SANS TOML, which supports these options, has been bumped to 2.
-- Update SANS Command Line Interface to pass a save algorithm directly to the ``WavRangeReduction`` command.
-- Update documentation for :ref:`scripting SANS reduction<ScriptingSansReductions>` using command line interface.
-- New algorithm :ref:`algm-ReflectometryISISCalculatePolEff` added. This algorithm provides a convenient wrapper for the :ref:`algm-ReflectometryISISCreateTransmission`, :ref:`algm-PolarizationEfficienciesWildes` and :ref:`algm-JoinISISPolarizationEfficiencies` algorithms.
-- Add new :ref:`algm-SavePolarizedNXcanSAS` algorithm to save reduced polarized SANS data in NXcanSAS format.
+- A new :ref:`algm-SavePolarizedNXcanSAS` algorithm has been added to save reduced polarized SANS data in NXcanSAS
+  format.
+
+  - :ref:`algm-SANSSave` now supports the new :ref:`algm-SavePolarizedNXcanSAS` algorithm.
+  - :ref:`algm-LoadNXcanSAS` has been modified to load polarized NXcanSAS data saved via
+    :ref:`algm-SavePolarizedNXcanSAS`.
+  - Polarization options have been added the :ref:`sans_toml_v1-ref` format. As a result, the most up-to-date version of
+    SANS TOML, which supports these options, is now V2.
+  - ISIS SANS Batch Reductions (such as those performed by ``WavRangeReduction`` from the
+    :ref:`ISIS Command Interface <ScriptingSANSReductions>`) can now use polarization properties defined in the V2 User
+    File to save using :ref:`algm-SavePolarizedNXcanSAS`.
+
+- The :ref:`ISIS Command Interface <ScriptingSANSReductions>` now allows a save algorithm to be passed directly to the
+  ``WavRangeReduction`` command.
+- The documentation for :ref:`scripting SANS reduction<ScriptingSansReductions>` has been updated with more information
+  about using the command line interface.
+- The ``SANSadd2`` and ``CreateSANSWavelengthPixelAdjustment`` functions have been modified to enable the summing of LOQ
+  event mode data, and allow for the use of the new LOQ IDF.
 
 Bugfixes
 --------
-- :ref:`ISIS_SANS_Sum_Runs_Tab-ref` in the ISIS SANS interface now maintains the sample properties
-  (shape, thickness, height, and width) of the runs in the added output file.
+- :ref:`ISIS_SANS_Sum_Runs_Tab-ref` in the ISIS SANS interface now maintains the sample properties (shape, thickness,
+  height, and width) of the runs in the output file after performing a sum.
 
 :ref:`Release 6.13.0 <v6.13.0>`

--- a/docs/source/release/v6.13.0/sans.rst
+++ b/docs/source/release/v6.13.0/sans.rst
@@ -7,14 +7,14 @@ SANS Changes
 
 New Features
 ------------
-- A new :ref:`algm-SavePolarizedNXcanSAS` algorithm has been added to save reduced polarized SANS data in NXcanSAS
+- A new :ref:`algm-SavePolarizedNXcanSAS` algorithm has been added to save reduced polarized SANS data in the NXcanSAS
   format.
 
   - :ref:`algm-SANSSave` now supports the new :ref:`algm-SavePolarizedNXcanSAS` algorithm.
   - :ref:`algm-LoadNXcanSAS` has been modified to load polarized NXcanSAS data saved via
     :ref:`algm-SavePolarizedNXcanSAS`.
-  - Polarization options have been added the :ref:`sans_toml_v1-ref` format. As a result, the most up-to-date version of
-    SANS TOML, which supports these options, is now V2.
+  - Polarization options have been added the :ref:`sans_toml_v1-ref` format. The most up-to-date version of SANS TOML,
+    which supports these options, is now V2.
   - ISIS SANS Batch Reductions (such as those performed by ``WavRangeReduction`` from the
     :ref:`ISIS Command Interface <ScriptingSANSReductions>`) can now use polarization properties defined in the V2 User
     File to save using :ref:`algm-SavePolarizedNXcanSAS`.

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -18,7 +18,6 @@ Format Changes
 
 V1 (Mantid 6.4+) to V2 (Mantid 6.13+)
 -------------------------------------
-**NOTE: These are valid user file entries but have not yet been implemented as part of the reduction process.**
 
 *polarization* options have been added to the TOML format.
 


### PR DESCRIPTION
### Description of work

#### Summary of work
Edit the release notes to fix formatting and some grammar stuff. 

Refs #39471 

#### Further detail of work
- Also removes a line from the SANS documentation that is no longer needed.

### To test:
1. Build the docs and open the SANS release doc in a browser

*This does not require release notes* because **[RECURSION_ERROR]**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
