### PR TITLE
Remove link between muon and curvefitting libs

### DIFF
--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -122,7 +122,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 
 target_link_libraries(
   Muon
-  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry Mantid::CurveFitting
+  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
   PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 # Add the unit tests directory

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -266,9 +266,9 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
     }
   }
 
-  Eigen::Matrix<double, 2, 2> muLamMatrix;
+  Eigen::Matrix2d muLamMatrix;
   muLamMatrix << sxx, sxy, sxy, syy;
-  muLamMatrix = muLamMatrix.inverse().eval();
+  muLamMatrix = Eigen::PartialPivLU<Eigen::Matrix2d>(muLamMatrix).inverse();
 
   std::vector<double> aj(nspec), bj(nspec);
   for (size_t h = 0; h < nspec; h++) {

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -266,8 +266,8 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
     }
   }
 
-  std::vector<double> muLamVec{sxx, sxy, sxy, syy};
-  Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> muLamMatrix(muLamVec.data(), 2, 1);
+  std::array<double, 4> muLamVec{sxx, sxy, sxy, syy};
+  Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<2, 1>> muLamMatrix(muLamVec.data(), 2, 2);
   muLamMatrix = muLamMatrix.inverse();
 
   std::vector<double> aj(nspec), bj(nspec);

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -266,8 +266,8 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
     }
   }
 
-  Eigen::MatrixXd muLamMatrix(2, 2);
-  muLamMatrix << sxx, sxy, sxy, syy;
+  std::vector<double> muLamVec{sxx, sxy, sxy, syy};
+  Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> muLamMatrix(muLamVec.data(), 2, 1);
   muLamMatrix = muLamMatrix.inverse();
 
   std::vector<double> aj(nspec), bj(nspec);

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -266,9 +266,9 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
     }
   }
 
-  Eigen::Matrix2d muLamMatrix;
+  Eigen::MatrixXd muLamMatrix(2, 2);
   muLamMatrix << sxx, sxy, sxy, syy;
-  muLamMatrix = Eigen::PartialPivLU<Eigen::Matrix2d>(muLamMatrix).inverse();
+  muLamMatrix = muLamMatrix.inverse();
 
   std::vector<double> aj(nspec), bj(nspec);
   for (size_t h = 0; h < nspec; h++) {

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -224,19 +224,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.1969, DELTA);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
     TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
-    TS_ASSERT_DELTA(specReY[50], -0.0525, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0024, DELTA);
-    TS_ASSERT_DELTA(specReE[20], 0.0041, DELTA);
-    TS_ASSERT_DELTA(specReE[50], 0.0047, DELTA);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], -0.1035, DELTA);
-    TS_ASSERT_DELTA(specImY[20], -0.0006, DELTA);
-    TS_ASSERT_DELTA(specImY[50], 0.0047, DELTA);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0002, DELTA);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
     TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
     TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }
@@ -280,19 +280,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.1969, DELTA);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
     TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
-    TS_ASSERT_DELTA(specReY[50], -0.0525, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0024, DELTA);
-    TS_ASSERT_DELTA(specReE[20], 0.0041, DELTA);
-    TS_ASSERT_DELTA(specReE[50], 0.0047, DELTA);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], -0.1035, DELTA);
-    TS_ASSERT_DELTA(specImY[20], -0.0006, DELTA);
-    TS_ASSERT_DELTA(specImY[50], 0.0047, DELTA);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0002, DELTA);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
     TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
     TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -312,14 +312,14 @@ public:
 
   void setUp() override {
     m_loadedData = loadMuonDataset();
-    phaseQuad = setupAlg(m_loadedData, false);
+    m_phaseQuad = setupAlg(m_loadedData, false);
   }
 
   void tearDown() override { Mantid::API::AnalysisDataService::Instance().remove("outputWs"); }
 
-  void testPerformanceWs() { phaseQuad->execute(); }
+  void testPerformanceWs() { m_phaseQuad->execute(); }
 
 private:
   MatrixWorkspace_sptr m_loadedData;
-  IAlgorithm_sptr phaseQuad;
+  IAlgorithm_sptr m_phaseQuad;
 };

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -224,19 +224,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
+    TS_ASSERT_DELTA(specReY[0], 2.1969, DELTA);
     TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
-    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0525, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
-    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
-    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
+    TS_ASSERT_DELTA(specReE[0], 0.0024, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0041, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0047, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
-    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
-    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
+    TS_ASSERT_DELTA(specImY[0], -0.1035, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0006, DELTA);
+    TS_ASSERT_DELTA(specImY[50], 0.0047, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
+    TS_ASSERT_DELTA(specImE[0], 0.0002, DELTA);
     TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
     TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }
@@ -280,19 +280,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
+    TS_ASSERT_DELTA(specReY[0], 2.1969, DELTA);
     TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
-    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0525, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
-    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
-    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
+    TS_ASSERT_DELTA(specReE[0], 0.0024, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0041, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0047, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
-    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
-    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
+    TS_ASSERT_DELTA(specImY[0], -0.1035, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0006, DELTA);
+    TS_ASSERT_DELTA(specImY[50], 0.0047, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
+    TS_ASSERT_DELTA(specImE[0], 0.0002, DELTA);
     TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
     TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -92,7 +92,7 @@ cd $WORKSPACE/build
 # mkdir for test logs
 mkdir -p test_logs
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$UNIT_TEST_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log -R PhaseQuadMuonTest --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$UNIT_TEST_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -92,7 +92,7 @@ cd $WORKSPACE/build
 # mkdir for test logs
 mkdir -p test_logs
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$UNIT_TEST_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$UNIT_TEST_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log -R PhaseQuadMuonTest --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then


### PR DESCRIPTION
### Description of work

#### Summary of work

This PR removes the use of `Mantid::CurveFitting::EigenMatrix` from the `Muon` library to avoid the linking of two plugin libraries.

We use `PartialPivLU` decomposition in calculating the inverse, replicating what the `Mantid::CurveFitting::EigenMatrix` is doing under the hood.

`long double` is used on arm mac, as it brings precision of eigen matrix multiplication inline (lowers it) with the other operating systems. I'm not sure why, you would expect a greater degree of precision.

Here is a compiler explorer used to interrogate the differences when different types are used with eigen across our compilers: https://godbolt.org/z/51W6KPecb

This illustrates the issue, but doesn't show the same impact on arm64 of switching to `long double`.

Testing change on arm: https://builds.mantidproject.org/job/build_packages_from_branch/1200/

Fixes #39644 

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
