### PR TITLE
`Nexus::File` to use a shared pointer to a `FileID` object

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -37,11 +37,20 @@ namespace Nexus {
 static Entry const EOD_ENTRY(NULL_STR, NULL_STR);
 
 /**
- * FileID
- * Like a hid_t, except makes sure to call close on deletion
+ * \class FileID
+ * \brief A wrapper class for managing HDF5 file handles (hid_t).
+ *
+ * The FileID class is designed to manage the lifecycle of HDF5 file handles (hid_t),
+ * ensuring that the handle is properly closed when the FileID object is destroyed.
+ * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
  */
 class MANTID_NEXUS_DLL FileID {
+private:
   hid_t m_fid;
+  // There is no reason to copy or assign a file ID
+  FileID(FileID const &f) = delete;
+  FileID &operator=(hid_t const) = delete;
+  FileID &operator=(FileID const &) = delete;
 
 public:
   bool operator==(int const v) const { return static_cast<int>(m_fid) == v; }
@@ -50,9 +59,6 @@ public:
   hid_t getId() const { return m_fid; }
   FileID() : m_fid(-1) {}
   FileID(hid_t const v) : m_fid(v) {}
-  FileID(FileID const &f) : m_fid(f.m_fid) {}
-  FileID &operator=(hid_t const);
-  FileID &operator=(FileID const &);
   ~FileID();
 };
 
@@ -129,21 +135,20 @@ public:
    *
    * \param pf Pointer to file to copy over
    */
-  File(File const *const pf);
+  File(File const *const pf) : File(*pf) {}
 
   /**
-   * Copy constructor from pointer
+   * Copy constructor from shared pointer
    *
    * \param pf Pointer to file to copy over
    */
-  File(std::shared_ptr<File> pf);
+  File(std::shared_ptr<File> pf) : File(*pf) {}
 
   /**
-   * Assignment operator, to complete the rule of three
-   *
-   * \param f File to assign
+   * Prohibit assignment, as it can lead to
+   * race conditions when closing the HDF5 file handles
    */
-  File &operator=(File const &f);
+  File &operator=(File const &f) = delete;
 
   /** Destructor. This does close the file. */
   ~File();

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -4,7 +4,6 @@
 #include "MantidNexus/NexusAddress.h"
 #include "MantidNexus/NexusDescriptor.h"
 #include "MantidNexus/NexusFile_fwd.h"
-#include <H5Cpp.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -38,6 +37,27 @@ namespace Nexus {
 static Entry const EOD_ENTRY(NULL_STR, NULL_STR);
 
 /**
+ * FileID
+ * Like a hid_t, except makes sure to call close on deletion
+ */
+class MANTID_NEXUS_DLL FileID {
+  hid_t m_fid;
+
+public:
+  bool operator==(int const v) const { return static_cast<int>(m_fid) == v; }
+  bool operator<=(int const v) const { return static_cast<int>(m_fid) <= v; }
+  operator hid_t const &() const { return m_fid; }
+  hid_t getId() const { return m_fid; }
+  FileID() : m_fid(-1) {}
+  FileID(hid_t const v) : m_fid(v) {}
+  FileID(FileID const &f) : m_fid(f.m_fid) {}
+  FileID &operator=(hid_t const);
+  FileID &operator=(FileID const &);
+  ~FileID();
+  friend File;
+};
+
+/**
  * The Object that allows access to the information in the file.
  * \ingroup cpp_core
  */
@@ -58,10 +78,10 @@ private:
    * \li m_current_group_id -- the ID for currently opened group (or 0 if none)
    * \li m_current_data_id -- the ID for currently opened dataset (or 0 if none)
    * \li m_current_type_id -- the ID of the type of the opened dataset
-   * \li m_current_soace_id -- the ID of the dataspace for the opened dataset
+   * \li m_current_space_id -- the ID of the dataspace for the opened dataset
    * \li m_gid_stack -- a vector stack of opened group IDs
    */
-  std::shared_ptr<H5::H5File> m_pfile;
+  std::shared_ptr<FileID> m_pfile;
   hid_t m_current_group_id;
   hid_t m_current_data_id;
   hid_t m_current_type_id;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -76,8 +76,6 @@ private:
   NXaccess m_access;
   /** The address of currently-opened element */
   NexusAddress m_address;
-  /** should be close handle on exit */
-  bool m_close_handle;
   /** Variables for use inside the C-API, formerly of NexusFile5
    * \li m_pfile -- shared ptr to a H5File object
    * \li m_current_group_id -- the ID for currently opened group (or 0 if none)

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -4,6 +4,7 @@
 #include "MantidNexus/NexusAddress.h"
 #include "MantidNexus/NexusDescriptor.h"
 #include "MantidNexus/NexusFile_fwd.h"
+#include <H5Cpp.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -53,12 +54,14 @@ private:
   /** should be close handle on exit */
   bool m_close_handle;
   /** Variables for use inside the C-API, formerly of NexusFile5
-   * \li m_fid -- the ID for open file object
+   * \li m_pfile -- shared ptr to a H5File object
    * \li m_current_group_id -- the ID for currently opened group (or 0 if none)
-   * \li m_current_data_id -- the ID forcurrently opened dataset (or 0 if none)
+   * \li m_current_data_id -- the ID for currently opened dataset (or 0 if none)
+   * \li m_current_type_id -- the ID of the type of the opened dataset
+   * \li m_current_soace_id -- the ID of the dataspace for the opened dataset
    * \li m_gid_stack -- a vector stack of opened group IDs
    */
-  hid_t m_fid;
+  std::shared_ptr<H5::H5File> m_pfile;
   hid_t m_current_group_id;
   hid_t m_current_data_id;
   hid_t m_current_type_id;
@@ -72,6 +75,8 @@ private:
   NexusDescriptor m_descriptor;
   /** NOTE: this is temporary until `napi` is fully deleted*/
   NexusAddress m_group_address;
+  /** NOTE: this is temporary until `napi` is fully deleted*/
+  hid_t m_fid;
 
   //------------------------------------------------------------------------------------------------------------------
   // CONSTRUCTORS / ASSIGNMENT / DECONSTRUCTOR

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -54,7 +54,6 @@ public:
   FileID &operator=(hid_t const);
   FileID &operator=(FileID const &);
   ~FileID();
-  friend File;
 };
 
 /**

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -125,17 +125,11 @@ namespace Mantid::Nexus {
 
 // new constructors
 
-File::File(const string &filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_current_group_id(0),
-      m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
-      m_descriptor(m_filename, m_access) {
-  this->initOpenFile(m_filename, m_access);
-}
+File::File(const string &filename, const NXaccess access) : File(filename.c_str(), access) {}
 
 File::File(const char *filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_current_group_id(0),
-      m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
-      m_descriptor(m_filename, m_access) {
+    : m_filename(filename), m_access(access), m_address(), m_current_group_id(0), m_current_data_id(0),
+      m_current_type_id(0), m_current_space_id(0), m_gid_stack{0}, m_descriptor(m_filename, m_access) {
   this->initOpenFile(m_filename, m_access);
 }
 
@@ -215,9 +209,8 @@ void File::initOpenFile(std::string const &filename, NXaccess const am) {
 // copy constructors
 
 File::File(File const &f)
-    : m_filename(f.m_filename), m_access(f.m_access), m_address(), m_close_handle(false), m_pfile(f.m_pfile),
-      m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
-      m_descriptor(f.m_descriptor) {
+    : m_filename(f.m_filename), m_access(f.m_access), m_address(), m_pfile(f.m_pfile), m_current_group_id(0),
+      m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0}, m_descriptor(f.m_descriptor) {
   if (m_pfile <= 0)
     throw Mantid::Nexus::Exception("Error reopening file");
 }
@@ -255,11 +248,6 @@ File::~File() {
 void File::close() {
   /* close the file handle */
   if (m_pfile != nullptr) {
-    if (m_pfile.use_count() > 1) {
-      g_log->warning("WARNING: closing file " + m_filename + " which still has open references.");
-    }
-    H5Fclose(m_pfile->getId());
-    H5garbage_collect();
     m_pfile.reset();
   }
 }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -231,7 +231,7 @@ File &File::operator=(File const &f) {
     this->m_filename = f.m_filename;
     this->m_access = f.m_access;
     this->m_address = NexusAddress::root();
-    this->m_pfile = m_pfile;
+    this->m_pfile = f.m_pfile;
     this->m_current_group_id = this->m_current_data_id = this->m_current_type_id = this->m_current_space_id = 0;
     this->m_gid_stack.assign({0});
     this->m_close_handle = f.m_close_handle;

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -113,14 +113,14 @@ namespace Mantid::Nexus {
 // new constructors
 
 File::File(const string &filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_fid(-1), m_current_group_id(0),
+    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_current_group_id(0),
       m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
       m_descriptor(m_filename, m_access) {
   this->initOpenFile(m_filename, m_access);
 }
 
 File::File(const char *filename, const NXaccess access)
-    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_fid(-1), m_current_group_id(0),
+    : m_filename(filename), m_access(access), m_address(), m_close_handle(true), m_current_group_id(0),
       m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
       m_descriptor(m_filename, m_access) {
   this->initOpenFile(m_filename, m_access);
@@ -175,11 +175,11 @@ void File::initOpenFile(std::string const &filename, NXaccess const am) {
     // use H5Cpp to interface with H5Util
     hid_t root_id = H5Gopen(temp_fid, "/", H5P_DEFAULT);
     H5::Group root(root_id);
-    std::vector<std::pair<std::string, std::string>> attrs{{"NeXus_version", NEXUS_VERSION},
-                                                           {"file_name", filename},
-                                                           {"HDF5_Version", version_str},
-                                                           {"file_time", NXIformatNeXusTime()},
-                                                           {group_class_spec, "NXroot"}};
+    std::vector<Entry> attrs{{"NeXus_version", NEXUS_VERSION},
+                             {"file_name", filename},
+                             {"HDF5_Version", version_str},
+                             {"file_time", NXIformatNeXusTime()},
+                             {group_class_spec, "NXroot"}};
     for (auto const &attr : attrs) {
       Mantid::NeXus::H5Util::writeStrAttribute(root, attr.first, attr.second);
     }
@@ -195,40 +195,34 @@ void File::initOpenFile(std::string const &filename, NXaccess const am) {
     msg << "File::initOpenFile(" << filename << ", " << am << ") failed";
     throw NXEXCEPTION(msg.str());
   } else {
-    m_fid = temp_fid;
+    m_pfile = std::make_shared<H5::H5File>(temp_fid);
   }
 }
 
 // copy constructors
 
 File::File(File const &f)
-    : m_filename(f.m_filename), m_access(f.m_access), m_address(f.m_address), m_close_handle(false), m_fid(-1),
+    : m_filename(f.m_filename), m_access(f.m_access), m_address(f.m_address), m_close_handle(false), m_pfile(f.m_pfile),
       m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
       m_descriptor(f.m_descriptor) {
-  if (f.m_fid <= 0)
+  if (m_pfile->getId() <= 0)
     throw Mantid::Nexus::Exception("Error reopening file");
-  else
-    m_fid = f.m_fid;
 }
 
 File::File(File const *const pf)
-    : m_filename(pf->m_filename), m_access(pf->m_access), m_address(pf->m_address), m_close_handle(false), m_fid(-1),
-      m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
-      m_descriptor(pf->m_descriptor) {
-  if (pf->m_fid <= 0)
+    : m_filename(pf->m_filename), m_access(pf->m_access), m_address(pf->m_address), m_close_handle(false),
+      m_pfile(pf->m_pfile), m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0),
+      m_gid_stack{0}, m_descriptor(pf->m_descriptor) {
+  if (m_pfile->getId() <= 0)
     throw Mantid::Nexus::Exception("Error reopening file");
-  else
-    m_fid = pf->m_fid;
 }
 
 File::File(std::shared_ptr<File> pf)
-    : m_filename(pf->m_filename), m_access(pf->m_access), m_address(pf->m_address), m_close_handle(false), m_fid(-1),
-      m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0},
-      m_descriptor(pf->m_descriptor) {
-  if (pf->m_fid <= 0)
+    : m_filename(pf->m_filename), m_access(pf->m_access), m_address(pf->m_address), m_close_handle(false),
+      m_pfile(pf->m_pfile), m_current_group_id(0), m_current_data_id(0), m_current_type_id(0), m_current_space_id(0),
+      m_gid_stack{0}, m_descriptor(pf->m_descriptor) {
+  if (m_pfile->getId() <= 0)
     throw Mantid::Nexus::Exception("Error reopening file");
-  else
-    m_fid = pf->m_fid;
 }
 
 File &File::operator=(File const &f) {
@@ -236,12 +230,13 @@ File &File::operator=(File const &f) {
   } else {
     this->m_filename = f.m_filename;
     this->m_access = f.m_access;
-    this->m_address = f.m_address;
-    this->m_fid = H5Freopen(f.m_fid);
+    this->m_address = NexusAddress::root();
+    this->m_pfile = m_pfile;
     this->m_current_group_id = this->m_current_data_id = this->m_current_type_id = this->m_current_space_id = 0;
     this->m_gid_stack.assign({0});
     this->m_close_handle = f.m_close_handle;
     this->m_descriptor = f.m_descriptor;
+    this->m_fid = -1;
   }
   return *this;
 }
@@ -274,12 +269,20 @@ File::~File() {
   if (m_close_handle) {
     close();
   }
+  m_pfile.reset();
   H5garbage_collect();
 }
 
 void File::close() {
   /* close the file handle */
-  H5Fclose(m_fid);
+  if (m_pfile != nullptr) {
+    // NOTE you actually need both closes
+    H5Fclose(m_pfile->getId());
+    m_pfile->close();
+    H5garbage_collect();
+    m_pfile.reset();
+    m_pfile = nullptr;
+  }
 }
 
 void File::flush() {
@@ -296,6 +299,7 @@ void File::flush() {
 
 NexusFile5 File::getFileStruct() {
   m_group_address = groupAddress(m_address);
+  m_fid = m_pfile->getId();
   return NexusFile5{m_gid_stack,       m_fid,          m_current_group_id, m_current_data_id, m_current_space_id,
                     m_current_type_id, m_group_address};
 }
@@ -384,7 +388,7 @@ hid_t File::getCurrentId() const {
   } else if (m_current_group_id != 0) {
     return m_current_group_id;
   } else {
-    return m_fid;
+    return m_pfile->getId();
   }
 }
 
@@ -394,7 +398,7 @@ std::shared_ptr<H5::H5Object> File::getCurrentObject() const {
   } else if (m_current_group_id != 0) {
     return std::make_shared<H5::Group>(m_current_group_id);
   } else {
-    return std::make_shared<H5::H5File>(m_fid);
+    return m_pfile;
   }
 }
 
@@ -424,8 +428,7 @@ void File::makeGroup(const std::string &name, const std::string &nxclass, bool o
   // get full address
   NexusAddress const absaddr(formAbsoluteAddress(name));
   // create group with H5Util by getting an H5File object from iFID
-  H5::H5File h5file(m_fid);
-  Mantid::NeXus::H5Util::createGroupNXS(h5file, absaddr, nxclass);
+  Mantid::NeXus::H5Util::createGroupNXS(*m_pfile, absaddr, nxclass);
 
   // cleanup
   registerEntry(absaddr, nxclass);
@@ -450,7 +453,7 @@ void File::openGroup(std::string const &name, std::string const &nxclass) {
 
   hid_t iVID;
   if (m_descriptor.isEntry(absaddr, nxclass)) {
-    iVID = H5Gopen(m_fid, absaddr.c_str(), H5P_DEFAULT);
+    iVID = H5Gopen(m_pfile->getId(), absaddr.c_str(), H5P_DEFAULT);
   } else {
     throw NXEXCEPTION("The supplied group " + absaddr + " does not exist");
   }
@@ -534,7 +537,7 @@ void File::openData(std::string const &name) {
 
   /* find the ID number and open the dataset */
   hid_t newData, newType, newSpace;
-  newData = H5Dopen(m_fid, absaddr.c_str(), H5P_DEFAULT);
+  newData = H5Dopen(m_pfile->getId(), absaddr.c_str(), H5P_DEFAULT);
   if (newData < 0) {
     throw NXEXCEPTION("dataset (" + absaddr + ") not found at this level");
   }
@@ -913,7 +916,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
 
   // create the dataset with the compression parameters
   NexusAddress absaddr(formAbsoluteAddress(name));
-  hid_t dataset = H5Dcreate(m_fid, absaddr.c_str(), datatype, dataspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
+  hid_t dataset = H5Dcreate(m_pfile->getId(), absaddr.c_str(), datatype, dataspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
   H5Pclose(cparms);
   if (dataset < 0) {
     H5Tclose(datatype);
@@ -1458,8 +1461,8 @@ Entries File::getEntries() const {
 void File::getEntries(Entries &result) const {
   result.clear();
 
-  int iRet = H5Literate_by_name(m_fid, groupAddress(m_address).c_str(), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr,
-                                gr_iterate_cb, &result, H5P_DEFAULT);
+  int iRet = H5Literate_by_name(m_pfile->getId(), groupAddress(m_address).c_str(), H5_INDEX_NAME, H5_ITER_NATIVE,
+                                nullptr, gr_iterate_cb, &result, H5P_DEFAULT);
   if (iRet < 0) {
     throw NXEXCEPTION("H5Literate failed on group: " + m_address.parent_path());
   }
@@ -1681,7 +1684,8 @@ void File::makeLink(NXlink const &link) {
      of the thing to link
    */
   std::string linkTarget(groupAddress(m_address) / itemName);
-  H5Lcreate_hard(m_fid, link.targetAddress.c_str(), H5L_SAME_LOC, linkTarget.c_str(), H5P_DEFAULT, H5P_DEFAULT);
+  H5Lcreate_hard(m_pfile->getId(), link.targetAddress.c_str(), H5L_SAME_LOC, linkTarget.c_str(), H5P_DEFAULT,
+                 H5P_DEFAULT);
 
   // register the entry
   registerEntry(linkTarget, m_descriptor.classTypeForName(link.targetAddress));

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -248,6 +248,11 @@ File::~File() {
 void File::close() {
   /* close the file handle */
   if (m_pfile != nullptr) {
+    if (m_pfile.use_count() > 1) {
+      g_log->warning("WARNING: closing file " + m_filename + " which still has open references.");
+    }
+    H5Fclose(m_pfile->getId());
+    H5garbage_collect();
     m_pfile.reset();
   }
 }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -195,7 +195,7 @@ void File::initOpenFile(std::string const &filename, NXaccess const am) {
     msg << "File::initOpenFile(" << filename << ", " << am << ") failed";
     throw NXEXCEPTION(msg.str());
   } else {
-    m_pfile = std::make_shared<H5::H5File>(temp_fid);
+    m_pfile = std::make_shared<H5::H5File>(std::move(temp_fid));
   }
 }
 
@@ -281,7 +281,6 @@ void File::close() {
     m_pfile->close();
     H5garbage_collect();
     m_pfile.reset();
-    m_pfile = nullptr;
   }
 }
 

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -99,6 +99,7 @@ public:
   }
 
   void test_double_root() {
+    std::cout << "test double root issue\n" << std::flush;
     // this protects against a regression that could occur, only on Windows,
     // and only in the tests of LoadMuonNexus3 and LoadMuonNexusV2
     std::string filename(NexusTest::getFullPath("EMU00102347.nxs_v2"));
@@ -109,6 +110,7 @@ public:
   }
 
   void test_proper_concat() {
+    std::cout << "test proper concat of addresses\n" << std::flush;
     // this protects against a regression that can occur in LoadILLSANS
     std::string filename = NexusTest::getFullPath("ILL/D16/025786.nxs");
     Mantid::Nexus::NXRoot root(filename);

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -52,15 +52,13 @@ public:
     std::string const szFile(fr.fullPath());
 
     File file_obj(szFile, NXaccess::CREATE5);
-    file_obj.close();
 
     for (int iReOpen = 0; iReOpen < nReOpen; iReOpen++) {
       if (0 == iReOpen % 100) {
         cout << "loop count " << iReOpen << "\n";
       }
 
-      file_obj = File(szFile, NXaccess::RDWR);
-      file_obj.close();
+      File other_file(file_obj);
     }
 
     cout << "Leak Test 1 Success!\n";

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -104,6 +104,13 @@ public:
     TS_ASSERT_EQUALS(result, "test_value2");
   }
 
+  void test_open_real_file() {
+    cout << "\ntest open existing file in unit test data\n";
+    // open the file in read-only mode
+    std::string filename = getFullPath("CG2_monotonically_increasing_pulse_times.nxs.h5");
+    TS_ASSERT_THROWS_NOTHING(Mantid::Nexus::File file(filename, NXaccess::READ));
+  }
+
   void test_fail_open() {
     // test opening a file that exists, but is unreadable
     std::string filename = getFullPath("Test_characterizations_char.txt");
@@ -1455,4 +1462,206 @@ public:
   // ################################################################################################################
 
   /* NOTE for historical reasons these exist in NexusFileReadWriteTest.h*/
+
+  // ##################################################################################################################
+  // TEST RULE OF THREE
+  // ################################################################################################################
+
+  bool file_is_closed(std::string const &filename) {
+    // this will check if a file is already opened, by trying to open it with incompativle (WEAK) access
+    // if this operation FAILS (fid <= 0), then the file is STILL OPENED
+    // if this operation SUCCEEDS (fid > 0), then the file was closed
+    // NOTE is ONLY meaningful AFTER a file with the name has been definitely opened
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_WEAK);
+    hid_t fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+    bool ret = (fid > 0);
+    H5Fclose(fid);
+    return ret;
+  }
+
+  void test_file_is_closed() {
+    cout << "\ntest closing files\n" << std::flush;
+
+    FileResource resource("test_nexus_close.nxs");
+    std::string filename(resource.fullPath());
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    TS_ASSERT(!file_is_closed(filename));
+    file.close();
+    TS_ASSERT(file_is_closed(filename));
+
+    { // scope the file to check deconstructor
+      Mantid::Nexus::File file2(filename, NXaccess::READ);
+      TS_ASSERT(!file_is_closed(filename));
+    }
+    TS_ASSERT(file_is_closed(filename));
+  }
+
+  void test_open_concurrent() {
+    cout << "\ntest open two concurrent files\n" << std::flush;
+
+    FileResource resource("test_nexus_concurrent.nxs");
+    std::string filename(resource.fullPath());
+    // create a file with two entries
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry1", "NXshorts", false);
+    file.makeGroup("entry2", "NXpants", false);
+    file.close();
+    // check the file is closed
+    TS_ASSERT(file_is_closed(filename));
+
+    { // scope the files to verify close
+      // open the file, twice
+      Mantid::Nexus::File file1(filename, NXaccess::READ);
+      Mantid::Nexus::File file2(filename, NXaccess::READ);
+      // go to different entries
+      file1.openGroup("entry1", "NXshorts");
+      file2.openGroup("entry2", "NXpants");
+      // confirm we are in different locations
+      TS_ASSERT_EQUALS(file2.getAddress(), "/entry2");
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+      TS_ASSERT(!file_is_closed(filename));
+    }
+    // check the file is closed
+    TS_ASSERT(file_is_closed(filename));
+  }
+
+  void test_copy_creation() {
+    cout << "\ntest copy creation\n" << std::flush;
+
+    // create a file with two entries
+    FileResource resource("test_nexus_copy_create.nxs");
+    std::string filename(resource.fullPath());
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry1", "NXshorts", true);
+    file.putAttr("info", "some info");
+    file.closeGroup();
+    file.makeGroup("entry2", "NXpants", false);
+    file.close();
+
+    { // scope file1
+      // open the file and go to an entry
+      Mantid::Nexus::File file1(filename, NXaccess::READ);
+      file1.openGroup("entry1", "NXshorts");
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+      TS_ASSERT_EQUALS(file1.getStrAttr("info"), "some info");
+      { // sccope file2
+        // copy the file and go to a different entry
+        Mantid::Nexus::File file2(file1);
+        TS_ASSERT_EQUALS(file2.getAddress(), "/");
+        file2.openGroup("entry2", "NXpants");
+        TS_ASSERT_EQUALS(file2.getAddress(), "/entry2");
+      } // file2 goes out of scope
+
+      // confirm the first did not move
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+      // confirm it can still be interacted with
+      TS_ASSERT_THROWS_NOTHING(file1.getStrAttr("info"));
+      TS_ASSERT_EQUALS(file1.getStrAttr("info"), "some info");
+      TS_ASSERT_THROWS_NOTHING(file1.openAddress("/entry2"));
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry2");
+    }
+    // check the file is closed
+    TS_ASSERT(file_is_closed(filename));
+  }
+
+  void test_assignment() {
+    cout << "\ntest assignmrnt operator\n" << std::flush;
+
+    // create a file with two entries
+    FileResource resource("test_nexus_assignment.nxs");
+    std::string filename(resource.fullPath());
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry1", "NXshorts", false);
+    file.makeGroup("entry2", "NXpants", false);
+    file.close();
+
+    // create a dummy file
+    FileResource resource2("test_nexus_assign2.nxs");
+    std::string filename2(resource2.fullPath());
+    Mantid::Nexus::File other(filename2, NXaccess::CREATE5);
+    other.makeGroup("something", "NXshoes", false);
+    other.close();
+
+    { // scope file1
+      // open the file and go to an entry
+      Mantid::Nexus::File file1(filename, NXaccess::READ);
+      file1.openGroup("entry1", "NXshorts");
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+
+      { // scope the second file
+        // open some other file and go somewhere
+        Mantid::Nexus::File file2(filename2, NXaccess::READ);
+        file2.openGroup("something", "NXshoes");
+        TS_ASSERT_EQUALS(file2.getAddress(), "/something");
+
+        // now use the assignment operator
+        file2 = file1;
+        TS_ASSERT_EQUALS(file2.getAddress(), "/");
+
+        // open a different group and confirm
+        file2.openGroup("entry2", "NXpants");
+        TS_ASSERT_EQUALS(file2.getAddress(), "/entry2");
+      } // file2 goes out of scope
+
+      // confirm the first did not move
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+    } // file1 goes out of scope and file will close
+    // check the file is closed
+    TS_ASSERT(file_is_closed(filename));
+  }
+
+  void test_assignment_closing_other_order() {
+    cout << "\ntest assignment and closing order\n" << std::flush;
+
+    // create a file with two entries
+    FileResource resource("test_nexus_assignment.nxs");
+    std::string filename(resource.fullPath());
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry1", "NXshorts", true);
+    file.putAttr("info", "entry one");
+    file.closeGroup();
+    file.makeGroup("entry2", "NXpants", false);
+    file.close();
+
+    // create a dummy file
+    FileResource resource2("test_nexus_assign2.nxs");
+    std::string filename2(resource2.fullPath());
+    Mantid::Nexus::File other(filename2, NXaccess::CREATE5);
+    other.makeGroup("something", "NXshoes", false);
+    other.close();
+
+    { // scope file1
+      // open the file and go to an entry
+      Mantid::Nexus::File file1(filename2, NXaccess::READ);
+      file1.openGroup("something", "NXshoes");
+      TS_ASSERT_EQUALS(file1.getAddress(), "/something");
+
+      { // scope the second file
+        // open some other file and go somewhere
+        Mantid::Nexus::File file2(filename, NXaccess::READ);
+        file2.openGroup("entry2", "NXpants");
+        TS_ASSERT_EQUALS(file2.getAddress(), "/entry2");
+
+        // now use the assignment operator
+        file1 = file2; // file1 is set to file2, and file2 will close on delete
+        TS_ASSERT_EQUALS(file1.getAddress(), "/");
+
+        // open a different group and confirm
+        file1.openGroup("entry1", "NXshorts");
+        TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+        TS_ASSERT_EQUALS(file1.getStrAttr("info"), "entry one");
+      } // file2 goes out of scope, file1 persists
+
+      // confirm the first did not move
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
+      TS_ASSERT_THROWS_NOTHING(file1.getStrAttr("info"));
+      TS_ASSERT_EQUALS(file1.getStrAttr("info"), "entry one");
+      // go somewhere else
+      TS_ASSERT_THROWS_NOTHING(file1.openAddress("/entry2"));
+      TS_ASSERT_EQUALS(file1.getAddress(), "/entry2");
+    } // file1 goes out of scope, file is closed
+    // check the file is closed
+    TS_ASSERT(file_is_closed(filename));
+  }
 };

--- a/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
@@ -204,6 +204,19 @@ class FocusNoSolidAnglePromptSubtractedTest(systemtesting.MantidSystemTest):
 
 
 class VanadiumAndFocusWithSolidAngleTest(systemtesting.MantidSystemTest):
+    """
+    NOTE changes to the copy or delete methods of Nexus::File can lead to a very strange error occuring here,
+    which will give the message
+        [Error] H5 Exception in execution of algorithm LoadNexusProcessed:
+        [Error] Group::getObjTypeByIdx: H5Gget_objtype_by_idx failed
+    This error is being raised inside the splined vanadium file, VanSplined_66031_hrpd_new_072_01_corr.cal.nxs
+    when trying to access the object type at the address "/mantid_workspace_1/instrument/author".
+    The error is raised inside NexusDescriptor during initialization, as called from the NexusFileLoader algorithm.
+    The cause of the error is very difficult to track down, but occurs due to some
+    conflict with Load, LoadNexus, LoadNexusProcessed1 and LoadNexusProcessed2.
+    Efforts to reproduce the error more directly have failed.
+    """
+
     focus_results = None
     existing_config = config["datasearch.directories"]
 


### PR DESCRIPTION
### Description of work

#### Summary of work

Currently `Nexus::File` uses an `hid_t` as an identifier to an open HDF5 file object.  However, this could potentially cause problems with the close functionality, leading to a memory leak of no one closes the file, or leading to someone closing the file while other tasks are using it.

Using an `H5File` object will ensure that the file is closed (as opposed to the `hid_t` deleted) when the last owner to the pointer releases it.  However, `H5File` is part of the C++ library, and contains a lot of other memory overhead that is not strictly needed in this instance.

Instead a new class `FileID` was created which does exactly what is needed, which is to call `H5Fclose()` when it deletes.  Now `Nexus::File` has a `shared_ptr<FileID>` which can easily handle sharing the same file while making sure the last user closes it.

While doing this, I realized the `Nexus::File` assignment operator can be deleted.  It is not used, and using it could create strange conditions for the file ID.

#### Purpose of work

This is part of #38332 
EWM 11399

#### Further detail of work

The variable `m_fid`, along with `m_groupaddr` will be deleted in the next PR in this series.

There were not formerly unit tests of the rule of three.  This adds tests of copying and deletion of `Nexus::File`

### To test:

This is a refactor.  Ensure all unit and system tests pass.

This does not require release notes because it is an internal matter.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
