### PR TITLE
AlignAndFocusPowderSlim change disk access

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -27,13 +27,16 @@ public:
   class MANTID_DATAHANDLING_DLL BankCalibration {
   public:
     BankCalibration(const detid_t idmin, const detid_t idmax, const double time_conversion,
-                    const std::map<detid_t, double> &calibration_map);
+                    const std::map<detid_t, double> &calibration_map, const std::set<detid_t> &mask);
     const double &value(const detid_t detid) const;
+    bool use(const detid_t detid) const;
+    bool useAll() const;
     const detid_t &idmin() const;
     detid_t idmax() const;
 
   private:
     std::vector<double> m_calibration;
+    std::set<detid_t> m_mask;
     const detid_t m_detid_offset;
   };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -26,14 +26,15 @@ public:
 
   class MANTID_DATAHANDLING_DLL BankCalibration {
   public:
-    BankCalibration(const detid_t idmin, const detid_t idmax, const std::map<detid_t, double> &calibration_map);
+    BankCalibration(const detid_t idmin, const detid_t idmax, const double time_conversion,
+                    const std::map<detid_t, double> &calibration_map);
     const double &value(const detid_t detid) const;
     const detid_t &idmin() const;
     detid_t idmax() const;
 
   private:
     std::vector<double> m_calibration;
-    detid_t m_detid_offset;
+    const detid_t m_detid_offset;
   };
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -29,14 +29,11 @@ public:
     BankCalibration(const detid_t idmin, const detid_t idmax, const double time_conversion,
                     const std::map<detid_t, double> &calibration_map, const std::set<detid_t> &mask);
     const double &value(const detid_t detid) const;
-    bool use(const detid_t detid) const;
-    bool useAll() const;
     const detid_t &idmin() const;
     detid_t idmax() const;
 
   private:
     std::vector<double> m_calibration;
-    std::set<detid_t> m_mask;
     const detid_t m_detid_offset;
   };
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -65,8 +65,8 @@ const std::string EVENTS_PER_THREAD("EventsPerThread");
 } // namespace PropertyNames
 
 namespace NxsFieldNames {
-const std::string TIME_OF_FLIGHT("event_time_offset");
-const std::string DETID("event_id");
+const std::string TIME_OF_FLIGHT("event_time_offset"); // float32 in ORNL nexus files
+const std::string DETID("event_id");                   // uint32 in ORNL nexus files
 const std::string INDEX_ID("event_index");
 } // namespace NxsFieldNames
 
@@ -158,13 +158,14 @@ public:
     // groups close themselves
   }
 
-  template <typename NumT>
-  void loadTOF(H5::DataSet &tof_SDS, std::unique_ptr<std::vector<NumT>> &data, const size_t offset,
+  template <typename TofType>
+  void loadTOF(H5::DataSet &tof_SDS, std::unique_ptr<std::vector<TofType>> &data, const size_t offset,
                const size_t slabsize) {
     NeXus::H5Util::readArray1DCoerce(tof_SDS, *data, slabsize, offset);
   }
 
-  void loadDetid(H5::DataSet &detID_SDS, std::unique_ptr<std::vector<detid_t>> &data, const size_t offset,
+  template <typename DetidType>
+  void loadDetid(H5::DataSet &detID_SDS, std::unique_ptr<std::vector<DetidType>> &data, const size_t offset,
                  const size_t slabsize) {
     NeXus::H5Util::readArray1DCoerce(detID_SDS, *data, slabsize, offset);
   }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -802,6 +802,7 @@ API::MatrixWorkspace_sptr AlignAndFocusPowderSlim::editInstrumentGeometry(
  * @param time_conversion Value to bundle into the calibration constant to account for converting the time-of-flight
  * into microseconds. Applying it here is effectively the same as applying it to each event time-of-flight.
  * @param calibration_map Calibration for the entire instrument.
+ * @param mask detector ids that exist in the map should not be included.
  */
 AlignAndFocusPowderSlim::BankCalibration::BankCalibration(const detid_t idmin, const detid_t idmax,
                                                           const double time_conversion,

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -329,8 +329,7 @@ public:
       // TODO REMOVE debug print
       std::cout << bankName << " has " << eventRangeFull.second << " events\n"
                 << "   and should be read in " << (1 + (eventRangeFull.second / m_events_per_chunk)) << " chunks of "
-                << m_events_per_chunk << " (" << (m_events_per_chunk / 1024 / 1024) << "MB)"
-                << "\n";
+                << m_events_per_chunk << " (" << (m_events_per_chunk / 1024 / 1024) << "MB)\n";
 
       // create a histogrammer to process the events
       auto &spectrum = m_wksp->getSpectrum(wksp_index);
@@ -644,6 +643,7 @@ void AlignAndFocusPowderSlim::exec() {
     const int DISK_CHUNK = getProperty(PropertyNames::READ_SIZE_FROM_DISK);
     const int GRAINSIZE_EVENTS = getProperty(PropertyNames::EVENTS_PER_THREAD);
     auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
+    std::cout << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n"; // TODO REMOVE debug print
     ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, pulse_start_index, pulse_stop_index, wksp,
                          m_calibration, m_masked, static_cast<size_t>(DISK_CHUNK),
                          static_cast<size_t>(GRAINSIZE_EVENTS), progress);

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -331,12 +331,10 @@ void readArray1DCoerce(const H5::Group &group, const std::string &name, std::vec
   try {
     DataSet dataset = group.openDataSet(name);
     readArray1DCoerce<OutT, narrow>(dataset, output);
-  } catch (const H5::GroupIException &e) {
-    UNUSED_ARG(e);
-    g_log->information("Failed to open dataset \"" + name + "\"\n");
-  } catch (const H5::DataTypeIException &e) {
-    UNUSED_ARG(e);
-    g_log->information("DataSet \"" + name + "\" should be double" + "\n");
+  } catch (const H5::GroupIException &) {
+    g_log->information("Failed to open dataset \"" + name + "\"");
+  } catch (const H5::DataTypeIException &) {
+    g_log->information("DataSet \"" + name + "\" should be double");
   }
 }
 
@@ -346,12 +344,10 @@ std::vector<OutT> readArray1DCoerce(const H5::Group &group, const std::string &n
   try {
     DataSet dataset = group.openDataSet(name);
     readArray1DCoerce<OutT, narrow>(dataset, result);
-  } catch (const H5::GroupIException &e) {
-    UNUSED_ARG(e);
-    g_log->information("Failed to open dataset \"" + name + "\"\n");
-  } catch (const H5::DataTypeIException &e) {
-    UNUSED_ARG(e);
-    g_log->information("DataSet \"" + name + "\" should be double" + "\n");
+  } catch (const H5::GroupIException &) {
+    g_log->information("Failed to open dataset \"" + name + "\"");
+  } catch (const H5::DataTypeIException &) {
+    g_log->information("DataSet \"" + name + "\" should be double");
   }
 
   return result;


### PR DESCRIPTION
Various changes with an eye on improved performance and reduced memory usage.
1. Move the opening of datasets outside of the main data reading loop
2. Make `BankCalibration` responsible for what pixels are masked in the bank by setting them to a known bad value
3. Apply the time-of-flight unit conversion on the calibration constants. This is one floating operation per pixel rather than one per event.
4. Additional documentation for the `BankCalibration` class
5. Read the detector-ids as uint32 which is the type they are stored on disk as. This moves the responsibility of casting the values to happen on individual events and reduces overall memory usage.
6. Added `tbb::parallel_invoke` so reading of and detid can happen at relatively the same time
7. Moved around the `tbb::task_group` and `tbb::task_group_context` so memory can be allocated once in the main `while` loop.
8. Modified `ProcessEventsTask` to use more (CPU) efficient methods for checking event information. This makes it that so (according to vtune) ~65% of that method is spent in `std::upper_bound`.

*There is no associated issue.*
[EWM11553](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11553)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

Run the standard examples before and after this change and see the difference in execution time.

*This does not require release notes* because it is a minor performance bump and no user facing change.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
