### PR TITLE
Lower the logging priority of "Goniometer was initialized from a rotation matrix" message

### DIFF
--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -345,8 +345,8 @@ std::string Goniometer::getConventionFromMotorAxes() const {
 /// Private function to recalculate the rotation matrix of the goniometer
 void Goniometer::recalculateR() {
   if (m_initFromR) {
-    g_log.warning() << "Goniometer was initialized from a rotation matrix. No "
-                    << "recalculation from motors will be done.\n";
+    g_log.information() << "Goniometer was initialized from a rotation matrix. No "
+                        << "recalculation from motors will be done.\n";
     return;
   }
 


### PR DESCRIPTION
### Description of work

#### Summary of work
The priority of the message `"Goniometer was initialized from a rotation matrix. No recalculation from motors will be done."` has been lowered from a warning to a debug.

Please review as to whether this seems to be a more appropriate level, an argument could also be made for information or notice

#### Purpose of work
The message was initially written with the intention of protecting users from confusing behaviour when the `recalculateR` Goniometer method is called. This method seems to mostly be called internally rather than by users, and now appears to users when they might not expected it (see example script below)

#### Further detail of work
Lowered the priority to debug as the `recalculateR` seems to be called fairly frequently, potentially just as a precaution, and the user probably doesn't need to be warned about this every time. 

The thinking behind moving it to debug is that a user is probably only interested in this information in the situation where they  are getting unexpected behaviour, and so debugging is probably the goal there?

### To test:
previously this script would warn the user upon loading, which feels a bit excessive, now it should only appear when log level is set to debug 
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import os

save_path = r"C:\Users\kcd17618\Documents\TestingTMP\39709"

CreateSampleWorkspace(OutputWorkspace='eg')
fname = os.path.join("eg.nxs")
SaveNexus(InputWorkspace = "eg", Filename = fname)
LoadNexus(Filename = fname, OutputWorkspace = "load_eg")
```

*This might not require release notes* because **not really a bug fix nor a new feature, the best fit location I could think to put one would be Framework/Data_Objects/BugFixes just to provide a notice that the priority of the message has now changed?**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
