### PR TITLE
Allow different binning for each output histogram in AlignAndFocusPowderSlim

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -41,7 +41,7 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
-  API::MatrixWorkspace_sptr createOutputWorkspace(const size_t numHist, const bool linearBins, const double x_delta);
+  API::MatrixWorkspace_sptr createOutputWorkspace();
   API::MatrixWorkspace_sptr editInstrumentGeometry(API::MatrixWorkspace_sptr &wksp, const double l1,
                                                    const std::vector<double> &polars,
                                                    const std::vector<specnum_t> &specids,

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -473,7 +473,7 @@ void AlignAndFocusPowderSlim::init() {
   declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::X_MAX, std::vector<double>{16667}),
                   "Minimum x-value for the output binning");
   declareProperty(std::make_unique<EnumeratedStringProperty<BinningMode, &binningModeNames>>(PropertyNames::BINMODE),
-                  "Specify binning behavior ('Logorithmic')");
+                  "Specify binning behavior ('Logarithmic')");
   declareProperty(
       std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(PropertyNames::OUTPUT_WKSP, "", Direction::Output),
       "An output workspace.");

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -43,9 +43,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", filename));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", wksp_name));
     if (xmin >= 0.)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmin));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", std::vector<double>{xmin}));
     if (xmax >= 0.)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmax));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", std::vector<double>{xmax}));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
     std::cout << "==================> " << timer << '\n';

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -23,7 +23,6 @@ Current limitations compared to ``AlignAndFocusPowderFromFiles``
 
 - only supports the VULCAN instrument
 - hard coded for 6 particular groups
-- common binning across all output spectra
 - only specify binning in time-of-flight
 - does not support event filtering
 - does not support copping data

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39533.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39533.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` now allows different binning to be specified for each output spectra.


### PR DESCRIPTION
This is a version of #39533 into `ornl-next`