### PR TITLE
Add new output options to PlotPeakByLogValue algorithm and Sequetial Fit dialouge

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -81,7 +81,7 @@ private:
 
   void finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
                                 const std::vector<std::string> &parameterWorkspaces,
-                                const std::vector<std::string> &covarianceWorkspaces, std::string range);
+                                const std::vector<std::string> &covarianceWorkspaces, const std::string &range);
 
   API::IFunction_sptr setupFunction(bool individual, bool passWSIndexToFunction,
                                     const API::IFunction_sptr &inputFunction, const std::vector<double> &initialParams,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -81,7 +81,7 @@ private:
 
   void finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
                                 const std::vector<std::string> &parameterWorkspaces,
-                                const std::vector<std::string> &covarianceWorkspaces);
+                                const std::vector<std::string> &covarianceWorkspaces, std::string range);
 
   API::IFunction_sptr setupFunction(bool individual, bool passWSIndexToFunction,
                                     const API::IFunction_sptr &inputFunction, const std::vector<double> &initialParams,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -79,9 +79,9 @@ private:
   void appendTableRow(bool isDataName, API::ITableWorkspace_sptr &result, const API::IFunction_sptr &ifun,
                       const InputSpectraToFit &data, double logValue, double chi2) const;
 
-  void finaliseOutputWorkspaces(bool createFitOutput, const std::vector<API::MatrixWorkspace_sptr> &fitWorkspaces,
-                                const std::vector<API::ITableWorkspace_sptr> &parameterWorkspaces,
-                                const std::vector<API::ITableWorkspace_sptr> &covarianceWorkspaces);
+  void finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
+                                const std::vector<std::string> &parameterWorkspaces,
+                                const std::vector<std::string> &covarianceWorkspaces);
 
   API::IFunction_sptr setupFunction(bool individual, bool passWSIndexToFunction,
                                     const API::IFunction_sptr &inputFunction, const std::vector<double> &initialParams,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -67,7 +67,7 @@ private:
   void setWorkspaceIndexAttribute(const API::IFunction_sptr &fun, int wsIndex) const;
 
   std::shared_ptr<Algorithm> runSingleFit(bool createFitOutput, bool outputCompositeMembers,
-                                          bool outputConvolvedMembers, const API::IFunction_sptr &ifun,
+                                          bool outputConvolvedMembers, bool appendIdx, const API::IFunction_sptr &ifun,
                                           const InputSpectraToFit &data, double startX, double endX,
                                           const std::string &exclude);
 
@@ -79,9 +79,19 @@ private:
   void appendTableRow(bool isDataName, API::ITableWorkspace_sptr &result, const API::IFunction_sptr &ifun,
                       const InputSpectraToFit &data, double logValue, double chi2) const;
 
-  void finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
-                                const std::vector<std::string> &parameterWorkspaces,
-                                const std::vector<std::string> &covarianceWorkspaces, const std::string &range);
+  void finaliseOutputWorkspacesWithAppend(const std::vector<std::string> &fitWorkspaces,
+                                          const std::vector<std::string> &parameterWorkspaces,
+                                          const std::vector<std::string> &covarianceWorkspaces,
+                                          const std::vector<InputSpectraToFit> &wsNames);
+
+  void finaliseOutputWorkspaces(const std::vector<API::MatrixWorkspace_sptr> &fitWorkspaces,
+                                const std::vector<API::ITableWorkspace_sptr> &parameterWorkspaces,
+                                const std::vector<API::ITableWorkspace_sptr> &covarianceWorkspaces);
+
+  void groupResParams(const std::vector<API::ITableWorkspace_sptr> &paramsWs,
+                      const std::vector<std::string> &paramsNames);
+
+  void finaliseMinimizerOutput();
 
   API::IFunction_sptr setupFunction(bool individual, bool passWSIndexToFunction,
                                     const API::IFunction_sptr &inputFunction, const std::vector<double> &initialParams,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
@@ -36,8 +36,8 @@ struct InputSpectraToFit {
   API::MatrixWorkspace_sptr ws; ///< shared pointer to the workspace
 };
 /// Get a workspace
-MANTID_CURVEFITTING_DLL void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList,
-                                                      const std::shared_ptr<API::MatrixWorkspace> &wsMatrix,
+MANTID_CURVEFITTING_DLL void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const std::string &name,
+                                                      const std::shared_ptr<API::MatrixWorkspace> &ws,
                                                       int workspaceIndex, int spectrumNumber, double start, double end,
                                                       int period, const bool &workspaceOptional);
 MANTID_CURVEFITTING_DLL std::optional<API::Workspace_sptr> getWorkspace(const std::string &name, int period);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
@@ -23,18 +23,23 @@ namespace Algorithms {
 
 struct InputSpectraToFit {
   /// Constructor
-  InputSpectraToFit(const std::string &nam, int ix, int p) : name(nam), i(ix), period(p) {}
+  InputSpectraToFit(const std::string &nam, int ix, double isp, double iv, int p, API::MatrixWorkspace_sptr mws)
+      : name(nam), i(ix), sp(isp), v(iv), period(p), ws(mws) {}
   /// Copy constructor
   InputSpectraToFit(const InputSpectraToFit &data) = default;
 
   std::string name;             ///< Name of a workspace or file
   int i;                        ///< Workspace index of the spectra to fit
+  double sp;                    ///< Spectrum number of the spectra to fit
+  double v;                     ///< Numerix axis value associated with the spectra to fit
   int period;                   ///< Period, needed if a file contains several periods
   API::MatrixWorkspace_sptr ws; ///< shared pointer to the workspace
 };
 /// Get a workspace
-MANTID_CURVEFITTING_DLL std::vector<int> getWorkspaceIndicesFromAxes(const API::MatrixWorkspace &ws, int workspaceIndex,
-                                                                     int spectrumNumber, double start, double end);
+MANTID_CURVEFITTING_DLL void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList,
+                                                      const std::shared_ptr<API::MatrixWorkspace> &wsMatrix,
+                                                      int workspaceIndex, int spectrumNumber, double start, double end,
+                                                      int period, const bool &workspaceOptional);
 MANTID_CURVEFITTING_DLL std::optional<API::Workspace_sptr> getWorkspace(const std::string &name, int period);
 
 /// Create a list of input workspace names

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
@@ -24,14 +24,14 @@ namespace Algorithms {
 struct InputSpectraToFit {
   /// Constructor
   InputSpectraToFit(const std::string &nam, int ix, double isp, double iv, int p, API::MatrixWorkspace_sptr mws)
-      : name(nam), i(ix), sp(isp), v(iv), period(p), ws(mws) {}
+      : name(nam), wsIdx(ix), spectrumNum(isp), numericValue(iv), period(p), ws(mws) {}
   /// Copy constructor
   InputSpectraToFit(const InputSpectraToFit &data) = default;
 
   std::string name;             ///< Name of a workspace or file
-  int i;                        ///< Workspace index of the spectra to fit
-  double sp;                    ///< Spectrum number of the spectra to fit
-  double v;                     ///< Numerix axis value associated with the spectra to fit
+  int wsIdx;                    ///< Workspace index of the spectra to fit
+  double spectrumNum;           ///< Spectrum number of the spectra to fit
+  double numericValue;          ///< Numerix axis value associated with the spectra to fit
   int period;                   ///< Period, needed if a file contains several periods
   API::MatrixWorkspace_sptr ws; ///< shared pointer to the workspace
 };

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -171,6 +171,11 @@ std::map<std::string, std::string> PlotPeakByLogValue::validateInputs() {
   int default_wi = getProperty("WorkspaceIndex");
   int default_spec = getProperty("Spectrum");
   const std::vector<InputSpectraToFit> wsNames = makeNames(inputList, default_wi, default_spec);
+  for (auto &wsName : wsNames) {
+    if (wsName.wsIdx == -1 && wsName.spectrumNum == -1 && wsName.numericValue == -1) {
+      errors["InvalidRange"] = "Range is out of bounds. Please make sure the selected range is within the boundaries.";
+    }
+  }
   std::vector<std::string> excludeList = getProperty("ExcludeMultiple");
   if (!excludeList.empty() && excludeList.size() != wsNames.size()) {
     errors["ExcludeMultiple"] = "ExcludeMultiple must be the same size has the number of spectra.";

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -345,14 +345,14 @@ IFunction_sptr PlotPeakByLogValue::setupFunction(bool individual, bool passWSInd
 void PlotPeakByLogValue::finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
                                                   const std::vector<std::string> &parameterWorkspaces,
                                                   const std::vector<std::string> &covarianceWorkspaces,
-                                                  std::string range) {
+                                                  const std::string &range) {
   if (createFitOutput) {
     // collect output of fit for each spectrum into workspace groups
     auto const groupAlg = this->createChildAlgorithm("GroupWorkspaces");
     std::vector<std::pair<std::vector<std::string>, std::string>> groupingOperations = {
-        {covarianceWorkspaces, std::format("{}_{}_NormalisedCovarianceMatrices", m_baseName, range)},
-        {parameterWorkspaces, std::format("{}_{}_Parameters", m_baseName, range)},
-        {fitWorkspaces, std::format("{}_{}_Workspaces", m_baseName, range)}};
+        {covarianceWorkspaces, std::format("{}_NormalisedCovarianceMatrices", m_baseName)},
+        {parameterWorkspaces, std::format("{}_Parameters", m_baseName)},
+        {fitWorkspaces, std::format("{}_Workspaces", m_baseName)}};
 
     for (const auto &[inputWorkspaces, outputName] : groupingOperations) {
       groupAlg->initialize();

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -131,11 +131,13 @@ void PlotPeakByLogValue::init() {
                   "If true and CreateOutput is true then the value of each "
                   "member of a Composite Function is also output.");
 
-  declareProperty(
-      "AppendIdxToOutputName", false,
-      "Append either spectrum index, workspace index, or numeric axis value depending on the input format.");
+  declareProperty("AppendIdxToOutputName", false,
+                  "If true and CreateOutput is true then append either spectrum index, workspace index, or numeric "
+                  "axis value depending on the input format.");
 
-  declareProperty("Output2D", false, "Output res in 2D workspace");
+  declareProperty(
+      "Output2D", false,
+      "If true and CreateOutput is true then create a new output of the result table in workspace 2D format.");
 
   declareProperty(std::make_unique<Kernel::PropertyWithValue<bool>>("ConvolveMembers", false),
                   "If true and OutputCompositeMembers is true members of any "

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -171,7 +171,7 @@ std::map<std::string, std::string> PlotPeakByLogValue::validateInputs() {
   int default_wi = getProperty("WorkspaceIndex");
   int default_spec = getProperty("Spectrum");
   const std::vector<InputSpectraToFit> wsNames = makeNames(inputList, default_wi, default_spec);
-  for (auto &wsName : wsNames) {
+  for (const auto &wsName : wsNames) {
     if (wsName.wsIdx == -1 && wsName.spectrumNum == -1 && wsName.numericValue == -1) {
       errors["InvalidRange"] = "Range is out of bounds. Please make sure the selected range is within the boundaries.";
     }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -335,13 +335,6 @@ void PlotPeakByLogValue::groupResParams(const std::vector<ITableWorkspace_sptr> 
   std::map<std::string, std::vector<double>> parameterValues;
   std::map<std::string, std::vector<double>> parameterErrors;
 
-  std::vector<std::string> columnNames;
-  if (params.size() > 0) {
-    if (params[0]) {
-      columnNames = params[0]->getColumnNames();
-    }
-  }
-
   for (size_t i = 0; i < params.size(); ++i) {
     for (size_t rowNo = 0; rowNo < params[i]->rowCount(); ++rowNo) {
       TableRow row = params[i]->getRow(rowNo);
@@ -492,8 +485,6 @@ void PlotPeakByLogValue::finaliseOutputWorkspacesWithAppend(const std::vector<st
 }
 
 void PlotPeakByLogValue::finaliseMinimizerOutput() {
-  auto const groupAlg = this->createChildAlgorithm("GroupWorkspaces");
-
   for (auto &minimizerWorkspace : this->m_minimizerWorkspaces) {
     const std::string paramName = minimizerWorkspace.first;
     auto groupAlg = this->createChildAlgorithm("GroupWorkspaces");

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -26,6 +26,7 @@
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidCurveFitting/Algorithms/PlotPeakByLogValue.h"
@@ -130,6 +131,12 @@ void PlotPeakByLogValue::init() {
                   "If true and CreateOutput is true then the value of each "
                   "member of a Composite Function is also output.");
 
+  declareProperty(
+      "AppendIdxToOutputName", false,
+      "Append either spectrum index, workspace index, or numeric axis value depending on the input format.");
+
+  declareProperty("Output2D", false, "Output res in 2D workspace");
+
   declareProperty(std::make_unique<Kernel::PropertyWithValue<bool>>("ConvolveMembers", false),
                   "If true and OutputCompositeMembers is true members of any "
                   "Convolution are output convolved\n"
@@ -184,6 +191,8 @@ void PlotPeakByLogValue::exec() {
   bool individual = getPropertyValue("FitType") == "Individual";
   bool passWSIndexToFunction = getProperty("PassWSIndexToFunction");
   bool createFitOutput = getProperty("CreateOutput");
+  bool appendIdxToOutput = getProperty("AppendIdxToOutputName");
+  bool output2D = getProperty("Output2D");
   bool outputCompositeMembers = getProperty("OutputCompositeMembers");
   bool outputConvolvedMembers = getProperty("ConvolveMembers");
   bool outputFitStatus = getProperty("OutputFitStatus");
@@ -213,14 +222,12 @@ void PlotPeakByLogValue::exec() {
   }
   ITableWorkspace_sptr result = createResultsTable(logName, ifunSingle, isDataName);
 
-  std::vector<std::string> fitWorkspaces;
-  std::vector<std::string> parameterWorkspaces;
-  std::vector<std::string> covarianceWorkspaces;
-  if (createFitOutput) {
-    covarianceWorkspaces.reserve(wsNames.size());
-    fitWorkspaces.reserve(wsNames.size());
-    parameterWorkspaces.reserve(wsNames.size());
-  }
+  std::vector<std::string> fitNames;
+  std::vector<std::string> parameterNames;
+  std::vector<std::string> covarianceNames;
+  std::vector<MatrixWorkspace_sptr> fitWorkspaces;
+  std::vector<ITableWorkspace_sptr> parameterWorkspaces;
+  std::vector<ITableWorkspace_sptr> covarianceWorkspaces;
 
   std::vector<std::string> fitStatus;
   std::vector<double> fitChiSquared;
@@ -250,26 +257,29 @@ void PlotPeakByLogValue::exec() {
         setupFunction(individual, passWSIndexToFunction, inputFunction, initialParams, isMultiDomainFunction, i, data);
     std::shared_ptr<Algorithm> fit;
     if (startX.size() == 0) {
-      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, ifun, data, EMPTY_DBL(),
-                         EMPTY_DBL(), exclude[i]);
+      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, appendIdxToOutput, ifun, data,
+                         EMPTY_DBL(), EMPTY_DBL(), exclude[i]);
     } else if (startX.size() == 1) {
-      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, ifun, data, startX[0],
-                         endX[0], exclude[i]);
+      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, appendIdxToOutput, ifun, data,
+                         startX[0], endX[0], exclude[i]);
     } else {
-      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, ifun, data, startX[i],
-                         endX[i], exclude[i]);
+      fit = runSingleFit(createFitOutput, outputCompositeMembers, outputConvolvedMembers, appendIdxToOutput, ifun, data,
+                         startX[i], endX[i], exclude[i]);
     }
 
     ifun = fit->getProperty("Function");
     double chi2 = fit->getProperty("OutputChi2overDoF");
 
     if (createFitOutput) {
-      std::string outputFitWorkspace = fit->getPropertyValue("OutputWorkspace");
-      std::string outputParamWorkspace = fit->getPropertyValue("OutputParameters");
-      std::string outputCovarianceWorkspace = fit->getPropertyValue("OutputNormalisedCovarianceMatrix");
-      fitWorkspaces.emplace_back(outputFitWorkspace);
-      parameterWorkspaces.emplace_back(outputParamWorkspace);
-      covarianceWorkspaces.emplace_back(outputCovarianceWorkspace);
+      if (appendIdxToOutput) {
+        fitNames.emplace_back(fit->getPropertyValue("OutputWorkspace"));
+        parameterNames.emplace_back(fit->getPropertyValue("OutputParameters"));
+        covarianceNames.emplace_back(fit->getPropertyValue("OutputNormalisedCovarianceMatrix"));
+      } else {
+        fitWorkspaces.emplace_back(fit->getProperty("OutputWorkspace"));
+        parameterWorkspaces.emplace_back(fit->getProperty("OutputParameters"));
+        covarianceWorkspaces.emplace_back(fit->getProperty("OutputNormalisedCovarianceMatrix"));
+      }
     }
     if (outputFitStatus) {
       fitStatus.push_back(fit->getProperty("OutputStatus"));
@@ -294,23 +304,96 @@ void PlotPeakByLogValue::exec() {
     setProperty("OutputChiSquared", fitChiSquared);
   }
 
-  std::string range;
   if (createFitOutput) {
-    auto start = wsNames[0];
-    auto end = wsNames[wsNames.size() - 1];
-    if (start.sp != -1) {
-      range = wsNames.size() > 1 && start.sp != end.sp ? std::format("sp{:g}-{:g}", start.sp, end.sp)
-                                                       : std::format("sp{:g}", start.sp);
-    } else if (start.v != -1) {
-      range = wsNames.size() > 1 && start.v != end.v ? std::format("v{:g}-{:g}", start.v, end.v)
-                                                     : std::format("v{:g}", start.v);
+    if (output2D) {
+      groupResParams(parameterWorkspaces, parameterNames);
+    }
+
+    if (appendIdxToOutput) {
+      finaliseOutputWorkspacesWithAppend(fitNames, parameterNames, covarianceNames, wsNames);
     } else {
-      range = wsNames.size() > 1 && start.i != end.i ? std::format("i{}-{}", start.i, end.i)
-                                                     : "i" + std::to_string(start.i);
+      finaliseOutputWorkspaces(fitWorkspaces, parameterWorkspaces, covarianceWorkspaces);
     }
   }
 
-  finaliseOutputWorkspaces(createFitOutput, fitWorkspaces, parameterWorkspaces, covarianceWorkspaces, range);
+  finaliseMinimizerOutput();
+}
+
+void PlotPeakByLogValue::groupResParams(const std::vector<ITableWorkspace_sptr> &paramsWs,
+                                        const std::vector<std::string> &paramsNames) {
+  std::vector<ITableWorkspace_sptr> params;
+
+  if (paramsWs.size() > 0) {
+    params = paramsWs;
+  } else if (paramsNames.size() > 0) {
+    std::transform(paramsNames.cbegin(), paramsNames.cend(), std::back_inserter(params),
+                   [](std::string name) { return AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(name); });
+  } else {
+    return;
+  }
+
+  std::map<std::string, std::vector<double>> parameterValues;
+  std::map<std::string, std::vector<double>> parameterErrors;
+
+  std::vector<std::string> columnNames;
+  if (params.size() > 0) {
+    if (params[0]) {
+      columnNames = params[0]->getColumnNames();
+    }
+  }
+
+  for (size_t i = 0; i < params.size(); ++i) {
+    for (size_t rowNo = 0; rowNo < params[i]->rowCount(); ++rowNo) {
+      TableRow row = params[i]->getRow(rowNo);
+
+      auto paramName = row.String(0);
+      auto value = row.Double(1);
+      auto error = row.Double(2);
+
+      parameterValues[paramName].push_back(value);
+      parameterErrors[paramName].push_back(error);
+    }
+  }
+
+  if (!parameterValues.empty()) {
+    size_t numParams = parameterValues.size();
+    size_t numDataPoints = parameterValues.begin()->second.size();
+
+    auto matrixWs =
+        Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", numParams, numDataPoints, numDataPoints);
+
+    auto textAxis = std::make_unique<Mantid::API::TextAxis>(numParams);
+
+    size_t spectrumIndex = 0;
+    for (const auto &paramPair : parameterValues) {
+      const std::string &paramName = paramPair.first;
+      const std::vector<double> &values = paramPair.second;
+      const std::vector<double> &errors = parameterErrors[paramName];
+
+      auto &xData = matrixWs->mutableX(spectrumIndex);
+      for (size_t i = 0; i < numDataPoints; ++i) {
+        xData[i] = static_cast<double>(i);
+      }
+
+      auto &yData = matrixWs->mutableY(spectrumIndex);
+      std::copy(values.begin(), values.end(), yData.begin());
+
+      auto &eData = matrixWs->mutableE(spectrumIndex);
+      std::copy(errors.begin(), errors.end(), eData.begin());
+
+      textAxis->setLabel(spectrumIndex, paramName);
+
+      ++spectrumIndex;
+    }
+
+    matrixWs->replaceAxis(1, std::move(textAxis));
+    matrixWs->setTitle("Grouped Parameter Results");
+    matrixWs->getAxis(0)->setUnit("Empty");
+    matrixWs->setYUnitLabel("Parameter Value");
+
+    std::string outputWsName = this->m_baseName + "_ws";
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(outputWsName, matrixWs);
+  }
 }
 
 IFunction_sptr PlotPeakByLogValue::setupFunction(bool individual, bool passWSIndexToFunction,
@@ -342,26 +425,25 @@ IFunction_sptr PlotPeakByLogValue::setupFunction(bool individual, bool passWSInd
   return ifun;
 }
 
-void PlotPeakByLogValue::finaliseOutputWorkspaces(bool createFitOutput, const std::vector<std::string> &fitWorkspaces,
-                                                  const std::vector<std::string> &parameterWorkspaces,
-                                                  const std::vector<std::string> &covarianceWorkspaces,
-                                                  const std::string &range) {
-  if (createFitOutput) {
-    // collect output of fit for each spectrum into workspace groups
-    auto const groupAlg = this->createChildAlgorithm("GroupWorkspaces");
-    std::vector<std::pair<std::vector<std::string>, std::string>> groupingOperations = {
-        {covarianceWorkspaces, std::format("{}_NormalisedCovarianceMatrices", m_baseName)},
-        {parameterWorkspaces, std::format("{}_Parameters", m_baseName)},
-        {fitWorkspaces, std::format("{}_Workspaces", m_baseName)}};
+void PlotPeakByLogValue::finaliseOutputWorkspaces(const std::vector<MatrixWorkspace_sptr> &fitWorkspaces,
+                                                  const std::vector<ITableWorkspace_sptr> &paramsWorkspaces,
+                                                  const std::vector<ITableWorkspace_sptr> &covarianceWorkspaces) {
 
-    for (const auto &[inputWorkspaces, outputName] : groupingOperations) {
-      groupAlg->initialize();
-      groupAlg->setProperty("InputWorkspaces", inputWorkspaces);
-      groupAlg->setProperty("OutputWorkspace", outputName);
-      groupAlg->setAlwaysStoreInADS(true);
-      groupAlg->execute();
-    }
-  }
+  // collect output of fit for each spectrum into workspace groups
+  WorkspaceGroup_sptr covarianceGroup = std::make_shared<WorkspaceGroup>();
+  for (auto const &workspace : covarianceWorkspaces)
+    covarianceGroup->addWorkspace(workspace);
+  AnalysisDataService::Instance().addOrReplace(this->m_baseName + "_NormalisedCovarianceMatrices", covarianceGroup);
+
+  WorkspaceGroup_sptr parameterGroup = std::make_shared<WorkspaceGroup>();
+  for (auto const &workspace : paramsWorkspaces)
+    parameterGroup->addWorkspace(workspace);
+  AnalysisDataService::Instance().addOrReplace(this->m_baseName + "_Parameters", parameterGroup);
+
+  WorkspaceGroup_sptr fitGroup = std::make_shared<WorkspaceGroup>();
+  for (auto const &workspace : fitWorkspaces)
+    fitGroup->addWorkspace(workspace);
+  AnalysisDataService::Instance().addOrReplace(this->m_baseName + "_Workspaces", fitGroup);
 
   for (auto &minimizerWorkspace : this->m_minimizerWorkspaces) {
     const std::string paramName = minimizerWorkspace.first;
@@ -369,7 +451,55 @@ void PlotPeakByLogValue::finaliseOutputWorkspaces(bool createFitOutput, const st
     groupAlg->initialize();
     groupAlg->setProperty("InputWorkspaces", minimizerWorkspace.second);
     groupAlg->setProperty("OutputWorkspace", this->m_baseName + "_" + paramName);
+    groupAlg->execute();
+  }
+}
+
+void PlotPeakByLogValue::finaliseOutputWorkspacesWithAppend(const std::vector<std::string> &fitNames,
+                                                            const std::vector<std::string> &paramsNames,
+                                                            const std::vector<std::string> &covarianceNames,
+                                                            const std::vector<InputSpectraToFit> &wsNames) {
+
+  std::string range;
+
+  auto start = wsNames[0];
+  auto end = wsNames[wsNames.size() - 1];
+  if (start.sp != -1) {
+    range = wsNames.size() > 1 && start.sp != end.sp ? std::format("sp{:g}-{:g}", start.sp, end.sp)
+                                                     : std::format("sp{:g}", start.sp);
+  } else if (start.v != -1) {
+    range = wsNames.size() > 1 && start.v != end.v ? std::format("v{:g}-{:g}", start.v, end.v)
+                                                   : std::format("v{:g}", start.v);
+  } else {
+    range =
+        wsNames.size() > 1 && start.i != end.i ? std::format("i{}-{}", start.i, end.i) : "i" + std::to_string(start.i);
+  }
+
+  // collect output of fit for each spectrum into workspace groups
+  auto const groupAlg = this->createChildAlgorithm("GroupWorkspaces");
+  std::vector<std::pair<std::vector<std::string>, std::string>> groupingOperations = {
+      {covarianceNames, std::format("{}_{}_NormalisedCovarianceMatrices", m_baseName, range)},
+      {paramsNames, std::format("{}_{}_Parameters", m_baseName, range)},
+      {fitNames, std::format("{}_{}_Workspaces", m_baseName, range)}};
+
+  for (const auto &[inputWorkspaces, outputName] : groupingOperations) {
+    groupAlg->initialize();
+    groupAlg->setProperty("InputWorkspaces", inputWorkspaces);
+    groupAlg->setProperty("OutputWorkspace", outputName);
     groupAlg->setAlwaysStoreInADS(true);
+    groupAlg->execute();
+  }
+}
+
+void PlotPeakByLogValue::finaliseMinimizerOutput() {
+  auto const groupAlg = this->createChildAlgorithm("GroupWorkspaces");
+
+  for (auto &minimizerWorkspace : this->m_minimizerWorkspaces) {
+    const std::string paramName = minimizerWorkspace.first;
+    auto groupAlg = this->createChildAlgorithm("GroupWorkspaces");
+    groupAlg->initialize();
+    groupAlg->setProperty("InputWorkspaces", minimizerWorkspace.second);
+    groupAlg->setProperty("OutputWorkspace", this->m_baseName + "_" + paramName);
     groupAlg->execute();
   }
 }
@@ -466,9 +596,9 @@ ITableWorkspace_sptr PlotPeakByLogValue::createResultsTable(const std::string &l
 }
 
 std::shared_ptr<Algorithm> PlotPeakByLogValue::runSingleFit(bool createFitOutput, bool outputCompositeMembers,
-                                                            bool outputConvolvedMembers, const IFunction_sptr &ifun,
-                                                            const InputSpectraToFit &data, double startX, double endX,
-                                                            const std::string &exclude) {
+                                                            bool outputConvolvedMembers, bool appendIdx,
+                                                            const IFunction_sptr &ifun, const InputSpectraToFit &data,
+                                                            double startX, double endX, const std::string &exclude) {
   g_log.debug() << "Fitting " << data.ws->getName() << " index " << data.i << " with \n";
   g_log.debug() << ifun->asString() << '\n';
 
@@ -476,12 +606,14 @@ std::shared_ptr<Algorithm> PlotPeakByLogValue::runSingleFit(bool createFitOutput
 
   if (createFitOutput) {
     wsBaseName = data.name;
-    if (data.sp != -1) {
-      wsBaseName += "_" + std::format("sp{:g}", data.sp);
-    } else if (data.v != -1) {
-      wsBaseName += "_" + std::format("v{:g}", data.v);
-    } else {
-      wsBaseName += "_i" + std::to_string(data.i);
+    if (appendIdx) {
+      if (data.sp != -1) {
+        wsBaseName += "_" + std::format("sp{:g}", data.sp);
+      } else if (data.v != -1) {
+        wsBaseName += "_" + std::format("v{:g}", data.v);
+      } else {
+        wsBaseName += "_i" + std::to_string(data.i);
+      }
     }
   }
 
@@ -504,7 +636,7 @@ std::shared_ptr<Algorithm> PlotPeakByLogValue::runSingleFit(bool createFitOutput
   fit->setPropertyValue("PeakRadius", this->getPropertyValue("PeakRadius"));
   fit->setProperty("CalcErrors", true);
   fit->setProperty("CreateOutput", createFitOutput);
-  fit->setAlwaysStoreInADS(true);
+  fit->setAlwaysStoreInADS(createFitOutput && appendIdx);
   if (!histogramFit) {
     fit->setProperty("OutputCompositeMembers", outputCompositeMembers);
     fit->setProperty("ConvolveMembers", outputConvolvedMembers);

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -159,14 +159,15 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
   API::Axis *axis = ws->getAxis(1);
   if (axis->isSpectra()) {
     if (spectrumNumber < 0) {
-      for (int i = 0; i < axis->length(); ++i) {
-        auto s = double(axis->spectraNo(i));
-        if (s >= start && s <= end) {
-          nameList.emplace_back(name, i, s, -1, period, mws);
+      for (size_t i = 0; i < axis->length(); ++i) {
+        double spec = double(axis->spectraNo(i));
+        int wsIdx = static_cast<int>(i);
+        if (spec >= start && spec <= end) {
+          nameList.emplace_back(name, wsIdx, spec, -1, period, mws);
         }
       }
     } else {
-      for (int i = 0; i < axis->length(); ++i) {
+      for (size_t i = 0; i < axis->length(); ++i) {
         int j = axis->spectraNo(i);
         if (j == spectrumNumber) {
           nameList.emplace_back(name, i, j, -1, period, mws);
@@ -179,10 +180,11 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
       start = (*axis)(0);
       end = (*axis)(axis->length() - 1);
     }
-    for (int i = 0; i < axis->length(); ++i) {
-      double s = (*axis)(i);
-      if (s >= start && s <= end) {
-        nameList.emplace_back(name, i, -1, s, period, mws);
+    for (size_t i = 0; i < axis->length(); ++i) {
+      double value = (*axis)(i);
+      int wsIdx = static_cast<int>(i);
+      if (value >= start && value <= end) {
+        nameList.emplace_back(name, wsIdx, -1, value, period, mws);
       }
     }
   }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -169,8 +169,9 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
     } else {
       for (size_t i = 0; i < axis->length(); ++i) {
         int j = axis->spectraNo(i);
+        int wsIdx = static_cast<int>(i);
         if (j == spectrumNumber) {
-          nameList.emplace_back(name, i, j, -1, period, mws);
+          nameList.emplace_back(name, wsIdx, j, -1, period, mws);
           break;
         }
       }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -70,8 +70,8 @@ void parseValueRange(const std::string &index, double &start, double &end, int &
 
 void addGroupWorkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, int wi, int spec, int period,
                        const std::shared_ptr<API::WorkspaceGroup> &wsg);
-void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, std::string &name, int wi,
-                        int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
+void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, const std::string &name,
+                        int wi, int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
                         const std::shared_ptr<API::MatrixWorkspace> &wsMatrix);
 /// Create a list of input workspace names
 std::vector<InputSpectraToFit> makeNames(const std::string &inputList, int default_wi, int default_spec) {
@@ -119,8 +119,8 @@ std::vector<InputSpectraToFit> makeNames(const std::string &inputList, int defau
   }
   return nameList;
 }
-void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, std::string &name, int wi,
-                        int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
+void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, const std::string &name,
+                        int wi, int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
                         const std::shared_ptr<API::MatrixWorkspace> &wsMatrix) {
   appendInputSpectraToList(nameList, wsMatrix, wi, spec, start, end, period, workspaceOptional.has_value());
 }

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -158,6 +158,15 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
 
   API::Axis *axis = ws->getAxis(1);
   if (axis->isSpectra()) {
+    double specStart = axis->spectraNo(0);
+    double specEnd = axis->spectraNo(axis->length() - 1);
+
+    if (start < specStart || end > specEnd) {
+      // Invalid input range append dummy spectra
+      nameList.emplace_back("", -1, -1, -1, -1, nullptr);
+      return;
+    }
+
     if (spectrumNumber < 0) {
       for (size_t i = 0; i < axis->length(); ++i) {
         double spec = double(axis->spectraNo(i));
@@ -177,10 +186,20 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
       }
     }
   } else { // numeric axis
+    double numericStart = (*axis)(0);
+    double numericEnd = (*axis)(axis->length() - 1);
+
     if (workspaceIndex <= SpecialIndex::WHOLE_RANGE) {
-      start = (*axis)(0);
-      end = (*axis)(axis->length() - 1);
+      start = numericStart;
+      end = numericEnd;
     }
+
+    if (start < numericStart || end > numericEnd) {
+      // Invalid input range append dummy spectra
+      nameList.emplace_back("", -1, -1, -1, -1, nullptr);
+      return;
+    }
+
     for (size_t i = 0; i < axis->length(); ++i) {
       double value = (*axis)(i);
       int wsIdx = static_cast<int>(i);

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -158,16 +158,16 @@ void appendInputSpectraToList(std::vector<InputSpectraToFit> &nameList, const st
 
   API::Axis *axis = ws->getAxis(1);
   if (axis->isSpectra()) {
-    double specStart = axis->spectraNo(0);
-    double specEnd = axis->spectraNo(axis->length() - 1);
-
-    if (start < specStart || end > specEnd) {
-      // Invalid input range append dummy spectra
-      nameList.emplace_back("", -1, -1, -1, -1, nullptr);
-      return;
-    }
-
     if (spectrumNumber < 0) {
+      double specStart = axis->spectraNo(0);
+      double specEnd = axis->spectraNo(axis->length() - 1);
+
+      if (start < specStart || end > specEnd) {
+        // Invalid input range append dummy spectra
+        nameList.emplace_back("", -1, -1, -1, -1, nullptr);
+        return;
+      }
+
       for (size_t i = 0; i < axis->length(); ++i) {
         double spec = double(axis->spectraNo(i));
         int wsIdx = static_cast<int>(i);

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
@@ -54,15 +54,32 @@ public:
     std::string workspaceName = "irs26176_graphite002_red.nxs,v1.1:3.2";
 
     auto namesList = makeNames(workspaceName, -1, -1);
-    auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 2);
-    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 1);
-    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, 2);
-    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
+    TS_ASSERT_EQUALS(namesList[0].wsIdx, 1);
     TS_ASSERT_EQUALS(namesList[1].wsIdx, 2);
-    TS_ASSERT(inputWithWorkspace.ws);
-    TS_ASSERT_EQUALS(inputWithWorkspace.name, "irs26176_graphite002_red.nxs");
+    TS_ASSERT_EQUALS(namesList[0].spectrumNum, 2);
+    TS_ASSERT_EQUALS(namesList[1].spectrumNum, 3);
+    TS_ASSERT_EQUALS(namesList[0].numericValue, -1);
+    TS_ASSERT_EQUALS(namesList[1].numericValue, -1);
+    TS_ASSERT(namesList[0].ws);
+    TS_ASSERT(namesList[1].ws);
+    TS_ASSERT_EQUALS(namesList[0].name, "irs26176_graphite002_red.nxs");
+    TS_ASSERT_EQUALS(namesList[1].name, "irs26176_graphite002_red.nxs");
+  }
+
+  void testWorkspaceRangeSpecifiedSpectrumAxisOutOfBounds() {
+    std::string workspaceName = "irs26176_graphite002_red.nxs,v-1.1:3.2";
+
+    auto namesList = makeNames(workspaceName, -1, -1);
+    auto inputWithWorkspace = namesList[0];
+
+    TS_ASSERT_EQUALS(namesList.size(), 1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, -1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
+    TS_ASSERT(!inputWithWorkspace.ws);
+    TS_ASSERT_EQUALS(inputWithWorkspace.name, "");
   }
 
   void testWorkspaceIndexNumericAxis() {
@@ -98,15 +115,22 @@ public:
     std::string workspaceName = "saveNISTDAT_data.nxs";
 
     auto namesList = makeNames(workspaceName, -2, -2);
-    auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 321);
-    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 0);
-    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
-    TS_ASSERT_DELTA(inputWithWorkspace.numericValue, -0.16, 1e-3);
+
+    TS_ASSERT_EQUALS(namesList[0].wsIdx, 0);
+    TS_ASSERT_EQUALS(namesList[0].spectrumNum, -1);
+    TS_ASSERT_DELTA(namesList[0].numericValue, -0.16, 1e-3);
+
     TS_ASSERT_EQUALS(namesList[200].wsIdx, 200);
-    TS_ASSERT(inputWithWorkspace.ws);
-    TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
+    TS_ASSERT_DELTA(namesList[200].numericValue, 0.04, 1e-3);
+    TS_ASSERT_EQUALS(namesList[200].spectrumNum, -1);
+
+    TS_ASSERT(namesList[0].ws);
+    TS_ASSERT_EQUALS(namesList[0].name, "saveNISTDAT_data.nxs");
+
+    TS_ASSERT(namesList[200].ws);
+    TS_ASSERT_EQUALS(namesList[200].name, "saveNISTDAT_data.nxs");
   }
 
   void testWorkspaceRangeSpecifiedNumericAxis() {
@@ -116,11 +140,31 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 19);
-    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 151);
+
+    TS_ASSERT_EQUALS(namesList[0].wsIdx, 151);
+    TS_ASSERT_EQUALS(namesList[0].spectrumNum, -1);
+    TS_ASSERT_DELTA(namesList[0].numericValue, -0.01, 1e-3);
+    TS_ASSERT(namesList[0].ws);
+    TS_ASSERT_EQUALS(namesList[0].name, "saveNISTDAT_data.nxs");
+
+    TS_ASSERT_EQUALS(namesList[18].wsIdx, 169);
+    TS_ASSERT_EQUALS(namesList[18].spectrumNum, -1);
+    TS_ASSERT_DELTA(namesList[18].numericValue, 0.01, 1e-3);
+    TS_ASSERT(namesList[18].ws);
+    TS_ASSERT_EQUALS(namesList[18].name, "saveNISTDAT_data.nxs");
+  }
+
+  void testWorkspaceRangeSpecifiedNumericAxisOutOfBounds() {
+    std::string workspaceName = "saveNISTDAT_data.nxs,v-0.01:100";
+
+    auto namesList = makeNames(workspaceName, -1, -1);
+    auto inputWithWorkspace = namesList[0];
+
+    TS_ASSERT_EQUALS(namesList.size(), 1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, -1);
     TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
-    TS_ASSERT_DELTA(inputWithWorkspace.numericValue, -0.01, 1e-3);
-    TS_ASSERT_EQUALS(namesList[15].wsIdx, 166);
-    TS_ASSERT(inputWithWorkspace.ws);
-    TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
+    TS_ASSERT(!inputWithWorkspace.ws);
+    TS_ASSERT_EQUALS(inputWithWorkspace.name, "");
   }
 };

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
@@ -29,7 +29,9 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 1);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "irs26176_graphite002_red.nxs");
   }
@@ -41,7 +43,9 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 1);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, 1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "irs26176_graphite002_red.nxs");
   }
@@ -53,8 +57,10 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 2);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 1);
-    TS_ASSERT_EQUALS(namesList[1].i, 2);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, 2);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
+    TS_ASSERT_EQUALS(namesList[1].wsIdx, 2);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "irs26176_graphite002_red.nxs");
   }
@@ -66,7 +72,10 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 1);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, -1);
+
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
   }
@@ -78,7 +87,9 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 1);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 160);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 160);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_EQUALS(inputWithWorkspace.numericValue, 0);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
   }
@@ -90,8 +101,10 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 321);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 0);
-    TS_ASSERT_EQUALS(namesList[200].i, 200);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 0);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_DELTA(inputWithWorkspace.numericValue, -0.16, 1e-3);
+    TS_ASSERT_EQUALS(namesList[200].wsIdx, 200);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
   }
@@ -103,8 +116,10 @@ public:
     auto inputWithWorkspace = namesList[0];
 
     TS_ASSERT_EQUALS(namesList.size(), 19);
-    TS_ASSERT_EQUALS(inputWithWorkspace.i, 151);
-    TS_ASSERT_EQUALS(namesList[15].i, 166);
+    TS_ASSERT_EQUALS(inputWithWorkspace.wsIdx, 151);
+    TS_ASSERT_EQUALS(inputWithWorkspace.spectrumNum, -1);
+    TS_ASSERT_DELTA(inputWithWorkspace.numericValue, -0.01, 1e-3);
+    TS_ASSERT_EQUALS(namesList[15].wsIdx, 166);
     TS_ASSERT(inputWithWorkspace.ws);
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
   }

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -101,322 +101,323 @@ public:
 
   PlotPeakByLogValueTest() { FrameworkManager::Instance(); }
 
-  void testWorkspaceGroup() {
-    createData();
+  // void testWorkspaceGroup() {
+  //   createData();
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setPropertyValue("WorkspaceIndex", "1");
-    alg.setPropertyValue("LogValue", "var");
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-                                     "1");
-    alg.execute();
-    TS_ASSERT(alg.isExecuted());
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setPropertyValue("WorkspaceIndex", "1");
+  //   alg.setPropertyValue("LogValue", "var");
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+  //                                    "1");
+  //   alg.execute();
+  //   TS_ASSERT(alg.isExecuted());
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT_EQUALS(result->columnCount(), 14);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    std::vector<std::string> tnames = result->getColumnNames();
-    TS_ASSERT_EQUALS(tnames.size(), 14);
-    TS_ASSERT_EQUALS(tnames[0], "var");
-    TS_ASSERT_EQUALS(tnames[1], "f0.A0");
-    TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
-    TS_ASSERT_EQUALS(tnames[3], "f0.A1");
-    TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
-    TS_ASSERT_EQUALS(tnames[5], "f1.Height");
-    TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
-    TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
-    TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
-    TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
-    TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
-    TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
-    TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
-    TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
+  //   std::vector<std::string> tnames = result->getColumnNames();
+  //   TS_ASSERT_EQUALS(tnames.size(), 14);
+  //   TS_ASSERT_EQUALS(tnames[0], "var");
+  //   TS_ASSERT_EQUALS(tnames[1], "f0.A0");
+  //   TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
+  //   TS_ASSERT_EQUALS(tnames[3], "f0.A1");
+  //   TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
+  //   TS_ASSERT_EQUALS(tnames[5], "f1.Height");
+  //   TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
+  //   TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
+  //   TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
+  //   TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
+  //   TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
+  //   TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
+  //   TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
+  //   TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
 
-    TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
 
-    TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
 
-    TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
 
-    /* Check intensity column: */
-    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+  //   /* Check intensity column: */
+  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void testWorkspaceList() {
-    createData();
+  // void testWorkspaceList() {
+  //   createData();
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setPropertyValue("WorkspaceIndex", "1");
-    alg.setPropertyValue("LogValue", "var");
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-                                     "1");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setPropertyValue("WorkspaceIndex", "1");
+  //   alg.setPropertyValue("LogValue", "var");
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+  //                                    "1");
+  //   alg.execute();
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT_EQUALS(result->columnCount(), 14);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    std::vector<std::string> tnames = result->getColumnNames();
-    TS_ASSERT_EQUALS(tnames.size(), 14);
-    TS_ASSERT_EQUALS(tnames[0], "var");
-    TS_ASSERT_EQUALS(tnames[1], "f0.A0");
-    TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
-    TS_ASSERT_EQUALS(tnames[3], "f0.A1");
-    TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
-    TS_ASSERT_EQUALS(tnames[5], "f1.Height");
-    TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
-    TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
-    TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
-    TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
-    TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
-    TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
-    TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
-    TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
+  //   std::vector<std::string> tnames = result->getColumnNames();
+  //   TS_ASSERT_EQUALS(tnames.size(), 14);
+  //   TS_ASSERT_EQUALS(tnames[0], "var");
+  //   TS_ASSERT_EQUALS(tnames[1], "f0.A0");
+  //   TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
+  //   TS_ASSERT_EQUALS(tnames[3], "f0.A1");
+  //   TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
+  //   TS_ASSERT_EQUALS(tnames[5], "f1.Height");
+  //   TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
+  //   TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
+  //   TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
+  //   TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
+  //   TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
+  //   TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
+  //   TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
+  //   TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
 
-    TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
-    TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
 
-    TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
-    TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
 
-    TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
-    TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
+  //   TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
 
-    /* Check intensity column: */
-    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+  //   /* Check intensity column: */
+  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void testWorkspaceList_plotting_against_ws_names() {
-    createData();
+  // void testWorkspaceList_plotting_against_ws_names() {
+  //   createData();
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setPropertyValue("WorkspaceIndex", "1");
-    alg.setPropertyValue("LogValue", "SourceName");
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-                                     "1");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setPropertyValue("WorkspaceIndex", "1");
+  //   alg.setPropertyValue("LogValue", "SourceName");
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+  //                                    "1");
+  //   alg.execute();
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT_EQUALS(result->columnCount(), 14);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    std::vector<std::string> tnames = result->getColumnNames();
-    TS_ASSERT_EQUALS(tnames.size(), 14);
-    TS_ASSERT_EQUALS(tnames[0], "SourceName");
+  //   std::vector<std::string> tnames = result->getColumnNames();
+  //   TS_ASSERT_EQUALS(tnames.size(), 14);
+  //   TS_ASSERT_EQUALS(tnames[0], "SourceName");
 
-    TS_ASSERT_EQUALS(result->String(0, 0), "PlotPeakGroup_0");
-    TS_ASSERT_EQUALS(result->String(1, 0), "PlotPeakGroup_1");
-    TS_ASSERT_EQUALS(result->String(2, 0), "PlotPeakGroup_2");
+  //   TS_ASSERT_EQUALS(result->String(0, 0), "PlotPeakGroup_0");
+  //   TS_ASSERT_EQUALS(result->String(1, 0), "PlotPeakGroup_1");
+  //   TS_ASSERT_EQUALS(result->String(2, 0), "PlotPeakGroup_2");
 
-    /* Check intensity column: */
-    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+  //   /* Check intensity column: */
+  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void testSpectraList_plotting_against_bin_edge_axis() {
-    auto ws = createTestWorkspace();
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  // void testSpectraList_plotting_against_bin_edge_axis() {
+  //   auto ws = createTestWorkspace();
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,i0;PLOTPEAKBYLOGVALUETEST_WS,i1");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-                                     "1");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,i0;PLOTPEAKBYLOGVALUETEST_WS,i1");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+  //                                    "1");
+  //   alg.execute();
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT_EQUALS(result->columnCount(), 14);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    std::vector<std::string> tnames = result->getColumnNames();
-    TS_ASSERT_EQUALS(tnames.size(), 14);
-    TS_ASSERT_EQUALS(tnames[0], "axis-1");
+  //   std::vector<std::string> tnames = result->getColumnNames();
+  //   TS_ASSERT_EQUALS(tnames.size(), 14);
+  //   TS_ASSERT_EQUALS(tnames[0], "axis-1");
 
-    TS_ASSERT_EQUALS(result->Double(0, 0), 0.5);
-    TS_ASSERT_EQUALS(result->Double(1, 0), 3.0);
+  //   TS_ASSERT_EQUALS(result->Double(0, 0), 0.5);
+  //   TS_ASSERT_EQUALS(result->Double(1, 0), 3.0);
 
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-    WorkspaceCreationHelper::removeWS("PLOTPEAKBYLOGVALUETEST_WS");
-  }
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  //   WorkspaceCreationHelper::removeWS("PLOTPEAKBYLOGVALUETEST_WS");
+  // }
 
-  void test_passWorkspaceIndexToFunction() {
-    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("PassWSIndexToFunction", true);
-    alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
-    alg.execute();
+  // void test_passWorkspaceIndexToFunction() {
+  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("PassWSIndexToFunction", true);
+  //   alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT(result);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT(result);
 
-    // each spectrum contains values equal to its spectrum number (from 1 to 3)
-    TableRow row = result->getFirstRow();
-    do {
-      TS_ASSERT_DELTA(row.Double(1), 1.0, 1e-15);
-    } while (row.next());
+  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
+  //   TableRow row = result->getFirstRow();
+  //   do {
+  //     TS_ASSERT_DELTA(row.Double(1), 1.0, 1e-15);
+  //   } while (row.next());
 
-    AnalysisDataService::Instance().clear();
-  }
+  //   AnalysisDataService::Instance().clear();
+  // }
 
-  void test_dont_passWorkspaceIndexToFunction() {
-    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("PassWSIndexToFunction", false);
-    alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
-    alg.execute();
+  // void test_dont_passWorkspaceIndexToFunction() {
+  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("PassWSIndexToFunction", false);
+  //   alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT(result);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT(result);
 
-    // each spectrum contains values equal to its spectrum number (from 1 to 3)
-    double a = 1.0;
-    TableRow row = result->getFirstRow();
-    do {
-      TS_ASSERT_DELTA(row.Double(1), a, 1e-15);
-      a += 1.0;
-    } while (row.next());
+  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
+  //   double a = 1.0;
+  //   TableRow row = result->getFirstRow();
+  //   do {
+  //     TS_ASSERT_DELTA(row.Double(1), a, 1e-15);
+  //     a += 1.0;
+  //   } while (row.next());
 
-    AnalysisDataService::Instance().clear();
-  }
+  //   AnalysisDataService::Instance().clear();
+  // }
 
-  void test_passWorkspaceIndexToFunction_composit_function_case() {
-    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("PassWSIndexToFunction", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
-    alg.execute();
+  // void test_passWorkspaceIndexToFunction_composit_function_case() {
+  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("PassWSIndexToFunction", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT(result);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT(result);
 
-    // each spectrum contains values equal to its spectrum number (from 1 to 3)
-    TableRow row = result->getFirstRow();
-    do {
-      TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
-    } while (row.next());
+  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
+  //   TableRow row = result->getFirstRow();
+  //   do {
+  //     TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
+  //   } while (row.next());
 
-    AnalysisDataService::Instance().clear();
-  }
+  //   AnalysisDataService::Instance().clear();
+  // }
 
-  void test_createOutputOption() {
-    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("PassWSIndexToFunction", true);
-    alg.setProperty("CreateOutput", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
-    alg.execute();
+  // void test_createOutputOption() {
+  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("PassWSIndexToFunction", true);
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-    TS_ASSERT(result);
+  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+  //   TS_ASSERT(result);
 
-    // each spectrum contains values equal to its spectrum number (from 1 to 3)
-    TableRow row = result->getFirstRow();
-    do {
-      TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
-    } while (row.next());
+  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
+  //   TableRow row = result->getFirstRow();
+  //   do {
+  //     TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
+  //   } while (row.next());
 
-    auto matrices =
-        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
-    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
+  //   auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+  //       "PlotPeakResult_sp1-3_NormalisedCovarianceMatrices");
+  //   auto params = AnalysisDataService::Instance().retrieveWS<const
+  //   WorkspaceGroup>("PlotPeakResult_sp1-3_Parameters"); auto fits = AnalysisDataService::Instance().retrieveWS<const
+  //   WorkspaceGroup>("PlotPeakResult_sp1-3_Workspaces");
 
-    TS_ASSERT(matrices);
-    TS_ASSERT(params);
-    TS_ASSERT(fits);
+  //   TS_ASSERT(matrices);
+  //   TS_ASSERT(params);
+  //   TS_ASSERT(fits);
 
-    TS_ASSERT(matrices->getNames().size() == 3);
-    TS_ASSERT(params->getNames().size() == 3);
-    TS_ASSERT(fits->getNames().size() == 3);
+  //   TS_ASSERT(matrices->getNames().size() == 3);
+  //   TS_ASSERT(params->getNames().size() == 3);
+  //   TS_ASSERT(fits->getNames().size() == 3);
 
-    auto matricesNames = matrices->getNames();
-    auto paramsNames = params->getNames();
-    auto wsNames = fits->getNames();
+  //   auto matricesNames = matrices->getNames();
+  //   auto paramsNames = params->getNames();
+  //   auto wsNames = fits->getNames();
 
-    for (int i = 0; i < 3; i++) {
-      auto specNum = std::to_string(i);
-      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_NormalisedCovarianceMatrix");
-      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Parameters");
-      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Workspace");
-    }
+  //   for (int i = 0; i < matrices->getNames().size(); i++) {
+  //     auto specNum = std::to_string(i + 1);
+  //     TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
+  //     TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
+  //     TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Workspace");
+  //   }
 
-    AnalysisDataService::Instance().clear();
-  }
+  //   AnalysisDataService::Instance().clear();
+  // }
 
   void test_createOutputOptionMultipleWorkspaces() {
     createData();
@@ -436,10 +437,10 @@ public:
     TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
     TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    auto matrices =
-        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
-    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
+    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+        "PlotPeakResult_i1_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Workspaces");
 
     TS_ASSERT(matrices);
     TS_ASSERT(params);
@@ -453,11 +454,11 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < matrices->getNames().size(); i++) {
       auto wsIdx = std::to_string(i);
-      TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_1_NormalisedCovarianceMatrix");
-      TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_1_Parameters");
-      TS_ASSERT_EQUALS(wsNames[i], "PlotPeakGroup_" + wsIdx + "_1_Workspace");
+      TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_i1_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Workspace");
     }
 
     AnalysisDataService::Instance().clear();
@@ -485,10 +486,10 @@ public:
     TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
     TS_ASSERT(result);
 
-    auto matrices =
-        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
-    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
+    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+        "PlotPeakResult_v0-1_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Workspaces");
 
     TS_ASSERT(matrices);
     TS_ASSERT(params);
@@ -502,11 +503,11 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < 2; i++) {
-      auto specNum = std::to_string(i);
-      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_NormalisedCovarianceMatrix");
-      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Parameters");
-      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Workspace");
+    for (int i = 0; i < matrices->getNames().size(); i++) {
+      auto vIdx = std::to_string(i);
+      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_v" + vIdx + "_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_v" + vIdx + "_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_v" + vIdx + "_Workspace");
     }
 
     for (const auto &wsName : wsNames) {
@@ -537,143 +538,143 @@ public:
     alg.execute();
     TS_ASSERT(alg.isExecuted());
 
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Workspaces");
     TS_ASSERT(fits);
 
     if (fits->size() > 0) {
       auto fit = fits->getItem(0);
       TS_ASSERT_EQUALS(fit->history().size(), 0);
-      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakGroup_0_1_Workspace");
+      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakGroup_0_i1_Workspace");
     }
 
     AnalysisDataService::Instance().clear();
   }
 
-  void test_parameters_are_correct_for_a_histogram_fit() {
-    createHistogramWorkspace("InputWS", 10, -10.0, 10.0);
+  // void test_parameters_are_correct_for_a_histogram_fit() {
+  //   createHistogramWorkspace("InputWS", 10, -10.0, 10.0);
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setAlwaysStoreInADS(false);
-    alg.setProperty("EvaluationType", "Histogram");
-    alg.setPropertyValue("Input", "InputWS,v1:3");
-    alg.setPropertyValue("OutputWorkspace", "out");
-    alg.setProperty("CreateOutput", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setAlwaysStoreInADS(false);
+  //   alg.setProperty("EvaluationType", "Histogram");
+  //   alg.setPropertyValue("Input", "InputWS,v1:3");
+  //   alg.setPropertyValue("OutputWorkspace", "out");
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+  //   alg.execute();
 
-    ITableWorkspace_sptr params = alg.getProperty("OutputWorkspace");
-    TS_ASSERT_DELTA(params->Double(0, 1), 1.0, 1e-15);
-    TS_ASSERT_DELTA(params->Double(1, 1), 1.1, 1e-15);
-    TS_ASSERT_DELTA(params->Double(2, 1), 0.6, 1e-15);
+  //   ITableWorkspace_sptr params = alg.getProperty("OutputWorkspace");
+  //   TS_ASSERT_DELTA(params->Double(0, 1), 1.0, 1e-15);
+  //   TS_ASSERT_DELTA(params->Double(1, 1), 1.1, 1e-15);
+  //   TS_ASSERT_DELTA(params->Double(2, 1), 0.6, 1e-15);
 
-    AnalysisDataService::Instance().clear();
-  }
+  //   AnalysisDataService::Instance().clear();
+  // }
 
-  void test_single_exclude_range_single_Spectra() {
-    createData();
+  // void test_single_exclude_range_single_Spectra() {
+  //   createData();
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup_0");
-    alg.setPropertyValue("Exclude", "-0.5, 0.5");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("CreateOutput", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-    alg.setPropertyValue("MaxIterations", "50");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup_0");
+  //   alg.setPropertyValue("Exclude", "-0.5, 0.5");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+  //   alg.setPropertyValue("MaxIterations", "50");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void test_single_exclude_range_multiple_Spectra() {
-    createData();
+  // void test_single_exclude_range_multiple_Spectra() {
+  //   createData();
 
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
-    alg.setPropertyValue("Exclude", "-0.5, 0.5");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("CreateOutput", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-    alg.setPropertyValue("MaxIterations", "50");
-    alg.execute();
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
+  //   alg.setPropertyValue("Exclude", "-0.5, 0.5");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+  //   alg.setPropertyValue("MaxIterations", "50");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void test_multiple_exclude_range_multiple_Spectra() {
-    createData();
-    std::vector<std::string> excludeRanges;
-    excludeRanges.emplace_back("-0.5, 0.0");
-    excludeRanges.emplace_back("0.5, 1.5");
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
-    alg.setProperty("ExcludeMultiple", excludeRanges);
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("CreateOutput", true);
-    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-    alg.setPropertyValue("MaxIterations", "50");
-    alg.execute();
+  // void test_multiple_exclude_range_multiple_Spectra() {
+  //   createData();
+  //   std::vector<std::string> excludeRanges;
+  //   excludeRanges.emplace_back("-0.5, 0.0");
+  //   excludeRanges.emplace_back("0.5, 1.5");
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
+  //   alg.setProperty("ExcludeMultiple", excludeRanges);
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+  //   alg.setPropertyValue("MaxIterations", "50");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
+  //   TS_ASSERT(alg.isExecuted());
 
-    deleteData();
-    WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  }
+  //   deleteData();
+  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  // }
 
-  void test_startX_single_value() {
-    auto ws = createTestWorkspace();
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("StartX", "1000.0");
-    alg.setProperty("EndX", "3000.0");
-    alg.setProperty("PassWSIndexToFunction", true);
-    alg.setProperty("CreateOutput", true);
-    alg.setProperty("OutputCompositeMembers", true);
-    alg.setProperty("ConvolveMembers", true);
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
-                                     "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                                     "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
-                                     "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
-    alg.execute();
+  // void test_startX_single_value() {
+  //   auto ws = createTestWorkspace();
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("StartX", "1000.0");
+  //   alg.setProperty("EndX", "3000.0");
+  //   alg.setProperty("PassWSIndexToFunction", true);
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setProperty("OutputCompositeMembers", true);
+  //   alg.setProperty("ConvolveMembers", true);
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
+  //                                    "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+  //                                    "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
+  //                                    "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
-    AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
-  }
+  //   TS_ASSERT(alg.isExecuted());
+  //   AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
+  // }
 
-  void test_startX_multiple_value() {
-    auto ws = createTestWorkspace();
-    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-    PlotPeakByLogValue alg;
-    alg.initialize();
-    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
-    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-    alg.setProperty("StartX", "1000.0,1000.0");
-    alg.setProperty("EndX", "3000.0,3000.0");
-    alg.setProperty("PassWSIndexToFunction", true);
-    alg.setProperty("CreateOutput", true);
-    alg.setProperty("OutputCompositeMembers", true);
-    alg.setProperty("ConvolveMembers", true);
-    alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
-                                     "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                                     "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
-                                     "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
-    alg.execute();
+  // void test_startX_multiple_value() {
+  //   auto ws = createTestWorkspace();
+  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  //   PlotPeakByLogValue alg;
+  //   alg.initialize();
+  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
+  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+  //   alg.setProperty("StartX", "1000.0,1000.0");
+  //   alg.setProperty("EndX", "3000.0,3000.0");
+  //   alg.setProperty("PassWSIndexToFunction", true);
+  //   alg.setProperty("CreateOutput", true);
+  //   alg.setProperty("OutputCompositeMembers", true);
+  //   alg.setProperty("ConvolveMembers", true);
+  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
+  //                                    "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+  //                                    "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
+  //                                    "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
+  //   alg.execute();
 
-    TS_ASSERT(alg.isExecuted());
-    AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
-  }
+  //   TS_ASSERT(alg.isExecuted());
+  //   AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
+  // }
 
 private:
   WorkspaceGroup_sptr m_wsg;

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -525,7 +525,7 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < matrices->getNames().size(); i++) {
+    for (size_t i = 0; i < matrices->getNames().size(); i++) {
       auto specNum = std::to_string(i + 1);
       TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
       TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
@@ -571,7 +571,7 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < matrices->getNames().size(); i++) {
+    for (size_t i = 0; i < matrices->getNames().size(); i++) {
       auto wsIdx = std::to_string(i);
       TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_i1_NormalisedCovarianceMatrix");
       TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Parameters");
@@ -621,7 +621,7 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < matrices->getNames().size(); i++) {
+    for (size_t i = 0; i < matrices->getNames().size(); i++) {
       auto vIdx = std::to_string(i);
       TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_v" + vIdx + "_NormalisedCovarianceMatrix");
       TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_v" + vIdx + "_Parameters");
@@ -679,7 +679,7 @@ public:
     auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
 
-    for (int i = 0; i < matrices->getNames().size(); i++) {
+    for (size_t i = 0; i < matrices->getNames().size(); i++) {
       auto specNum = std::to_string(i + 1);
       TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
       TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -404,6 +404,17 @@ public:
     TS_ASSERT(params->getNames().size() == 3);
     TS_ASSERT(fits->getNames().size() == 3);
 
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
+    auto wsNames = fits->getNames();
+
+    for (int i = 0; i < 3; i++) {
+      auto specNum = std::to_string(i);
+      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Workspace");
+    }
+
     AnalysisDataService::Instance().clear();
   }
 
@@ -437,6 +448,19 @@ public:
     TS_ASSERT(matrices->getNames().size() == 3);
     TS_ASSERT(params->getNames().size() == 3);
     TS_ASSERT(fits->getNames().size() == 3);
+
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
+    auto wsNames = fits->getNames();
+
+    for (int i = 0; i < 3; i++) {
+      auto wsIdx = std::to_string(i);
+      TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_1_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_1_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PlotPeakGroup_" + wsIdx + "_1_Workspace");
+    }
+
+    AnalysisDataService::Instance().clear();
   }
 
   void test_createOutputWithExtraOutputOptions() {
@@ -474,7 +498,17 @@ public:
     TS_ASSERT(params->getNames().size() == 2);
     TS_ASSERT(fits->getNames().size() == 2);
 
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
     auto wsNames = fits->getNames();
+
+    for (int i = 0; i < 2; i++) {
+      auto specNum = std::to_string(i);
+      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_" + specNum + "_Workspace");
+    }
+
     for (const auto &wsName : wsNames) {
       auto fit = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(wsName);
       TS_ASSERT(fit);
@@ -509,7 +543,7 @@ public:
     if (fits->size() > 0) {
       auto fit = fits->getItem(0);
       TS_ASSERT_EQUALS(fit->history().size(), 0);
-      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakResult_Workspaces_1");
+      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakGroup_0_1_Workspace");
     }
 
     AnalysisDataService::Instance().clear();

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -101,323 +101,322 @@ public:
 
   PlotPeakByLogValueTest() { FrameworkManager::Instance(); }
 
-  // void testWorkspaceGroup() {
-  //   createData();
+  void testWorkspaceGroup() {
+    createData();
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setPropertyValue("WorkspaceIndex", "1");
-  //   alg.setPropertyValue("LogValue", "var");
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-  //                                    "1");
-  //   alg.execute();
-  //   TS_ASSERT(alg.isExecuted());
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setPropertyValue("WorkspaceIndex", "1");
+    alg.setPropertyValue("LogValue", "var");
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+                                     "1");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-  //   std::vector<std::string> tnames = result->getColumnNames();
-  //   TS_ASSERT_EQUALS(tnames.size(), 14);
-  //   TS_ASSERT_EQUALS(tnames[0], "var");
-  //   TS_ASSERT_EQUALS(tnames[1], "f0.A0");
-  //   TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
-  //   TS_ASSERT_EQUALS(tnames[3], "f0.A1");
-  //   TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
-  //   TS_ASSERT_EQUALS(tnames[5], "f1.Height");
-  //   TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
-  //   TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
-  //   TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
-  //   TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
-  //   TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
-  //   TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
-  //   TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
-  //   TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
+    std::vector<std::string> tnames = result->getColumnNames();
+    TS_ASSERT_EQUALS(tnames.size(), 14);
+    TS_ASSERT_EQUALS(tnames[0], "var");
+    TS_ASSERT_EQUALS(tnames[1], "f0.A0");
+    TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
+    TS_ASSERT_EQUALS(tnames[3], "f0.A1");
+    TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
+    TS_ASSERT_EQUALS(tnames[5], "f1.Height");
+    TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
+    TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
+    TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
+    TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
+    TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
+    TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
+    TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
+    TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
 
-  //   TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
 
-  //   TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
 
-  //   TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
 
-  //   /* Check intensity column: */
-  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+    /* Check intensity column: */
+    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void testWorkspaceList() {
-  //   createData();
+  void testWorkspaceList() {
+    createData();
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setPropertyValue("WorkspaceIndex", "1");
-  //   alg.setPropertyValue("LogValue", "var");
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-  //                                    "1");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setPropertyValue("WorkspaceIndex", "1");
+    alg.setPropertyValue("LogValue", "var");
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+                                     "1");
+    alg.execute();
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-  //   std::vector<std::string> tnames = result->getColumnNames();
-  //   TS_ASSERT_EQUALS(tnames.size(), 14);
-  //   TS_ASSERT_EQUALS(tnames[0], "var");
-  //   TS_ASSERT_EQUALS(tnames[1], "f0.A0");
-  //   TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
-  //   TS_ASSERT_EQUALS(tnames[3], "f0.A1");
-  //   TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
-  //   TS_ASSERT_EQUALS(tnames[5], "f1.Height");
-  //   TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
-  //   TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
-  //   TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
-  //   TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
-  //   TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
-  //   TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
-  //   TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
-  //   TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
+    std::vector<std::string> tnames = result->getColumnNames();
+    TS_ASSERT_EQUALS(tnames.size(), 14);
+    TS_ASSERT_EQUALS(tnames[0], "var");
+    TS_ASSERT_EQUALS(tnames[1], "f0.A0");
+    TS_ASSERT_EQUALS(tnames[2], "f0.A0_Err");
+    TS_ASSERT_EQUALS(tnames[3], "f0.A1");
+    TS_ASSERT_EQUALS(tnames[4], "f0.A1_Err");
+    TS_ASSERT_EQUALS(tnames[5], "f1.Height");
+    TS_ASSERT_EQUALS(tnames[6], "f1.Height_Err");
+    TS_ASSERT_EQUALS(tnames[7], "f1.PeakCentre");
+    TS_ASSERT_EQUALS(tnames[8], "f1.PeakCentre_Err");
+    TS_ASSERT_EQUALS(tnames[9], "f1.Sigma");
+    TS_ASSERT_EQUALS(tnames[10], "f1.Sigma_Err");
+    TS_ASSERT_EQUALS(tnames[11], "f1.Integrated Intensity");
+    TS_ASSERT_EQUALS(tnames[12], "f1.Integrated Intensity_Err");
+    TS_ASSERT_EQUALS(tnames[13], "Chi_squared");
 
-  //   TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 0), 1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 1), 1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 3), 0.3, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 5), 2, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 7), 5, 1e-10);
+    TS_ASSERT_DELTA(result->Double(0, 9), 0.1, 1e-10);
 
-  //   TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 0), 1.3, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 1), 1.1, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 3), 0.28, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 5), 1.8, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 7), 5.03, 1e-10);
+    TS_ASSERT_DELTA(result->Double(1, 9), 0.11, 1e-10);
 
-  //   TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
-  //   TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 0), 1.6, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 1), 1.2, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 3), 0.26, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 5), 1.6, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 7), 5.06, 1e-10);
+    TS_ASSERT_DELTA(result->Double(2, 9), 0.12, 1e-10);
 
-  //   /* Check intensity column: */
-  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+    /* Check intensity column: */
+    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void testWorkspaceList_plotting_against_ws_names() {
-  //   createData();
+  void testWorkspaceList_plotting_against_ws_names() {
+    createData();
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setPropertyValue("WorkspaceIndex", "1");
-  //   alg.setPropertyValue("LogValue", "SourceName");
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-  //                                    "1");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setPropertyValue("WorkspaceIndex", "1");
+    alg.setPropertyValue("LogValue", "SourceName");
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+                                     "1");
+    alg.execute();
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-  //   std::vector<std::string> tnames = result->getColumnNames();
-  //   TS_ASSERT_EQUALS(tnames.size(), 14);
-  //   TS_ASSERT_EQUALS(tnames[0], "SourceName");
+    std::vector<std::string> tnames = result->getColumnNames();
+    TS_ASSERT_EQUALS(tnames.size(), 14);
+    TS_ASSERT_EQUALS(tnames[0], "SourceName");
 
-  //   TS_ASSERT_EQUALS(result->String(0, 0), "PlotPeakGroup_0");
-  //   TS_ASSERT_EQUALS(result->String(1, 0), "PlotPeakGroup_1");
-  //   TS_ASSERT_EQUALS(result->String(2, 0), "PlotPeakGroup_2");
+    TS_ASSERT_EQUALS(result->String(0, 0), "PlotPeakGroup_0");
+    TS_ASSERT_EQUALS(result->String(1, 0), "PlotPeakGroup_1");
+    TS_ASSERT_EQUALS(result->String(2, 0), "PlotPeakGroup_2");
 
-  //   /* Check intensity column: */
-  //   TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
-  //   TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
+    /* Check intensity column: */
+    TS_ASSERT_DELTA(result->Double(0, 11), 0.501326, 1e-6);
+    TS_ASSERT_DELTA(result->Double(1, 11), 0.496312, 1e-6);
+    TS_ASSERT_DELTA(result->Double(2, 11), 0.481273, 1e-6);
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void testSpectraList_plotting_against_bin_edge_axis() {
-  //   auto ws = createTestWorkspace();
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+  void testSpectraList_plotting_against_bin_edge_axis() {
+    auto ws = createTestWorkspace();
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,i0;PLOTPEAKBYLOGVALUETEST_WS,i1");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
-  //                                    "Gaussian,PeakCentre=5,Height=2,Sigma=0."
-  //                                    "1");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,i0;PLOTPEAKBYLOGVALUETEST_WS,i1");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+                                     "1");
+    alg.execute();
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT_EQUALS(result->columnCount(), 14);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-  //   std::vector<std::string> tnames = result->getColumnNames();
-  //   TS_ASSERT_EQUALS(tnames.size(), 14);
-  //   TS_ASSERT_EQUALS(tnames[0], "axis-1");
+    std::vector<std::string> tnames = result->getColumnNames();
+    TS_ASSERT_EQUALS(tnames.size(), 14);
+    TS_ASSERT_EQUALS(tnames[0], "axis-1");
 
-  //   TS_ASSERT_EQUALS(result->Double(0, 0), 0.5);
-  //   TS_ASSERT_EQUALS(result->Double(1, 0), 3.0);
+    TS_ASSERT_EQUALS(result->Double(0, 0), 0.5);
+    TS_ASSERT_EQUALS(result->Double(1, 0), 3.0);
 
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  //   WorkspaceCreationHelper::removeWS("PLOTPEAKBYLOGVALUETEST_WS");
-  // }
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+    WorkspaceCreationHelper::removeWS("PLOTPEAKBYLOGVALUETEST_WS");
+  }
 
-  // void test_passWorkspaceIndexToFunction() {
-  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("PassWSIndexToFunction", true);
-  //   alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
-  //   alg.execute();
+  void test_passWorkspaceIndexToFunction() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT(result);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
 
-  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
-  //   TableRow row = result->getFirstRow();
-  //   do {
-  //     TS_ASSERT_DELTA(row.Double(1), 1.0, 1e-15);
-  //   } while (row.next());
+    // each spectrum contains values equal to its spectrum number (from 1 to 3)
+    TableRow row = result->getFirstRow();
+    do {
+      TS_ASSERT_DELTA(row.Double(1), 1.0, 1e-15);
+    } while (row.next());
 
-  //   AnalysisDataService::Instance().clear();
-  // }
+    AnalysisDataService::Instance().clear();
+  }
 
-  // void test_dont_passWorkspaceIndexToFunction() {
-  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("PassWSIndexToFunction", false);
-  //   alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
-  //   alg.execute();
+  void test_dont_passWorkspaceIndexToFunction() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", false);
+    alg.setPropertyValue("Function", "name=PLOTPEAKBYLOGVALUETEST_Fun");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT(result);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
 
-  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
-  //   double a = 1.0;
-  //   TableRow row = result->getFirstRow();
-  //   do {
-  //     TS_ASSERT_DELTA(row.Double(1), a, 1e-15);
-  //     a += 1.0;
-  //   } while (row.next());
+    // each spectrum contains values equal to its spectrum number (from 1 to 3)
+    double a = 1.0;
+    TableRow row = result->getFirstRow();
+    do {
+      TS_ASSERT_DELTA(row.Double(1), a, 1e-15);
+      a += 1.0;
+    } while (row.next());
 
-  //   AnalysisDataService::Instance().clear();
-  // }
+    AnalysisDataService::Instance().clear();
+  }
 
-  // void test_passWorkspaceIndexToFunction_composit_function_case() {
-  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("PassWSIndexToFunction", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
-  //   alg.execute();
+  void test_passWorkspaceIndexToFunction_composit_function_case() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT(result);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
 
-  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
-  //   TableRow row = result->getFirstRow();
-  //   do {
-  //     TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
-  //   } while (row.next());
+    // each spectrum contains values equal to its spectrum number (from 1 to 3)
+    TableRow row = result->getFirstRow();
+    do {
+      TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
+    } while (row.next());
 
-  //   AnalysisDataService::Instance().clear();
-  // }
+    AnalysisDataService::Instance().clear();
+  }
 
-  // void test_createOutputOption() {
-  //   auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("PassWSIndexToFunction", true);
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
-  //   alg.execute();
+  void test_createOutputOption() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
-  //   TS_ASSERT(result);
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
 
-  //   // each spectrum contains values equal to its spectrum number (from 1 to 3)
-  //   TableRow row = result->getFirstRow();
-  //   do {
-  //     TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
-  //   } while (row.next());
+    // each spectrum contains values equal to its spectrum number (from 1 to 3)
+    TableRow row = result->getFirstRow();
+    do {
+      TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
+    } while (row.next());
 
-  //   auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
-  //       "PlotPeakResult_sp1-3_NormalisedCovarianceMatrices");
-  //   auto params = AnalysisDataService::Instance().retrieveWS<const
-  //   WorkspaceGroup>("PlotPeakResult_sp1-3_Parameters"); auto fits = AnalysisDataService::Instance().retrieveWS<const
-  //   WorkspaceGroup>("PlotPeakResult_sp1-3_Workspaces");
+    auto matrices =
+        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
 
-  //   TS_ASSERT(matrices);
-  //   TS_ASSERT(params);
-  //   TS_ASSERT(fits);
+    TS_ASSERT(matrices);
+    TS_ASSERT(params);
+    TS_ASSERT(fits);
 
-  //   TS_ASSERT(matrices->getNames().size() == 3);
-  //   TS_ASSERT(params->getNames().size() == 3);
-  //   TS_ASSERT(fits->getNames().size() == 3);
+    TS_ASSERT(matrices->getNames().size() == 3);
+    TS_ASSERT(params->getNames().size() == 3);
+    TS_ASSERT(fits->getNames().size() == 3);
 
-  //   auto matricesNames = matrices->getNames();
-  //   auto paramsNames = params->getNames();
-  //   auto wsNames = fits->getNames();
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
+    auto wsNames = fits->getNames();
 
-  //   for (int i = 0; i < matrices->getNames().size(); i++) {
-  //     auto specNum = std::to_string(i + 1);
-  //     TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
-  //     TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
-  //     TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Workspace");
-  //   }
+    for (int i = 0; i < matrices->getNames().size(); i++) {
+      auto specNum = std::to_string(i + 1);
+      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Workspace");
+    }
 
-  //   AnalysisDataService::Instance().clear();
-  // }
+    AnalysisDataService::Instance().clear();
+  }
 
   void test_createOutputOptionMultipleWorkspaces() {
     createData();
@@ -437,10 +436,10 @@ public:
     TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
     TS_ASSERT_EQUALS(result->columnCount(), 14);
 
-    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
-        "PlotPeakResult_i1_NormalisedCovarianceMatrices");
-    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Parameters");
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Workspaces");
+    auto matrices =
+        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
 
     TS_ASSERT(matrices);
     TS_ASSERT(params);
@@ -486,10 +485,10 @@ public:
     TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
     TS_ASSERT(result);
 
-    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
-        "PlotPeakResult_v0-1_NormalisedCovarianceMatrices");
-    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Parameters");
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Workspaces");
+    auto matrices =
+        AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
 
     TS_ASSERT(matrices);
     TS_ASSERT(params);
@@ -538,7 +537,7 @@ public:
     alg.execute();
     TS_ASSERT(alg.isExecuted());
 
-    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Workspaces");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
     TS_ASSERT(fits);
 
     if (fits->size() > 0) {
@@ -550,131 +549,131 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
-  // void test_parameters_are_correct_for_a_histogram_fit() {
-  //   createHistogramWorkspace("InputWS", 10, -10.0, 10.0);
+  void test_parameters_are_correct_for_a_histogram_fit() {
+    createHistogramWorkspace("InputWS", 10, -10.0, 10.0);
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setAlwaysStoreInADS(false);
-  //   alg.setProperty("EvaluationType", "Histogram");
-  //   alg.setPropertyValue("Input", "InputWS,v1:3");
-  //   alg.setPropertyValue("OutputWorkspace", "out");
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setAlwaysStoreInADS(false);
+    alg.setProperty("EvaluationType", "Histogram");
+    alg.setPropertyValue("Input", "InputWS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "out");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.execute();
 
-  //   ITableWorkspace_sptr params = alg.getProperty("OutputWorkspace");
-  //   TS_ASSERT_DELTA(params->Double(0, 1), 1.0, 1e-15);
-  //   TS_ASSERT_DELTA(params->Double(1, 1), 1.1, 1e-15);
-  //   TS_ASSERT_DELTA(params->Double(2, 1), 0.6, 1e-15);
+    ITableWorkspace_sptr params = alg.getProperty("OutputWorkspace");
+    TS_ASSERT_DELTA(params->Double(0, 1), 1.0, 1e-15);
+    TS_ASSERT_DELTA(params->Double(1, 1), 1.1, 1e-15);
+    TS_ASSERT_DELTA(params->Double(2, 1), 0.6, 1e-15);
 
-  //   AnalysisDataService::Instance().clear();
-  // }
+    AnalysisDataService::Instance().clear();
+  }
 
-  // void test_single_exclude_range_single_Spectra() {
-  //   createData();
+  void test_single_exclude_range_single_Spectra() {
+    createData();
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup_0");
-  //   alg.setPropertyValue("Exclude", "-0.5, 0.5");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-  //   alg.setPropertyValue("MaxIterations", "50");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0");
+    alg.setPropertyValue("Exclude", "-0.5, 0.5");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.setPropertyValue("MaxIterations", "50");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void test_single_exclude_range_multiple_Spectra() {
-  //   createData();
+  void test_single_exclude_range_multiple_Spectra() {
+    createData();
 
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
-  //   alg.setPropertyValue("Exclude", "-0.5, 0.5");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-  //   alg.setPropertyValue("MaxIterations", "50");
-  //   alg.execute();
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
+    alg.setPropertyValue("Exclude", "-0.5, 0.5");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.setPropertyValue("MaxIterations", "50");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void test_multiple_exclude_range_multiple_Spectra() {
-  //   createData();
-  //   std::vector<std::string> excludeRanges;
-  //   excludeRanges.emplace_back("-0.5, 0.0");
-  //   excludeRanges.emplace_back("0.5, 1.5");
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
-  //   alg.setProperty("ExcludeMultiple", excludeRanges);
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
-  //   alg.setPropertyValue("MaxIterations", "50");
-  //   alg.execute();
+  void test_multiple_exclude_range_multiple_Spectra() {
+    createData();
+    std::vector<std::string> excludeRanges;
+    excludeRanges.emplace_back("-0.5, 0.0");
+    excludeRanges.emplace_back("0.5, 1.5");
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1");
+    alg.setProperty("ExcludeMultiple", excludeRanges);
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,A0=2");
+    alg.setPropertyValue("MaxIterations", "50");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-  //   deleteData();
-  //   WorkspaceCreationHelper::removeWS("PlotPeakResult");
-  // }
+    deleteData();
+    WorkspaceCreationHelper::removeWS("PlotPeakResult");
+  }
 
-  // void test_startX_single_value() {
-  //   auto ws = createTestWorkspace();
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("StartX", "1000.0");
-  //   alg.setProperty("EndX", "3000.0");
-  //   alg.setProperty("PassWSIndexToFunction", true);
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setProperty("OutputCompositeMembers", true);
-  //   alg.setProperty("ConvolveMembers", true);
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
-  //                                    "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-  //                                    "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
-  //                                    "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
-  //   alg.execute();
+  void test_startX_single_value() {
+    auto ws = createTestWorkspace();
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("StartX", "1000.0");
+    alg.setProperty("EndX", "3000.0");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setProperty("CreateOutput", true);
+    alg.setProperty("OutputCompositeMembers", true);
+    alg.setProperty("ConvolveMembers", true);
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
+                                     "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+                                     "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
+                                     "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
-  //   AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
-  // }
+    TS_ASSERT(alg.isExecuted());
+    AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
+  }
 
-  // void test_startX_multiple_value() {
-  //   auto ws = createTestWorkspace();
-  //   AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
-  //   PlotPeakByLogValue alg;
-  //   alg.initialize();
-  //   alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
-  //   alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
-  //   alg.setProperty("StartX", "1000.0,1000.0");
-  //   alg.setProperty("EndX", "3000.0,3000.0");
-  //   alg.setProperty("PassWSIndexToFunction", true);
-  //   alg.setProperty("CreateOutput", true);
-  //   alg.setProperty("OutputCompositeMembers", true);
-  //   alg.setProperty("ConvolveMembers", true);
-  //   alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
-  //                                    "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-  //                                    "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
-  //                                    "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
-  //   alg.execute();
+  void test_startX_multiple_value() {
+    auto ws = createTestWorkspace();
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("StartX", "1000.0,1000.0");
+    alg.setProperty("EndX", "3000.0,3000.0");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setProperty("CreateOutput", true);
+    alg.setProperty("OutputCompositeMembers", true);
+    alg.setProperty("ConvolveMembers", true);
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
+                                     "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+                                     "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
+                                     "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
+    alg.execute();
 
-  //   TS_ASSERT(alg.isExecuted());
-  //   AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
-  // }
+    TS_ASSERT(alg.isExecuted());
+    AnalysisDataService::Instance().remove("PLOTPEAKBYLOGVALUETEST_WS");
+  }
 
 private:
   WorkspaceGroup_sptr m_wsg;

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -404,17 +404,6 @@ public:
     TS_ASSERT(params->getNames().size() == 3);
     TS_ASSERT(fits->getNames().size() == 3);
 
-    auto matricesNames = matrices->getNames();
-    auto paramsNames = params->getNames();
-    auto wsNames = fits->getNames();
-
-    for (int i = 0; i < matrices->getNames().size(); i++) {
-      auto specNum = std::to_string(i + 1);
-      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
-      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
-      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Workspace");
-    }
-
     AnalysisDataService::Instance().clear();
   }
 
@@ -448,19 +437,6 @@ public:
     TS_ASSERT(matrices->getNames().size() == 3);
     TS_ASSERT(params->getNames().size() == 3);
     TS_ASSERT(fits->getNames().size() == 3);
-
-    auto matricesNames = matrices->getNames();
-    auto paramsNames = params->getNames();
-    auto wsNames = fits->getNames();
-
-    for (int i = 0; i < matrices->getNames().size(); i++) {
-      auto wsIdx = std::to_string(i);
-      TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_i1_NormalisedCovarianceMatrix");
-      TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Parameters");
-      TS_ASSERT_EQUALS(wsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Workspace");
-    }
-
-    AnalysisDataService::Instance().clear();
   }
 
   void test_createOutputWithExtraOutputOptions() {
@@ -489,6 +465,149 @@ public:
         AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_NormalisedCovarianceMatrices");
     auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Parameters");
     auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_Workspaces");
+
+    TS_ASSERT(matrices);
+    TS_ASSERT(params);
+    TS_ASSERT(fits);
+
+    TS_ASSERT(matrices->getNames().size() == 2);
+    TS_ASSERT(params->getNames().size() == 2);
+    TS_ASSERT(fits->getNames().size() == 2);
+
+    auto wsNames = fits->getNames();
+    for (const auto &wsName : wsNames) {
+      auto fit = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(wsName);
+      TS_ASSERT(fit);
+      TS_ASSERT(fit->getNumberHistograms() == 5);
+    }
+
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_createOutputOptionWithAppend() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 3, -5.0, 5.0, 0.1, false);
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v1:3");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setProperty("AppendIdxToOutputName", true);
+    alg.setProperty("CreateOutput", true);
+    alg.setPropertyValue("Function", "name=FlatBackground,ties=(A0=0.5);name=PLOTPEAKBYLOGVALUETEST_Fun");
+    alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
+
+    // each spectrum contains values equal to its spectrum number (from 1 to 3)
+    TableRow row = result->getFirstRow();
+    do {
+      TS_ASSERT_DELTA(row.Double(1), 0.5, 1e-15);
+    } while (row.next());
+
+    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+        "PlotPeakResult_sp1-3_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_sp1-3_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_sp1-3_Workspaces");
+
+    TS_ASSERT(matrices);
+    TS_ASSERT(params);
+    TS_ASSERT(fits);
+
+    TS_ASSERT(matrices->getNames().size() == 3);
+    TS_ASSERT(params->getNames().size() == 3);
+    TS_ASSERT(fits->getNames().size() == 3);
+
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
+    auto wsNames = fits->getNames();
+
+    for (int i = 0; i < matrices->getNames().size(); i++) {
+      auto specNum = std::to_string(i + 1);
+      TS_ASSERT_EQUALS(matricesNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PLOTPEAKBYLOGVALUETEST_WS_sp" + specNum + "_Workspace");
+    }
+
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_createOutputOptionMultipleWorkspacesWithAppend() {
+    createData();
+
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PlotPeakGroup_0;PlotPeakGroup_1;PlotPeakGroup_2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setPropertyValue("WorkspaceIndex", "1");
+    alg.setPropertyValue("LogValue", "var");
+    alg.setProperty("CreateOutput", true);
+    alg.setProperty("AppendIdxToOutputName", true);
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=1,A1=0.3;name="
+                                     "Gaussian,PeakCentre=5,Height=2,Sigma=0."
+                                     "1");
+    TS_ASSERT(alg.execute());
+
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT_EQUALS(result->columnCount(), 14);
+
+    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+        "PlotPeakResult_i1_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_i1_Workspaces");
+
+    TS_ASSERT(matrices);
+    TS_ASSERT(params);
+    TS_ASSERT(fits);
+
+    TS_ASSERT(matrices->getNames().size() == 3);
+    TS_ASSERT(params->getNames().size() == 3);
+    TS_ASSERT(fits->getNames().size() == 3);
+
+    auto matricesNames = matrices->getNames();
+    auto paramsNames = params->getNames();
+    auto wsNames = fits->getNames();
+
+    for (int i = 0; i < matrices->getNames().size(); i++) {
+      auto wsIdx = std::to_string(i);
+      TS_ASSERT_EQUALS(matricesNames[i], "PlotPeakGroup_" + wsIdx + "_i1_NormalisedCovarianceMatrix");
+      TS_ASSERT_EQUALS(paramsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Parameters");
+      TS_ASSERT_EQUALS(wsNames[i], "PlotPeakGroup_" + wsIdx + "_i1_Workspace");
+    }
+
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_createOutputWithExtraOutputOptionsWithAppend() {
+    auto ws = createTestWorkspace();
+    AnalysisDataService::Instance().add("PLOTPEAKBYLOGVALUETEST_WS", ws);
+    PlotPeakByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("Input", "PLOTPEAKBYLOGVALUETEST_WS,v0:2");
+    alg.setPropertyValue("OutputWorkspace", "PlotPeakResult");
+    alg.setProperty("PassWSIndexToFunction", true);
+    alg.setProperty("CreateOutput", true);
+    alg.setProperty("AppendIdxToOutputName", true);
+    alg.setProperty("OutputCompositeMembers", true);
+    alg.setProperty("ConvolveMembers", true);
+    alg.setPropertyValue("Function", "name=LinearBackground,A0=0,A1=0;"
+                                     "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+                                     "name=Resolution,Workspace=PLOTPEAKBYLOGVALUETEST_WS,WorkspaceIndex=0;"
+                                     "name=Gaussian,Height=3000,PeakCentre=6493,Sigma=50;);");
+    alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+
+    TWS_type result = WorkspaceCreationHelper::getWS<TableWorkspace>("PlotPeakResult");
+    TS_ASSERT(result);
+
+    auto matrices = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>(
+        "PlotPeakResult_v0-1_NormalisedCovarianceMatrices");
+    auto params = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Parameters");
+    auto fits = AnalysisDataService::Instance().retrieveWS<const WorkspaceGroup>("PlotPeakResult_v0-1_Workspaces");
 
     TS_ASSERT(matrices);
     TS_ASSERT(params);
@@ -543,7 +662,7 @@ public:
     if (fits->size() > 0) {
       auto fit = fits->getItem(0);
       TS_ASSERT_EQUALS(fit->history().size(), 0);
-      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakGroup_0_i1_Workspace");
+      TS_ASSERT_EQUALS(fit->getName(), "PlotPeakResult_Workspaces_1");
     }
 
     AnalysisDataService::Instance().clear();

--- a/docs/source/release/v6.14.0/Framework/Algorithms/New_features/39294.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/New_features/39294.rst
@@ -1,0 +1,1 @@
+- :ref:`PlotPeakByLogValue <algm-PlotPeakByLogValue>` output workspace names now include the spectrum number when it is enabled.

--- a/docs/source/release/v6.14.0/Framework/Algorithms/New_features/39294.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/New_features/39294.rst
@@ -1,1 +1,2 @@
-- :ref:`PlotPeakByLogValue <algm-PlotPeakByLogValue>` output workspace names now include the spectrum number when it is enabled.
+- :ref:`PlotPeakByLogValue <algm-PlotPeakByLogValue>` has new "AppendIdxToOutputName" that when enabled with "CreateOutput" option will append indices of output workspaces (spectrum, workspace or numeric) based on the input format.
+- :ref:`PlotPeakByLogValue <algm-PlotPeakByLogValue>` has new "Output2D" that when enabled with "CreateOutput" option will create a 2D workspace of the results table that could be plotted.

--- a/docs/source/release/v6.14.0/Workbench/New_features/39294.rst
+++ b/docs/source/release/v6.14.0/Workbench/New_features/39294.rst
@@ -1,0 +1,1 @@
+- Sequential fit output workspace names now include the spectrum number to distinguish between different spectra results.

--- a/docs/source/release/v6.14.0/Workbench/New_features/39294.rst
+++ b/docs/source/release/v6.14.0/Workbench/New_features/39294.rst
@@ -1,1 +1,2 @@
-- Sequential fit output workspace names now include the spectrum number to distinguish between different spectra results.
+- Sequential fit output workspace names now include the numeric (spectra) axis to distinguish between different results.
+- Sequential fit interface now has an option to create the results output in a workspace 2D format which could be plotted.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.h
@@ -108,6 +108,9 @@ private:
   /// Return true if data source in a row is a file (rather than a workspace)
   bool isFile(int row) const;
 
+  /// Return true if the range format is valid
+  bool isValidRangeFormat(const QString &range) const;
+
   int rowCount() const;
 
   int defaultSpectrum() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
@@ -181,7 +181,7 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>Output spectrum vs params</string>
+        <string>Output workspace index vs params</string>
        </property>
       </widget>
      </item>
@@ -244,7 +244,7 @@
             <string>Range</string>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a range of values on the numeric axis (spectum number incase of a spectra axis) associated with the workspace index. The range is specfied by a start value and an end value and separated by a colon e.g. 2:5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a range of values on the numeric axis (spectrum number incase of a spectra axis) associated with the workspace index. The range is specfied by a start value and an end value and separated by a colon e.g. 2:5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </column>
          </widget>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
@@ -234,7 +234,7 @@
             <string>Range</string>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a range of values on the numeric axis associated with the workspace index. The range is specfied by a start value and an end value and separated by a colon e.g. 2:5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a range of values on the numeric axis (spectum number incase of a spectra axis) associated with the workspace index. The range is specfied by a start value and an end value and separated by a colon e.g. 2:5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </column>
          </widget>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.ui
@@ -176,6 +176,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="ckOutputSpecParams">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Output spectrum vs params</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_5">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -12,6 +12,9 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidAPI/TextAxis.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidQtWidgets/Common/FitPropertyBrowser.h"
@@ -53,6 +56,7 @@ SequentialFitDialog::SequentialFitDialog(FitPropertyBrowser *fitBrowser, QObject
   connect(ui.ckbLogPlot, SIGNAL(toggled(bool)), this, SLOT(plotAgainstLog(bool)));
   connect(ui.ckCreateOutput, SIGNAL(toggled(bool)), ui.ckOutputCompMembers, SLOT(setEnabled(bool)));
   connect(ui.ckCreateOutput, SIGNAL(toggled(bool)), ui.ckConvolveMembers, SLOT(setEnabled(bool)));
+  connect(ui.ckCreateOutput, SIGNAL(toggled(bool)), ui.ckOutputSpecParams, SLOT(setEnabled(bool)));
 
   ui.cbLogValue->setEditable(true);
   ui.ckbLogPlot->setChecked(true);
@@ -315,6 +319,8 @@ void SequentialFitDialog::accept() {
   alg->setProperty("CreateOutput", ui.ckCreateOutput->isChecked());
   alg->setProperty("OutputCompositeMembers", ui.ckOutputCompMembers->isChecked());
   alg->setProperty("ConvolveMembers", ui.ckConvolveMembers->isChecked());
+  alg->setProperty("Output2D", ui.ckOutputSpecParams->isChecked());
+  alg->setProperty("AppendIdxToOutputName", true);
   if (ui.ckbLogPlot->isChecked()) {
     std::string logName = ui.cbLogValue->currentText().toStdString();
     alg->setPropertyValue("LogValue", logName);

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -238,7 +238,7 @@ bool SequentialFitDialog::isFile(int row) const {
   return !item || item->flags().testFlag(Qt::ItemIsEnabled) == false;
 }
 
-bool isValidRangeFormat(const QString &range) {
+bool SequentialFitDialog::isValidRangeFormat(const QString &range) const {
   // Check if range contains exactly one colon
   int colonCount = range.count(':');
   if (colonCount != 1) {
@@ -388,6 +388,15 @@ void SequentialFitDialog::accept() {
 
   bool passWSIndexToFunction = ui.ckbPassWS->isChecked();
   alg->setProperty("PassWSIndexToFunction", passWSIndexToFunction);
+
+  auto errors = alg->validateInputs();
+
+  if (!errors.empty()) {
+    for (const auto &[key, error] : errors) {
+      g_log.error() << error << std::endl;
+    }
+    return;
+  }
 
   alg->executeAsync();
   QDialog::accept();


### PR DESCRIPTION
### Description of work
This PR add two new options to the PlotPeakByLogValue algorithm that are enabled when the "CreateOutput" option is true. First option "AppendIdxToOutputName", appends the index of the corresponding output depending on which format is used in the input (either spectrum number, workspace index, or numeric value). This is enabled now by default for the sequential fit output. The second option, "Output2D", creates a 2D workspace of the results table, displaying the workspace index versus parameter value. This option groups the parameter results together to create a workspace index vs parameters 
It also adds a new UI option to the Sequential fit dialogue to enable this new 2D option.  

Fixes #39294

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The implementation involves enabling the `alwaysStoreInAds` option in the child Fit algorithms. It turned out that because this option was not enabled, the output workspace returned by the Fit algorithm was an empty string. This is why the output names are the same as the group workspace name, numbered by their position. One thing to note is that the final outputs seem to be duplicated using both the workspace names and workspace objects. This is because if you enable `alwaysStoreInAds`, then the returned workspace objects from the algorithm will be null, and the only way to access the workspaces is from the ADS. In the case of  `alwaysStoreInAds` being false, the returned workspaces will contain the actual workspace, but their names will be null. This is one of the drawbacks of using ADS vs not. 

### To test:
1- Load any data (e.g. iris26176_graphite002_red)
2- Go to Plot Spectrum and click Fit 
3- Add a peak (e.g. Lorentzian)
4- Press Sequential Fit, and a dialogue will open
5- Check the `Create Output` check box
6- In the table view, set `Range` to any preferred workspace index range (e.g. 4-6)
7- Press Fit
8- You will see 3 output group workspaces suffixed with "_Parameters", "_NormalisedCovarianceMatrices" and "_Workspaces"
9- Each group workspace will have the same number of spectra in the selected range
10- You can see that each workspace name includes the spectrum number and is suffixed with "_Parameters", "_NormalisedCovarianceMatrix" and "_Workspace" in each group, respectively (e.g. iris26176_graphite002_red_res_3_Parameters)

11- Try to enable the new "Output spectrum vs params" in the sequential fit dialogue, and a new output suffixed with "_ws" will appear. Plot the workspace, and it will contain a plot for each parameter. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
