### PR TITLE
Revert "Update to CMake 4"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake version check.
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.21)
 
 # Define the project name.
 project(Mantid)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,9 +1,9 @@
 {
   "version": 2,
   "cmakeMinimumRequired": {
-    "major": 4,
-    "minor": 0,
-    "patch": 2
+    "major": 3,
+    "minor": 21,
+    "patch": 0
   },
   "configurePresets": [
     {
@@ -41,8 +41,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_FIND_FRAMEWORK": "LAST",
-        "USE_PYTHON_DYNAMIC_LIB": "OFF",
-        "CMAKE_CXX_SCAN_FOR_MODULES": "OFF"
+        "USE_PYTHON_DYNAMIC_LIB": "OFF"
       }
     },
     {

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -27,7 +27,7 @@ libboost_python_devel:
   - 1.86 # Aim to follow conda-forge
 
 cmake:
-  - '>=4.0.2'
+  - '>=3.21.0,<4'
 
 # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
 doxygen:

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.cpp
@@ -7,7 +7,7 @@
 #include "ParameterEstimation.h"
 #include "MantidAPI/IFunction.h"
 
-#include <cmath>
+#include <math.h>
 
 namespace {
 


### PR DESCRIPTION
The main nightly failed macOS packaging stages with this error:
/bin/sh: CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND: command not found

The best course of action is to revert the changes so that main is functioning, and fix the error on a branch before merging it back in.

Reverts mantidproject/mantid#39334