### PR TITLE
Version 6.13.1 patch release changes

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    */index
 
 * :doc:`v6.14.0 <v6.14.0/index>`
+* :doc:`v6.13.1 <v6.13.1/index>`
 * :doc:`v6.13.0 <v6.13.0/index>`
 * :doc:`v6.12.0 <v6.12.0/index>`
 * :doc:`v6.11.0 <v6.11.0/index>`

--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
@@ -1,1 +1,0 @@
-- Exposed `ExperimentInfo.populateInstrumentParameters` to the Python api.  This will facilitate the update of parameterized instruments from Python, allowing parameters to be directly transferred as properties without converting to and from `string`.

--- a/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
+++ b/docs/source/release/v6.12.0/Muon/ALC/Bugfixes/39442.rst
@@ -1,1 +1,0 @@
-- :ref:`ALC interface <MuonALC-ref>` no longer crashes when non numeric characters are input in Backward and Forward Grouping line edits.

--- a/docs/source/release/v6.13.0/framework.rst
+++ b/docs/source/release/v6.13.0/framework.rst
@@ -143,6 +143,8 @@ New features
 - ``Instrument.getFilename()`` and ``Instrument.setFilename()`` have been exposed to python.
 - A new method named ``getFittingParameter`` has been added to ``Mantid::Geometry::Component`` class and exposed to
   python. This allows access to fitting parameters from components in an instrument definition file.
+- Exposed ``ExperimentInfo.populateInstrumentParameters`` to the Python api.  This will facilitate the update of parameterized
+  instruments from Python, allowing parameters to be directly transferred as properties without converting to and from ``string``.
 
 Bugfixes
 ############

--- a/docs/source/release/v6.13.0/muon.rst
+++ b/docs/source/release/v6.13.0/muon.rst
@@ -5,6 +5,13 @@ Muon Changes
 .. contents:: Table of Contents
    :local:
 
+ALC
+---
+
+Bugfixes
+############
+- :ref:`ALC interface <MuonALC-ref>` no longer crashes when non numeric characters are input in Backward and Forward Grouping line edits.
+
 Muon Analysis
 -------------
 

--- a/docs/source/release/v6.13.1/index.rst
+++ b/docs/source/release/v6.13.1/index.rst
@@ -1,0 +1,42 @@
+.. _v6.13.1:
+
+===========================
+Mantid 6.13.1 Release Notes
+===========================
+
+.. contents:: Table of Contents
+   :local:
+
+This is a patch release that corrects some significant issues since :ref:`version 6.13.0 <v6.13.0>`.
+
+The changes are:
+
+- MantidWorkbench full installers will now work correctly on all Linux distributions.
+- Muon Analysis and Frequency Domain Analysis interfaces will now open on all Linux distributions.
+- :ref:`SaveNXSPE <algm-SaveNXSPE-v1>` will no longer throw an exception when creating nested groups with the same name.
+
+Citation
+--------
+
+Please cite any usage of Mantid as follows:
+
+- *Mantid 6.13.1: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*.
+  `doi: 10.5286/Software/Mantid6.13.1 <http://dx.doi.org/10.5286/Software/Mantid6.13.1>`_
+
+- Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments
+  and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166
+  `doi: 10.1016/j.nima.2014.07.029 <https://doi.org/10.1016/j.nima.2014.07.029>`_
+  (`download bibtex <https://raw.githubusercontent.com/mantidproject/mantid/master/docs/source/mantid.bib>`_)
+
+Changes in this version
+-----------------------
+
+* `39670 <https://github.com/mantidproject/mantid/pull/39670>`_ Avoid Linux standalone launching error
+* `39656 <https://github.com/mantidproject/mantid/pull/39656>`_ Remove link between muon and curvefitting libs
+* `39686 <https://github.com/mantidproject/mantid/pull/39686>`_ Allow Nexus to make nested groups with same name
+
+.. _download page: http://download.mantidproject.org
+
+.. _forum: http://forum.mantidproject.org
+
+.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.13.1

--- a/installers/conda/common/common.sh
+++ b/installers/conda/common/common.sh
@@ -27,16 +27,7 @@ function trim_conda() {
     # We don't use this workbench script in the Linux standalone, so remove it to avoid confusion
     rm "$bundle_conda_prefix"/bin/workbench
   fi
-  # Heavily cut down share
-  mv "$bundle_conda_prefix"/share "$bundle_conda_prefix"/share_tmp
-  mkdir "$bundle_conda_prefix"/share
-  mv "$bundle_conda_prefix"/share_tmp/doc "$bundle_conda_prefix"/share/
-  mkdir -p "$bundle_conda_prefix"/share/glib-2.0/schemas
-  mv "$bundle_conda_prefix"/share_tmp/glib-2.0/schemas "$bundle_conda_prefix"/share/glib-2.0/
-  if [ -d "$bundle_conda_prefix"/share_tmp/X11 ]; then
-    # On some linux flavours we need this on some otherwise workbench won't launch
-    mv "$bundle_conda_prefix"/share_tmp/X11 "$bundle_conda_prefix"/share/
-  fi
+
   # Heavily cut down translations
   mv "$bundle_conda_prefix"/translations "$bundle_conda_prefix"/translations_tmp
   mkdir -p "$bundle_conda_prefix"/translations/qtwebengine_locales
@@ -51,7 +42,6 @@ function trim_conda() {
     "$bundle_conda_prefix"/phrasebooks \
     "$bundle_conda_prefix"/qml \
     "$bundle_conda_prefix"/qsci \
-    "$bundle_conda_prefix"/share_tmp \
     "$bundle_conda_prefix"/translations_tmp
 
   find "$bundle_conda_prefix" -name '*.a' -delete

--- a/tools/release_generator/patch.py
+++ b/tools/release_generator/patch.py
@@ -10,9 +10,9 @@ import requests
 
 doc = """.. _v{version}:
 
-==========================
+===========================
 Mantid {version} Release Notes
-==========================
+===========================
 
 .. contents:: Table of Contents
    :local:


### PR DESCRIPTION
This individually pulls in the changes from v6.13.1 into `ornl-next` that haven't been accounted for already
* #39662 
* #39670
* #39700