### PR TITLE
Add unit test for linearAbsorpCoef function

### DIFF
--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -258,4 +258,18 @@ public:
     TS_ASSERT_EQUALS(cf[3].atom->symbol, "O");
     TS_ASSERT_DELTA(cf[3].multiplicity, 6.56, .01);
   }
+
+  void test_linearAbsorpCoefl() {
+    const std::vector<double> lambda{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    Material::ChemicalFormula cf;
+    cf = Material::parseChemicalFormula("F14");
+    Material test("test", cf, 5.0, 0.5, 50.0, 50.0);
+    const auto linearCoef = test.linearAbsorpCoef(lambda.begin(), lambda.end());
+
+    const std::vector<double> expectedResults{1.33466, 2.66936, 4.00400, 5.33867, 6.67334,
+                                              8.00800, 9.34268, 10.6773, 12.0120, 13.3467};
+    for (size_t i = 0; i < linearCoef.size(); i++) {
+      TS_ASSERT_DELTA(linearCoef[i], expectedResults[i], 0.0001)
+    }
+  }
 };

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -259,7 +259,7 @@ public:
     TS_ASSERT_DELTA(cf[3].multiplicity, 6.56, .01);
   }
 
-  void test_linearAbsorpCoefl() {
+  void test_linearAbsorpCoef() {
     const std::vector<double> lambda{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     Material::ChemicalFormula cf;
     cf = Material::parseChemicalFormula("F14");


### PR DESCRIPTION
### Description of work

#### Summary of work

When testing the new windows CI image running with docker 17 we fell foul of a compiler bug in a recent version of MSVC:
https://developercommunity.visualstudio.com/t/Serious-compiler-bug-in-144435207-duri/10908277?sort=newest&viewtype=solutions

This bug caused errors in tests that touch upon the `AbsorptionCorrection` class, which themselves are several steps removed from the root cause of the issue.

We will look to avoid the compiler verison with the bug, but to make this error easier to identify in the future, I've added a unit test which tests the offending function directly.

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
