### PR TITLE
Add EmptyCellFilename property to DepolarizedAnalyserTransmission

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h
@@ -41,5 +41,7 @@ private:
 
   /// Fit using UserFunction1D to find the pxd and transmission values.
   void calcWavelengthDependentTransmission(API::MatrixWorkspace_sptr const &inputWs, std::string const &outputWsName);
+
+  API::MatrixWorkspace_sptr m_mtWs;
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
@@ -128,7 +128,7 @@ std::map<std::string, std::string> DepolarizedAnalyserTransmission::validateInpu
     validateWorkspace(mtWs, PropNames::MT_WORKSPACE, result);
     m_mtWs = mtWs;
   } else if (!isDefault(PropNames::MT_FILE)) {
-    auto loadAlg = createChildAlgorithm("Load");
+    auto loadAlg = createChildAlgorithm("LoadNexus");
     loadAlg->initialize();
     loadAlg->setProperty("Filename", getPropertyValue(PropNames::MT_FILE));
     loadAlg->execute();
@@ -142,7 +142,7 @@ std::map<std::string, std::string> DepolarizedAnalyserTransmission::validateInpu
     m_mtWs = mtWs;
   } else {
     result[PropNames::MT_WORKSPACE] =
-        "Must set either " + std::string(PropNames::MT_WORKSPACE) + " or " + std::string(PropNames::MT_FILE);
+        "Must set either " + std::string(PropNames::MT_WORKSPACE) + " or " + std::string(PropNames::MT_FILE) + ".";
     return result;
   }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -6,8 +6,11 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include <cstdio>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h"
 
@@ -44,6 +47,18 @@ public:
     alg->execute();
 
     // THEN
+    TS_ASSERT(alg->isExecuted());
+    ITableWorkspace_sptr const &outputWs = alg->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr const &fitWs = alg->getProperty("OutputFitCurves");
+    validateOutputParameters(outputWs);
+    TS_ASSERT_EQUALS(fitWs, nullptr)
+  }
+
+  void test_normal_exec_with_file() {
+    auto const &[mtWs, depWs] = createDefaultWorkspaces();
+    auto alg = createAlgorithmUsingFilename(mtWs, depWs);
+    alg->execute();
+
     TS_ASSERT(alg->isExecuted());
     ITableWorkspace_sptr const &outputWs = alg->getProperty("OutputWorkspace");
     MatrixWorkspace_sptr const &fitWs = alg->getProperty("OutputFitCurves");
@@ -129,6 +144,18 @@ public:
     TS_ASSERT(!alg->isExecuted());
   }
 
+  void test_invalid_empty_cell_workspace_length_from_file() {
+    MatrixWorkspace_sptr const &mtWs =
+        createTestingWorkspace("__mt", "name=LinearBackground, A0=0.112, A1=-0.004397", 12);
+    auto const &depWs = createTestingWorkspace("__dep", "name=ExpDecay, Height=0.1239, Lifetime=1.338", 1);
+    auto alg = createAlgorithmUsingFilename(mtWs, depWs);
+
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
+                            "Some invalid Properties found: \n EmptyCellFilename: EmptyCellFilename "
+                            "must contain a single spectrum. Contains 12 spectra.");
+    TS_ASSERT(!alg->isExecuted());
+  }
+
   void test_non_matching_workspace_bins() {
     // GIVEN
     MatrixWorkspace_sptr const &mtWs =
@@ -140,6 +167,22 @@ public:
     TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
                             "Some invalid Properties found: \n DepolarizedWorkspace: The bins in the "
                             "DepolarizedWorkspace and EmptyCellWorkspace do not match.");
+    TS_ASSERT(!alg->isExecuted());
+  }
+
+  void test_error_if_neither_empty_cell_workspace_or_file_are_set() {
+    auto const &depWs = createTestingWorkspace("__dep", "name=ExpDecay, Height=0.1239, Lifetime=1.338");
+
+    auto alg = std::make_shared<DepolarizedAnalyserTransmission>();
+    alg->setChild(true);
+    alg->initialize();
+    TS_ASSERT(alg->isInitialized());
+    alg->setProperty("DepolarizedWorkspace", depWs);
+    alg->setPropertyValue("OutputWorkspace", "__unused_for_child");
+
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
+                            "Some invalid Properties found: \n EmptyCellWorkspace: Must set either EmptyCellWorkspace "
+                            "or EmptyCellFilename.");
     TS_ASSERT(!alg->isExecuted());
   }
 
@@ -182,6 +225,28 @@ private:
     TS_ASSERT(alg->isInitialized());
     alg->setProperty("DepolarizedWorkspace", depWs);
     alg->setProperty("EmptyCellWorkspace", mtWs);
+    alg->setPropertyValue("OutputWorkspace", "__unused_for_child");
+    return alg;
+  }
+
+  std::shared_ptr<DepolarizedAnalyserTransmission> createAlgorithmUsingFilename(MatrixWorkspace_sptr const &mtWs,
+                                                                                MatrixWorkspace_sptr const &depWs) {
+    std::string filePath = std::tmpnam(nullptr);
+
+    auto saveAlg = Mantid::API::AlgorithmManager::Instance().create("SaveNexus");
+    saveAlg->setChild(true);
+    saveAlg->initialize();
+    saveAlg->setProperty("Filename", filePath);
+    saveAlg->setProperty("InputWorkspace", mtWs);
+    saveAlg->execute();
+    TS_ASSERT(std::filesystem::exists(filePath));
+
+    auto alg = std::make_shared<DepolarizedAnalyserTransmission>();
+    alg->setChild(true);
+    alg->initialize();
+    TS_ASSERT(alg->isInitialized());
+    alg->setProperty("DepolarizedWorkspace", depWs);
+    alg->setProperty("EmptyCellFilename", filePath);
     alg->setPropertyValue("OutputWorkspace", "__unused_for_child");
     return alg;
   }

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -55,10 +55,12 @@ public:
   }
 
   void test_normal_exec_with_file() {
+    // GIVEN
     auto const &[mtWs, depWs] = createDefaultWorkspaces();
     auto alg = createAlgorithmUsingFilename(mtWs, depWs);
     alg->execute();
 
+    // THEN
     TS_ASSERT(alg->isExecuted());
     ITableWorkspace_sptr const &outputWs = alg->getProperty("OutputWorkspace");
     MatrixWorkspace_sptr const &fitWs = alg->getProperty("OutputFitCurves");
@@ -145,11 +147,13 @@ public:
   }
 
   void test_invalid_empty_cell_workspace_length_from_file() {
+    // GIVEN
     MatrixWorkspace_sptr const &mtWs =
         createTestingWorkspace("__mt", "name=LinearBackground, A0=0.112, A1=-0.004397", 12);
     auto const &depWs = createTestingWorkspace("__dep", "name=ExpDecay, Height=0.1239, Lifetime=1.338", 1);
     auto alg = createAlgorithmUsingFilename(mtWs, depWs);
 
+    // THEN
     TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
                             "Some invalid Properties found: \n EmptyCellFilename: EmptyCellFilename "
                             "must contain a single spectrum. Contains 12 spectra.");
@@ -171,6 +175,7 @@ public:
   }
 
   void test_error_if_neither_empty_cell_workspace_or_file_are_set() {
+    // GIVEN
     auto const &depWs = createTestingWorkspace("__dep", "name=ExpDecay, Height=0.1239, Lifetime=1.338");
 
     auto alg = std::make_shared<DepolarizedAnalyserTransmission>();
@@ -180,6 +185,7 @@ public:
     alg->setProperty("DepolarizedWorkspace", depWs);
     alg->setPropertyValue("OutputWorkspace", "__unused_for_child");
 
+    // THEN
     TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
                             "Some invalid Properties found: \n EmptyCellWorkspace: Must set either EmptyCellWorkspace "
                             "or EmptyCellFilename.");

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -6,13 +6,13 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <cstdio>
 #include <cxxtest/TestSuite.h>
 #include <filesystem>
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h"
+#include "MantidKernel/Strings.h"
 
 namespace {
 constexpr double PXD_VALUE = 9.32564;
@@ -231,12 +231,13 @@ private:
 
   std::shared_ptr<DepolarizedAnalyserTransmission> createAlgorithmUsingFilename(MatrixWorkspace_sptr const &mtWs,
                                                                                 MatrixWorkspace_sptr const &depWs) {
-    std::string filePath = std::tmpnam(nullptr);
+
+    std::filesystem::path filePath = std::filesystem::temp_directory_path() / Mantid::Kernel::Strings::randomString(8);
 
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().create("SaveNexus");
     saveAlg->setChild(true);
     saveAlg->initialize();
-    saveAlg->setProperty("Filename", filePath);
+    saveAlg->setProperty("Filename", filePath.string());
     saveAlg->setProperty("InputWorkspace", mtWs);
     saveAlg->execute();
     TS_ASSERT(std::filesystem::exists(filePath));
@@ -246,7 +247,7 @@ private:
     alg->initialize();
     TS_ASSERT(alg->isInitialized());
     alg->setProperty("DepolarizedWorkspace", depWs);
-    alg->setProperty("EmptyCellFilename", filePath);
+    alg->setProperty("EmptyCellFilename", filePath.string());
     alg->setPropertyValue("OutputWorkspace", "__unused_for_child");
     return alg;
   }

--- a/docs/source/release/v6.14.0/SANS/New_features/37457.rst
+++ b/docs/source/release/v6.14.0/SANS/New_features/37457.rst
@@ -1,0 +1,1 @@
+- Added ``EmptyCellFilename`` as an optional property of :ref:`algm-DepolarizedAnalyserTransmission` to be used instead of ``EmptyCellWorkspace``. :ref:`algm-DepolarizedAnalyserTransmission` will load the provided file with :ref:`algm-LoadNexus` and then use it the same as ``EmptyCellWorkspace``.


### PR DESCRIPTION
### Description of work
Added `EmptyCellFilename` property to `DepolarizedAnalyserTransmission` to be optionally used instead of `EmptyCellWorkspace`.

Fixes #37457
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

```
CreateSampleWorkspace(OutputWorkspace='mt', Function='User Defined', UserDefinedFunction='name=LinearBackground, A0=-0.112, A1=-0.004397', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='dep', Function='User Defined', UserDefinedFunction='name=ExpDecay, Height=0.1239, Lifetime=1.338', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
```
then save `mt` to a nxs file somewhere.
```
output = DepolarizedAnalyserTransmission("dep", EmptyCellFilename="your/file/path")
```
and output should look like
```
pxd	                | 10.418661499194474    | 7.874466765836638
Cost function value	| 5.300464932501122e-07 | 0.0
```

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
