### PR TITLE
Try running kernel tests on build

### DIFF
--- a/conda/recipes/mantid/build.sh
+++ b/conda/recipes/mantid/build.sh
@@ -26,5 +26,6 @@ cmake \
   -GNinja \
   ../
 
-ninja
+ninja all AllTests
+ctest -j 12 -R KernelTest
 ninja install

--- a/conda/recipes/mantid/build.sh
+++ b/conda/recipes/mantid/build.sh
@@ -26,6 +26,6 @@ cmake \
   -GNinja \
   ../
 
-ninja all AllTests
+ninja all KernelTest
 ctest -j 12 -R KernelTest
 ninja install


### PR DESCRIPTION
This was an attempt to run `KernelTest` during the build phase of making the `mantid` conda package. It does not correctly configure creating the output of the test run, so issues are not seen in the build. Only 3 of `KernelTest` failed, but it points out some of the issues that will be found if this were expanded:
* Every test started with the warning/error `DllOpen-[Error] Could not open library .../build/bin/libMantidPythonInterfaceCore.so`
* `KernelTest_ConfigServiceTest` L218 - username returned by configservice is empty and the test expects it to be non-empty
* `KernelTest_FileDescriptorTest` L23 (multiple times) - could not find AutoTestData directory in the search path
* `KernelTest_LegacyNexusDescriptorTest` L25 (multiple times) - could not find AutoTestData directory in the search path

This build ran build+test as well as creating the package so more issues are shown.
* [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1195)](https://builds.mantidproject.org/job/build_packages_from_branch/1195/console)
