### PR TITLE
Enable use of a unit test thread limit in Jenkins.

### DIFF
--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -26,6 +26,13 @@ if [[ -z "$BUILD_THREADS_SYSTEM_TESTS" ]]; then
     BUILD_THREADS_SYSTEM_TESTS=3
 fi
 
+# Jenkins nodes may specify the maximum number of unit tests to run in parallel.
+# This is useful to prevent test timeouts for machines with limited RAM.
+if [[ -z "$UNIT_TEST_THREADS" ]]; then
+    # Default is number of build threads.
+    UNIT_TEST_THREADS=$BUILD_THREADS
+fi
+
 function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then
         # Use -e because a bug on RHEL7 means --error-file produces an error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=337703;msg=2
@@ -85,7 +92,7 @@ cd $WORKSPACE/build
 # mkdir for test logs
 mkdir -p test_logs
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$UNIT_TEST_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then


### PR DESCRIPTION
### Description of work
Add a check for a new `UNIT_TEST_THREADS` environment variable that can be set in the Jenkins configuration for each node that can be used to limit the number of unit tests to be run in parallel. This has been done so that we can limit the number of unit tests processes on out macOS builders, some of which have limited RAM (compared to the core count).

### Further detail of work
I have set `UNIT_TEST_THREADS=6` on the following nodes, which have been observed to timeout on tests:
- isis-ndw2564
- isis-ndw2995
- isis-ndw2996

This value is two below the number of cores, so will hopefully give the machines more resources to run the tests in parallel successfully. We can tweak the number inside the Jenkins configuration if required.

#### Purpose of work
Often the nightly will fail because unit tests have timed out on macOS.

Fixes #39434 (hopefully!)

### To test:
Search the osx build log for this PR for `ctest -j`. If it is one of the machines listed above, it should have a 6 as the next character.

*This does not require release notes* because **it is a build configuration change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
