### PR TITLE
Fix small issue when AlignAndFocusPowderSlim loads in chunks

### DIFF
--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -903,7 +903,7 @@ const double &AlignAndFocusPowderSlim::BankCalibration::value(const detid_t deti
 
 const detid_t &AlignAndFocusPowderSlim::BankCalibration::idmin() const { return m_detid_offset; }
 detid_t AlignAndFocusPowderSlim::BankCalibration::idmax() const {
-  return m_detid_offset + static_cast<detid_t>(m_calibration.size());
+  return m_detid_offset + static_cast<detid_t>(m_calibration.size()) - 1;
 }
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -86,6 +86,28 @@ public:
     TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 4744.);
 
     // do not need to cleanup because workspace did not go into the ADS
+
+    // The default chunk size will load VULCAN_218062.nxs.h5 in 1 chunk so try loading with ReadSizeFromDisk=1000000
+    // which will load the banks in 9 to 27 chunks. The output should be the same as with the default chunk size.
+    AlignAndFocusPowderSlim alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", filename));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("ReadSizeFromDisk", 1000000));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+
+    MatrixWorkspace_sptr outputWS2 = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS2);
+
+    // Run CompareWorkspaces algorithm to verify the output
+    auto compareAlg = alg.createChildAlgorithm("CompareWorkspaces");
+    compareAlg->setProperty("Workspace1", outputWS);
+    compareAlg->setProperty("Workspace2", outputWS2);
+    compareAlg->execute();
+    bool result = compareAlg->getProperty("Result");
+    TS_ASSERT(result);
   }
 
   void test_common_x() {


### PR DESCRIPTION
### Description of work

`BankCalibration::idmax` was wrong which resulted in a new calibration not being created sometimes when needed [here](https://github.com/mantidproject/mantid/blob/f04d7cbfe3001a19ecb31fe15413ff6a829ce5a8/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp#L399).

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


[12206: Add test coverage and fix small bugs](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/12206)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Currently on `main` these do not match, now they should.

```python
ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5")
ws_chunk=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", ReadSizeFromDisk=2000000)
CompareWorkspaces(ws, ws_chunk)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because it's a small bug fix in this prototype algorithm which is still under heavy development.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
