### PR TITLE
Fix coverity warnings introduced by DetermineSpinStateOrder

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
+#include "MantidKernel/EmptyValues.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -31,8 +32,8 @@ private:
   void init() override;
   void exec() override;
 
-  std::string m_spinFlipperLogName;
-  double m_rfStateCondition;
+  std::string m_spinFlipperLogName = "";
+  double m_rfStateCondition = EMPTY_DBL();
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
+++ b/Framework/Algorithms/src/DetermineSpinStateOrder.cpp
@@ -11,7 +11,6 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 
@@ -151,6 +150,9 @@ void DetermineSpinStateOrder::exec() {
     const auto groupItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(ws);
     const auto sfLog =
         dynamic_cast<const Kernel::TimeSeriesProperty<double> *>(groupItem->run().getLogData(m_spinFlipperLogName));
+    if (!sfLog) {
+      throw std::runtime_error(m_spinFlipperLogName + " was not a TimeSeriesProperty.");
+    }
     const auto sfLogValues = sfLog->filteredValuesAsVector();
     const double rfState =
         std::accumulate(sfLogValues.cbegin(), sfLogValues.cend(), 0.0) / static_cast<double>(sfLogValues.size());


### PR DESCRIPTION
### Description of work

Fix coverity warning introduced by #39600, specifically:

```
** CID 1612270:       Uninitialized members  (UNINIT_CTOR)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h: 35           in Mantid::Algorithms::DetermineSpinStateOrder::DetermineSpinStateOrder()()


_____________________________________________________________________________________________
*** CID 1612270:         Uninitialized members  (UNINIT_CTOR)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/inc/MantidAlgorithms/DetermineSpinStateOrder.h: 35             in Mantid::Algorithms::DetermineSpinStateOrder::DetermineSpinStateOrder()()
29     
30     private:
31       void init() override;
32       void exec() override;
33     
34       std::string m_spinFlipperLogName;
>>>     CID 1612270:         Uninitialized members  (UNINIT_CTOR)
>>>     The compiler-generated constructor for this class does not initialize "m_rfStateCondition".
35       double m_rfStateCondition;
36     };
37     
38     } // namespace Algorithms

** CID 1612269:       Null pointer dereferences  (FORWARD_NULL)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/DetermineSpinStateOrder.cpp: 154           in Mantid::Algorithms::DetermineSpinStateOrder::exec()()


_____________________________________________________________________________________________
*** CID 1612269:         Null pointer dereferences  (FORWARD_NULL)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/DetermineSpinStateOrder.cpp: 154             in Mantid::Algorithms::DetermineSpinStateOrder::exec()()
148       std::vector<std::string> spinStatesOrder;
149     
150       for (const API::Workspace_sptr &ws : wsGroup->getAllItems()) {
151         const auto groupItem = std::dynamic_pointer_cast<API::MatrixWorkspace>(ws);
152         const auto sfLog =
153             dynamic_cast<const Kernel::TimeSeriesProperty<double> *>(groupItem->run().getLogData(m_spinFlipperLogName));
>>>     CID 1612269:         Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "sfLog" to "filteredValuesAsVector", which dereferences it. (The dereference happens because this is a virtual function call.)
154         const auto sfLogValues = sfLog->filteredValuesAsVector();
155         const double rfState =
156             std::accumulate(sfLogValues.cbegin(), sfLogValues.cend(), 0.0) / static_cast<double>(sfLogValues.size());
157         const double heState = *std::max_element(groupItem->readY(0).cbegin(), groupItem->readY(0).cend()) - averageTrans;
158     
159         if (rfState > m_rfStateCondition) {

** CID 1612268:       Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Nexus/src/NexusFile.cpp: 1387           in Mantid::Nexus::<unnamed>::gr_iterate_cb(long, const char *, const H5L_info2_t *, void *)()
```

*There is no associated issue.*

### To test:

Code review wrt the warnings.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
