### PR TITLE
Change how AlignAndFocusPowderSlim is histogramming events

### DIFF
--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -61,7 +61,6 @@ const std::string BINMODE("BinningMode");
 const std::string OUTPUT_WKSP("OutputWorkspace");
 const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
 const std::string EVENTS_PER_THREAD("EventsPerThread");
-const std::string EVENTS_BLOCK_SIZE("EventsToSort");
 } // namespace PropertyNames
 
 namespace NxsFieldNames {
@@ -266,9 +265,9 @@ template <typename CountsType> class ProcessEventsTask {
 public:
   ProcessEventsTask(const std::vector<detid_t> *detids, const std::vector<float> *tofs,
                     const AlignAndFocusPowderSlim::BankCalibration *calibration, std::vector<CountsType> *y_temp,
-                    const std::vector<double> *binedges, const std::set<detid_t> *masked, const size_t events_blocksize)
+                    const std::vector<double> *binedges, const std::set<detid_t> *masked)
       : m_detids(detids), m_tofs(tofs), m_calibration(calibration), y_temp(y_temp), m_binedges(binedges),
-        masked(masked), no_mask(masked->empty()), m_events_blocksize(events_blocksize) {}
+        masked(masked), no_mask(masked->empty()) {}
 
   void operator()(const tbb::blocked_range<size_t> &range) const {
     // Fast histogramming without sorting or cumulative counting
@@ -312,8 +311,7 @@ private:
   std::vector<CountsType> *y_temp;
   const std::vector<double> *m_binedges;
   const std::set<detid_t> *masked;
-  const bool no_mask;              // whether there are any masked pixels
-  const size_t m_events_blocksize; // number of events to process as a group
+  const bool no_mask; // whether there are any masked pixels
 };
 
 class ProcessBankTask {
@@ -322,11 +320,11 @@ public:
                   const size_t pulse_start_index, const size_t pulse_stop_index, MatrixWorkspace_sptr &wksp,
                   const std::map<detid_t, double> &calibration, const std::set<detid_t> &masked, const double binWidth,
                   const bool linearBins, const size_t events_per_chunk, const size_t grainsize_event,
-                  const size_t events_blocksize, std::shared_ptr<API::Progress> &progress)
+                  std::shared_ptr<API::Progress> &progress)
       : m_h5file(h5file), m_bankEntries(bankEntryNames),
         m_loader(is_time_filtered, pulse_start_index, pulse_stop_index), m_wksp(wksp), m_calibration(calibration),
         m_masked(masked), m_binWidth(binWidth), m_linearBins(linearBins), m_events_per_chunk(events_per_chunk),
-        m_grainsize_event(grainsize_event), m_events_blocksize(events_blocksize), m_progress(progress) {
+        m_grainsize_event(grainsize_event), m_progress(progress) {
     if (false) { // H5Freopen_async(h5file.getId(), m_h5file.getId()) < 0) {
       throw std::runtime_error("failed to reopen async");
     }
@@ -401,7 +399,7 @@ public:
 
           // threaded processing of the events
           ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), calibration.get(), &y_temp,
-                                 &spectrum.readX(), &m_masked, m_events_blocksize);
+                                 &spectrum.readX(), &m_masked);
           if (numEvent > m_grainsize_event) {
             // use tbb
             tbb::parallel_for(tbb::blocked_range<size_t>(0, numEvent, m_grainsize_event), task);
@@ -435,7 +433,6 @@ private:
   const size_t m_events_per_chunk;
   /// number of events to histogram in a single thread
   const size_t m_grainsize_event;
-  const size_t m_events_blocksize;
   std::shared_ptr<API::Progress> m_progress;
 };
 
@@ -492,11 +489,6 @@ void AlignAndFocusPowderSlim::init() {
       std::make_unique<Kernel::PropertyWithValue<int>>(PropertyNames::EVENTS_PER_THREAD, 1000000, positiveIntValidator),
       "Number of events to read in a single thread. Higher means less threads are created.");
   setPropertyGroup(PropertyNames::EVENTS_PER_THREAD, CHUNKING_PARAM_GROUP);
-  declareProperty(
-      std::make_unique<Kernel::PropertyWithValue<int>>(PropertyNames::EVENTS_BLOCK_SIZE, 65536, positiveIntValidator),
-      "Number of events to sort/histogram at a time. "
-      "It should be smaller than the number of events processed in a single thread.");
-  setPropertyGroup(PropertyNames::EVENTS_BLOCK_SIZE, CHUNKING_PARAM_GROUP);
 }
 
 std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {
@@ -509,14 +501,6 @@ std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {
     const std::string msg(PropertyNames::READ_SIZE_FROM_DISK + " must be larger than " +
                           PropertyNames::EVENTS_PER_THREAD);
     errors[PropertyNames::READ_SIZE_FROM_DISK] = msg;
-    errors[PropertyNames::EVENTS_PER_THREAD] = msg;
-  }
-
-  const int events_block = getProperty(PropertyNames::EVENTS_BLOCK_SIZE);
-  if (events_block > grainsize_events) {
-    const std::string msg(PropertyNames::EVENTS_PER_THREAD + " must be larger than " +
-                          PropertyNames::EVENTS_BLOCK_SIZE);
-    errors[PropertyNames::EVENTS_BLOCK_SIZE] = msg;
     errors[PropertyNames::EVENTS_PER_THREAD] = msg;
   }
 
@@ -659,11 +643,10 @@ void AlignAndFocusPowderSlim::exec() {
     // threaded processing of the banks
     const int DISK_CHUNK = getProperty(PropertyNames::READ_SIZE_FROM_DISK);
     const int GRAINSIZE_EVENTS = getProperty(PropertyNames::EVENTS_PER_THREAD);
-    const int EVENTS_BLOCK_SIZE = getProperty(PropertyNames::EVENTS_BLOCK_SIZE);
     auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
     ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, pulse_start_index, pulse_stop_index, wksp,
                          m_calibration, m_masked, x_delta, linearBins, static_cast<size_t>(DISK_CHUNK),
-                         static_cast<size_t>(GRAINSIZE_EVENTS), static_cast<size_t>(EVENTS_BLOCK_SIZE), progress);
+                         static_cast<size_t>(GRAINSIZE_EVENTS), progress);
     // generate threads only if appropriate
     if (num_banks_to_read > 1) {
       tbb::parallel_for(tbb::blocked_range<size_t>(0, num_banks_to_read), task);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -276,12 +276,13 @@ public:
     // create output vector same size as binedges
     std::vector<size_t> cum_n(m_binedges->size(), 0);
 
+    // create a subset of the tof vector with masked pixels removed and calibration applied
+    std::vector<double> subset_tofs;
+    subset_tofs.reserve(m_events_blocksize);
+
     // process the events in blocks, extracting a subset of the tof vector before sorting and histogramming it
     for (size_t start = range.begin(); start < range.end(); start += m_events_blocksize) {
       const size_t end = std::min(start + m_events_blocksize, range.end());
-
-      // create a subset of the tof vector with masked pixels removed and calibration applied
-      std::vector<double> subset_tofs(end - start);
 
       auto detid_ptr = m_detids->cbegin() + start;
       auto tof_ptr = m_tofs->cbegin() + start;
@@ -303,6 +304,9 @@ public:
         search_start = std::lower_bound(search_start, subset_tofs.cend(), m_binedges->at(i));
         cum_n[i] += std::distance(subset_tofs.cbegin(), search_start);
       }
+
+      // clear the subset for the next block
+      subset_tofs.clear();
     }
 
     for (size_t i = 0; i < cum_n.size() - 1; ++i)

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -299,14 +299,10 @@ public:
       std::sort(subset_tofs.begin(), subset_tofs.end());
       // loop over bin edges and count the number of events in each bin
       auto search_start = subset_tofs.cbegin(); // we can advance the search starting point since binedges are sorted
-      for (size_t i = 0; i < m_binedges->size() - 1; ++i) {
+      for (size_t i = 0; i < m_binedges->size(); ++i) {
         search_start = std::lower_bound(search_start, subset_tofs.cend(), m_binedges->at(i));
         cum_n[i] += std::distance(subset_tofs.cbegin(), search_start);
       }
-
-      // last bin inclusive
-      cum_n.back() +=
-          std::distance(subset_tofs.cbegin(), std::upper_bound(search_start, subset_tofs.cend(), m_binedges->back()));
     }
 
     for (size_t i = 0; i < cum_n.size() - 1; ++i)

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -309,8 +309,12 @@ public:
       subset_tofs.clear();
     }
 
-    for (size_t i = 0; i < cum_n.size() - 1; ++i)
-      y_temp->at(i) += static_cast<uint32_t>(cum_n[i + 1] - cum_n[i]);
+    for (size_t i = 0; i < cum_n.size() - 1; ++i) {
+      uint32_t count = static_cast<uint32_t>(cum_n[i + 1] - cum_n[i]);
+      if (count > 0) {
+        (*y_temp)[i].fetch_add(count, std::memory_order_relaxed);
+      }
+    }
   }
 
 private:


### PR DESCRIPTION
### Description of work

This was found to improve the performance of the algorithm when loading large files (tested up to ~100GB) on analysis.sns.gov. 

Two big changes.
  1. Instead of calculating which bin the tof will land in it does a binary search of the bins.
  1. The output is accumulated in each `ProcessEventsTask` thread before writing writing it to the output spectra which was also changed to use `fetch_add`.
  2. Run ProcessBankTask in a tbb::task_group. This should allow the data to continue loading while ProcessBankTask is running.

The output should be identical to before.

This algorithm is a prototype for testing purposes so this change will allow further testing.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM11553](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/11553)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
