### PR TITLE
Fix crash when input wrong character in ALC interface

### DIFF
--- a/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
+++ b/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
@@ -1,0 +1,1 @@
+- :ref:`ALC interface <MuonALC-ref>` no longer crashes when non numeric characters are input in Backward and Forward Grouping line edits.

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingModel.h
@@ -54,7 +54,6 @@ public:
   void setFilesToLoad(const std::vector<std::string> &files) override;
 
 private:
-  static std::string isCustomGroupingValid(const std::string &group, bool &isValid);
   static int extractRunNumber(const std::string &file);
 
   /// Last loaded data workspace

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -72,7 +72,7 @@ void ALCDataLoadingView::initialize() {
   m_ui.forwardEdit->setValidator(validator);
   m_ui.forwardEdit->setMaxLength(LINE_EDIT_MAX_LENGTH);
   m_ui.backwardEdit->setValidator(validator);
-  m_ui.forwardEdit->setMaxLength(LINE_EDIT_MAX_LENGTH);
+  m_ui.backwardEdit->setMaxLength(LINE_EDIT_MAX_LENGTH);
 
   // Alpha to only accept positive doubles
   m_ui.alpha->setValidator(new QDoubleValidator(0, 99999, 10, this));

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -21,6 +21,7 @@ using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 
 const QString DEFAULT_LOG("run_number");
+constexpr int LINE_EDIT_MAX_LENGTH(1000);
 const std::vector<std::string> INSTRUMENTS{"ARGUS", "CHRONUS", "EMU", "HIFI", "MUSR"};
 
 namespace MantidQt::CustomInterfaces {
@@ -67,6 +68,11 @@ void ALCDataLoadingView::initialize() {
   QRegExp re("[0-9]+(,[0-9]+)*(-[0-9]+(($)|(,[0-9]+))+)*");
   QValidator *validator = new QRegExpValidator(re, this);
   m_ui.runs->setTextValidator(validator);
+
+  m_ui.forwardEdit->setValidator(validator);
+  m_ui.forwardEdit->setMaxLength(LINE_EDIT_MAX_LENGTH);
+  m_ui.backwardEdit->setValidator(validator);
+  m_ui.forwardEdit->setMaxLength(LINE_EDIT_MAX_LENGTH);
 
   // Alpha to only accept positive doubles
   m_ui.alpha->setValidator(new QDoubleValidator(0, 99999, 10, this));
@@ -201,8 +207,7 @@ bool ALCDataLoadingView::displayWarning(const std::string &warning) {
                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   if (reply == QMessageBox::Yes)
     return true;
-  else
-    return false;
+  return false;
 }
 
 /**


### PR DESCRIPTION
### Description of work
Fixes #39442. 
QRegExp validator has been added to the offending line edits so that the detector grouping input format is always correct and the crash no longer happens. 


Fixes #39442

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

- All tests are passing. 
- The crash described in #39442 no longer happens (you can set the instrument as MUSR and use the usage data run "15189") if you don't want to load HIFI runs. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

_Added a release note_

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
