### PR TITLE
Avoid Linux standalone launching error

### DIFF
--- a/installers/conda/common/common.sh
+++ b/installers/conda/common/common.sh
@@ -27,16 +27,7 @@ function trim_conda() {
     # We don't use this workbench script in the Linux standalone, so remove it to avoid confusion
     rm "$bundle_conda_prefix"/bin/workbench
   fi
-  # Heavily cut down share
-  mv "$bundle_conda_prefix"/share "$bundle_conda_prefix"/share_tmp
-  mkdir "$bundle_conda_prefix"/share
-  mv "$bundle_conda_prefix"/share_tmp/doc "$bundle_conda_prefix"/share/
-  mkdir -p "$bundle_conda_prefix"/share/glib-2.0/schemas
-  mv "$bundle_conda_prefix"/share_tmp/glib-2.0/schemas "$bundle_conda_prefix"/share/glib-2.0/
-  if [ -d "$bundle_conda_prefix"/share_tmp/X11 ]; then
-    # On some linux flavours we need this on some otherwise workbench won't launch
-    mv "$bundle_conda_prefix"/share_tmp/X11 "$bundle_conda_prefix"/share/
-  fi
+
   # Heavily cut down translations
   mv "$bundle_conda_prefix"/translations "$bundle_conda_prefix"/translations_tmp
   mkdir -p "$bundle_conda_prefix"/translations/qtwebengine_locales
@@ -51,7 +42,6 @@ function trim_conda() {
     "$bundle_conda_prefix"/phrasebooks \
     "$bundle_conda_prefix"/qml \
     "$bundle_conda_prefix"/qsci \
-    "$bundle_conda_prefix"/share_tmp \
     "$bundle_conda_prefix"/translations_tmp
 
   find "$bundle_conda_prefix" -name '*.a' -delete


### PR DESCRIPTION
### Description of work
On some Linux distributions (reported by users on Ubuntu 22.04 and AlmaLinux 9.6), there are some files missing from the `share` folder, which prevents mantidworkbench from launching with the following error:
`xkbcommon: ERROR: failed to add default include path /jenkins_workdir/workspace/release-next_nightly_deployment/_bundle_build/mantidworkbench/share/X11/xkb`
In the packaging script that generates the standalone installer, we currently trim down the share folder to cut down on the size of the package.

The easiest and most maintainable solution is to keep all of the share directory when creating standalone installers. There have been two releases now where we have had to add extra things that have been missing because we trim the share folder. We only save 20mb by trimming it down, and the risk is too high to justify that.

Fixes #39655 

### To test:
Download the tarball from here, extract it and run bin/mantidworkbench:
https://builds.mantidproject.org/job/build_packages_from_branch/1191/
I was able to reproduce the reported error on both Ubuntu 22.04 and AlmaLinux 9.6, and the above package fixed the issue on both OS.


*This does not require release notes* because **I will add them in the final patch release PR**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
