### PR TITLE
Add SplitterWorkspace input for AlignAndFocusPowderSlim

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/TimeROI.h"
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
@@ -38,6 +39,7 @@ private:
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                    const std::vector<double> &difc_focus);
+  Kernel::TimeROI timeROIFromSplitterWorkspace(const Types::Core::DateAndTime &);
 
   std::map<detid_t, double> m_calibration; // detid: 1/difc
   std::set<detid_t> m_masked;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -39,6 +39,7 @@ private:
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                    const std::vector<double> &difc_focus);
+  void determinePulseIndices(const API::MatrixWorkspace_sptr &wksp);
   Kernel::TimeROI timeROIFromSplitterWorkspace(const Types::Core::DateAndTime &);
 
   std::map<detid_t, double> m_calibration; // detid: 1/difc

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -569,6 +569,10 @@ TimeROI AlignAndFocusPowderSlim::timeROIFromSplitterWorkspace(const Types::Core:
         DataObjects::TimeSplitter(matrixSplitterWS, isSplittersRelativeTime ? filterStartTime : DateAndTime::GPS_EPOCH);
   }
 
+  if (timeSplitter.outputWorkspaceIndices().size() != 1) {
+    throw std::runtime_error("Current we only support a single output workspace from the splitter workspace");
+  }
+
   return timeSplitter.getTimeROI(0);
 }
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -159,10 +159,10 @@ void AlignAndFocusPowderSlim::init() {
   declareProperty(std::make_unique<API::WorkspaceProperty<API::Workspace>>(
                       PropertyNames::SPLITTER_WS, "", Direction::Input, API::PropertyMode::Optional),
                   "Input workspace specifying \"splitters\", i.e. time intervals and targets for event filtering. "
-                  "Currently only a single workspace is supported.");
+                  "Currently only a single output workspace is supported.");
   declareProperty(PropertyNames::SPLITTER_RELATIVE, false,
                   "Flag indicating whether in SplitterWorkspace the times are absolute or "
-                  "relative. If true, they are relative to either the run start time.");
+                  "relative. If true, they are relative to the run start time.");
   const std::vector<std::string> cal_exts{".h5", ".hd5", ".hdf", ".cal"};
   declareProperty(std::make_unique<FileProperty>(PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad, cal_exts),
                   "The .cal file containing the position correction factors. Either this or OffsetsWorkspace needs to "

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -577,7 +577,7 @@ TimeROI AlignAndFocusPowderSlim::timeROIFromSplitterWorkspace(const Types::Core:
   }
 
   const int splitter_target = this->getProperty(PropertyNames::SPLITTER_TARGET);
-  if (static_cast<size_t>(splitter_target) >= timeSplitter.outputWorkspaceIndices().size()) {
+  if (!timeSplitter.outputWorkspaceIndices().contains(splitter_target)) {
     throw std::invalid_argument("Selected splitter target is out of range.");
   }
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
@@ -11,7 +11,7 @@
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
-NexusLoader::NexusLoader(const bool is_time_filtered, const std::vector<std::pair<size_t, size_t>> &pulse_indices)
+NexusLoader::NexusLoader(const bool is_time_filtered, const std::vector<PulseROI> &pulse_indices)
     : m_is_time_filtered(is_time_filtered), m_pulse_indices(pulse_indices) {}
 
 template <typename Type>
@@ -54,10 +54,9 @@ void NexusLoader::loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<Type>> 
   SDS.read(data->data(), dataType, memspace, filespace);
 }
 
-std::stack<std::pair<uint64_t, uint64_t>> NexusLoader::getEventIndexRanges(H5::Group &event_group,
-                                                                           const uint64_t number_events) {
+std::stack<EventROI> NexusLoader::getEventIndexRanges(H5::Group &event_group, const uint64_t number_events) {
   // This will return a stack of pairs, where each pair is the start and stop index of the event ranges
-  std::stack<std::pair<uint64_t, uint64_t>> ranges;
+  std::stack<EventROI> ranges;
   if (m_is_time_filtered) {
     // TODO this should be made smarter to only read the necessary range
     std::unique_ptr<std::vector<uint64_t>> event_index = std::make_unique<std::vector<uint64_t>>();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.h
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.h
@@ -21,17 +21,20 @@ const std::string DETID("event_id");                   // uint32 in ORNL nexus f
 const std::string INDEX_ID("event_index");
 } // namespace NxsFieldNames
 
+using PulseROI = std::pair<size_t, size_t>;     // start and stop indices for the pulse ROIs
+using EventROI = std::pair<uint64_t, uint64_t>; // start and stop indices for the events ROIs
+
 class NexusLoader {
 public:
-  NexusLoader(const bool is_time_filtered, const std::vector<std::pair<size_t, size_t>> &pulse_indices);
+  NexusLoader(const bool is_time_filtered, const std::vector<PulseROI> &pulse_indices);
   template <typename Type>
   void loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<Type>> &data, const std::vector<size_t> &offsets,
                 const std::vector<size_t> &slabsizes);
-  std::stack<std::pair<uint64_t, uint64_t>> getEventIndexRanges(H5::Group &event_group, const uint64_t number_events);
+  std::stack<EventROI> getEventIndexRanges(H5::Group &event_group, const uint64_t number_events);
 
 private:
   const bool m_is_time_filtered;
-  const std::vector<std::pair<size_t, size_t>> m_pulse_indices;
+  const std::vector<PulseROI> m_pulse_indices;
   void loadEventIndex(H5::Group &event_group, std::unique_ptr<std::vector<uint64_t>> &data);
 };
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -64,8 +64,7 @@ ProcessBankTask::ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H
                                  const bool is_time_filtered, API::MatrixWorkspace_sptr &wksp,
                                  const std::map<detid_t, double> &calibration, const std::set<detid_t> &masked,
                                  const size_t events_per_chunk, const size_t grainsize_event,
-                                 std::vector<std::pair<size_t, size_t>> pulse_indices,
-                                 std::shared_ptr<API::Progress> &progress)
+                                 std::vector<PulseROI> pulse_indices, std::shared_ptr<API::Progress> &progress)
     : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(is_time_filtered, pulse_indices), m_wksp(wksp),
       m_calibration(calibration), m_masked(masked), m_events_per_chunk(events_per_chunk),
       m_grainsize_event(grainsize_event), m_progress(progress) {}

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -22,7 +22,7 @@ public:
   ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
                   API::MatrixWorkspace_sptr &wksp, const std::map<detid_t, double> &calibration,
                   const std::set<detid_t> &masked, const size_t events_per_chunk, const size_t grainsize_event,
-                  std::vector<std::pair<size_t, size_t>> pulse_indices, std::shared_ptr<API::Progress> &progress);
+                  std::vector<PulseROI> pulse_indices, std::shared_ptr<API::Progress> &progress);
 
   void operator()(const tbb::blocked_range<size_t> &range) const;
 

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -395,14 +395,14 @@ public:
     TS_ASSERT_EQUALS(outputWS->readY(5).front(), 590230);
   }
 
-  void test_splitter_table_abosolute_time() {
+  void test_splitter_table_absolute_time() {
     Mantid::DataObjects::TableWorkspace_sptr tablesplitter = create_splitter_table(false);
 
     MatrixWorkspace_sptr outputWS =
         run_algorithm("VULCAN_218062.nxs.h5", std::vector<double>{0.}, std::vector<double>{50000.},
                       std::vector<double>{50000.}, "Linear", "TOF", -1., -1., false, tablesplitter, false);
 
-    /* expected results came from running the same as above but with absolute time */
+    /* expected results should be the same as test_splitter_table but produced with absolute time */
 
     TS_ASSERT_EQUALS(outputWS->readY(0).front(), 807206);
     TS_ASSERT_EQUALS(outputWS->readY(1).front(), 805367);

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/TimeROI.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
@@ -20,6 +21,7 @@
 
 using Mantid::API::MatrixWorkspace_sptr;
 using Mantid::DataHandling::AlignAndFocusPowderSlim::AlignAndFocusPowderSlim;
+using Mantid::DataObjects::TableWorkspace_sptr;
 
 class AlignAndFocusPowderSlimTest : public CxxTest::TestSuite {
 public:
@@ -39,7 +41,8 @@ public:
                                      const std::vector<double> &xmax = {}, const std::vector<double> &xdelta = {},
                                      const std::string binning = "Logarithmic",
                                      const std::string binningUnits = "dSpacing", const double timeMin = -1.,
-                                     const double timeMax = -1., const bool should_throw = false) {
+                                     const double timeMax = -1., const bool should_throw = false,
+                                     TableWorkspace_sptr tablesplitter = nullptr, const bool relativeTime = false) {
     const std::string wksp_name("VULCAN");
 
     std::cout << "==================> " << filename << '\n';
@@ -63,6 +66,10 @@ public:
       TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStart", timeMin));
     if (timeMax > 0.)
       TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStop", timeMax));
+    if (tablesplitter != nullptr) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("SplitterWorkspace", tablesplitter));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("RelativeTime", relativeTime));
+    }
 
     if (should_throw) {
       TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
@@ -352,6 +359,117 @@ public:
     // start time longer than run time of ~600 seconds
     run_algorithm("VULCAN_218062.nxs.h5", std::vector<double>{0.}, std::vector<double>{50000.},
                   std::vector<double>{50000.}, "Linear", "TOF", 1000., 2000., true);
+  }
+
+  void test_splitter_table() {
+    Mantid::DataObjects::TableWorkspace_sptr tablesplitter = create_splitter_table();
+
+    MatrixWorkspace_sptr outputWS =
+        run_algorithm("VULCAN_218062.nxs.h5", std::vector<double>{0.}, std::vector<double>{50000.},
+                      std::vector<double>{50000.}, "Linear", "TOF", -1., -1., false, tablesplitter, true);
+
+    /* expected results came from running
+
+    splitter = CreateEmptyTableWorkspace()
+    splitter.addColumn('float', 'start')
+    splitter.addColumn('float', 'stop')
+    splitter.addColumn('str', 'target')
+    splitter.addRow((10,20, '0'))
+    splitter.addRow((200,210, '0'))
+    splitter.addRow((400,410, '0'))
+
+    ws = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
+    grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
+    ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")
+
+    FilterEvents(ws, SplitterWorkspace=splitter, RelativeTime=True, FilterByPulseTime=True,
+    OutputWorkspaceBaseName="filtered")
+
+    print(mtd["filtered_0"].extractY())
+    */
+    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 807206);
+    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 805367);
+    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 920983);
+    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 909955);
+    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 310676);
+    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 590230);
+  }
+
+  void test_splitter_table_abosolute_time() {
+    Mantid::DataObjects::TableWorkspace_sptr tablesplitter = create_splitter_table(false);
+
+    MatrixWorkspace_sptr outputWS =
+        run_algorithm("VULCAN_218062.nxs.h5", std::vector<double>{0.}, std::vector<double>{50000.},
+                      std::vector<double>{50000.}, "Linear", "TOF", -1., -1., false, tablesplitter, false);
+
+    /* expected results came from running the same as above but with absolute time */
+
+    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 807206);
+    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 805367);
+    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 920983);
+    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 909955);
+    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 310676);
+    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 590230);
+  }
+
+  void test_splitter_table_and_time_start_stop() {
+    TableWorkspace_sptr tablesplitter = create_splitter_table();
+
+    MatrixWorkspace_sptr outputWS =
+        run_algorithm("VULCAN_218062.nxs.h5", std::vector<double>{0.}, std::vector<double>{50000.},
+                      std::vector<double>{50000.}, "Linear", "TOF", 15., 300., false, tablesplitter, true);
+
+    /* expected results came from running
+
+    splitter = CreateEmptyTableWorkspace()
+    splitter.addColumn('float', 'start')
+    splitter.addColumn('float', 'stop')
+    splitter.addColumn('str', 'target')
+    splitter.addRow((15,20, '0'))
+    splitter.addRow((200,210, '0'))
+
+    ws = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
+    grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
+    ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")
+
+    FilterEvents(ws, SplitterWorkspace=splitter, RelativeTime=True, FilterByPulseTime=True,
+    OutputWorkspaceBaseName="filtered")
+
+    print(mtd["filtered_0"].extractY())
+    */
+    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 415525);
+    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 414435);
+    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 476903);
+    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 471846);
+    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 160000);
+    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 304167);
+  }
+
+  TableWorkspace_sptr create_splitter_table(const bool relativeTime = true) {
+    // create splitter table
+    TableWorkspace_sptr tablesplitter = std::make_shared<Mantid::DataObjects::TableWorkspace>();
+    tablesplitter->addColumn("double", "start");
+    tablesplitter->addColumn("double", "stop");
+    tablesplitter->addColumn("str", "target");
+
+    // start time was 2022-05-31T02:57:22.028123667 which is 1022813842.0281236 seconds since epoch
+    const double offset = relativeTime ? 0. : 1022813842.0281236;
+
+    tablesplitter->appendRow();
+    tablesplitter->cell<double>(0, 0) = 10.0 + offset;
+    tablesplitter->cell<double>(0, 1) = 20.0 + offset;
+    tablesplitter->cell<std::string>(0, 2) = "0";
+
+    tablesplitter->appendRow();
+    tablesplitter->cell<double>(1, 0) = 200.0 + offset;
+    tablesplitter->cell<double>(1, 1) = 210.0 + offset;
+    tablesplitter->cell<std::string>(1, 2) = "0";
+
+    tablesplitter->appendRow();
+    tablesplitter->cell<double>(2, 0) = 400.0 + offset;
+    tablesplitter->cell<double>(2, 1) = 410.0 + offset;
+    tablesplitter->cell<std::string>(2, 2) = "0";
+    return tablesplitter;
   }
 
   // ==================================

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -23,8 +23,6 @@ Current limitations compared to ``AlignAndFocusPowderFromFiles``
 
 - only supports the VULCAN instrument
 - hard coded for 6 particular groups
-- only specify binning in time-of-flight
-- does not support event filtering
 - does not support copping data
 - does not support removing prompt pulse
 - does not support removing bad pulses

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -33,7 +33,71 @@ Child algorithms used are
 - :ref:`algm-LoadIDFFromNexus-v1`
 - :ref:`algm-EditInstrumentGeometry`
 - :ref:`algm-LoadNexusLogs`
+- :ref:`algm-ConvertUnits`
 
+Usage
+-----
+
+**Example - event filtering**
+
+This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents <algm-FilterEvents>`.
+
+.. code-block:: python
+
+    # create splitter table using relative time
+    splitter = CreateEmptyTableWorkspace()
+    splitter.addColumn('float', 'start')
+    splitter.addColumn('float', 'stop')
+    splitter.addColumn('str', 'target')
+
+    splitter.addRow((10,20, '0'))
+    splitter.addRow((200,210, '0'))
+    splitter.addRow((400,410, '0'))
+
+    # pass the splitter table to AlignAndFocusPowderSlim
+    ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
+                               SplitterWorkspace=splitter, RelativeTime=True,
+                               XMin=0, XMax=50000, XDelta=50000,
+                               BinningMode="Linear",
+                               BinningUnits="TOF")
+
+    # This is equilvalent to using FilterEvents with the same splitter table.
+    # But note that this example doesn't align the data so put everything in 1 big bin to compare.
+    ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
+    grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
+    ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="grp")
+
+    FilterEvents(ws2,
+                 SplitterWorkspace=splitter, RelativeTime=True,
+                 FilterByPulseTime=True,
+                 OutputWorkspaceBaseName="filtered")
+
+    np.testing.assert_array_equal(mtd["filtered_0"].extractY(), ws.extractY())
+
+**Example - filter events based on log values**
+
+.. code-block:: python
+
+    # Load only the log we need
+    cave_temperature = LoadEventNexus("VULCAN_218062.nxs.h5",
+                                      MetaDataOnly=True,
+                                      AllowList="CaveTemperature")
+
+    # Use GenerateEventsFilter to create a splitter table based on the log values
+    GenerateEventsFilter(cave_temperature,
+                         OutputWorkspace='splitter',
+                         InformationWorkspace='info',
+                         LogName='CaveTemperature',
+                         MinimumLogValue=70.10,
+                         MaximumLogValue=70.15)
+
+    # Use the splitter table to filter the events during loading
+    ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter')
+
+
+.. note::
+
+    We currently only support a single output workspace when filtering events from a splitter table. We also can currently only filter base on the pulse time, not the event time-of-flight.
 
 .. categories::
 

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -40,7 +40,7 @@ Usage
 
 **Example - event filtering**
 
-This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents <algm-FilterEvents>`.
+This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEvents <algm-FilterEvents>` and more information can be found on the :ref:`Event Filtering <EventFiltering>` page.
 
 .. code-block:: python
 
@@ -61,7 +61,7 @@ This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents
                                BinningMode="Linear",
                                BinningUnits="TOF")
 
-    # This is equilvalent to using FilterEvents with the same splitter table.
+    # This is equivalent to using FilterEvents with the same splitter table.
     # But note that this example doesn't align the data so put everything in 1 big bin to compare.
     ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
     grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
@@ -71,8 +71,9 @@ This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents
                  SplitterWorkspace=splitter, RelativeTime=True,
                  FilterByPulseTime=True,
                  OutputWorkspaceBaseName="filtered")
+    out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)
 
-    np.testing.assert_array_equal(mtd["filtered_0"].extractY(), ws.extractY())
+    CompareWorkspaces(ws, out, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
 
 **Example - filter events based on log values**
 
@@ -97,7 +98,7 @@ This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents
 
 .. note::
 
-    While we currently only support a single output workspace when filtering events from a splitter table but the output target can be selected with the ``SplitterTarget`` property and you can run the algorithm multiple times with different targets. We also can currently only filter base on the pulse time, not the event time-of-flight.
+    While we currently only support a single output workspace when filtering events from a splitter table but the output target can be selected with the ``SplitterTarget`` property and you can run the algorithm multiple times with different targets. We also can currently only filter based on the pulse time, not the event time-of-flight.
 
 .. categories::
 

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -97,7 +97,7 @@ This algorithm accepts the sample SplitterWorkspace inputs as :ref:`FilterEvents
 
 .. note::
 
-    We currently only support a single output workspace when filtering events from a splitter table. We also can currently only filter base on the pulse time, not the event time-of-flight.
+    While we currently only support a single output workspace when filtering events from a splitter table but the output target can be selected with the ``SplitterTarget`` property and you can run the algorithm multiple times with different targets. We also can currently only filter base on the pulse time, not the event time-of-flight.
 
 .. categories::
 

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39721.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39721.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` can do event filtering with a Splitter Workspace but only with a single output workspace and filtering on pulse time only.


### PR DESCRIPTION
~~This include the change from #39701 and should be reviewed after that is in.~~

This adds a `SplitterWorkspace` input, the same as [FilterEvents](https://docs.mantidproject.org/nightly/algorithms/FilterEvents-v1.html), which will allow you to filter based on pulse time the event that are loaded. This can be used to filter by log by first loading the log then using [GenerateEventsFilter](https://docs.mantidproject.org/nightly/algorithms/GenerateEventsFilter-v1.html) as should in the usage examples.

[EWM12210: Add more complicated filtering, Splitter Workspace input](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/12210)

### To test:

You can check that you get the same results to `FilterEvents` algorithms (note in FilterEvents examples we are not aligning the data so must test with one big bin, AlignAndFocusPowderSlim is also not yet setting the uncertainty so we don't check that).

```python
splitter = CreateEmptyTableWorkspace()
splitter.addColumn('float', 'start')
splitter.addColumn('float', 'stop')
splitter.addColumn('str', 'target')

splitter.addRow((10,20, '0'))
splitter.addRow((200,210, '0'))
splitter.addRow((400,410, '0'))

ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace=splitter, RelativeTime=True, XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF")

ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="grp")
FilterEvents(ws2, SplitterWorkspace=splitter, RelativeTime=True, FilterByPulseTime=True, OutputWorkspaceBaseName="filtered")
out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)

CompareWorkspaces(ws, out, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
```

You can also create the splitter workspace with `GenerateEventsFilter` from a sample log

```python
ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="grp")
GenerateEventsFilter(ws2, OutputWorkspace='log_splitter', InformationWorkspace='info', LogName='CaveTemperature', MinimumLogValue=70.10, MaximumLogValue=70.15)

ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='log_splitter', XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF")

FilterEvents(ws2, SplitterWorkspace='log_splitter', FilterByPulseTime=True, OutputWorkspaceBaseName="filtered")
out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)

CompareWorkspaces(ws, out, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)

```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
