### PR TITLE
Fix NX5SIGNATURE error

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -13,6 +13,8 @@
 
 typedef const char CONSTCHAR;
 
+#define NX5SIGNATURE 959695
+
 /*
  * Any new NXaccess_mode options should be numbered in 2^n format
  * (8, 16, 32, etc) so that they can be bit masked and tested easily.

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -55,7 +55,6 @@ struct NexusFile5 {
   hid_t iCurrentA;
   hsize_t iCurrentIDX;
   int iNX;
-  int iNXID;
   int iStackPtr;
   char name_ref[1024];
   char name_tmp[1024];

--- a/Framework/Nexus/inc/MantidNexus/napi5.h
+++ b/Framework/Nexus/inc/MantidNexus/napi5.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define NX5SIGNATURE 959695
-
 /* Hide deprecated API from HDF5 versions before 1.8
  * Required to build on Ubuntu 12.04 */
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -19,7 +19,6 @@ using std::stringstream;
 using std::vector;
 
 #define NXEXCEPTION(message) Exception((message), __func__, m_filename);
-#define NX5SIGNATURE 959695
 #define NX_UNKNOWN_GROUP ""
 
 #define NAPI_CALL(status, msg)                                                                                         \

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -50,14 +50,7 @@ template <typename NumT> static string toString(const vector<NumT> &data) {
   return result.str();
 }
 
-pNexusFile5 assertNXID(std::shared_ptr<NXhandle> fid) {
-  pNexusFile5 pRes;
-
-  assert(fid != NULL);
-  pRes = static_cast<pNexusFile5>(*fid);
-  assert(pRes->iNXID == NX5SIGNATURE);
-  return pRes;
-}
+pNexusFile5 assertNXID(std::shared_ptr<NXhandle> fid) { return *fid; }
 
 herr_t attr_check(hid_t loc_id, const char *member_name, const H5A_info_t *unused, void *opdata) {
   UNUSED_ARG(loc_id);

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -126,7 +126,6 @@ NXstatus NXreopen(NXhandle origHandle, NXhandle &newHandle) {
     free(pNew);
     return NXstatus::NX_ERROR;
   }
-  pNew->iNXID = NX5SIGNATURE;
   pNew->iStack5[0].iVref = 0; /* root! */
   newHandle = static_cast<NXhandle>(pNew);
   return NXstatus::NX_OK;

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -178,8 +178,6 @@ NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle &handle) {
 
     H5Gclose(root_id);
   }
-
-  pNew->iNXID = NX5SIGNATURE;
   pNew->iStack5[0].iVref = 0; /* root! */
   handle = static_cast<NXhandle>(pNew);
   return NXstatus::NX_OK;

--- a/Framework/Nexus/src/napi_helper.cpp
+++ b/Framework/Nexus/src/napi_helper.cpp
@@ -6,14 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-pNexusFile5 NXI5assert(NXhandle fid) {
-  pNexusFile5 pRes;
-
-  assert(fid != NULL);
-  pRes = static_cast<pNexusFile5>(fid);
-  assert(pRes->iNXID == NX5SIGNATURE);
-  return pRes;
-}
+pNexusFile5 NXI5assert(NXhandle fid) { return fid; }
 
 void NXI5KillDir(pNexusFile5 self) { self->iStack5[self->iStackPtr].iCurrentIDX = 0; }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -593,4 +593,4 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowse
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:863
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:862

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -593,4 +593,4 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowse
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:862
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:855


### PR DESCRIPTION
### Description of work

#### Summary of work

The value `NX5SIGNATURE` is used inside the Nexus/napi package to ensure a file is an HDF5 file.

This needed to be moved to a more visible location.

Refs #38332 

Fixes a user-reported error due to NX5SIGNATURE on Windows, in [Mantid slack channel](https://mantid.slack.com/archives/C45NYR1BM/p1750856031711669).

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Build this branch on Windows.    IThe build servers are not sufficient, because for some reason this passes there.

It is probably sufficient to build the `Nexus` target instead of the entire program.

If this did NOT work, there will be an error 
```
5>C:\Users\kcd17618\Documents\dev\mantid\mantid\Framework\Nexus\src\napi_helper.cpp(14,3): error C2065: 'NX5SIGNATURE': undeclared identifier
5>Done building project "Nexus.vcxproj" -- FAILED.
```

If this DID work, there will be no error.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
