### PR TITLE
Crosshair colorfill normalisation fix

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1717,6 +1717,8 @@ class _WorkspaceArtists(object):
         :param plot_kwargs: Key word args to pass to plotting function
         """
         if plot_kwargs:
+            if "specNum" in plot_kwargs:
+                del plot_kwargs["specNum"]
             new_artists = self._data_replace_cb(self._artists, workspace, plot_kwargs)
         else:
             new_artists = self._data_replace_cb(self._artists, workspace)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1717,7 +1717,7 @@ class _WorkspaceArtists(object):
         :param plot_kwargs: Key word args to pass to plotting function
         """
         if plot_kwargs:
-            if "specNum" in plot_kwargs:
+            if "specNum" in plot_kwargs and plot_kwargs["specNum"] is None:
                 del plot_kwargs["specNum"]
             new_artists = self._data_replace_cb(self._artists, workspace, plot_kwargs)
         else:


### PR DESCRIPTION
### Description of work
It appears the issue that crashes colorfill plot is a keyword "specNum" being passed in plot_kwargs while carrying a "None" value. 

The fix is implemented by removeing it if that happens. "specNum" should not be removed if it carries actual numbers (1,2,3..etc).
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #39618 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Run the following script to load MAR11060. Test normalisation, error bar in tiled plots doesn't crash. Then right click on the workspace and plot in colorfill mode and test normalisation does not crash


```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType

MAR11060 = Load('MAR11060')

fig, axes = plt.subplots(edgecolor='#ffffff', ncols=2, nrows=2, num='MAR11060-1', subplot_kw={'projection': 'mantid'})
axes[0][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 1', wkspIndex=0)
axes[0][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[0][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 2', wkspIndex=1)
axes[0][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[0][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][0].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 3', wkspIndex=2)
axes[1][0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][0].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][0].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

axes[1][1].plot(MAR11060, color='#1f77b4', label='MAR11060: spec 4', wkspIndex=3)
axes[1][1].set_xlabel('Time-of-flight ($\\mu s$)')
axes[1][1].set_ylabel('Counts ($\\mu s$)$^{-1}$')
legend = axes[1][1].legend(fontsize=8.0) #.set_draggable(True).legend # uncomment to set the legend draggable

fig.show()
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
