### PR TITLE
Add diagnostics checkbox to refl gui

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -103,6 +103,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             "FloodCorrection",
             "FloodWorkspace",
             "Debug",
+            "Diagnostics",
             "TimeInterval",
             "LogValueInterval",
             "LogName",

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -35,6 +35,7 @@ class Prop:
     GROUP_TOF = "GroupTOFWorkspaces"
     RELOAD = "ReloadInvalidWorkspaces"
     DEBUG = "Debug"
+    DIAGNOSTICS = "Diagnostics"
     HIDE_INPUT = "HideInputWorkspaces"
     OUTPUT_WS = "OutputWorkspace"
     OUTPUT_WS_BINNED = "OutputWorkspaceBinned"
@@ -247,6 +248,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
     def _declareOutputProperties(self):
         properties = [
             Prop.DEBUG,
+            Prop.DIAGNOSTICS,
             "MomentumTransferMin",
             "MomentumTransferStep",
             "MomentumTransferMax",
@@ -666,6 +668,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
 
     def _isDebug(self):
         return not self.getProperty(Prop.DEBUG).isDefault
+
+    def _isDiagnostics(self):
+        return not self.getProperty(Prop.DIAGNOSTICS).isDefault
 
     def _finalize(self, child_alg):
         """Set our output properties from the results in the given child algorithm"""

--- a/instrument/unit_testing/REFL_Parameters_Experiment.xml
+++ b/instrument/unit_testing/REFL_Parameters_Experiment.xml
@@ -59,6 +59,10 @@
       <value val="1"/>
   </parameter>
 
+  <parameter name="Diagnostics">
+      <value val="1"/>
+  </parameter>
+
   <!-- Per Theta options -->
 
   <parameter name="QMin">

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -124,6 +124,7 @@ void updateFloodCorrectionProperties(AlgorithmRuntimeProps &properties, FloodCor
 void updateExperimentProperties(AlgorithmRuntimeProps &properties, Experiment const &experiment) {
   AlgorithmProperties::update("AnalysisMode", analysisModeToString(experiment.analysisMode()), properties);
   AlgorithmProperties::update("Debug", experiment.debug(), properties);
+  AlgorithmProperties::update("Diagnostics", experiment.diagnostics(), properties);
   SummationType summationType = experiment.summationType();
   AlgorithmProperties::update("SummationType", summationTypeToString(summationType), properties);
   // The ReductionType value is only relevant when the SummationType is SumInQ

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -46,6 +46,7 @@ Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrum
       summationTypeFromString(defaults.getStringOrDefault("SummationType", "SummationType", "SumInLambda"));
   auto includePartialBins = defaults.getBoolOrFalse("IncludePartialBins", "IncludePartialBins");
   auto debug = defaults.getBoolOrFalse("Debug", "Debug");
+  auto diagnostics = defaults.getBoolOrFalse("Diagnostics", "Diagnostics");
 
   auto backgroundSubtractionMethod =
       defaults.getStringOrEmpty("BackgroundCalculationMethod", "BackgroundCalculationMethod");
@@ -111,7 +112,7 @@ Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrum
 
   return Experiment(analysisMode, reductionType, summationType, includePartialBins, debug, backgroundSubtraction,
                     polarizationCorrections, std::move(floodCorrections), std::move(transmissionStitchOptions),
-                    stitchParameters, lookupTableValidationResult.assertValid());
+                    stitchParameters, lookupTableValidationResult.assertValid(), diagnostics);
 }
 } // unnamed namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -358,6 +358,7 @@ ExperimentValidationResult ExperimentPresenter::validateExperimentFromView() {
     auto const summationType = summationTypeFromString(m_view->getSummationType());
     auto const includePartialBins = m_view->getIncludePartialBins();
     auto const debugOption = m_view->getDebugOption();
+    auto const diagnosticsOption = m_view->getDiagnosticsOption();
     auto transmissionStitchOptions = transmissionStitchOptionsFromView();
     auto backgroundSubtraction = backgroundSubtractionFromView();
     auto polarizationCorrections = polarizationCorrectionsFromView();
@@ -366,7 +367,7 @@ ExperimentValidationResult ExperimentPresenter::validateExperimentFromView() {
     return ExperimentValidationResult(Experiment(analysisMode, reductionType, summationType, includePartialBins,
                                                  debugOption, backgroundSubtraction, polarizationCorrections,
                                                  floodCorrections, transmissionStitchOptions, stitchParameters,
-                                                 lookupTableValidationResult.assertValid()));
+                                                 lookupTableValidationResult.assertValid(), diagnosticsOption));
   } else {
     return ExperimentValidationResult(ExperimentValidationErrors(lookupTableValidationResult.assertError()));
   }
@@ -421,6 +422,7 @@ void ExperimentPresenter::updateViewFromModel() {
   m_view->setSummationType(summationTypeToString(m_model.summationType()));
   m_view->setIncludePartialBins(m_model.includePartialBins());
   m_view->setDebugOption(m_model.debug());
+  m_view->setDiagnosticsOption(m_model.diagnostics());
   m_view->setLookupTable(m_model.lookupTableToArray());
   // Transmission
   if (m_model.transmissionStitchOptions().overlapRange()) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -119,6 +119,7 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
   }
   if (auto const foundRow = m_model.findLookupRow(previewRow, m_thetaTolerance)) {
     if (!hasUpdatedSettings(foundRow, previewRow)) {
+      g_log.information("No updated experiment settings to apply from preview.");
       return;
     }
 
@@ -133,6 +134,7 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
     m_model.updateLookupRow(std::move(lookupRowCopy), m_thetaTolerance);
     updateViewFromModel();
     m_mainPresenter->notifySettingsChanged();
+    g_log.information("Updated experiment settings applied from preview.");
   } else {
     throw RowNotFoundException("There is no row with angle matching '" + std::to_string(previewRow.theta()) +
                                "' in the Lookup Table.");

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -267,6 +267,19 @@
        </property>
       </widget>
      </item>
+	<item row="2" column="3">
+		<widget class="QCheckBox" name="diagnosticsCheckBox">
+			<property name="minimumSize">
+				<size>
+					<width>50</width>
+					<height>0</height>
+				</size>
+			</property>
+			<property name="text">
+				<string/>
+			</property>
+		</widget>
+	</item>
      <item row="17" column="3">
       <widget class="QPushButton" name="getExpDefaultsButton">
        <property name="sizePolicy">
@@ -309,6 +322,19 @@
        </property>
       </widget>
      </item>
+	<item row="2" column="2">
+		<widget class="QLabel" name="diagnosticsLabel">
+			<property name="minimumSize">
+				<size>
+					<width>117</width>
+					<height>0</height>
+				</size>
+			</property>
+			<property name="text">
+				<string>Diagnostics</string>
+			</property>
+		</widget>
+	</item>
      <item row="14" column="2">
       <widget class="QLabel" name="floodWorkspaceWsSelectorLabel">
        <property name="sizePolicy">

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -63,6 +63,9 @@ public:
   virtual bool getDebugOption() const = 0;
   virtual void setDebugOption(bool enable) = 0;
 
+  virtual bool getDiagnosticsOption() const = 0;
+  virtual void setDiagnosticsOption(bool enable) = 0;
+
   virtual std::vector<LookupRow::ValueArray> getLookupTable() const = 0;
   virtual void setLookupTable(std::vector<LookupRow::ValueArray> rows) = 0;
   virtual void showLookupRowAsInvalid(int row, int column) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -306,6 +306,7 @@ void QtExperimentView::setEnabledStateForAllWidgets(bool enabled) {
   m_floodCorrWsSelector->setEnabled(enabled);
   m_floodCorrLineEdit->setEnabled(enabled);
   m_ui.debugCheckBox->setEnabled(enabled);
+  m_ui.diagnosticsCheckBox->setEnabled(enabled);
   m_ui.subtractBackgroundCheckBox->setEnabled(enabled);
   m_ui.backgroundMethodComboBox->setEnabled(enabled);
   m_ui.polynomialDegreeSpinBox->setEnabled(enabled);
@@ -339,6 +340,7 @@ void QtExperimentView::registerExperimentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_floodCorrWsSelector, "FloodWorkspace", alg);
   registerSettingWidget(*m_floodCorrLineEdit, "FloodWorkspace", alg);
   registerSettingWidget(*m_ui.debugCheckBox, "Debug", alg);
+  registerSettingWidget(*m_ui.diagnosticsCheckBox, "Diagnostics", alg);
   registerSettingWidget(*m_ui.subtractBackgroundCheckBox, "SubtractBackground", alg);
   registerSettingWidget(*m_ui.backgroundMethodComboBox, "BackgroundCalculationMethod", alg);
   registerSettingWidget(*m_ui.polynomialDegreeSpinBox, "DegreeOfPolynomial", alg);
@@ -369,6 +371,7 @@ void QtExperimentView::connectExperimentSettingsWidgets() {
   connectSettingsChange(*m_floodCorrWsSelector);
   connectSettingsChange(*m_floodCorrLineEdit);
   connectSettingsChange(*m_ui.debugCheckBox);
+  connectSettingsChange(*m_ui.diagnosticsCheckBox);
   connectSettingsChange(*m_ui.subtractBackgroundCheckBox);
   connectSettingsChange(*m_ui.backgroundMethodComboBox);
   connectSettingsChange(*m_ui.polynomialDegreeSpinBox);
@@ -394,6 +397,7 @@ void QtExperimentView::disconnectExperimentSettingsWidgets() {
   disconnectSettingsChange(*m_floodCorrWsSelector);
   disconnectSettingsChange(*m_floodCorrLineEdit);
   disconnectSettingsChange(*m_ui.debugCheckBox);
+  disconnectSettingsChange(*m_ui.diagnosticsCheckBox);
   disconnectSettingsChange(*m_ui.subtractBackgroundCheckBox);
   disconnectSettingsChange(*m_ui.backgroundMethodComboBox);
   disconnectSettingsChange(*m_ui.polynomialDegreeSpinBox);
@@ -714,6 +718,10 @@ void QtExperimentView::setIncludePartialBins(bool enable) { setChecked(*m_ui.inc
 bool QtExperimentView::getDebugOption() const { return m_ui.debugCheckBox->isChecked(); }
 
 void QtExperimentView::setDebugOption(bool enable) { setChecked(*m_ui.debugCheckBox, enable); }
+
+bool QtExperimentView::getDiagnosticsOption() const { return m_ui.diagnosticsCheckBox->isChecked(); }
+
+void QtExperimentView::setDiagnosticsOption(bool enable) { setChecked(*m_ui.diagnosticsCheckBox, enable); }
 
 void QtExperimentView::setReductionType(std::string const &reductionType) {
   return setSelected(*m_ui.reductionTypeComboBox, reductionType);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -51,6 +51,9 @@ public:
   bool getDebugOption() const override;
   void setDebugOption(bool enable) override;
 
+  bool getDiagnosticsOption() const override;
+  void setDiagnosticsOption(bool enable) override;
+
   std::vector<LookupRow::ValueArray> getLookupTable() const override;
   void setLookupTable(std::vector<LookupRow::ValueArray> rows) override;
   void showLookupRowAsInvalid(int row, int column) override;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -20,27 +20,27 @@ Experiment::Experiment()
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)), m_transmissionStitchOptions(),
       m_stitchParameters(std::map<std::string, std::string>()),
       m_lookupTable(LookupTable({LookupRow(std::nullopt, std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(),
-                                           std::nullopt, ProcessingInstructions(), std::nullopt, std::nullopt)})) {}
+                                           std::nullopt, ProcessingInstructions(), std::nullopt, std::nullopt)})),
+      m_diagnostics(false) {}
 
 Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType, SummationType summationType,
                        bool includePartialBins, bool debug, BackgroundSubtraction backgroundSubtraction,
                        PolarizationCorrections polarizationCorrections, FloodCorrections floodCorrections,
                        TransmissionStitchOptions transmissionStitchOptions,
-
-                       std::map<std::string, std::string> stitchParameters,
-
-                       LookupTable lookupTable)
+                       std::map<std::string, std::string> stitchParameters, LookupTable lookupTable, bool diagnostics)
     : m_analysisMode(analysisMode), m_reductionType(reductionType), m_summationType(summationType),
       m_includePartialBins(includePartialBins), m_debug(debug), m_backgroundSubtraction(backgroundSubtraction),
       m_polarizationCorrections(polarizationCorrections), m_floodCorrections(std::move(floodCorrections)),
       m_transmissionStitchOptions(std::move(transmissionStitchOptions)),
-      m_stitchParameters(std::move(stitchParameters)), m_lookupTable(std::move(lookupTable)) {}
+      m_stitchParameters(std::move(stitchParameters)), m_lookupTable(std::move(lookupTable)),
+      m_diagnostics(diagnostics) {}
 
 AnalysisMode Experiment::analysisMode() const { return m_analysisMode; }
 ReductionType Experiment::reductionType() const { return m_reductionType; }
 SummationType Experiment::summationType() const { return m_summationType; }
 bool Experiment::includePartialBins() const { return m_includePartialBins; }
 bool Experiment::debug() const { return m_debug; }
+bool Experiment::diagnostics() const { return m_diagnostics; }
 
 BackgroundSubtraction const &Experiment::backgroundSubtraction() const { return m_backgroundSubtraction; }
 
@@ -89,6 +89,7 @@ bool operator==(Experiment const &lhs, Experiment const &rhs) {
          lhs.polarizationCorrections() == rhs.polarizationCorrections() &&
          lhs.floodCorrections() == rhs.floodCorrections() &&
          lhs.transmissionStitchOptions() == rhs.transmissionStitchOptions() &&
-         lhs.stitchParameters() == rhs.stitchParameters() && lhs.m_lookupTable == rhs.m_lookupTable;
+         lhs.stitchParameters() == rhs.stitchParameters() && lhs.m_lookupTable == rhs.m_lookupTable &&
+         lhs.diagnostics() == rhs.diagnostics();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -40,13 +40,14 @@ public:
              bool includePartialBins, bool debug, BackgroundSubtraction backgroundSubtraction,
              PolarizationCorrections polarizationCorrections, FloodCorrections floodCorrections,
              TransmissionStitchOptions transmissionStitchOptions, std::map<std::string, std::string> stitchParameters,
-             LookupTable lookupTable);
+             LookupTable lookupTable, bool diagnostics);
 
   AnalysisMode analysisMode() const;
   ReductionType reductionType() const;
   SummationType summationType() const;
   bool includePartialBins() const;
   bool debug() const;
+  bool diagnostics() const;
   BackgroundSubtraction const &backgroundSubtraction() const;
   PolarizationCorrections const &polarizationCorrections() const;
   FloodCorrections const &floodCorrections() const;
@@ -78,6 +79,7 @@ private:
 
   std::map<std::string, std::string> m_stitchParameters;
   LookupTable m_lookupTable;
+  bool m_diagnostics;
 
   friend bool operator==(Experiment const &lhs, Experiment const &rhs);
   friend bool operator!=(Experiment const &lhs, Experiment const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -426,28 +426,29 @@ TransmissionStitchOptions makeEmptyTransmissionStitchOptions() {
 Experiment makeExperiment() {
   return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample, SummationType::SumInQ, true, true,
                     makeBackgroundSubtraction(), makeWorkspacePolarizationCorrections(), makeFloodCorrections(),
-                    makeTransmissionStitchOptions(), makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard());
+                    makeTransmissionStitchOptions(), makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard(),
+                    false);
 }
 
 Experiment makeEmptyExperiment() {
   return Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                     makeEmptyBackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                     FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
-                    std::map<std::string, std::string>(), LookupTable());
+                    std::map<std::string, std::string>(), LookupTable(), false);
 }
 
 Experiment makeExperimentWithValidDuplicateCriteria() {
   return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample, SummationType::SumInQ, true, true,
                     makeBackgroundSubtraction(), makePolarizationCorrections(), makeFloodCorrections(),
                     makeTransmissionStitchOptions(), makeStitchOptions(),
-                    makeLookupTableWithTwoValidDuplicateCriteria());
+                    makeLookupTableWithTwoValidDuplicateCriteria(), false);
 }
 
 Experiment makeExperimentWithReductionTypeSetForSumInLambda() {
   return Experiment(AnalysisMode::PointDetector, ReductionType::NonFlatSample, SummationType::SumInLambda, false, false,
                     makeEmptyBackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                     FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
-                    std::map<std::string, std::string>(), LookupTable());
+                    std::map<std::string, std::string>(), LookupTable(), false);
 }
 
 /* Instrument */

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/GroupProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/GroupProcessingAlgorithmTest.h
@@ -77,7 +77,7 @@ public:
         Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                    BackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                    FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(), makeStitchOptions(),
-                   std::vector<LookupRow>());
+                   std::vector<LookupRow>(), false);
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -92,7 +92,7 @@ public:
         Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                    BackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                    FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
-                   std::map<std::string, std::string>(), std::move(lookupTable));
+                   std::map<std::string, std::string>(), std::move(lookupTable), false);
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -104,7 +104,7 @@ public:
         Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                    BackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                    FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
-                   std::map<std::string, std::string>(), makeLookupTableWithTwoAnglesAndWildcard());
+                   std::map<std::string, std::string>(), makeLookupTableWithTwoAnglesAndWildcard(), false);
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithMixedQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -116,7 +116,7 @@ public:
         Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                    BackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                    FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
-                   std::map<std::string, std::string>(), makeLookupTableWithTwoAnglesAndWildcard());
+                   std::map<std::string, std::string>(), makeLookupTableWithTwoAnglesAndWildcard(), false);
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithOutputQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -272,7 +272,7 @@ public:
                    BackgroundSubtraction(false, BackgroundSubtractionType::AveragePixelFit, 3,
                                          CostFunctionType::UnweightedLeastSquares),
                    makePolarizationCorrections(), makeFloodCorrections(), makeTransmissionStitchOptions(),
-                   makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard());
+                   makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard(), false);
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"SubtractBackground", "1"}});
     auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -338,6 +338,7 @@ public:
     declareProperty("FloodCorrection", "");
     declareProperty("FloodWorkspace", "");
     declareProperty("Debug", "");
+    declareProperty("Diagnostics", "");
     declareProperty("SubtractBackground", "");
     declareProperty("BackgroundCalculationMethod", "");
     declareProperty("DegreeOfPolynomial", "");

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -65,10 +65,20 @@ public:
     TS_ASSERT_EQUALS(result.debug(), false);
   }
 
+  void testDefaultDiagnosticsOptions() {
+    auto result = getDefaults();
+    TS_ASSERT_EQUALS(result.diagnostics(), false);
+  }
+
   void testValidDebugOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Experiment");
     TS_ASSERT_EQUALS(result.debug(), true);
   }
+
+  // void testValidDiagnosticsOptionsFromParamsFile() {
+  //   auto result = getDefaultsFromParamsFile("Experiment");
+  //   TS_ASSERT_EQUALS(result.diagnostics(), true);
+  // }
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -75,10 +75,10 @@ public:
     TS_ASSERT_EQUALS(result.debug(), true);
   }
 
-  // void testValidDiagnosticsOptionsFromParamsFile() {
-  //   auto result = getDefaultsFromParamsFile("Experiment");
-  //   TS_ASSERT_EQUALS(result.diagnostics(), true);
-  // }
+  void testValidDiagnosticsOptionsFromParamsFile() {
+    auto result = getDefaultsFromParamsFile("Experiment");
+    TS_ASSERT_EQUALS(result.diagnostics(), true);
+  }
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -652,7 +652,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesDebugOptionsInView() {
-    auto model = makeModelWithDebug(true);
+    auto model = makeModelWithSetDebugFlag(true);
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     EXPECT_CALL(m_view, setDebugOption(true)).Times(1);
@@ -660,7 +660,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesDebugOptionsInModel() {
-    auto model = makeModelWithDebug(true);
+    auto model = makeModelWithSetDebugFlag(true);
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
@@ -668,7 +668,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesDiagnosticsOptionsInView() {
-    auto model = makeModelWithDiagnostics(true);
+    auto model = makeModelWithSetDiagnosticsFlag(true);
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     EXPECT_CALL(m_view, setDiagnosticsOption(true)).Times(1);
@@ -676,7 +676,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesDiagnosticsOptionsInModel() {
-    auto model = makeModelWithDiagnostics(true);
+    auto model = makeModelWithSetDiagnosticsFlag(true);
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
@@ -951,13 +951,13 @@ private:
                       makeEmptyTransmissionStitchOptions(), makeEmptyStitchOptions(), makeLookupTable(), false);
   }
 
-  Experiment makeModelWithDebug(bool debug) {
+  Experiment makeModelWithSetDebugFlag(bool debug) {
     return Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, debug,
                       BackgroundSubtraction(), makeEmptyPolarizationCorrections(), makeFloodCorrections(),
                       makeEmptyTransmissionStitchOptions(), makeEmptyStitchOptions(), makeLookupTable(), false);
   }
 
-  Experiment makeModelWithDiagnostics(bool diagnostics) {
+  Experiment makeModelWithSetDiagnosticsFlag(bool diagnostics) {
     return Experiment(AnalysisMode::PointDetector, ReductionType::Normal, SummationType::SumInLambda, false, false,
                       BackgroundSubtraction(), makeEmptyPolarizationCorrections(), makeFloodCorrections(),
                       makeEmptyTransmissionStitchOptions(), makeEmptyStitchOptions(), makeLookupTable(), diagnostics);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
@@ -25,6 +25,7 @@ public:
     ON_CALL(*this, getPolarizationCorrectionOption()).WillByDefault(testing::Return("None"));
     ON_CALL(*this, getFloodCorrectionType()).WillByDefault(testing::Return("Workspace"));
     ON_CALL(*this, getDebugOption()).WillByDefault(testing::Return(false));
+    ON_CALL(*this, getDiagnosticsOption()).WillByDefault(testing::Return(false));
     ON_CALL(*this, getIncludePartialBins()).WillByDefault(testing::Return(false));
   }
   MOCK_METHOD1(subscribe, void(ExperimentViewSubscriber *));
@@ -45,6 +46,8 @@ public:
   MOCK_METHOD0(disableIncludePartialBins, void());
   MOCK_CONST_METHOD0(getDebugOption, bool());
   MOCK_METHOD1(setDebugOption, void(bool));
+  MOCK_CONST_METHOD0(getDiagnosticsOption, bool());
+  MOCK_METHOD1(setDiagnosticsOption, void(bool));
   MOCK_CONST_METHOD0(getLookupTable, std::vector<LookupRow::ValueArray>());
   MOCK_METHOD1(setLookupTable, void(std::vector<LookupRow::ValueArray>));
   MOCK_METHOD2(showLookupRowAsInvalid, void(int row, int column));


### PR DESCRIPTION
### Description of work

This PR adds a checkbox to the reflectometry GUI that exposes the ability to output intermediate workspaces for diagnostics.

### To test:

Ensure access to data archive.

1) Open Reflectometry GUI
2) On `Reduction Preview` tab, enter run `84884` then click `Load` (You will see unrelated, unconcerning error with this dataset)
3) On the instrument view graphic, use the region selector above to select an interesting portion of the detectors.
4) On the sliceviewer plot next to it, use the region selector above that to select a signal range (containing the specular)
5) Using the drop own next to the signal region selector, select a background range on the same plot.
6) Click apply, these settings will be sent to the relevant tabs.
7) On the `Experiment Settings` tab check the `Diagnostics` checkbox, also, select the `Subtract Background` checkbox.
8) Finally, return to the runs tab. Enter a random group name in the first row, then in the second row enter the run number `84884` and the angle `0.8`. Click the process button below the table widget to run the reduction
9) Check the out workspaces in the ADS. You should see intermediate workspaces appended in `_lambda`, `_lambda_subtracted)bg` etc.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
