### PR TITLE
Removed boost optional in FallbackBoostOptionallO.h

### DIFF
--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
@@ -4,7 +4,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <boost/optional.hpp>
 #include <optional>
 #include <ostream>
 

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
@@ -21,11 +21,4 @@ inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<Ch
   return (os << "std::optional @ " << reinterpret_cast<const void *>(&value));
 }
 
-/// Simple prints the address of the optional object - this can be removed once boost::optional is converted to
-/// std::optional
-template <class CharType, class CharTrait, class OptionalValueType>
-inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &os,
-                                                           boost::optional<OptionalValueType> const &value) {
-  return (os << "boost::optional @ " << reinterpret_cast<const void *>(&value));
-}
 } // namespace boost


### PR DESCRIPTION
### Description of work

Removed `boost::optional` in FallbackBoostOptionallO.h with the aim to get rid of `boost::optional` in the whole Mantid code base.

Fixes #39616.

### To test:

It will be difficult to test this change directly as it removes a printer for boost::optional objects as a test helper. This is not required anymore once the `boost::optional` is not used anywhere in the code base. It will be enough to ensure that this was indeed the last place where `boost::optional` was used in Mantid.

*This does not require release notes* because **this change is invisible to the user.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
