### PR TITLE
Crosshair bug fix

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1325,10 +1325,13 @@ class MantidAxes(Axes):
         :returns: None
         """
         for index, creation_arg in enumerate(self.creation_args):  # type: int, dict
-            if workspace_name == creation_arg["workspaces"]:
-                if creation_arg.get("wkspIndex", -1) == workspace_index or creation_arg.get("specNum", -1) == spec_num:
-                    del self.creation_args[index]
-                    return
+            try:
+                if workspace_name == creation_arg["workspaces"]:
+                    if creation_arg.get("wkspIndex", -1) == workspace_index or creation_arg.get("specNum", -1) == spec_num:
+                        del self.creation_args[index]
+                        return
+            except KeyError:
+                continue
         raise ValueError("Curve does not have existing creation args")
 
 

--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button can be enabled in a single plot or tiled plots(subplots)
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area.

--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area.
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.

--- a/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39242.rst
@@ -1,1 +1,1 @@
-- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button is disabled (invisible) in titled plots.
+- A crosshair toggle option has been added in mantidplots on the top right of the toolbar area. The crosshair button can be enabled in a single plot or tiled plots(subplots)

--- a/docs/source/release/v6.14.0/Workbench/New_features/39491.rst
+++ b/docs/source/release/v6.14.0/Workbench/New_features/39491.rst
@@ -1,0 +1,1 @@
+- The crosshair button is now enabled in tiled plots(subplots).

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -874,39 +874,41 @@ class FigureInteraction(object):
         for arg_set in ax.creation_args:
             if arg_set["function"] == "contour":
                 continue
-
-            if arg_set["workspaces"] in ax.tracked_workspaces:
-                workspace = ads.retrieve(arg_set["workspaces"])
-                arg_set["distribution"] = is_normalized
-                if "specNum" not in arg_set:
-                    if "wkspIndex" in arg_set:
-                        arg_set["specNum"] = workspace.getSpectrum(arg_set.pop("wkspIndex")).getSpectrumNo()
-                    else:
-                        raise RuntimeError("No spectrum number associated with plot of workspace '{}'".format(workspace.name()))
-
-                arg_set_copy = copy(arg_set)
-                for key in ["function", "workspaces", "autoscale_on_update", "norm"]:
-                    try:
-                        del arg_set_copy[key]
-                    except KeyError:
-                        continue
-                # 2D plots have no spec number so remove it
-                if figure_type(self.canvas.figure) in [FigureType.Image, FigureType.Contour]:
-                    arg_set_copy.pop("specNum")
-                for ws_artist in ax.tracked_workspaces[workspace.name()]:
-                    if ws_artist.spec_num == arg_set_copy.get("specNum"):
-                        ws_artist.is_normalized = not is_normalized
-
-                        # This check is to prevent the contour lines being re-plotted using the colorfill plot args.
-                        if isinstance(ws_artist._artists[0], QuadContourSet):
-                            contour_line_colour = ws_artist._artists[0].get_edgecolor()
-
-                            ws_artist.replace_data(workspace, None)
-
-                            # Re-apply the contour line colour
-                            ws_artist._artists[0].set_color(contour_line_colour)
+            try:
+                if arg_set["workspaces"] in ax.tracked_workspaces:
+                    workspace = ads.retrieve(arg_set["workspaces"])
+                    arg_set["distribution"] = is_normalized
+                    if "specNum" not in arg_set:
+                        if "wkspIndex" in arg_set:
+                            arg_set["specNum"] = workspace.getSpectrum(arg_set.pop("wkspIndex")).getSpectrumNo()
                         else:
-                            ws_artist.replace_data(workspace, arg_set_copy)
+                            raise RuntimeError("No spectrum number associated with plot of workspace '{}'".format(workspace.name()))
+
+                    arg_set_copy = copy(arg_set)
+                    for key in ["function", "workspaces", "autoscale_on_update", "norm"]:
+                        try:
+                            del arg_set_copy[key]
+                        except KeyError:
+                            continue
+                    # 2D plots have no spec number so remove it
+                    if figure_type(self.canvas.figure) in [FigureType.Image, FigureType.Contour]:
+                        arg_set_copy.pop("specNum")
+                    for ws_artist in ax.tracked_workspaces[workspace.name()]:
+                        if ws_artist.spec_num == arg_set_copy.get("specNum"):
+                            ws_artist.is_normalized = not is_normalized
+
+                            # This check is to prevent the contour lines being re-plotted using the colorfill plot args.
+                            if isinstance(ws_artist._artists[0], QuadContourSet):
+                                contour_line_colour = ws_artist._artists[0].get_edgecolor()
+
+                                ws_artist.replace_data(workspace, None)
+
+                                # Re-apply the contour line colour
+                                ws_artist._artists[0].set_color(contour_line_colour)
+                            else:
+                                ws_artist.replace_data(workspace, arg_set_copy)
+            except KeyError:
+                continue
 
     def _can_toggle_normalization(self, ax):
         """

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -605,9 +605,17 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             ax.add_line(line)
 
     def crosshair_toggle(self, on):
-        cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
-        if not on:
-            self.canvas.mpl_disconnect(cid)
+        if on:
+            # Create crosshair lines for each axes (except colorbars)
+            self._crosshair_lines = {}
+            for ax in self._axes_that_are_not_colour_bars():
+                ax.set_autoscalex_on(False)
+                ax.set_autoscaley_on(False)
+                hline = ax.axhline(color="r", lw=1.0, ls="-", visible=False)
+                vline = ax.axvline(color="r", lw=1.0, ls="-", visible=False)
+                self._crosshair_lines[ax] = (hline, vline)
+
+            self._crosshair_cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
 
     def crosshair(self, event):
         axes = self.canvas.figure.gca()

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -132,14 +132,14 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_crosshair_button_visible(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
-    def test_button_hiden_for_tiled_plots(self, mock_qappthread):
+    def test_button_for_tiled_plots(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread
 
         fig, axes = plt.subplots(2)
         axes[0].plot([-10, 10], [1, 2])
         axes[1].plot([3, 2, 1], [1, 2, 3])
         # crosshair button should be hidden because this is a tiled plot
-        self.assertFalse(self._is_crosshair_button_visible(fig))
+        self.assertTrue(self._is_crosshair_button_visible(fig))
         self.assertFalse(self._is_crosshair_button_checked(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -234,10 +234,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
             self.set_fit_enabled(False)
             self.set_superplot_enabled(False)
 
-        # disable crosshair in tiled plots, 3D plots but keep it enabled in color contour plot
-        if (len(fig.get_axes()) > 1 and figure_type(fig) not in [FigureType.Contour]) or (
-            figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]
-        ):
+        # disable crosshair in 3D plots
+        if figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]:
             self.set_crosshair_enabled(False)
 
         for ax in fig.get_axes():


### PR DESCRIPTION
### Description of work
This PR handles errors that arises from crosshair functions interacting with mantid. PR [39491](https://github.com/mantidproject/mantid/pull/39491)

The issue is when changing normalisation and error bars, the figure object is treated as mantid object such as mantidaxes with key word arg such as "workspaces". The crosshair, at the moment, is implemented purely as matplotlib object and would cause error and crash the plot. A quick fix is to catch these errors.

In the long term,  we will integrate the crosshair as a mantid specific object for handling mantid data.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #39592 .

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Run the instructions in the smoking tests, specifically focusing on changing normalisation and error bars while crosshair is open.

This script can be used to quickly open the plot pannel for testing: 

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType

MAR11060 = Load('MAR11060')

fig, axes = plt.subplots(edgecolor='#ffffff', ncols=2, nrows=2, num='MAR11060-1', subplot_kw={'projection': 'mantid'})
axes[0][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 1', wkspIndex=0)
axes[0][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[0][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 2', wkspIndex=1)
axes[0][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 3', wkspIndex=2)
axes[1][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 4', wkspIndex=3)
axes[1][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

fig.show()
```
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
