### PR TITLE
Move release notes that were meant to be in v6.13

### DIFF
--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
@@ -1,1 +1,0 @@
-- Exposed `ExperimentInfo.populateInstrumentParameters` to the Python api.  This will facilitate the update of parameterized instruments from Python, allowing parameters to be directly transferred as properties without converting to and from `string`.

--- a/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
+++ b/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
@@ -1,1 +1,0 @@
-- :ref:`ALC interface <MuonALC-ref>` no longer crashes when non numeric characters are input in Backward and Forward Grouping line edits.

--- a/docs/source/release/v6.13.0/framework.rst
+++ b/docs/source/release/v6.13.0/framework.rst
@@ -143,6 +143,8 @@ New features
 - ``Instrument.getFilename()`` and ``Instrument.setFilename()`` have been exposed to python.
 - A new method named ``getFittingParameter`` has been added to ``Mantid::Geometry::Component`` class and exposed to
   python. This allows access to fitting parameters from components in an instrument definition file.
+- Exposed ``ExperimentInfo.populateInstrumentParameters`` to the Python api.  This will facilitate the update of parameterized
+  instruments from Python, allowing parameters to be directly transferred as properties without converting to and from ``string``.
 
 Bugfixes
 ############

--- a/docs/source/release/v6.13.0/muon.rst
+++ b/docs/source/release/v6.13.0/muon.rst
@@ -5,6 +5,13 @@ Muon Changes
 .. contents:: Table of Contents
    :local:
 
+ALC
+---
+
+Bugfixes
+############
+- :ref:`ALC interface <MuonALC-ref>` no longer crashes when non numeric characters are input in Backward and Forward Grouping line edits.
+
 Muon Analysis
 -------------
 


### PR DESCRIPTION
### Description of work
Some of the v6.13 release notes accidentally ended up in v6.12 folder. This PR moves them to where they should be.

*There is no associated issue.*


### To test:

- all tests should pass
- Check that there are no longer release notes floating in the v6.12 folder
- check the v6.13 release notes for `Framework` and `Muon` build locally and render correctly.

*This does not require release notes* because **it is moving release notes**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
