### PR TITLE
Speedup CreateMDHistoWorkspace

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CreateMDHistoWorkspace.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CreateMDHistoWorkspace.h
@@ -29,6 +29,8 @@ public:
   const std::vector<std::string> seeAlso() const override { return {"ConvertToMD", "CreateMDWorkspace"}; }
   const std::string category() const override;
 
+  std::map<std::string, std::string> validateInputs() override;
+
 private:
   void init() override;
   void exec() override;

--- a/Framework/MDAlgorithms/test/CreateMDHistoWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/CreateMDHistoWorkspaceTest.h
@@ -62,7 +62,7 @@ public:
     auto alg = make_standard_algorithm(outWSName);
     alg->setProperty("SignalInput",
                      "1"); // Only one signal value provided, but NumberOfBins set to 5!
-    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
     AnalysisDataService::Instance().remove(outWSName);
   }
 
@@ -71,7 +71,7 @@ public:
     auto alg = make_standard_algorithm(outWSName);
     alg->setProperty("ErrorInput",
                      "1"); // Only one error value provided, but NumberOfBins set to 5!
-    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
     AnalysisDataService::Instance().remove(outWSName);
   }
 
@@ -81,7 +81,7 @@ public:
     alg->setProperty("NumberOfEvents", "1"); // Only one number of events value
                                              // provided, but NumberOfBins set
                                              // to 5!
-    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
     AnalysisDataService::Instance().remove(outWSName);
   }
 


### PR DESCRIPTION
Be more memory efficient with accessing property values. Also small refactor to move property checking to before `exec()` is called. Unfortunately, this changed the type of exception thrown.

*There is no associated issue.*

### To test:

This is a refactor so it should continue to work as before.

*This does not require release notes* because it is a small refactor.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
