### PR TITLE
Fix hdf5 version in test

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -10,6 +10,11 @@
 #include <utility>
 #include <vector>
 
+/** NeXus HDF45
+ * major.minor.patch
+ */
+#define NEXUS_VERSION "4.4.3"
+
 namespace {
 static const std::string NULL_STR("NULL");
 }

--- a/Framework/Nexus/inc/MantidNexus/napi.h
+++ b/Framework/Nexus/inc/MantidNexus/napi.h
@@ -29,9 +29,6 @@
 #include "MantidNexus/NexusFile_fwd.h"
 #include <stdint.h>
 
-/* NeXus HDF45 */
-#define NEXUS_VERSION "4.4.3" /* major.minor.patch */
-
 /**
  * NeXus groups are NeXus way of structuring information into a hierarchy.
  * This function creates a group but does not open it.

--- a/Framework/Nexus/test/NexusFileNapiTest.h
+++ b/Framework/Nexus/test/NexusFileNapiTest.h
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <hdf5.h>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -216,8 +217,14 @@ private:
     // NOTE napi_test_cpp.cpp had logic here to print out global attributes
     // should have NeXus_version, file_name, HDF5_Version, and file_time
     std::vector<Mantid::Nexus::AttrInfo> attr_infos = file.getAttrInfos();
-    std::map<std::string, std::string> global_attrs{
-        {"NeXus_version", "4.4.3"}, {"file_name", filename}, {"HDF5_Version", "1.14.6"}, {"file_time", "today's date"}};
+    // set up the correct HDF5 version
+    unsigned major, minor, release;
+    H5get_libversion(&major, &minor, &release);
+    std::string hdf_version = strmakef("%u.%u.%u", major, minor, release);
+    Entries global_attrs{{"NeXus_version", NEXUS_VERSION},
+                         {"file_name", filename},
+                         {"HDF5_Version", hdf_version},
+                         {"file_time", "today's date"}};
     TS_ASSERT_EQUALS(attr_infos.size(), 4);
     for (Mantid::Nexus::AttrInfo const &attr : attr_infos) {
       TS_ASSERT_EQUALS(global_attrs.count(attr.name), 1);


### PR DESCRIPTION
### Description of work

#### Summary of work

In one of the tests of `Nexus::File`, fix a test so that it reads the HDF5 version rather than using a static string.

#### Purpose of work

Fixes a bug in this test.  The tests effectively pinned the HDF5 version.

Bug reported by @jclarkeSTFC 

#### Further detail of work

Also fixed the Nexus version string.

### To test:

In your `mantid-developer` environment, run
``` bash
mamba install "hdf5=1.14.4"
```
and then 
``` bash
ninja NexusTest && ctest -R NexusFileNapiTest
```
It should complete.

Then run
``` bash
mamba install "hdf5=1.14.6"
```
and 
``` bash
ninja NexusTest && ctest -R NexusFIleNapiTest
```

The test should also pass.

This does not require release notes because it is an internal issue.


---


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
