### PR TITLE
Minor refactors for char data in napi5

### DIFF
--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -442,16 +442,16 @@ public:
 
       if (attrInfos1.size() == 6) {
         TS_ASSERT_EQUALS(attrInfos1[0].name, "row_size_0");
-        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos1[0]), 1);
+        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos1[0].name), 1);
 
         TS_ASSERT_EQUALS(attrInfos1[2].name, "row_size_2");
-        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos1[2]), 4);
+        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos1[2].name), 4);
 
         TS_ASSERT_EQUALS(attrInfos1[4].name, "interpret_as");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos1[4]), "");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos1[4].name), "");
 
         TS_ASSERT_EQUALS(attrInfos1[5].name, "name");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos1[5]), "IntVectorColumn");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos1[5].name), "IntVectorColumn");
       }
 
       // -- Checking double column -----
@@ -477,16 +477,16 @@ public:
 
       if (attrInfos2.size() == 6) {
         TS_ASSERT_EQUALS(attrInfos2[0].name, "row_size_0");
-        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos2[0]), 1);
+        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos2[0].name), 1);
 
         TS_ASSERT_EQUALS(attrInfos2[1].name, "row_size_1");
-        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos2[1]), 2);
+        TS_ASSERT_EQUALS(savedNexus.getAttr<int>(attrInfos2[1].name), 2);
 
         TS_ASSERT_EQUALS(attrInfos2[4].name, "interpret_as");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos2[4]), "");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos2[4].name), "");
 
         TS_ASSERT_EQUALS(attrInfos2[5].name, "name");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos2[5]), "DoubleVectorColumn");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos2[5].name), "DoubleVectorColumn");
       }
     } catch (std::exception &e) {
       TS_FAIL(e.what());
@@ -650,13 +650,13 @@ public:
 
       if (attrInfos.size() == 3) {
         TS_ASSERT_EQUALS(attrInfos[1].name, "interpret_as");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[1]), "A string");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[1].name), "A string");
 
         TS_ASSERT_EQUALS(attrInfos[2].name, "name");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[2]), "StringColumn");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[2].name), "StringColumn");
 
         TS_ASSERT_EQUALS(attrInfos[0].name, "units");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[0]), "N/A");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[0].name), "N/A");
       }
 
       std::vector<char> data;
@@ -731,13 +731,13 @@ public:
 
       if (attrInfos.size() == 3) {
         TS_ASSERT_EQUALS(attrInfos[1].name, "interpret_as");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[1]), "A string");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[1].name), "A string");
 
         TS_ASSERT_EQUALS(attrInfos[2].name, "name");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[2]), "EmptyColumn");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[2].name), "EmptyColumn");
 
         TS_ASSERT_EQUALS(attrInfos[0].name, "units");
-        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[0]), "N/A");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[0].name), "N/A");
       }
 
       std::vector<char> data;
@@ -1048,13 +1048,13 @@ private:
 
     if (attrInfos.size() == 3) {
       TSM_ASSERT_EQUALS(name, attrInfos[1].name, "interpret_as");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[1]), interpret_as);
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[1].name), interpret_as);
 
       TSM_ASSERT_EQUALS(name, attrInfos[2].name, "name");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[2]), name);
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[2].name), name);
 
       TSM_ASSERT_EQUALS(name, attrInfos[0].name, "units");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[0]), "Not known");
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[0].name), "Not known");
     }
   }
 
@@ -1071,13 +1071,13 @@ private:
 
     if (attrInfos.size() == 6) {
       TSM_ASSERT_EQUALS(name, attrInfos[4].name, "interpret_as");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[4]), interpret_as);
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[4].name), interpret_as);
 
       TSM_ASSERT_EQUALS(name, attrInfos[5].name, "name");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[5]), name);
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[5].name), name);
 
       TSM_ASSERT_EQUALS(name, attrInfos[3].name, "units");
-      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[3]), "Not known");
+      TSM_ASSERT_EQUALS(name, file.getStrAttr(attrInfos[3].name), "Not known");
     }
   }
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -566,6 +566,7 @@ public:
 
   /**
    * Get the value of the attribute specified by the AttrInfo supplied.
+   * Only use this method if you know what the type on disk should be.
    *
    * \param info Designation of which attribute to read.
    * \param data The pointer to put the attribute value in.
@@ -577,17 +578,16 @@ public:
   /**
    * Get the value of an attribute that is a scalar number.
    *
-   * \param info Designation of which attribute to read.
+   * \param name Name of attribute to read.
    * \tparam NumT numeric data type of result
    *
    * \return The attribute value.
    */
-  template <typename NumT> NumT getAttr(const AttrInfo &info);
-
   template <typename NumT> NumT getAttr(std::string const &name);
 
   /**
    * Get the value of an attribute that is a scalar number.
+   * Only use this method if you do not care about precisely matching the data type on disk
    *
    * \param[in] name Name of attribute to read
    * \param[out] value The read attribute value.
@@ -598,11 +598,11 @@ public:
   /**
    * Get the value of a string attribute.
    *
-   * \param info Which attribute to read.
+   * \param name Name of attribute to read.
    *
    * \return The value of the attribute.
    */
-  std::string getStrAttr(const AttrInfo &info);
+  std::string getStrAttr(std::string const &name);
 
   // NAVIGATE ATTRIBUTES
 

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -117,7 +117,7 @@ void NXDataSet::getAttributes() {
 
     switch (ainfo.type) {
     case NXnumtype::CHAR: {
-      attributes.set(ainfo.name, m_fileID->getStrAttr(ainfo));
+      attributes.set(ainfo.name, m_fileID->getStrAttr(ainfo.name));
       break;
     }
     case NXnumtype::INT16: {

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -1170,6 +1170,7 @@ NXstatus NX5getdataID(NXhandle fid, NXlink *sRes) {
 
 NXstatus NX5printlink(NXhandle fid, NXlink const *sLink) {
   NXI5assert(fid);
+  printf("HDF5 link: targetAddress = \"%s\", linkType = \"%d\"\n", sLink->targetAddress.c_str(), sLink->linkType);
   return NXstatus::NX_OK;
 }
 

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -1170,7 +1170,6 @@ NXstatus NX5getdataID(NXhandle fid, NXlink *sRes) {
 
 NXstatus NX5printlink(NXhandle fid, NXlink const *sLink) {
   NXI5assert(fid);
-  printf("HDF5 link: targetAddress = \"%s\", linkType = \"%d\"\n", sLink->targetAddress.c_str(), sLink->linkType);
   return NXstatus::NX_OK;
 }
 
@@ -1704,7 +1703,6 @@ NXstatus NX5getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *d
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getchardata(NXhandle fid, void *data) {
-  printf("%s:%d %s | %s\n", __FILE__, __LINE__, __func__, buildCurrentAddress(fid).c_str());
   fflush(stdout);
   pNexusFile5 pFile = NXI5assert(fid);
   NXstatus status = NXstatus::NX_ERROR;
@@ -1724,17 +1722,13 @@ NXstatus NX5getchardata(NXhandle fid, void *data) {
     hsize_t len = H5Tget_size(pFile->iCurrentT);
     // for a 2D char array, handle block size
     int rank = H5Sget_simple_extent_dims(pFile->iCurrentS, dims, NULL);
-    printf("RANK = %d\n", rank);
-    printf("DIM0 = %lu\n", dims[0]);
     if (rank >= 0) {
       len *= (dims[0] > 1 ? dims[0] : 1); // min of dims[0], 1
     }
-    printf("LEN = %lu\n", len);
     // reserve space in memory
     char *cdata = new char[len + 1];
     memset(cdata, 0, (len + 1) * sizeof(char));
     herr_t ret = H5Dread(pFile->iCurrentD, pFile->iCurrentT, H5S_ALL, H5S_ALL, H5P_DEFAULT, cdata);
-    printf("CDATA: %s\n", cdata);
     if (ret < 0) {
       status = NXstatus::NX_ERROR;
     } else {
@@ -1762,7 +1756,6 @@ NXstatus NX5getdata(NXhandle fid, void *data) {
   ndims = static_cast<hsize_t>(H5Sget_simple_extent_dims(pFile->iCurrentS, dims, NULL));
 
   if (H5Tget_class(pFile->iCurrentT) == H5T_STRING) {
-    printf("%s:%d %s\n", __FILE__, __LINE__, __func__);
     return NX5getchardata(fid, data);
   }
 

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -29,6 +29,8 @@
 #include <string>
 #define H5Aiterate_vers 2
 
+#include <algorithm>
+#include <array>
 #include <assert.h>
 #include <cstring>
 #include <map>
@@ -920,10 +922,8 @@ NXstatus NX5closedata(NXhandle fid) {
 NXstatus NX5putdata(NXhandle fid, const void *data) {
   pNexusFile5 pFile;
   herr_t iRet;
-  int64_t myStart[H5S_MAX_RANK];
-  int64_t mySize[H5S_MAX_RANK];
-  hsize_t thedims[H5S_MAX_RANK], maxdims[H5S_MAX_RANK];
-  int i, rank, unlimiteddim = 0;
+  std::array<hsize_t, H5S_MAX_RANK> thedims{0}, maxdims{0};
+  int rank;
 
   pFile = NXI5assert(fid);
   rank = H5Sget_simple_extent_ndims(pFile->iCurrentS);
@@ -931,23 +931,25 @@ NXstatus NX5putdata(NXhandle fid, const void *data) {
     NXReportError("ERROR: Cannot determine dataset rank");
     return NXstatus::NX_ERROR;
   }
-  iRet = H5Sget_simple_extent_dims(pFile->iCurrentS, thedims, maxdims);
+  iRet = H5Sget_simple_extent_dims(pFile->iCurrentS, thedims.data(), maxdims.data());
   if (iRet < 0) {
     NXReportError("ERROR: Cannot determine dataset dimensions");
     return NXstatus::NX_ERROR;
   }
-  for (i = 0; i < rank; ++i) {
-    myStart[i] = 0;
-    mySize[i] = static_cast<int64_t>(thedims[i]);
-    if (maxdims[i] == H5S_UNLIMITED) {
-      unlimiteddim = 1;
-      myStart[i] = static_cast<int64_t>(thedims[i] + 1);
-      mySize[i] = 1;
-    }
-  }
-  /* If we are using putdata on an unlimied dimesnion dataset, assume we want to append one single new slab */
+  bool unlimiteddim = std::any_of(maxdims.cbegin(), maxdims.cend(), [](auto x) -> bool { return x == H5S_UNLIMITED; });
+  /* If we are using putdata on an unlimied dimension dataset, assume we want to append one single new slab */
   if (unlimiteddim) {
-    return NX5putslab64(fid, data, myStart, mySize);
+    std::array<int64_t, H5S_MAX_RANK> myStart{0}, mySize{0};
+    for (std::size_t i = 0; i < myStart.size(); i++) {
+      if (maxdims[i] == H5S_UNLIMITED) {
+        myStart[i] = static_cast<int64_t>(thedims[i] + 1);
+        mySize[i] = 1;
+      } else {
+        myStart[i] = 0;
+        mySize[i] = static_cast<int64_t>(thedims[i]);
+      }
+    }
+    return NX5putslab64(fid, data, myStart.data(), mySize.data());
   } else {
     iRet = H5Dwrite(pFile->iCurrentD, pFile->iCurrentT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
     if (iRet < 0) {

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -1703,13 +1703,55 @@ NXstatus NX5getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *d
 
 /*-------------------------------------------------------------------------*/
 
+NXstatus NX5getchardata(NXhandle fid, void *data) {
+  printf("%s:%d %s | %s\n", __FILE__, __LINE__, __func__, buildCurrentAddress(fid).c_str());
+  fflush(stdout);
+  pNexusFile5 pFile = NXI5assert(fid);
+  NXstatus status = NXstatus::NX_ERROR;
+
+  if (H5Tis_variable_str(pFile->iCurrentT)) {
+    char *cdata = nullptr;
+    herr_t ret = H5Dread(pFile->iCurrentD, pFile->iCurrentT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &cdata);
+    if (ret < 0 || cdata == nullptr) {
+      status = NXstatus::NX_ERROR;
+    } else {
+      memcpy(data, cdata, strlen(cdata) * sizeof(char));
+      H5free_memory(cdata);
+      status = NXstatus::NX_OK;
+    }
+  } else {
+    hsize_t dims[NX_MAXRANK] = {0};
+    hsize_t len = H5Tget_size(pFile->iCurrentT);
+    // for a 2D char array, handle block size
+    int rank = H5Sget_simple_extent_dims(pFile->iCurrentS, dims, NULL);
+    printf("RANK = %d\n", rank);
+    printf("DIM0 = %lu\n", dims[0]);
+    if (rank >= 0) {
+      len *= (dims[0] > 1 ? dims[0] : 1); // min of dims[0], 1
+    }
+    printf("LEN = %lu\n", len);
+    // reserve space in memory
+    char *cdata = new char[len + 1];
+    memset(cdata, 0, (len + 1) * sizeof(char));
+    herr_t ret = H5Dread(pFile->iCurrentD, pFile->iCurrentT, H5S_ALL, H5S_ALL, H5P_DEFAULT, cdata);
+    printf("CDATA: %s\n", cdata);
+    if (ret < 0) {
+      status = NXstatus::NX_ERROR;
+    } else {
+      cdata[len] = '\0';                       // ensure null termination
+      memcpy(data, cdata, len * sizeof(char)); // NOTE cdata may have \0 bw char arrays, len is correct length
+      status = NXstatus::NX_OK;
+    }
+    delete[] cdata;
+  }
+  return status;
+}
+
 NXstatus NX5getdata(NXhandle fid, void *data) {
   pNexusFile5 pFile;
   int iStart[H5S_MAX_RANK], status;
   hid_t memtype_id;
-  H5T_class_t tclass;
   hsize_t ndims, dims[H5S_MAX_RANK];
-  char **vstrdata = NULL;
 
   pFile = NXI5assert(fid);
   /* check if there is an Dataset open */
@@ -1719,33 +1761,19 @@ NXstatus NX5getdata(NXhandle fid, void *data) {
   }
   ndims = static_cast<hsize_t>(H5Sget_simple_extent_dims(pFile->iCurrentS, dims, NULL));
 
+  if (H5Tget_class(pFile->iCurrentT) == H5T_STRING) {
+    printf("%s:%d %s\n", __FILE__, __LINE__, __func__);
+    return NX5getchardata(fid, data);
+  }
+
   if (ndims == 0) { /* SCALAR dataset */
     hid_t datatype = H5Dget_type(pFile->iCurrentD);
     hid_t filespace = H5Dget_space(pFile->iCurrentD);
 
-    tclass = H5Tget_class(datatype);
-
-    if (H5Tis_variable_str(pFile->iCurrentT)) {
-      char *strdata = static_cast<char *>(calloc(512, sizeof(char)));
-      status = H5Dread(pFile->iCurrentD, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &strdata);
-      if (status >= 0) {
-#if defined(__GNUC__) && !(defined(__clang__))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-#endif
-        // there is a danger of overflowing output string
-        std::strncpy(static_cast<char *>(data), strdata, strlen(strdata));
-#if defined(__GNUC__) && !(defined(__clang__))
-#pragma GCC diagnostic pop
-#endif
-      }
-      free(strdata);
-    } else {
-      memtype_id = H5Screate(H5S_SCALAR);
-      H5Sselect_all(filespace);
-      status = H5Dread(pFile->iCurrentD, datatype, memtype_id, filespace, H5P_DEFAULT, data);
-      H5Sclose(memtype_id);
-    }
+    memtype_id = H5Screate(H5S_SCALAR);
+    H5Sselect_all(filespace);
+    status = H5Dread(pFile->iCurrentD, datatype, memtype_id, filespace, H5P_DEFAULT, data);
+    H5Sclose(memtype_id);
 
     H5Sclose(filespace);
     H5Tclose(datatype);
@@ -1756,29 +1784,8 @@ NXstatus NX5getdata(NXhandle fid, void *data) {
 
   memset(iStart, 0, H5S_MAX_RANK * sizeof(int));
   /* map datatypes of other plateforms */
-  tclass = H5Tget_class(pFile->iCurrentT);
-  if (H5Tis_variable_str(pFile->iCurrentT)) {
-    vstrdata = static_cast<char **>(malloc((size_t)dims[0] * sizeof(char *)));
-    memtype_id = H5Tcopy(H5T_C_S1);
-    H5Tset_size(memtype_id, H5T_VARIABLE);
-    status = H5Dread(pFile->iCurrentD, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, vstrdata);
-    static_cast<char *>(data)[0] = '\0';
-    if (status >= 0) {
-      for (hsize_t i = 0; i < dims[0]; ++i) {
-        if (vstrdata[i] != NULL) {
-          strcat(static_cast<char *>(data), vstrdata[i]);
-        }
-      }
-    }
-    H5Dvlen_reclaim(memtype_id, pFile->iCurrentS, H5P_DEFAULT, vstrdata);
-    free(vstrdata);
-    H5Tclose(memtype_id);
-  } else if (tclass == H5T_STRING) {
-    status = H5Dread(pFile->iCurrentD, pFile->iCurrentT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
-  } else {
-    memtype_id = h5MemType(pFile->iCurrentT);
-    status = H5Dread(pFile->iCurrentD, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
-  }
+  memtype_id = h5MemType(pFile->iCurrentT);
+  status = H5Dread(pFile->iCurrentD, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
   if (status < 0) {
     NXReportError("ERROR: failed to transfer dataset");
     return NXstatus::NX_ERROR;

--- a/Framework/Nexus/test/NeXusFileTest.h
+++ b/Framework/Nexus/test/NeXusFileTest.h
@@ -775,6 +775,9 @@ public:
     file.getAttr("units", actual);
     TS_ASSERT_EQUALS(actual, "kg * mol / parsec");
 
+    std::string again = file.getStrAttr("units");
+    TS_ASSERT_EQUALS(again, "kg * mol / parsec");
+
     // check attr infos
     auto attrInfos = file.getAttrInfos();
     TS_ASSERT_EQUALS(attrInfos.size(), 2);
@@ -807,12 +810,12 @@ public:
     // get attribute asserting the type -- make sure there is a failure
     Mantid::Nexus::AttrInfo info32{NXnumtype::INT32, 1, "SaveMDVersion"}; // int32_t will fail because it is int64_t
     Mantid::Nexus::AttrInfo info64{NXnumtype::INT64, 1, "SaveMDVersion"}; // int64_t will pass
-    TS_ASSERT_THROWS_NOTHING(file.getAttr(info32, &version32));
+    TS_ASSERT_THROWS(file.getAttr(info32, &version32), Mantid::Nexus::Exception const &)
     TS_ASSERT_THROWS_NOTHING(file.getAttr(info64, &version64));
   }
 
   void test_existing_attr_bad_length() {
-    // some fiels have the unit attribute set with value "microsecond" but with a length of 8 instead of 11
+    // some fields have the unit attribute set with value "microsecond" but with a length of 8 instead of 11
     // this prevents a regression that will otherwise show up in tests of LoadEventNexus and various python algorithms
     cout << "\ntest open existing file with system-dependent type\n";
 

--- a/Framework/Nexus/test/NeXusFileTest.h
+++ b/Framework/Nexus/test/NeXusFileTest.h
@@ -810,7 +810,7 @@ public:
     // get attribute asserting the type -- make sure there is a failure
     Mantid::Nexus::AttrInfo info32{NXnumtype::INT32, 1, "SaveMDVersion"}; // int32_t will fail because it is int64_t
     Mantid::Nexus::AttrInfo info64{NXnumtype::INT64, 1, "SaveMDVersion"}; // int64_t will pass
-    TS_ASSERT_THROWS(file.getAttr(info32, &version32), Mantid::Nexus::Exception const &)
+    TS_ASSERT_THROWS_NOTHING(file.getAttr(info32, &version32))
     TS_ASSERT_THROWS_NOTHING(file.getAttr(info64, &version64));
   }
 

--- a/Framework/Nexus/test/napi_test_cpp.cpp
+++ b/Framework/Nexus/test/napi_test_cpp.cpp
@@ -210,7 +210,7 @@ int readTest(const string &filename) {
         it->name != "XML_version") {
       cout << "   " << it->name << " = ";
       if (it->type == NXnumtype::CHAR) {
-        cout << file.getStrAttr(*it);
+        cout << file.getStrAttr(it->name);
       }
       cout << endl;
     }
@@ -223,7 +223,7 @@ int readTest(const string &filename) {
   for (vector<Mantid::Nexus::AttrInfo>::iterator it = attr_infos.begin(); it != attr_infos.end(); ++it) {
     cout << "   " << it->name << " = ";
     if (it->type == NXnumtype::CHAR) {
-      cout << file.getStrAttr(*it);
+      cout << file.getStrAttr(it->name);
     }
     cout << endl;
   }


### PR DESCRIPTION
### Description of work

#### Summary of work

This refactors the handling of char/string data in napi5 to be easier to read and work more efficiently with the HDF5 C library methods.  This is meant to make future work of integrating into Nexus File with H5Cpp easier.

The following:
- removed on the many `getAttr()` methods
- changed `getStrAttr()` to be called with the attribute's *name* and not its `Info` object
- all the fixes to make the above ^ changes work
- cleaned up `NX5getdata()` to have fewer labyrinthine if/else blocks, and cleanly handle char data
- more tests in NexusFileTest which safeguard several ways reading data can go wrong when string data dimensions are inconsistent with the actual data

Refs Issue #38332 
[EWM 11399](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11399)

#### Further detail of work

There is a single new function for reading char data, `NX5getchardata()`.  Char data is either variable or fixed-width string.

If variable string, use the hdf5 functionality that sets the proper string array size for us, together with [`H5free_memory()`](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5.html#ga71872bf6445cba956da86d4762b662cf).

If fixed-width, use a combination of the dataspace's `dims` aray, together with the datatypes size property, to create a proper char block array and read data into that.  There are several precautions around incorrect or imprecise usage, which are protected by the new tests.

### To test:

Ensure high code quality in the new `NX5getchardata()` function.

Review the new tests, and make sure they are convincing.  They are
- making a new dataset while a dataset is already open should create it within the parent group
- saving a `vector<string>` object by converting it to a big char array, as in `TimeSeriesProperty`, can read the correct values back in later
- strings saved as scalar properties (hence with `dims = {0}`) can still get the correct string length

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
