### PR TITLE
Abins systemtests cleanup

### DIFF
--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -72,8 +72,7 @@ class AbinsTestingMixin(ABC):
 
 class AbinsCRYSTALTestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from scratch with input data from CRYSTAL and for 1-2 quantum
-    order events is correct.
+    Test calculation with input data from CRYSTAL for 1-2 quantum orders.
     """
 
     system_name = "TolueneScratchAbins"
@@ -88,8 +87,7 @@ class AbinsCRYSTALTestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
 
 class AbinsCRYSTALTestBiggerSystem(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from scratch with input data from CRYSTAL and for only 1 quantum
-    order event is correct.
+    Test calculation with input data from CRYSTAL for only 1 quantum order.
     """
 
     system_name = "Crystalb3lypScratchAbins"
@@ -101,15 +99,15 @@ class AbinsCRYSTALTestBiggerSystem(AbinsTestingMixin, systemtesting.MantidSystem
 
 class AbinsCRYSTALTestT(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this scenario a restart is considered in which data for other
-    temperature already exists in an hdf file.
+    Test a restart in which data for other temperature already exists in cache.
 
     First a simulation is run for T=10K; then a T=20K for which S has to be
     recalculated. After that another T=10K simulation is requested; the other
     parameters are identical across calculations. In the third run the required
-    data /should/ be read from the hdf file. We only check that here that the
-    results are correct.
+    data /should/ be read from the hdf file.
 
+    We only check that here that the results are correct, we cannot tell if the
+    cache was used.
     """
 
     system_name = "TolueneTAbins"
@@ -137,8 +135,7 @@ class AbinsCRYSTALTestT(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
 class AbinsCRYSTALTestLargerOrder(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from restart with input data from CRYSTAL is correct. Requested order
-    of quantum event is larger than the one which is saved to an hdf file so S has to be calculated.
+    Test calculation of order 1-2 when cache already contains order 1
     """
 
     system_name = "TolueneLargerOrderAbins"
@@ -160,8 +157,7 @@ class AbinsCRYSTALTestLargerOrder(AbinsTestingMixin, systemtesting.MantidSystemT
 
 class AbinsCRYSTALTestSmallerOrder(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from restart with input data from CRYSTAL is correct. Requested
-    order of quantum event is smaller than the one which is saved to an hdf file so S is loaded from an hdf file.
+    Test calculation of order 1 when cache already contains orders 1-2
     """
 
     system_name = "TolueneSmallerOrderAbins"
@@ -180,7 +176,7 @@ class AbinsCRYSTALTestSmallerOrder(AbinsTestingMixin, systemtesting.MantidSystem
 
 class AbinsCRYSTALTestScale(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if scaling is correct.
+    Test result scaling with Scale parameter
     """
 
     system_name = "TolueneScale"
@@ -198,7 +194,11 @@ class AbinsCRYSTALTestScale(AbinsTestingMixin, systemtesting.MantidSystemTest):
 # noinspection PyAttributeOutsideInit,PyPep8Naming
 class AbinsCASTEPNoH(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation for systems without H is correct.
+    Test if calculation for systems without H is correct
+
+    (Other elements are treated identically, but H tends to dominate the
+    results and its mass of 1 could cause some operations to get the right
+    result for the wrong reason!)
     """
 
     system_name = "Na2SiF6_CASTEP"
@@ -211,7 +211,9 @@ class AbinsCASTEPNoH(AbinsTestingMixin, systemtesting.MantidSystemTest):
 # noinspection PyAttributeOutsideInit,PyPep8Naming
 class AbinsCASTEP1DDispersion(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation of S from phonon dispersion is correct (1D case).
+    Tested calculation of S from CASTEP phonon dispersion data (1D case).
+
+    Note that this is NOT good practice, but some users will do it anyway.
     """
 
     system_name = "Mapi"
@@ -223,8 +225,7 @@ class AbinsCASTEP1DDispersion(AbinsTestingMixin, systemtesting.MantidSystemTest)
 
 class AbinsDMOL3TestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from scratch with input data from DMOL3 and for 1-2 quantum
-    order events is correct.
+    Test calculation with input data from DMOL3 for 1-2 quantum orders.
     """
 
     system_name = "Na2SiF6_DMOL3"
@@ -239,8 +240,7 @@ class AbinsDMOL3TestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
 class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation from scratch with input data from GAUSSIAN and for 1-4 quantum
-    order events is correct.
+    Test calculation with input data from GAUSSIAN for 1-2 quantum orders.
     """
 
     system_name = "C6H5Cl-Gaussian"
@@ -255,9 +255,7 @@ class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
 
 class AbinsBinWidth(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation with bin width different than the default value is correct.
-    Calculation performed for crystalline benzene for 1st and 2nd quantum event for output from CASTEP and bin width
-    3 cm^-1. This system test should be fast so no need for excludeInPullRequests flag.
+    Test calculation with bin width different than the default value.
     """
 
     system_name = "BenzeneBinWidthCASTEP"
@@ -269,9 +267,7 @@ class AbinsBinWidth(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
 class AbinsCASTEPIsotopes(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
-    In this benchmark it is tested if calculation of the system with isotopic substitutions: H -> 2H, Li -> 7Li,
-    produces correct results. Input data is generated by CASTEP. This system test should be fast so no need for
-    excludeInPullRequests flag.
+    Test calculation with isotopic substitutions: H -> 2H, Li -> 7Li.
     """
 
     system_name = "LiOH_H2O_2D2O_CASTEP"

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -29,6 +29,9 @@ class AbinsTestingMixin(ABC):
     def __init__(self):
         super().__init__()  # Init the base class as well as this mix-in
 
+        # Tolerance used when calling validate()
+        self.tolerance = 1e-2
+
         # This is usually the ref result, can always override later if needed
         self.ref_result = self.system_name + ".nxs"
 
@@ -63,7 +66,6 @@ class AbinsTestingMixin(ABC):
         mtd.clear()
 
     def validate(self):
-        self.tolerance = 1e-1
         return self.system_name, self.ref_result
 
 
@@ -81,10 +83,6 @@ class AbinsCRYSTALTestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
 
     def excludeInPullRequests(self):
         return True
-
-    def validate(self):
-        self.tolerance = 1e-2
-        return self.system_name, self.ref_result
 
 
 class AbinsCRYSTALTestBiggerSystem(AbinsTestingMixin, systemtesting.MantidSystemTest):
@@ -130,6 +128,11 @@ class AbinsCRYSTALTestT(AbinsTestingMixin, systemtesting.MantidSystemTest):
     def excludeInPullRequests(self):
         return True
 
+    def validate(self):
+        """Loosen validation parameters for this test case"""
+        self.tolerance = 1e-1
+        return super().validate()
+
 
 class AbinsCRYSTALTestLargerOrder(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -148,6 +151,11 @@ class AbinsCRYSTALTestLargerOrder(AbinsTestingMixin, systemtesting.MantidSystemT
     def excludeInPullRequests(self):
         return True
 
+    def validate(self):
+        """Loosen validation parameters for this test case"""
+        self.tolerance = 1e-1
+        return super().validate()
+
 
 class AbinsCRYSTALTestSmallerOrder(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -163,6 +171,11 @@ class AbinsCRYSTALTestSmallerOrder(AbinsTestingMixin, systemtesting.MantidSystem
         DeleteWorkspace(self.system_name)
         Abins(**self.default_kwargs)
 
+    def validate(self):
+        """Loosen validation parameters for this test case"""
+        self.tolerance = 1e-1
+        return super().validate()
+
 
 class AbinsCRYSTALTestScale(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -174,6 +187,11 @@ class AbinsCRYSTALTestScale(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
     def runTest(self):
         Abins(**(self.default_kwargs | {"QuantumOrderEventsNumber": "2", "Scale": 2.0}))
+
+    def validate(self):
+        """Loosen validation parameters for this test case"""
+        self.tolerance = 1e-1
+        return super().validate()
 
 
 # noinspection PyAttributeOutsideInit,PyPep8Naming
@@ -217,10 +235,6 @@ class AbinsDMOL3TestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     def excludeInPullRequests(self):
         return True
 
-    def validate(self):
-        self.tolerance = 1e-2
-        return self.system_name, self.ref_result
-
 
 class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -237,10 +251,6 @@ class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
     def excludeInPullRequests(self):
         return True
 
-    def validate(self):
-        self.tolerance = 1e-2
-        return self.system_name, self.ref_result
-
 
 class AbinsBinWidth(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -255,10 +265,6 @@ class AbinsBinWidth(AbinsTestingMixin, systemtesting.MantidSystemTest):
     def runTest(self):
         Abins(**(self.default_kwargs | {"QuantumOrderEventsNumber": "2", "BinWidthInWavenumber": 3.0}))
 
-    def validate(self):
-        self.tolerance = 1e-2
-        return self.system_name, self.ref_result
-
 
 class AbinsCASTEPIsotopes(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -272,10 +278,6 @@ class AbinsCASTEPIsotopes(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
     def runTest(self):
         Abins(**(self.default_kwargs | {"BinWidthInWavenumber": 2.0}))
-
-    def validate(self):
-        self.tolerance = 1e-2
-        return self.system_name, self.ref_result
 
 
 class AbinsCRYSTAL2D(AbinsTestingMixin, systemtesting.MantidSystemTest):
@@ -305,6 +307,7 @@ class AbinsCRYSTAL2D(AbinsTestingMixin, systemtesting.MantidSystemTest):
         )
 
     def validate(self):
+        """Tweak validation parameters for this test case"""
         self.tolerance = 1e-4
         self.nanEqual = True
-        return self.system_name, self.ref_result
+        super().validate()

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -14,8 +14,6 @@ from abins.constants import (
     ALL_SUPPORTED_AB_INITIO_PROGRAMS,
     QUANTUM_ORDER_ONE,
     QUANTUM_ORDER_TWO,
-    QUANTUM_ORDER_THREE,
-    QUANTUM_ORDER_FOUR,
 )
 
 
@@ -63,7 +61,7 @@ class HelperTestingClass:
             raise RuntimeError("Unsupported ab initio program: %s " % ab_initio_program)
 
     def set_order(self, order=None):
-        orders = [QUANTUM_ORDER_ONE, QUANTUM_ORDER_TWO, QUANTUM_ORDER_THREE, QUANTUM_ORDER_FOUR]
+        orders = [QUANTUM_ORDER_ONE, QUANTUM_ORDER_TWO]
 
         if order in orders:
             self._quantum_order_event = order

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -81,9 +81,6 @@ class AbinsCRYSTALTestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
     def runTest(self):
         Abins(**(self.default_kwargs) | {"QuantumOrderEventsNumber": "2"})
 
-    def excludeInPullRequests(self):
-        return True
-
 
 class AbinsCRYSTALTestBiggerSystem(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -124,9 +121,6 @@ class AbinsCRYSTALTestT(AbinsTestingMixin, systemtesting.MantidSystemTest):
         for case_kwargs in (case_1_kwargs, case_2_kwargs, case_3_kwargs):
             Abins(**case_kwargs)
 
-    def excludeInPullRequests(self):
-        return True
-
     def validate(self):
         """Loosen validation parameters for this test case"""
         self.tolerance = 1e-1
@@ -145,9 +139,6 @@ class AbinsCRYSTALTestLargerOrder(AbinsTestingMixin, systemtesting.MantidSystemT
         Abins(**self.default_kwargs)
         DeleteWorkspace(self.system_name)
         Abins(**(self.default_kwargs | {"QuantumOrderEventsNumber": "2"}))
-
-    def excludeInPullRequests(self):
-        return True
 
     def validate(self):
         """Loosen validation parameters for this test case"""
@@ -234,9 +225,6 @@ class AbinsDMOL3TestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     def runTest(self):
         Abins(**(self.default_kwargs | {"QuantumOrderEventsNumber": "2", "ScaleByCrossSection": "Total"}))
 
-    def excludeInPullRequests(self):
-        return True
-
 
 class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest):
     """
@@ -248,9 +236,6 @@ class AbinsGAUSSIANestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
 
     def runTest(self):
         Abins(**(self.default_kwargs | {"QuantumOrderEventsNumber": "2"}))
-
-    def excludeInPullRequests(self):
-        return True
 
 
 class AbinsBinWidth(AbinsTestingMixin, systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -11,10 +11,6 @@ from types import MappingProxyType
 import systemtesting
 from mantid.simpleapi import Abins, Abins2D, mtd, DeleteWorkspace
 
-from abins.constants import (
-    QUANTUM_ORDER_TWO,
-)
-
 
 class AbinsTestingMixin(ABC):
     _extensions = {"CASTEP": ".phonon", "CRYSTAL": ".out", "DMOL3": ".outmol", "GAUSSIAN": ".log"}
@@ -79,7 +75,7 @@ class AbinsCRYSTALTestScratch(AbinsTestingMixin, systemtesting.MantidSystemTest)
     ab_initio_program = "CRYSTAL"
 
     def runTest(self):
-        Abins(**(self.default_kwargs) | {"QuantumOrderEventsNumber": str(QUANTUM_ORDER_TWO)})
+        Abins(**(self.default_kwargs) | {"QuantumOrderEventsNumber": "2"})
 
     def excludeInPullRequests(self):
         return True

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -19,6 +19,7 @@ class AbinsTestingMixin(ABC):
     @abstractmethod
     def system_name(self) -> str: ...
 
+    @property
     @abstractmethod
     def ab_initio_program(self) -> str: ...
 

--- a/Testing/SystemTests/tests/framework/AbinsTest.py
+++ b/Testing/SystemTests/tests/framework/AbinsTest.py
@@ -13,7 +13,7 @@ from mantid.simpleapi import Abins, Abins2D, mtd, DeleteWorkspace
 
 
 class AbinsTestingMixin(ABC):
-    _extensions = {"CASTEP": ".phonon", "CRYSTAL": ".out", "DMOL3": ".outmol", "GAUSSIAN": ".log"}
+    _extensions = {"CASTEP": "phonon", "CRYSTAL": "out", "DMOL3": "outmol", "GAUSSIAN": "log"}
 
     @property
     @abstractmethod
@@ -22,6 +22,10 @@ class AbinsTestingMixin(ABC):
     @property
     @abstractmethod
     def ab_initio_program(self) -> str: ...
+
+    @property
+    def ext(self) -> str:
+        return self._extensions[self.ab_initio_program]
 
     def __init__(self):
         super().__init__()  # Init the base class as well as this mix-in
@@ -39,7 +43,7 @@ class AbinsTestingMixin(ABC):
         self.default_kwargs = MappingProxyType(
             {
                 "AbInitioProgram": self.ab_initio_program,
-                "VibrationalOrPhononFile": self.system_name + self._extensions[self.ab_initio_program],
+                "VibrationalOrPhononFile": f"{self.system_name}.{self.ext}",
                 "TemperatureInKelvin": 10,
                 "SampleForm": "Powder",
                 "Instrument": "TOSCA",
@@ -290,7 +294,7 @@ class AbinsCRYSTAL2D(AbinsTestingMixin, systemtesting.MantidSystemTest):
 
         Abins2D(
             AbInitioProgram="CRYSTAL",
-            VibrationalOrPhononFile="TolueneScratchAbins" + self._extensions[self.ab_initio_program],
+            VibrationalOrPhononFile=f"TolueneScratchAbins.{self.ext}",
             TemperatureInKelvin=10,
             Instrument="MARI",
             Atoms="",


### PR DESCRIPTION
### Description of work

~~Currently includes changes from #39669 , will rebase when that is merged~~

#### Summary of work
Tidy up and simplify Abins systemtests. With a better base class setup we need a lot less boilerplate and the tests themselves can call Abins algorithm directly without too many lines of code. This seems a better verbosity/clarity tradeoff than the existing design.

This should make the systemtests faster and easier to debug, fix and extend.

Some slow systemtests are currently disabled for pull-requests, only running during full checks. These run quite quickly now due to performance improvements in Abins, so have been re-enabled.

#### Further detail of work
The existing implementation of Abins systemtests involves a lot of boilerplate. The calls to Abins algorithms are abstracted by method calls, and parameters are set individually following a kind of "builder" pattern.

That pattern provides some validation of appropriate parameters, but a test suite is not a good place to have such validation. We are supposed to be testing the behaviour of the production code when it is fed whatever paramteters we choose to test!

By providing a default dictionary attribute and using compact `{some: dict} | {data: update}` notation to produce modified copies, we can make direct calls to Abins that express their intent clearly and avoid the need to read back-and-forth in the file to make sense of each test.

### To test:

This change updates the logic of some systemtests but not the reference data. If all is well, they should run without issue.

*This does not require release notes* because **only testing is affected**.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
