### PR TITLE
NaN values after DiffractionFocussing

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -151,7 +151,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CropWorkspa
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp:176
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp:54
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing.cpp:116
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:830
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:351
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:367
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EQSANSTofStructure.cpp:71

--- a/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39627.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39627.rst
@@ -1,0 +1,1 @@
+- Fixes bug in :ref:`DiffractionFocussing <algm-DiffractionFocussing>` where NaN data values were introduced when explicit binning domains were requested that exceeded the actual input-data domains.  This bug only occurred when `PreserveEvents=False`.


### PR DESCRIPTION
### Description of work
During the `DiffractionFocussing` rebinning process, weights are calculated and applied to the rebinned data.  Previously, when the requested output-data domain _contained_ the input-data domains (i.e., actually exceeded it on either end for _all_ input spectra), _zero_ values were computed for the weights near the boundary.  At application, these weights produced NaN values in the output data (, as `0.0 / 0.0`).

#### Summary of work
An additional `std::transform` is applied to the \< group weights \> vector after its calculation, setting any zero values to `1.0`.  Note that this treatment will _additionally_ mask any defects which produce _interior_ zero values for the weights.  However, considering the specifics of the weights calculation, it doesn't look as if such interior values should ever occur.

Fixes [EWM #12058](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=12058) 

### To test:

1. Build Mantid and run `ctest -R DiffractionFocussing` -- these tests should pass.
2. Comment out `DiffractionFocussing2.cpp` L382-389 (e.g. using `#if 0` ... `#endif`).  Rebuild and rerun the tests -- now the same tests should fail because there will be NaN in the output data.




<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
