### PR TITLE
Edit Mantid Workbench Release Notes for v6.13.0

### DIFF
--- a/docs/source/release/v6.13.0/mantidworkbench.rst
+++ b/docs/source/release/v6.13.0/mantidworkbench.rst
@@ -21,7 +21,7 @@ New Features
     will help us to diagnose some problems where previously no stacktrace was available
     after a crash.
   - On Linux, core dumps are now always turned on for the workbench process.
-
+  - This property and additional stack trace information are not currently available on macOS or Windows.
 
 Bugfixes
 --------
@@ -47,7 +47,7 @@ SliceViewer
 
 New features
 ############
-- When plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample`, it it now possible to use the
+- When plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample`, it is now possible to use the
   UB instead of peak index.
 
 Bugfixes

--- a/docs/source/release/v6.13.0/mantidworkbench.rst
+++ b/docs/source/release/v6.13.0/mantidworkbench.rst
@@ -7,22 +7,26 @@ Mantid Workbench Changes
 
 New Features
 ------------
-- The :ref:`Python script editor <WorkbenchScriptWindow>` now supports Bool syntax highlighting.
-- The :ref:`Python script editor <WorkbenchScriptWindow>` now supports f-string syntax highlighting.
-- Users can now save multiple selected workspaces as ASCII.
-- The crosshair button is disabled (invisible) in 3D plots, which include surface plot, wireframe plot and mesh plot.
-- The settings widget 'Apply' button is now disabled when there are no pending changes.
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.
-- Deprecated parameter ``Unwrap Ref`` has been removed from the Powder
-  Diffraction Reduction Interface.
-- Added property ``errorreports.core_dumps``. Linux users can set this to the directory on their system where core dump files are put after a crash (e.g ``errorreports.core_dumps=/var/lib/apport/coredump``).
-  Workbench will then be able to use this property to extract useful information from the core dump file created after a crash and give that to the error reporting service.
-  This will help us to diagnose some problems where previously no stacktrace was available after a crash. On Linux, core dumps are now always turned on for the workbench process.
+- The :ref:`Python script editor <WorkbenchScriptWindow>` now supports ``bool`` and f-string syntax highlighting.
+- Users can now save multiple selected workspaces in the ASCII format.
+- A crosshair toggle option has been added in mantid plots on the top right of the toolbar area. The crosshair button is
+  disabled (invisible) in tiled and 3D plots.
+- The :ref:`WorkbenchSettings` widget's ``Apply`` button is now disabled when there are no pending changes.
+- Deprecated parameter ``Unwrap Ref`` has been removed from the Powder Diffraction Reduction Interface.
+- Added property ``errorreports.core_dumps``.
+
+  - Linux users can set this to the directory on their system where core dump files are put after a crash (e.g
+    ``errorreports.core_dumps=/var/lib/apport/coredump``). Workbench will then be able to use this property to extract
+    useful information from the core dump file created after a crash and give that to the error reporting service. This
+    will help us to diagnose some problems where previously no stacktrace was available
+    after a crash.
+  - On Linux, core dumps are now always turned on for the workbench process.
 
 
 Bugfixes
 --------
-- The ``...`` button for a :ref:`user defined function <user_defined_function>` is no longer obscured by the scroll bar in the :ref:`Fit Property Browser <WorkbenchPlotWindow_Fitting>` on macOS.
+- The ``...`` button for a :ref:`user defined function <user_defined_function>` is no longer obscured by the scroll bar
+  in the :ref:`Fit Property Browser <WorkbenchPlotWindow_Fitting>` on macOS.
 - Minimizing the sample log plot on the ``SampleLogs`` widget so that it is not visible no longer throws an error.
 
 
@@ -43,10 +47,11 @@ SliceViewer
 
 New features
 ############
-- Added the option when plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample` using the UB instead of peak index.
+- When plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample`, it it now possible to use the
+  UB instead of peak index.
 
 Bugfixes
 ############
-- Sliceviwer no longer raises an error when exporting a pixel cut from a MDHistoWorkspace
+- The :ref:`sliceviewer` no longer raises an error when exporting a pixel cut from an :ref:`MDHistoWorkspace`
 
 :ref:`Release 6.13.0 <v6.13.0>`


### PR DESCRIPTION
### Description of work

#### Summary of work
Editing of workbench release notes for v6.13.0.

Refs #39471 

### To test:
1. Build release notes `cmake --build . --target docs-html`. Open in a browser and check for any formatting/spelling issues.


*This does not require release notes* because **`RecursionError: maximum recursion depth reached.`**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
