### PR TITLE
Refactors of `Nexus::File` and co.

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceHistory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceHistory.h
@@ -77,7 +77,7 @@ private:
   /// Parse an algorithm history string loaded from file
   AlgorithmHistory_sptr parseAlgorithmHistory(const std::string &rawData);
   /// Find the history entries at this level in the file.
-  std::set<int> findHistoryEntries(Nexus::File *file);
+  std::set<int> findHistoryEntries(Nexus::File const *file);
   /// The environment of the workspace
   const Kernel::EnvironmentHistory m_environment;
   /// The algorithms which have been called on the workspace

--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -309,7 +309,7 @@ void WorkspaceHistory::loadNestedHistory(Nexus::File *file, const AlgorithmHisto
  * @param file :: The handle to the nexus file
  * @returns set of integers. One for each algorithm at the level in the file.
  */
-std::set<int> WorkspaceHistory::findHistoryEntries(Nexus::File *file) {
+std::set<int> WorkspaceHistory::findHistoryEntries(Nexus::File const *file) {
   std::set<int> historyNumbers;
   std::map<std::string, std::string> entries;
   file->getEntries(entries);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -79,7 +79,7 @@ const std::string BAD_PULSES_CUTOFF("FilterBadPulsesLowerCutoff");
  * @param name : sub entry name to look for
  * @return true only if it exists
  */
-bool exists(Nexus::File &file, const std::string &name) {
+bool exists(Nexus::File const &file, const std::string &name) {
   const auto entries = file.getEntries();
   return exists(entries, name);
 }

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -92,7 +92,7 @@ bool keyExists(std::string const &key, std::map<std::string, std::string> const 
 
 // returns true if all of the entries necessary for a histogram exist monitor in
 // the currently open group
-bool isHistoMonitor(Nexus::File &monitorFileHandle) {
+bool isHistoMonitor(Nexus::File const &monitorFileHandle) {
   const auto fields = monitorFileHandle.getEntries();
   return keyExists("data", fields) && keyExists("time_of_flight", fields);
 }

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -998,10 +998,9 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
   try {
     m_nexusFile->openAddress(entry.address()); // This is
   } catch (std::runtime_error &re) {
-    throw std::runtime_error("Error while opening a address in a Peaks entry in a "
-                             "Nexus processed file. "
-                             "This address is wrong: " +
-                             entry.address() + ". Lower level error description: " + re.what());
+    throw std::runtime_error(
+        "Error while opening a address in a Peaks entry in a Nexus processed file. This address is wrong: " +
+        std::string(entry.address()) + ". Lower level error description: " + re.what());
   }
   try {
     // Get information from all but data group
@@ -1021,8 +1020,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
   try {
     m_nexusFile->openGroup(peaksWSName, "NXentry");
   } catch (std::runtime_error &re) {
-    throw std::runtime_error("Error while opening a peaks workspace in a Nexus processed file. "
-                             "Cannot open gropu " +
+    throw std::runtime_error("Error while opening a peaks workspace in a Nexus processed file. Cannot open group " +
                              peaksWSName + ". Lower level error description: " + re.what());
   }
   try {
@@ -1278,10 +1276,9 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
   try {
     m_nexusFile->openAddress(entry.address()); // This is
   } catch (std::runtime_error &re) {
-    throw std::runtime_error("Error while opening a address in a Peaks entry in a "
-                             "Nexus processed file. "
-                             "This address is wrong: " +
-                             entry.address() + ". Lower level error description: " + re.what());
+    throw std::runtime_error(
+        "Error while opening a address in a Peaks entry in a Nexus processed file. This address is wrong: " +
+        std::string(entry.address()) + ". Lower level error description: " + re.what());
   }
   try {
     // Get information from all but data group
@@ -1301,8 +1298,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
   try {
     m_nexusFile->openGroup(peaksWSName, "NXentry");
   } catch (std::runtime_error &re) {
-    throw std::runtime_error("Error while opening a peaks workspace in a Nexus processed file. "
-                             "Cannot open gropu " +
+    throw std::runtime_error("Error while opening a peaks workspace in a Nexus processed file. Cannot open group " +
                              peaksWSName + ". Lower level error description: " + re.what());
   }
   try {

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     src/NexusDescriptor.cpp
     src/NexusException.cpp
     src/NexusFile.cpp
+    src/NexusAddress.cpp
 )
 
 set(INC_FILES
@@ -20,6 +21,7 @@ set(INC_FILES
     inc/MantidNexus/NexusDescriptor.h
     inc/MantidNexus/NexusException.h
     inc/MantidNexus/NexusFile.h
+    inc/MantidNexus/NexusAddress.h
 )
 
 set(TEST_FILES
@@ -31,6 +33,7 @@ set(TEST_FILES
     NexusFileLeakTest.h
     NexusFileNapiTest.h
     NexusFileReadWriteTest.h
+    NexusAddressTest.h
     NapiUnitTest.h
 )
 

--- a/Framework/Nexus/inc/MantidNexus/NexusAddress.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusAddress.h
@@ -86,9 +86,9 @@ public:
 
   std::string operator+(std::string const &s) const;
 
-  operator std::string() const { return m_path.generic_string(); }
+  operator std::string() const { return m_resolved_path; }
 
-  std::string string() const { return m_path.generic_string(); }
+  std::string string() const { return m_resolved_path; }
 
   char const *c_str() const { return m_resolved_path.c_str(); }
 

--- a/Framework/Nexus/inc/MantidNexus/NexusAddress.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusAddress.h
@@ -88,7 +88,7 @@ public:
 
   operator std::string() const { return m_resolved_path; }
 
-  std::string string() const { return m_resolved_path; }
+  std::string const &string() const { return m_resolved_path; }
 
   char const *c_str() const { return m_resolved_path.c_str(); }
 

--- a/Framework/Nexus/inc/MantidNexus/NexusAddress.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusAddress.h
@@ -86,6 +86,8 @@ public:
 
   std::string operator+(std::string const &s) const;
 
+  std::string operator+(char const s[]) const;
+
   operator std::string() const { return m_resolved_path; }
 
   std::string const &string() const { return m_resolved_path; }
@@ -106,5 +108,7 @@ MANTID_NEXUS_DLL bool operator==(std::string const &s, Mantid::Nexus::NexusAddre
 MANTID_NEXUS_DLL bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p);
 
 MANTID_NEXUS_DLL std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p);
+
+MANTID_NEXUS_DLL std::string operator+(char const s[], Mantid::Nexus::NexusAddress const &p);
 
 MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, Mantid::Nexus::NexusAddress const &p);

--- a/Framework/Nexus/inc/MantidNexus/NexusAddress.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusAddress.h
@@ -1,0 +1,110 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidNexus/DllConfig.h"
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace Mantid::Nexus {
+
+/**
+ * This simple class encapsulates some methods for working with paths inside a NeXus file.
+ * The base is std::filesystem::path, but the root will always resolve to "/" regardless of OS.
+ * New paths are always cast to lexically normal during creation.
+ */
+class MANTID_NEXUS_DLL NexusAddress {
+
+public:
+  NexusAddress(std::filesystem::path const &p);
+
+  NexusAddress(std::string const &p);
+
+  NexusAddress(char const *const p);
+
+  NexusAddress();
+
+  NexusAddress &operator=(NexusAddress const &nd) = default;
+
+  NexusAddress &operator=(std::string const &s);
+
+  NexusAddress(NexusAddress const &nd) = default;
+
+  ~NexusAddress() = default;
+
+  // comparison operators
+
+  bool operator==(NexusAddress const &p) const;
+
+  bool operator==(std::string const &s) const;
+
+  bool operator==(char const *const s) const;
+
+  bool operator!=(NexusAddress const &p) const;
+
+  bool operator!=(std::string const &s) const;
+
+  bool operator!=(char const *const s) const;
+
+  // concatenation
+
+  NexusAddress operator/(std::string const &s) const;
+
+  NexusAddress operator/(char const *const s) const;
+
+  NexusAddress operator/(NexusAddress const &p) const;
+
+  NexusAddress &operator/=(std::string const &s);
+
+  NexusAddress &operator/=(char const *const s);
+
+  NexusAddress &operator/=(NexusAddress const &p);
+
+  // access
+
+  bool isAbsolute() const;
+
+  bool isRoot() const;
+
+  NexusAddress parent_path() const;
+
+  NexusAddress fromRoot() const;
+
+  NexusAddress stem() const;
+
+  static NexusAddress root();
+
+  std::vector<std::string> parts() const;
+
+  // printing
+
+  std::string operator+(std::string const &s) const;
+
+  operator std::string() const { return m_path.generic_string(); }
+
+  std::string string() const { return m_path.generic_string(); }
+
+  char const *c_str() const { return m_resolved_path.c_str(); }
+
+private:
+  /** standard filesystem path */
+  std::filesystem::path m_path;
+  // in order to return c_str from the generic_string, this must remain in memory
+  std::string m_resolved_path;
+};
+
+} // namespace Mantid::Nexus
+
+MANTID_NEXUS_DLL bool operator==(std::string const &s, Mantid::Nexus::NexusAddress const &p);
+
+MANTID_NEXUS_DLL bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p);
+
+MANTID_NEXUS_DLL std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p);
+
+MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, Mantid::Nexus::NexusAddress const &p);

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -100,15 +100,15 @@ public:
   // definition.
   // virtual bool isStandard()const = 0;
   /// Returns the absolute address to the object
-  std::string const &address() const { return m_address; }
+  NexusAddress const &address() const { return m_address; }
   /// Returns the name of the object
   std::string name() const;
   /// Nexus file id
   std::shared_ptr<File> m_fileID;
 
 protected:
-  std::string m_address; ///< Keeps the absolute address to the object
-  bool m_open;           ///< Set to true if the object has been open
+  NexusAddress m_address; ///< Keeps the absolute address to the object
+  bool m_open;            ///< Set to true if the object has been open
 private:
   NXObject(); ///< Private default constructor
 };

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -27,9 +27,9 @@ public:
    * Unique constructor
    * @param filename input HDF5 Nexus file name
    */
-  NexusDescriptor(std::string filename);
+  NexusDescriptor(std::string const &filename);
 
-  NexusDescriptor(std::string filename, NXaccess access);
+  NexusDescriptor(std::string const &filename, NXaccess access);
 
   NexusDescriptor() = delete;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MantidNexus/DllConfig.h"
+#include "MantidNexus/NexusAddress.h"
 #include "MantidNexus/NexusDescriptor.h"
 #include "MantidNexus/NexusFile_fwd.h"
 #include <map>
@@ -42,6 +43,8 @@ class MANTID_NEXUS_DLL File {
 private:
   std::string m_filename;
   NXaccess m_access;
+  /** The address of currently-opened element */
+  NexusAddress m_address;
   /** should be close handle on exit */
   bool m_close_handle;
   /** The handle for the C-API. */
@@ -51,7 +54,7 @@ private:
    * - hasRootAttr
    * - firstEntryNameType
    */
-  Mantid::Nexus::NexusDescriptor m_descriptor;
+  NexusDescriptor m_descriptor;
 
   //------------------------------------------------------------------------------------------------------------------
   // CONSTRUCTORS / ASSIGNMENT / DECONSTRUCTOR
@@ -147,30 +150,33 @@ public:
    * \return A unix like address string pointing to the current
    *         position in the file
    */
-  std::string getAddress();
+  std::string getAddress() const;
 
   // CHECK ADDRESS EXISTENCE
 
-  bool hasAddress(std::string const &);
+  bool hasAddress(std::string const &) const;
 
-  bool hasGroup(std::string const &, std::string const &);
+  bool hasGroup(std::string const &, std::string const &) const;
 
-  bool hasData(std::string const &);
+  bool hasData(std::string const &) const;
 
   /**
    * This function checks if we are in an open dataset
    * \returns true if we are currently in an open dataset else false
    */
-  bool isDataSetOpen();
+  bool isDataSetOpen() const;
 
   /** Return true if the data opened is of one of the
    * int data types, 32 bits or less.
    */
-  bool isDataInt();
+  bool isDataInt() const;
 
 private:
   // EXPLORE FILE LEVEL ENTRIES / ATTRIBUTES
 
+  /** get the ID of current open location
+   * \returns if a datset is open, the ID of the dataset; else ID of open group
+   */
   hid_t getCurrentId() const;
 
   /** It is sometimes necessary to interface with code using the H5Cpp library
@@ -181,7 +187,8 @@ private:
   std::shared_ptr<H5::H5Object> getCurrentObject() const;
 
   // these are used for updating the NexusDescriptor
-  std::string formAbsoluteAddress(std::string const &);
+  NexusAddress groupAddress(NexusAddress const &) const;
+  NexusAddress formAbsoluteAddress(NexusAddress const &) const;
   void registerEntry(std::string const &, std::string const &);
 
   //------------------------------------------------------------------------------------------------------------------
@@ -510,27 +517,22 @@ public:
   Info getInfo();
 
   /**
-   * Initialize the pending group search to start again.
-   */
-  void initGroupDir();
-
-  /**
    * Return the entries available in the current place in the file.
    */
-  Entries getEntries();
+  Entries getEntries() const;
 
   /** Return the entries available in the current place in the file,
    * but avoids the map copy of getEntries().
    *
    * \param result The map that will be filled with the entries
    */
-  void getEntries(Entries &result);
+  void getEntries(Entries &result) const;
 
   /** Return the string name of the top-level entry
    *
    * \return a string with the name (not abs address) of the top-level entry
    */
-  std::string getTopLevelEntryName();
+  std::string getTopLevelEntryName() const;
 
   //------------------------------------------------------------------------------------------------------------------
   // ATTRIBUTE METHODS
@@ -603,7 +605,7 @@ public:
    *  \return true if the current point in the file has the named attribute
    *  \param name the name of the attribute to look for.
    */
-  bool hasAttr(const std::string &name);
+  bool hasAttr(const std::string &name) const;
 
   //------------------------------------------------------------------------------------------------------------------
   // LINK METHODS

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "MantidNexus/DllConfig.h"
+#include "MantidNexus/NexusAddress.h"
 #include <iosfwd>
 #include <map>
 #include <string>
@@ -28,28 +29,18 @@ enum class NXaccess : unsigned int { READ = 0x0000u, RDWR = 0x0001u, CREATE5 = 0
 
 MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXaccess &value);
 
-struct stackEntry {
-  std::string irefn;
-  hid_t iVref;
-  hsize_t iCurrentIDX;
-};
-
 /** NexusFile5
  * NOTE this needs to either be moved to a separate file,
  * or entirely absorbed inside Nexus::File
  */
 struct MANTID_NEXUS_DLL NexusFile5 {
-  std::vector<stackEntry> iStack5;
+  std::vector<hid_t> iStack5;
   hid_t iFID;
   hid_t iCurrentG;
   hid_t iCurrentD;
   hid_t iCurrentS;
   hid_t iCurrentT;
-  hid_t iCurrentA;
-  hsize_t iCurrentIDX;
-  int iNX;
-  std::string name_ref;
-  std::string name_tmp;
+  Mantid::Nexus::NexusAddress groupaddr;
 
   // constructors
   NexusFile5() = delete;
@@ -65,11 +56,6 @@ typedef NexusFile5 *pNexusFile5;
 typedef NexusFile5 *NXhandle;
 
 typedef char NXname[128];
-
-typedef struct {
-  char *iname;
-  int type;
-} info_type, *pinfo;
 
 /** \enum NXentrytype
  * Describes the type of entry in a NeXus file, either group or dataset

--- a/Framework/Nexus/inc/MantidNexus/napi.h
+++ b/Framework/Nexus/inc/MantidNexus/napi.h
@@ -307,20 +307,6 @@ MANTID_NEXUS_DLL NXstatus NXgetinfo64(NXhandle handle, std::size_t &rank, Mantid
                                       NXnumtype &datatype);
 
 /**
- * Get the next entry in the currently open group. This is for retrieving infromation about the
- * content of a NeXus group. In order to search a group #NXgetnextentry is called in a loop until
- * #NXgetnextentry returns NX_EOD which indicates that there are no further items in the group.
- * Reset search using #NXinitgroupdir
- * \param handle A NeXus file handle as initialized by NXopen.
- * \param name The name of the object
- * \param nxclass The NeXus class name for a group or the string SDS for a dataset.
- * \param datatype The NeXus data type if the item is a SDS.
- * \return NX_OK on success, NX_ERROR in the case of an error, NX_EOD when there are no more items.
- * \ingroup c_navigation
- */
-MANTID_NEXUS_DLL NXstatus NXgetnextentry(NXhandle handle, std::string &name, std::string &nxclass, NXnumtype &datatype);
-
-/**
  * Read a subset of data from file into memory.
  * \param handle A NeXus file handle as initialized by NXopen.
  * \param data A pointer to the memory data where to copy the data too. The pointer must point
@@ -357,54 +343,6 @@ MANTID_NEXUS_DLL NXstatus NXgetattr(NXhandle handle, std::string const &name, vo
  * \ingroup c_linking
  */
 MANTID_NEXUS_DLL NXstatus NXgetgroupID(NXhandle handle, NXlink &pLink);
-
-/**
- * Tests if two link data structures describe the same item.
- * \param handle A NeXus file handle as initialized by NXopen.
- * \param pFirstID The first link data for the test.
- * \param pSecondID The second link data structure.
- * \return NX_OK when both link data structures describe the same item, NX_ERROR else.
- * \ingroup c_linking
- */
-MANTID_NEXUS_DLL NXstatus NXsameID(NXhandle handle, NXlink const &pFirstID, NXlink const &pSecondID);
-
-/**
- * Resets a pending group search to the start again. To be called in a #NXgetnextentry loop when
- * a group search has to be restarted.
- * \param handle A NeXus file handle as initialized by NXopen.
- * \return NX_OK on success, NX_ERROR in the case of an error.
- * \ingroup c_navigation
- */
-MANTID_NEXUS_DLL NXstatus NXinitgroupdir(NXhandle handle);
-
-/**
- * Resets a pending attribute search to the start again. To be called in a NXgetnextattr loop when
- * an attribute search has to be restarted.
- * \param handle A NeXus file handle as initialized by NXopen.
- * \return NX_OK on success, NX_ERROR in the case of an error.
- * \ingroup c_navigation
- */
-MANTID_NEXUS_DLL NXstatus NXinitattrdir(NXhandle handle);
-
-/**
- * Utility function which allocates a suitably sized memory area for the dataset characteristics specified.
- * \param data A pointer to a pointer which will be initialized with a pointer to a suitably sized memory area.
- * \param rank the rank of the data.
- * \param dims An array holding the size of the data in each dimension.
- * \param datatype The NeXus data type of the data.
- * \return NX_OK when allocation succeeds, NX_ERROR in the case of an error.
- * \ingroup c_memory
- */
-MANTID_NEXUS_DLL NXstatus NXmalloc64(void *&data, std::size_t rank, Mantid::Nexus::DimVector const &dims,
-                                     NXnumtype datatype);
-
-/**
- * Utility function to release the memory for data.
- * \param data A pointer to a pointer to free.
- * \return NX_OK on success, NX_ERROR in the case of an error.
- * \ingroup c_memory
- */
-MANTID_NEXUS_DLL NXstatus NXfree(void **data);
 
 /**
  * Dispatches the error message

--- a/Framework/Nexus/inc/MantidNexus/napi5.h
+++ b/Framework/Nexus/inc/MantidNexus/napi5.h
@@ -10,8 +10,5 @@
 
 NXstatus NX5getdata(NXhandle handle, void *data);
 NXstatus NX5getinfo64(NXhandle handle, std::size_t &rank, Mantid::Nexus::DimVector &dims, NXnumtype &datatype);
-NXstatus NX5getnextentry(NXhandle handle, std::string &name, std::string &nxclass, NXnumtype &datatype);
 
-herr_t attr_info(hid_t loc_id, const char *name, const H5A_info_t *unused, void *opdata);
 herr_t group_info(hid_t loc_id, const char *name, const H5L_info_t *unused, void *opdata);
-herr_t nxgroup_info(hid_t loc_id, const char *name, const H5L_info_t *unused, void *op_data);

--- a/Framework/Nexus/inc/MantidNexus/napi_helper.h
+++ b/Framework/Nexus/inc/MantidNexus/napi_helper.h
@@ -8,13 +8,11 @@
 
 MANTID_NEXUS_DLL pNexusFile5 NXI5assert(NXhandle fid);
 
-MANTID_NEXUS_DLL void NXI5KillDir(pNexusFile5 self);
-
 MANTID_NEXUS_DLL herr_t readStringAttribute(hid_t attr, char **data);
 
 MANTID_NEXUS_DLL herr_t readStringAttributeN(hid_t attr, char *data, std::size_t maxlen);
 
-MANTID_NEXUS_DLL void NXI5KillAttDir(pNexusFile5 self);
+MANTID_NEXUS_DLL std::string getObjectAddress(hid_t obj);
 
 MANTID_NEXUS_DLL std::string buildCurrentAddress(pNexusFile5 fid);
 
@@ -35,19 +33,10 @@ MANTID_NEXUS_DLL herr_t attr_check(hid_t loc_id, const char *member_name, const 
 /*------------------------------------------------------------------------
   Implementation of NXopenaddress
   --------------------------------------------------------------------------*/
-MANTID_NEXUS_DLL int isDataSetOpen(NXhandle hfil);
-MANTID_NEXUS_DLL int isRoot(NXhandle hfil);
-MANTID_NEXUS_DLL std::string extractNextAddress(std::string const &address, std::string &element);
-MANTID_NEXUS_DLL NXstatus gotoRoot(NXhandle hfil);
-MANTID_NEXUS_DLL int isRelative(std::string const &address);
-MANTID_NEXUS_DLL NXstatus moveOneDown(NXhandle hfil);
-MANTID_NEXUS_DLL std::string moveDown(NXhandle hfil, std::string const &address, NXstatus &code);
-MANTID_NEXUS_DLL NXstatus stepOneUp(NXhandle hfil, std::string const &name);
-MANTID_NEXUS_DLL NXstatus stepOneGroupUp(NXhandle hfil, std::string const &name);
+MANTID_NEXUS_DLL bool isDataSetOpen(NXhandle hfil);
 
 /*---------------------------------------------------------------------
  * private functions used in NX5open
  */
 
-hid_t create_file_access_plist(std::string const &filename);
 herr_t set_str_attribute(hid_t parent_id, std::string const &name, std::string const &buffer);

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -38,21 +38,21 @@ NexusAddress::NexusAddress() : m_path(nxroot), m_resolved_path(m_path.generic_st
 
 NexusAddress &NexusAddress::operator=(std::string const &s) {
   m_path = cleanup(s);
-  m_resolved_path = m_path.generic_string();
+  m_resolved_path = std::string(m_path.generic_string());
   return *this;
 }
 
 bool NexusAddress::operator==(NexusAddress const &p) const { return m_path == p.m_path; }
 
-bool NexusAddress::operator==(std::string const &s) const { return m_path.string() == s; }
+bool NexusAddress::operator==(std::string const &s) const { return m_resolved_path == s; }
 
-bool NexusAddress::operator==(char const *const s) const { return m_path.string() == std::string(s); }
+bool NexusAddress::operator==(char const *const s) const { return m_resolved_path == std::string(s); }
 
 bool NexusAddress::operator!=(NexusAddress const &p) const { return m_path != p.m_path; }
 
-bool NexusAddress::operator!=(std::string const &s) const { return m_path.string() != s; }
+bool NexusAddress::operator!=(std::string const &s) const { return m_resolved_path != s; }
 
-bool NexusAddress::operator!=(char const *const s) const { return m_path.string() != std::string(s); }
+bool NexusAddress::operator!=(char const *const s) const { return m_resolved_path != std::string(s); }
 
 NexusAddress NexusAddress::operator/(std::string const &s) const { return NexusAddress(m_path / s); }
 
@@ -99,13 +99,13 @@ std::vector<std::string> NexusAddress::parts() const {
 }
 } // namespace Mantid::Nexus
 
-bool operator==(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s == std::string(p); }
+bool operator==(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s == p.string(); }
 
-bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s != std::string(p); }
+bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s != p.string(); }
 
-std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s + std::string(p); }
+std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s + p.string(); }
 
 std::ostream &operator<<(std::ostream &os, Mantid::Nexus::NexusAddress const &p) {
-  os << std::string(p);
+  os << p.string();
   return os;
 }

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -1,0 +1,111 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidNexus/NexusAddress.h"
+
+namespace Mantid::Nexus {
+
+namespace {
+std::filesystem::path const nxroot("/");
+
+std::filesystem::path cleanup(std::string const &s) {
+  std::filesystem::path ret(s);
+  std::string ns(s);
+  if (ret == nxroot) {
+    // the root path is already clean
+  } else if (ns.back() == '/') {
+    // make sure no entries end in "/" -- this confuses path location
+    ns.pop_back();
+    ret = ns;
+  }
+  // cast as lexically normal
+  return ret.lexically_normal();
+}
+} // namespace
+
+NexusAddress::NexusAddress(std::filesystem::path const &path)
+    : m_path(path.lexically_normal()), m_resolved_path(m_path.generic_string()) {}
+
+NexusAddress::NexusAddress(std::string const &path) : m_path(cleanup(path)), m_resolved_path(m_path.generic_string()) {}
+
+NexusAddress::NexusAddress(char const *const path) : NexusAddress(std::string(path)) {}
+
+NexusAddress::NexusAddress() : m_path(nxroot), m_resolved_path(m_path.generic_string()) {}
+
+NexusAddress &NexusAddress::operator=(std::string const &s) {
+  m_path = cleanup(s);
+  m_resolved_path = m_path.generic_string();
+  return *this;
+}
+
+bool NexusAddress::operator==(NexusAddress const &p) const { return m_path == p.m_path; }
+
+bool NexusAddress::operator==(std::string const &s) const { return m_path.string() == s; }
+
+bool NexusAddress::operator==(char const *const s) const { return m_path.string() == std::string(s); }
+
+bool NexusAddress::operator!=(NexusAddress const &p) const { return m_path != p.m_path; }
+
+bool NexusAddress::operator!=(std::string const &s) const { return m_path.string() != s; }
+
+bool NexusAddress::operator!=(char const *const s) const { return m_path.string() != std::string(s); }
+
+NexusAddress NexusAddress::operator/(std::string const &s) const { return NexusAddress(m_path / s); }
+
+NexusAddress NexusAddress::operator/(char const *const s) const { return *this / std::string(s); }
+
+NexusAddress NexusAddress::operator/(NexusAddress const &p) const { return NexusAddress(m_path / p.m_path); }
+
+NexusAddress &NexusAddress::operator/=(std::string const &s) {
+  m_path /= s;
+  m_resolved_path = m_path.generic_string();
+  return *this;
+}
+
+NexusAddress &NexusAddress::operator/=(char const *const s) { return *this /= std::string(s); }
+
+NexusAddress &NexusAddress::operator/=(NexusAddress const &p) {
+  m_path /= p.m_path;
+  m_resolved_path = m_path.generic_string();
+  return *this;
+}
+
+bool NexusAddress::isAbsolute() const { return *m_path.begin() == nxroot; }
+
+bool NexusAddress::isRoot() const { return (m_path == nxroot); }
+
+NexusAddress NexusAddress::parent_path() const { return NexusAddress(m_path.parent_path()); }
+
+NexusAddress NexusAddress::fromRoot() const { return NexusAddress(nxroot / m_path); }
+
+NexusAddress NexusAddress::stem() const { return NexusAddress(m_path.stem()); }
+
+NexusAddress NexusAddress::root() { return NexusAddress(nxroot); }
+
+std::string NexusAddress::operator+(std::string const &s) const { return m_path.string() + s; }
+
+std::vector<std::string> NexusAddress::parts() const {
+  std::vector<std::string> names;
+  for (auto it = m_path.begin(); it != m_path.end(); it++) {
+    if (*it != nxroot) {
+      names.push_back(*it);
+    }
+  }
+  return names;
+}
+} // namespace Mantid::Nexus
+
+bool operator==(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s == std::string(p); }
+
+bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s != std::string(p); }
+
+std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s + std::string(p); }
+
+std::ostream &operator<<(std::ostream &os, Mantid::Nexus::NexusAddress const &p) {
+  os << std::string(p);
+  return os;
+}

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -92,7 +92,7 @@ std::vector<std::string> NexusAddress::parts() const {
   std::vector<std::string> names;
   for (auto it = m_path.begin(); it != m_path.end(); it++) {
     if (*it != nxroot) {
-      names.push_back(*it);
+      names.push_back(it->generic_string());
     }
   }
   return names;

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -86,7 +86,7 @@ NexusAddress NexusAddress::stem() const { return NexusAddress(m_path.stem()); }
 
 NexusAddress NexusAddress::root() { return NexusAddress(nxroot); }
 
-std::string NexusAddress::operator+(std::string const &s) const { return m_path.string() + s; }
+std::string NexusAddress::operator+(std::string const &s) const { return m_resolved_path + s; }
 
 std::vector<std::string> NexusAddress::parts() const {
   std::vector<std::string> names;

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -88,6 +88,8 @@ NexusAddress NexusAddress::root() { return NexusAddress(nxroot); }
 
 std::string NexusAddress::operator+(std::string const &s) const { return m_resolved_path + s; }
 
+std::string NexusAddress::operator+(char const s[]) const { return m_resolved_path + s; }
+
 std::vector<std::string> NexusAddress::parts() const {
   std::vector<std::string> names;
   for (auto it = m_path.begin(); it != m_path.end(); it++) {
@@ -104,6 +106,8 @@ bool operator==(std::string const &s, Mantid::Nexus::NexusAddress const &p) { re
 bool operator!=(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s != p.string(); }
 
 std::string operator+(std::string const &s, Mantid::Nexus::NexusAddress const &p) { return s + p.string(); }
+
+std::string operator+(char const s[], Mantid::Nexus::NexusAddress const &p) { return s + p.string(); }
 
 std::ostream &operator<<(std::ostream &os, Mantid::Nexus::NexusAddress const &p) {
   os << p.string();

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -54,11 +54,17 @@ bool NexusAddress::operator!=(std::string const &s) const { return m_resolved_pa
 
 bool NexusAddress::operator!=(char const *const s) const { return m_resolved_path != std::string(s); }
 
-NexusAddress NexusAddress::operator/(std::string const &s) const { return NexusAddress(m_path / s); }
+NexusAddress NexusAddress::operator/(std::string const &s) const { return *this / NexusAddress(s); }
 
-NexusAddress NexusAddress::operator/(char const *const s) const { return *this / std::string(s); }
+NexusAddress NexusAddress::operator/(char const *const s) const { return *this / NexusAddress(s); }
 
-NexusAddress NexusAddress::operator/(NexusAddress const &p) const { return NexusAddress(m_path / p.m_path); }
+NexusAddress NexusAddress::operator/(NexusAddress const &p) const {
+  std::string fp(p);
+  if (p.isAbsolute()) {
+    fp = fp.substr(1);
+  }
+  return NexusAddress(m_path / fp);
+}
 
 NexusAddress &NexusAddress::operator/=(std::string const &s) {
   m_path /= s;

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -81,7 +81,7 @@ NXObject::NXObject() : m_fileID(nullptr), m_open(false) {}
  */
 NXObject::NXObject(File *fileID, NXClass const *parent, const std::string &name) : m_fileID(fileID), m_open(false) {
   if (parent && !name.empty()) {
-    m_address = parent->address() + "/" + name;
+    m_address = parent->address() / name;
   }
 }
 
@@ -94,17 +94,11 @@ NXObject::NXObject(File *fileID, NXClass const *parent, const std::string &name)
 NXObject::NXObject(std::shared_ptr<File> fileID, NXClass const *parent, const std::string &name)
     : m_fileID(fileID), m_open(false) {
   if (parent && !name.empty()) {
-    m_address = parent->address() + "/" + name;
+    m_address = parent->address() / name;
   }
 }
 
-std::string NXObject::name() const {
-  size_t i = m_address.find_last_of('/');
-  if (i == std::string::npos)
-    return m_address;
-  else
-    return m_address.substr(i + 1, m_address.size() - i - 1);
-}
+std::string NXObject::name() const { return m_address.stem(); }
 
 /**  Reads in attributes
  */
@@ -330,10 +324,9 @@ NXDataSet::NXDataSet(const NXClass &parent, const std::string &name) : NXObject(
 
 // Opens the data set. Does not read in any data. Call load(...) to load the data
 void NXDataSet::open() {
-  size_t i = m_address.find_last_of('/');
-  if (i == std::string::npos || i == 0)
+  NexusAddress group_address(m_address.parent_path());
+  if (group_address == NexusAddress::root())
     return; // we are in the root group, assume it is open
-  std::string group_address = m_address.substr(0, i);
   m_fileID->openAddress(group_address);
   m_fileID->openData(name());
   m_info = NXInfo(m_fileID->getInfo(), name());

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -151,7 +151,7 @@ void NXClass::readAllInfo() {
       NXInfo info(m_fileID->getInfo(), entry.first);
       m_fileID->closeData();
       m_datasets->emplace_back(info);
-    } else if (entry.second.substr(0, 2) == "NX" || entry.second.substr(0, 2) == "IX") {
+    } else if (entry.second.starts_with("NX") || entry.second.starts_with("IX")) {
       m_groups->emplace_back(NXClassInfo(entry));
     }
   }

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -71,12 +71,12 @@ void getGroup(H5::Group groupID, std::map<std::string, std::set<std::string>> &a
 
 // PUBLIC
 
-NexusDescriptor::NexusDescriptor(std::string filename)
-    : m_filename(std::move(filename)), m_extension(std::filesystem::path(m_filename).extension().string()),
-      m_firstEntryNameType(), m_allEntries(initAllEntries()) {}
+NexusDescriptor::NexusDescriptor(std::string const &filename)
+    : m_filename(filename), m_extension(std::filesystem::path(m_filename).extension().string()), m_firstEntryNameType(),
+      m_allEntries(initAllEntries()) {}
 
-NexusDescriptor::NexusDescriptor(std::string filename, NXaccess access)
-    : m_filename(std::move(filename)), m_extension(std::filesystem::path(m_filename).extension().string()),
+NexusDescriptor::NexusDescriptor(std::string const &filename, NXaccess access)
+    : m_filename(filename), m_extension(std::filesystem::path(m_filename).extension().string()),
       m_firstEntryNameType() {
   // if we are creating a file and it already exists, then delete it first
   if (access == NXaccess::CREATE5) {

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1018,9 +1018,9 @@ template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &sta
   }
 
   pNexusFile5 pFile;
-  hsize_t myStart[H5S_MAX_RANK];
-  hsize_t mySize[H5S_MAX_RANK];
-  hsize_t mStart[H5S_MAX_RANK];
+  hsize_t myStart[H5S_MAX_RANK] = {0};
+  hsize_t mySize[H5S_MAX_RANK] = {0};
+  hsize_t mStart[H5S_MAX_RANK] = {0};
   hid_t memspace, iRet;
   H5T_class_t tclass;
   hid_t memtype_id;
@@ -1066,8 +1066,11 @@ template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &sta
       if (mySize[0] == 1) {
         mySize[0] = H5Tget_size(pFile->iCurrentT);
       }
-      tmp_data = static_cast<char *>(malloc((size_t)mySize[0]));
-      memset(tmp_data, 0, sizeof(mySize[0]));
+      if (mySize[0] > 0) {
+        tmp_data = static_cast<char *>(calloc(mySize[0]), sizeof(char));
+      } else {
+        tmp_data = static_cast<char *>(calloc(1, sizeof(char)));
+      }
       iRet = H5Sselect_hyperslab(pFile->iCurrentS, H5S_SELECT_SET, mStart, NULL, mySize, NULL);
     } else {
       iRet = H5Sselect_hyperslab(pFile->iCurrentS, H5S_SELECT_SET, myStart, NULL, mySize, NULL);

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1067,7 +1067,7 @@ template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &sta
         mySize[0] = H5Tget_size(pFile->iCurrentT);
       }
       if (mySize[0] > 0) {
-        tmp_data = static_cast<char *>(calloc(mySize[0]), sizeof(char));
+        tmp_data = static_cast<char *>(calloc(mySize[0], sizeof(char)));
       } else {
         tmp_data = static_cast<char *>(calloc(1, sizeof(char)));
       }
@@ -1334,10 +1334,10 @@ Entries File::getEntries() const {
 void File::getEntries(Entries &result) const {
   result.clear();
 
-  int iRet = H5Literate_by_name(m_pfile_id->iFID, m_pfile_id->name_ref.c_str(), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr,
+  int iRet = H5Literate_by_name(m_pfile_id->iFID, m_pfile_id->groupaddr.c_str(), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr,
                                 gr_iterate_cb, &result, H5P_DEFAULT);
   if (iRet < 0) {
-    throw NXEXCEPTION("H5Literate failed on group: " + m_pfile_id->name_ref);
+    throw NXEXCEPTION("H5Literate failed on group: " + m_pfile_id->groupaddr);
   }
 }
 

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -39,6 +39,7 @@
 
 // cppcheck-suppress-begin [unmatchedSuppression, variableScope]
 // cppcheck-suppress-begin [constVariablePointer, constParameterReference, unusedVariable, unreadVariable]
+// cppcheck-suppress-begin [nullPointerArithmeticOutOfMemory, nullPointerOutOfMemory]
 
 // this has to be after the other napi includes
 #include "MantidNexus/napi5.h"
@@ -1309,5 +1310,6 @@ std::string NXIformatNeXusTime() {
   return res;
 }
 
+// cppcheck-suppress-end [nullPointerArithmeticOutOfMemory, nullPointerOutOfMemory]
 // cppcheck-suppress-end [constVariablePointer, constParameterReference, unusedVariable, unreadVariable]
 // cppcheck-suppress-end [unmatchedSuppression, variableScope]

--- a/Framework/Nexus/src/napi.cpp
+++ b/Framework/Nexus/src/napi.cpp
@@ -121,7 +121,6 @@ NXstatus NXclose(NXhandle &fid) {
     NXReportError("ERROR: cannot close HDF file");
   }
   /* release memory */
-  NXI5KillDir(pFile);
   delete fid;
   fid = nullptr;
   H5garbage_collect();
@@ -134,15 +133,10 @@ NXstatus NXmakegroup(NXhandle fid, std::string const &name, std::string const &n
   pNexusFile5 pFile;
   hid_t iVID;
   hid_t attr1, aid1, aid2;
-  std::string pBuffer;
 
   pFile = NXI5assert(fid);
   /* create and configure the group */
-  if (pFile->iCurrentG == 0) {
-    pBuffer = "/" + std::string(name);
-  } else {
-    pBuffer = "/" + std::string(pFile->name_ref) + "/" + std::string(name);
-  }
+  Mantid::Nexus::NexusAddress pBuffer = pFile->groupaddr / name;
   iVID = H5Gcreate(pFile->iFID, pBuffer.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   if (iVID < 0) {
     NXReportError("ERROR: could not create Group");
@@ -173,23 +167,16 @@ NXstatus NXmakegroup(NXhandle fid, std::string const &name, std::string const &n
 /*------------------------------------------------------------------------*/
 
 NXstatus NXopengroup(NXhandle fid, std::string const &name, std::string const &nxclass) {
-  std::string pBuffer;
-
   pNexusFile5 pFile = NXI5assert(fid);
-  if (pFile->iCurrentG == 0) {
-    pBuffer = name;
-  } else {
-    pBuffer = pFile->name_tmp + "/" + name;
-  }
+  std::string pBuffer = pFile->groupaddr / name;
   hid_t iVID = H5Gopen(pFile->iFID, pBuffer.c_str(), H5P_DEFAULT);
   if (iVID < 0) {
-    std::string msg = std::string("ERROR: group ") + pFile->name_tmp + " does not exist";
+    std::string msg = std::string("ERROR: group ") + pFile->groupaddr + " does not exist";
     NXReportError(const_cast<char *>(msg.c_str()));
     return NXstatus::NX_ERROR;
   }
   pFile->iCurrentG = iVID;
-  pFile->name_tmp = pBuffer;
-  pFile->name_ref = pBuffer;
+  pFile->groupaddr = pBuffer;
 
   if ((!nxclass.empty()) && (nxclass != NX_UNKNOWN_GROUP)) {
     /* check group attribute */
@@ -232,10 +219,8 @@ NXstatus NXopengroup(NXhandle fid, std::string const &name, std::string const &n
   }
 
   /* maintain stack */
-  pFile->iStack5.emplace_back(name, pFile->iCurrentG, 0);
-  pFile->iCurrentIDX = 0;
+  pFile->iStack5.push_back(pFile->iCurrentG);
   pFile->iCurrentD = 0;
-  NXI5KillDir(pFile);
   return NXstatus::NX_OK;
 }
 
@@ -249,43 +234,15 @@ NXstatus NXclosegroup(NXhandle fid) {
      deeper into a negative directory hierarchy (anti-directory)
    */
   if (pFile->iCurrentG == 0) {
-    NXI5KillDir(pFile);
     return NXstatus::NX_OK;
   } else {
-    /* close the current group and decrement name_ref */
+    /* close the current group and decrement groupaddr */
     H5Gclose(pFile->iCurrentG);
-    size_t i = pFile->iStack5.back().irefn.size();
-    size_t ii = pFile->name_ref.size();
-    if (pFile->iStack5.size() > 2) {
-      ii = ii - i - 1;
-    } else {
-      ii = ii - i;
-    }
-    if (ii > 0) {
-      char *uname = strdup(pFile->name_ref.c_str());
-      char *u1name = NULL;
-      u1name = static_cast<char *>(malloc((ii + 1) * sizeof(char)));
-      memset(u1name, 0, ii);
-      for (i = 0; i < ii; i++) {
-        *(u1name + i) = *(uname + i);
-      }
-      *(u1name + i) = '\0';
-      /*
-         strncpy(u1name, uname, ii);
-       */
-      pFile->name_ref = u1name;
-      pFile->name_tmp = u1name;
-      free(uname);
-      free(u1name);
-    } else {
-      pFile->name_ref = "";
-      pFile->name_tmp = "";
-    }
-    NXI5KillDir(pFile);
+    pFile->groupaddr = pFile->groupaddr.parent_path();
     pFile->iCurrentD = 0;
     pFile->iStack5.pop_back();
     if (!pFile->iStack5.empty()) {
-      pFile->iCurrentG = pFile->iStack5.back().iVref;
+      pFile->iCurrentG = pFile->iStack5.back();
     } else {
       pFile->iCurrentG = 0;
     }
@@ -468,15 +425,19 @@ NXstatus NXcompmakedata64(NXhandle fid, std::string const &name, NXnumtype const
 
 NXstatus NXopendata(NXhandle fid, std::string const &name) {
   pNexusFile5 pFile = NXI5assert(fid);
-  /* clear pending attribute directories first */
-  NXI5KillAttDir(pFile);
 
+  // if a dataset is already open, close it
+  if (pFile->iCurrentD != 0) {
+    H5Dclose(pFile->iCurrentD);
+    pFile->iCurrentD = 0;
+  }
   /* find the ID number and open the dataset */
   pFile->iCurrentD = H5Dopen(pFile->iCurrentG, name.c_str(), H5P_DEFAULT);
   if (pFile->iCurrentD < 0) {
     char pBuffer[256];
     sprintf(pBuffer, "ERROR: dataset \"%s\" not found at this level", name.c_str());
     NXReportError(pBuffer);
+    pFile->iCurrentD = 0;
     return NXstatus::NX_ERROR;
   }
   /* find the ID number of datatype */
@@ -512,6 +473,8 @@ NXstatus NXclosedata(NXhandle fid) {
     return NXstatus::NX_ERROR;
   }
   pFile->iCurrentD = 0;
+  pFile->iCurrentS = 0;
+  pFile->iCurrentT = 0;
   return NXstatus::NX_OK;
 }
 
@@ -755,7 +718,7 @@ NXstatus NXmakelink(NXhandle fid, NXlink const &sLink) {
      build addressname to link from our current group and the name
      of the thing to link
    */
-  linkTarget = "/" + pFile->name_ref + "/" + itemName;
+  linkTarget = pFile->groupaddr / itemName;
 
   H5Lcreate_hard(pFile->iFID, sLink.targetAddress.c_str(), H5L_SAME_LOC, linkTarget.c_str(), H5P_DEFAULT, H5P_DEFAULT);
 
@@ -786,70 +749,14 @@ NXstatus NXflush(NXhandle &fid) {
 }
 
 /*-------------------------------------------------------------------------*/
-
-NXstatus NXmalloc64(void *&data, std::size_t rank, Mantid::Nexus::DimVector const &dims, NXnumtype datatype) {
-  size_t size = 1;
-  data = nullptr;
-  for (size_t i = 0; i < rank; i++) {
-    size *= dims[i];
-  }
-  switch (datatype) {
-  case NXnumtype::CHAR:
-  case NXnumtype::INT8:
-  case NXnumtype::UINT8:
-    size += 2;
-    break;
-  case NXnumtype::INT16:
-  case NXnumtype::UINT16:
-    size *= 2;
-    break;
-  case NXnumtype::INT32:
-  case NXnumtype::UINT32:
-  case NXnumtype::FLOAT32:
-    size *= 4;
-    break;
-  case NXnumtype::INT64:
-  case NXnumtype::UINT64:
-  case NXnumtype::FLOAT64:
-    size *= 8;
-    break;
-  default:
-    NXReportError("ERROR: NXmalloc - unknown data type in array");
-    return NXstatus::NX_ERROR;
-  }
-  data = calloc(size, 1);
-  return NXstatus::NX_OK;
-}
-
 /*-------------------------------------------------------------------------*/
-
-NXstatus NXfree(void **data) {
-  if (data == nullptr) {
-    NXReportError("ERROR: passing NULL to NXfree");
-    return NXstatus::NX_ERROR;
-  }
-  if (*data == nullptr) {
-    NXReportError("ERROR: passing already freed pointer to NXfree");
-    return NXstatus::NX_ERROR;
-  }
-  free(*data);
-  *data = nullptr;
-  return NXstatus::NX_OK;
-}
-
 /* --------------------------------------------------------------------- */
-
-NXstatus NXgetnextentry(NXhandle fid, std::string &name, std::string &nxclass, NXnumtype &datatype) {
-  return NX5getnextentry(fid, name, nxclass, datatype);
-}
-
 /*----------------------------------------------------------------------*/
 /*
 **  TRIM.C - Remove leading, trailing, & excess embedded spaces
 **
 **  public domain by Bob Stout
 */
-#define NUL '\0'
 
 char *nxitrim(char *str) {
   // Trap NULL
@@ -866,7 +773,7 @@ char *nxitrim(char *str) {
       if (!isspace(str[i]))
         break;
     }
-    str[++i] = NUL;
+    str[++i] = '\0';
   }
   return str;
 }
@@ -1125,45 +1032,44 @@ NXstatus NXgetcharattr(NXhandle fid, std::string const &name, void *data, std::s
 
 // cppcheck-suppress constParameterCallback
 NXstatus NXgetattr(NXhandle fid, std::string const &name, void *data, std::size_t &datalen, NXnumtype &iType) {
-  pNexusFile5 pFile;
-  hid_t vid, iNew;
-  hsize_t dims[H5S_MAX_RANK], totalsize;
   herr_t iRet;
-  hid_t type, filespace;
   char pBuffer[256];
 
-  pFile = NXI5assert(fid);
+  pNexusFile5 pFile = NXI5assert(fid);
 
-  type = nxToHDF5Type(iType);
+  hid_t type = nxToHDF5Type(iType);
 
-  vid = getAttVID(pFile);
-  iNew = H5Aopen_by_name(vid, ".", name.c_str(), H5P_DEFAULT, H5P_DEFAULT);
-  if (iNew < 0) {
+  hid_t vid = getAttVID(pFile);
+  hid_t attrid = H5Aopen_by_name(vid, ".", name.c_str(), H5P_DEFAULT, H5P_DEFAULT);
+  if (attrid < 0) {
     sprintf(pBuffer, "ERROR: attribute \"%s\" not found", name.c_str());
     killAttVID(pFile, vid);
     NXReportError(pBuffer);
     return NXstatus::NX_ERROR;
   }
-  pFile->iCurrentA = iNew;
 
   // get the dataspace and proper dimensions
-  filespace = H5Aget_space(pFile->iCurrentA);
-  totalsize = 1;
-  const auto ndims = H5Sget_simple_extent_dims(filespace, dims, NULL);
-  for (int i = 0; i < ndims; i++) {
-    totalsize *= dims[i];
-  }
-  if (ndims != 0 && totalsize > 1) {
-    NXReportError("ERROR: attribute arrays not supported by this api");
-    return NXstatus::NX_ERROR;
+  hid_t filespace = H5Aget_space(attrid);
+  int ndims = H5Sget_simple_extent_ndims(filespace);
+  if (ndims > 0) {
+    hsize_t totalsize = 1;
+    hsize_t *dims = new hsize_t[ndims];
+    H5Sget_simple_extent_dims(filespace, dims, NULL);
+    for (int i = 0; i < ndims; i++) {
+      totalsize *= dims[i];
+    }
+    if (totalsize > 1) {
+      NXReportError("ERROR: attribute arrays not supported by this api");
+      return NXstatus::NX_ERROR;
+    }
   }
 
   /* finally read the data */
   if (type == H5T_C_S1) {
-    iRet = readStringAttributeN(pFile->iCurrentA, static_cast<char *>(data), datalen);
+    iRet = readStringAttributeN(attrid, static_cast<char *>(data), datalen);
     datalen = strlen(static_cast<char *>(data));
   } else {
-    iRet = H5Aread(pFile->iCurrentA, type, data);
+    iRet = H5Aread(attrid, type, data);
     datalen = 1;
   }
 
@@ -1174,7 +1080,7 @@ NXstatus NXgetattr(NXhandle fid, std::string const &name, void *data, std::size_
     return NXstatus::NX_ERROR;
   }
 
-  H5Aclose(pFile->iCurrentA);
+  H5Aclose(attrid);
 
   killAttVID(pFile, vid);
   return NXstatus::NX_OK;
@@ -1211,34 +1117,7 @@ NXstatus NXgetgroupID(NXhandle fileid, NXlink &sRes) {
 
 /*-------------------------------------------------------------------------*/
 /*-------------------------------------------------------------------------*/
-
-NXstatus NXsameID(NXhandle fileid, NXlink const &pFirstID, NXlink const &pSecondID) {
-  NXI5assert(fileid);
-  if (pFirstID.targetAddress == pSecondID.targetAddress) {
-    return NXstatus::NX_OK;
-  } else {
-    return NXstatus::NX_ERROR;
-  }
-}
-
 /*-------------------------------------------------------------------------*/
-
-NXstatus NXinitattrdir(NXhandle fid) {
-  pNexusFile5 pFile;
-
-  pFile = NXI5assert(fid);
-  NXI5KillAttDir(pFile);
-  return NXstatus::NX_OK;
-}
-
-NXstatus NXinitgroupdir(NXhandle fid) {
-  pNexusFile5 pFile;
-
-  pFile = NXI5assert(fid);
-  NXI5KillDir(pFile);
-  return NXstatus::NX_OK;
-}
-
 /*------------------------------------------------------------------------
   Implementation of NXopenaddress
   --------------------------------------------------------------------------*/
@@ -1246,60 +1125,116 @@ NXstatus NXinitgroupdir(NXhandle fid) {
 /*-------------------------------------------------------------------*/
 /*---------------------------------------------------------------------*/
 NXstatus NXopenaddress(NXhandle fid, std::string const &address) {
-  NXstatus status;
-  int run = 1;
   std::string addressElement;
-  if (fid == NULL || address.empty()) {
-    NXReportError("ERROR: NXopendata needs both a file handle and a address string");
+  if (fid == nullptr || address.empty()) {
+    NXReportError("ERROR: NXopenaddress needs both a file handle and a address string");
     return NXstatus::NX_ERROR;
   }
 
-  std::string pPtr(moveDown(fid, address, status));
-  if (status != NXstatus::NX_OK) {
-    NXReportError("ERROR: NXopendata failed to move down in hierarchy");
-    return status;
+  // establish the new address absolutely
+  Mantid::Nexus::NexusAddress absaddr(address);
+  if (!absaddr.isAbsolute()) {
+    absaddr = fid->groupaddr / address;
   }
 
-  while (run == 1) {
-    pPtr = extractNextAddress(pPtr, addressElement);
-    status = stepOneUp(fid, addressElement);
-    if (status != NXstatus::NX_OK) {
-      return status;
+  // if we are already there, do nothing
+  if (absaddr == buildCurrentAddress(fid)) {
+    return NXstatus::NX_OK;
+  }
+
+  // go all the way down to the root
+  // if a dataset is open then close it
+  if (isDataSetOpen(fid)) {
+    H5Dclose(fid->iCurrentD);
+    H5Sclose(fid->iCurrentS);
+    H5Tclose(fid->iCurrentT);
+    fid->iCurrentD = 0;
+    fid->iCurrentS = 0;
+    fid->iCurrentT = 0;
+  }
+  // now close all the groups in the stack
+  for (hid_t gid : fid->iStack5) {
+    if (gid != 0) {
+      H5Gclose(gid);
     }
-    if (pPtr.empty()) {
-      run = 0;
+  }
+  fid->iStack5.clear();
+  // reset to the root condition
+  fid->iStack5.push_back(0);
+
+  // if we wanted to go to root, then stop here
+  if (absaddr == Mantid::Nexus::NexusAddress::root()) {
+    fid->iCurrentG = 0;
+    fid->groupaddr = Mantid::Nexus::NexusAddress::root();
+    return NXstatus::NX_OK;
+  }
+
+  // build new address
+  Mantid::Nexus::NexusAddress up(absaddr.parent_path());
+  std::string last(absaddr.stem());
+  // open groups up the address
+  if (up.isRoot()) {
+    fid->iCurrentG = 0;
+  } else {
+    fid->iCurrentG = fid->iFID;
+    for (auto const &name : up.parts()) {
+      hid_t gid = H5Gopen(fid->iCurrentG, name.c_str(), H5P_DEFAULT);
+      if (gid < 0) {
+        return NXstatus::NX_ERROR;
+      }
+      fid->iStack5.push_back(gid);
+      fid->iCurrentG = gid;
+      fid->groupaddr /= name;
     }
+  }
+  // now open the last element -- either a group or a dataset
+  H5O_info2_t op_data;
+  H5Oget_info_by_name(fid->iFID, absaddr.c_str(), &op_data, H5O_INFO_BASIC, H5P_DEFAULT);
+  if (op_data.type == H5O_TYPE_GROUP) {
+    hid_t gid = H5Gopen(fid->iFID, absaddr.c_str(), H5P_DEFAULT);
+    if (gid < 0) {
+      return NXstatus::NX_ERROR;
+    }
+    fid->iStack5.push_back(gid);
+    fid->iCurrentG = gid;
+  } else if (op_data.type == H5O_TYPE_DATASET) {
+    NXstatus ret = NXopendata(fid, last);
+    if (ret != NXstatus::NX_OK) {
+      return ret;
+    }
+  } else {
+    return NXstatus::NX_ERROR;
+  }
+  // now set the address
+  if (fid->iCurrentG == 0) {
+    fid->groupaddr = Mantid::Nexus::NexusAddress::root();
+  } else {
+    fid->groupaddr = getObjectAddress(fid->iCurrentG);
   }
   return NXstatus::NX_OK;
 }
 
 /*---------------------------------------------------------------------*/
 NXstatus NXopengroupaddress(NXhandle fid, std::string const &address) {
-  NXstatus status;
-  std::string addressElement;
-
   if (fid == nullptr || address.empty()) {
     NXReportError("ERROR: NXopengroupaddress needs both a file handle and a address string");
     return NXstatus::NX_ERROR;
   }
 
-  std::string pPtr(moveDown(fid, address, status));
-  if (status != NXstatus::NX_OK) {
-    NXReportError("ERROR: NXopengroupaddress failed to move down in hierarchy");
-    return status;
+  Mantid::Nexus::NexusAddress groupAddress(address);
+  // determine whether this address refers to a group or a dataset
+  // if a dataset, then go to the parent
+  H5O_info2_t op_data;
+  H5Oget_info_by_name(fid->iFID, address.c_str(), &op_data, H5O_INFO_BASIC, H5P_DEFAULT);
+  if (op_data.type == H5O_TYPE_GROUP) {
+    // leave address as it is
+  } else if (op_data.type == H5O_TYPE_DATASET) {
+    groupAddress = groupAddress.parent_path();
+  } else {
+    return NXstatus::NX_ERROR;
   }
-
-  do {
-    pPtr = extractNextAddress(pPtr, addressElement);
-    status = stepOneGroupUp(fid, addressElement);
-    if (status == NXstatus::NX_ERROR) {
-      std::string msg("ERROR: NXopengroupaddress cannot reach address ");
-      msg += address;
-      NXReportError(msg.c_str());
-      return NXstatus::NX_ERROR;
-    }
-  } while (!pPtr.empty() && status != NXstatus::NX_EOD);
-  return NXstatus::NX_OK;
+  // now open the correct address
+  return NXopenaddress(fid, groupAddress.string());
 }
 
 /*---------------------------------------------------------------------*/

--- a/Framework/Nexus/test/NapiUnitTest.h
+++ b/Framework/Nexus/test/NapiUnitTest.h
@@ -34,16 +34,14 @@ using std::vector;
 #define NX_ASSERT_OKAY(status, msg)                                                                                    \
   if ((status) != NXstatus::NX_OK) {                                                                                   \
     NXclose(fid);                                                                                                      \
-    std::cerr << msg;                                                                                                  \
-    fflush(stderr);                                                                                                    \
+    std::cerr << msg << std::flush;                                                                                    \
     TS_FAIL(msg);                                                                                                      \
   }
 
 #define NX_ASSERT_ERROR(status, msg)                                                                                   \
   if ((status) != NXstatus::NX_ERROR) {                                                                                \
     NXclose(fid);                                                                                                      \
-    std::cerr << msg;                                                                                                  \
-    fflush(stderr);                                                                                                    \
+    std::cerr << msg << std::flush;                                                                                    \
     TS_FAIL(msg);                                                                                                      \
   }
 
@@ -118,8 +116,7 @@ public:
   }
 
   void test_clear_on_create() {
-    cout << "\ncreation clear old\n";
-    fflush(stdout);
+    cout << "\ncreation clear old\n" << std::flush;
 
     // create an empty file
     FileResource resource("fake_empty_file.nxs.h5");
@@ -540,7 +537,7 @@ public:
   }
 
   void test_data_putget_array() {
-    cout << "\ntest dataset read/write -- arrays\n";
+    cout << "\ntest dataset read/write -- arrays\n" << std::flush;
 
     // open a file
     FileResource resource("test_napi_file_dataRW.h5");
@@ -632,7 +629,7 @@ public:
   // #################################################################################################################
 
   void test_get_address_groups() {
-    cout << "\ntest get address -- groups only\n";
+    cout << "\ntest get address -- groups only\n" << std::flush;
     FileResource resource("test_napi_file_grp.h5");
     std::string filename = resource.fullPath();
     std::string address;
@@ -681,7 +678,7 @@ public:
   }
 
   void test_get_address_data() {
-    cout << "\ntest get address -- groups and data!\n";
+    cout << "\ntest get address -- groups and data!\n" << std::flush;
     FileResource resource("test_napi_file_grpdata.h5");
     std::string filename = resource.fullPath();
     NexusFile5 *fid;
@@ -708,7 +705,7 @@ public:
   }
 
   void test_open_address() {
-    cout << "tests for open address\n";
+    cout << "tests for open address\n" << std::flush;
 
     // make file with path /entry
     FileResource resource("test_napi_openpathtest.nxs");
@@ -780,7 +777,7 @@ public:
   }
 
   void test_get_info() {
-    cout << "\ntest get info -- good\n";
+    cout << "\ntest get info -- good\n" << std::flush;
 
     // open a file
     FileResource resource("test_napi_file_dataRW.h5");
@@ -835,7 +832,7 @@ public:
   }
 
   void test_get_info_bad() {
-    cout << "\ntest get info -- bad\n";
+    cout << "\ntest get info -- bad\n" << std::flush;
     // open a file
     FileResource resource("test_napi_file_dataRW.h5");
     std::string filename = resource.fullPath();
@@ -868,7 +865,7 @@ public:
   // ################################################################################################################
 
   template <typename T> void do_test_putget_attr(NexusFile5 *fid, string name, T const &data) {
-    cout << "\tput/get attribute " << name << "\n";
+    cout << "\tput/get attribute " << name << "\n" << std::flush;
     // test put/get by pointer to data
     T out;
     std::size_t len;
@@ -881,7 +878,7 @@ public:
   }
 
   void test_putget_attr_basic() {
-    cout << "\ntest attribute read/write\n";
+    cout << "\ntest attribute read/write\n" << std::flush;
 
     // open a file
     FileResource resource("test_napi_attr.h5");
@@ -905,7 +902,7 @@ public:
   }
 
   void test_putget_attr_str() {
-    cout << "\ntest string attribute read/write\n";
+    cout << "\ntest string attribute read/write\n" << std::flush;
 
     // open a file
     FileResource resource("test_napi_attr.h5");
@@ -958,7 +955,7 @@ public:
   // ################################################################################################################
 
   void test_links() {
-    cout << "tests of linkature\n";
+    cout << "tests of linkature\n" << std::flush;
 
     FileResource resource("test_napi_link.nxs");
     std::string filename = resource.fullPath();
@@ -968,7 +965,7 @@ public:
     NX_ASSERT_OKAY(NXopengroup(fid, "entry", "NXentry"), "failed to open group");
 
     // Create some data
-    cout << "create entry at /entry/some_data\n";
+    cout << "create entry at /entry/some_data\n" << std::flush;
     string const somedata("this is some data");
     DimVector dims{static_cast<dimsize_t>(somedata.size())};
     NX_ASSERT_OKAY(NXmakedata64(fid, "some_data", NXnumtype::CHAR, 1, dims), "failed to make data");
@@ -985,7 +982,7 @@ public:
     NX_ASSERT_OKAY(NXclosedata(fid), "failed to close data");
 
     // Create a group, and link it to that data
-    cout << "create group at /entry/data to link to the data\n";
+    cout << "create group at /entry/data to link to the data\n" << std::flush;
     NX_ASSERT_OKAY(NXmakegroup(fid, "data", "NXdata"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "data", "NXdata"), "failed to open group");
     NX_ASSERT_OKAY(NXmakelink(fid, datalink), "failed to make link");
@@ -1000,13 +997,14 @@ public:
     cout << "data link works\n";
     NX_ASSERT_OKAY(NXclosedata(fid), "failed to close linked data");
 
-    NXopenaddress(fid, "/entry");
+    NX_ASSERT_OKAY(NXopenaddress(fid, "/entry"), "failed to open /entry");
+    TS_ASSERT_EQUALS(fid->groupaddr, "/entry");
 
     // Create two groups, group1 and group2
     // Make a link inside group2 to group1
 
     // make group1
-    cout << "create group /entry/group1\n";
+    cout << "create group /entry/group1\n" << std::flush;
     NX_ASSERT_OKAY(NXmakegroup(fid, "group1", "NXpants"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "group1", "NXpants"), "failed to open group");
     NXlink grouplink;
@@ -1016,7 +1014,7 @@ public:
     NX_ASSERT_OKAY(NXclosegroup(fid), "failed to close group");
 
     // make group 2
-    cout << "create group /entry/group2/group1\n";
+    cout << "create group /entry/group2/group1\n" << std::flush;
     NX_ASSERT_OKAY(NXmakegroup(fid, "group2", "NXshorts"), "failed to make group");
     NX_ASSERT_OKAY(NXopengroup(fid, "group2", "NXshorts"), "failed to open group");
     NX_ASSERT_OKAY(NXmakelink(fid, grouplink), "failed to make link");
@@ -1028,7 +1026,7 @@ public:
     NX_ASSERT_OKAY(NXgetgroupID(fid, res2), "failed to get linked group ID");
     TS_ASSERT_EQUALS(grouplink.linkType, res2.linkType);
     TS_ASSERT_EQUALS(string(grouplink.targetAddress), string(res2.targetAddress));
-    cout << "group link works\n";
+    cout << "group link works\n" << std::flush;
 
     // cleanup
     NX_ASSERT_OKAY(NXclose(fid), "failed to close");

--- a/Framework/Nexus/test/NexusAddressTest.h
+++ b/Framework/Nexus/test/NexusAddressTest.h
@@ -247,4 +247,13 @@ public:
     TS_ASSERT_EQUALS(np, NexusAddress("/raw_data_1"));
     TS_ASSERT_EQUALS(np.string(), "/raw_data_1");
   }
+
+  void test_abs_slash_abs() {
+    NexusAddress np("/entry0");
+    std::string name("/data");
+    TS_ASSERT_EQUALS((np / name).string(), "/entry0/data");
+
+    NexusAddress np2("/data");
+    TS_ASSERT_EQUALS((np / np2).string(), "/entry0/data");
+  }
 };

--- a/Framework/Nexus/test/NexusAddressTest.h
+++ b/Framework/Nexus/test/NexusAddressTest.h
@@ -38,7 +38,7 @@ public:
   }
 
   void test_construct_from_filepath_lexically_normal() {
-    std::filesystem::path p("/path/good/../other");
+    std::filesystem::path p("/path/good/../other/");
     NexusAddress np(p);
     TS_ASSERT_EQUALS(np.string(), "/path/other");
   }
@@ -246,6 +246,10 @@ public:
     NexusAddress np("//raw_data_1");
     TS_ASSERT_EQUALS(np, NexusAddress("/raw_data_1"));
     TS_ASSERT_EQUALS(np.string(), "/raw_data_1");
+
+    std::filesystem::path p("//raw_data_1");
+    NexusAddress np2(p);
+    TS_ASSERT_EQUALS(np2.string(), "/raw_data_1");
   }
 
   void test_abs_slash_abs() {
@@ -255,5 +259,14 @@ public:
 
     NexusAddress np2("/data");
     TS_ASSERT_EQUALS((np / np2).string(), "/entry0/data");
+  }
+
+  void test_slash() {
+    NexusAddress np("/entry0");
+    std::string name("data/copy");
+    TS_ASSERT_EQUALS((np / name).string(), "/entry0/data/copy");
+
+    NexusAddress np2("data/copy");
+    TS_ASSERT_EQUALS((np / np2).string(), "/entry0/data/copy");
   }
 };

--- a/Framework/Nexus/test/NexusAddressTest.h
+++ b/Framework/Nexus/test/NexusAddressTest.h
@@ -215,9 +215,12 @@ public:
     NexusAddress np("/entry1/two");
     std::string pref = "path located at ";
     std::string post = " is a good path";
+    char carr[] = " a c style string ";
 
     TS_ASSERT_EQUALS("path located at /entry1/two", pref + np);
     TS_ASSERT_EQUALS("/entry1/two is a good path", np + post);
+    TS_ASSERT_EQUALS(" a c style string /entry1/two", carr + np);
+    TS_ASSERT_EQUALS("/entry1/two a c style string ", np + carr);
   }
 
   std::string function_with_string_argument(std::string x) {

--- a/Framework/Nexus/test/NexusAddressTest.h
+++ b/Framework/Nexus/test/NexusAddressTest.h
@@ -1,0 +1,241 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/ConfigService.h"
+#include "MantidNexus/NexusAddress.h"
+
+#include <filesystem>
+
+#include <cstddef> // std::size_t
+
+#include <cxxtest/TestSuite.h>
+
+using Mantid::Nexus::NexusAddress;
+
+class NexusAddressTest : public CxxTest::TestSuite {
+
+public:
+  void test_construct_is_root() {
+    NexusAddress np;
+    TS_ASSERT_EQUALS(np.string(), "/");
+  }
+
+  void test_construct_copy() {
+    NexusAddress np1("/entry1");
+    NexusAddress np2(np1);
+    TS_ASSERT_EQUALS(np2.string(), np1.string());
+  }
+
+  void test_construct_from_filepath() {
+    std::filesystem::path p("/path/good");
+    NexusAddress np(p);
+    TS_ASSERT_EQUALS(np.string(), p.string());
+  }
+
+  void test_construct_from_filepath_lexically_normal() {
+    std::filesystem::path p("/path/good/../other");
+    NexusAddress np(p);
+    TS_ASSERT_EQUALS(np.string(), "/path/other");
+  }
+
+  void test_construct_from_string() {
+    std::string p("/path/good");
+    NexusAddress np(p);
+    TS_ASSERT_EQUALS(np.string(), p);
+  }
+
+  void test_construct_from_string_lexically_normal() {
+    std::string p("/path/good/../other/");
+    NexusAddress np(p);
+    TS_ASSERT_EQUALS(np.string(), "/path/other");
+  }
+
+  void test_assignment_operator_path() {
+    NexusAddress np1("/entry");
+    NexusAddress np2("/other");
+    TS_ASSERT_DIFFERS(np1.string(), np2.string())
+    np2 = np1;
+    TS_ASSERT_EQUALS(np1.string(), np2.string());
+  }
+
+  void test_assignment_operator_string() {
+    NexusAddress np("/entry");
+    std::string str("/other");
+    TS_ASSERT_DIFFERS(np.string(), str)
+    np = str;
+    TS_ASSERT_EQUALS(np.string(), str);
+  }
+
+  void test_comparisons() {
+    std::string str1("/entry"), str2("/entry"), str3("/other");
+    NexusAddress np1(str1), np2(str2), np3(str3);
+    // comparison with NexusAddress
+    TS_ASSERT_EQUALS((np1 == np2), true);
+    TS_ASSERT_EQUALS((np1 != np2), false);
+    TS_ASSERT_EQUALS((np1 == np3), false);
+    TS_ASSERT_EQUALS((np1 != np3), true);
+    // comparison with string
+    TS_ASSERT_EQUALS((np1 == str1), true);
+    TS_ASSERT_EQUALS((np1 != str1), false);
+    TS_ASSERT_EQUALS((np1 == str2), true);
+    TS_ASSERT_EQUALS((np1 != str2), false);
+    TS_ASSERT_EQUALS((np1 == str3), false);
+    TS_ASSERT_EQUALS((np1 != str3), true);
+    // swap comparison order
+    TS_ASSERT_EQUALS((str1 == np1), true);
+    TS_ASSERT_EQUALS((str1 != np1), false);
+    // TS ASSERTS
+    TS_ASSERT_EQUALS(np1, np2);
+    TS_ASSERT_DIFFERS(np1, np3);
+    TS_ASSERT_EQUALS(np1, str2);
+    TS_ASSERT_DIFFERS(np1, str3);
+  }
+
+  void test_append() {
+    NexusAddress start("/entry"), next("another");
+    std::string another("one_more");
+
+    // operator /
+    NexusAddress up1 = start / next;
+    TS_ASSERT_EQUALS(up1, "/entry/another");
+
+    NexusAddress up2 = start / another;
+    TS_ASSERT_EQUALS(up2, "/entry/one_more");
+
+    // operator /=
+    start /= another;
+    TS_ASSERT_EQUALS(start, up2);
+  }
+
+  void test_isAbsolute() {
+    NexusAddress abs("/entry/data1"), notabs("data2/something");
+    TS_ASSERT_EQUALS(abs.isAbsolute(), true);
+    TS_ASSERT_EQUALS(notabs.isAbsolute(), false);
+  }
+
+  void test_isRoot() {
+    NexusAddress root1, root2("/"), notroot("/entry1");
+    TS_ASSERT_EQUALS(NexusAddress::root().isRoot(), true);
+    TS_ASSERT_EQUALS(root1.isRoot(), true);
+    TS_ASSERT_EQUALS(root2.isRoot(), true);
+    TS_ASSERT_EQUALS(NexusAddress::root().isAbsolute(), true);
+    TS_ASSERT_EQUALS(root1.isAbsolute(), true);
+    TS_ASSERT_EQUALS(root2.isAbsolute(), true);
+    // not root
+    TS_ASSERT_EQUALS(notroot.isRoot(), false);
+  }
+
+  void test_parent_path() {
+    NexusAddress root;
+    TS_ASSERT_EQUALS(root.parent_path(), root);
+
+    std::filesystem::path path("/entry1/data_points/logs/log_values");
+    NexusAddress long_path(path);
+    TS_ASSERT_EQUALS(long_path, path.string());
+
+    long_path = long_path.parent_path();
+    path = path.parent_path();
+    TS_ASSERT_EQUALS(long_path, path.string());
+    TS_ASSERT_EQUALS(long_path, "/entry1/data_points/logs");
+
+    long_path = long_path.parent_path();
+    path = path.parent_path();
+    TS_ASSERT_EQUALS(long_path, path.string());
+    TS_ASSERT_EQUALS(long_path, "/entry1/data_points");
+
+    long_path = long_path.parent_path();
+    path = path.parent_path();
+    TS_ASSERT_EQUALS(long_path, path.string());
+    TS_ASSERT_EQUALS(long_path, "/entry1");
+
+    long_path = long_path.parent_path();
+    path = path.parent_path();
+    TS_ASSERT_EQUALS(long_path, path.string());
+    TS_ASSERT_EQUALS(long_path, "/");
+
+    long_path = long_path.parent_path();
+    path = path.parent_path();
+    TS_ASSERT_EQUALS(long_path, path.string());
+    TS_ASSERT_EQUALS(long_path, "/");
+  }
+
+  void test_fromRoot() {
+    NexusAddress np("entry2/data");
+    NexusAddress npabs = np.fromRoot();
+    TS_ASSERT_EQUALS(np.isAbsolute(), false);
+    TS_ASSERT_EQUALS(npabs.isAbsolute(), true);
+    TS_ASSERT_EQUALS(npabs, "/" + np.string());
+    TS_ASSERT_EQUALS(npabs.fromRoot(), npabs);
+  }
+
+  void test_stem() {
+    NexusAddress root;
+    TS_ASSERT_EQUALS(root.stem(), "");
+
+    NexusAddress long_path("/entry1/data_points/logs/log_values");
+    TS_ASSERT_EQUALS(long_path.stem(), "log_values");
+  }
+
+  void test_root() {
+    NexusAddress root;
+    TS_ASSERT_EQUALS(root.root(), root);
+    TS_ASSERT_EQUALS(root.root(), NexusAddress::root());
+    TS_ASSERT_EQUALS(root.root(), "/");
+
+    NexusAddress long_path("/entry1/data_points/logs/log_values");
+    TS_ASSERT_EQUALS(long_path.root(), root);
+    TS_ASSERT_EQUALS(long_path.root(), NexusAddress::root());
+    TS_ASSERT_EQUALS(long_path.root(), "/");
+  }
+
+  void test_parts() {
+    std::vector<std::string> names{"one", "two", "three", "four"};
+    NexusAddress np;
+    for (auto name : names) {
+      np /= name;
+    }
+    TS_ASSERT_EQUALS(np.string(), "/one/two/three/four");
+    std::vector<std::string> actual(np.parts());
+    for (std::size_t i = 0; i < actual.size(); i++) {
+      TS_ASSERT_EQUALS(names[i], actual[i]);
+    }
+
+    NexusAddress np2("/notroot");
+    std::vector<std::string> part(np2.parts());
+    TS_ASSERT_EQUALS(part.size(), 1);
+    TS_ASSERT_EQUALS(part[0], "notroot")
+  }
+
+  void test_string_concat() {
+    NexusAddress np("/entry1/two");
+    std::string pref = "path located at ";
+    std::string post = " is a good path";
+
+    TS_ASSERT_EQUALS("path located at /entry1/two", pref + np);
+    TS_ASSERT_EQUALS("/entry1/two is a good path", np + post);
+  }
+
+  std::string function_with_string_argument(std::string x) {
+    std::stringstream msg;
+    msg << "Writing out string " << x << "\n";
+    return msg.str();
+  }
+
+  void test_nexuspath_as_string_argument() {
+    NexusAddress np("/entry1/two");
+    std::string out;
+    TS_ASSERT_THROWS_NOTHING(out = function_with_string_argument(np));
+    TS_ASSERT_EQUALS(out, "Writing out string /entry1/two\n");
+  }
+
+  void test_c_str() {
+    NexusAddress np("/entry/data/comp_data");
+    std::string out(np.c_str());
+    TS_ASSERT_EQUALS(out, np.string());
+  }
+};

--- a/Framework/Nexus/test/NexusAddressTest.h
+++ b/Framework/Nexus/test/NexusAddressTest.h
@@ -238,4 +238,10 @@ public:
     std::string out(np.c_str());
     TS_ASSERT_EQUALS(out, np.string());
   }
+
+  void test_root_root() {
+    NexusAddress np("//raw_data_1");
+    TS_ASSERT_EQUALS(np, NexusAddress("/raw_data_1"));
+    TS_ASSERT_EQUALS(np.string(), "/raw_data_1");
+  }
 };

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -74,4 +74,27 @@ public:
     duration.load();
     TS_ASSERT_DELTA(duration[0], 7200., .1);
   }
+
+  void test_concurrent_read_address_and_id() {
+    std::cout << "test file and nexus classes\n" << std::flush;
+    // this test mimics behavior found inside LoadNexusProcessed::loadLeanelasticPeaksEntry
+    // and protects against a regression that can occur in tests of LoadNexusProcessed
+    // This error occurs when multiple places are trying to access the same file resource,
+    // and put the stack of HDF IDs in an inconsistent state.
+    std::string filename = NexusTest::getFullPath("SingleCrystalLeanElasticPeakTableNew.nxs");
+
+    // open an NXRoot and a NexusFile
+    Mantid::Nexus::NXRoot root(filename);
+    Mantid::Nexus::File file(root.m_fileID);
+
+    // in the file, go to one place, in the NXRoot another
+    TS_ASSERT_THROWS_NOTHING(file.openGroupAddress("/mantid_workspace_1"));
+    TS_ASSERT_THROWS_NOTHING(root.openEntry("mantid_workspace_1"));
+    TS_ASSERT_THROWS_NOTHING(file.openGroupAddress("/mantid_workspace_1/peaks_workspace"));
+    // If the error is not fixed, the result of the above COULD mean that the file is in an
+    // inconsistent situation.  It will then try to open a dataset "definition", which is
+    // inside "/mantid_workspace_1", even though the currently opened group is "peaks_workspace"
+    // This can cause an error in `File::getEntries()` which can be very hard to pin down
+    TS_ASSERT_THROWS_NOTHING(root.openEntry("mantid_workspace_1"));
+  }
 };

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -97,4 +97,14 @@ public:
     // This can cause an error in `File::getEntries()` which can be very hard to pin down
     TS_ASSERT_THROWS_NOTHING(root.openEntry("mantid_workspace_1"));
   }
+
+  void test_double_root() {
+    // this protects against a regression that could occur, only on Windows,
+    // and only in the tests of LoadMuonNexus3 and LoadMuonNexusV2
+    std::string filename(NexusTest::getFullPath("EMU00102347.nxs_v2"));
+    std::string entryName("/raw_data_1");
+    Mantid::Nexus::NXRoot root(filename);
+    Mantid::Nexus::NXEntry entry = root.openEntry(entryName);
+    TS_ASSERT_EQUALS(entry.address(), entryName);
+  }
 };

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -107,4 +107,17 @@ public:
     Mantid::Nexus::NXEntry entry = root.openEntry(entryName);
     TS_ASSERT_EQUALS(entry.address(), entryName);
   }
+
+  void test_proper_concat() {
+    // this protects against a regression that can occur in LoadILLSANS
+    std::string filename = NexusTest::getFullPath("ILL/D16/025786.nxs");
+    Mantid::Nexus::NXRoot root(filename);
+    Mantid::Nexus::NXEntry firstEntry(root.openFirstEntry());
+
+    std::string relAddr = "data_scan/scanned_variables/data";
+    TS_ASSERT_THROWS_NOTHING(firstEntry.openNXData(relAddr));
+
+    std::string absAddr = "/data_scan/scanned_variables/data";
+    TS_ASSERT_THROWS_NOTHING(firstEntry.openNXData(absAddr));
+  }
 };

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -111,8 +111,7 @@ public:
   }
 
   void test_leak3() {
-    cout << "Running Leak Test 3\n";
-    fflush(stdout);
+    cout << "Running Leak Test 3\n" << std::flush;
     const int nFiles = 10;
     const int nEntry = 2;
     const int nData = 2;
@@ -129,8 +128,7 @@ public:
     std::string const szFile(fr.fullPath());
 
     int const iBinarySize = TEST_SIZE * TEST_SIZE;
-    cout << "Creating array of " << iBinarySize << " integers\n";
-    fflush(stdout);
+    cout << "Creating array of " << iBinarySize << " integers\n" << std::flush;
     int16_t aiBinaryData[iBinarySize];
 
     for (int i = 0; i < iBinarySize; i++) {

--- a/Framework/Nexus/test/NexusFileReadWriteTest.h
+++ b/Framework/Nexus/test/NexusFileReadWriteTest.h
@@ -313,7 +313,7 @@ public:
   }
 
   void test_links() {
-    cout << "tests of linkature\n";
+    cout << "tests of linkature\n" << std::flush;
 
     string const filename("NexusFile_linktest.nxs");
     removeFile(filename);
@@ -354,7 +354,7 @@ public:
     // Create two groups, group1 and group2
     // Make a link inside group2 to group1
     // make group1
-    cout << "create group /entry/group1\n";
+    cout << "create group /entry/group1\n" << std::flush;
     std::string const strdata("NeXus sample data");
     fileid.makeGroup("group1", "NXentry");
     fileid.openGroup("group1", "NXentry");

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -45,7 +45,7 @@ public:
 
   void test_remove() {
     // create a simple file, and make sure removeFile works as intended
-    cout << "\nremoving\n";
+    cout << "\nremoving\n" << std::flush;
     FileResource resource("not_a_real_file.txt");
     std::string filename = resource.fullPath();
 
@@ -69,7 +69,7 @@ public:
   }
 
   void test_can_create() {
-    cout << "\ntest creation\n";
+    cout << "\ntest creation\n" << std::flush;
 
     FileResource resource("test_nexus_file_init.h5");
     std::string filename = resource.fullPath();
@@ -81,7 +81,7 @@ public:
   }
 
   void test_can_open_existing() {
-    cout << "\ntest open exisitng\n";
+    cout << "\ntest open exisitng\n" << std::flush;
 
     FileResource resource("test_nexus_file_init.h5");
     std::string filename = resource.fullPath();
@@ -325,6 +325,7 @@ public:
     // make and open lateral data
     TS_ASSERT_THROWS_NOTHING(file.makeData("data2", NXnumtype::CHAR, 2, false));
     TS_ASSERT_THROWS_NOTHING(file.openData("data2"));
+    TS_ASSERT(file.hasData("/entry/data2"));
     std::string address2 = file.getAddress();
 
     // make sure new data is created off of entry
@@ -717,6 +718,16 @@ public:
 
     // put an initial entry
     hid_t groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    // add a NX_class attribute
+    hid_t attrtype = H5Tcopy(H5T_C_S1);
+    H5Tset_size(attrtype, 7);
+    hid_t attrspce = H5Screate(H5S_SCALAR);
+    hid_t attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
+    H5Awrite(attrid, attrtype, "NXpants");
+    // cleanup attribute
+    H5Sclose(attrspce);
+    H5Tclose(attrtype);
+    H5Aclose(attrid);
 
     // make and put the data
     hid_t datatype = H5Tcopy(H5T_C_S1);
@@ -899,8 +910,8 @@ public:
     TS_ASSERT_EQUALS(file.getAddress(), "/");
     TS_ASSERT_THROWS(file.openAddress("/pants"), Mantid::Nexus::Exception &);
     TS_ASSERT_EQUALS(file.getAddress(), "/");
+    // NOTE pre-existent behavior will partially open invalid paths
     TS_ASSERT_THROWS(file.openAddress("/entry1/pants"), Mantid::Nexus::Exception &);
-    // Should this still be "/"?
     TS_ASSERT_EQUALS(file.getAddress(), "/entry1");
 
     // open the root

--- a/Framework/Nexus/test/napi_test.cpp
+++ b/Framework/Nexus/test/napi_test.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
     return TEST_SUCCEED; /* create only */
   }
 
-  std::string name, nxclass, address;
+  std::string address;
 
   // read test
   std::cout << "Read/Write to read \"" << nxFile << "\"" << std::endl;

--- a/Framework/Nexus/test/napi_test_cpp.cpp
+++ b/Framework/Nexus/test/napi_test_cpp.cpp
@@ -93,7 +93,7 @@ static void writeTest(const string &filename, NXaccess create_code) {
   file.putAttr("ch_attribute", "NeXus");
   file.putAttr("i4_attribute", 42);
   file.putAttr("r4_attribute", 3.14159265);
-  std::cout << "... done" << std::endl;
+  std::cout << "... done" << std::endl << std::flush;
 
   // set up for creating a link
   NXlink link = file.getDataID();
@@ -177,9 +177,12 @@ static void writeTest(const string &filename, NXaccess create_code) {
   // make more links
   NXlink glink = file.getGroupID();
   file.openAddress("/");
+  if (file.getAddress() != "/") {
+    throw std::runtime_error("root not at root");
+  }
   file.makeGroup("link", "NXentry", true);
   file.makeLink(glink);
-  std::cout << "writeTest(" << filename << ") successful\n";
+  std::cout << "writeTest(" << filename << ") successful\n" << std::flush;
 }
 
 template <typename NumT> string toString(const vector<NumT> &data) {
@@ -197,38 +200,38 @@ template <typename NumT> string toString(const vector<NumT> &data) {
 }
 
 int readTest(const string &filename) {
-  std::cout << "readTest(" << filename << ") started\n";
+  std::cout << "readTest(" << filename << ") started\n" << std::flush;
   const string SDS("SDS");
   // top level file information
   Mantid::Nexus::File file(filename);
   vector<Mantid::Nexus::AttrInfo> attr_infos = file.getAttrInfos();
-  cout << "Number of global attributes: " << attr_infos.size() << endl;
+  cout << "Number of global attributes: " << attr_infos.size() << endl << std::flush;
   for (vector<Mantid::Nexus::AttrInfo>::iterator it = attr_infos.begin(); it != attr_infos.end(); ++it) {
     if (it->name != "file_time" && it->name != "HDF_version" && it->name != "HDF5_Version" &&
         it->name != "XML_version") {
-      cout << "   " << it->name << " = ";
+      cout << "   " << it->name << " = " << std::flush;
       if (it->type == NXnumtype::CHAR) {
         cout << file.getStrAttr(it->name);
       }
-      cout << endl;
+      cout << endl << std::flush;
     }
   }
 
   // check group attributes
   file.openGroup("entry", "NXentry");
   attr_infos = file.getAttrInfos();
-  cout << "Number of group attributes: " << attr_infos.size() << endl;
+  cout << "Number of group attributes: " << attr_infos.size() << endl << std::flush;
   for (vector<Mantid::Nexus::AttrInfo>::iterator it = attr_infos.begin(); it != attr_infos.end(); ++it) {
-    cout << "   " << it->name << " = ";
+    cout << "   " << it->name << " = " << std::flush;
     if (it->type == NXnumtype::CHAR) {
       cout << file.getStrAttr(it->name);
     }
-    cout << endl;
+    cout << endl << std::flush << std::flush;
   }
 
   // print out the entry level fields
   map<string, string> entries = file.getEntries();
-  cout << "Group contains " << entries.size() << " items" << endl;
+  cout << "Group contains " << entries.size() << " items" << endl << std::flush;
   Mantid::Nexus::Info info;
   for (map<string, string>::const_iterator it = entries.begin(); it != entries.end(); ++it) {
     cout << "   " << it->first;
@@ -284,10 +287,10 @@ int readTest(const string &filename) {
         cout << toString(result);
       }
       cout << endl;
-      cout << "   Address = " << file.getAddress() << endl;
+      cout << "   Address = " << file.getAddress() << endl << std::flush;
       file.closeData();
     } else {
-      cout << ":" << it->second << endl;
+      cout << ":" << it->second << endl << std::flush;
     }
   }
 
@@ -347,7 +350,7 @@ int readTest(const string &filename) {
     file.openData("r8_data");
     file.getDataCoerce(ints);
     file.closeData();
-    cout << "getDataCoerce(int) of doubles did not throw (it is supposed to throw)." << endl;
+    cout << "getDataCoerce(int) of doubles did not throw (it is supposed to throw)." << endl << std::flush;
   } catch (...) {
     // Good! It is supposed to throw
     didThrow = true;
@@ -363,20 +366,20 @@ int readTest(const string &filename) {
   file.openAddress("/entry/data/comp_data");
   file.openAddress("/entry/data/comp_data");
   file.openAddress("../r8_data");
-  printf("NXopenaddress checks OK\n");
+  cout << "NXopenaddress checks OK\n" << std::flush;
 
   // everything went fine
-  std::cout << "readTest(" << filename << ") successful\n";
+  std::cout << "readTest(" << filename << ") successful\n" << std::flush;
   return TEST_SUCCEED;
 }
 
 int testLoadPath(const string &filename) {
   if (getenv("NX_LOAD_PATH") != NULL) {
     Mantid::Nexus::File file(filename);
-    cout << "Success loading NeXus file from path" << endl;
+    cout << "Success loading NeXus file from path" << endl << std::flush;
     return TEST_SUCCEED;
   } else {
-    cout << "NX_LOAD_PATH variable not defined. Skipping testLoadPath\n";
+    cout << "NX_LOAD_PATH variable not defined. Skipping testLoadPath\n" << std::flush;
     return TEST_SUCCEED;
   }
 }
@@ -390,30 +393,30 @@ int main(int argc, char **argv) {
   try {
     writeTest(fullname, nx_creation_code);
     if (!std::filesystem::exists(fullname)) {
-      std::cerr << "NeXus file \"" << fullname << "\" does not exist after write test\n";
+      std::cerr << "NeXus file \"" << fullname << "\" does not exist after write test\n" << std::flush;
       return TEST_FAILED;
     }
   } catch (const std::runtime_error &e) {
-    cout << "writeTest failed:\n" << e.what() << endl;
+    cout << "writeTest failed:\n" << e.what() << endl << std::flush;
     return TEST_FAILED;
   }
   if ((argc >= 2) && !strcmp(argv[1], "-q")) {
-    cout << "Ending test early\n";
+    cout << "Ending test early\n" << std::flush;
     return TEST_SUCCEED;
   }
 
   if (!std::filesystem::exists(fullname)) {
-    std::cerr << "NeXus file \"" << fullname << "\" does not exist after write test\n";
+    std::cerr << "NeXus file \"" << fullname << "\" does not exist after write test\n" << std::flush;
     return TEST_FAILED;
   }
   // try reading a file
   try {
     if (readTest(fullname) != TEST_SUCCEED) {
-      cout << "readTest failed" << endl;
+      cout << "readTest failed" << endl << std::flush;
       return TEST_FAILED;
     }
   } catch (const std::runtime_error &e) {
-    cout << "readTest failed:\n" << e.what() << endl;
+    cout << "readTest failed:\n" << e.what() << endl << std::flush;
     return TEST_FAILED;
   }
 
@@ -422,7 +425,7 @@ int main(int argc, char **argv) {
   // try using the load path
   std::string fileext(".h5");
   if (testLoadPath(DMC01 + fileext) != TEST_SUCCEED) {
-    cout << "testLoadPath failed" << endl;
+    cout << "testLoadPath failed" << endl << std::flush;
     return TEST_FAILED;
   }
 

--- a/Framework/Nexus/test/napi_test_util.h
+++ b/Framework/Nexus/test/napi_test_util.h
@@ -8,7 +8,7 @@ constexpr int TEST_SUCCEED{0};
 // error out and return failure
 #define ON_ERROR(msgstr)                                                                                               \
   {                                                                                                                    \
-    std::cout << msgstr << std::endl;                                                                                  \
+    std::cout << msgstr << std::endl << std::flush;                                                                    \
     return TEST_FAILED;                                                                                                \
   }
 

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
 #include "MantidKernel/ChecksumHelper.h"
+#include "MantidNexus/H5Util.h"
 #include "MantidNexusGeometry/AbstractLogger.h"
 #include "MantidNexusGeometry/Hdf5Version.h"
 #include "MantidNexusGeometry/InstrumentBuilder.h"
@@ -799,9 +800,7 @@ public:
 
 std::unique_ptr<const Mantid::Geometry::Instrument>
 NexusGeometryParser::createInstrument(const std::string &fileName, std::unique_ptr<AbstractLogger> logger) {
-  H5::FileAccPropList access_plist;
-  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
-  const H5File file(fileName, H5F_ACC_RDONLY, access_plist);
+  const H5File file(fileName, H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
   auto rootGroup = file.openGroup("/");
   auto parentGroup = utilities::findGroupOrThrow(rootGroup, NX_ENTRY);
 
@@ -812,9 +811,7 @@ NexusGeometryParser::createInstrument(const std::string &fileName, std::unique_p
 std::unique_ptr<const Geometry::Instrument>
 NexusGeometryParser::createInstrument(const std::string &fileName, const std::string &parentGroupName,
                                       std::unique_ptr<AbstractLogger> logger) {
-  H5::FileAccPropList access_plist;
-  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
-  const H5File file(fileName, H5F_ACC_RDONLY, access_plist);
+  const H5File file(fileName, H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
   auto parentGroup = file.openGroup(std::string("/") + parentGroupName);
 
   Parser parser(std::move(logger));

--- a/Framework/NexusGeometry/test/NexusGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometryParserTest.h
@@ -67,10 +67,8 @@ public:
     {
       // Load the multiple NXentry test input.
       // (See notes about `NexusGeometrySave` and `NexusGeometryParser` at `_verify_basic_instrument` below.)
-      H5::FileAccPropList access_plist;
-      access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
       H5::H5File input(instrument_path("unit_testing/SMALLFAKE_example_multiple_entries.hdf5"), H5F_ACC_RDONLY,
-                       access_plist);
+                       Mantid::NeXus::H5Util::defaultFileAcc());
 
       // Copy all of the NXentry groups to a new file.
       H5::H5File testInput(multipleEntryInput.fullPath(), H5F_ACC_TRUNC, access_plist);

--- a/Framework/NexusGeometry/test/NexusGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometryParserTest.h
@@ -71,7 +71,7 @@ public:
                        Mantid::NeXus::H5Util::defaultFileAcc());
 
       // Copy all of the NXentry groups to a new file.
-      H5::H5File testInput(multipleEntryInput.fullPath(), H5F_ACC_TRUNC, access_plist);
+      H5::H5File testInput(multipleEntryInput.fullPath(), H5F_ACC_TRUNC, Mantid::NeXus::H5Util::defaultFileAcc());
       H5Util::copyGroup(testInput, "/mantid_workspace_1", input, "/mantid_workspace_1");
       H5Util::copyGroup(testInput, "/mantid_workspace_2", input, "/mantid_workspace_2");
       H5Util::copyGroup(testInput, "/mantid_workspace_3", input, "/mantid_workspace_3");

--- a/Framework/Parallel/src/IO/EventLoader.cpp
+++ b/Framework/Parallel/src/IO/EventLoader.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/MantidVersion.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "MantidNexus/H5Util.h"
 #include "MantidParallel/IO/EventLoaderHelpers.h"
 #include "MantidParallel/IO/MultiProcessEventLoader.h"
 #include "MantidParallel/IO/NXEventDataLoader.h"
@@ -25,9 +26,7 @@ namespace Mantid::Parallel::IO::EventLoader {
 std::unordered_map<int32_t, size_t> makeAnyEventIdToBankMap(const std::string &filename, const std::string &groupName,
                                                             const std::vector<std::string> &bankNames) {
   std::unordered_map<int32_t, size_t> idToBank;
-  H5::FileAccPropList access_plist;
-  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
-  H5::H5File file(filename, H5F_ACC_RDONLY, access_plist);
+  H5::H5File file(filename, H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
   H5::Group group = file.openGroup(groupName);
   for (size_t i = 0; i < bankNames.size(); ++i) {
     try {

--- a/Framework/Parallel/src/IO/MultiProcessEventLoader.cpp
+++ b/Framework/Parallel/src/IO/MultiProcessEventLoader.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <utility>
 
+#include "MantidNexus/H5Util.h"
 #include "MantidParallel/IO/MultiProcessEventLoader.h"
 #include "MantidParallel/IO/NXEventDataLoader.h"
 #include "MantidTypes/Event/TofEvent.h"
@@ -57,9 +58,7 @@ void MultiProcessEventLoader::load(const std::string &filename, const std::strin
                                    std::vector<std::vector<Types::Event::TofEvent> *> eventLists) const {
 
   try {
-    H5::FileAccPropList access_plist;
-    access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
-    H5::H5File file(filename.c_str(), H5F_ACC_RDONLY, access_plist);
+    H5::H5File file(filename.c_str(), H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
     auto instrument = file.openGroup(groupname);
 
     auto bkSz = EventLoader::readBankSizes(instrument, bankNames);
@@ -219,9 +218,7 @@ void MultiProcessEventLoader::fillFromFile(EventsListsShmemStorage &storage, con
                                            const std::string &groupname, const std::vector<std::string> &bankNames,
                                            const std::vector<int32_t> &bankOffsets, const std::size_t from,
                                            const std::size_t to, bool precalc) {
-  H5::FileAccPropList access_plist;
-  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
-  H5::H5File file(filename.c_str(), H5F_ACC_RDONLY, access_plist);
+  H5::H5File file(filename.c_str(), H5F_ACC_RDONLY, Mantid::NeXus::H5Util::defaultFileAcc());
   auto instrument = file.openGroup(groupname);
 
   auto type = EventLoader::readDataType(instrument, bankNames, "event_time_offset");

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -363,12 +363,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/Replicate
 templateRecursion:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SliceMD.cpp:300
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/TransposeMD.cpp:83
 uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/UnaryOperationMD.cpp:59
-nullPointerOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:545
-nullPointerArithmeticOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:549
-nullPointerOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFile.cpp:1129
-nullPointerOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/napi.cpp:268
-nullPointerArithmeticOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/napi.cpp:272
-nullPointerOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/napi.cpp:1027
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/NDArrayToVector.cpp:151
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/NDArrayToVector.cpp:156
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/PyObjectToMatrix.cpp:44


### PR DESCRIPTION
### Description of work

#### Summary of work

This takes a lot of refactors that were in PR #39658 , which were unrelated to the core behavior of that PR.

These refactors are individually small, but it may seem like a lot of changes.

- create `NexusAddress`, which creates a path-like object to specifying locations inside a Nexus file
- `NexusFile` uses a `NexusAddress` to hold the current address in the file
- Cleaned up or removed structures in Nexus layer
- From `napi` removed: `NXgetnextentry`, `NXsameID`, `NXinitgroupdir`, `NXinitattrdir`, `NXmalloc64`, and `NXfree`.  These were either unused, or used only in a test of`napi`, and so could be safely removed.
- From `napi5` removed: `NXgetnextentry`, `attr_info`, and `nxgroup_info`.  The first was only used in a single test of `napi`, which could be deleted.
- From `napi_helper` removed: all of the methods listed under implementation of `NXopenaddress`, used to manipulate addresses or the group ID stack
- Inside many unit tests, added a `std::flush` command to print-outs.  This makes debugging easier, especially when an error causes a segfault.
- Refactored any place in the code that opened an `H5File` object to make sure it used `H5Util::defaultFileAcc()` instead of constructing its own access list, to ensure consistency across the code base.
- Many code quality refactors inside `NexusFile`


Refs #38332 
EWM 11399

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

This is a refactor, so ensure existing tests pass.  Also check logic of new tests.

Please check the refactors inside `NexusFile`, as these are the most important and substantial refactors.

This does not require release notes because it is a purely internal issues

<!-- x -->
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
