### PR TITLE
`Nexus` enum classes :lock:

### DIFF
--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -442,7 +442,7 @@ public:
     std::string path = FileFinder::Instance().getFullPath(testFile);
 
     // Get nexus file for this.
-    Mantid::Nexus::File nxFile(path, NXACC_READ);
+    Mantid::Nexus::File nxFile(path, NXaccess::READ);
 
     // Load the Nexus IDF info
     std::string params;
@@ -464,7 +464,7 @@ public:
     std::string path = FileFinder::Instance().getFullPath(testFile);
 
     // Get nexus file for this.
-    Mantid::Nexus::File nxFile(path, NXACC_READ);
+    Mantid::Nexus::File nxFile(path, NXaccess::READ);
     // Open instrument group
     nxFile.openGroup("instrument", "NXinstrument");
 

--- a/Framework/API/test/FileBackedExperimentInfoTest.h
+++ b/Framework/API/test/FileBackedExperimentInfoTest.h
@@ -33,7 +33,7 @@ public:
     }
 
     m_inMemoryExptInfo = std::make_shared<ExperimentInfo>();
-    Mantid::Nexus::File nxFile(m_filename, NXACC_READ);
+    Mantid::Nexus::File nxFile(m_filename, NXaccess::READ);
     nxFile.openGroup("mantid_workspace_1", "NXentry");
     std::string paramString;
     m_inMemoryExptInfo->loadExperimentInfoNexus(m_filename, &nxFile, paramString);

--- a/Framework/API/test/WorkspaceHistoryIOTest.h
+++ b/Framework/API/test/WorkspaceHistoryIOTest.h
@@ -203,7 +203,8 @@ public:
       testHistory.addHistory(std::make_shared<AlgorithmHistory>(algHist));
     }
 
-    auto savehandle = std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXACC_CREATE5);
+    auto savehandle =
+        std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXaccess::CREATE5);
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 
@@ -233,7 +234,8 @@ public:
     algHist.addChildHistory(std::make_shared<AlgorithmHistory>(childHist));
     testHistory.addHistory(std::make_shared<AlgorithmHistory>(algHist));
 
-    auto savehandle = std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXACC_CREATE5);
+    auto savehandle =
+        std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXaccess::CREATE5);
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 
@@ -256,7 +258,8 @@ public:
   void test_SaveNexus_Empty() {
     WorkspaceHistory testHistory;
 
-    auto savehandle = std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXACC_CREATE5);
+    auto savehandle =
+        std::make_shared<Mantid::Nexus::File>("WorkspaceHistoryTest_test_SaveNexus.nxs", NXaccess::CREATE5);
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 

--- a/Framework/DataHandling/src/LoadCSNSNexus.cpp
+++ b/Framework/DataHandling/src/LoadCSNSNexus.cpp
@@ -400,7 +400,7 @@ void LoadCSNSNexus::exec() {
   const std::string m_filename = getPropertyValue("Filename");
   m_entry = getPropertyValue("NXentryName");
   const std::vector<std::string> bankNames = getProperty("Bankname");
-  m_file = std::make_unique<Nexus::File>(m_filename, NXACC_READ);
+  m_file = std::make_unique<Nexus::File>(m_filename, NXaccess::READ);
   const bool m_loadBank = getProperty("LoadBank");
   const bool m_loadEvent = getProperty("LoadEvent");
   const auto start_time = getExperimentTime("start_time_utc");

--- a/Framework/DataHandling/src/LoadDetectorInfo.cpp
+++ b/Framework/DataHandling/src/LoadDetectorInfo.cpp
@@ -221,7 +221,7 @@ void LoadDetectorInfo::loadFromRAW(const std::string &filename) {
  */
 void LoadDetectorInfo::loadFromIsisNXS(const std::string &filename) {
   Nexus::File nxsFile(filename,
-                      NXACC_READ); // will throw if file can't be opened
+                      NXaccess::READ); // will throw if file can't be opened
 
   // two types of file:
   //   - new type entry per detector

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -942,7 +942,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
       prog->doReport("Loading all logs");
       try {
         // Open NeXus file
-        Nexus::File nxHandle(m_filename, NXACC_READ);
+        Nexus::File nxHandle(m_filename, NXaccess::READ);
         LoadHelper::addNexusFieldsToWsRun(nxHandle, m_ws->mutableRun(), "", true);
       } catch (Nexus::Exception const &e) {
         g_log.debug() << "Failed to open nexus file \"" << m_filename << "\" in read mode: " << e.what() << "\n";
@@ -1683,7 +1683,7 @@ void LoadEventNexus::loadSampleDataISIScompatibility(Nexus::File &file, EventWor
  */
 void LoadEventNexus::safeOpenFile(const std::string &fname) {
   try {
-    m_file = std::make_unique<Nexus::File>(m_filename, NXACC_READ);
+    m_file = std::make_unique<Nexus::File>(m_filename, NXaccess::READ);
   } catch (std::runtime_error &e) {
     throw std::runtime_error("Severe failure when trying to open NeXus file: " + std::string(e.what()));
   }

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -226,7 +226,7 @@ void LoadILLDiffraction::loadMetaData() {
 
   // get some information from the NeXus file
   try {
-    Nexus::File filehandle(m_filename, NXACC_READ);
+    Nexus::File filehandle(m_filename, NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(filehandle, mutableRun);
   } catch (Nexus::Exception const &e) {
     g_log.debug() << "Failed to open nexus file \"" << m_filename << "\" in read mode: " << e.what() << "\n";

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -339,7 +339,7 @@ void LoadILLIndirect2::loadNexusEntriesIntoProperties(const std::string &nexusfi
   API::Run &runDetails = m_localWorkspace->mutableRun();
 
   try {
-    Nexus::File nxfileID(nexusfilename, NXACC_READ);
+    Nexus::File nxfileID(nexusfilename, NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(nxfileID, runDetails);
   } catch (Nexus::Exception const &e) {
     g_log.debug() << "convertNexusToProperties: Error loading  \"" << nexusfilename << "\" in read mode: " << e.what()

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -180,7 +180,7 @@ void LoadILLLagrange::loadMetaData() {
 
   // Open NeXus file
   try {
-    Nexus::File nxHandle(getPropertyValue("Filename"), NXACC_READ);
+    Nexus::File nxHandle(getPropertyValue("Filename"), NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(nxHandle, m_outputWorkspace->mutableRun(), "entry0");
   } catch (Nexus::Exception const &e) {
     g_log.debug() << "Failed to open nexus file \"" << getPropertyValue("Filename") << "\" in read mode: " << e.what()

--- a/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
@@ -212,7 +212,7 @@ void LoadILLPolarizedDiffraction::loadMetaData() {
 
   // Open NeXus file
   try {
-    Nexus::File nxHandle(m_fileName, NXACC_READ);
+    Nexus::File nxHandle(m_fileName, NXaccess::READ);
     for (auto workspaceId = 0; workspaceId < static_cast<int>(m_outputWorkspaceGroup.size()); ++workspaceId) {
       MatrixWorkspace_sptr workspace =
           std::static_pointer_cast<API::MatrixWorkspace>(m_outputWorkspaceGroup[workspaceId]);

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -505,7 +505,7 @@ void LoadILLReflectometry::loadNexusEntriesIntoProperties() {
   API::Run &runDetails = m_localWorkspace->mutableRun();
 
   try {
-    Nexus::File nxfileID(filename, NXACC_READ);
+    Nexus::File nxfileID(filename, NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(nxfileID, runDetails);
   } catch (Nexus::Exception const &) {
     throw Kernel::Exception::FileError("Unable to open File:", filename);

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -262,7 +262,7 @@ void LoadILLSALSA::loadNexusV2(const H5::H5File &h5file) {
 void LoadILLSALSA::fillWorkspaceMetadata(const std::string &filename) {
   API::Run &runDetails = m_outputWorkspace->mutableRun();
 
-  Nexus::File nxHandle(filename, NXACC_READ);
+  Nexus::File nxHandle(filename, NXaccess::READ);
   LoadHelper::addNexusFieldsToWsRun(nxHandle, runDetails);
 }
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -1002,7 +1002,7 @@ void LoadILLSANS::loadMetaData(const Nexus::NXEntry &entry, const std::string &i
 void LoadILLSANS::setFinalProperties(const std::string &filename) {
   API::Run &runDetails = m_localWorkspace->mutableRun();
   try {
-    Nexus::File nxHandle(filename, NXACC_READ);
+    Nexus::File nxHandle(filename, NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(nxHandle, runDetails);
   } catch (Nexus::Exception const &e) {
     g_log.debug() << "Failed to open nexus file \"" << filename << "\" in read mode: " << e.what() << "\n";

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -542,7 +542,7 @@ void LoadILLTOF2::addAllNexusFieldsAsProperties(const std::string &filename) {
 
   // Open NeXus file
   try {
-    LegacyNexus::File nxfileID(filename, LegacyNexus::NXaccess::READ);
+    LegacyNexus::File nxfileID(filename, LegacyNexus::NXACC_READ);
     LegacyLoadHelper::addNexusFieldsToWsRun(nxfileID, runDetails);
   } catch (const LegacyNexus::Exception &) {
     g_log.debug() << "convertNexusToProperties: Error loading " << filename;

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -542,7 +542,7 @@ void LoadILLTOF2::addAllNexusFieldsAsProperties(const std::string &filename) {
 
   // Open NeXus file
   try {
-    LegacyNexus::File nxfileID(filename, LegacyNexus::NXACC_READ);
+    LegacyNexus::File nxfileID(filename, LegacyNexus::NXaccess::READ);
     LegacyLoadHelper::addNexusFieldsToWsRun(nxfileID, runDetails);
   } catch (const LegacyNexus::Exception &) {
     g_log.debug() << "convertNexusToProperties: Error loading " << filename;

--- a/Framework/DataHandling/src/LoadILLTOF3.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF3.cpp
@@ -264,7 +264,7 @@ void LoadILLTOF3::addAllNexusFieldsAsProperties(const std::string &filename) {
 
   // Open NeXus file
   try {
-    Nexus::File nxfileID(filename, NXACC_READ);
+    Nexus::File nxfileID(filename, NXaccess::READ);
     LoadHelper::addNexusFieldsToWsRun(nxfileID, runDetails);
   } catch (Nexus::Exception const &) {
     g_log.debug() << "convertNexusToProperties: Error loading " << filename;

--- a/Framework/DataHandling/src/SNSAppendGeometryToNexus.cpp
+++ b/Framework/DataHandling/src/SNSAppendGeometryToNexus.cpp
@@ -164,7 +164,7 @@ void SNSAppendGeometryToNexus::exec() {
   Geometry::IComponent_const_sptr source = instrument->getSource();
 
   // Open the NeXus file
-  Nexus::File nxfile(m_filename, NXACC_RDWR);
+  Nexus::File nxfile(m_filename, NXaccess::RDWR);
 
   // using string_map_t = std::map<std::string,std::string>;
   std::map<std::string, std::string>::const_iterator root_iter;

--- a/Framework/DataHandling/src/SaveNXSPE.cpp
+++ b/Framework/DataHandling/src/SaveNXSPE.cpp
@@ -90,7 +90,7 @@ void SaveNXSPE::exec() {
   std::string filename = getPropertyValue("Filename");
 
   // Create the file.
-  Nexus::File nxFile(filename, NXACC_CREATE5);
+  Nexus::File nxFile(filename, NXaccess::CREATE5);
 
   // Make the top level entry (and open it)
   std::string entryName = getPropertyValue("InputWorkspace");

--- a/Framework/DataHandling/src/SaveNXTomo.cpp
+++ b/Framework/DataHandling/src/SaveNXTomo.cpp
@@ -165,7 +165,7 @@ void SaveNXTomo::setupFile() {
   // if we can overwrite, try to open the file
   if (!m_overwriteFile) {
     try {
-      m_nxFile = std::make_unique<Nexus::File>(m_filename, NXACC_RDWR);
+      m_nxFile = std::make_unique<Nexus::File>(m_filename, NXaccess::RDWR);
       return;
     } catch (Nexus::Exception const &) {
     }
@@ -173,7 +173,7 @@ void SaveNXTomo::setupFile() {
 
   // If not overwriting, or no existing file found above, create new file
   if (!m_nxFile) {
-    m_nxFile = std::make_unique<Nexus::File>(m_filename, NXACC_CREATE5);
+    m_nxFile = std::make_unique<Nexus::File>(m_filename, NXaccess::CREATE5);
   }
   // Make the top level entry (and open it)
   m_nxFile->makeGroup("entry1", "NXentry", true);

--- a/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
@@ -85,7 +85,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName, NexusFileIO::optio
   // open named file and entry - file may exist
   // @throw Exception::FileError if cannot open Nexus file for writing
   //
-  NXaccess mode(NXACC_CREATE5);
+  NXaccess mode(NXaccess::CREATE5);
   std::string mantidEntryName;
   m_filename = fileName;
   //
@@ -94,7 +94,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName, NexusFileIO::optio
   // format otherwise as compressed hdf5
   //
   if ((Poco::File(m_filename).exists() && append_to_file) || m_filehandle)
-    mode = NXACC_RDWR;
+    mode = NXaccess::RDWR;
 
   else {
     if (fileName.find(".xml") < fileName.size() || fileName.find(".XML") < fileName.size()) {
@@ -125,7 +125,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName, NexusFileIO::optio
   // new name to be n+1 so that we do not over-write by default. This may need
   // changing.
   //
-  if (mode == NXACC_RDWR) {
+  if (mode == NXaccess::RDWR) {
     size_t count = 0;
     if (entryNumber.has_value()) {
       // Use the entry number provided.

--- a/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
+++ b/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
@@ -21,7 +21,7 @@ enum class NexusType { Muon, Processed, ISIS, TofRaw };
 enum class TimeType { StartTime, EndTime };
 
 Mantid::Types::Core::DateAndTime getValue(const std::string &filename, const std::string &absAddress) {
-  Nexus::File nxfile(filename, NXACC_READ);
+  Nexus::File nxfile(filename, NXaccess::READ);
   nxfile.openAddress(absAddress);
   const auto valueStr = nxfile.getStrData();
   g_log.debug(valueStr + " from " + absAddress + " in " + filename);
@@ -54,7 +54,7 @@ NexusType whichNexusType(const std::string &filename) {
   } else if (entryName[0] == "raw_data_1") {
     nexusType = NexusType::ISIS;
   } else {
-    Nexus::File nxfile(filename, NXACC_READ);
+    Nexus::File nxfile(filename, NXaccess::READ);
     const auto entries = nxfile.getEntries();
     const auto firstEntryName = entries.begin()->first;
     try {

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -82,7 +82,7 @@ void writeSmallDatFile(const std::string &filename) {
 }
 
 void writeDetNXSfile(const std::string &filename, const int nDets) {
-  Mantid::Nexus::File nxsfile(filename, NXACC_CREATE5);
+  Mantid::Nexus::File nxsfile(filename, NXaccess::CREATE5);
   nxsfile.makeGroup("detectors.dat", "NXEntry", true);
   nxsfile.putAttr("version", "1.0");
 

--- a/Framework/DataHandling/test/LoadNexusMonitorsTest.h
+++ b/Framework/DataHandling/test/LoadNexusMonitorsTest.h
@@ -244,7 +244,7 @@ public:
   }
 
   void createFakeFile(const std::string &filename) {
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     const bool openGroup = true;
     file.makeGroup("raw_data_1", "NXentry", openGroup);

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -676,16 +676,16 @@ Mantid::Nexus::File *MDBoxFlatTree::createOrOpenMDWSgroup(const std::string &fil
   if (!fileExists && readOnly)
     throw Kernel::Exception::FileError("Attempt to open non-existing file in read-only mode", fileName);
 
-  NXaccess access(NXACC_RDWR);
+  NXaccess access(NXaccess::RDWR);
   if (readOnly)
-    access = NXACC_READ;
+    access = NXaccess::READ;
 
   file_holder_type hFile;
   try {
     if (fileExists)
       hFile = file_holder_type(new Mantid::Nexus::File(fileName, access));
     else
-      hFile = file_holder_type(new Mantid::Nexus::File(fileName, NXACC_CREATE5));
+      hFile = file_holder_type(new Mantid::Nexus::File(fileName, NXaccess::CREATE5));
   } catch (...) {
     throw Kernel::Exception::FileError("Can not open NeXus file", fileName);
   }

--- a/Framework/Geometry/test/ComponentParserTest.h
+++ b/Framework/Geometry/test/ComponentParserTest.h
@@ -90,7 +90,7 @@ public:
   //    if (true)
   //    {
   //      Nexus::File * file = new ::Nexus::File("components.nxs",
-  //      NXACC_CREATE5);
+  //      NXaccess::CREATE5);
   //      file->makeGroup("test_comps", "NXdata",1);
   //      std::vector<double> posArray(num*3);
   //      std::vector<double> rotArray(num*4);

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -128,10 +128,10 @@ void LoadMD::execLoader() {
   if (fileBacked) {
 
     for_access = "for Read/Write access";
-    m_file.reset(new Nexus::File(m_filename, NXACC_RDWR));
+    m_file.reset(new Nexus::File(m_filename, NXaccess::RDWR));
   } else {
     for_access = "for Read access";
-    m_file.reset(new Nexus::File(m_filename, NXACC_READ));
+    m_file.reset(new Nexus::File(m_filename, NXaccess::READ));
   }
 
   if (!m_file)

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -227,7 +227,7 @@ void SaveMD::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) {
     oldFile.remove();
 
   // Create a new file in HDF5 mode.
-  auto file = std::make_unique<Nexus::File>(filename, NXACC_CREATE5);
+  auto file = std::make_unique<Nexus::File>(filename, NXaccess::CREATE5);
 
   // The base entry. Named so as to distinguish from other workspace types.
   file->makeGroup("MDHistoWorkspace", "NXentry", true);

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -79,7 +79,7 @@ void SaveMD2::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) 
     oldFile.remove();
 
   // Create a new file in HDF5 mode.
-  auto file = std::make_unique<Nexus::File>(filename, NXACC_CREATE5);
+  auto file = std::make_unique<Nexus::File>(filename, NXaccess::CREATE5);
 
   // The base entry. Named so as to distinguish from other workspace types.
   file->makeGroup("MDHistoWorkspace", "NXentry", true);

--- a/Framework/MDAlgorithms/src/SaveZODS.cpp
+++ b/Framework/MDAlgorithms/src/SaveZODS.cpp
@@ -58,7 +58,7 @@ void SaveZODS::exec() {
                        "Saving anyway...\n";
 
   // Create a HDF5 file
-  auto file = std::make_unique<Nexus::File>(Filename, NXACC_CREATE5);
+  auto file = std::make_unique<Nexus::File>(Filename, NXaccess::CREATE5);
 
   // ----------- Coordinate system -----------
   uint32_t isLocal = 1;

--- a/Framework/Muon/src/LoadMuonNexus1.cpp
+++ b/Framework/Muon/src/LoadMuonNexus1.cpp
@@ -813,7 +813,7 @@ void LoadMuonNexus1::addPeriodLog(const DataObjects::Workspace2D_sptr &localWork
 void LoadMuonNexus1::addGoodFrames(const DataObjects::Workspace2D_sptr &localWorkspace, int64_t period, int nperiods) {
 
   // Get handle to nexus file
-  LegacyNexus::File handle(m_filename, LegacyNexus::NXaccess::READ);
+  LegacyNexus::File handle(m_filename, LegacyNexus::NXACC_READ);
 
   // For single-period datasets, read /run/instrument/beam/frames_good
   if (nperiods == 1) {

--- a/Framework/Muon/src/LoadMuonNexus1.cpp
+++ b/Framework/Muon/src/LoadMuonNexus1.cpp
@@ -813,7 +813,7 @@ void LoadMuonNexus1::addPeriodLog(const DataObjects::Workspace2D_sptr &localWork
 void LoadMuonNexus1::addGoodFrames(const DataObjects::Workspace2D_sptr &localWorkspace, int64_t period, int nperiods) {
 
   // Get handle to nexus file
-  LegacyNexus::File handle(m_filename, LegacyNexus::NXACC_READ);
+  LegacyNexus::File handle(m_filename, LegacyNexus::NXaccess::READ);
 
   // For single-period datasets, read /run/instrument/beam/frames_good
   if (nperiods == 1) {

--- a/Framework/Muon/src/MuonNexusReader.cpp
+++ b/Framework/Muon/src/MuonNexusReader.cpp
@@ -80,7 +80,7 @@ void MuonNexusReader::openFirstNXentry(Mantid::LegacyNexus::File &handle) {
 //
 // @param filename ::  name of existing NeXus Muon file to read
 void MuonNexusReader::readFromFile(const string &filename) {
-  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXaccess::READ);
+  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXACC_READ);
   openFirstNXentry(handle);
 
   // find all of the NXdata in the entry
@@ -238,7 +238,7 @@ void MuonNexusReader::readLogData(const string &filename) {
   // reset the count of logs
   m_nexusLogCount = 0;
 
-  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXaccess::READ);
+  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXACC_READ);
   openFirstNXentry(handle);
 
   // read nexus fields at this level looking for NXlog and loading these into

--- a/Framework/Muon/src/MuonNexusReader.cpp
+++ b/Framework/Muon/src/MuonNexusReader.cpp
@@ -80,7 +80,7 @@ void MuonNexusReader::openFirstNXentry(Mantid::LegacyNexus::File &handle) {
 //
 // @param filename ::  name of existing NeXus Muon file to read
 void MuonNexusReader::readFromFile(const string &filename) {
-  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXACC_READ);
+  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXaccess::READ);
   openFirstNXentry(handle);
 
   // find all of the NXdata in the entry
@@ -238,7 +238,7 @@ void MuonNexusReader::readLogData(const string &filename) {
   // reset the count of logs
   m_nexusLogCount = 0;
 
-  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXACC_READ);
+  Mantid::LegacyNexus::File handle(filename, Mantid::LegacyNexus::NXaccess::READ);
   openFirstNXentry(handle);
 
   // read nexus fields at this level looking for NXlog and loading these into

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -290,10 +290,19 @@ public:
         }
       }
     }
+    if constexpr (std::is_same_v<T, char>) {
+      // For char type we need to add one for the null terminator
+      num_ele += 1;
+    }
     this->alloc(static_cast<std::size_t>(num_ele));
 
     // do the actual load
     getData(m_data.data());
+
+    if constexpr (std::is_same_v<T, char>) {
+      // For char type we need to add a null terminator
+      m_data.push_back('\0');
+    }
   }
 
   /**

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 // from NexusFile_fwd.h
-typedef int NXaccess;
+enum class NXaccess : unsigned int;
 
 namespace Mantid {
 namespace Nexus {

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -58,7 +58,7 @@ public:
    * \param filename The name of the file to open.
    * \param access How to access the file.
    */
-  File(std::string const &filename, NXaccess const access = NXACC_READ);
+  File(std::string const &filename, NXaccess const access = NXaccess::READ);
 
   /**
    * Create a new File.
@@ -66,7 +66,7 @@ public:
    * \param filename The name of the file to open.
    * \param access How to access the file.
    */
-  File(char const *filename, NXaccess const access = NXACC_READ);
+  File(char const *filename, NXaccess const access = NXaccess::READ);
 
   /**
    * Copy constructor
@@ -111,7 +111,7 @@ private:
    * \param filename The name of the file to open.
    * \param access How to access the file.
    */
-  void initOpenFile(const std::string &filename, const NXaccess access = NXACC_READ);
+  void initOpenFile(const std::string &filename, const NXaccess access = NXaccess::READ);
 
   //------------------------------------------------------------------------------------------------------------------
   // FILE NAVIGATION METHODS

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -16,19 +16,9 @@ typedef const char CONSTCHAR;
 #define NX5SIGNATURE 959695
 
 /*
- * Any new NXaccess_mode options should be numbered in 2^n format
+ * Any new NXaccess options should be numbered in 2^n format
  * (8, 16, 32, etc) so that they can be bit masked and tested easily.
- *
- * To test older non bit masked options (values below 8) use e.g.
- *
- *       if ( (mode & NXACCMASK_REMOVEFLAGS) == NXACC_CREATE )
- *
- * To test new (>=8) options just use normal bit masking e.g.
- *
- *       if ( mode & NXACC_NOSTRIP )
- *
  */
-constexpr int NXACCMASK_REMOVEFLAGS = (0x7); /* bit mask to remove higher flag options */
 
 constexpr int NX_UNLIMITED = -1;
 
@@ -65,22 +55,19 @@ typedef NexusFile5 *NXhandle;
 
 typedef char NXname[128];
 
-/** \enum NXaccess_mode
+/** \enum NXaccess
  * NeXus file access codes.
- * \li NXACC_READ read-only
- * \li NXACC_RDWR open an existing file for reading and writing.
- * \li NXACC_CREATE5 create a NeXus HDF-5 file.
+ * \li READ read-only
+ * \li RDWR open an existing file for reading and writing.
+ * \li CREATE5 create a NeXus HDF-5 file.
  */
-typedef enum {
-  NXACC_READ = 1,
-  NXACC_RDWR = 2,
-  NXACC_CREATE5 = 5,
-} NXaccess_mode;
+enum class NXaccess : unsigned int {
+  READ = 1,   //< 0x0001u = 0001
+  RDWR = 2,   //< 0x0002u = 0010
+  CREATE5 = 5 //< 0x0005u = 0101
+};
 
-/**
- * A combination of options from #NXaccess_mode
- */
-typedef int NXaccess;
+MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXaccess &value);
 
 typedef struct {
   char *iname;
@@ -92,7 +79,7 @@ typedef struct {
  * \li group the entry is a group
  * \li sds the entry is a dataset (class SDS)
  */
-enum NXentrytype : int { group = 0, sds = 1 };
+enum class NXentrytype : int { group = 0, sds = 1 };
 
 /**
  * \struct NXlink
@@ -105,13 +92,6 @@ typedef struct {
   NXentrytype linkType;      /* HDF5: 0 for group link, 1 for SDS link */
 } NXlink;
 
-/* Map NeXus compression methods to HDF compression methods */
-constexpr int NX_CHUNK = 0;
-constexpr int NX_COMP_NONE = 100;
-constexpr int NX_COMP_LZW = 200;
-constexpr int NX_COMP_RLE = 300;
-constexpr int NX_COMP_HUF = 400;
-
 /**
  * Special codes for NeXus file status.
  * \li OKAY success +1.
@@ -120,46 +100,6 @@ constexpr int NX_COMP_HUF = 400;
  * \ingroup cpp_types
  */
 enum class NXstatus : const int { NX_OK = 1, NX_ERROR = 0, NX_EOD = -1 };
-
-/**
- * \ingroup c_types
- * \def NX_FLOAT32
- * 32 bit float
- * \def NX_FLOAT64
- * 64 bit float == double
- * \def NX_INT8
- * 8 bit integer == byte
- * \def NX_UINT8
- * 8 bit unsigned integer
- * \def NX_INT16
- * 16 bit integer
- * \def NX_UINT16
- * 16 bit unsigned integer
- * \def NX_INT32
- * 32 bit integer
- * \def NX_UINT32
- * 32 bit unsigned integer
- * \def NX_CHAR
- * 8 bit character
- * \def NX_BINARY
- * lump of binary data == NX_UINT8
- */
-/*--------------------------------------------------------------------------*/
-
-/* Map NeXus to HDF types */
-constexpr int NX_FLOAT32{5};
-constexpr int NX_FLOAT64{6};
-constexpr int NX_INT8{20};
-constexpr int NX_UINT8{21};
-constexpr int NX_BOOLEAN{NX_UINT8};
-constexpr int NX_INT16{22};
-constexpr int NX_UINT16{23};
-constexpr int NX_INT32{24};
-constexpr int NX_UINT32{25};
-constexpr int NX_INT64{26};
-constexpr int NX_UINT64{27};
-constexpr int NX_CHAR{4};
-constexpr int NX_BINARY{21};
 
 /** \class NXnumtype
  * The primitive types published by this API.
@@ -177,19 +117,19 @@ constexpr int NX_BINARY{21};
  */
 class MANTID_NEXUS_DLL NXnumtype {
 public:
-  static int const FLOAT32 = NX_FLOAT32;
-  static int const FLOAT64 = NX_FLOAT64;
-  static int const INT8 = NX_INT8;
-  static int const UINT8 = NX_UINT8;
-  static int const BOOLEAN = NX_BOOLEAN;
-  static int const INT16 = NX_INT16;
-  static int const UINT16 = NX_UINT16;
-  static int const INT32 = NX_INT32;
-  static int const UINT32 = NX_UINT32;
-  static int const INT64 = NX_INT64;
-  static int const UINT64 = NX_UINT64;
-  static int const CHAR = NX_CHAR;
-  static int const BINARY = NX_BINARY;
+  static int const FLOAT32 = 5;
+  static int const FLOAT64 = 6;
+  static int const INT8 = 20;
+  static int const UINT8 = 21;
+  static int const BOOLEAN = 21;
+  static int const INT16 = 22;
+  static int const UINT16 = 23;
+  static int const INT32 = 24;
+  static int const UINT32 = 25;
+  static int const INT64 = 26;
+  static int const UINT64 = 27;
+  static int const CHAR = 4;
+  static int const BINARY = 21;
   static int const BAD = -1;
 
 private:
@@ -214,13 +154,9 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXnumtype &val
  * \li HUF Huffmann encoding (only HDF-4)
  * \ingroup cpp_types
  */
-enum NXcompression : int {
-  CHUNK = NX_CHUNK,
-  NONE = NX_COMP_NONE,
-  LZW = NX_COMP_LZW,
-  RLE = NX_COMP_RLE,
-  HUF = NX_COMP_HUF
-};
+enum class NXcompression { CHUNK, NONE, LZW, RLE, HUF };
+
+MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression &value);
 
 // forward declare
 namespace Mantid::Nexus {

--- a/Framework/Nexus/inc/MantidNexus/napi.h
+++ b/Framework/Nexus/inc/MantidNexus/napi.h
@@ -54,18 +54,6 @@
 /* NeXus HDF45 */
 #define NEXUS_VERSION "4.4.3" /* major.minor.patch */
 
-/* levels for deflate - to test for these we use ((value / 100) == NX_COMP_LZW) */
-#define NX_COMP_LZW_LVL0 (100 * NX_COMP_LZW + 0)
-#define NX_COMP_LZW_LVL1 (100 * NX_COMP_LZW + 1)
-#define NX_COMP_LZW_LVL2 (100 * NX_COMP_LZW + 2)
-#define NX_COMP_LZW_LVL3 (100 * NX_COMP_LZW + 3)
-#define NX_COMP_LZW_LVL4 (100 * NX_COMP_LZW + 4)
-#define NX_COMP_LZW_LVL5 (100 * NX_COMP_LZW + 5)
-#define NX_COMP_LZW_LVL6 (100 * NX_COMP_LZW + 6)
-#define NX_COMP_LZW_LVL7 (100 * NX_COMP_LZW + 7)
-#define NX_COMP_LZW_LVL8 (100 * NX_COMP_LZW + 8)
-#define NX_COMP_LZW_LVL9 (100 * NX_COMP_LZW + 9)
-
 /*
  * Standard interface
  *
@@ -85,14 +73,12 @@
  * or a NXflush will the data file be valid.
  * \param filename The name of the file to open
  * \param access_method The file access method. This can be:
- * \li NXACC__READ read access
- * \li NXACC_RDWR read write access
- * \li NXACC_CREATE, NXACC_CREATE4 create a new HDF-4 NeXus file
- * \li NXACC_CREATE5 create a new HDF-5 NeXus file
- * \li NXACC_CREATEXML create an XML NeXus file.
- * see #NXaccess_mode
+ * \li READ read access
+ * \li RDWR read write access
+ * \li CREATE5 create a new HDF-5 NeXus file
+ * see #NXaccess
  * Support for HDF-4 is deprecated.
- * \param pHandle A file handle which will be initialized upon successfull completeion of NXopen.
+ * \param handle A file handle which will be initialized upon successfull completeion of NXopen.
  * \return NX_OK on success, NX_ERROR in the case of an error.
  * \ingroup c_init
  */
@@ -204,10 +190,10 @@ MANTID_NEXUS_DLL NXstatus NXmakedata64(NXhandle handle, CONSTCHAR *label, NXnumt
  * \param datatype The data type of this data set.
  * \param rank The number of dimensions this dataset is going to have
  * \param comp_typ The compression scheme to use. Possible values:
- * \li NX_COMP_NONE no compression
- * \li NX_COMP_LZW (recommended) despite the name this enabled zlib compression (of various levels, see above)
- * \li NX_COMP_RLE run length encoding (only HDF-4)
- * \li NX_COMP_HUF Huffmann encoding (only HDF-4)
+ * \li NONE no compression
+ * \li LZW (recommended) despite the name this enabled zlib compression (of various levels, see above)
+ * \li RLE run length encoding (only HDF-4)
+ * \li HUF Huffmann encoding (only HDF-4)
  * \param dim An array of size rank holding the size of the dataset in each dimension. The first dimension
  * can be NX_UNLIMITED. Data can be appended to such a dimension using NXputslab.
  * \param bufsize The dimensions of the subset of the data which usually be writen in one go.
@@ -217,7 +203,7 @@ MANTID_NEXUS_DLL NXstatus NXmakedata64(NXhandle handle, CONSTCHAR *label, NXnumt
  * \ingroup c_readwrite
  */
 MANTID_NEXUS_DLL NXstatus NXcompmakedata64(NXhandle handle, CONSTCHAR *label, NXnumtype datatype, int rank,
-                                           int64_t const dim[], int comp_typ, int64_t const chunk_size[]);
+                                           int64_t const dim[], NXcompression const comp, int64_t const chunk_size[]);
 
 /**
  * Open access to a dataset. After this call it is possible to write and read data or
@@ -466,8 +452,6 @@ MANTID_NEXUS_DLL const char *NXgetversion();
  * \ingroup c_memory
  */
 MANTID_NEXUS_DLL NXstatus NXfree(void **data);
-
-MANTID_NEXUS_DLL NXstatus NXIprintlink(NXhandle fid, NXlink const *link);
 
 /**
  * Dispatches the error message

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -271,7 +271,7 @@ bool NXClass::containsDataSet(const std::string &query) const { return getDataSe
 NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
   // Open NeXus file
   try {
-    m_fileID = std::make_shared<File>(m_filename, NXACC_READ);
+    m_fileID = std::make_shared<File>(m_filename, NXaccess::READ);
   } catch (Exception const &e) {
     std::cout << "NXRoot: Error loading " << m_filename << "\" in read mode: " << e.what() << "\n";
     throw;
@@ -287,7 +287,7 @@ NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
 NXRoot::NXRoot(std::string fname, const std::string &entry) : m_filename(std::move(fname)) {
   UNUSED_ARG(entry);
   // Open NeXus file
-  m_fileID = std::make_shared<File>(m_filename, NXACC_CREATE5);
+  m_fileID = std::make_shared<File>(m_filename, NXaccess::CREATE5);
 }
 
 NXRoot::~NXRoot() { m_fileID->close(); }

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -79,7 +79,7 @@ NexusDescriptor::NexusDescriptor(std::string filename, NXaccess access)
     : m_filename(std::move(filename)), m_extension(std::filesystem::path(m_filename).extension().string()),
       m_firstEntryNameType() {
   // if we are creating a file and it already exists, then delete it first
-  if (access == NXaccess_mode::NXACC_CREATE5) {
+  if (access == NXaccess::CREATE5) {
     if (std::filesystem::exists(m_filename)) {
       std::filesystem::remove(m_filename);
     }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -782,7 +782,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
 
   // do the work
   int i_type = static_cast<int>(type);
-  int compress_type = static_cast<int>(comp);
 
   hid_t datatype1, dataspace, iNew;
   hid_t dtype, cparms = -1;
@@ -872,12 +871,8 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     /*       H5Tset_strpad(H5T_STR_SPACEPAD); */
   }
   compress_level = 6;
-  if ((compress_type / 100) == NX_COMP_LZW) {
-    compress_level = static_cast<unsigned int>(compress_type % 100);
-    compress_type = NX_COMP_LZW;
-  }
   hid_t dID;
-  if (compress_type == NX_COMP_LZW) {
+  if (comp == NXcompression::LZW) {
     cparms = H5Pcreate(H5P_DATASET_CREATE);
     iNew = H5Pset_chunk(cparms, rank, chunkdims);
     if (iNew < 0) {
@@ -887,7 +882,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     H5Pset_shuffle(cparms); // mrt: improves compression
     H5Pset_deflate(cparms, compress_level);
     dID = H5Dcreate(pFile->iCurrentG, name.c_str(), datatype1, dataspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
-  } else if (compress_type == NX_COMP_NONE) {
+  } else if (comp == NXcompression::NONE) {
     if (unlimiteddim) {
       cparms = H5Pcreate(H5P_DATASET_CREATE);
       iNew = H5Pset_chunk(cparms, rank, chunkdims);
@@ -899,7 +894,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     } else {
       dID = H5Dcreate(pFile->iCurrentG, name.c_str(), datatype1, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     }
-  } else if (compress_type == NX_CHUNK) {
+  } else if (comp == NXcompression::CHUNK) {
     cparms = H5Pcreate(H5P_DATASET_CREATE);
     iNew = H5Pset_chunk(cparms, rank, chunkdims);
     if (iNew < 0) {
@@ -1136,7 +1131,7 @@ template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &sta
      */
     int mtype = 0;
     if (tclass == H5T_STRING) {
-      mtype = NX_CHAR;
+      mtype = NXnumtype::CHAR;
       if (mySize[0] == 1) {
         mySize[0] = H5Tget_size(pFile->iCurrentT);
       }
@@ -1158,7 +1153,7 @@ template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &sta
       throw NXEXCEPTION("Selecting memspace failed");
     }
     /* read slab */
-    if (mtype == NX_CHAR) {
+    if (mtype == NXnumtype::CHAR) {
       iRet = H5Dread(pFile->iCurrentD, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp_data);
       char const *data1;
       data1 = tmp_data + myStart[0];
@@ -1702,7 +1697,7 @@ void File::makeLink(NXlink const &link) {
   /*
      set the target attribute
    */
-  if (link.linkType > 0) {
+  if (link.linkType == NXentrytype::sds) {
     dataID = H5Dopen(pFile->iFID, link.targetAddress.c_str(), H5P_DEFAULT);
   } else {
     dataID = H5Gopen(pFile->iFID, link.targetAddress.c_str(), H5P_DEFAULT);
@@ -1729,7 +1724,7 @@ void File::makeLink(NXlink const &link) {
   H5Tclose(aid1);
   H5Sclose(aid2);
   H5Aclose(attID);
-  if (link.linkType > 0) {
+  if (link.linkType == NXentrytype::sds) {
     H5Dclose(dataID);
   } else {
     H5Gclose(dataID);
@@ -1796,6 +1791,36 @@ NXnumtype::operator std::string() const {
 
 std::ostream &operator<<(std::ostream &os, const NXnumtype &value) {
   os << std::string(value);
+  return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const NXaccess &value) {
+  std::string ret("Unknown access type");
+  if (value == NXaccess::CREATE5) {
+    ret = NXTYPE_PRINT(NXaccess::CREATE5);
+  } else if (value == NXaccess::READ) {
+    ret = NXTYPE_PRINT(NXaccess::READ);
+  } else if (value == NXaccess::RDWR) {
+    ret = NXTYPE_PRINT(NXaccess::RDWR);
+  }
+  os << ret;
+  return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const NXcompression &value) {
+  std::string ret("Unknown compression type");
+  if (value == NXcompression::NONE) {
+    ret = NXTYPE_PRINT(NXcompression::NONE);
+  } else if (value == NXcompression::CHUNK) {
+    ret = NXTYPE_PRINT(NXcompression::CHUNK);
+  } else if (value == NXcompression::LZW) {
+    ret = NXTYPE_PRINT(NXcompression::LZW);
+  } else if (value == NXcompression::RLE) {
+    ret = NXTYPE_PRINT(NXcompression::RLE);
+  } else if (value == NXcompression::HUF) {
+    ret = NXTYPE_PRINT(NXcompression::HUF);
+  }
+  os << ret;
   return os;
 }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -851,7 +851,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     }
     mydim1[rank - 1] = 1;
     if (mydim[rank - 1] > 1) {
-      mydim[rank - 1] = maxdims[rank - 1] = dsize[rank - 1] = 1;
+      maxdims[rank - 1] = dsize[rank - 1] = 1;
     }
     if (chunkdims[rank - 1] > 1) {
       chunkdims[rank - 1] = 1;
@@ -1737,11 +1737,15 @@ void File::makeLink(NXlink const &link) {
 using namespace Mantid::Nexus;
 int NXnumtype::validate_val(int const x) {
   int val = BAD;
+  // NOTE for user-readability it is better to check all of these cases
+  // cppcheck doesn't like this, as some of these have the same value, making checks redundant
+  // cppcheck-suppress-begin knownConditionTrueFalse
   if ((x == FLOAT32) || (x == FLOAT64) || (x == INT8) || (x == UINT8) || (x == BOOLEAN) || (x == INT16) ||
       (x == UINT16) || (x == INT32) || (x == UINT32) || (x == INT64) || (x == UINT64) || (x == CHAR) || (x == BINARY) ||
       (x == BAD)) {
     val = x;
   }
+  // cppcheck-suppress-end knownConditionTrueFalse
   return val;
 }
 
@@ -1758,6 +1762,9 @@ NXnumtype::operator int() const { return m_val; };
 #define NXTYPE_PRINT(var) #var // stringify the variable name, for cleaner code
 
 NXnumtype::operator std::string() const {
+  // NOTE for user-readability it is better to check all of these cases
+  // cppcheck doesn't like this, as some of these have the same value, making checks redundant
+  // cppcheck-suppress-begin knownConditionTrueFalse
   std::string ret = NXTYPE_PRINT(BAD);
   if (m_val == FLOAT32) {
     ret = NXTYPE_PRINT(FLOAT32);
@@ -1786,6 +1793,7 @@ NXnumtype::operator std::string() const {
   } else if (m_val == BINARY) {
     ret = NXTYPE_PRINT(BINARY);
   }
+  // cppcheck-suppress-end knownConditionTrueFalse
   return ret;
 }
 

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -91,7 +91,7 @@ NXstatus NXopen(CONSTCHAR *userfilename, NXaccess am, NXhandle &gHandle) {
   // determine the filename for opening
   std::string filename(userfilename);
   // determine if the file can be opened
-  bool isHDF5 = (am == NXACC_CREATE5 ? true : canBeOpened(filename.c_str()));
+  bool isHDF5 = (am == NXaccess::CREATE5 ? true : canBeOpened(filename.c_str()));
   NXstatus status = NXstatus::NX_ERROR;
   if (isHDF5) {
     // call NX5open to set variables on it
@@ -327,13 +327,13 @@ NXstatus NXmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int ran
       chunk_size[i] = 1;
     }
   }
-  return NXcompmakedata64(fid, name, datatype, rank, dimensions, NX_COMP_NONE, chunk_size);
+  return NXcompmakedata64(fid, name, datatype, rank, dimensions, NXcompression::NONE, chunk_size);
 }
 
 /* --------------------------------------------------------------------- */
 
 NXstatus NXcompmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int rank, int64_t const dimensions[],
-                          int compress_type, int64_t const chunk_size[]) {
+                          NXcompression const compress_type, int64_t const chunk_size[]) {
   hid_t datatype1, dataspace, iNew;
   hid_t type, cparms = -1;
   pNexusFile5 pFile;
@@ -420,12 +420,8 @@ NXstatus NXcompmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int
     /*       H5Tset_strpad(H5T_STR_SPACEPAD); */
   }
   compress_level = 6;
-  if ((compress_type / 100) == NX_COMP_LZW) {
-    compress_level = static_cast<unsigned int>(compress_type % 100);
-    compress_type = NX_COMP_LZW;
-  }
   hid_t dID;
-  if (compress_type == NX_COMP_LZW) {
+  if (compress_type == NXcompression::LZW) {
     cparms = H5Pcreate(H5P_DATASET_CREATE);
     iNew = H5Pset_chunk(cparms, rank, chunkdims);
     if (iNew < 0) {
@@ -436,7 +432,7 @@ NXstatus NXcompmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int
     H5Pset_deflate(cparms, compress_level);
     dID = H5Dcreate(pFile->iCurrentG, static_cast<const char *>(name), datatype1, dataspace, H5P_DEFAULT, cparms,
                     H5P_DEFAULT);
-  } else if (compress_type == NX_COMP_NONE) {
+  } else if (compress_type == NXcompression::NONE) {
     if (unlimiteddim) {
       cparms = H5Pcreate(H5P_DATASET_CREATE);
       iNew = H5Pset_chunk(cparms, rank, chunkdims);
@@ -450,7 +446,7 @@ NXstatus NXcompmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int
       dID = H5Dcreate(pFile->iCurrentG, static_cast<const char *>(name), datatype1, dataspace, H5P_DEFAULT, H5P_DEFAULT,
                       H5P_DEFAULT);
     }
-  } else if (compress_type == NX_CHUNK) {
+  } else if (compress_type == NXcompression::CHUNK) {
     cparms = H5Pcreate(H5P_DATASET_CREATE);
     iNew = H5Pset_chunk(cparms, rank, chunkdims);
     if (iNew < 0) {
@@ -973,7 +969,7 @@ NXstatus NXgetslab64(NXhandle fid, void *data, const int64_t iStart[], const int
      */
     int mtype = 0;
     if (tclass == H5T_STRING) {
-      mtype = NX_CHAR;
+      mtype = NXnumtype::CHAR;
       if (mySize[0] == 1) {
         mySize[0] = H5Tget_size(pFile->iCurrentT);
       }
@@ -997,7 +993,7 @@ NXstatus NXgetslab64(NXhandle fid, void *data, const int64_t iStart[], const int
       return NXstatus::NX_ERROR;
     }
     /* read slab */
-    if (mtype == NX_CHAR) {
+    if (mtype == NXnumtype::CHAR) {
       iRet = H5Dread(pFile->iCurrentD, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp_data);
       char const *data1;
       data1 = tmp_data + myStart[0];
@@ -1169,12 +1165,6 @@ NXstatus NXopengroupaddress(NXhandle hfil, CONSTCHAR *address) {
 }
 
 /*---------------------------------------------------------------------*/
-NXstatus NXIprintlink(NXhandle fid, NXlink const *link) {
-  NXI5assert(fid);
-  printf("HDF5 link: targetAddress = \"%s\", linkType = \"%d\"\n", link->targetAddress.c_str(), link->linkType);
-  return NXstatus::NX_OK;
-}
-
 /*----------------------------------------------------------------------*/
 NXstatus NXgetaddress(NXhandle fid, std::string &address) {
   hid_t current;

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -85,9 +85,6 @@ NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle &handle) {
     return NXstatus::NX_ERROR;
   }
 
-  /* mask of any options for now */
-  am = (NXaccess)(am & NXACCMASK_REMOVEFLAGS);
-
   /* turn off the automatic HDF error handling */
   H5Eset_auto(H5E_DEFAULT, NULL, NULL);
 #ifdef USE_FTIME
@@ -105,11 +102,11 @@ NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle &handle) {
   }
 
   /* start HDF5 interface */
-  if (am == NXACC_CREATE5) {
+  if (am == NXaccess::CREATE5) {
     am1 = H5F_ACC_TRUNC;
     pNew->iFID = H5Fcreate(filename, am1, H5P_DEFAULT, fapl);
   } else {
-    if (am == NXACC_READ)
+    if (am == NXaccess::READ)
       am1 = H5F_ACC_RDONLY;
     else
       am1 = H5F_ACC_RDWR;
@@ -132,7 +129,7 @@ NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle &handle) {
    * at some point for new files
    */
 
-  if (am == NXACC_CREATE5) {
+  if (am == NXaccess::CREATE5) {
     root_id = H5Gopen(pNew->iFID, "/", H5P_DEFAULT);
     if (set_str_attribute(root_id, "NeXus_version", NEXUS_VERSION) < 0) {
       H5Gclose(root_id);

--- a/Framework/Nexus/src/napi_helper.cpp
+++ b/Framework/Nexus/src/napi_helper.cpp
@@ -137,7 +137,7 @@ NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink *sLink) {
   /*
      set the target attribute
    */
-  if (sLink->linkType > 0) {
+  if (sLink->linkType == NXentrytype::sds) {
     dataID = H5Dopen(pFile->iFID, sLink->targetAddress.c_str(), H5P_DEFAULT);
   } else {
     dataID = H5Gopen(pFile->iFID, sLink->targetAddress.c_str(), H5P_DEFAULT);
@@ -165,7 +165,7 @@ NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink *sLink) {
   H5Tclose(aid1);
   H5Sclose(aid2);
   H5Aclose(attID);
-  if (sLink->linkType > 0) {
+  if (sLink->linkType == NXentrytype::sds) {
     H5Dclose(dataID);
   } else {
     H5Gclose(dataID);

--- a/Framework/Nexus/test/NapiUnitTest.h
+++ b/Framework/Nexus/test/NapiUnitTest.h
@@ -85,7 +85,7 @@ public:
 
     // create the file and ensure it exists
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "NXopen file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "NXopen file");
 
     // make sure the fid is set
     TS_ASSERT_DIFFERS(fid->iFID, NULL);
@@ -103,14 +103,14 @@ public:
 
     // create the file and ensure it exists
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "NXopen file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "NXopen file");
     TS_ASSERT_DIFFERS(fid->iFID, NULL);
     NX_ASSERT_OKAY(NXclose(fid), "Nxclose file");
     TS_ASSERT(std::filesystem::exists(filename));
 
     // now open it in read mode
     fid = NULL;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_READ, fid), "NXopen existing file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::READ, fid), "NXopen existing file");
     char path[10];
     H5Iget_name(fid->iFID, path, 10);
     TS_ASSERT_EQUALS(std::string(path), "/");
@@ -131,7 +131,7 @@ public:
     NexusFile5 *fid;
 
     // open the existing file
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "NXopen bad existing file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "NXopen bad existing file");
     char path[10];
     H5Iget_name(fid->iFID, path, 10);
     TS_ASSERT_EQUALS(std::string(path), "/");
@@ -146,7 +146,7 @@ public:
     FileResource resource("test_napi_file_flush.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "Can't open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "Can't open");
     NX_ASSERT_OKAY(NXflush(fid), "Can't flush");
     NX_ASSERT_OKAY(NXclose(fid), "Can't close");
   }
@@ -160,7 +160,7 @@ public:
     FileResource resource("test_napi_file_grp.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "opening file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "opening file");
     NX_ASSERT_OKAY(NXmakegroup(fid, "test_group", "NXsample"), "making group");
     NX_ASSERT_OKAY(NXclose(fid), "closing file");
   }
@@ -172,7 +172,7 @@ public:
     NexusFile5 *fid;
 
     // open the fie
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open file");
 
     // create a group, to be opened
     string grp("test_group"), cls("NXsample");
@@ -193,7 +193,7 @@ public:
     FileResource resource("test_napi_file_grp.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open file");
 
     // create a group, to be opened
     string grp("test_group"), cls("NXpants");
@@ -212,7 +212,7 @@ public:
 
     // create a file with group -- open it
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open file");
     NX_ASSERT_OKAY(NXmakegroup(fid, grp1.c_str(), cls1.c_str()), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, grp1.c_str(), cls1.c_str()), "failed to open group");
 
@@ -238,7 +238,7 @@ public:
     FileResource resource("test_napi_file_grp.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open file");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open file");
 
     char root[128];
     H5Iget_name(fid->iFID, root, 128);
@@ -282,7 +282,7 @@ public:
     DimVector dims{1};
     NXnumtype type(NXnumtype::CHAR);
 
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
 
     // if there is not a top-level NXentry, should throw error
     NX_ASSERT_ERROR(NXmakedata64(fid, name, type, 1, dims.data()), "data made without error");
@@ -301,7 +301,7 @@ public:
     FileResource resource("test_napi_file_data.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -331,7 +331,7 @@ public:
 
     // setup file for data
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -367,7 +367,7 @@ public:
     FileResource resource("test_napi_file_dataclose.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -394,7 +394,7 @@ public:
 
     // setup file for data
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -450,7 +450,7 @@ public:
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -494,7 +494,7 @@ public:
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -515,7 +515,7 @@ public:
     FileResource resource("test_napi_file_stringrw.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -548,7 +548,7 @@ public:
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -640,7 +640,7 @@ public:
     std::string address;
 
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
 
     // at root, path should be "/"
     NX_ASSERT_OKAY(NXgetaddress(fid, address), "could not get root address");
@@ -687,7 +687,7 @@ public:
     FileResource resource("test_napi_file_grpdata.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
 
     // make and open a group -- now at "/abc"
     std::string address;
@@ -716,7 +716,7 @@ public:
     FileResource resource("test_napi_openpathtest.nxs");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -788,7 +788,7 @@ public:
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -842,7 +842,7 @@ public:
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
@@ -889,7 +889,7 @@ public:
     FileResource resource("test_napi_attr.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     // move to an entry to avoid conflict with some root-level attributes
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
@@ -928,7 +928,7 @@ public:
     FileResource resource("test_napi_attr.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     // move to an entry to avoid conflict with some root-level attributes
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
@@ -980,7 +980,7 @@ public:
     FileResource resource("test_napi_link.nxs");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
-    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXACC_CREATE5, fid), "failed to open");
+    NX_ASSERT_OKAY(NXopen(filename.c_str(), NXaccess::CREATE5, fid), "failed to open");
     NX_ASSERT_OKAY(NXmakegroup(fid, "entry", "NXentry"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -51,7 +51,7 @@ public:
     FileResource fr("nexus_leak_test1.nxs");
     std::string const szFile(fr.fullPath());
 
-    File file_obj(szFile, NXACC_CREATE5);
+    File file_obj(szFile, NXaccess::CREATE5);
     file_obj.close();
 
     for (int iReOpen = 0; iReOpen < nReOpen; iReOpen++) {
@@ -59,7 +59,7 @@ public:
         cout << "loop count " << iReOpen << "\n";
       }
 
-      file_obj = File(szFile, NXACC_RDWR);
+      file_obj = File(szFile, NXaccess::RDWR);
       file_obj.close();
     }
 
@@ -74,7 +74,7 @@ public:
 
     cout << "Running Leak Test 2: " << nFiles << " iterations\n";
 
-    NXaccess access_mode = NXACC_CREATE5;
+    NXaccess access_mode = NXaccess::CREATE5;
     std::string strFile;
 
     for (int iFile = 0; iFile < nFiles; iFile++) {
@@ -141,7 +141,7 @@ public:
     for (int iFile = 0; iFile < nFiles; iFile++) {
       cout << "file " << iFile << "\n";
 
-      File fileid(szFile, NXACC_CREATE5);
+      File fileid(szFile, NXaccess::CREATE5);
 
       for (int iEntry = 0; iEntry < nEntry; iEntry++) {
         std::string oss(strmakef("entry_%d", iEntry));

--- a/Framework/Nexus/test/NexusFileNapiTest.h
+++ b/Framework/Nexus/test/NexusFileNapiTest.h
@@ -268,7 +268,7 @@ private:
 
   void do_test_loadPath(const string &filename) {
     if (getenv("NX_LOAD_PATH") != NULL) {
-      TS_ASSERT_THROWS_NOTHING(Mantid::Nexus::File file(filename, NXACC_RDWR));
+      TS_ASSERT_THROWS_NOTHING(Mantid::Nexus::File file(filename, NXaccess::RDWR));
       cout << "Success loading NeXus file from path" << endl;
     } else {
       cout << "NX_LOAD_PATH variable not defined. Skipping testLoadPath\n";
@@ -278,7 +278,7 @@ private:
 public:
   void test_readwrite_hdf5() {
     cout << " Nexus File Tests\n";
-    NXaccess const nx_creation_code = NXACC_CREATE5;
+    NXaccess const nx_creation_code = NXaccess::CREATE5;
     string const fileext = ".h5";
     string const filename("nexus_file_napi_test_cpp" + fileext);
 

--- a/Framework/Nexus/test/NexusFileReadWriteTest.h
+++ b/Framework/Nexus/test/NexusFileReadWriteTest.h
@@ -50,7 +50,7 @@ private:
 
     cout << "Creating \"" << nxFile << "\"" << endl;
     // create file
-    File fileid(nxFile, NXACC_CREATE5);
+    File fileid(nxFile, NXaccess::CREATE5);
 
     fileid.makeGroup("entry", "NXentry");
     fileid.openGroup("entry", "NXentry");

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -75,7 +75,7 @@ public:
     std::string filename = resource.fullPath();
 
     // create the file and ensure it exists
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.close();
     TS_ASSERT(std::filesystem::exists(filename));
   }
@@ -83,14 +83,14 @@ public:
   void test_fail_open() {
     // test opening a file that exists, but is unreadable
     std::string filename = getFullPath("Test_characterizations_char.txt");
-    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(filename, NXACC_READ));
+    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(filename, NXaccess::READ));
 
     // test opening an empty file
     FileResource resource("fake_empty_file.nxs.h5");
     std::ofstream file(resource.fullPath());
     file << "mock";
     file.close();
-    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(resource.fullPath(), NXACC_READ));
+    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(resource.fullPath(), NXaccess::READ));
   }
 
   void test_clear_on_create() {
@@ -101,10 +101,10 @@ public:
     file.close();
 
     // this file cannot be opened for read
-    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(resource.fullPath(), NXACC_READ));
+    TS_ASSERT_THROWS_ANYTHING(Mantid::Nexus::File file(resource.fullPath(), NXaccess::READ));
 
     // but no issue if opened for create
-    TS_ASSERT_THROWS_NOTHING(Mantid::Nexus::File file(resource.fullPath(), NXACC_CREATE5));
+    TS_ASSERT_THROWS_NOTHING(Mantid::Nexus::File file(resource.fullPath(), NXaccess::CREATE5));
   }
 
   void test_flush() {
@@ -113,7 +113,7 @@ public:
     // TODO actually test the buffers
     FileResource resource("test_nexus_file_flush.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.flush();
   }
 
@@ -125,7 +125,7 @@ public:
     cout << "\ntest makeGroup\n";
     FileResource resource("test_nexus_file_grp.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     string grp("test_group"), cls("NXsample");
 
@@ -140,7 +140,7 @@ public:
     cout << "\ntest openGroup\n";
     FileResource resource("test_nexus_file_grp.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // create a group, to be opened
     string grp("test_group"), cls("NXsample");
@@ -159,7 +159,7 @@ public:
     cout << "\ntest openGroup bad\n";
     FileResource resource("test_nexus_file_grp.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // create a group, to be opened
     string grp("test_group"), cls("NXpants");
@@ -177,7 +177,7 @@ public:
     string grp1("layer1"), grp2("layer2"), cls1("NXpants1"), cls2("NXshorts");
 
     // create a file with group -- open it
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup(grp1, cls1, false);
     file.openGroup(grp1, cls1);
 
@@ -190,7 +190,7 @@ public:
     cout << "\ntest closeGroup\n";
     FileResource resource("test_nexus_file_grp.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // check error at root
     TS_ASSERT_THROWS_NOTHING(file.closeGroup());
@@ -216,7 +216,7 @@ public:
     Mantid::Nexus::DimVector dims({1});
     NXnumtype type(NXnumtype::CHAR);
 
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // if there is not a top-level NXentry, should throw error
     TS_ASSERT_THROWS(file.makeData(name, type, dims), Mantid::Nexus::Exception const &);
@@ -237,7 +237,7 @@ public:
     FileResource resource("test_nexus_file_data.h5");
     std::string filename = resource.fullPath();
 
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     NXnumtype type(NXnumtype::CHAR);
@@ -252,7 +252,7 @@ public:
     cout << "\ntest openData\n";
     FileResource resource("test_nexus_file_data.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // create a dataset, to be opened
@@ -276,7 +276,7 @@ public:
     cout << "\ntest make data lateral\n";
     FileResource resource("test_napi_file_rdwr.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // make and open data
@@ -299,7 +299,7 @@ public:
     cout << "\ntest makeData layers -- bad\n";
     FileResource resource("test_nexus_file_rdwr.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     NXnumtype type(NXnumtype::CHAR);
     string data1("layer1"), data2("layer2");
@@ -314,7 +314,7 @@ public:
     cout << "\ntest closeData\n";
     FileResource resource("test_nexus_file_dataclose.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // check error at root
@@ -342,7 +342,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put/get an int
@@ -381,7 +381,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // try to put data when not in a dataset -- should fail
@@ -396,7 +396,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_stringrw.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put/get a string
@@ -411,7 +411,7 @@ public:
   void test_check_str_length() {
     FileResource resource("test_nexus_str_len.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     std::string testStr("some_str_data");
@@ -439,7 +439,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put/get an int
@@ -511,7 +511,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW_vec.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put/get an int vector
@@ -545,7 +545,7 @@ public:
 
     // open a file
     std::string filename = getFullPath("md_missing_paramater_map.nxs");
-    Mantid::Nexus::File file(filename, NXACC_READ);
+    Mantid::Nexus::File file(filename, NXaccess::READ);
 
     std::string addressOfBad("/MDHistoWorkspace/experiment0/sample");
     TS_ASSERT_EQUALS(file.hasAddress(addressOfBad), true);
@@ -579,7 +579,7 @@ public:
 
     // create a file and write string data through a char
     // this mimics behavior from TimeSeriesProperty::saveProperty()
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
     // setup the string data
     std::vector<std::string> values{"help me i", "am stuck in a NXS file", "forever"};
@@ -664,7 +664,7 @@ public:
     H5Fclose(fid);
 
     // now open the file and read
-    Mantid::Nexus::File file(filename, NXACC_READ);
+    Mantid::Nexus::File file(filename, NXaccess::READ);
     if (file.hasAddress("entry/data")) {
       file.openAddress("entry/data");
     } else {
@@ -693,7 +693,7 @@ public:
 
     // open a file
     std::string filename = getFullPath("SANS2D00022048.nxs");
-    Mantid::Nexus::File file(filename, NXACC_READ);
+    Mantid::Nexus::File file(filename, NXaccess::READ);
 
     // this is the dataset that can cause the buffer errors
     std::string addressOfBad("/raw_data_1/selog/S6/value_log/value");
@@ -721,7 +721,7 @@ public:
     cout << "\ntest get_address -- groups only\n";
     FileResource resource("test_nexus_file_grp.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // at root, address should be "/"
     TS_ASSERT_EQUALS("/", file.getAddress());
@@ -747,7 +747,7 @@ public:
     cout << "\ntest get_address -- groups and data!\n";
     FileResource resource("test_nexus_file_grpdata.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // at root, address should be "/"
     TS_ASSERT_EQUALS("/", file.getAddress());
@@ -770,7 +770,7 @@ public:
     // open a file
     FileResource resource("test_nexus_entries.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // setup a recursive group tree
     std::vector<Entry> tree{Entry{"/entry1", "NXentry"},
@@ -839,7 +839,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put an integer
@@ -872,7 +872,7 @@ public:
     // open a file
     FileResource resource("test_nexus_file_dataRW.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     file.makeGroup("entry", "NXentry", true);
 
     // put an integer
@@ -904,7 +904,7 @@ public:
     // open a file
     FileResource resource("test_nexus_attr.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     // move to an entry to avoid conflict with some root-level attributes
     file.makeGroup("entry", "NXentry", true);
 
@@ -931,7 +931,7 @@ public:
     // open a file
     FileResource resource("test_nexus_attr.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     // move to an entry to avoid conflict with some root-level attributes
     file.makeGroup("entry", "NXentry", true);
 
@@ -966,7 +966,7 @@ public:
 
     // open the file in read-only mode
     std::string filename = getFullPath("md_missing_paramater_map.nxs");
-    Mantid::Nexus::File file(filename, NXACC_READ);
+    Mantid::Nexus::File file(filename, NXaccess::READ);
 
     // go to main entry (for this file, MDHistoWorkspace)
     file.openGroup("MDHistoWorkspace", "NXentry");
@@ -991,7 +991,7 @@ public:
 
     // open the file in read-only mode
     std::string filename = getFullPath("CG2_monotonically_increasing_pulse_times.nxs.h5");
-    Mantid::Nexus::File file(filename, NXACC_READ);
+    Mantid::Nexus::File file(filename, NXaccess::READ);
 
     // go to the trouble spot -- /entry/bank39_events/event_time_offset
     std::string entryName("/entry/bank39_events/event_time_offset");
@@ -1016,7 +1016,7 @@ public:
     // open a file
     FileResource resource("test_nexus_entries.h5");
     std::string filename = resource.fullPath();
-    Mantid::Nexus::File file(filename, NXACC_CREATE5);
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
     // setup a recursive group tree
     std::vector<Entry> tree{Entry{"/entry1", "NXentry"},

--- a/Framework/Nexus/test/leak_test1.cpp
+++ b/Framework/Nexus/test/leak_test1.cpp
@@ -7,7 +7,7 @@
 using NexusNapiTest::removeFile;
 
 int main() {
-  NXaccess access_mode = NXACC_CREATE5;
+  NXaccess access_mode = NXaccess::CREATE5;
   const int nReOpen = 1000;
   printf("Running for %d iterations\n", nReOpen);
   int iReOpen;
@@ -26,7 +26,7 @@ int main() {
     if (0 == iReOpen % 100)
       printf("loop count %d\n", iReOpen);
 
-    if (NXopen(szFile.c_str(), NXACC_RDWR, fileid) != NXstatus::NX_OK)
+    if (NXopen(szFile.c_str(), NXaccess::RDWR, fileid) != NXstatus::NX_OK)
       ON_ERROR("NXopen failed!\n");
 
     if (NXclose(fileid) != NXstatus::NX_OK)

--- a/Framework/Nexus/test/leak_test2.cpp
+++ b/Framework/Nexus/test/leak_test2.cpp
@@ -18,7 +18,7 @@ int iFile, iReOpen, iEntry, iData, iNXdata, iSimpleArraySize = 4;
 
 int main() {
   printf("Running for %d iterations\n", nFiles);
-  NXaccess access_mode = NXACC_CREATE5;
+  NXaccess access_mode = NXaccess::CREATE5;
   char strFile[512];
 
   for (iFile = 0; iFile < nFiles; iFile++) {

--- a/Framework/Nexus/test/leak_test3.cpp
+++ b/Framework/Nexus/test/leak_test3.cpp
@@ -37,7 +37,7 @@ int main() {
 
     NXhandle fileid;
     NXlink aLink;
-    if (NXopen(szFile, NXACC_CREATE5, fileid) != NXstatus::NX_OK)
+    if (NXopen(szFile, NXaccess::CREATE5, fileid) != NXstatus::NX_OK)
       ON_ERROR("NXopen_failed")
 
     for (iEntry = 0; iEntry < nEntry; iEntry++) {
@@ -65,8 +65,8 @@ int main() {
           ostringstream oss3;
           oss3 << "i2_data_" << iData;
 
-          if (NXcompmakedata64(fileid, PSZ(oss3.str()), NXnumtype::INT16, 2, array_dims, NX_COMP_LZW, array_dims) !=
-              NXstatus::NX_OK)
+          if (NXcompmakedata64(fileid, PSZ(oss3.str()), NXnumtype::INT16, 2, array_dims, NXcompression::LZW,
+                               array_dims) != NXstatus::NX_OK)
             ON_ERROR("NXcompmakedata failed!")
 
           if (NXopendata(fileid, PSZ(oss3.str())) != NXstatus::NX_OK)

--- a/Framework/Nexus/test/napi_test.cpp
+++ b/Framework/Nexus/test/napi_test.cpp
@@ -48,9 +48,9 @@ using NexusNapiTest::write_dmc02;
 int main(int argc, char *argv[]) {
   std::cout << "determining file type" << std::endl;
   std::string nxFile;
-  NXaccess_mode nx_creation_code;
+  NXaccess nx_creation_code;
   if (strstr(argv[0], "napi_test_hdf5") != NULL) {
-    nx_creation_code = NXACC_CREATE5;
+    nx_creation_code = NXaccess::CREATE5;
     nxFile = "NXtest.h5";
   } else {
     ON_ERROR(std::string(argv[0]) + " is not supported");
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Creating \"" << nxFile << "\"" << std::endl;
   // create file
   ASSERT_NO_ERROR(NXopen(nxFile.c_str(), nx_creation_code, fileid), "Failure in NXopen for " + nxFile);
-  if (nx_creation_code == NXACC_CREATE5) {
+  if (nx_creation_code == NXaccess::CREATE5) {
     std::cout << "Trying to reopen the file handle" << std::endl;
     NXhandle clone_fileid;
     ASSERT_NO_ERROR(NXreopen(fileid, clone_fileid), "Failed to NXreopen " + nxFile);
@@ -124,7 +124,8 @@ int main(int argc, char *argv[]) {
   ASSERT_NO_ERROR(NXopendata(fileid, "i4_data"), "");
   ASSERT_NO_ERROR(NXputdata(fileid, i4_array), "");
   ASSERT_NO_ERROR(NXclosedata(fileid), "");
-  ASSERT_NO_ERROR(NXcompmakedata64(fileid, "r4_data", NXnumtype::FLOAT32, 2, array_dims, NX_COMP_LZW, chunk_size), "");
+  ASSERT_NO_ERROR(
+      NXcompmakedata64(fileid, "r4_data", NXnumtype::FLOAT32, 2, array_dims, NXcompression::LZW, chunk_size), "");
   ASSERT_NO_ERROR(NXopendata(fileid, "r4_data"), "");
   ASSERT_NO_ERROR(NXputdata(fileid, r4_array), "");
   ASSERT_NO_ERROR(NXclosedata(fileid), "");
@@ -168,7 +169,7 @@ int main(int argc, char *argv[]) {
     }
   }
   int64_t cdims[2] = {20, 20};
-  ASSERT_NO_ERROR(NXcompmakedata64(fileid, "comp_data", NXnumtype::INT32, 2, dims, NX_COMP_LZW, cdims),
+  ASSERT_NO_ERROR(NXcompmakedata64(fileid, "comp_data", NXnumtype::INT32, 2, dims, NXcompression::LZW, cdims),
                   "NXcompmakedata64 comp_data");
   ASSERT_NO_ERROR(NXopendata(fileid, "comp_data"), "NXopendata comp_data");
   ASSERT_NO_ERROR(NXputdata(fileid, comp_array), "NXputdata comp_data");
@@ -219,7 +220,7 @@ int main(int argc, char *argv[]) {
 
   // read test
   std::cout << "Read/Write to read \"" << nxFile << "\"" << std::endl;
-  ASSERT_NO_ERROR(NXopen(nxFile.c_str(), NXACC_RDWR, fileid), "Failed to open \"" << nxFile << "\" for read/write");
+  ASSERT_NO_ERROR(NXopen(nxFile.c_str(), NXaccess::RDWR, fileid), "Failed to open \"" << nxFile << "\" for read/write");
   NXgetattrinfo(fileid, &i);
   if (i > 0) {
     std::cout << "Number of global attributes: " << i << std::endl;
@@ -373,11 +374,7 @@ int main(int argc, char *argv[]) {
   ASSERT_NO_ERROR(NXgetdataID(fileid, &blink), "");
   ASSERT_NO_ERROR(NXclosedata(fileid), "");
   if (NXsameID(fileid, &dlink, &blink) != NXstatus::NX_OK) {
-    std::cout << "Link check FAILED (r8_data)\n"
-              << "original data\n";
-    NXIprintlink(fileid, &dlink);
-    std::cout << "linked data\n";
-    NXIprintlink(fileid, &blink);
+    std::cout << "Link check FAILED (r8_data)\n";
     return TEST_FAILED;
   }
   ASSERT_NO_ERROR(NXclosegroup(fileid), "");
@@ -388,11 +385,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Group address " << address << "\n";
   ASSERT_NO_ERROR(NXgetgroupID(fileid, &blink), "");
   if (NXsameID(fileid, &glink, &blink) != NXstatus::NX_OK) {
-    std::cout << "Link check FAILED (sample)\n"
-              << "original group\n";
-    NXIprintlink(fileid, &glink);
-    std::cout << "linked group\n";
-    NXIprintlink(fileid, &blink);
+    std::cout << "Link check FAILED (sample)\n";
     return TEST_FAILED;
   }
   ASSERT_NO_ERROR(NXclosegroup(fileid), "");
@@ -428,7 +421,7 @@ int testLoadPath() {
     // TODO create file and cleanup
     // std::string filename("data/dmc01.h5");
     NXhandle h;
-    if (NXopen("dmc01.hdf", NXACC_RDWR, h) != NXstatus::NX_OK) {
+    if (NXopen("dmc01.hdf", NXaccess::RDWR, h) != NXstatus::NX_OK) {
       std::cout << "Loading NeXus file dmc01.hdf from path " << getenv("NX_LOAD_PATH") << " FAILED\n";
       return TEST_FAILED;
     } else {

--- a/Framework/Nexus/test/napi_test_cpp.cpp
+++ b/Framework/Nexus/test/napi_test_cpp.cpp
@@ -387,7 +387,7 @@ int main(int argc, char **argv) {
   NXaccess nx_creation_code;
   string fileext;
   if (strstr(argv[0], "napi_test_cpp-hdf5") != NULL) {
-    nx_creation_code = NXACC_CREATE5;
+    nx_creation_code = NXaccess::CREATE5;
     fileext = ".h5";
   } else if (strstr(argv[0], "napi_test_cpp-xml-table") != NULL) {
     cout << "napi_test_cpp-xml-table is not supported" << endl;

--- a/Framework/Nexus/test/napi_test_util.cpp
+++ b/Framework/Nexus/test/napi_test_util.cpp
@@ -63,7 +63,7 @@ void putAttr(Mantid::Nexus::File &file, const std::string &dataName, const std::
 void write_dmc(const std::string &filename, const std::string &start_time, const std::vector<int32_t> &counts,
                const std::vector<double> &two_theta) {
   std::cout << "Creating external file \"" << filename << "\"\n";
-  Mantid::Nexus::File file(filename, NXACC_CREATE5);
+  Mantid::Nexus::File file(filename, NXaccess::CREATE5);
 
   const std::string title("Ga0.94Mn0.04Sb_8mm 2.567A T=4");
 

--- a/Framework/Nexus/test/test_nxunlimited.cpp
+++ b/Framework/Nexus/test/test_nxunlimited.cpp
@@ -32,7 +32,7 @@
 
 #define DATA_SIZE 200000
 
-int test_unlimited(int file_type, const char *filename) {
+int test_unlimited(NXaccess file_type, const char *filename) {
   // cppcheck-suppress constVariable
   static double d[DATA_SIZE];
   int64_t dims[2] = {NX_UNLIMITED, DATA_SIZE};
@@ -64,7 +64,7 @@ int main() {
 
   printf("Testing HDF5\n");
   time(&tim);
-  test_unlimited(NXACC_CREATE5, "test_unlimited.nx5");
+  test_unlimited(NXaccess::CREATE5, "test_unlimited.nx5");
   printf("Took %u seconds\n", (unsigned)(time(NULL) - tim));
 
   return 0;

--- a/Framework/TestHelpers/src/NexusTestHelper.cpp
+++ b/Framework/TestHelpers/src/NexusTestHelper.cpp
@@ -50,7 +50,7 @@ void NexusTestHelper::createFile(const std::string &barefilename) {
   filename = (Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory") + barefilename);
   if (Poco::File(filename).exists())
     Poco::File(filename).remove();
-  file = std::make_unique<Mantid::Nexus::File>(filename, NXACC_CREATE5);
+  file = std::make_unique<Mantid::Nexus::File>(filename, NXaccess::CREATE5);
   file->makeGroup("test_entry", "NXentry", true);
 }
 
@@ -60,6 +60,6 @@ void NexusTestHelper::reopenFile() {
   if (!file)
     throw std::runtime_error("NexusTestHelper: you must call createFile() before reopenFile().");
   file->close();
-  file = std::make_unique<Mantid::Nexus::File>(filename, NXACC_READ);
+  file = std::make_unique<Mantid::Nexus::File>(filename, NXaccess::READ);
   file->openGroup("test_entry", "NXentry");
 }

--- a/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
@@ -97,7 +97,7 @@ bool SANSSensitivityCorrection::fileCheck(const std::string &filePath) {
 
   // open file and make sure it has entries
   try {
-    Nexus::File handle(filePath, NXACC_READ);
+    Nexus::File handle(filePath, NXaccess::READ);
     const auto entries = handle.getEntries();
     if (entries.size() == 0) {
       g_log.error("Error no entries found in " + filePath);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -593,4 +593,3 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowse
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:855


### PR DESCRIPTION
### Description of work

#### Summary of work

There are several collections of variables inside `NexsFile_fwd`, which were defined as part of the `napi` package, which really should have been `enum class`.

This makes them `enum class`, removes the `#define` and `constexpr` declarations of the values a separate integers (so they are *only* inside the `enum class`), and changes things to use the `enum` version.

Refs #38332 
EWM 11399

#### Further detail of work

It looks like a lot of changes, but it isn't.

The biggest change was to the file access mode, `NXaccess`, which was used in about 50 files.  The changes made going from `NXACC_CREATE5` --> `NXaccess:CREATE5` was purely mechanical.

Because of the large number of files touched by this, it makes more sense to do this standalone.

I added two methods for printing out `NXaccess` and `NXcompression`, which will now be strings instead of integers.

I also deleted the `napi` method `NXIprintlink`.  This did nothing more than print info about a `NXlink` object, and was going to be deleted soon anyway.  It was used in one test for error results, and that test will also be deleted soon anyway.

### To test:

This is a pure refactor, existing unit tests should be enough.

*This does not require release notes* because this is a purely internal issue

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
