### PR TITLE
Add option to update UB matrix when CommonUBForAll=False and table contains only peaks from one run 

### DIFF
--- a/docs/source/release/v6.14.0/Framework/Algorithms/New_features/38964.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/New_features/38964.rst
@@ -1,0 +1,1 @@
+- Add UpdateUB option to :ref:`algm-IndexPeaks` that enables saving the optimized UB matrix in the case where there is a single run and CommonUBForAll=False.


### PR DESCRIPTION
### Description of work
This PR adds `UpdateUB` option to `IndexPeaks` which saves the optimized UB matrix to the peaks workspace if `CommonUBForAll=False` and the workspace contains a single run. 

Fixes #38964. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
Run the following script:
```
ws = LoadEmptyInstrument(Filename="SXD_Definition.xml", OutputWorkspace="empty_SXD")
axis = ws.getAxis(0)
axis.setUnit("TOF")

bad_ub = np.diag([1/3.8, 0.25, 0.1])  # alatt = [3.8, 4, 10]

peaks = CreatePeaksWorkspace(InstrumentWorkspace=ws, NumberOfPeaks=0, OutputWorkspace="peaks")
for K in range(1, 6):
    for L in range(1, 6):
        pk = peaks.createPeakHKL([2, K, L])
        peaks.addPeak(pk)
SetUB(peaks, UB=bad_ub)

print(bad_ub)

IndexPeaks(peaks, Tolerance=0.15, CommonUBForAll=False, UpdateUB=True) 

print(peaks.sample().getOrientedLattice().getUB())
```
with following configuration:
1- CommonUBForAll=False, UpdateUB=True -> You should get a notice message that the UB matrix is optimized and the second print should output the optimized UB
2- CommonUBForAll=False, UpdateUB=False -> You should get a warning message that an optimized UB is used to index peaks but it is not saved
3- CommonUBForAll=True, UpdateUB=False/True -> You shouldn't any message
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
