### PR TITLE
Rewrite internal of AlignAndFocusPowderSlim filtering to support TimeROI

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/TimeROI.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -56,12 +57,12 @@ private:
   std::map<detid_t, double> m_calibration; // detid: 1/difc
   std::set<detid_t> m_masked;
   bool is_time_filtered{false};
-  size_t pulse_start_index{0};
-  size_t pulse_stop_index{std::numeric_limits<size_t>::max()};
   /// Index to load start at in the file
   std::vector<int64_t> loadStart;
   /// How much to load in the file
   std::vector<int64_t> loadSize;
+  Kernel::TimeROI roi;
+  std::vector<size_t> pulse_indices;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -10,7 +10,6 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidKernel/TimeROI.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -61,7 +60,6 @@ private:
   std::vector<int64_t> loadStart;
   /// How much to load in the file
   std::vector<int64_t> loadSize;
-  Kernel::TimeROI roi;
   std::vector<size_t> pulse_indices;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -60,7 +60,7 @@ private:
   std::vector<int64_t> loadStart;
   /// How much to load in the file
   std::vector<int64_t> loadSize;
-  std::vector<size_t> pulse_indices;
+  std::vector<std::pair<size_t, size_t>> pulse_indices;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -664,7 +664,7 @@ void AlignAndFocusPowderSlim::exec() {
     }
     const auto pulse_times =
         std::make_unique<std::vector<Mantid::Types::Core::DateAndTime>>(frequency_log->timesAsVector());
-    const auto startOfRun = wksp->run().getFirstPulseTime();
+    const auto startOfRun = wksp->run().startTime();
 
     try {
       roi.addROI(startOfRun + (filter_time_start_sec == EMPTY_DBL() ? 0.0 : filter_time_start_sec),
@@ -734,6 +734,10 @@ void AlignAndFocusPowderSlim::exec() {
 
   // close the file so child algorithms can do their thing
   h5file.close();
+
+  // update the run TimeROI and remove log data outside the time ROI
+  wksp->mutableRun().setTimeROI(roi);
+  wksp->mutableRun().removeDataOutsideTimeROI();
 
   setProperty(PropertyNames::OUTPUT_WKSP, std::move(wksp));
 }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -37,6 +37,7 @@
 #include <numbers>
 #include <ranges>
 #include <regex>
+#include <stack>
 
 namespace Mantid::DataHandling {
 using Mantid::API::FileProperty;
@@ -420,6 +421,15 @@ public:
             // Continue to next range
           }
         }
+
+        // log the event ranges being processed
+        std::ostringstream oss;
+        oss << "Processing " << bankName << " with " << total_events_to_read << " events in the ranges: ";
+        for (size_t i = 0; i < offsets.size(); ++i) {
+          oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
+        }
+        oss << "\n";
+        std::cout << oss.str();
 
         // load detid and tof at the same time
         tbb::parallel_invoke(

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -151,33 +151,6 @@ std::vector<double> calculate_difc_focused(const double l1, const std::vector<do
   return difc;
 }
 
-std::vector<size_t> calculate_pulse_indices_from_timeroi(const TimeROI &roi,
-                                                         const std::vector<DateAndTime> &pulse_times) {
-  std::vector<size_t> indices;
-
-  if (roi.useAll()) {
-    // if the ROI is set to use all, then we just return the whole range
-    indices.push_back(0);
-    indices.push_back(std::numeric_limits<size_t>::max());
-    return indices;
-  }
-  indices.reserve(roi.numBoundaries());
-
-  for (size_t i = 0; i < roi.numBoundaries(); i += 2) {
-    const auto start = std::lower_bound(pulse_times.cbegin(), pulse_times.cend(), roi.timeAtIndex(i));
-    if (start != pulse_times.cend()) {
-      indices.push_back(std::distance(pulse_times.cbegin(), start));
-      const auto stop = std::lower_bound(pulse_times.cbegin(), pulse_times.cend(), roi.timeAtIndex(i + 1));
-      if (stop != pulse_times.cend())
-        indices.push_back(std::distance(pulse_times.cbegin(), stop));
-      else
-        indices.push_back(std::numeric_limits<size_t>::max());
-    }
-  }
-
-  return indices;
-}
-
 class NexusLoader {
 public:
   NexusLoader(const bool is_time_filtered, const std::vector<size_t> &pulse_indices)
@@ -688,7 +661,7 @@ void AlignAndFocusPowderSlim::exec() {
 
     // hard coded ROI for testing
     // roi.addROI(startOfRun + 200., startOfRun + 210.);
-    pulse_indices = calculate_pulse_indices_from_timeroi(roi, *pulse_times);
+    pulse_indices = roi.calculate_indices(*pulse_times);
     if (pulse_indices.empty())
       throw std::invalid_argument("No valid pulse time indices found for filtering");
 

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -10,7 +10,9 @@
 
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
 
@@ -265,6 +267,18 @@ public:
     TS_ASSERT_EQUALS(outputWS->readY(3).front(), 4244796);
     TS_ASSERT_EQUALS(outputWS->readY(4).front(), 1435593);
     TS_ASSERT_EQUALS(outputWS->readY(5).front(), 2734113);
+
+    // check the time ROI
+    const auto &run_timeroi = outputWS->run().getTimeROI();
+    TS_ASSERT_EQUALS(run_timeroi.numberOfRegions(), 1);
+    TS_ASSERT_EQUALS(run_timeroi.timeAtIndex(0), outputWS->run().startTime() + 200.);
+    TS_ASSERT_EQUALS(run_timeroi.timeAtIndex(1), outputWS->run().startTime() + 300.);
+
+    // check that the logs are filtered corerctly by checking first and last pulse times
+    TS_ASSERT_DELTA(outputWS->run().getFirstPulseTime().totalNanoseconds(),
+                    (outputWS->run().startTime() + 200.).totalNanoseconds(), 1e8 /* 0.1 sec */);
+    TS_ASSERT_DELTA(outputWS->run().getLastPulseTime().totalNanoseconds(),
+                    (outputWS->run().startTime() + 300.).totalNanoseconds(), 1e8 /* 0.1 sec */);
   }
 
   void test_start_time_filtering() {

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -63,6 +63,7 @@ public:
   std::string debugStrPrint(const std::size_t type = 0) const;
   size_t getMemorySize() const;
   Types::Core::DateAndTime timeAtIndex(unsigned long index) const;
+  std::vector<size_t> calculate_indices(const std::vector<Types::Core::DateAndTime> &times) const;
 
   // nexus items
   void saveNexus(Nexus::File *file) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -63,7 +63,7 @@ public:
   std::string debugStrPrint(const std::size_t type = 0) const;
   size_t getMemorySize() const;
   Types::Core::DateAndTime timeAtIndex(unsigned long index) const;
-  std::vector<size_t> calculate_indices(const std::vector<Types::Core::DateAndTime> &times) const;
+  std::vector<std::pair<size_t, size_t>> calculate_indices(const std::vector<Types::Core::DateAndTime> &times) const;
 
   // nexus items
   void saveNexus(Nexus::File *file) const;

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -342,6 +342,32 @@ Types::Core::DateAndTime TimeROI::timeAtIndex(unsigned long index) const {
   return (index < m_roi.size()) ? m_roi[index] : DateAndTime::GPS_EPOCH;
 }
 
+// return the indices of the TimeROI would fall in the supplied vector of times
+std::vector<size_t> TimeROI::calculate_indices(const std::vector<DateAndTime> &times) const {
+  std::vector<size_t> indices;
+  if (this->useAll()) {
+    // if the ROI is set to use all, then we just return the whole range
+    indices.push_back(0);
+    indices.push_back(std::numeric_limits<size_t>::max());
+    return indices;
+  }
+  indices.reserve(m_roi.size() / 2);
+
+  for (size_t i = 0; i < m_roi.size(); i += 2) {
+    const auto start = std::lower_bound(times.cbegin(), times.cend(), m_roi[i]);
+    if (start != times.cend()) {
+      indices.push_back(std::distance(times.cbegin(), start));
+      const auto stop = std::lower_bound(times.cbegin(), times.cend(), m_roi[i + 1]);
+      if (stop != times.cend())
+        indices.push_back(std::distance(times.cbegin(), stop));
+      else
+        indices.push_back(std::numeric_limits<size_t>::max());
+    }
+  }
+
+  return indices;
+}
+
 /// get a list of all unique times. order is not guaranteed
 std::vector<DateAndTime> TimeROI::getAllTimes(const TimeROI &other) {
 
@@ -543,6 +569,7 @@ const std::vector<Kernel::TimeInterval> TimeROI::toTimeIntervals() const {
  * in TimeSeriesProperty.
  * @param after Only give TimeIntervals after this time
  */
+
 const std::vector<Kernel::TimeInterval> TimeROI::toTimeIntervals(const Types::Core::DateAndTime &after) const {
   const auto NUM_VAL = m_roi.size();
   std::vector<TimeInterval> output;

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -343,12 +343,11 @@ Types::Core::DateAndTime TimeROI::timeAtIndex(unsigned long index) const {
 }
 
 // return the indices of the TimeROI would fall in the supplied vector of times
-std::vector<size_t> TimeROI::calculate_indices(const std::vector<DateAndTime> &times) const {
-  std::vector<size_t> indices;
+std::vector<std::pair<size_t, size_t>> TimeROI::calculate_indices(const std::vector<DateAndTime> &times) const {
+  std::vector<std::pair<size_t, size_t>> indices;
   if (this->useAll()) {
     // if the ROI is set to use all, then we just return the whole range
-    indices.push_back(0);
-    indices.push_back(std::numeric_limits<size_t>::max());
+    indices.emplace_back(0, std::numeric_limits<size_t>::max());
     return indices;
   }
   indices.reserve(m_roi.size() / 2);
@@ -356,12 +355,11 @@ std::vector<size_t> TimeROI::calculate_indices(const std::vector<DateAndTime> &t
   for (size_t i = 0; i < m_roi.size(); i += 2) {
     const auto start = std::lower_bound(times.cbegin(), times.cend(), m_roi[i]);
     if (start != times.cend()) {
-      indices.push_back(std::distance(times.cbegin(), start));
       const auto stop = std::lower_bound(times.cbegin(), times.cend(), m_roi[i + 1]);
       if (stop != times.cend())
-        indices.push_back(std::distance(times.cbegin(), stop));
+        indices.emplace_back(std::distance(times.cbegin(), start), std::distance(times.cbegin(), stop));
       else
-        indices.push_back(std::numeric_limits<size_t>::max());
+        indices.emplace_back(std::distance(times.cbegin(), start), std::numeric_limits<size_t>::max());
     }
   }
 

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -344,6 +344,7 @@ Types::Core::DateAndTime TimeROI::timeAtIndex(unsigned long index) const {
 
 // return the indices of the TimeROI would fall in the supplied vector of times
 std::vector<std::pair<size_t, size_t>> TimeROI::calculate_indices(const std::vector<DateAndTime> &times) const {
+  // this will create a vector of pairs, where each pair is the start and stop index of the time intervals
   std::vector<std::pair<size_t, size_t>> indices;
   if (this->useAll()) {
     // if the ROI is set to use all, then we just return the whole range
@@ -352,6 +353,8 @@ std::vector<std::pair<size_t, size_t>> TimeROI::calculate_indices(const std::vec
   }
   indices.reserve(m_roi.size() / 2);
 
+  // Iterate through the m_roi vector in pairs to find the start and stop indices for each ROI.
+  // Don't add anything if the start is out of range. Set stop to max if the stop is out of range.
   for (size_t i = 0; i < m_roi.size(); i += 2) {
     const auto start = std::lower_bound(times.cbegin(), times.cend(), m_roi[i]);
     if (start != times.cend()) {

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -473,4 +473,23 @@ public:
     TS_ASSERT_EQUALS(roi.debugStrPrint(1),
                      "2022-Dec-19 00:01:00 2022-Dec-26 00:01:00 2022-Dec-31 00:01:00 2023-Jan-01 00:01:00 \n");
   }
+
+  void test_calculate_indices() {
+    TimeROI roi;
+    roi.addROI(ONE, TWO);
+    roi.addROI(THREE, FOUR);
+    roi.addROI(FIVE, SIX);
+    roi.addROI(SIX + 100.0, SIX + 200.0); // region that is not included in the times
+
+    std::vector<DateAndTime> times{ONE + 100.0, TWO + 100.0, THREE, FOUR - 100.0, FIVE + 100.0};
+
+    auto indices = roi.calculate_indices(times);
+    TS_ASSERT_EQUALS(indices.size(), 6);
+    TS_ASSERT_EQUALS(indices[0], 0);                                  // ONE
+    TS_ASSERT_EQUALS(indices[1], 1);                                  // TWO
+    TS_ASSERT_EQUALS(indices[2], 2);                                  // THREE
+    TS_ASSERT_EQUALS(indices[3], 4);                                  // FOUR
+    TS_ASSERT_EQUALS(indices[4], 4);                                  // FIVE
+    TS_ASSERT_EQUALS(indices[5], std::numeric_limits<size_t>::max()); // SIX
+  }
 };

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -484,12 +484,12 @@ public:
     std::vector<DateAndTime> times{ONE + 100.0, TWO + 100.0, THREE, FOUR - 100.0, FIVE + 100.0};
 
     auto indices = roi.calculate_indices(times);
-    TS_ASSERT_EQUALS(indices.size(), 6);
-    TS_ASSERT_EQUALS(indices[0], 0);                                  // ONE
-    TS_ASSERT_EQUALS(indices[1], 1);                                  // TWO
-    TS_ASSERT_EQUALS(indices[2], 2);                                  // THREE
-    TS_ASSERT_EQUALS(indices[3], 4);                                  // FOUR
-    TS_ASSERT_EQUALS(indices[4], 4);                                  // FIVE
-    TS_ASSERT_EQUALS(indices[5], std::numeric_limits<size_t>::max()); // SIX
+    TS_ASSERT_EQUALS(indices.size(), 3);
+    TS_ASSERT_EQUALS(indices[0].first, 0);                                   // ONE
+    TS_ASSERT_EQUALS(indices[0].second, 1);                                  // TWO
+    TS_ASSERT_EQUALS(indices[1].first, 2);                                   // THREE
+    TS_ASSERT_EQUALS(indices[1].second, 4);                                  // FOUR
+    TS_ASSERT_EQUALS(indices[2].first, 4);                                   // FIVE
+    TS_ASSERT_EQUALS(indices[2].second, std::numeric_limits<size_t>::max()); // SIX
   }
 };


### PR DESCRIPTION
### Description of work

This PR changes the filtering based on a TimeROI, at this stage that is just created from the `FilterByTimeStart`/`FilterByTimeStop`, so only has a single ROI but later it will add other sources of `TimeROI`, like a splitter workspace, then do a `update_intersection` to combine multiple different ROI.

The reading of multiple intervals, so non-contiguous data, is implemented (look at the `selectHyperslab` stuff`) but is not easily testable until later when other inputs are added.

There are already many unittest covering AlignAndFocusPowderSlim which should verify it still functions correctly.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [12209: Add ability to filter based on TimeROI (Time start/stop)](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/12209)
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Should function the same as before but you manually test the timer filtering in the same away as in #39652

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because it's a interval change in this prototype algorithm which is still under heavy development.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
