### PR TITLE
AlignAndFocusPowderSlim add ability to specify input binning units

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -48,6 +48,7 @@ private:
                                                    const std::vector<specnum_t> &specids,
                                                    const std::vector<double> &l2s,
                                                    const std::vector<double> &azimuthals);
+  API::MatrixWorkspace_sptr convertToTOF(API::MatrixWorkspace_sptr &wksp);
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                    const std::vector<double> &difc_focus);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -473,13 +473,12 @@ void AlignAndFocusPowderSlim::init() {
                   "be specified.");
   auto mustBePosArr = std::make_shared<Kernel::ArrayBoundedValidator<double>>();
   mustBePosArr->setLower(0.0);
-  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::X_MIN, std::vector<double>{10}, mustBePosArr),
+  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::X_MIN, std::vector<double>{0.1}, mustBePosArr),
                   "Minimum x-value for the output binning");
   declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::X_DELTA, std::vector<double>{0.0016}),
                   "Bin size for output data");
-  declareProperty(
-      std::make_unique<ArrayProperty<double>>(PropertyNames::X_MAX, std::vector<double>{16667}, mustBePosArr),
-      "Minimum x-value for the output binning");
+  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::X_MAX, std::vector<double>{2.0}, mustBePosArr),
+                  "Minimum x-value for the output binning");
   declareProperty(std::make_unique<EnumeratedStringProperty<BinUnit, &unitNames>>(PropertyNames::BIN_UNITS),
                   "The units of the input X min, max and delta values. Output will always be TOF");
   declareProperty(std::make_unique<EnumeratedStringProperty<BinningMode, &binningModeNames>>(PropertyNames::BINMODE),

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -32,7 +32,8 @@ public:
   // run the algorithm do some common checks and return output workspace name
   MatrixWorkspace_sptr run_algorithm(const std::string &filename, const std::vector<double> &xmin = {},
                                      const std::vector<double> &xmax = {}, const std::vector<double> &xdelta = {},
-                                     const std::string binning = "Logarithmic") {
+                                     const std::string binning = "Logarithmic",
+                                     const std::string binningUnits = "TOF") {
     const std::string wksp_name("VULCAN");
 
     std::cout << "==================> " << filename << '\n';
@@ -45,6 +46,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", filename));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", wksp_name));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("BinningMode", binning));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BinningUnits", binningUnits));
     if (!xmin.empty())
       TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmin));
     if (!xmax.empty())

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -12,6 +12,9 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim.h"
 #include "MantidKernel/Timer.h"
+#include "MantidKernel/Unit.h"
+
+#include <numbers>
 
 using Mantid::API::MatrixWorkspace_sptr;
 using Mantid::DataHandling::AlignAndFocusPowderSlim;
@@ -33,7 +36,7 @@ public:
   MatrixWorkspace_sptr run_algorithm(const std::string &filename, const std::vector<double> &xmin = {},
                                      const std::vector<double> &xmax = {}, const std::vector<double> &xdelta = {},
                                      const std::string binning = "Logarithmic",
-                                     const std::string binningUnits = "TOF") {
+                                     const std::string binningUnits = "dSpacing") {
     const std::string wksp_name("VULCAN");
 
     std::cout << "==================> " << filename << '\n';
@@ -66,21 +69,21 @@ public:
     const std::string filename("VULCAN_218062.nxs.h5");
     MatrixWorkspace_sptr outputWS = run_algorithm(filename);
 
-    constexpr size_t NUM_Y{4641}; // observed value
+    constexpr size_t NUM_Y{1874}; // observed value
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
     TS_ASSERT_EQUALS(outputWS->blocksize(), NUM_Y);
     TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "TOF");
     // default values in algorithm
-    TS_ASSERT_EQUALS(outputWS->readX(0).front(), 10.);
-    TS_ASSERT_EQUALS(outputWS->readX(0).back(), 16667.);
+    TS_ASSERT_DELTA(outputWS->readX(0).front(), 1646., 1);
+    TS_ASSERT_DELTA(outputWS->readX(0).back(), 32925., 1);
     // observed values from running
     const auto y_values = outputWS->readY(0);
     TS_ASSERT_EQUALS(y_values.size(), NUM_Y);
     TS_ASSERT_EQUALS(y_values[0], 0.);
     TS_ASSERT_EQUALS(y_values[NUM_Y / 2], 0.);
-    TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 20719);
+    TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 4744.);
 
     // do not need to cleanup because workspace did not go into the ADS
   }
@@ -88,14 +91,16 @@ public:
   void test_common_x() {
     const std::vector<double> xmin{13000.};
     const std::vector<double> xmax{36000.};
+    const std::vector<double> xdelta{};
     const std::string filename("VULCAN_218062.nxs.h5");
-    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax);
+    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax, xdelta, "Logarithmic", "TOF");
 
     constexpr size_t NUM_Y{637}; // observed value
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
     TS_ASSERT_EQUALS(outputWS->blocksize(), NUM_Y);
+    TS_ASSERT(outputWS->isCommonBins());
     TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "TOF");
     // default values in algorithm
     TS_ASSERT_EQUALS(outputWS->readX(0).front(), xmin[0]);
@@ -113,8 +118,9 @@ public:
   void test_ragged_bins_x_min_max() {
     const std::vector<double> xmin{13000., 14000., 15000., 16000., 17000., 18000.};
     const std::vector<double> xmax{36000., 37000., 38000., 39000., 40000., 41000.};
+    const std::vector<double> xdelta{}; // empty means use the default binning
     const std::string filename("VULCAN_218062.nxs.h5");
-    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax);
+    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax, xdelta, "Logarithmic", "TOF");
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -135,7 +141,7 @@ public:
     const std::vector<double> xdelta{1000., 2000., 3000., 4000., 5000., 6000.};
     // this will create
     const std::string filename("VULCAN_218062.nxs.h5");
-    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax, xdelta, "Linear");
+    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax, xdelta, "Linear", "TOF");
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -149,6 +155,62 @@ public:
     }
 
     // do not need to cleanup because workspace did not go into the ADS
+  }
+
+  void test_different_units() {
+    const double l1{43.755};
+    const std::vector<double> polars{90, 90, 120, 150, 157, 65.5}; // two-theta
+    const std::vector<double> l2s{2.296, 2.296, 2.070, 2.070, 2.070, 2.530};
+
+    // test TOF
+    const std::vector<double> tof_mins(6, 13000);
+    const std::vector<double> tof_maxs(6, 36000);
+    const std::vector<double> tof_deltas(6, (36000 - 13000) / 20.);
+    run_test_with_different_units(tof_mins, tof_maxs, tof_deltas, "TOF");
+
+    std::vector<double> dmin;
+    std::vector<double> dmax;
+    std::vector<double> ddelta;
+    std::vector<double> qmin;
+    std::vector<double> qmax;
+    std::vector<double> qdelta;
+
+    const double deg2rad = std::numbers::pi_v<double> / 180.;
+    const double pi2 = 2 * std::numbers::pi_v<double>;
+
+    // setup dSpacing and Q vectors so that we get the same output TOF range of 13000 to 36000 with 20
+    // bins
+    for (size_t i = 0; i < 6; ++i) {
+      const double tofToD = Mantid::Kernel::Units::tofToDSpacingFactor(l1, l2s[i], deg2rad * polars[i], 0.);
+      dmin.push_back(tof_mins[i] * tofToD);
+      dmax.push_back(tof_maxs[i] * tofToD);
+      ddelta.push_back((dmax[i] - dmin[i]) / 20.);
+      qmin.push_back(pi2 / dmax[i]);
+      qmax.push_back(pi2 / dmin[i]);
+      qdelta.push_back((qmax[i] - qmin[i]) / 20.);
+    }
+
+    // test dSpacing
+    run_test_with_different_units(dmin, dmax, ddelta, "dSpacing");
+    // test Q
+    run_test_with_different_units(qmin, qmax, qdelta, "MomentumTransfer");
+  }
+
+  void run_test_with_different_units(std::vector<double> xmin, std::vector<double> xmax, std::vector<double> xdelta,
+                                     std::string units) {
+    const std::string filename("VULCAN_218062.nxs.h5");
+
+    MatrixWorkspace_sptr outputWS = run_algorithm(filename, xmin, xmax, xdelta, "Linear", units);
+
+    // verify the output
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
+    TS_ASSERT(outputWS->isCommonBins());
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 20);
+    TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "TOF");
+    for (size_t i = 0; i < outputWS->getNumberHistograms(); ++i) {
+      TS_ASSERT_DELTA(outputWS->readX(i).front(), 13000., 1e-5);
+      TS_ASSERT_DELTA(outputWS->readX(i).back(), 36000., 1e-5);
+    }
   }
 
   // ==================================

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39613.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39613.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` now allows different binning units, the default being d-spacing. The output will always be in time-of-flight.


### PR DESCRIPTION
### Description of work

The output will always be in TOF but you can now define the binning in TOF,  d-space or Q. The default is now d.



#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [11962: Add ability to specify binning in tof, d-spacing, or momentum transfer](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/11962)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Using the existing test data.

```python
ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", BinningUnits="dSpacing", Xmin=0.5, XMax=1.5)
ws2 = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", BinningUnits="TOF", Xmin=10000, XMax=40000)
ws3 = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", BinningUnits="MomentumTransfer", Xmin=2, XMax=10)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
