### PR TITLE
AlignAndFocusPowderSlim add test for FilterByTimeStart/Stop and fix slabsize calculation

### DIFF
--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -383,9 +383,8 @@ public:
         // H5Cpp will truncate correctly
         // H5Util resizes the vector
         const size_t offset = event_index_start;
-        const size_t slabsize = (event_index_start + m_events_per_chunk == std::numeric_limits<size_t>::max())
-                                    ? std::numeric_limits<size_t>::max()
-                                    : m_events_per_chunk;
+        const size_t slabsize =
+            std::min(m_events_per_chunk, static_cast<size_t>(eventRangeFull.second) - event_index_start);
 
         // load detid and tof at the same time
         tbb::parallel_invoke(

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -213,6 +213,41 @@ public:
     }
   }
 
+  void test_start_stop_time_filtering() {
+    AlignAndFocusPowderSlim alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", "VULCAN_218062.nxs.h5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStart", 200.));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStop", 300.));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("BinningUnits", "TOF"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("BinningMode", "Linear"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", std::vector<double>{0.}));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", std::vector<double>{50000.}));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XDelta", std::vector<double>{50000.}));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+
+    /* expected results came from running
+
+    ws = LoadEventNexus("VULCAN_218062.nxs.h5", FilterByTimeStart=200, FilterByTimeStop=300, NumberOfBins=1)
+    grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
+    ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")
+    print(ws.extractY())
+    */
+
+    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 3742475);
+    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 3735653);
+    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 4295302);
+    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 4244796);
+    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 1435593);
+    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 2734113);
+  }
+
   // ==================================
   // TODO things below this point are for benchmarking and will be removed later
   // ==================================


### PR DESCRIPTION
### Description of work

This adds a test for the `FilterByTimeStart`/`FilterByTimeStop` options in `AlignAndFocusPowderSlim` and fixes a bug in the `slabsize` calculation that was found with this test.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


[12206: Add test coverage and fix small bugs](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/12206)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Previously this would fail but now it should pass

```python
ws_slim = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", FilterByTimeStart=200, FilterByTimeStop=300, XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF")

ws = LoadEventNexus("VULCAN_218062.nxs.h5", FilterByTimeStart=200, FilterByTimeStop=300, NumberOfBins=1)
grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")

np.testing.assert_array_equal(ws_slim.extractY(), ws.extractY())
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes*  because it's a small bug fix in this prototype algorithm which is still under heavy development.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
