### PR TITLE
Add DetermineSpinStateOrder algorithm for PolSans epic

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SRC_FILES
     src/CorrectKiKf.cpp
     src/CorrectTOFAxis.cpp
     src/CorrectToFile.cpp
+    src/CreateBootstrapWorkspaces.cpp
     src/CreateCalFileByNames.cpp
     src/CreateDetectorTable.cpp
     src/CreateDummyCalFile.cpp
@@ -87,7 +88,6 @@ set(SRC_FILES
     src/CreateLogPropertyTable.cpp
     src/CreateLogTimeCorrection.cpp
     src/CreateMonteCarloWorkspace.cpp
-    src/CreateBootstrapWorkspaces.cpp
     src/CreatePSDBleedMask.cpp
     src/CreatePeaksWorkspace.cpp
     src/CreateSampleWorkspace.cpp
@@ -108,6 +108,7 @@ set(SRC_FILES
     src/DetectorEfficiencyCor.cpp
     src/DetectorEfficiencyCorUser.cpp
     src/DetectorEfficiencyVariation.cpp
+    src/DetermineSpinStateOrder.cpp
     src/DiffractionEventCalibrateDetectors.cpp
     src/DiffractionFocussing.cpp
     src/DiffractionFocussing2.cpp
@@ -428,6 +429,7 @@ set(INC_FILES
     inc/MantidAlgorithms/CorrectKiKf.h
     inc/MantidAlgorithms/CorrectTOFAxis.h
     inc/MantidAlgorithms/CorrectToFile.h
+    inc/MantidAlgorithms/CreateBootstrapWorkspaces.h
     inc/MantidAlgorithms/CreateCalFileByNames.h
     inc/MantidAlgorithms/CreateDetectorTable.h
     inc/MantidAlgorithms/CreateDummyCalFile.h
@@ -438,7 +440,6 @@ set(INC_FILES
     inc/MantidAlgorithms/CreateLogPropertyTable.h
     inc/MantidAlgorithms/CreateLogTimeCorrection.h
     inc/MantidAlgorithms/CreateMonteCarloWorkspace.h
-    inc/MantidAlgorithms/CreateBootstrapWorkspaces.h
     inc/MantidAlgorithms/CreatePSDBleedMask.h
     inc/MantidAlgorithms/CreatePeaksWorkspace.h
     inc/MantidAlgorithms/CreateSampleWorkspace.h
@@ -459,6 +460,7 @@ set(INC_FILES
     inc/MantidAlgorithms/DetectorEfficiencyCor.h
     inc/MantidAlgorithms/DetectorEfficiencyCorUser.h
     inc/MantidAlgorithms/DetectorEfficiencyVariation.h
+    inc/MantidAlgorithms/DetermineSpinStateOrder.h
     inc/MantidAlgorithms/DiffractionEventCalibrateDetectors.h
     inc/MantidAlgorithms/DiffractionFocussing.h
     inc/MantidAlgorithms/DiffractionFocussing2.h
@@ -786,6 +788,7 @@ set(TEST_FILES
     CorrectKiKfTest.h
     CorrectTOFAxisTest.h
     CorrectToFileTest.h
+    CreateBootstrapWorkspacesTest.h
     CreateCalFileByNamesTest.h
     CreateDetectorTableTest.h
     CreateDummyCalFileTest.h
@@ -795,7 +798,6 @@ set(TEST_FILES
     CreateLogPropertyTableTest.h
     CreateLogTimeCorrectionTest.h
     CreateMonteCarloWorkspaceTest.h
-    CreateBootstrapWorkspacesTest.h
     CreatePSDBleedMaskTest.h
     CreatePeaksWorkspaceTest.h
     CreateSampleWorkspaceTest.h
@@ -817,6 +819,7 @@ set(TEST_FILES
     DetectorEfficiencyCorUserTest.h
     DetectorEfficiencyVariationTest.h
     DetectorGridDefinitionTest.h
+    DetermineSpinStateOrderTest.h
     DiffractionEventCalibrateDetectorsTest.h
     DiffractionFocussing2Test.h
     DiffractionFocussingTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -13,7 +13,8 @@
 namespace Mantid {
 namespace Algorithms {
 
-/** DetermineSpinStateOrder : TODO: DESCRIPTION
+/** DetermineSpinStateOrder : Takes a workspace group of Polarised SANS run periods and returns
+a string (e.g '--, -+, +-, ++') of thier corresponding spin states.
  */
 class MANTID_ALGORITHMS_DLL DetermineSpinStateOrder : public API::Algorithm {
 public:

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -25,7 +25,7 @@ public:
   std::map<std::string, std::string> validateInputs() override;
 
 protected:
-  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr const &wsGroup) const;
+  double averageTransmission(Mantid::API::WorkspaceGroup_const_sptr const &wsGroup) const;
 
 private:
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
@@ -20,10 +21,16 @@ public:
   int version() const override;
   const std::string category() const override;
   const std::string summary() const override;
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   void init() override;
   void exec() override;
+
+  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr wsGroup) const;
+
+  std::string m_spinFlipperLogName;
+  int m_rfStateCondition;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -24,7 +24,7 @@ public:
   std::map<std::string, std::string> validateInputs() override;
 
 protected:
-  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr wsGroup) const;
+  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr const &wsGroup) const;
 
 private:
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -14,7 +14,7 @@ namespace Mantid {
 namespace Algorithms {
 
 /** DetermineSpinStateOrder : Takes a workspace group of Polarised SANS run periods and returns
-a string (e.g '11, 10, 01, 00') of thier corresponding flipper/analyser states.
+a string (e.g '11, 10, 01, 00') of their corresponding flipper/analyser states.
  */
 class MANTID_ALGORITHMS_DLL DetermineSpinStateOrder : public API::Algorithm {
 public:

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -23,11 +23,12 @@ public:
   const std::string summary() const override;
   std::map<std::string, std::string> validateInputs() override;
 
+protected:
+  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr wsGroup) const;
+
 private:
   void init() override;
   void exec() override;
-
-  double averageTransmition(Mantid::API::WorkspaceGroup_const_sptr wsGroup) const;
 
   std::string m_spinFlipperLogName;
   int m_rfStateCondition;

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -1,0 +1,30 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** DetermineSpinStateOrder : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL DetermineSpinStateOrder : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -32,7 +32,7 @@ private:
   void exec() override;
 
   std::string m_spinFlipperLogName;
-  int m_rfStateCondition;
+  double m_rfStateCondition;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -14,7 +14,7 @@ namespace Mantid {
 namespace Algorithms {
 
 /** DetermineSpinStateOrder : Takes a workspace group of Polarised SANS run periods and returns
-a string (e.g '--, -+, +-, ++') of thier corresponding spin states.
+a string (e.g '11, 10, 01, 00') of thier corresponding flipper/analyser states.
  */
 class MANTID_ALGORITHMS_DLL DetermineSpinStateOrder : public API::Algorithm {
 public:

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -36,8 +36,8 @@ const std::string DetermineSpinStateOrder::category() const { return "SANS"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
 const std::string DetermineSpinStateOrder::summary() const {
-  return "Takes a workspace group of Polarised SANS run periods and returns a string (e.g '--, -+, +-, ++') of thier "
-         "corresponding spin states.";
+  return "Takes a workspace group of Polarised SANS run periods and returns a string (e.g '11, 10, 01, 00') of thier "
+         "corresponding spin states in Wildes notation.";
 }
 
 //----------------------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ void DetermineSpinStateOrder::init() {
   declareProperty(std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("InputWorkspace", "", Direction::Input),
                   "A Polarised SANS run from either LARMOR or ZOOM (group workspace with 4 periods).");
   declareProperty("SpinStates", std::string(""),
-                  "A comma-seperated string of the spin states of each of the run periods e.g '++,--,+-,-+'",
+                  "A comma-seperated string of the spin states of each of the run periods e.g '11, 10, 01, 00'",
                   Direction::Output);
 }
 
@@ -126,15 +126,15 @@ void DetermineSpinStateOrder::exec() {
 
     if (rfState > m_rfStateCondition) {
       if (heState < 0) {
-        spinStatesOrder.push_back("-+");
+        spinStatesOrder.push_back("10");
       } else {
-        spinStatesOrder.push_back("--");
+        spinStatesOrder.push_back("11");
       }
     } else {
       if (heState < 0) {
-        spinStatesOrder.push_back("+-");
+        spinStatesOrder.push_back("01");
       } else {
-        spinStatesOrder.push_back("++");
+        spinStatesOrder.push_back("00");
       }
     }
   }

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -6,6 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidAlgorithms/DetermineSpinStateOrder.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidGeometry/Instrument.h"
+
+#include <algorithm>
 
 namespace Mantid {
 namespace Algorithms {
@@ -24,7 +30,7 @@ const std::string DetermineSpinStateOrder::name() const { return "DetermineSpinS
 int DetermineSpinStateOrder::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string DetermineSpinStateOrder::category() const { return "TODO: FILL IN A CATEGORY"; }
+const std::string DetermineSpinStateOrder::category() const { return "Reflectometry"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
 const std::string DetermineSpinStateOrder::summary() const { return "TODO: FILL IN A SUMMARY"; }
@@ -33,17 +39,86 @@ const std::string DetermineSpinStateOrder::summary() const { return "TODO: FILL 
 /** Initialize the algorithm's properties.
  */
 void DetermineSpinStateOrder::init() {
-  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("InputWorkspace", "", Direction::Input),
+  declareProperty(std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("InputWorkspace", "", Direction::Input),
                   "An input workspace.");
-  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
-                  "An output workspace.");
+  declareProperty("SpinStates", std::string(""),
+                  "A comma-seperated string of the spin states of each of the child workspacese.g '++,--,+-,-+'",
+                  Direction::Output);
+}
+
+std::map<std::string, std::string> DetermineSpinStateOrder::validateInputs() {
+  std::map<std::string, std::string> helpMessages;
+
+  API::WorkspaceGroup_const_sptr wsGroup = getProperty("InputWorkspace");
+  if (wsGroup->getNumberOfEntries() != 4) {
+    helpMessages["InputWorkspace"] = "Input workspace group must have 4 entries (PA data)";
+  }
+
+  const auto firstItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(wsGroup->getItem(0));
+  const auto instrument = firstItem->getInstrument()->getName();
+
+  if (instrument == "LARMOR") {
+    m_spinFlipperLogName = "FlipperCurrent";
+    m_rfStateCondition = 4;
+  } else if (instrument == "ZOOM") {
+    m_spinFlipperLogName = "Spin_flipper";
+    m_rfStateCondition = 0;
+  } else {
+    helpMessages["InputWorkspace"] = "Sub workspaces must be data from either LARMOR or ZOOM";
+  }
+
+  return helpMessages;
 }
 
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
 void DetermineSpinStateOrder::exec() {
-  // TODO Auto-generated execute stub
+  API::WorkspaceGroup_const_sptr wsGroup = getProperty("InputWorkspace");
+
+  const double averageTrans = averageTransmition(wsGroup);
+  std::vector<std::string> spinStatesOrder;
+
+  for (const API::Workspace_sptr &ws : wsGroup->getAllItems()) {
+    const auto groupItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(ws);
+    const auto sfLog =
+        dynamic_cast<Kernel::TimeSeriesProperty<double> *>(groupItem->run().getLogData(m_spinFlipperLogName));
+    const auto sfLogValues = sfLog->filteredValuesAsVector();
+    const double rfState =
+        std::accumulate(sfLogValues.cbegin(), sfLogValues.cend(), 0.0) / static_cast<double>(sfLogValues.size());
+    const double heState = *std::max_element(groupItem->readY(0).cbegin(), groupItem->readY(0).cend()) - averageTrans;
+
+    if (rfState > m_rfStateCondition) {
+      if (heState < 0) {
+        spinStatesOrder.push_back("-+");
+      } else {
+        spinStatesOrder.push_back("--");
+      }
+    } else {
+      if (heState < 0) {
+        spinStatesOrder.push_back("+-");
+      } else {
+        spinStatesOrder.push_back("++");
+      }
+    }
+  }
+
+  const std::string spinStates = std::accumulate(
+      spinStatesOrder.cbegin() + 1, spinStatesOrder.cend(), spinStatesOrder[0],
+      [](const std::string spinStatesStr, const std::string spinState) { return spinStatesStr + "," + spinState; });
+  setProperty("SpinStates", spinStates);
+}
+
+double DetermineSpinStateOrder::averageTransmition(API::WorkspaceGroup_const_sptr wsGroup) const {
+  const auto workspaces = wsGroup->getAllItems();
+
+  double total =
+      std::accumulate(workspaces.cbegin(), workspaces.cend(), 0.0, [](double total, const API::Workspace_sptr ws) {
+        const auto groupItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(ws);
+        return total + *std::max_element(groupItem->readY(0).cbegin(), groupItem->readY(0).cend());
+      });
+
+  return total / static_cast<double>(workspaces.size());
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -36,7 +36,7 @@ const std::string DetermineSpinStateOrder::category() const { return "SANS"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
 const std::string DetermineSpinStateOrder::summary() const {
-  return "Takes a workspace group of Polarised SANS run periods and returns a string (e.g '11, 10, 01, 00') of thier "
+  return "Takes a workspace group of Polarised SANS run periods and returns a string (e.g '11, 10, 01, 00') of their "
          "corresponding spin states in Wildes notation.";
 }
 
@@ -81,7 +81,7 @@ std::map<std::string, std::string> DetermineSpinStateOrder::validateInputs() {
 
   API::WorkspaceGroup_const_sptr wsGroup = getProperty("InputWorkspace");
   if (wsGroup->getNumberOfEntries() != 4) {
-    helpMessages["InputWorkspace"] = "Input workspace group must have 4 entries (PA data)";
+    helpMessages["InputWorkspace"] = "Input workspace group must have 4 entries.";
     return helpMessages;
   }
 

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -11,14 +11,18 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 
 #include <algorithm>
+#include <sstream>
 
 namespace Mantid {
 namespace Algorithms {
 using Mantid::API::WorkspaceProperty;
 using Mantid::Kernel::Direction;
+
+Kernel::Logger g_log("DetermineSpinStateOrder");
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(DetermineSpinStateOrder)
@@ -143,6 +147,9 @@ void DetermineSpinStateOrder::exec() {
   }
 
   const std::string spinStates = Kernel::Strings::join(spinStatesOrder.cbegin(), spinStatesOrder.cend(), ",");
+  std::stringstream msg;
+  msg << "Determined the following spin state order for " << wsGroup->getName() << ": " << spinStates;
+  g_log.notice(msg.str());
   setProperty("SpinStates", spinStates);
 }
 

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -118,7 +118,7 @@ void DetermineSpinStateOrder::exec() {
   for (const API::Workspace_sptr &ws : wsGroup->getAllItems()) {
     const auto groupItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(ws);
     const auto sfLog =
-        dynamic_cast<Kernel::TimeSeriesProperty<double> *>(groupItem->run().getLogData(m_spinFlipperLogName));
+        dynamic_cast<const Kernel::TimeSeriesProperty<double> *>(groupItem->run().getLogData(m_spinFlipperLogName));
     const auto sfLogValues = sfLog->filteredValuesAsVector();
     const double rfState =
         std::accumulate(sfLogValues.cbegin(), sfLogValues.cend(), 0.0) / static_cast<double>(sfLogValues.size());

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -1,0 +1,50 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/DetermineSpinStateOrder.h"
+
+namespace Mantid {
+namespace Algorithms {
+using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(DetermineSpinStateOrder)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string DetermineSpinStateOrder::name() const { return "DetermineSpinStateOrder"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int DetermineSpinStateOrder::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string DetermineSpinStateOrder::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string DetermineSpinStateOrder::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void DetermineSpinStateOrder::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("InputWorkspace", "", Direction::Input),
+                  "An input workspace.");
+  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
+                  "An output workspace.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void DetermineSpinStateOrder::exec() {
+  // TODO Auto-generated execute stub
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -115,7 +115,7 @@ std::map<std::string, std::string> DetermineSpinStateOrder::validateInputs() {
 void DetermineSpinStateOrder::exec() {
   API::WorkspaceGroup_const_sptr wsGroup = getProperty("InputWorkspace");
 
-  const double averageTrans = averageTransmition(wsGroup);
+  const double averageTrans = averageTransmission(wsGroup);
   std::vector<std::string> spinStatesOrder;
 
   for (const API::Workspace_sptr &ws : wsGroup->getAllItems()) {
@@ -146,7 +146,7 @@ void DetermineSpinStateOrder::exec() {
   setProperty("SpinStates", spinStates);
 }
 
-double DetermineSpinStateOrder::averageTransmition(API::WorkspaceGroup_const_sptr const &wsGroup) const {
+double DetermineSpinStateOrder::averageTransmission(API::WorkspaceGroup_const_sptr const &wsGroup) const {
   const auto workspaces = wsGroup->getAllItems();
 
   double total =

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -52,24 +52,27 @@ void DetermineSpinStateOrder::init() {
 }
 
 void validateGroupItem(API::MatrixWorkspace_sptr const &workspace, std::map<std::string, std::string> &errorList) {
-  if (workspace == nullptr) {
+  std::vector<std::string> workspaceIssues;
+  if (!workspace) {
     errorList["InputWorkspace"] = "All input workspaces must be of type MatrixWorkspace.";
     return;
   }
 
   Kernel::Unit_const_sptr unit = workspace->getAxis(0)->unit();
   if (unit->unitID() != "Wavelength") {
-    errorList["InputWorkspace"] = "All input workspaces must be in units of Wavelength.";
-    return;
+    workspaceIssues.push_back("All input workspaces must be in units of Wavelength.");
   }
 
   if (workspace->getNumberHistograms() != 1) {
-    errorList["InputWorkspace"] = "All input workspaces must contain a single histogram.";
-    return;
+    workspaceIssues.push_back("All input workspaces must contain a single histogram.");
   }
 
   if (!workspace->isHistogramData()) {
-    errorList["InputWorkspace"] = "All input workspaces must be histogram data.";
+    workspaceIssues.push_back("All input workspaces must be histogram data.");
+  }
+
+  if (!workspaceIssues.empty()) {
+    errorList["InputWorkspace"] = Kernel::Strings::join(workspaceIssues.cbegin(), workspaceIssues.cend(), " ");
   }
 }
 

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -32,19 +32,22 @@ const std::string DetermineSpinStateOrder::name() const { return "DetermineSpinS
 int DetermineSpinStateOrder::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string DetermineSpinStateOrder::category() const { return "Reflectometry"; }
+const std::string DetermineSpinStateOrder::category() const { return "SANS"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string DetermineSpinStateOrder::summary() const { return "TODO: FILL IN A SUMMARY"; }
+const std::string DetermineSpinStateOrder::summary() const {
+  return "Takes a workspace group of Polarised SANS run periods and returns a string (e.g '--, -+, +-, ++') of thier "
+         "corresponding spin states.";
+}
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
  */
 void DetermineSpinStateOrder::init() {
   declareProperty(std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("InputWorkspace", "", Direction::Input),
-                  "An input workspace.");
+                  "A Polarised SANS run from either LARMOR or ZOOM (group workspace with 4 periods).");
   declareProperty("SpinStates", std::string(""),
-                  "A comma-seperated string of the spin states of each of the child workspacese.g '++,--,+-,-+'",
+                  "A comma-seperated string of the spin states of each of the run periods e.g '++,--,+-,-+'",
                   Direction::Output);
 }
 

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/Strings.h"
 
 #include <algorithm>
 
@@ -103,9 +104,7 @@ void DetermineSpinStateOrder::exec() {
     }
   }
 
-  const std::string spinStates = std::accumulate(
-      spinStatesOrder.cbegin() + 1, spinStatesOrder.cend(), spinStatesOrder[0],
-      [](const std::string spinStatesStr, const std::string spinState) { return spinStatesStr + "," + spinState; });
+  const std::string spinStates = Kernel::Strings::join(spinStatesOrder.cbegin(), spinStatesOrder.cend(), ",");
   setProperty("SpinStates", spinStates);
 }
 

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -48,10 +48,10 @@ Mantid::API::WorkspaceGroup_sptr createWorkpsaceGroupWithYValuesAndFlipperLogs(c
   auto wsGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
   Mantid::Types::Core::DateAndTime start("2025-06-25T10:08:00");
   std::vector<Mantid::Types::Core::DateAndTime> logTimes;
-  for (double i = 0.0; i < logMeans.size(); i++) {
+  for (double i = 0.0; i < static_cast<double>(logMeans.size()); i++) {
     logTimes.push_back(start + i);
   }
-  for (double i = 0.0; i < yValues.size(); i++) {
+  for (int i = 0; i < static_cast<int>(yValues.size()); i++) {
     const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithValuesAndXerror(1, 100, true, 100, yValues[i], 0, 0);
     ws->getAxis(0)->setUnit("WaveLength");
     InstrumentCreationHelper::addFullInstrumentToWorkspace(*ws, false, false, instrumentName);

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/DetermineSpinStateOrder.h"
+
+using Mantid::Algorithms::DetermineSpinStateOrder;
+
+class DetermineSpinStateOrderTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DetermineSpinStateOrderTest *createSuite() { return new DetermineSpinStateOrderTest(); }
+  static void destroySuite(DetermineSpinStateOrderTest *suite) { delete suite; }
+
+  void test_Init() {
+    DetermineSpinStateOrder alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary by filling in appropriate code below.
+    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
+    // MatrixWorkspace_sptr inputWS =
+
+    DetermineSpinStateOrder alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -194,13 +194,13 @@ public:
 
   void test_heStateWhenRfIsNegative() {
     const std::vector<double> transmissionValues = {10.0, 20.0, 80.0, 90.0};
-    const std::vector<char> expectedSpinStates = {'+', '+', '-', '-'};
+    const std::vector<char> expectedSpinStates = {'0', '0', '1', '1'};
     heStateTest(transmissionValues, expectedSpinStates, 10.0, "LARMOR", "FlipperCurrent");
   }
 
   void test_heStateWhenRfIsPositive() {
     const std::vector<double> transmissionValues = {10.0, 20.0, 80.0, 90.0};
-    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    const std::vector<char> expectedSpinStates = {'1', '1', '0', '0'};
     heStateTest(transmissionValues, expectedSpinStates, -10.0, "LARMOR", "FlipperCurrent");
   }
 
@@ -225,13 +225,13 @@ public:
 
   void test_rfState_larmor() {
     const std::vector<double> logMeans = {6.0, 5.5, 0.0, 2.0};
-    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    const std::vector<char> expectedSpinStates = {'1', '1', '0', '0'};
     rfStateTest(logMeans, expectedSpinStates, "LARMOR", "FlipperCurrent");
   }
 
   void test_rfState_zoom() {
     const std::vector<double> logMeans = {2.0, 3.5, -1.5, -4.0};
-    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    const std::vector<char> expectedSpinStates = {'1', '1', '0', '0'};
     rfStateTest(logMeans, expectedSpinStates, "ZOOM", "Spin_flipper");
   }
 };

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -8,11 +8,59 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/DetermineSpinStateOrder.h"
+#include "MantidFrameworkTestHelpers/InstrumentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/StringTokenizer.h"
+
+#include <random>
 
 using Mantid::Algorithms::DetermineSpinStateOrder;
 
-class DetermineSpinStateOrderTest : public CxxTest::TestSuite {
+std::vector<double> createFakeLogValues(size_t size, double mean) {
+  std::random_device rd{};
+  std::mt19937 gen{rd()};
+  std::normal_distribution d(mean, 0.5);
+
+  std::vector<double> logs;
+  for (size_t i = 0; i < size; i++) {
+    logs.push_back(d(gen));
+  }
+  return logs;
+}
+
+Mantid::API::WorkspaceGroup_sptr createWorkspaceGroupWithYValues(const std::vector<double> &yValues) {
+  auto wsGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
+  for (const double yValue : yValues) {
+    const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithValuesAndXerror(1, 100, true, 100, yValue, 0, 0);
+    wsGroup->addWorkspace(ws);
+  }
+  return wsGroup;
+}
+
+Mantid::API::WorkspaceGroup_sptr createWorkpsaceGroupWithYValuesAndFlipperLogs(const std::vector<double> &yValues,
+                                                                               const std::vector<double> &logMeans,
+                                                                               const std::string &instrumentName,
+                                                                               const std::string &logName) {
+  auto wsGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
+  Mantid::Types::Core::DateAndTime start("2025-06-25T10:08:00");
+  std::vector<Mantid::Types::Core::DateAndTime> logTimes;
+  for (double i = 0.0; i < logMeans.size(); i++) {
+    logTimes.push_back(start + i);
+  }
+  for (double i = 0.0; i < yValues.size(); i++) {
+    const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithValuesAndXerror(1, 100, true, 100, yValues[i], 0, 0);
+    InstrumentCreationHelper::addFullInstrumentToWorkspace(*ws, false, false, instrumentName);
+    auto spinFlipperLog = new Mantid::Kernel::TimeSeriesProperty<double>(
+        logName, logTimes, createFakeLogValues(logTimes.size(), logMeans[i]));
+    ws->mutableRun().addLogData(spinFlipperLog);
+    wsGroup->addWorkspace(ws);
+  }
+  return wsGroup;
+}
+
+class DetermineSpinStateOrderTest : public CxxTest::TestSuite, DetermineSpinStateOrder {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -25,28 +73,109 @@ public:
     TS_ASSERT(alg.isInitialized())
   }
 
-  void test_exec() {
-    // Create test input if necessary by filling in appropriate code below.
-    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
-    // MatrixWorkspace_sptr inputWS =
+  void test_validateInputs_inputWorkspaceSize() {
+    auto wsGroupWithThreeItems = std::make_shared<Mantid::API::WorkspaceGroup>();
+    for (int i = 0; i < 3; ++i) {
+      const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10, false, false, true, "ZOOM");
+      wsGroupWithThreeItems->addWorkspace(ws);
+    }
 
     DetermineSpinStateOrder alg;
-    // Don't put output in ADS by default
-    alg.setChild(true);
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
-    TS_ASSERT(alg.isExecuted());
+    alg.initialize();
+    alg.setProperty("InputWorkspace", wsGroupWithThreeItems);
 
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS);
-    TS_FAIL("TODO: Check the results and remove this line");
+    auto errors = alg.validateInputs();
+    TS_ASSERT(!errors.empty())
+    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Input workspace group must have 4 entries (PA data)")
+    WorkspaceCreationHelper::removeWS("three_items");
   }
 
-  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+  void test_validateInputs_unsupportedInstrument() {
+    auto wsGroupOsiris = std::make_shared<Mantid::API::WorkspaceGroup>();
+    for (int i = 0; i < 4; ++i) {
+      const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10, false, false, true, "OSIRIS");
+      wsGroupOsiris->addWorkspace(ws);
+    }
+
+    DetermineSpinStateOrder alg;
+    alg.initialize();
+    alg.setProperty("InputWorkspace", wsGroupOsiris);
+
+    auto errors = alg.validateInputs();
+    TS_ASSERT(!errors.empty())
+    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Sub workspaces must be data from either LARMOR or ZOOM")
+  }
+
+  void test_averageTransmission() {
+    const std::vector<double> yValues = {10.0, 25.0, 80.0, 4.5};
+    auto wsGroup = createWorkspaceGroupWithYValues(yValues);
+
+    const double result = averageTransmition(wsGroup);
+
+    const double averageYValue =
+        std::accumulate(yValues.cbegin(), yValues.cend(), 0.0) / static_cast<double>(yValues.size());
+    TS_ASSERT_EQUALS(result, averageYValue);
+  }
+
+  void heStateTest(const std::vector<double> &transmissionValues, const std::vector<char> &expectedSpinStates,
+                   double flipperLogValue, const std::string &instrumentName, const std::string &sfLogName) {
+    auto wsGroup = createWorkpsaceGroupWithYValuesAndFlipperLogs(
+        transmissionValues, std::vector<double>(transmissionValues.size(), flipperLogValue), instrumentName, sfLogName);
+
+    DetermineSpinStateOrder alg;
+    alg.initialize();
+    alg.setProperty("InputWorkspace", wsGroup);
+    alg.execute();
+
+    const std::string result = alg.getPropertyValue("SpinStates");
+    auto spinStates = Mantid::Kernel::StringTokenizer(result, ",").asVector();
+    for (int i = 0; i < 4; ++i) {
+      // get second char of the state string
+      char rfState = spinStates[i][1];
+      TS_ASSERT_EQUALS(rfState, expectedSpinStates[i]);
+    }
+  }
+
+  void test_heStateWhenRfIsNegative() {
+    const std::vector<double> transmissionValues = {10.0, 20.0, 80.0, 90.0};
+    const std::vector<char> expectedSpinStates = {'+', '+', '-', '-'};
+    heStateTest(transmissionValues, expectedSpinStates, 10.0, "LARMOR", "FlipperCurrent");
+  }
+
+  void test_heStateWhenRfIsPositive() {
+    const std::vector<double> transmissionValues = {10.0, 20.0, 80.0, 90.0};
+    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    heStateTest(transmissionValues, expectedSpinStates, -10.0, "LARMOR", "FlipperCurrent");
+  }
+
+  void rfStateTest(const std::vector<double> &logMeans, const std::vector<char> &expectedSpinStates,
+                   const std::string &instrumentName, const std::string &sfLogName) {
+    auto wsGroup =
+        createWorkpsaceGroupWithYValuesAndFlipperLogs({0.0, 0.0, 0.0, 0.0}, logMeans, instrumentName, sfLogName);
+
+    DetermineSpinStateOrder alg;
+    alg.initialize();
+    alg.setProperty("InputWorkspace", wsGroup);
+    alg.execute();
+
+    std::string result = alg.getPropertyValue("SpinStates");
+    auto spinStates = Mantid::Kernel::StringTokenizer(result, ",").asVector();
+    for (int i = 0; i < 4; ++i) {
+      // get first char of the state string
+      char rfState = spinStates[i][0];
+      TS_ASSERT_EQUALS(rfState, expectedSpinStates[i]);
+    }
+  }
+
+  void test_rfState_larmor() {
+    const std::vector<double> logMeans = {6.0, 5.5, 0.0, 2.0};
+    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    rfStateTest(logMeans, expectedSpinStates, "LARMOR", "FlipperCurrent");
+  }
+
+  void test_rfState_zoom() {
+    const std::vector<double> logMeans = {2.0, 3.5, -1.5, -4.0};
+    const std::vector<char> expectedSpinStates = {'-', '-', '+', '+'};
+    rfStateTest(logMeans, expectedSpinStates, "ZOOM", "Spin_flipper");
+  }
 };

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -90,7 +90,7 @@ public:
 
     auto errors = alg.validateInputs();
     TS_ASSERT(!errors.empty())
-    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Input workspace group must have 4 entries (PA data)")
+    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Input workspace group must have 4 entries.")
     WorkspaceCreationHelper::removeWS("three_items");
   }
 

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -166,7 +166,7 @@ public:
     const std::vector<double> yValues = {10.0, 25.0, 80.0, 4.5};
     auto wsGroup = createWorkspaceGroupWithYValues(yValues);
 
-    const double result = averageTransmition(wsGroup);
+    const double result = averageTransmission(wsGroup);
 
     const double averageYValue =
         std::accumulate(yValues.cbegin(), yValues.cend(), 0.0) / static_cast<double>(yValues.size());

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -94,7 +94,7 @@ public:
     WorkspaceCreationHelper::removeWS("three_items");
   }
 
-  void test_validateInputs_unsupportedInstrument() {
+  void test_validateInputs_unsupportedInstrumentForNoLogInfo() {
     auto wsGroupOsiris = std::make_shared<Mantid::API::WorkspaceGroup>();
     for (int i = 0; i < 4; ++i) {
       const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10, false, false, true, "OSIRIS");
@@ -108,7 +108,8 @@ public:
 
     auto errors = alg.validateInputs();
     TS_ASSERT(!errors.empty())
-    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Sub workspaces must be data from either LARMOR or ZOOM")
+    TS_ASSERT_EQUALS(errors["InputWorkspace"], "Sub workspaces must be data from either LARMOR or ZOOM when "
+                                               "SpinFlipperLogName or SpinFlipperAverageCurrent are not provided")
   }
 
   void test_validateInputs_wavelengthAxis() {

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -15,6 +15,8 @@ Takes a Polarised SANS transmission run and attempts to determine the spin state
 The average current through the RF flipper for every run is extracted from the appropriate spin flipper log in the instrument. The beam polarisation is determined by
 comparing each period transmission to the average transmission (greater than the average suggests the same state as the flipper).
 
+If the data is from LARMOR or ZOOM, properties **SpinFlipperLogName** and **SpinFlipperAverageCurrent** can be inferred by the algorithm (don't need to be set).
+
 Usage
 -----
 

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -15,7 +15,17 @@ Takes a Polarised SANS transmission run and attempts to determine the spin state
 The average current through the RF flipper for every run is extracted from the appropriate spin flipper log in the instrument. The beam polarisation is determined by
 comparing each period transmission to the average transmission (greater than the average suggests the same state as the flipper).
 
-If the data is from LARMOR or ZOOM, properties **SpinFlipperLogName** and **SpinFlipperAverageCurrent** can be inferred by the algorithm (don't need to be set).
+If the data is from LARMOR or ZOOM, properties **SpinFlipperLogName** and **SpinFlipperAverageCurrent** can be inferred by the algorithm.
+
++-----------+----------------------+---------------------------------+
+|Instrument | **SpinFlipperLogName** | **SpinFlipperAverageCurrent** |
++====================================+===============================+
+|LARMOR     | ``FlipperCurrent``     | ``4.0``                       |
++------------------------------------+-------------------------------+
+|ZOOM       | ``Spin_flipper``       | ``0.0``                       |
++-----------+------------------------+-------------------------------+
+
+Otherwise, they can be supplied explicitly by the user.
 
 Usage
 -----

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -12,8 +12,8 @@ Description
 
 Takes a Polarised SANS transmission run and attempts to determine the spin state for each run period.
 
-To determine if the RF flipper is on or not the algorithm uses the spin flipper current log, to determine the beam polarisation the
-algorithm compares the period transmission to the average transmission (greater than the average suggests the same state as the flipper).
+The average current through the RF flipper for every run is extracted from the appropriate spin flipper log in the instrument. The beam polarisation is determined by 
+comparing each period transmission to the average transmission (greater than the average suggests the same state as the flipper).
 
 Usage
 -----

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -12,7 +12,7 @@ Description
 
 Takes a Polarised SANS transmission run and attempts to determine the spin state for each run period.
 
-The average current through the RF flipper for every run is extracted from the appropriate spin flipper log in the instrument. The beam polarisation is determined by 
+The average current through the RF flipper for every run is extracted from the appropriate spin flipper log in the instrument. The beam polarisation is determined by
 comparing each period transmission to the average transmission (greater than the average suggests the same state as the flipper).
 
 Usage

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -46,7 +46,7 @@ Output:
 
 .. testoutput:: DetermineSpinStateOrderExample
 
-   Spin state order from wsGroup is +-,++,-+,--
+   Spin state order from wsGroup is 01,00,10,11
 
 .. categories::
 

--- a/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
+++ b/docs/source/algorithms/DetermineSpinStateOrder-v1.rst
@@ -1,0 +1,45 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - DetermineSpinStateOrder**
+
+.. testcode:: DetermineSpinStateOrderExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = DetermineSpinStateOrder()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: DetermineSpinStateOrderExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.14.0/SANS/New_features/36138.rst
+++ b/docs/source/release/v6.14.0/SANS/New_features/36138.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`algm-DetermineSpinStateOrder` which takes a Polarised SANS transmission run and attempts to determine the spin state for each run period.


### PR DESCRIPTION
### Description of work

Add algorithm to implement SANS scientists' script to automatically determine the order of spin states for each workspace in a PolSans transmission run.

The algorithm uses the spin flipper current log to determine the flipper states. It compares the beam transmission to the average transmission (over all state combinations) to determine the beam polarisation.

Fixes #36138

### To test:

Involved to test as this algorithm requires data to have be pre-processed (which is not currently automated) so to be tested by developers / scientists familiar with the area.
Docs provide an example with fake data.
Should be tested with both ZOOM and LARMOR data.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
