### PR TITLE
Remove link between muon and curvefitting libs

### DIFF
--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -122,7 +122,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 
 target_link_libraries(
   Muon
-  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry Mantid::CurveFitting
+  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
   PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 # Add the unit tests directory

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -9,12 +9,21 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspaceValidator.h"
-#include "MantidCurveFitting/EigenMatrix.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/Unit.h"
+
+#include "Eigen/Dense"
+
+// Use of a `long double` datatype is required on osx-arm64 to bring the precision of eigen vector-matrix multiplication
+// inline with the other operating systems.
+#if defined(__APPLE__) && defined(__arm64__)
+typedef long double eigenDataType;
+#else
+typedef double eigenDataType;
+#endif
 
 using namespace Mantid::DataObjects;
 using namespace Mantid::HistogramData;
@@ -238,7 +247,7 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
   }
   std::vector<bool> emptySpectrum;
   emptySpectrum.reserve(nspec);
-  std::vector<CurveFitting::EigenVector> n0Vectors(nspec);
+  std::vector<Eigen::Vector<eigenDataType, 2>> n0Vectors(nspec);
 
   // Calculate coefficients aj, bj
 
@@ -254,23 +263,21 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
       const double phi = phase->Double(h, phaseIndex);
       const double X = n0[h] * asym * cos(phi);
       const double Y = n0[h] * asym * sin(phi);
-      n0Vectors[h] = CurveFitting::EigenVector({X, Y});
+      Eigen::Vector<eigenDataType, 2> n0vec;
+      n0Vectors[h] = {X, Y};
       sxx += X * X;
       syy += Y * Y;
       sxy += X * Y;
     } else {
-      n0Vectors[h] = CurveFitting::EigenVector({0.0, 0.0});
+      n0Vectors[h] = Eigen::Vector<eigenDataType, 2>::Zero();
     }
   }
 
-  CurveFitting::EigenMatrix muLamMatrix(2, 2);
-  muLamMatrix.set(0, 0, sxx);
-  muLamMatrix.set(0, 1, sxy);
-  muLamMatrix.set(1, 0, sxy);
-  muLamMatrix.set(1, 1, syy);
-  muLamMatrix.invert();
+  Eigen::Matrix<eigenDataType, 2, 2> muLamMatrix;
+  muLamMatrix << sxx, sxy, sxy, syy;
+  muLamMatrix = Eigen::PartialPivLU<Eigen::Matrix<eigenDataType, 2, 2>>(muLamMatrix).inverse();
 
-  std::vector<double> aj(nspec), bj(nspec);
+  std::vector<eigenDataType> aj(nspec), bj(nspec);
   for (size_t h = 0; h < nspec; h++) {
     aj[h] = bj[h] = 0;
     if (!emptySpectrum[h]) {

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -312,14 +312,14 @@ public:
 
   void setUp() override {
     m_loadedData = loadMuonDataset();
-    phaseQuad = setupAlg(m_loadedData, false);
+    m_phaseQuad = setupAlg(m_loadedData, false);
   }
 
   void tearDown() override { Mantid::API::AnalysisDataService::Instance().remove("outputWs"); }
 
-  void testPerformanceWs() { phaseQuad->execute(); }
+  void testPerformanceWs() { m_phaseQuad->execute(); }
 
 private:
   MatrixWorkspace_sptr m_loadedData;
-  IAlgorithm_sptr phaseQuad;
+  IAlgorithm_sptr m_phaseQuad;
 };


### PR DESCRIPTION
This is a version of #39656 into `ornl-next`