### PR TITLE
Allow AlignAndFocusPowderSlim to filter bad pulses during loading

### DIFF
--- a/Framework/Algorithms/src/FilterBadPulses.cpp
+++ b/Framework/Algorithms/src/FilterBadPulses.cpp
@@ -79,7 +79,7 @@ void FilterBadPulses::exec() {
   // workspace
   auto filterAlgo = createChildAlgorithm("FilterByLogValue", 0., 1.);
   filterAlgo->setProperty("InputWorkspace", inputWS);
-  filterAlgo->setProperty("LogName", "proton_charge");
+  filterAlgo->setProperty("LogName", LOG_CHARGE_NAME);
   filterAlgo->setProperty("MinimumValue", min_pcharge);
   filterAlgo->setProperty("MaximumValue", max_pcharge);
   filterAlgo->execute();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -364,7 +364,7 @@ void AlignAndFocusPowderSlim::exec() {
     const int DISK_CHUNK = getProperty(PropertyNames::READ_SIZE_FROM_DISK);
     const int GRAINSIZE_EVENTS = getProperty(PropertyNames::EVENTS_PER_THREAD);
     auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
-    g_log.debug() << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n"; // TODO REMOVE debug print
+    g_log.debug() << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n";
     ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, wksp, m_calibration, m_masked,
                          static_cast<size_t>(DISK_CHUNK), static_cast<size_t>(GRAINSIZE_EVENTS), pulse_indices,
                          progress);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -172,11 +172,12 @@ void AlignAndFocusPowderSlim::init() {
   auto mustBePositive = std::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(0);
   declareProperty(PropertyNames::SPLITTER_TARGET, 0, mustBePositive, "The target workspace index for the splitter.");
-  declareProperty(PropertyNames::FILTER_BAD_PULSES, false, "FilterBadPules");
+  declareProperty(PropertyNames::FILTER_BAD_PULSES, false,
+                  "Filter bad pulses in the same way that :ref:`algm-FilterBadPulses` does.");
   auto range = std::make_shared<BoundedValidator<double>>();
   range->setBounds(0., 100.);
   declareProperty(PropertyNames::FILTER_BAD_PULSES_LOWER_CUTOFF, 95., range,
-                  "The percentage of the average to use as the lower bound");
+                  "The percentage of the average to use as the lower bound when filtering bad pulses.");
   const std::vector<std::string> cal_exts{".h5", ".hd5", ".hdf", ".cal"};
   declareProperty(std::make_unique<FileProperty>(PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad, cal_exts),
                   "The .cal file containing the position correction factors. Either this or OffsetsWorkspace needs to "

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -547,6 +547,7 @@ void AlignAndFocusPowderSlim::determinePulseIndices(const API::MatrixWorkspace_s
 
     const auto log = dynamic_cast<const TimeSeriesProperty<double> *>(wksp->run().getLogData(LOG_CHARGE_NAME));
     if (log) {
+      // need to have centre=true for proton_charge
       roi = log->makeFilterByValue(min_pcharge, max_pcharge, true, Mantid::Kernel::TimeInterval(run_start, run_stop),
                                    0.0, true, &roi);
     }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -364,7 +364,7 @@ void AlignAndFocusPowderSlim::exec() {
     const int DISK_CHUNK = getProperty(PropertyNames::READ_SIZE_FROM_DISK);
     const int GRAINSIZE_EVENTS = getProperty(PropertyNames::EVENTS_PER_THREAD);
     auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
-    std::cout << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n"; // TODO REMOVE debug print
+    g_log.debug() << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n"; // TODO REMOVE debug print
     ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, wksp, m_calibration, m_masked,
                          static_cast<size_t>(DISK_CHUNK), static_cast<size_t>(GRAINSIZE_EVENTS), pulse_indices,
                          progress);
@@ -480,6 +480,7 @@ API::MatrixWorkspace_sptr AlignAndFocusPowderSlim::editInstrumentGeometry(
     API::MatrixWorkspace_sptr &wksp, const double l1, const std::vector<double> &polars,
     const std::vector<specnum_t> &specids, const std::vector<double> &l2s, const std::vector<double> &azimuthals) {
   API::IAlgorithm_sptr editAlg = createChildAlgorithm("EditInstrumentGeometry");
+  editAlg->setLoggingOffset(1);
   editAlg->setProperty("Workspace", wksp);
   if (l1 > 0.)
     editAlg->setProperty("PrimaryFlightPath", l1);
@@ -535,12 +536,11 @@ void AlignAndFocusPowderSlim::determinePulseIndices(const API::MatrixWorkspace_s
   // filter bad pulses
   if (getProperty(PropertyNames::FILTER_BAD_PULSES)) {
     this->progress(.16, "Filtering bad pulses");
-    g_log.information() << "Filtering bad pulses\n";
 
     // get limits from proton_charge
     const auto [min_pcharge, max_pcharge, mean] =
         wksp->run().getBadPulseRange(LOG_CHARGE_NAME, getProperty(PropertyNames::FILTER_BAD_PULSES_LOWER_CUTOFF));
-    g_log.information() << "Filtering pcharge outside of " << min_pcharge << " to " << max_pcharge << '\n';
+    g_log.information() << "Filtering bad pulses; pcharge outside of " << min_pcharge << " to " << max_pcharge << '\n';
 
     const auto run_start = wksp->getFirstPulseTime();
     const auto run_stop = wksp->getLastPulseTime();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -6,19 +6,22 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "ProcessBankTask.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
 #include "MantidNexus/H5Util.h"
 #include "ProcessEventsTask.h"
 #include "tbb/parallel_for.h"
 #include "tbb/parallel_reduce.h"
-#include <iostream>
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 namespace {
 
 const std::string MICROSEC("microseconds");
+
+// Logger for this class
+auto g_log = Kernel::Logger("ProcessBankTask");
 
 template <typename Type> class MinMax {
   const std::vector<Type> *vec;
@@ -74,7 +77,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
   for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
     const auto &bankName = m_bankEntries[wksp_index];
     Kernel::Timer timer;
-    std::cout << bankName << " start" << std::endl;
+    g_log.debug() << bankName << " start" << std::endl;
 
     // open the bank
     auto event_group = entry.openGroup(bankName); // type=NXevent_data
@@ -158,7 +161,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
         oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
       }
       oss << "\n";
-      std::cout << oss.str();
+      g_log.debug() << oss.str();
 
       // load detid and tof at the same time
       tbb::parallel_invoke(
@@ -198,7 +201,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     auto &y_values = spectrum.dataY();
     std::copy(y_temp.cbegin(), y_temp.cend(), y_values.begin());
 
-    std::cout << bankName << " stop " << timer << std::endl;
+    g_log.debug() << bankName << " stop " << timer << std::endl;
     m_progress->report();
   }
 }

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -54,11 +54,11 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
     splitter.addRow((400,410, '0'))
 
     # pass the splitter table to AlignAndFocusPowderSlim
-    ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
-                               SplitterWorkspace=splitter, RelativeTime=True,
-                               XMin=0, XMax=50000, XDelta=50000,
-                               BinningMode="Linear",
-                               BinningUnits="TOF")
+    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
+                                 SplitterWorkspace=splitter, RelativeTime=True,
+                                 XMin=0, XMax=50000, XDelta=50000,
+                                 BinningMode="Linear",
+                                 BinningUnits="TOF")
 
     # This is equivalent to using FilterEvents with the same splitter table.
     # But note that this example doesn't align the data so put everything in 1 big bin to compare.
@@ -92,8 +92,28 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                          MaximumLogValue=70.15)
 
     # Use the splitter table to filter the events during loading
-    ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter')
+    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter')
 
+
+**Example - filter bad pulses**
+
+.. code-block:: python
+
+    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
+                                 XMin=0, XMax=50000, XDelta=50000,
+                                 BinningMode="Linear",
+                                 BinningUnits="TOF",
+                                 FilterBadPulses=True)
+
+    # This is equivalent to using FilterBadPulses.
+    # But note that this example doesn't align the data so put everything in 1 big bin to compare.
+    ws2 = LoadEventNexus("VULCAN_218062.nxs.h5")
+    grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
+    ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="grp")
+    ws2 = FilterBadPulses(ws2)
+    ws2 = Rebin(ws2, "0,50000,50000", PreserveEvents=False)
+
+    CompareWorkspaces(ws, ws2, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
 
 .. note::
 

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -25,7 +25,6 @@ Current limitations compared to ``AlignAndFocusPowderFromFiles``
 - hard coded for 6 particular groups
 - does not support copping data
 - does not support removing prompt pulse
-- does not support removing bad pulses
 
 Child algorithms used are
 

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39740.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39740.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` can now filter out bad pulses during loading.


### PR DESCRIPTION
### Description of work

This includes the changes from  #39721 and should be reviewed after.

This includes the functionality of [FilterBadPulses](https://docs.mantidproject.org/nightly/algorithms/FilterBadPulses-v1.html) in [AlignAndFocusPowderSlim](https://docs.mantidproject.org/nightly/algorithms/AlignAndFocusPowderSlim-v1.html) so "bad pulses" can be excluded during loading.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [12244: Add ability to filter like FilterBadPulses](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/12244)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You can compare this to using other algorithms

```python
ws_aafps=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF", FilterBadPulses=True)
```

should be the same result as (note in this we are aligning the data so must test with one big bin)

```python
ws = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")
ws = FilterBadPulses(ws)
ws = Rebin(ws, "0,50000,50000", PreserveEvents=False)
```

The data should be the same, there are differences in the instrument and AlignAndFocusPowderSlim does not yet set the uncertainty.

```python
CompareWorkspaces(ws, ws_aafps, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
