### PR TITLE
Small tweak to release day instructions

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -595,8 +595,6 @@ publish a new `release <https://github.com/mantidproject/mantid/releases>`__ on 
 Open a PR updating the software ``doi``, ``date-released`` and ``version`` in the ``CITATION.cff`` file
 at the root of the repository.
 
-Notify the Release Manager when you complete all your tasks.
-
 **Deploy Versioned Documentation**
 
 Versioned documentation is accessible at https://docs.mantidproject.org/vX.Y.Z/.
@@ -613,3 +611,5 @@ To do this:
 * Copy the built documentation into this new directory. The built documentation will be in your mantid build directory at ``<build directory>/docs/html``.
 * Stage the newly created directory and commit it to your branch.
 * After double-checking that these instructions have been followed correctly, push your branch to the main repository to deploy.
+
+Notify the Release Manager when you complete all your tasks.


### PR DESCRIPTION


### Description of work
Move instruction to notify release manager right to the end so that the versioned docs are deployed before they make their announcement, otherwise links might not be operational in time.

*There is no associated issue.*

### To test:
Make sure that:
- dev-docs build with no warnings
- formatting is correct
- my logic is sound

*This does not require release notes* because **it's an update to developer documentation**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
