### PR TITLE
Nexus `napi` strangle -- round 2.5

### DIFF
--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -329,17 +329,17 @@ int Sample::loadNexus(Nexus::File *file, const std::string &group) {
 
   // Version 0 = saveNexusProcessed before Sep 8, 2011
   int version = 0;
-  try {
+  if (file->hasAttr("version")) {
     file->getAttr("version", version);
-  } catch (Nexus::Exception const &) {
+  } else {
     version = 0;
   }
 
   if (version == 0) {
     // Sample NAME field may/may not be present
-    try {
+    if (file->hasData("name")) {
       file->readData("name", m_name);
-    } catch (Nexus::Exception const &) {
+    } else {
       m_name = "";
     }
   }

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -198,6 +198,7 @@ private:
 
 public:
   void test_load_event_nexus_v20_ess() {
+    std::cout << "test load v20_ess\n" << std::flush;
     const std::string file = "V20_ESS_example.nxs";
     LoadEventNexus alg;
     alg.setChild(true);
@@ -216,6 +217,7 @@ public:
   }
 
   void test_load_event_nexus_v20_ess_log_filtered() {
+    std::cout << "test load v20_ess log filtered\n" << std::flush;
     const std::string file = "V20_ESS_example.nxs";
     std::vector<std::string> allowed = {"proton_charge", "S2HGap", "S2VGap"};
 
@@ -240,6 +242,7 @@ public:
   }
 
   void test_load_event_nexus_v20_ess_integration_2018() {
+    std::cout << "test load v20_ess integration 2018\n" << std::flush;
     // Only perform this test if the version of hdf5 supports vlen strings
     if (NexusGeometry::Hdf5Version::checkVariableLengthStringSupport()) {
       const std::string file = "V20_ESSIntegration_2018-12-13_0942.nxs";
@@ -266,6 +269,7 @@ public:
   }
 
   void test_load_event_nexus_POLARIS() {
+    std::cout << "test load polaris" << std::flush;
     // POLARIS file slow to create geometry cache so use a pregenerated vtp file. Details of the geometry don't matter
     // for this test
     const std::string vtpDirectoryKey = "instrumentDefinition.vtp.directory";
@@ -299,6 +303,7 @@ public:
   }
 
   void test_NumberOfBins() {
+    std::cout << "test number bins SANS2D\n" << std::flush;
     const std::string file = "SANS2D00022048.nxs";
     int nBins = 273;
     LoadEventNexus alg;
@@ -317,6 +322,7 @@ public:
   }
 
   void test_load_event_nexus_sans2d_ess() {
+    std::cout << "test load SANS2D ESS\n" << std::flush;
     const std::string file = "SANS2D_ESS_example.nxs";
     LoadEventNexus alg;
     alg.setChild(true);
@@ -350,6 +356,7 @@ public:
   bool windows = false;
 #endif // _WIN32
   void test_multiprocess_loader_precount() {
+    std::cout << "test multiprocess loader precount\n" << std::flush;
     if (!windows) {
       run_multiprocess_load("SANS2D00022048.nxs", true);
       run_multiprocess_load("LARMOR00003368.nxs", true);
@@ -357,6 +364,7 @@ public:
   }
 
   void test_multiprocess_loader_producer_consumer() {
+    std::cout << "test multiprocess loader consumer\n" << std::flush;
     if (!windows) {
       run_multiprocess_load("SANS2D00022048.nxs", false);
       run_multiprocess_load("LARMOR00003368.nxs", false);
@@ -366,6 +374,7 @@ public:
   void test_SingleBank_PixelsOnlyInThatBank() { doTestSingleBank(true, false); }
 
   void test_load_event_nexus_ornl_eqsans() {
+    std::cout << "test nexus ornl eqsans \n" << std::flush;
     // This file has a 2D entry/sample/name
     const std::string file = "EQSANS_89157.nxs.h5";
     LoadEventNexus alg;
@@ -384,6 +393,7 @@ public:
   }
 
   void test_wallclock_filtering() {
+    std::cout << "test wallclock filtering\n" << std::flush;
     const std::string wsName("test_wallclock_filtering");
     const std::string filename("EQSANS_89157.nxs.h5");
     constexpr double filterStart{200}; // seconds
@@ -472,6 +482,7 @@ public:
 
   // FilteredLoadvsLoadThenFilter system test and algorithm usage example
   void test_CNCS_7860_filtering() {
+    std::cout << "test CNCS 7860 filtering\n" << std::flush;
     const std::string filename("CNCS_7860_event.nxs");
     const std::string wsName("CNCS_7860");
     constexpr double filterStart{60};
@@ -516,6 +527,7 @@ public:
   }
 
   void test_Normal_vs_Precount() {
+    std::cout << "test normal vs precount\n" << std::flush;
     Mantid::API::FrameworkManager::Instance();
     LoadEventNexus ld;
     std::string outws_name = "cncs_noprecount";
@@ -634,6 +646,7 @@ public:
   }
 
   void test_TOF_filtered_loading() {
+    std::cout << "test TOF filtering\n" << std::flush;
     const std::string wsName = "test_filtering";
     const double filterStart = 45000;
     const double filterEnd = 59000;
@@ -668,6 +681,7 @@ public:
   }
 
   void test_partial_spectra_loading() {
+    std::cout << "test partial spectra loading\n" << std::flush;
     std::string wsName = "test_partial_spectra_loading_SpectrumList";
     std::vector<int32_t> specList;
     specList.emplace_back(13);
@@ -761,6 +775,7 @@ public:
   }
 
   void test_partial_spectra_loading_ISIS() {
+    std::cout << "test partial spectra loading ISIS\n" << std::flush;
     // This is to test a specific bug where if you selected any spectra and had
     // precount on you got double the number of events
     std::string wsName = "test_partial_spectra_loading_SpectrumListISIS";
@@ -812,6 +827,7 @@ public:
   }
 
   void test_CNCSMonitors() {
+    std::cout << "test CNCS monitors\n" << std::flush;
     // Re-uses the workspace loaded in test_partial_spectra_loading to save a
     // load execution
     // This is a very simple test for performance issues. There's no real event
@@ -832,6 +848,7 @@ public:
   }
 
   void test_Load_And_CompressEvents() {
+    std::cout << "test load and compress events\n" << std::flush;
     constexpr std::size_t NUM_HIST{51200};
     const std::string filename{"CNCS_7860_event.nxs"};
 
@@ -886,6 +903,7 @@ public:
   }
 
   void test_Monitors() {
+    std::cout << "test CNCS compressed monitors\n" << std::flush;
     // Uses the workspace loaded in the last test to save a load execution
     std::string mon_outws_name = "cncs_compressed_monitors";
     auto &ads = AnalysisDataService::Instance();
@@ -915,6 +933,7 @@ public:
   }
 
   void test_Load_And_Filter_Everything() {
+    std::cout << "test ARCS sim filtering everything\n" << std::flush;
     // This test set the FilterByTimeStart value so that everything should be filtered
     // So we should end up with 0 events
     const std::string filename{"ARCS_sim_event.nxs"};
@@ -936,6 +955,7 @@ public:
   }
 
   void test_Load_And_CompressEvents_weighted() {
+    std::cout << "test ARCS sim event weighted\n" << std::flush;
     constexpr std::size_t NUM_HIST{117760};
     const std::string filename{"ARCS_sim_event.nxs"};
 
@@ -989,6 +1009,7 @@ public:
   }
 
   void test_Load_And_CompressEvents_with_nperiod_data() {
+    std::cout << "test LARMOR compress with nperiods\n" << std::flush;
     constexpr std::size_t NUM_HIST{40960};
     const std::string filename{"LARMOR00003368.nxs"};
 
@@ -1040,6 +1061,7 @@ public:
   }
 
   void test_Load_And_CompressEvents_tolerance_0() {
+    std::cout << "test CNCS compress tol 0\n" << std::flush;
     // the is to verify that the compresssion works when the CompressTolerance=0
     // create compressed
     const std::string filename{"CNCS_7860_event.nxs"};
@@ -1070,6 +1092,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses() {
+    std::cout << "test CNCS filter bad pulses\n" << std::flush;
     // This will use ProcessBankData
     const std::string filename{"CNCS_7860_event.nxs"};
 
@@ -1120,6 +1143,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses_with_start_time_filter() {
+    std::cout << "test CNCS filter bad with start time\n" << std::flush;
     // This will use ProcessBankData
     // make sure the combination of bad pulse filter and start time filter work together
     const std::string filename{"CNCS_7860_event.nxs"};
@@ -1175,6 +1199,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses_and_compress() {
+    std::cout << "test CNCS filter bad pulses and compress\n" << std::flush;
     // This will use ProcessBankCompressed
     const std::string filename{"CNCS_7860_event.nxs"};
 
@@ -1239,6 +1264,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses_and_compress_and_start_time_filter() {
+    std::cout << "test CNCS filter bad compress and start time\n" << std::flush;
     // This will use ProcessBankCompressed
     const std::string filename{"CNCS_7860_event.nxs"};
 
@@ -1305,6 +1331,9 @@ public:
 
   void doTestSingleBank(bool SingleBankPixelsOnly, bool Precount, const std::string &BankName = "bank36",
                         bool willFail = false) {
+    std::cout << "test CNCS  single back with: " << SingleBankPixelsOnly << " " << Precount << " " << BankName << " "
+              << willFail << "\n"
+              << std::flush;
     Mantid::API::FrameworkManager::Instance();
     LoadEventNexus ld;
     std::string outws_name = "cncs";
@@ -1344,6 +1373,7 @@ public:
   void test_SingleBank_ThatDoesntExist() { doTestSingleBank(false, false, "bankDoesNotExist", true); }
 
   void test_SingleBank_with_no_events() {
+    std::cout << "test HYSA single bank no events\n" << std::flush;
     LoadEventNexus load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
     TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "HYSA_12509.nxs.h5"));
@@ -1360,6 +1390,7 @@ public:
   }
 
   void test_instrument_inside_nexus_file() {
+    std::cout << "test HYSA instrument inside nexus\n" << std::flush;
     LoadEventNexus load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
     TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "HYSA_12509.nxs.h5"));
@@ -1388,6 +1419,7 @@ public:
   }
 
   void test_instrument_and_default_param_loaded_when_inst_not_in_nexus_file() {
+    std::cout << "test CNCS load default param with no instrument\n" << std::flush;
     LoadEventNexus load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
     TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "CNCS_7860_event.nxs"));
@@ -1451,16 +1483,19 @@ public:
   }
 
   void test_start_and_end_time_filtered_loading_meta_data_only() {
+    std::cout << "test filtering start and end time only metadata\n" << std::flush;
     const bool metadataonly = true;
     do_test_filtering_start_and_end_filtered_loading(metadataonly);
   }
 
   void test_start_and_end_time_filtered_loading() {
+    std::cout << "test filtering start and end time not only metadata\n" << std::flush;
     const bool metadataonly = false;
     do_test_filtering_start_and_end_filtered_loading(metadataonly);
   }
 
   void testSimulatedFile() {
+    std::cout << "test simulated file ARCS\n" << std::flush;
     Mantid::API::FrameworkManager::Instance();
     LoadEventNexus ld;
     std::string wsname = "ARCS_sim";
@@ -1490,6 +1525,7 @@ public:
   }
 
   void test_extract_nperiod_data() {
+    std::cout << "test extract nperiod data\n" << std::flush;
     LoadEventNexus loader;
 
     loader.setChild(true);
@@ -1555,6 +1591,9 @@ public:
     // only one period has any data in it. It should load, but only one workspace instead
     // of two.
     // See https://github.com/mantidproject/mantid/issues/33729 for details
+
+    std::cout << "test LARMOR file with empty periods\n" << std::flush;
+
     LoadEventNexus loader;
     loader.initialize();
     loader.setPropertyValue("OutputWorkspace", "dummy");
@@ -1570,6 +1609,8 @@ public:
     // bank2: all event_id are out of range and should be ignored (91 events)
     // bank_error: all correct data but should be skipped because this bank is junk output (6052 events)
     // bank_unmapped: all junk data and shouldn't be loaded (91 events)
+
+    std::cout << "test CG3 bad event id\n" << std::flush;
 
     LoadEventNexus load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
@@ -1588,6 +1629,9 @@ public:
     // Some ISIS runs can be corrupted by instrument noise,
     // resulting in incorrect period numbers.
     // LoadEventNexus should fail in this case.
+
+    std::cout << "test SANS2D on corrupted run\n" << std::flush;
+
     LoadEventNexus loader;
 
     loader.setChild(true);
@@ -1600,6 +1644,8 @@ public:
   void test_load_ILL_no_triggers() {
     // ILL runs don't have any pulses, so in event mode, they are replaced in the event nexus by trigger signals.
     // But some of these nexuses don't have any triggers either, so they are modified to be allowed to be loaded.
+
+    std::cout << "test ILL no triggers\n" << std::flush;
 
     LoadEventNexus loader;
 
@@ -1629,6 +1675,8 @@ public:
   void test_load_ILL_triggers() {
     // ILL runs don't have any pulses, so in event mode, they are replaced in the event nexus by trigger signals.
 
+    std::cout << "test ILL triggers\n" << std::flush;
+
     LoadEventNexus loader;
 
     loader.initialize();
@@ -1656,6 +1704,9 @@ public:
   void test_load_event_nexus_ISIS_exc_inst() {
     // Test new format ISIS event data files which have some instrument information
     // but does not follow Mantid's NexusGeometry specifications
+
+    std::cout << "test load ISIS event data\n" << std::flush;
+
     const std::string file = "MAR28482.nxs";
     LoadEventNexus alg;
     alg.setChild(true);
@@ -1672,6 +1723,7 @@ public:
   }
 
   void test_monotonically_increasing_tofs() {
+    std::cout << "test load monotonically increasing TOFs\n" << std::flush;
     const std::string file = "CG2_monotonically_increasing_pulse_times.nxs.h5";
     const std::string wsName = "dummy_for_child";
     LoadEventNexus alg;
@@ -1699,6 +1751,8 @@ public:
   void test_no_events() {
     // this test was created for the strange case of an event file having no events anywhere
     // originally it was only an empty monitor but the test file was expanded
+
+    std::cout << "test load no events\n" << std::flush;
 
     const std::string filename = "CG3_22446_empty.nxs.h5";
     const std::string wsname = "CG3_empty";

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -595,9 +595,9 @@ void Material::loadNexus(Nexus::File *file, const std::string &group) {
   this->calculateTotalScatterXSection();
 
   file->readData("number_density", m_numberDensity);
-  try {
+  if (file->hasData("packing_fraction")) {
     file->readData("packing_fraction", m_packingFraction);
-  } catch (std::runtime_error &) {
+  } else {
     m_packingFraction = 1.;
   }
   file->readData("temperature", m_temperature);

--- a/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -940,6 +940,10 @@ public:
   }
 
   void test_loading_MD_with_missing_parameter_map() {
+    // NOTE if changes are made to Nexus::File::getAttr that create an error
+    // then this test will be one of the places the error appears
+    std::cout << "Test Loading MD with missing parameter map\n" << std::flush;
+
     // Arrange
     std::string filename("md_missing_paramater_map.nxs");
     std::string outWSName("LoadMD_md_missing_paramater_map");
@@ -975,6 +979,7 @@ public:
     if (iws) {
       AnalysisDataService::Instance().remove(outWSName);
     }
+    std::cout << "finished loading missing parameter map\n" << std::flush;
   }
 
   void test_simple_file() {

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -13,6 +13,11 @@ namespace {
 static const std::string NULL_STR("NULL");
 }
 
+namespace H5 {
+// forward declare
+class H5Object;
+} // namespace H5
+
 /**
  * \file NexusFile.h Definition of the NeXus C++ API.
  * \defgroup cpp_types C++ Types
@@ -165,6 +170,15 @@ public:
 
 private:
   // EXPLORE FILE LEVEL ENTRIES / ATTRIBUTES
+
+  hid_t getCurrentId() const;
+
+  /** It is sometimes necessary to interface with code using the H5Cpp library
+   * This method will return the current location as an object, which can be
+   * used with, for instance, H5Util or other parts of Mantid
+   * \returns a shared pointer to an H5Object corresponding to current location
+   */
+  std::shared_ptr<H5::H5Object> getCurrentObject() const;
 
   // these are used for updating the NexusDescriptor
   std::string formAbsoluteAddress(std::string const &);

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -117,20 +117,21 @@ enum class NXstatus : const int { NX_OK = 1, NX_ERROR = 0, NX_EOD = -1 };
  */
 class MANTID_NEXUS_DLL NXnumtype {
 public:
-  static int const FLOAT32 = 5;
-  static int const FLOAT64 = 6;
-  static int const INT8 = 20;
-  static int const UINT8 = 21;
-  static int const BOOLEAN = 21;
-  static int const INT16 = 22;
-  static int const UINT16 = 23;
-  static int const INT32 = 24;
-  static int const UINT32 = 25;
-  static int const INT64 = 26;
-  static int const UINT64 = 27;
-  static int const CHAR = 4;
-  static int const BINARY = 21;
-  static int const BAD = -1;
+  // first hexadigit: 2 = float, 1 = signed int, 0 = unsigned int, F = special
+  // second hexadigit: width in bytes
+  static unsigned short constexpr FLOAT32 = 0x24u; // 10 0100 = 0x24
+  static unsigned short constexpr FLOAT64 = 0x28u; // 10 1000 = 0x28
+  static unsigned short constexpr INT8 = 0x11u;    // 01 0001 = 0x11
+  static unsigned short constexpr INT16 = 0x12u;   // 01 0010 = 0x12
+  static unsigned short constexpr INT32 = 0x14u;   // 01 0100 = 0x14
+  static unsigned short constexpr INT64 = 0x18u;   // 01 1000 = 0x18
+  static unsigned short constexpr UINT8 = 0x01u;   // 00 0001 = 0x01
+  static unsigned short constexpr UINT16 = 0x02u;  // 00 0010 = 0x02
+  static unsigned short constexpr UINT32 = 0x04u;  // 00 0100 = 0x04
+  static unsigned short constexpr UINT64 = 0x08u;  // 00 1000 = 0x08
+  static unsigned short constexpr CHAR = 0xF0u;    // 11 0000 = 0xF0
+  static unsigned short constexpr BINARY = 0xF1u;  // 11 0001 = 0xF1
+  static unsigned short constexpr BAD = 0xFFu;     // 11 1111 = 0xFF
 
 private:
   int m_val;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -48,7 +48,6 @@ struct MANTID_NEXUS_DLL NexusFile5 {
   hid_t iCurrentA;
   hsize_t iCurrentIDX;
   int iNX;
-  std::size_t iStackPtr; // NOTE probably sufficient to use .back() instead
   std::string name_ref;
   std::string name_tmp;
 

--- a/Framework/Nexus/inc/MantidNexus/napi.h
+++ b/Framework/Nexus/inc/MantidNexus/napi.h
@@ -379,20 +379,6 @@ MANTID_NEXUS_DLL NXstatus NXgetnextattra(NXhandle handle, std::string &name, std
 MANTID_NEXUS_DLL NXstatus NXgetgroupID(NXhandle handle, NXlink &pLink);
 
 /**
- * Retrieve information about the currently open group.
- * \param handle A NeXus file handle as initialized by NXopen.
- * \param no_items A pointer to an integer which will be set to the count
- *   of group elements available. This is the count of other groups and
- * data sets in this group.
- * \param name The name of the group.
- * \param nxclass The NeXus class name of the group.
- * \return NX_OK on success, NX_ERROR in the case of an error.
- * \ingroup c_metadata
- */
-MANTID_NEXUS_DLL NXstatus NXgetgroupinfo(NXhandle handle, std::size_t &no_items, std::string &name,
-                                         std::string &nxclass);
-
-/**
  * Tests if two link data structures describe the same item.
  * \param handle A NeXus file handle as initialized by NXopen.
  * \param pFirstID The first link data for the test.

--- a/Framework/Nexus/inc/MantidNexus/napi5.h
+++ b/Framework/Nexus/inc/MantidNexus/napi5.h
@@ -17,7 +17,6 @@ NXstatus NX5getnextentry(NXhandle handle, std::string &name, std::string &nxclas
 
 NXstatus NX5getnextattr(NXhandle handle, std::string &pName, std::size_t &iLength, NXnumtype &iType);
 NXstatus NX5getattr(NXhandle handle, std::string const &name, void *data, std::size_t &iDataLen, NXnumtype &iType);
-NXstatus NX5getgroupinfo(NXhandle handle, std::size_t &no_items, std::string &name, std::string &nxclass);
 
 NXstatus NX5getnextattra(NXhandle handle, std::string &pName, std::size_t &rank, Mantid::Nexus::DimVector &dim,
                          NXnumtype &iType);

--- a/Framework/Nexus/inc/MantidNexus/napi_helper.h
+++ b/Framework/Nexus/inc/MantidNexus/napi_helper.h
@@ -24,8 +24,6 @@ MANTID_NEXUS_DLL void killAttVID(const pNexusFile5 pFile, hid_t vid);
 
 MANTID_NEXUS_DLL NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink const &sLink);
 
-MANTID_NEXUS_DLL int countObjectsInGroup(hid_t loc_id);
-
 MANTID_NEXUS_DLL NXnumtype hdf5ToNXType(H5T_class_t tclass, hid_t atype);
 
 MANTID_NEXUS_DLL hid_t nxToHDF5Type(NXnumtype datatype);

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -579,10 +579,15 @@ template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, con
 
 template MANTID_NEXUS_DLL float readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL double readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL int8_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL uint8_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL int16_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL uint16_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL int32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL uint32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL int64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL uint64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL char readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 
 // -------------------------------------------------------------------
 // instantiations for readNumArrayAttributeCoerce

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -33,17 +33,6 @@ using std::vector;
     throw NXEXCEPTION(msg);                                                                                            \
   }
 
-#define DEBUG_LOG()                                                                                                    \
-  printf("%s:%d %s\n", __FILE__, __LINE__, __func__);                                                                  \
-  fflush(stdout);
-
-#define FILE_EXISTS(filename)                                                                                          \
-  if (!std::filesystem::exists(filename)) {                                                                            \
-    throw std::runtime_error(std::string(__FILE__) + ":" + std::to_string(__LINE__));                                  \
-  } else {                                                                                                             \
-    DEBUG_LOG();                                                                                                       \
-  }
-
 /**
  * \file NexusFile.cpp
  * The implementation of the NeXus C++ API
@@ -175,7 +164,7 @@ namespace Mantid::Nexus {
 // catch for undefined types
 template <typename NumT> NXnumtype getType(NumT const number) {
   stringstream msg;
-  msg << "NeXus::getType() does not know type of " << typeid(number).name();
+  msg << "Nexus::getType() does not know type of " << typeid(number).name();
   throw Exception(msg.str(), "NXnumtype getType<NumT>");
 }
 
@@ -231,7 +220,7 @@ void File::initOpenFile(const string &filename, const NXaccess access) {
   NexusFile5 tmp(filename, access);
   if (tmp.iFID <= 0) {
     stringstream msg;
-    msg << "NXopen(" << filename << ", " << access << ") failed";
+    msg << "File::initOpenFile(" << filename << ", " << access << ") failed";
     throw NXEXCEPTION(msg.str());
   } else {
     m_pfile_id = std::make_shared<NexusFile5>(tmp);
@@ -763,7 +752,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
   }
 
   // do the work
-  int i_type = static_cast<int>(type);
 
   hid_t datatype1, dataspace, iNew;
   hid_t dtype, cparms = -1;
@@ -777,7 +765,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
   bool unlimiteddim = false;
   int rank = static_cast<int>(dims.size());
   stringstream msg;
-  msg << "NXcompmakedata64(" << name << ", " << i_type << ", " << dims.size() << ", " << toString(dims) << ", " << comp
+  msg << "NXcompmakedata64(" << name << ", " << type << ", " << dims.size() << ", " << toString(dims) << ", " << comp
       << ", " << toString(chunk) << ") failed: ";
 
   pFile = assertNXID(m_pfile_id);

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1690,18 +1690,12 @@ void File::makeLink(NXlink const &link) {
 using namespace Mantid::Nexus;
 int NXnumtype::validate_val(int const x) {
   int val = BAD;
-  // NOTE for user-readability it is better to check all of these cases
-  // cppcheck doesn't like this, as some of these have the same value, making checks redundant
-  // cppcheck-suppress-begin knownConditionTrueFalse
-  if ((x == FLOAT32) || (x == FLOAT64) || (x == INT8) || (x == UINT8) || (x == BOOLEAN) || (x == INT16) ||
-      (x == UINT16) || (x == INT32) || (x == UINT32) || (x == INT64) || (x == UINT64) || (x == CHAR) || (x == BINARY) ||
-      (x == BAD)) {
+  if ((x == INT8) || (x == UINT8) || (x == INT16) || (x == UINT16) || (x == INT32) || (x == UINT32) || (x == INT64) ||
+      (x == UINT64) || (x == FLOAT32) || (x == FLOAT64) || (x == CHAR) || (x == BINARY) || (x == BAD)) {
     val = x;
   }
-  // cppcheck-suppress-end knownConditionTrueFalse
   return val;
 }
-
 NXnumtype::NXnumtype() : m_val(BAD) {};
 NXnumtype::NXnumtype(int const val) : m_val(validate_val(val)) {};
 
@@ -1714,43 +1708,28 @@ NXnumtype::operator int() const { return m_val; };
 
 #define NXTYPE_PRINT(var) #var // stringify the variable name, for cleaner code
 
-// cppcheck-suppress-begin knownConditionTrueFalse
 NXnumtype::operator std::string() const {
-  // NOTE for user-readability it is better to check all of these cases
-  // cppcheck doesn't like this, as some of these have the same value, making checks redundant
-  // cppcheck-suppress-begin knownConditionTrueFalse
+  // isolate each hexadigit
+  unsigned short type = static_cast<unsigned short>(m_val & 0xF0);
+  unsigned short size = static_cast<unsigned short>(m_val & 0x0F);
+  std::string sizestr = std::to_string(size * 8u); // width in bits
   std::string ret = NXTYPE_PRINT(BAD);
-  if (m_val == FLOAT32) {
-    ret = NXTYPE_PRINT(FLOAT32);
-  } else if (m_val == FLOAT64) {
-    ret = NXTYPE_PRINT(FLOAT64);
-  } else if (m_val == INT8) {
-    ret = NXTYPE_PRINT(INT8);
-  } else if (m_val == UINT8) {
-    ret = NXTYPE_PRINT(UINT8);
-  } else if (m_val == BOOLEAN) {
-    ret = NXTYPE_PRINT(BOOLEAN);
-  } else if (m_val == INT16) {
-    ret = NXTYPE_PRINT(INT16);
-  } else if (m_val == UINT16) {
-    ret = NXTYPE_PRINT(UINT16);
-  } else if (m_val == INT32) {
-    ret = NXTYPE_PRINT(INT32);
-  } else if (m_val == UINT32) {
-    ret = NXTYPE_PRINT(UINT32);
-  } else if (m_val == INT64) {
-    ret = NXTYPE_PRINT(INT64);
-  } else if (m_val == UINT64) {
-    ret = NXTYPE_PRINT(UINT64);
-  } else if (m_val == CHAR) {
-    ret = NXTYPE_PRINT(CHAR);
-  } else if (m_val == BINARY) {
-    ret = NXTYPE_PRINT(BINARY);
+  if (type == 0x00u) {
+    ret = "UINT" + sizestr;
+  } else if (type == 0x10u) {
+    ret = "INT" + sizestr;
+  } else if (type == 0x20u) {
+    ret = "FLOAT" + sizestr;
+  } else if (type == 0xF0u) {
+    // special types
+    if (m_val == CHAR) {
+      ret = NXTYPE_PRINT(CHAR);
+    } else if (m_val == BINARY) {
+      ret = NXTYPE_PRINT(BINARY);
+    }
   }
-  // cppcheck-suppress-end knownConditionTrueFalse
   return ret;
 }
-// cppcheck-suppress-end knownConditionTrueFalse
 
 std::ostream &operator<<(std::ostream &os, const NXnumtype &value) {
   os << std::string(value);

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -1016,11 +1016,6 @@ NXstatus NXgetgroupID(NXhandle fileid, NXlink &sRes) {
 }
 
 /*-------------------------------------------------------------------------*/
-
-NXstatus NXgetgroupinfo(NXhandle fid, std::size_t &iN, std::string &pName, std::string &pClass) {
-  return NX5getgroupinfo(fid, iN, pName, pClass);
-}
-
 /*-------------------------------------------------------------------------*/
 
 NXstatus NXsameID(NXhandle fileid, NXlink const &pFirstID, NXlink const &pSecondID) {

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -37,17 +37,14 @@
 
 #include "MantidNexus/napi.h"
 
-// cppcheck-suppress-begin [constVariablePointer, unmatchedSuppression]
+// cppcheck-suppress-begin [unmatchedSuppression]
+// cppcheck-suppress-begin [constVariablePointer, constParameterReference, unusedVariable, unreadVariable]
 
 // this has to be after the other napi includes
 #include "MantidNexus/napi5.h"
 #include "MantidNexus/napi_helper.h"
 
 #define NX_UNKNOWN_GROUP "" /* for when no NX_class attr */
-
-#define DEBUG_LOG()                                                                                                    \
-  printf("%s:%d %s\n", __FILE__, __LINE__, __func__);                                                                  \
-  fflush(stdout);
 
 /*--------------------------------------------------------------------*/
 /* static int iFortifyScope; */
@@ -96,7 +93,7 @@ NXstatus NXopen(std::string const &filename, NXaccess const am, NXhandle &fid) {
   bool isHDF5 = (am == NXaccess::CREATE5 ? true : canBeOpened(filename));
   NXstatus status = NXstatus::NX_ERROR;
   if (isHDF5) {
-    // call NX5open to set variables on it
+    // construct on heap
     fid = new NexusFile5(filename, am);
     status = NXstatus::NX_OK;
   } else {
@@ -686,7 +683,7 @@ NXstatus NXgetdataID(NXhandle fid, NXlink &sRes) {
    */
   std::size_t datalen = 1024;
   char caddr[1024] = {0};
-  if (NX5getattr(fid, "target", caddr, datalen, type) != NXstatus::NX_OK) {
+  if (NXgetattr(fid, "target", caddr, datalen, type) != NXstatus::NX_OK) {
     sRes.targetAddress = buildCurrentAddress(pFile);
   } else {
     sRes.targetAddress = std::string(caddr);
@@ -1006,7 +1003,7 @@ NXstatus NXgetgroupID(NXhandle fileid, NXlink &sRes) {
      */
     std::size_t datalen = 1024;
     char caddr[1024] = {0};
-    if (NX5getattr(fileid, "target", caddr, datalen, type) != NXstatus::NX_OK) {
+    if (NXgetattr(fileid, "target", caddr, datalen, type) != NXstatus::NX_OK) {
       sRes.targetAddress = buildCurrentAddress(pFile);
     } else {
       sRes.targetAddress = std::string(caddr);
@@ -1191,4 +1188,5 @@ char *NXIformatNeXusTime() {
   return time_buffer;
 }
 
-// cppcheck-suppress-end [constVariablePointer, unmatchedSuppression]
+// cppcheck-suppress-end [constVariablePointer, constParameterReference, unusedVariable, unreadVariable]
+// cppcheck-suppress-end [unmatchedSuppression]

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -199,75 +199,7 @@ herr_t group_info(hid_t loc_id, const char *name, const H5L_info_t *statbuf, voi
 }
 
 /*-------------------------------------------------------------------------*/
-
-NXstatus NX5getgroupinfo_recurse(NXhandle fid, std::size_t &iN, std::string &name, std::string &nxclass) {
-  pNexusFile5 pFile;
-  hid_t atype, attr_id, grp;
-
-  pFile = NXI5assert(fid);
-  /* check if there is a group open */
-  if (pFile->iCurrentG == 0) {
-    name = "root";
-    nxclass = "NXroot";
-    pFile->iNX = 0;
-    grp = H5Gopen(pFile->iFID, "/", H5P_DEFAULT);
-    H5Literate(grp, H5_INDEX_NAME, H5_ITER_INC, 0, group_info, &pFile->iNX);
-    H5Gclose(grp);
-    iN = pFile->iNX;
-  } else {
-    name = pFile->name_ref;
-    attr_id = H5Aopen_by_name(pFile->iCurrentG, ".", "NX_class", H5P_DEFAULT, H5P_DEFAULT);
-    if (attr_id < 0) {
-      nxclass = NX_UNKNOWN_GROUP;
-    } else {
-      atype = H5Tcopy(H5T_C_S1);
-      char data[64];
-      H5Tset_size(atype, sizeof(data));
-      readStringAttributeN(attr_id, data, sizeof(data));
-      nxclass = data;
-      pFile->iNX = 0;
-      grp = H5Gopen(pFile->iFID, pFile->name_ref.c_str(), H5P_DEFAULT);
-      H5Literate(grp, H5_INDEX_NAME, H5_ITER_INC, 0, group_info, &pFile->iNX);
-      H5Gclose(grp);
-      iN = pFile->iNX;
-      H5Aclose(attr_id);
-    }
-  }
-  return NXstatus::NX_OK;
-}
-
 /*----------------------------------------------------------------------------*/
-NXstatus NX5getgroupinfo(NXhandle fid, std::size_t &iN, std::string &name, std::string &nxclass) {
-  pNexusFile5 pFile;
-  hid_t atype, attr_id, gid;
-
-  pFile = NXI5assert(fid);
-  /* check if there is a group open */
-  if (pFile->iCurrentG == 0) {
-    name = "root";
-    nxclass = "NXroot";
-    gid = H5Gopen(pFile->iFID, "/", H5P_DEFAULT);
-    iN = countObjectsInGroup(gid);
-    H5Gclose(gid);
-  } else {
-    name = pFile->name_ref;
-    attr_id = H5Aopen_by_name(pFile->iCurrentG, ".", "NX_class", H5P_DEFAULT, H5P_DEFAULT);
-    if (attr_id < 0) {
-      nxclass = NX_UNKNOWN_GROUP;
-    } else {
-      atype = H5Tcopy(H5T_C_S1);
-      char data[64];
-      H5Tset_size(atype, sizeof(data));
-      readStringAttributeN(attr_id, data, sizeof(data));
-      nxclass = data;
-      H5Aclose(attr_id);
-    }
-    pFile->iNX = 0;
-    iN = countObjectsInGroup(pFile->iCurrentG);
-  }
-  return NXstatus::NX_OK;
-}
-
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, NXnumtype &datatype) {

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -23,8 +23,10 @@
 
 ----------------------------------------------------------------------------*/
 
-// cppcheck-suppress-begin [unmatchedSuppression, variableScope, invalidPrintfArgType_uint, constParameterReference]
+// cppcheck-suppress-begin unmatchedSuppression
+// cppcheck-suppress-begin [variableScope, invalidPrintfArgType_uint, constParameterReference]
 // cppcheck-suppress-begin [constParameterCallback, unreadVariable, constParameter, constParameterPointer]
+// cppcheck-suppress-begin [shadowArgument]
 
 #include <string>
 #define H5Aiterate_vers 2
@@ -330,7 +332,7 @@ NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, 
          open group and find class name attribute
        */
       std::string ph_name("");
-      for (stackEntry entry : pFile->iStack5) {
+      for (stackEntry const &entry : pFile->iStack5) {
         ph_name += entry.irefn + "/";
       }
       ph_name += name;
@@ -760,5 +762,6 @@ NXstatus NX5getattrainfo(NXhandle handle, std::string const &name, std::size_t &
   return NXstatus::NX_OK;
 }
 
-// cppcheck-suppress-end [constParameterCallback, unreadVariable, constParameter, constParameterPointer]
-// cppcheck-suppress-end [unmatchedSuppression, variableScope, invalidPrintfArgType_uint, constParameterReference]
+// cppcheck-suppress-end [constParameterCallback, unreadVariable, constParameter, constParameterPointer, shadowArgument]
+// cppcheck-suppress-end [variableScope, invalidPrintfArgType_uint, constParameterReference]
+// cppcheck-suppress-end unmatchedSuppression

--- a/Framework/Nexus/src/napi5.cpp
+++ b/Framework/Nexus/src/napi5.cpp
@@ -283,7 +283,7 @@ NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, 
   /*
      iterate to next entry in group list
    */
-  idx = pFile->iStack5[pFile->iStackPtr].iCurrentIDX;
+  idx = pFile->iStack5.back().iCurrentIDX;
   if (pFile->name_ref.empty()) {
     /* root group */
     pFile->name_ref = "/";
@@ -317,12 +317,12 @@ NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, 
   }
 
   if (iRet > 0) {
-    pFile->iStack5[pFile->iStackPtr].iCurrentIDX++;
+    pFile->iStack5.back().iCurrentIDX++;
     if (op_data.iname != NULL) {
       name = op_data.iname;
       free(op_data.iname);
     } else {
-      pFile->iStack5[pFile->iStackPtr].iCurrentIDX = 0;
+      pFile->iStack5.back().iCurrentIDX = 0;
       return NXstatus::NX_EOD;
     }
     if (op_data.type == H5O_TYPE_GROUP) {
@@ -330,8 +330,8 @@ NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, 
          open group and find class name attribute
        */
       std::string ph_name("");
-      for (std::size_t i = 1; i < (pFile->iStackPtr + 1); i++) {
-        ph_name += pFile->iStack5[i].irefn + "/";
+      for (stackEntry entry : pFile->iStack5) {
+        ph_name += entry.irefn + "/";
       }
       ph_name += name;
       grp = H5Gopen(pFile->iFID, ph_name.c_str(), H5P_DEFAULT);
@@ -388,7 +388,7 @@ NXstatus NX5getnextentry(NXhandle fid, std::string &name, std::string &nxclass, 
       if (op_data.iname != NULL) {
         free(op_data.iname);
       }
-      pFile->iStack5[pFile->iStackPtr].iCurrentIDX = 0;
+      pFile->iStack5.back().iCurrentIDX = 0;
       return NXstatus::NX_EOD;
     }
     if (op_data.iname != NULL) {

--- a/Framework/Nexus/src/napi_helper.cpp
+++ b/Framework/Nexus/src/napi_helper.cpp
@@ -174,21 +174,23 @@ NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink const &sLink) {
   return NXstatus::NX_OK;
 }
 
-int countObjectsInGroup(hid_t loc_id) {
-  int count = 0;
-  H5G_info_t numobj;
-
-  herr_t status;
-
-  status = H5Gget_info(loc_id, &numobj);
-  if (status < 0) {
-    NXReportError("Internal error, failed to retrieve no of objects");
-    return 0;
-  }
-
-  count = (int)numobj.nlinks;
-  return count;
-}
+// NOTE save in case needed later as model
+// std::size_t countObjectsInGroup(pNexusFile5 const fid) {
+//   std::size_t count = 0;
+//   herr_t iRet;
+//   if (fid->iCurrentG == 0) {
+//     hid_t gid = H5Gopen(fid->iFID, "/", H5P_DEFAULT);
+//     iRet = H5Gget_num_objs(gid, &count);
+//     H5Gclose(gid);
+//   } else {
+//     iRet = H5Gget_num_objs(fid->iCurrentG, &count);
+//   }
+//   if (iRet < 0) {
+//     NXReportError("Internal error, failed to retrieve no of objects");
+//     return 0;
+//   }
+//   return count;
+// }
 
 NXnumtype hdf5ToNXType(H5T_class_t tclass, hid_t atype) {
   // NOTE this is exploiting the bit-level representation of NXnumtype

--- a/Framework/Nexus/src/napi_helper.cpp
+++ b/Framework/Nexus/src/napi_helper.cpp
@@ -191,54 +191,32 @@ int countObjectsInGroup(hid_t loc_id) {
 }
 
 NXnumtype hdf5ToNXType(H5T_class_t tclass, hid_t atype) {
+  // NOTE this is exploiting the bit-level representation of NXnumtype
+  // where the first hex stands for: 2 = float, 1 = signed int, 0 = unsigned int
+  // and where the second hex is the width in bytes (which is given by H5Tget_size)
+  // and where CHAR (0XF0) and BINARY (0xF1) are special values
+  unsigned short size = static_cast<unsigned short>(H5Tget_size(atype));
   NXnumtype iPtype = NXnumtype::BAD;
-  size_t size;
-  H5T_sign_t sign;
-
   if (tclass == H5T_STRING) {
     iPtype = NXnumtype::CHAR;
+  } else if (tclass == H5T_BITFIELD) {
+    // underused datatype, would be great for masks
+    iPtype = NXnumtype::BINARY;
   } else if (tclass == H5T_INTEGER) {
-    size = H5Tget_size(atype);
-    sign = H5Tget_sign(atype);
-    if (size == 1) {
-      if (sign == H5T_SGN_2) {
-        iPtype = NXnumtype::INT8;
-      } else {
-        iPtype = NXnumtype::UINT8;
-      }
-    } else if (size == 2) {
-      if (sign == H5T_SGN_2) {
-        iPtype = NXnumtype::INT16;
-      } else {
-        iPtype = NXnumtype::UINT16;
-      }
-    } else if (size == 4) {
-      if (sign == H5T_SGN_2) {
-        iPtype = NXnumtype::INT32;
-      } else {
-        iPtype = NXnumtype::UINT32;
-      }
-    } else if (size == 8) {
-      if (sign == H5T_SGN_2) {
-        iPtype = NXnumtype::INT64;
-      } else {
-        iPtype = NXnumtype::UINT64;
-      }
+    unsigned short type = size;
+    H5T_sign_t sign = H5Tget_sign(atype);
+    if (sign == H5T_SGN_2) {
+      type += 0x10; // signed data type
     }
+    iPtype = NXnumtype(type);
   } else if (tclass == H5T_FLOAT) {
-    size = H5Tget_size(atype);
-    if (size == 4) {
-      iPtype = NXnumtype::FLOAT32;
-    } else if (size == 8) {
-      iPtype = NXnumtype::FLOAT64;
-    }
+    iPtype = NXnumtype(0x20u + size);
   }
   if (iPtype == NXnumtype::BAD) {
     char message[80];
     snprintf(message, 79, "ERROR: hdf5ToNXtype: invalid type (%d)", tclass);
     NXReportError(message);
   }
-
   return iPtype;
 }
 
@@ -298,6 +276,7 @@ hid_t nxToHDF5Type(NXnumtype datatype) {
 }
 
 hid_t h5MemType(hid_t atype) {
+  // NOTE is this function actually necessary?
   hid_t memtype_id = -1;
   size_t size;
   H5T_sign_t sign;

--- a/Framework/Nexus/src/napi_helper.cpp
+++ b/Framework/Nexus/src/napi_helper.cpp
@@ -9,7 +9,7 @@
 
 pNexusFile5 NXI5assert(NXhandle fid) { return fid; }
 
-void NXI5KillDir(pNexusFile5 self) { self->iStack5[self->iStackPtr].iCurrentIDX = 0; }
+void NXI5KillDir(pNexusFile5 self) { self->iStack5.back().iCurrentIDX = 0; }
 
 herr_t readStringAttribute(hid_t attr, char **data) {
   herr_t iRet = 0;

--- a/Framework/Nexus/test/NapiUnitTest.h
+++ b/Framework/Nexus/test/NapiUnitTest.h
@@ -345,8 +345,6 @@ public:
     H5Iget_name(fid->iCurrentD, path1, 128);
 
     // make and open lateral data
-    // NOTE this behavior is not what is actually desired and causes confusion
-    // Making a dataset while a dataset is already open should be disallowed
     char data2[] = "data2";
     NX_ASSERT_OKAY(NXmakedata64(fid, data2, type, 1, dims), "made a nested data2");
     NX_ASSERT_OKAY(NXopendata(fid, data2), "failed to open data");
@@ -870,6 +868,7 @@ public:
   // ################################################################################################################
 
   template <typename T> void do_test_putget_attr(NexusFile5 *fid, string name, T const &data) {
+    cout << "\tput/get attribute " << name << "\n";
     // test put/get by pointer to data
     T out;
     std::size_t len;

--- a/Framework/Nexus/test/NapiUnitTest.h
+++ b/Framework/Nexus/test/NapiUnitTest.h
@@ -902,9 +902,6 @@ public:
     do_test_putget_attr(fid, expected_names[1], 120.2e6);
 
     // check attr infos
-    // std::size_t numattr;
-    // NX_ASSERT_OKAY(NXgetattrinfo(fid, numattr), "failed to get attr info");
-    // TS_ASSERT_EQUALS(numattr, 2);
     NX_ASSERT_OKAY(NXinitattrdir(fid), "failed to restart attributes");
     std::string name(20, 0);
     std::size_t len;

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -647,35 +647,6 @@ public:
     TS_ASSERT_EQUALS(ind, outd);
   }
 
-  void test_data_existing_missing() {
-    // this test protects against a regression that can occur in OSX inside of LoadMD
-    cout << "\ntest dataset read existing -- sample/material\n";
-
-    // open a file
-    std::string filename = getFullPath("md_missing_paramater_map.nxs");
-    Mantid::Nexus::File file(filename, NXaccess::READ);
-
-    std::string addressOfBad("/MDHistoWorkspace/experiment0/sample");
-    TS_ASSERT_EQUALS(file.hasAddress(addressOfBad), true);
-
-    // go to this address and read things in
-    file.openAddress(addressOfBad);
-
-    // confirm version is 2
-    int version;
-    file.getAttr("version", version);
-    TS_ASSERT_EQUALS(version, 1);
-
-    // read the name
-    std::string name;
-    file.getAttr("name", name);
-    TS_ASSERT(!name.empty());
-
-    // read the formula style
-    std::string formulaStyle;
-    TS_ASSERT_THROWS(file.getAttr("formulaStyle", formulaStyle), Mantid::Nexus::Exception const &);
-  }
-
   void test_data_string_array_as_char_array() {
     // this test checks that string arrays saved a block char arrays can be read back
     // this guards against a regression that would otherwise occur within PropertyNexusTest
@@ -1018,6 +989,54 @@ public:
     TS_ASSERT_THROWS(file.getInfo(), Mantid::Nexus::Exception const &);
   }
 
+  void test_isDataSetOpen() {
+    cout << "\ntest is data set open\n";
+    // open a file
+    FileResource resource("test_nexus_file_isdataopen.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+
+    // the root is not a dataset
+    TS_ASSERT(!file.isDataSetOpen());
+
+    // a group is not a dataset
+    file.makeGroup("entry", "NXentry", true);
+    TS_ASSERT(!file.isDataSetOpen());
+
+    // a dataset IS a dataset
+    file.makeData("data", NXnumtype::CHAR, 1, true);
+    TS_ASSERT(file.isDataSetOpen());
+
+    file.close();
+  }
+
+  void test_isDataInt() {
+    cout << "\ntest is data set open\n";
+    // open a file
+    FileResource resource("test_nexus_file_isdataopen.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry", "NXentry", true);
+
+    // char data is not int
+    file.makeData("chardata", NXnumtype::CHAR, 1, true);
+    TS_ASSERT(!file.isDataInt());
+
+    // float data is not int
+    file.makeData("floatdata", NXnumtype::FLOAT32, 1, true);
+    TS_ASSERT(!file.isDataInt());
+
+    // all the integer types are ints
+    std::vector<NXnumtype> inttypes{NXnumtype::INT8,  NXnumtype::UINT8,  NXnumtype::INT16, NXnumtype::UINT16,
+                                    NXnumtype::INT32, NXnumtype::UINT32, NXnumtype::INT64, NXnumtype::UINT64};
+    for (NXnumtype const &type : inttypes) {
+      file.makeData("data_" + std::string(type), type, 1, true);
+      TS_ASSERT(file.isDataInt());
+    }
+
+    file.close();
+  }
+
   // ##################################################################################################################
   // TEST ATTRIBUTE METHODS
   // ################################################################################################################
@@ -1060,6 +1079,33 @@ public:
     }
   }
 
+  void test_putget_attr_different_types() {
+    cout << "\ntest attribute -- different types\n";
+
+    // open a file
+    FileResource resource("test_nexus_attr_different.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry", "NXentry", true);
+
+    std::vector<std::string> expected_names{"int_attr", "dbl_attr"};
+
+    // put the attributes
+    int64_t in(7);
+    double rin(124.e7);
+    file.putAttr(expected_names[0], in);
+    file.putAttr(expected_names[1], rin);
+    file.flush();
+
+    int8_t out;
+    float rout;
+    file.getAttr(expected_names[0], out);
+    file.getAttr(expected_names[1], rout);
+    TS_ASSERT_EQUALS(in, out);
+    TS_ASSERT_EQUALS(rin, rout);
+    file.close();
+  }
+
   void test_putget_attr_str() {
     cout << "\ntest string attribute read/write\n";
 
@@ -1094,6 +1140,133 @@ public:
     TS_ASSERT_EQUALS(attrInfos[1].length, actual.size());
   }
 
+  void test_get_bad_attr_fails() {
+    cout << "\ntest atttribute -- bad\n";
+
+    // open a file
+    FileResource resource("test_nexus_attr_bad.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    // move to an entry to avoid conflict with some root-level attributes
+    file.makeGroup("entry", "NXentry", true);
+
+    std::vector<std::string> attr_names{"attr_1", "attr_2"};
+    int64_t in = 7, out;
+    TS_ASSERT_THROWS_NOTHING(file.putAttr(attr_names[0], in));
+    TS_ASSERT_THROWS_NOTHING(file.getAttr(attr_names[0], out));
+    TS_ASSERT_EQUALS(in, out);
+
+    // try to get an attribute that doesn't exist
+    TS_ASSERT(!file.hasAttr(attr_names[1]));
+    TS_ASSERT_THROWS(file.getAttr(attr_names[1], out), Mantid::Nexus::Exception const &);
+
+    // cleanup
+    file.close();
+  }
+
+  void test_attr_contrary_type() {
+    cout << "\ntest read existing -- sample/material\n";
+
+    // open a file
+    std::string filename = getFullPath("md_missing_paramater_map.nxs");
+    Mantid::Nexus::File file(filename, NXaccess::READ);
+
+    std::string addressOfBad("/MDHistoWorkspace/experiment0/sample/material");
+    TS_ASSERT_EQUALS(file.hasAddress(addressOfBad), true);
+
+    // go to this address and read things in
+    file.openAddress(addressOfBad);
+
+    // read the name
+    std::string name;
+    TS_ASSERT_THROWS_NOTHING(file.getAttr("name", name));
+    TS_ASSERT(name.empty());
+
+    // confirm version is 2
+    // note that it is stored internally as INT64
+    float version;
+    TS_ASSERT_THROWS_NOTHING(file.getAttr("version", version));
+    TS_ASSERT_EQUALS(version, 2);
+
+    // read the formula style
+    std::string formulaStyle;
+    TS_ASSERT_THROWS_NOTHING(file.getAttr("formulaStyle", formulaStyle));
+    TS_ASSERT_EQUALS(formulaStyle, "empty");
+    file.close();
+  }
+
+  void test_putget_attr_group_and_datasrt_and_root() {
+    cout << "\ntest attribute read/write on group, on dataset, and on root\n";
+
+    // open a file
+    FileResource resource("test_nexus_attr_different_obj.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+
+    std::vector<std::string> expected_names{"root_attr_", "group_attr_", "sds_attr_"};
+    std::vector<int> expected_values{13, 12, 17};
+    std::vector<std::string> expected_str_names{"root_str_attr_", "group_str_attr_", "sds_str_attr_"};
+    std::vector<std::string> expected_string{"root_data", "group_data", "data_data"};
+
+    // NOTE H5cpp catches and does not rethrow the error when closing a Group that was
+    // created from a DataSet or H5File ID.  It is only logged to std::cerr.  We therefore need to
+    // redirect std::cerr and make sure it stays blank to detect this sort of error.
+    // If uncaught this can cause memory leaks
+    std::stringstream errors;
+    std::streambuf *old_cerr = std::cerr.rdbuf();
+    std::cerr.rdbuf(errors.rdbuf());
+
+    // put/get an attribute at root
+    do_test_putget_attr(file, expected_names[0], expected_values[0]);
+    do_test_putget_attr(file, expected_str_names[0], expected_string[0]);
+
+    // put/get an attribute in a group
+    file.makeGroup("entry", "NXentry", true);
+    do_test_putget_attr(file, expected_names[1], expected_values[1]);
+    do_test_putget_attr(file, expected_str_names[1], expected_string[1]);
+
+    // put/get an attribute in a dataset
+    file.makeData("data", NXnumtype::INT64, 1, true);
+    do_test_putget_attr(file, expected_names[2], expected_values[2]);
+    do_test_putget_attr(file, expected_str_names[2], expected_string[2]);
+
+    // make sure none of the above logged any errors
+    TSM_ASSERT(errors.str(), errors.str().empty());
+
+    // cleanup
+    file.close();
+    std::cerr.rdbuf(old_cerr);
+  }
+
+  void test_attr_existing_missing() {
+    // this test protects against a regression that can occur in OSX inside of LoadMD
+    // for reference, see Material::loadNexus() in Material.cpp
+    // see also the test LoadMDTest::test_loading_MD_with_missing_parameter_map
+    cout << "\ntest dataset read existing -- sample/material\n";
+
+    // open a file
+    std::string filename = getFullPath("md_missing_paramater_map.nxs");
+    Mantid::Nexus::File file(filename, NXaccess::READ);
+
+    std::string addressOfBad("/MDHistoWorkspace/experiment0/sample");
+    TS_ASSERT_EQUALS(file.hasAddress(addressOfBad), true);
+
+    // go to this address and read things in
+    file.openAddress(addressOfBad);
+
+    // confirm version is 1 -- this has no formulaStyle
+    int32_t version32;
+    int64_t version64;
+    file.getAttr("version", version32);
+    file.getAttr("version", version64);
+    TS_ASSERT_EQUALS(version32, 1);
+    TS_ASSERT_EQUALS(version64, 1);
+
+    // read the formula style -- should throw exception
+    std::string formulaStyle;
+    TS_ASSERT_THROWS(file.getAttr("formulaStyle", formulaStyle), Mantid::Nexus::Exception const &);
+  }
+
   void test_existing_attr_resolved() {
     // test that attributes in existing files are corectly resolved
     // this prevents a regression that will otherwise show up in tests of LoadMD and various python algorithms
@@ -1122,7 +1295,7 @@ public:
   void test_existing_attr_bad_length() {
     // some fields have the unit attribute set with value "microsecond" but with a length of 8 instead of 11
     // this prevents a regression that will otherwise show up in tests of LoadEventNexus and various python algorithms
-    cout << "\ntest open existing file with system-dependent type\n";
+    cout << "\ntest open existing file with a badly set attr length\n";
 
     // open the file in read-only mode
     std::string filename = getFullPath("CG2_monotonically_increasing_pulse_times.nxs.h5");

--- a/Framework/Nexus/test/napi_test.cpp
+++ b/Framework/Nexus/test/napi_test.cpp
@@ -25,10 +25,6 @@
 
 ----------------------------------------------------------------------------*/
 
-#define DEBUG_LOG()                                                                                                    \
-  printf("%s:%d %s\n", __FILE__, __LINE__, __func__);                                                                  \
-  fflush(stdout);
-
 #include "MantidNexus/NexusFile.h"
 #include "MantidNexus/napi.h"
 #include "napi_test_util.h"

--- a/Framework/Nexus/test/napi_test.cpp
+++ b/Framework/Nexus/test/napi_test.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
     return TEST_SUCCEED; /* create only */
   }
 
-  std::string name, nxclass, group_name, class_name, address;
+  std::string name, nxclass, address;
   char char_buffer[128];
 
   // read test
@@ -251,9 +251,6 @@ int main(int argc, char *argv[]) {
     }
   } while (attr_status == NXstatus::NX_OK);
 
-  std::size_t num;
-  ASSERT_NO_ERROR(NXgetgroupinfo(fileid, num, group_name, class_name), "");
-  std::cout << "Group: " << group_name.c_str() << "(" << class_name.c_str() << ") contains " << num << " items\n";
   do {
     entry_status = NXgetnextentry(fileid, name, nxclass, NXtype);
     if (entry_status == NXstatus::NX_ERROR)

--- a/Framework/Nexus/test/napi_test_cpp.cpp
+++ b/Framework/Nexus/test/napi_test_cpp.cpp
@@ -20,10 +20,6 @@ using std::multimap;
 using std::string;
 using std::vector;
 
-#define DEBUG_LOG()                                                                                                    \
-  printf("%s:%d %s\n", __FILE__, __LINE__, __func__);                                                                  \
-  fflush(stdout);
-
 namespace { // anonymous namespace
 const std::string DMC01("dmc01cpp");
 const std::string DMC02("dmc02cpp");


### PR DESCRIPTION
### Description of work

#### Summary of work

Part of slow strangulation of `napi` adding in some small changes.

Given the repeated and bizarre failures on PR #39603, some of the smaller changes were isolated and put into this PR. These include

- the methods `NX5getgroupinfo()`, `NXgetgroupinfo()`, `countObjectsInGroup()` were removed, as these were only called in a single place in `napi` test to print a value.  This function is meant to count objects, and is  easily replaced with [`H5Gget_num_objs()`](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_g.html#ga3e30142e15ccf9a08bfc91ca9925c14d) if needed.
- the `NXnumtype` numerical values are changed, and this lets the type be set with sensible arithmetic instead of a big stack of `if`s
- `NexusFile5` no longer needs the `iStackPtr` attribute
- More tests added to `NexusFileTest.h`
- Minor refactors to attribute and data access in `Material.cpp` and `Sample.cpp`

Refs #38332 
EWM 11399
From PR #39603 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work

I think my `NXnumtype` assignments are pretty cool.

### To test:

This is a refactor.  The existing and old tests should be sufficient.

*This does not require release notes* because this is a purely internal issue.
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
