### PR TITLE
Crosshair in tiled plots

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button can be enabled in a single plot or tiled plots(subplots)
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area.

--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area.
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.

--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button can be enabled in a single plot or tiled plots(subplots)

--- a/docs/source/release/v6.14.0/Workbench/New_features/39491.rst
+++ b/docs/source/release/v6.14.0/Workbench/New_features/39491.rst
@@ -1,0 +1,1 @@
+- The crosshair button is now enabled in tiled plots(subplots).

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -605,9 +605,17 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             ax.add_line(line)
 
     def crosshair_toggle(self, on):
-        cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
-        if not on:
-            self.canvas.mpl_disconnect(cid)
+        if on:
+            # Create crosshair lines for each axes (except colorbars)
+            self._crosshair_lines = {}
+            for ax in self._axes_that_are_not_colour_bars():
+                ax.set_autoscalex_on(False)
+                ax.set_autoscaley_on(False)
+                hline = ax.axhline(color="r", lw=1.0, ls="-", visible=False)
+                vline = ax.axvline(color="r", lw=1.0, ls="-", visible=False)
+                self._crosshair_lines[ax] = (hline, vline)
+
+            self._crosshair_cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
 
     def crosshair(self, event):
         axes = self.canvas.figure.gca()

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -132,14 +132,14 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_crosshair_button_visible(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
-    def test_button_hiden_for_tiled_plots(self, mock_qappthread):
+    def test_button_for_tiled_plots(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread
 
         fig, axes = plt.subplots(2)
         axes[0].plot([-10, 10], [1, 2])
         axes[1].plot([3, 2, 1], [1, 2, 3])
         # crosshair button should be hidden because this is a tiled plot
-        self.assertFalse(self._is_crosshair_button_visible(fig))
+        self.assertTrue(self._is_crosshair_button_visible(fig))
         self.assertFalse(self._is_crosshair_button_checked(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -234,10 +234,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
             self.set_fit_enabled(False)
             self.set_superplot_enabled(False)
 
-        # disable crosshair in tiled plots, 3D plots but keep it enabled in color contour plot
-        if (len(fig.get_axes()) > 1 and figure_type(fig) not in [FigureType.Contour]) or (
-            figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]
-        ):
+        # disable crosshair in 3D plots
+        if figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]:
             self.set_crosshair_enabled(False)
 
         for ax in fig.get_axes():


### PR DESCRIPTION
### Description of work
EWM [11427](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11427)

This PR enables the crosshair option in 2D tiled plots and color contour plots. The crosshair is still disabled in 3D plots.

If there are multiple subplots, the crosshair's movement will sync up based on the actual data location. Zooming in and out of the figure will allow more accurate movement of the crosshair. See details in tests.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
First, test crosshair option works in a single plot. 
`MAR11060 = Load('MAR11060')`
Right-click in the workspace and plot some spectrum.
![image](https://github.com/user-attachments/assets/d5e34a59-ca06-45be-b26b-52982944230c).

Then test crosshair works in tiled plots:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType

MAR11060 = Load('MAR11060')

fig, axes = plt.subplots(edgecolor='#ffffff', ncols=2, nrows=2, num='MAR11060-1', subplot_kw={'projection': 'mantid'})
axes[0][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 1', wkspIndex=0)
axes[0][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[0][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 2', wkspIndex=1)
axes[0][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 3', wkspIndex=2)
axes[1][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 4', wkspIndex=3)
axes[1][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

fig.show()
```

This will produce the plots used in the video below

[Screencast from 2025-06-17 10-58-57.webm](https://github.com/user-attachments/assets/3488a14a-76cf-4b02-bd3c-7f9281929866)

Thirdly, test crosshair in 2D contour plots:

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

data = Load('SANSLOQCan2D.nxs')

fig, axes = plt.subplots(subplot_kw={'projection':'mantid'})

# IMPORTANT to set origin to lower
c = axes.imshow(data, origin = 'lower', cmap='viridis', aspect='auto')

# Overlay contours
axes.contour(data, levels=np.linspace(10, 60, 6), colors='yellow', alpha=0.5)
axes.set_title('SANSLOQCan2D.nxs')
cbar=fig.colorbar(c)
cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
fig.tight_layout()

fig.show()
```

![image](https://github.com/user-attachments/assets/5b16110e-49f6-4aaf-9c25-7f661f97ebbb).

Finally, check crosshair is disabled in 3D plots.

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

data = Load('MUSR00015189.nxs')
data = mtd['data_1'] # Extract individual workspace from group

fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(data, cmap='viridis')

fig.show()
```

![image](https://github.com/user-attachments/assets/c71371be-79f1-41fb-ad4b-424fad0414a9)

No crosshair option available here.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
