### PR TITLE
Algorithm to extract Time Difference between runs

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -194,6 +194,7 @@ set(PYTHON_PLUGINS
     algorithms/HYSPECSuggestTIB.py
     algorithms/Symmetrise.py
     algorithms/SymmetriseMDHisto.py
+    algorithms/TimeDifference.py
     algorithms/TOFTOFCropWorkspace.py
     algorithms/TOFTOFMergeRuns.py
     algorithms/TestWorkspaceGroupProperty.py

--- a/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
+++ b/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
@@ -52,7 +52,10 @@ class TimeDifference(PythonAlgorithm):
         return "TimeDifference"
 
     def summary(self):
-        return "Calculates the time differences of a series of workspaces with respect to a reference"
+        return (
+            "Calculates the time differences of a series of workspaces with respect to a reference. "
+            "If a reference workspace isn't provided, the first workspace from InputWorkspaces is used."
+        )
 
     def PyInit(self):
         self.declareProperty(
@@ -82,8 +85,7 @@ class TimeDifference(PythonAlgorithm):
         for name in workspace_names:
             ws = AnalysisDataService.retrieve(name)
             if not group_or_matrix(ws):
-                issues["InputWorkspaces"] = f"Workspace {name} is not a Group or Matrix Workspace."
-                return issues
+                issues["InputWorkspaces"] += f"Workspace {name} is not a Group or Matrix Workspace."
 
         reference_workspace = self.getProperty("ReferenceWorkspace").value
         if reference_workspace:
@@ -137,8 +139,6 @@ class TimeDifference(PythonAlgorithm):
     def _get_time_ws_group(self, workspaces: WorkspaceGroup) -> tuple[np.datetime64, np.timedelta64]:
         starts = ends = []
         for ws in workspaces:
-            if isinstance(ws, WorkspaceGroup):
-                continue
             time_start, time_end = self._get_time_ws(ws)
             if not np.isnat(time_start):
                 starts.append(time_start)

--- a/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
+++ b/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
@@ -29,12 +29,8 @@ if TYPE_CHECKING:
     from mantid.dataobjects import TableWorkspace
 
 # TIME LOGS
-START_TIME = "start_time"
-RUN_START = "run_start"
-END_TIME = "end_time"
-RUN_END = "run_end"
-START_LOGS = [RUN_START, START_TIME]
-END_LOGS = [RUN_END, END_TIME]
+START_LOGS = ["start_time", "run_start"]
+END_LOGS = ["end_time", "run_end"]
 ONE_SECOND = np.timedelta64(1, "s")
 
 
@@ -108,12 +104,12 @@ class TimeDifference(PythonAlgorithm):
         hours_diff = seconds_diff / 3600
         hours_diff_err = seconds_diff_err / 3600
         row = {
-            "WsName": name,
-            "MidTimeStamp": str(time),
-            "Seconds": seconds_diff,
-            "SecondsError": seconds_diff_err,
-            "Hours": hours_diff,
-            "HoursError": hours_diff_err,
+            "ws_name": name,
+            "midtime_stamp": str(time),
+            "seconds": seconds_diff,
+            "seconds_error": seconds_diff_err,
+            "hours": hours_diff,
+            "hours_error": hours_diff_err,
         }
         return row
 
@@ -121,7 +117,7 @@ class TimeDifference(PythonAlgorithm):
         # Create Times Table
         table = WorkspaceFactory.Instance().createTable()
         column_types = ["str", "str", *["float"] * 4]
-        column_names = ["WsName", "MidTimeStamp", "Seconds", "SecondsError", "Hours", "HoursError"]
+        column_names = ["ws_name", "midtime_stamp", "seconds", "seconds_error", "hours", "hours_error"]
         for col_name, col_type in zip(column_names, column_types):
             table.addColumn(type=col_type, name=col_name)
         for name, time in zip(names, times):

--- a/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
+++ b/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
@@ -85,7 +85,8 @@ class TimeDifference(PythonAlgorithm):
         for name in workspace_names:
             ws = AnalysisDataService.retrieve(name)
             if not group_or_matrix(ws):
-                issues["InputWorkspaces"] += f"Workspace {name} is not a Group or Matrix Workspace."
+                error_txt = f"Workspace {name} is not a Group or Matrix Workspace."
+                issues["InputWorkspaces"] = error_txt if "InputWorkspaces" not in issues else issues["InputWorkspaces"] + error_txt
 
         reference_workspace = self.getProperty("ReferenceWorkspace").value
         if reference_workspace:

--- a/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
+++ b/Framework/PythonInterface/plugins/algorithms/TimeDifference.py
@@ -1,0 +1,186 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=no-init,invalid-name
+
+from __future__ import annotations
+
+from mantid.api import (
+    AlgorithmFactory,
+    AnalysisDataService,
+    PythonAlgorithm,
+    ITableWorkspaceProperty,
+    MatrixWorkspace,
+    WorkspaceProperty,
+    WorkspaceGroup,
+    WorkspaceFactory,
+    PropertyMode,
+)
+
+from mantid.kernel import Direction, StringMandatoryValidator, logger
+
+import numpy as np
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mantid.dataobjects import TableWorkspace
+
+# TIME LOGS
+START_TIME = "start_time"
+RUN_START = "run_start"
+END_TIME = "end_time"
+RUN_END = "run_end"
+START_LOGS = [RUN_START, START_TIME]
+END_LOGS = [RUN_END, END_TIME]
+ONE_SECOND = np.timedelta64(1, "s")
+
+
+def _calculate_midtime_and_duration(start: np.datetime64, end: np.datetime64) -> tuple[np.datetime64, np.timedelta64]:
+    duration = end - start
+    mid = start + duration / 2
+    return mid, duration
+
+
+class TimeDifference(PythonAlgorithm):
+    reference_time = np.datetime64("NaT")
+    reference_duration = np.timedelta64("NaT")
+
+    def category(self):
+        return "Utility"
+
+    def name(self):
+        return "TimeDifference"
+
+    def summary(self):
+        return "Calculates the time differences of a series of workspaces with respect to a reference"
+
+    def PyInit(self):
+        self.declareProperty(
+            name="Workspaces",
+            defaultValue="",
+            validator=StringMandatoryValidator(),
+            direction=Direction.Input,
+            doc="Input workspaces. Comma separated workspace names",
+        )
+
+        self.declareProperty(
+            WorkspaceProperty(name="ReferenceWorkspace", optional=PropertyMode.Optional, defaultValue="", direction=Direction.Input),
+            doc="Workspace to be used as time reference",
+        )
+
+        self.declareProperty(
+            ITableWorkspaceProperty(name="OutputWorkspace", defaultValue="", direction=Direction.Output),
+            doc="Table containing difference time in relation to the reference workspace for each input workspace",
+        )
+
+    def checkGroups(self):
+        return False
+
+    def validateInputs(self):
+        def group_or_matrix(workspace: MatrixWorkspace) -> bool:
+            return isinstance(workspace, (MatrixWorkspace, WorkspaceGroup))
+
+        issues = dict()
+        workspace_names = self.getProperty("Workspaces").value.split(",")
+        for name in workspace_names:
+            if not AnalysisDataService.doesExist(name):
+                issues["Workspaces"] = f"Workspace {name} does not exists in the ADS."
+                return issues
+            else:
+                ws = AnalysisDataService.retrieve(name)
+                if not group_or_matrix(ws):
+                    issues["Workspaces"] = f"Workspace {name} is not a Group or Matrix Workspace."
+                    return issues
+
+        reference_workspace = self.getProperty("ReferenceWorkspace").value
+        if reference_workspace:
+            if not group_or_matrix(reference_workspace):
+                issues["ReferenceWorkspace"] = "ReferenceWorkspace is not a Group or Matrix Workspace."
+        return issues
+
+    def _build_row(self, name: str, time: np.datetime64, duration: np.timedelta64) -> dict[str, str | float]:
+        # We scale to transform to seconds
+        seconds_diff = (time - self.reference_time) / ONE_SECOND
+        seconds_diff_err = np.abs((duration + self.reference_duration) / ONE_SECOND)
+        hours_diff = seconds_diff / 3600
+        hours_diff_err = seconds_diff_err / 3600
+        row = {
+            "WsName": name,
+            "MidTimeStamp": str(time),
+            "Seconds": seconds_diff,
+            "SecondsError": seconds_diff_err,
+            "Hours": hours_diff,
+            "HoursError": hours_diff_err,
+        }
+        return row
+
+    def _build_output_table(self, names: list[str], times: list[tuple[np.datetime64, np.timedelta64]]) -> TableWorkspace:
+        # Create Times Table
+        table = WorkspaceFactory.Instance().createTable()
+        column_types = ["str", "str", *["float"] * 4]
+        column_names = ["WsName", "MidTimeStamp", "Seconds", "SecondsError", "Hours", "HoursError"]
+        for col_name, col_type in zip(column_names, column_types):
+            table.addColumn(type=col_type, name=col_name)
+        for name, time in zip(names, times):
+            table.addRow(self._build_row(name, time[0], time[1]))
+        return table
+
+    def _get_time_ws(self, ws: MatrixWorkspace) -> list[np.datetime64]:
+        time_start = time_end = None
+        try:
+            run = ws.getRun()
+            has_start_logs = [run.hasProperty(log) for log in START_LOGS]
+            has_end_logs = [run.hasProperty(log) for log in END_LOGS]
+            if not any(has_start_logs) * any(has_end_logs):
+                raise RuntimeError("Missing time logs")
+
+            time_start = run.getLogData(START_LOGS[np.argmax(has_start_logs)]).value
+            time_end = run.getLogData(END_LOGS[np.argmax(has_end_logs)]).value
+
+        except RuntimeError:
+            logger.error("Unable to access time logs on workspace " + ws.name())
+        return [np.datetime64(time, "ns") for time in [time_start, time_end]]
+
+    def _get_time_ws_group(self, workspaces: WorkspaceGroup) -> tuple[np.datetime64, np.timedelta64]:
+        starts = ends = []
+        for ws in workspaces:
+            if isinstance(ws, WorkspaceGroup):
+                continue
+            time_start, time_end = self._get_time_ws(ws)
+            if not np.isnat(time_start):
+                starts.append(time_start)
+                ends.append(time_end)
+
+        start = np.min(starts)
+        end = np.max(ends)
+        return _calculate_midtime_and_duration(start, end)
+
+    def PyExec(self):
+        ws_names = self.getProperty("Workspaces").value.split(",")
+        reference_ws = self.getProperty("ReferenceWorkspace").value
+
+        times = []
+        # Put reference on list if not present
+        reference_ws_name = ws_names[0]
+        if reference_ws:
+            reference_ws_name = reference_ws.name()
+            if reference_ws_name not in ws_names:
+                ws_names.insert(0, reference_ws_name)
+
+        for name in ws_names:
+            ws = AnalysisDataService.retrieve(name)
+            if isinstance(ws, MatrixWorkspace):
+                times.append(_calculate_midtime_and_duration(*self._get_time_ws(ws)))
+            elif isinstance(ws, WorkspaceGroup):
+                times.append(self._get_time_ws_group(ws))
+
+        self.reference_time = times[ws_names.index(reference_ws_name)][0]
+        self.reference_duration = times[ws_names.index(reference_ws_name)][1]
+        table = self._build_output_table(ws_names, times)
+        self.setProperty("OutputWorkspace", table)
+
+
+AlgorithmFactory.subscribe(TimeDifference)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -140,6 +140,7 @@ set(TEST_PY_FILES
     SymmetriseMDHistoTest.py
     UpdatePeakParameterTableValueTest.py
     SANSSubtractTest.py
+    TimeDifferenceTest.py
     TOFTOFCropWorkspaceTest.py
     TOFTOFMergeRunsTest.py
     ExportSampleLogsToCSVFileTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
@@ -83,18 +83,12 @@ class TimeDifferenceTest(unittest.TestCase):
     def test_time_difference_throws_for_incorrect_workspace_entry(self):
         CreateEmptyTableWorkspace(OutputWorkspace="test_table")
         with self.assertRaisesRegex(RuntimeError, "Workspace test_table is not a Group or Matrix Workspace."):
-            _ = TimeDifference(Workspaces="test_table")
-
-    def test_time_difference_throws_for_deleted_workspace(self):
-        CreateWorkspace(OutputWorkspace=TEST_NAME, DataX=0, DataY=1)
-        AnalysisDataService.remove(TEST_NAME)
-        with self.assertRaisesRegex(RuntimeError, f"Workspace {TEST_NAME} does not exists in the ADS."):
-            _ = TimeDifference(Workspaces=TEST_NAME)
+            _ = TimeDifference(InputWorkspaces="test_table")
 
     def test_algorithm_creates_NaT_if_time_logs_are_not_present(self):
         CreateWorkspace(OutputWorkspace=TEST_NAME, DataX=0, DataY=1)
 
-        table = TimeDifference(Workspaces=TEST_NAME)
+        table = TimeDifference(InputWorkspaces=TEST_NAME)
 
         # NaT : Not a Time
         self.assertEqual(["NaT"], table.column(TimeTable.time_stamp))
@@ -103,7 +97,7 @@ class TimeDifferenceTest(unittest.TestCase):
         start_times = [0, 1, 2, 3]
         names, times = _prepare_workspaces(start_times)
 
-        table = TimeDifference(Workspaces=",".join(names))
+        table = TimeDifference(InputWorkspaces=names)
 
         self._assert_table(table, names, _correct_midtimes(times), start_times)
 
@@ -118,7 +112,7 @@ class TimeDifferenceTest(unittest.TestCase):
                 run.addProperty(name=start, value=ISO_TIME_STAMP, replace=False)
                 run.addProperty(name=end, value=ISO_TIME_STAMP.replace("00.", "02."), replace=False)
 
-                table = TimeDifference(Workspaces=TEST_NAME)
+                table = TimeDifference(InputWorkspaces=TEST_NAME)
 
                 midtime = ISO_TIME_STAMP.replace("00.", "01.")
                 self.assertEqual([midtime], table.column(1))
@@ -133,7 +127,7 @@ class TimeDifferenceTest(unittest.TestCase):
         _add_time_log_to_workspace(ws_name=REFERENCE_NAME, time=str(ref_time))
         names, times = _prepare_workspaces(start_times, "s")
 
-        table = TimeDifference(Workspaces=",".join(names), ReferenceWorkspace=AnalysisDataService.retrieve(REFERENCE_NAME))
+        table = TimeDifference(InputWorkspaces=names, ReferenceWorkspace=AnalysisDataService.retrieve(REFERENCE_NAME))
 
         start_times = [d + reference for d in start_times]
         start_times.insert(0, 0)
@@ -145,7 +139,7 @@ class TimeDifferenceTest(unittest.TestCase):
         start_times = [0, 1, 2, 3]
         names, _ = _prepare_workspaces(start_times)
         GroupWorkspaces(names, OutputWorkspace=GROUP_NAME)
-        table = TimeDifference(Workspaces="group")
+        table = TimeDifference(InputWorkspaces="group")
 
         # Notice every experiment lasts for 1 seconds by default, so final time is at 4 seconds
         # and midtime is 2 seconds.
@@ -162,7 +156,7 @@ class TimeDifferenceTest(unittest.TestCase):
         # Add group to names lists
         names.append(GROUP_NAME)
 
-        table = TimeDifference(Workspaces=",".join(names))
+        table = TimeDifference(InputWorkspaces=names)
 
         # Add test data for group column
         errors = [DEFAULT_DURATION * 2] * len(start_times)
@@ -180,7 +174,7 @@ class TimeDifferenceTest(unittest.TestCase):
         start_times = [0, 100]
         names, times = _prepare_workspaces(start_times, "ns")
 
-        table = TimeDifference(Workspaces=",".join(names))
+        table = TimeDifference(InputWorkspaces=names)
 
         # convert initial times back to seconds to compare results in table
         start_times = [time / NANO_FACTOR for time in start_times]

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
@@ -1,0 +1,204 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from enum import IntEnum
+from mantid.api import AnalysisDataService
+from mantid.kernel import DateAndTime
+from mantid.simpleapi import TimeDifference, CreateWorkspace, GroupWorkspaces, CreateEmptyTableWorkspace
+import numpy as np
+import unittest
+
+ISO_TIME_STAMP = "2025-06-12T08:00:00.000000000"
+TEST_NAME = "test"
+GROUP_NAME = "group"
+REFERENCE_NAME = "reference"
+# Conversion factor between nanoseconds and seconds
+NANO_FACTOR = 1000000000
+# Conversion factor between seconds and hours
+HOUR_FACTOR = 3600
+# 1 second
+DEFAULT_DURATION = 1
+
+
+class TimeTable(IntEnum):
+    ws_name = 0
+    time_stamp = 1
+    seconds = 2
+    seconds_error = 3
+    hours = 4
+    hours_error = 5
+
+
+def _add_time_log_to_workspace(ws_name: str = TEST_NAME, time: str = ISO_TIME_STAMP, duration: int = DEFAULT_DURATION):
+    """
+    Start and End Time logs.
+    We are going to use native setStartAndEndtime method that uses the C++ DateAndTime class as a parameter,
+    adding the start_time and end_time logs to the workspace run.
+    This class accepts an iso time stamp, and overloads the addition operator so that a time delta
+    can be added as nanoseconds.
+    :param ws_name: Name of the workspace in which time logs are added.
+    :param time: Time stamp. Reference for start time log.
+    :param duration: Duration of experiment. Used to define end time log.
+
+    """
+    start_time = DateAndTime(time)
+    end_time = DateAndTime(start_time + int(duration * NANO_FACTOR))
+    AnalysisDataService.retrieve(ws_name).getRun().setStartAndEndTime(start_time, end_time)
+
+
+def _prepare_workspaces(start_times, unit: str = "s"):
+    names = []
+    times = []
+    t0 = np.datetime64(ISO_TIME_STAMP)
+    for t in start_times:
+        names.append(f"{TEST_NAME}_{t}")
+        times.append(t0 + np.timedelta64(t, unit))
+        CreateWorkspace(OutputWorkspace=names[-1], DataX=0, DataY=1)
+        _add_time_log_to_workspace(ws_name=names[-1], time=str(times[-1]))
+    return names, times
+
+
+def _correct_midtimes(time_stamps, duration=DEFAULT_DURATION):
+    return [time + np.timedelta64(int(duration / 2 * NANO_FACTOR), "ns") for time in time_stamps]
+
+
+class TimeDifferenceTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        AnalysisDataService.clear()
+
+    def test_time_difference_throws_for_incorrect_workspace_entry(self):
+        CreateEmptyTableWorkspace(OutputWorkspace="test_table")
+        with self.assertRaisesRegex(RuntimeError, "Workspace test_table is not a Group or Matrix Workspace."):
+            _ = TimeDifference(Workspaces="test_table")
+
+    def test_time_difference_throws_for_deleted_workspace(self):
+        CreateWorkspace(OutputWorkspace=TEST_NAME, DataX=0, DataY=1)
+        AnalysisDataService.remove(TEST_NAME)
+        with self.assertRaisesRegex(RuntimeError, f"Workspace {TEST_NAME} does not exists in the ADS."):
+            _ = TimeDifference(Workspaces=TEST_NAME)
+
+    def test_algorithm_creates_NaT_if_time_logs_are_not_present(self):
+        CreateWorkspace(OutputWorkspace=TEST_NAME, DataX=0, DataY=1)
+
+        table = TimeDifference(Workspaces=TEST_NAME)
+
+        # NaT : Not a Time
+        self.assertEqual(["NaT"], table.column(TimeTable.time_stamp))
+
+    def test_time_difference_uses_first_workspace_as_reference_if_not_provided(self):
+        start_times = [0, 1, 2, 3]
+        names, times = _prepare_workspaces(start_times)
+
+        table = TimeDifference(Workspaces=",".join(names))
+
+        self._assert_table(table, names, _correct_midtimes(times), start_times)
+
+    def test_time_difference_takes_run_logs_and_any_other_available_allowed_time_log(self):
+        start_logs = ["run_start", "start_time"]
+        end_logs = ["run_end", "end_time"]
+
+        for start in start_logs:
+            for end in end_logs:
+                CreateWorkspace(OutputWorkspace=TEST_NAME, DataX=0, DataY=1)
+                run = AnalysisDataService.retrieve(TEST_NAME).getRun()
+                run.addProperty(name=start, value=ISO_TIME_STAMP, replace=False)
+                run.addProperty(name=end, value=ISO_TIME_STAMP.replace("00.", "02."), replace=False)
+
+                table = TimeDifference(Workspaces=TEST_NAME)
+
+                midtime = ISO_TIME_STAMP.replace("00.", "01.")
+                self.assertEqual([midtime], table.column(1))
+                AnalysisDataService.clear()
+
+    def test_time_difference_puts_reference_workspace_on_top_of_result_table(self):
+        start_times = [0, 1, 2, 3]
+        reference = 5
+        # Create Ref Workspace
+        ref_time = np.datetime64(ISO_TIME_STAMP) - np.timedelta64(reference, "s")
+        CreateWorkspace(OutputWorkspace=REFERENCE_NAME, DataX=0, DataY=1)
+        _add_time_log_to_workspace(ws_name=REFERENCE_NAME, time=str(ref_time))
+        names, times = _prepare_workspaces(start_times, "s")
+
+        table = TimeDifference(Workspaces=",".join(names), ReferenceWorkspace=AnalysisDataService.retrieve(REFERENCE_NAME))
+
+        start_times = [d + reference for d in start_times]
+        start_times.insert(0, 0)
+        times.insert(0, ref_time)
+        names.insert(0, REFERENCE_NAME)
+        self._assert_table(table, names, _correct_midtimes(times), start_times)
+
+    def test_time_difference_takes_group_workspace_midtime(self):
+        start_times = [0, 1, 2, 3]
+        names, _ = _prepare_workspaces(start_times)
+        GroupWorkspaces(names, OutputWorkspace=GROUP_NAME)
+        table = TimeDifference(Workspaces="group")
+
+        # Notice every experiment lasts for 1 seconds by default, so final time is at 4 seconds
+        # and midtime is 2 seconds.
+        midtime = ISO_TIME_STAMP.replace("00.", "02.")
+        self.assertEqual([str(midtime)], table.column(TimeTable.time_stamp))
+
+    def test_time_difference_can_take_a_list_of_matrix_workspaces_and_groups(self):
+        start_times = [0, 1, 2, 3]
+        start_times_group = [4, 5]
+        names, times = _prepare_workspaces(start_times)
+        names_group, times_group = _prepare_workspaces(start_times_group)
+        GroupWorkspaces(names_group, OutputWorkspace=GROUP_NAME)
+
+        # Add group to names lists
+        names.append(GROUP_NAME)
+
+        table = TimeDifference(Workspaces=",".join(names))
+
+        # Add test data for group column
+        errors = [DEFAULT_DURATION * 2] * len(start_times)
+        # Group workspace duration is 2 seconds in this test, so the error is 3(duration + reference duration)
+        errors.append(3)
+        times = _correct_midtimes(times)
+        times.append(times_group[-1])
+        # Midtime of reference is 0.5 second and midtime of group is 5 seconds.
+        start_times.append(4.5)
+
+        self._assert_table(table, names, times, start_times, errors)
+
+    def test_time_difference_works_with_nano_second_precision(self):
+        # second run will start 100 nanoseconds later.
+        start_times = [0, 100]
+        names, times = _prepare_workspaces(start_times, "ns")
+
+        table = TimeDifference(Workspaces=",".join(names))
+
+        # convert initial times back to seconds to compare results in table
+        start_times = [time / NANO_FACTOR for time in start_times]
+        self._assert_table(table, names, _correct_midtimes(times), start_times)
+
+    def _assert_table(self, table, names, time_stamps, start_times, default_errors=None):
+        if default_errors is None:
+            default_errors = [DEFAULT_DURATION * 2] * len(start_times)
+
+        all_columns = {
+            0: names,
+            1: [str(time) for time in time_stamps],
+            2: start_times,
+            3: default_errors,
+            4: [delta / HOUR_FACTOR for delta in start_times],
+            5: [err / HOUR_FACTOR for err in default_errors],
+        }
+        types = table.columnTypes()
+        for column_number, column_values in all_columns.items():
+            match types[column_number]:
+                case "str":
+                    self.assertEqual(column_values, table.column(column_number))
+                case "float":
+                    np.testing.assert_almost_equal(column_values, table.column(column_number), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TimeDifferenceTest.py
@@ -50,6 +50,17 @@ def _add_time_log_to_workspace(ws_name: str = TEST_NAME, time: str = ISO_TIME_ST
     AnalysisDataService.retrieve(ws_name).getRun().setStartAndEndTime(start_time, end_time)
 
 
+def _correct_midtimes(time_stamps, duration=DEFAULT_DURATION):
+    """
+    This correction is done for the test data, as TimeDifference algorithm will retrieve the time stamps
+    of the middle of the run.
+    :param time_stamps: Middle of the run time stamps
+    :param duration: Set duration of each experiment, by default is 1 second
+    :return: Corrected time stamps
+    """
+    return [time + np.timedelta64(int(duration / 2 * NANO_FACTOR), "ns") for time in time_stamps]
+
+
 def _prepare_workspaces(start_times, unit: str = "s"):
     names = []
     times = []
@@ -60,10 +71,6 @@ def _prepare_workspaces(start_times, unit: str = "s"):
         CreateWorkspace(OutputWorkspace=names[-1], DataX=0, DataY=1)
         _add_time_log_to_workspace(ws_name=names[-1], time=str(times[-1]))
     return names, times
-
-
-def _correct_midtimes(time_stamps, duration=DEFAULT_DURATION):
-    return [time + np.timedelta64(int(duration / 2 * NANO_FACTOR), "ns") for time in time_stamps]
 
 
 class TimeDifferenceTest(unittest.TestCase):

--- a/docs/source/algorithms/TimeDifference-v1.rst
+++ b/docs/source/algorithms/TimeDifference-v1.rst
@@ -9,15 +9,17 @@
 Description
 -----------
 
-This algorithm takes a list of :ref:`Matrix <MatrixWorkspace>` and :ref:`Group <WorkspaceGroup>` workspaces and compares the
-middle time at which each run occurs to a reference value, defining these differences in seconds or hours in respective
-columns of an output table workspace.
+This algorithm takes a list of workspace names (workspaces can be :ref:`Matrix <MatrixWorkspace>` or :ref:`Group <WorkspaceGroup>`)
+and compares the middle time (defined below) at which each run occurs to a reference value.
+The differences are entered into the output table workspace with columns for the time in seconds and hours (plus errors).
 To establish the time at which each run occurs, the start times are taken from either ``run_start`` or ``start_time`` logs and the end times
 from ``run_end`` or ``end_time`` logs.
 For each workspace, the run duration is computed as : :math:`duration = end_{time} - start_{time}` and the time as the middle
 time of the duration interval: :math:`midtime = start_{time} + duration/2`.
+Then, each difference time is computed by subtracting the calculated ``midtime`` stamp from the reference.:math:`difference = midtime - midtime_{ref}` .
+Taking the duration as the absolute error of each ``midtime`` stamp, the error of the difference is computed as the sum of each ``midtime`` error.
 
-*  If a reference workspace is not provided, the first workspace on the Workspaces property list will be set as the reference.
+*  If a reference workspace is not provided, the first workspace in the Workspaces property list will be set as the reference.
 *  For group workspaces, start and end time stamps for all the workspaces contained in the group will be extracted, and the duration interval
    computed from the runs with the earliest and latest start and end times, respectively.
 

--- a/docs/source/algorithms/TimeDifference-v1.rst
+++ b/docs/source/algorithms/TimeDifference-v1.rst
@@ -16,7 +16,7 @@ To establish the time at which each run occurs, the start times are taken from e
 from ``run_end`` or ``end_time`` logs.
 For each workspace, the run duration is computed as : :math:`duration = end_{time} - start_{time}` and the time as the middle
 time of the duration interval: :math:`midtime = start_{time} + duration/2`.
-Then, each difference time is computed by subtracting the calculated ``midtime`` stamp from the reference.:math:`difference = midtime - midtime_{ref}` .
+Then, each difference time is computed by subtracting the calculated ``midtime`` stamp from the reference. :math:`difference = midtime - midtime_{ref}` .
 Taking the duration as the absolute error of each ``midtime`` stamp, the error of the difference is computed as the sum of each ``midtime`` error.
 
 *  If a reference workspace is not provided, the first workspace in the Workspaces property list will be set as the reference.

--- a/docs/source/algorithms/TimeDifference-v1.rst
+++ b/docs/source/algorithms/TimeDifference-v1.rst
@@ -43,7 +43,7 @@ Usage
         AddSampleLog(Workspace=names[-1], LogName='start_time', LogText=str(start_time), LogType='String')
         AddSampleLog(Workspace=names[-1], LogName='end_time', LogText=str(end_time), LogType='String')
 
-    table = TimeDifference(Workspaces=','.join(names))
+    table = TimeDifference(InputWorkspaces=names)
     print("Time Differences are, in seconds: " + str(table.column(2)))
 
 Output:

--- a/docs/source/algorithms/TimeDifference-v1.rst
+++ b/docs/source/algorithms/TimeDifference-v1.rst
@@ -1,0 +1,56 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm takes a list of :ref:`Matrix <MatrixWorkspace>` and :ref:`Group <WorkspaceGroup>` workspaces and compares the
+middle time at which each run occurs to a reference value, defining these differences in seconds or hours in respective
+columns of an output table workspace.
+To establish the time at which each run occurs, the start times are taken from either ``run_start`` or ``start_time`` logs and the end times
+from ``run_end`` or ``end_time`` logs.
+For each workspace, the run duration is computed as : :math:`duration = end_{time} - start_{time}` and the time as the middle
+time of the duration interval: :math:`midtime = start_{time} + duration/2`.
+
+*  If a reference workspace is not provided, the first workspace on the Workspaces property list will be set as the reference.
+*  For group workspaces, start and end time stamps for all the workspaces contained in the group will be extracted, and the duration interval
+   computed from the runs with the earliest and latest start and end times, respectively.
+
+
+Usage
+-----
+
+** Example **
+
+.. testcode:: ExTimeDifferences
+
+    time_origin = np.datetime64('2025-06-12T08:00:00.000000000')
+    experiment_duration = np.timedelta64(60,'s')
+
+    start_times = [0,100,200,300]
+
+    names = []
+    for start in start_times:
+        names.append(str(start))
+        start_time = time_origin + np.timedelta64(start,'s')
+        end_time = start_time + experiment_duration
+        CreateWorkspace(OutputWorkspace=names[-1], DataX = 0 , DataY = 1)
+        AddSampleLog(Workspace=names[-1], LogName='start_time', LogText=str(start_time), LogType='String')
+        AddSampleLog(Workspace=names[-1], LogName='end_time', LogText=str(end_time), LogType='String')
+
+    table = TimeDifference(Workspaces=','.join(names))
+    print('Time Differences are, in seconds: ', table.column(2))
+
+Output:
+
+.. testoutput:: ExTimeDifferences
+    Time Differences are, in seconds: [0,100,200,300]
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/TimeDifference-v1.rst
+++ b/docs/source/algorithms/TimeDifference-v1.rst
@@ -44,12 +44,13 @@ Usage
         AddSampleLog(Workspace=names[-1], LogName='end_time', LogText=str(end_time), LogType='String')
 
     table = TimeDifference(Workspaces=','.join(names))
-    print('Time Differences are, in seconds: ', table.column(2))
+    print("Time Differences are, in seconds: " + str(table.column(2)))
 
 Output:
 
 .. testoutput:: ExTimeDifferences
-    Time Differences are, in seconds: [0,100,200,300]
+
+    Time Differences are, in seconds: [0.0, 100.0, 200.0, 300.0]
 
 .. categories::
 

--- a/docs/source/release/v6.14.0/Framework/Python/New_features/36142.rst
+++ b/docs/source/release/v6.14.0/Framework/Python/New_features/36142.rst
@@ -1,0 +1,1 @@
+- Added new python algorithm, :ref:`algm-TimeDifference-v1`, for calculating the time difference between a series of runs and a reference run.


### PR DESCRIPTION
### Description of work
This PR is part of the Polarised SANS epic. The polarization of the He3 in the MEOP analysers decays with time. For a correct calibration of the efficiency, it is necessary to measure the polarization at different time stamps to fit the decay to a curve. This fit will be later used to calculate the efficiency of the analyzer for the scattering run.
 One of the necessary calculations for this calibration is to extract the time difference between different runs by looking at the start and end time logs (start_time/end_time or run_start/run_end) to extract the duration and middle time of the experiment for each run. These middle times are then compared to a reference to extract the times at which each run happened in relation to the reference. 

The algorithm takes a comma-separated list of names of workspaces in the ads, these workspaces can be either matrix or group workspaces. A reference workspace can be additionally provided, so that the times of all the input workspaces will be compared to this reference. If no reference is provided, the first workspace of the list will be taken as a reference. 

Algorithm will return a table with one column containing the middle of the run time stamps and additional columns the time differences (with errors) in seconds and hours with respect to the reference.


#### Purpose of work
This PR is necessary for #36143 

Fixes #36142  


#### Further detail of work
I have written the algorithm in Python as it is very lightweight and to profit from the time manipulations with numpy datetimes.

### To test:

- All tests passes. 
- Docs are clear and free of typos. 
- You can use this script (test code of the docs) to start exploring the algorithm : 

```
    time_origin = np.datetime64('2025-06-12T08:00:00.000000000')
    experiment_duration = np.timedelta64(60,'s')

    start_times = [0,100,200,300]

    names = []
    for start in start_times:
        names.append(str(start))
        start_time = time_origin + np.timedelta64(start,'s')
        end_time = start_time + experiment_duration
        CreateWorkspace(OutputWorkspace=names[-1], DataX = 0 , DataY = 1)
        AddSampleLog(Workspace=names[-1], LogName='start_time', LogText=str(start_time), LogType='String')
        AddSampleLog(Workspace=names[-1], LogName='end_time', LogText=str(end_time), LogType='String')

    table = TimeDifference(InputWorkspaces=names)
    print('Time Differences are, in seconds: ', table.column(2))
```

_Added release notes_

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
