### PR TITLE
Replaced boost::spirit grammar with boost::parser

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
@@ -18,6 +18,7 @@
 namespace std {
 #define CT(x)                                                                                                          \
   std::common_type_t<std::decay_t<decltype(rhs)>, std::decay_t<decltype(lhs)>> { x }
+#define _SILENCE_CXX23_DENORM_DEPRECATION_WARNING
 
 // numeric limits
 template <size_t Bits, typename Signed> class numeric_limits<wide_integer<Bits, Signed>> {

--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
@@ -18,7 +18,6 @@
 namespace std {
 #define CT(x)                                                                                                          \
   std::common_type_t<std::decay_t<decltype(rhs)>, std::decay_t<decltype(lhs)>> { x }
-#define _SILENCE_CXX23_DENORM_DEPRECATION_WARNING
 
 // numeric limits
 template <size_t Bits, typename Signed> class numeric_limits<wide_integer<Bits, Signed>> {
@@ -30,6 +29,10 @@ public:
   static constexpr bool has_infinity = false;
   static constexpr bool has_quiet_NaN = false;
   static constexpr bool has_signaling_NaN = true;
+#if defined(_WIN32)
+// disable warning about std::float_denorm_style has_denorm
+#pragma warning(disable : 4996)
+#endif
   static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
   static constexpr bool has_denorm_loss = false;
   static constexpr std::float_round_style round_style = std::round_toward_zero;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -8,13 +8,13 @@
 
 #include "MantidGeometry/Crystal/MatrixVectorPair.h"
 #include "MantidGeometry/Crystal/V3R.h"
+#include "MantidGeometry/DllConfig.h"
 #include "MantidKernel/Exception.h"
 
 #include <boost/parser/parser.hpp>
 
 #include <map>
 #include <optional>
-#include <ranges>
 #include <string>
 #include <tuple>
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <tuple>
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -171,17 +171,17 @@ template <typename T> MatrixVectorPair<T, V3R> parseMatrixVectorPair(const std::
 
   MatrixVectorPairBuilder builder;
 
-  auto positiveSignAction = [&builder](auto const &ctx) { builder.setCurrentSignPositive(); };
+  auto positiveSignAction = [&builder](auto const &) { builder.setCurrentSignPositive(); };
 
-  auto negativeSignAction = [&builder](auto const &ctx) { builder.setCurrentSignNegative(); };
+  auto negativeSignAction = [&builder](auto const &) { builder.setCurrentSignNegative(); };
 
   auto currentFactorAction = [&builder](auto &ctx) { builder.setCurrentFactor(_attr(ctx)); };
 
   auto currentDirectionAction = [&builder](auto &ctx) { builder.setCurrentDirection(_attr(ctx)); };
 
-  auto addCurrentStateToResultAction = [&builder](auto const &ctx) { builder.addCurrentStateToResult(); };
+  auto addCurrentStateToResultAction = [&builder](auto const &) { builder.addCurrentStateToResult(); };
 
-  auto advanceRowAction = [&builder](auto const &ctx) { builder.advanceRow(); };
+  auto advanceRowAction = [&builder](auto const &) { builder.advanceRow(); };
 
   // Switch sign in the builder
   auto m_sign = lit('+')[positiveSignAction] | lit('-')[negativeSignAction];

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -171,17 +171,17 @@ template <typename T> MatrixVectorPair<T, V3R> parseMatrixVectorPair(const std::
 
   MatrixVectorPairBuilder builder;
 
-  auto positiveSignAction = [&builder](auto &ctx) { builder.setCurrentSignPositive(); };
+  auto positiveSignAction = [&builder](auto const &ctx) { builder.setCurrentSignPositive(); };
 
-  auto negativeSignAction = [&builder](auto &ctx) { builder.setCurrentSignNegative(); };
+  auto negativeSignAction = [&builder](auto const &ctx) { builder.setCurrentSignNegative(); };
 
   auto currentFactorAction = [&builder](auto &ctx) { builder.setCurrentFactor(_attr(ctx)); };
 
   auto currentDirectionAction = [&builder](auto &ctx) { builder.setCurrentDirection(_attr(ctx)); };
 
-  auto addCurrentStateToResultAction = [&builder](auto &ctx) { builder.addCurrentStateToResult(); };
+  auto addCurrentStateToResultAction = [&builder](auto const &ctx) { builder.addCurrentStateToResult(); };
 
-  auto advanceRowAction = [&builder](auto &ctx) { builder.advanceRow(); };
+  auto advanceRowAction = [&builder](auto const &ctx) { builder.advanceRow(); };
 
   // Switch sign in the builder
   auto m_sign = lit('+')[positiveSignAction] | lit('-')[negativeSignAction];

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -8,18 +8,23 @@
 
 #include "MantidGeometry/Crystal/MatrixVectorPair.h"
 #include "MantidGeometry/Crystal/V3R.h"
-#include "MantidGeometry/DllConfig.h"
 
-#include "MantidKernel/Exception.h"
-#include <boost/spirit/include/qi.hpp>
-#include <functional>
+#include <boost/parser/parser.hpp>
+
 #include <map>
+#include <optional>
+#include <string>
+#include <tuple>
 
 namespace Mantid {
 namespace Geometry {
 
-// TODO moving from boost::optional to std::optoinal in this file is non-trivial
-using ParsedRationalNumber = boost::fusion::vector<int, boost::optional<int>>;
+namespace bp = boost::parser;
+
+using ParsedRationalNumber = std::tuple<int, std::optional<int>>;
+using bp::int_;
+using bp::lit;
+using bp::parse;
 
 class MatrixVectorPairBuilder {
 public:
@@ -54,15 +59,15 @@ public:
   /// Set the current factor, which is a rational number. Depending on whether a
   /// direction definition follows, it's processed differently later on.
   void setCurrentFactor(const ParsedRationalNumber &rationalNumberComponents) {
-    int numerator = boost::fusion::at_c<0>(rationalNumberComponents);
-    boost::optional<int> denominator = boost::fusion::at_c<1>(rationalNumberComponents);
+    int numerator = std::get<0>(rationalNumberComponents);
+    std::optional<int> denominator = std::get<1>(rationalNumberComponents);
 
-    if (denominator.is_initialized()) {
-      if (denominator.get() == 0) {
+    if (denominator.has_value()) {
+      if (denominator.value() == 0) {
         throw std::runtime_error("Zero denominator is not allowed in MatrixVectorPair-strings.");
       }
 
-      m_currentFactor = RationalNumber(numerator, denominator.get());
+      m_currentFactor = RationalNumber(numerator, denominator.value());
     } else {
       m_currentFactor = RationalNumber(numerator);
     }
@@ -149,12 +154,8 @@ private:
   size_t m_currentRow;
 };
 
-using boost::spirit::qi::grammar;
-using boost::spirit::qi::rule;
-
-/** MatrixVectorPairParser
-
-  MatrixVectorPairParser can parse matrix/vector pairs in
+/**
+  The MatrixVectorPair parser can parse matrix/vector pairs in
   Jones faithful notation of the form:
 
     a/b-x, cy, -z
@@ -162,99 +163,66 @@ using boost::spirit::qi::rule;
   The resulting matrix/vector pair can be retrieved through a
   templated method that lets the caller decide on the numeric
   type stored in the matrix. The vector is currently always V3R.
-
-  To reuse the internally constructed boost::spirit-based parser,
-  simply instantiate MatrixVectorPairParser once and use the
-  parse-method.
-
-      @author Michael Wedel, ESS
-      @date 02/11/2015
 */
-template <typename Iterator> class MatrixVectorPairParser : public grammar<Iterator, boost::spirit::qi::space_type> {
-public:
-  MatrixVectorPairParser(MatrixVectorPairBuilder &builder) : MatrixVectorPairParser::base_type(m_parser) {
-
-    using boost::spirit::unused_type;
-
-    namespace qi = boost::spirit::qi;
-
-    using qi::int_;
-    using qi::lit;
-    using qi::uint_;
-
-    /* MSVC currently has some problems using std::bind in connection
-     * with boost::spirit in some circumstances, but they can be circumvented
-     * using lambda-expressions as a sort of call proxy. For consistency,
-     * all semantic parse actions are formulated like that.
-     */
-    auto positiveSignAction = [&builder](unused_type, unused_type, unused_type) { builder.setCurrentSignPositive(); };
-
-    auto negativeSignAction = [&builder](unused_type, unused_type, unused_type) { builder.setCurrentSignNegative(); };
-
-    auto currentFactorAction = [&builder](const ParsedRationalNumber &rationalNumberComponents, unused_type,
-                                          unused_type) { builder.setCurrentFactor(rationalNumberComponents); };
-
-    auto currentDirectionAction = [&builder](const std::string &s, unused_type, unused_type) {
-      builder.setCurrentDirection(s);
-    };
-
-    auto addCurrentStateToResultAction = [&builder](unused_type, unused_type, unused_type) {
-      builder.addCurrentStateToResult();
-    };
-
-    auto advanceRowAction = [&builder](unused_type, unused_type, unused_type) { builder.advanceRow(); };
-
-    // Switch sign in the builder
-    m_sign = lit('+')[positiveSignAction] | lit('-')[negativeSignAction];
-
-    // This matches a rational number (also things like -1/-2 -> 1/2)
-    m_rational = (int_ >> -('/' >> int_))[currentFactorAction];
-
-    // Matches x, y or z.
-    m_direction = (qi::string("x") | qi::string("y") | qi::string("z"))[currentDirectionAction];
-
-    /* A "component", which is either a rational number possibly followed by a
-     * vector definition. Examples:
-     *    2/3, -2/3, -2/-3, -4, 2, -2x, 3y, 4/5z, ...
-     * Or a vector possibly preceded by a sign:
-     *    z, -y, +x
-     */
-    m_component = (m_rational >> -m_direction) | (-m_sign >> m_direction);
-
-    // One row of the matrix/vector pair can have many such "components".
-    m_componentSeries = m_component[addCurrentStateToResultAction] >> *(m_component[addCurrentStateToResultAction]);
-
-    // The entire matrix/vector pair is defined by three comma separated of
-    // those component strings.
-    m_parser = (m_componentSeries >> lit(',')[advanceRowAction] >> m_componentSeries >> lit(',')[advanceRowAction] >>
-                m_componentSeries);
-  }
-
-  rule<Iterator, boost::spirit::qi::space_type> m_sign, m_rational, m_direction, m_component, m_componentSeries,
-      m_parser;
-};
 
 /// Tries to parse the given string. Throws a ParseError-exception if there is
 /// unparsable string left at the end.
 template <typename T> MatrixVectorPair<T, V3R> parseMatrixVectorPair(const std::string &matrixVectorString) {
 
-  namespace qi = boost::spirit::qi;
-
-  auto strIterator = matrixVectorString.cbegin();
-  auto strEnd = matrixVectorString.cend();
-
   MatrixVectorPairBuilder builder;
-  MatrixVectorPairParser<std::string::const_iterator> parser(builder);
 
-  try {
-    qi::phrase_parse(strIterator, strEnd, parser, qi::space);
+  auto positiveSignAction = [&builder](auto &ctx) { builder.setCurrentSignPositive(); };
 
-    if (std::distance(strIterator, strEnd) > 0) {
-      throw std::runtime_error("Additional characters at end of string: '" + std::string(strIterator, strEnd) + "'.");
-    }
-  } catch (std::runtime_error &builderError) {
-    throw Kernel::Exception::ParseError("Parse error: " + std::string(builderError.what()), matrixVectorString, 0);
+  auto negativeSignAction = [&builder](auto &ctx) { builder.setCurrentSignNegative(); };
+
+  auto currentFactorAction = [&builder](auto &ctx) { builder.setCurrentFactor(_attr(ctx)); };
+
+  auto currentDirectionAction = [&builder](auto &ctx) { builder.setCurrentDirection(_attr(ctx)); };
+
+  auto addCurrentStateToResultAction = [&builder](auto &ctx) { builder.addCurrentStateToResult(); };
+
+  auto advanceRowAction = [&builder](auto &ctx) { builder.advanceRow(); };
+
+  // Switch sign in the builder
+  auto m_sign = lit('+')[positiveSignAction] | lit('-')[negativeSignAction];
+
+  // This matches a rational number (also things like -1/-2 -> 1/2)
+  auto m_rational = (int_ >> -('/' >> int_))[currentFactorAction];
+
+  // Matches x, y or z.
+  auto m_direction = (bp::string("x") | bp::string("y") | bp::string("z"))[currentDirectionAction];
+
+  /* A "component", which is either a rational number possibly followed by a
+   * vector definition. Examples:
+   *    2/3, -2/3, -2/-3, -4, 2, -2x, 3y, 4/5z, ...
+   * Or a vector possibly preceded by a sign:
+   *    z, -y, +x
+   */
+  auto m_component = (m_rational >> -m_direction) | (-m_sign >> m_direction);
+
+  // One row of the matrix/vector pair can have many such "components".
+  auto m_componentSeries = m_component[addCurrentStateToResultAction] >> *(m_component[addCurrentStateToResultAction]);
+
+  // The entire matrix/vector pair is defined by three comma separated of
+  // those component strings.
+  auto m_parser = (m_componentSeries >> lit(',')[advanceRowAction] >> m_componentSeries >> lit(',')[advanceRowAction] >>
+                   m_componentSeries);
+
+  auto success = parse(matrixVectorString, m_parser);
+
+  if (!success) {
+    throw std::runtime_error("Parse error");
   }
+
+  // try {
+  //   qi::phrase_parse(strIterator, strEnd, parser, qi::space);
+
+  //  if (std::distance(strIterator, strEnd) > 0) {
+  //    throw std::runtime_error("Additional characters at end of string: '" + std::string(strIterator, strEnd) + "'.");
+  //  }
+  //} catch (std::runtime_error &builderError) {
+  //  throw Kernel::Exception::ParseError("Parse error: " + std::string(builderError.what()), matrixVectorString, 0);
+  //}
 
   return builder.getMatrixVectorPair<T>();
 }

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -82,7 +82,7 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   # The new interface is not available in Clang yet so we haven't migrated
   add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
   if(APPLE)
-    add_definitions(-DBOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE)
+    add_definitions(-DBOOST_PARSER_USE_CONCEPTS=0)
   endif()
 
   find_package(Poco REQUIRED)

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -191,10 +191,11 @@ endif()
 set(AUTO_GENERATE_WARNING "/********** PLEASE NOTE! THIS FILE WAS AUTO-GENERATED FROM CMAKE.  ***********************/")
 
 # ######################################################################################################################
-# Enable CXX17_REMOVED_UNARY_BINARY_FUNCTION for boost on osx
+# Enable CXX17_REMOVED_UNARY_BINARY_FUNCTION for boost on osx Use GCC12 range adaptor closure for boost parser on osx
 # ######################################################################################################################
 if(APPLE)
   add_definitions(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
+  add_definitions(-DBOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE)
 endif()
 
 # ######################################################################################################################

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -81,6 +81,9 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   add_definitions(-D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
   # The new interface is not available in Clang yet so we haven't migrated
   add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
+  if(APPLE)
+    add_definitions(-DBOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE)
+  endif()
 
   find_package(Poco REQUIRED)
   find_package(TBB REQUIRED)
@@ -195,7 +198,6 @@ set(AUTO_GENERATE_WARNING "/********** PLEASE NOTE! THIS FILE WAS AUTO-GENERATED
 # ######################################################################################################################
 if(APPLE)
   add_definitions(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
-  add_definitions(-DBOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE)
 endif()
 
 # ######################################################################################################################

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -129,7 +129,7 @@ endif()
 # ######################################################################################################################
 # Set the c++ standard to 20 - cmake should do the right thing with msvc
 # ######################################################################################################################
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -24,8 +24,8 @@ python:
 
 # Aim to follow conda-forge
 libboost:
-  - 1.88 # [win or linux]
-  - 1.88 # [osx]
+  - '1.88.*'  # [win or linux]
+  - '1.88.*'  # [osx]
 
 cmake:
   - '>=3.21.0'

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -24,8 +24,8 @@ python:
 
 # Aim to follow conda-forge
 libboost:
-  - '1.88.*'  # [win or linux]
-  - '1.86.*'  # [osx]
+  - 1.88 # [win or linux]
+  - 1.88 # [osx]
 
 cmake:
   - '>=3.21.0'


### PR DESCRIPTION
### Description of work

#### Summary of work
Replaced `boost::spirit` with `boost::parser` so that `boost::optional` can be removed. `MatrixVectorPairParser.h` was one of the last places in the Mantid code base that used `boost::optional`. Unfortunately, this was required by the `boost::spirit `parser. From boost version 1.87 on there is a new parser library in `boost`, `boost::parser`. This does not rely on `boost::optional`.

Fixes #39617.

### To test:

Check that the unit tests are running, especially the ones for `MatrixVectorPairParser`. 

`MatrixVectorPairParser` is mainly used by `SymmetryOperationSymbolParser` and `GroupTransformation`. Running code like the examples in https://docs.mantidproject.org/nightly/concepts/SymmetryGroups.html will also use the  `MatrixVectorPairParser` and can be used for testing.


*This does not require release notes* because **this is a change that is invisible to the user.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
