### PR TITLE
Use `std::move` to pass `rotMat` to `setR`

### DIFF
--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -401,7 +401,7 @@ void Goniometer::loadNexus(Nexus::File *file, const std::string &group) {
     std::vector<double> matrixData;
     file->readData("rotation_matrix", matrixData);
     DblMatrix rotMat(matrixData);
-    setR(rotMat);
+    setR(std::move(rotMat));
     m_initFromR = true; // set as initFromR to prevent overwrite on R recalc
   } else {
     for (int i = 0; i < num_axes; i++) {


### PR DESCRIPTION
### Description of work

#### Summary of work
Hard to summarise any shorter than the title: now uses `std::move` to pass `rotMat` to `setR`

#### Purpose of work
Flagged as an inefficiency - previously created a copy of the `rotMat` to pass to the function rather than just moving the loaded data 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You can run this script and check everything still works:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

cuboid = " \
<cuboid id='some-cuboid'> \
<height val='2.0'  /> \
<width val='2.0' />  \
<depth  val='0.2' />  \
<centre x='10.0' y='10.0' z='10.0'  />  \
</cuboid>  \
<algebra val='some-cuboid' /> \
"

# just set this as a folder you are happy to have some files appear
root = "C:/Users/kcd17618/Documents/MantidScripts/SaveGoniometerBug"
ws = CreateSampleWorkspace()
other_ws = CreateSampleWorkspace()

# gon mat is a 30 degree rotation around (1,1,1)            
gon_mat = np.array([[ 0.9106836,  -0.24401694,  0.33333333],
 [ 0.33333333,  0.9106836,  -0.24401694],
 [-0.24401694,  0.33333333,  0.9106836 ]])
 
# try setting the matrix directly and using an equivalent axis definition
SetGoniometer(Workspace = ws, GoniometerMatrix = gon_mat)
SetGoniometer(Workspace = other_ws, Axis0 = "30,1,1,1,1")
SetSample(ws, Geometry={'Shape': 'CSG', 'Value': cuboid})
SetSample(other_ws, Geometry={'Shape': 'CSG', 'Value': cuboid})

# verify this is the same
print("Set with GoniometerMatrix: ",ws.run().getGoniometer().getR())
print("Set with Axis0: ",other_ws.run().getGoniometer().getR())

# Save the files
SaveNexus(InputWorkspace = ws, Filename= f"{root}/tmp_ws.nxs")
SaveNexus(InputWorkspace = other_ws, Filename= f"{root}/tmp_other_ws.nxs")

# Load the files
load_ws = Load(Filename = f"{root}/tmp_ws.nxs")
load_other_ws = Load(Filename = f"{root}/tmp_other_ws.nxs")

# Results should not have changed
print("Reloaded - Set with GoniometerMatrix: ",load_ws.run().getGoniometer().getR())
print("Reloaded - Set with Axis0: ",load_other_ws.run().getGoniometer().getR())
```

*This does not require release notes* because **not user facing**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
