### PR TITLE
Nexus to use unsigned dimensions

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -63,7 +63,7 @@ public:
 
 private:
   template <typename ValueType>
-  void readData(Nexus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start);
+  void readData(Nexus::File &file, std::size_t numValues, Mantid::Types::Core::DateAndTime &start);
 
   /// This determines the start time by finding the minimum value in the array
   void updateStartTime();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/Task.h"
 #include "MantidKernel/ThreadScheduler.h"
+#include "MantidNexus/NexusFile_fwd.h"
 
 #include <cstdint>
 
@@ -63,9 +64,9 @@ private:
   std::string m_detIdFieldName;
   std::string m_timeOfFlightFieldName;
   /// Index to load start at in the file
-  std::vector<int64_t> m_loadStart;
+  Nexus::DimVector m_loadStart;
   /// How much to load in the file
-  std::vector<int64_t> m_loadSize;
+  Nexus::DimVector m_loadSize;
   /// Minimum pixel ID in this data
   uint32_t m_min_id;
   /// Maximum pixel ID in this data

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
@@ -38,11 +38,12 @@ public:
 private:
   void loadPulseTimes(Nexus::File &file);
   std::unique_ptr<std::vector<uint64_t>> loadEventIndex(Nexus::File &file);
-  void prepareEventId(Nexus::File &file, int64_t &start_event, int64_t &stop_event, const uint64_t &start_event_index);
+  void prepareEventId(Nexus::File &file, uint64_t &start_event, uint64_t &stop_event,
+                      const uint64_t &start_event_index);
   std::unique_ptr<std::vector<uint32_t>> loadEventId(Nexus::File &file);
   std::unique_ptr<std::vector<float>> loadTof(Nexus::File &file);
   std::unique_ptr<std::vector<float>> loadEventWeights(Nexus::File &file);
-  int64_t recalculateDataSize(const int64_t size);
+  uint64_t recalculateDataSize(const int64_t size);
 
   /// Algorithm being run
   DefaultEventLoader &m_loader;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -20,6 +20,7 @@ namespace DataHandling {
 /** LoadHelper : Auxiliary functions for Loading Files
  */
 namespace LoadHelper {
+using detid_t = int32_t;
 
 std::string findInstrumentNexusAddress(const Mantid::Nexus::NXEntry &);
 std::string getStringFromNexusAddress(const Mantid::Nexus::NXEntry &, const std::string &);
@@ -41,14 +42,14 @@ void loadEmptyInstrument(const API::MatrixWorkspace_sptr &ws, const std::string 
 
 void fillStaticWorkspace(const API::MatrixWorkspace_sptr &, const Mantid::Nexus::NXInt &,
                          const std::vector<double> &xAxis, int64_t initialSpectrum = 0, bool pointData = false,
-                         const std::vector<int> &detectorIDs = std::vector<int>(),
-                         const std::set<int> &acceptedID = std::set<int>(),
+                         const std::vector<detid_t> &detectorIDs = std::vector<int>(),
+                         const std::set<detid_t> &acceptedID = std::set<int>(),
                          const std::tuple<short, short, short> &axisOrder = std::tuple<short, short, short>(0, 1, 2));
 
 void fillMovingWorkspace(const API::MatrixWorkspace_sptr &, const Mantid::Nexus::NXInt &,
                          const std::vector<double> &xAxis, int64_t initialSpectrum = 0,
-                         const std::set<int> &acceptedID = std::set<int>(),
-                         const std::vector<int> &customID = std::vector<int>(),
+                         const std::set<detid_t> &acceptedID = std::set<int>(),
+                         const std::vector<detid_t> &customID = std::vector<int>(),
                          const std::tuple<short, short, short> &axisOrder = std::tuple<short, short, short>(0, 1, 2));
 
 void loadingOrder(const std::tuple<short, short, short> &axisOrder, int *dataIndices);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
@@ -53,15 +53,15 @@ private:
   std::string m_instrumentName; ///< Name of the instrument
 
   // Variables describing the data in the detector
-  size_t m_numberOfTubes;           // number of tubes - X
-  size_t m_numberOfPixelsPerTube;   // number of pixels per tube - Y
-  size_t m_numberOfChannels;        // time channels - Z
-  size_t m_numberOfSimpleDetectors; // number of simple detector
-  size_t m_numberOfMonitors;        // number of monitors
-  std::set<int> m_activeSDIndices;  // set of Single Detector indices,
-                                    // that were actually active
-  bool m_bats;                      // A flag marking the BATS mode
-  size_t m_firstTubeAngleRounded;   // A flag holding the rounded angle of the first tube
+  size_t m_numberOfTubes;              // number of tubes - X
+  size_t m_numberOfPixelsPerTube;      // number of pixels per tube - Y
+  size_t m_numberOfChannels;           // time channels - Z
+  size_t m_numberOfSimpleDetectors;    // number of simple detector
+  size_t m_numberOfMonitors;           // number of monitors
+  std::set<int32_t> m_activeSDIndices; // set of Single Detector indices,
+                                       // that were actually active
+  bool m_bats;                         // A flag marking the BATS mode
+  size_t m_firstTubeAngleRounded;      // A flag holding the rounded angle of the first tube
 
   std::vector<std::string> m_supportedInstruments;
   std::string m_loadOption;

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXTomo.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXTomo.h
@@ -90,9 +90,9 @@ private:
 
   /// Write various pieces of data from the workspace log with checks on the
   /// structure of the nexus file
-  void writeLogValues(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd);
-  void writeIntensityValue(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd);
-  void writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd);
+  void writeLogValues(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd);
+  void writeIntensityValue(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd);
+  void writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd);
 
   /// Main exec routine, called for group or individual workspace processing.
   void processAll();

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXTomo.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXTomo.h
@@ -13,6 +13,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidNexus/NexusFile_fwd.h"
 #include <vector>
 
 namespace Mantid {
@@ -101,14 +102,14 @@ private:
   bool m_includeError;
   bool m_overwriteFile;
   size_t m_spectraCount;
-  std::vector<int64_t> m_slabStart;
-  std::vector<int64_t> m_slabSize;
+  Nexus::DimVector m_slabStart;
+  Nexus::DimVector m_slabSize;
   /// The filename of the output file
   std::string m_filename;
   // Dimensions for axis in nxTomo file.
-  std::vector<int64_t> m_dimensions;
+  Nexus::DimVector m_dimensions;
   // Infinite file range dimensions / for use with makeData data and error
-  std::vector<int64_t> m_infDimensions;
+  Nexus::DimVector m_infDimensions;
 
   /// file format version
   static const std::string NXTOMO_VER;

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -94,14 +94,13 @@ BankPulseTimes::BankPulseTimes(Nexus::File &file, const std::vector<int> &period
 template <typename ValueType>
 void BankPulseTimes::readData(Nexus::File &file, uint64_t numValues, Mantid::Types::Core::DateAndTime &start) {
   Nexus::DimVector indexStart{0};
-  Nexus::DimVector indexStep{
-      std::min(static_cast<Nexus::dimsize_t>(numValues), Nexus::dimsize_t(12 * 3600 * 60))}; // 12 hour at 60Hz
+  Nexus::DimVector indexStep{std::min(numValues, Nexus::dimsize_t(12 * 3600 * 60))}; // 12 hour at 60Hz
 
   // getSlab needs the data allocated already
   std::vector<ValueType> rawData(indexStep[0]);
 
   // loop over chunks of data and transform each chunk
-  while ((indexStep[0] > 0) && (indexStart[0] < static_cast<Nexus::dimsize_t>(numValues))) {
+  while ((indexStep[0] > 0) && (indexStart[0] < numValues)) {
     file.getSlab(rawData.data(), indexStart, indexStep);
 
     // Now create the pulseTimes
@@ -110,7 +109,7 @@ void BankPulseTimes::readData(Nexus::File &file, uint64_t numValues, Mantid::Typ
 
     // increment the slab to get
     indexStart[0] += indexStep[0];
-    indexStep[0] = std::min(indexStep[0], static_cast<Nexus::dimsize_t>(numValues) - indexStart[0]);
+    indexStep[0] = std::min(indexStep[0], numValues - indexStart[0]);
     // resize the vector
     rawData.resize(indexStep[0]);
   }

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -92,7 +92,7 @@ BankPulseTimes::BankPulseTimes(Nexus::File &file, const std::vector<int> &period
 }
 
 template <typename ValueType>
-void BankPulseTimes::readData(Nexus::File &file, uint64_t numValues, Mantid::Types::Core::DateAndTime &start) {
+void BankPulseTimes::readData(Nexus::File &file, std::size_t numValues, Mantid::Types::Core::DateAndTime &start) {
   Nexus::DimVector indexStart{0};
   Nexus::DimVector indexStep{std::min(numValues, Nexus::dimsize_t(12 * 3600 * 60))}; // 12 hour at 60Hz
 

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -94,7 +94,7 @@ BankPulseTimes::BankPulseTimes(Nexus::File &file, const std::vector<int> &period
 template <typename ValueType>
 void BankPulseTimes::readData(Nexus::File &file, std::size_t numValues, Mantid::Types::Core::DateAndTime &start) {
   Nexus::DimVector indexStart{0};
-  Nexus::DimVector indexStep{std::min(numValues, Nexus::dimsize_t(12 * 3600 * 60))}; // 12 hour at 60Hz
+  Nexus::DimVector indexStep{std::min(numValues, std::size_t(12 * 3600 * 60))}; // 12 hour at 60Hz
 
   // getSlab needs the data allocated already
   std::vector<ValueType> rawData(indexStep[0]);

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -70,8 +70,8 @@ BankPulseTimes::BankPulseTimes(Nexus::File &file, const std::vector<int> &period
 
   // number of pulse times
   const auto dataInfo = file.getInfo();
-  const int64_t numValues =
-      std::accumulate(dataInfo.dims.cbegin(), dataInfo.dims.cend(), int64_t{1}, std::multiplies<>());
+  const uint64_t numValues =
+      std::accumulate(dataInfo.dims.cbegin(), dataInfo.dims.cend(), uint64_t{1}, std::multiplies<>());
   if (numValues == 0)
     throw std::runtime_error("event_time_zero field has no data!");
 
@@ -92,9 +92,10 @@ BankPulseTimes::BankPulseTimes(Nexus::File &file, const std::vector<int> &period
 }
 
 template <typename ValueType>
-void BankPulseTimes::readData(Nexus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start) {
-  std::vector<int64_t> indexStart{0};
-  std::vector<int64_t> indexStep{std::min(numValues, static_cast<int64_t>(12 * 3600 * 60))}; // 12 hour at 60Hz
+void BankPulseTimes::readData(Nexus::File &file, uint64_t numValues, Mantid::Types::Core::DateAndTime &start) {
+  Nexus::DimVector indexStart{0};
+  Nexus::DimVector indexStep{
+      std::min(static_cast<Nexus::dimsize_t>(numValues), Nexus::dimsize_t(12 * 3600 * 60))}; // 12 hour at 60Hz
 
   // getSlab needs the data allocated already
   std::vector<ValueType> rawData(indexStep[0]);
@@ -109,7 +110,7 @@ void BankPulseTimes::readData(Nexus::File &file, int64_t numValues, Mantid::Type
 
     // increment the slab to get
     indexStart[0] += indexStep[0];
-    indexStep[0] = std::min(indexStep[0], numValues - indexStart[0]);
+    indexStep[0] = std::min(indexStep[0], static_cast<Nexus::dimsize_t>(numValues) - indexStart[0]);
     // resize the vector
     rawData.resize(indexStep[0]);
   }

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -101,7 +101,7 @@ void BankPulseTimes::readData(Nexus::File &file, uint64_t numValues, Mantid::Typ
   std::vector<ValueType> rawData(indexStep[0]);
 
   // loop over chunks of data and transform each chunk
-  while ((indexStep[0] > 0) && (indexStart[0] < numValues)) {
+  while ((indexStep[0] > 0) && (indexStart[0] < static_cast<Nexus::dimsize_t>(numValues))) {
     file.getSlab(rawData.data(), indexStart, indexStep);
 
     // Now create the pulseTimes

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -368,7 +368,7 @@ void LoadBankFromDiskTask::run() {
       m_loadStart[0] = start_event;
       m_loadSize[0] = stop_event - start_event;
 
-      if ((m_loader.alg->compressEvents) || ((m_loadSize[0] > 0) && (m_loadStart[0] >= 0))) {
+      if ((m_loader.alg->compressEvents) || ((m_loadSize[0] > 0))) {
         if (m_loader.alg->getCancel()) {
           m_loader.alg->getLogger().error() << "Loading bank " << entry_name << " is cancelled.\n";
           m_loadError = true; // To allow cancelling the algorithm

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -494,8 +494,8 @@ void LoadHelper::loadingOrder(const std::tuple<short, short, short> &dataOrder, 
  */
 void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const Mantid::Nexus::NXInt &data,
                                      const std::vector<double> &xAxis, int64_t initialSpectrum,
-                                     const std::set<int> &acceptedDetectorIDs,
-                                     const std::vector<int> &customDetectorIDs,
+                                     const std::set<detid_t> &acceptedDetectorIDs,
+                                     const std::vector<detid_t> &customDetectorIDs,
                                      const std::tuple<short, short, short> &axisOrder) {
 
   const auto useCustomSpectraMap = customDetectorIDs.size() != 0;

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -411,7 +411,8 @@ void LoadHelper::loadEmptyInstrument(const API::MatrixWorkspace_sptr &ws, const 
  */
 void LoadHelper::fillStaticWorkspace(const API::MatrixWorkspace_sptr &ws, const Mantid::Nexus::NXInt &data,
                                      const std::vector<double> &xAxis, int64_t initialSpectrum, bool pointData,
-                                     const std::vector<int> &detectorIDs, const std::set<int> &acceptedDetectorIDs,
+                                     const std::vector<detid_t> &detectorIDs,
+                                     const std::set<detid_t> &acceptedDetectorIDs,
                                      const std::tuple<short, short, short> &axisOrder) {
 
   const bool customDetectorIDs = detectorIDs.size() != 0;
@@ -435,7 +436,7 @@ void LoadHelper::fillStaticWorkspace(const API::MatrixWorkspace_sptr &ws, const 
 
 #pragma omp parallel for if (!excludeDetectorIDs && Kernel::threadSafe(*ws))
   for (specnum_t tube_no = 0; tube_no < static_cast<specnum_t>(nTubes); ++tube_no) {
-    for (specnum_t pixel_no = 0; pixel_no < nPixels; ++pixel_no) {
+    for (specnum_t pixel_no = 0; pixel_no < static_cast<specnum_t>(nPixels); ++pixel_no) {
       specnum_t currentSpectrum =
           static_cast<specnum_t>(initialSpectrum) + tube_no * static_cast<specnum_t>(nPixels) + pixel_no;
       if (excludeDetectorIDs != 0 && std::find(acceptedDetectorIDs.cbegin(), acceptedDetectorIDs.cend(),
@@ -446,7 +447,7 @@ void LoadHelper::fillStaticWorkspace(const API::MatrixWorkspace_sptr &ws, const 
       currentSpectrum -= nSkipped;
 
       std::vector<int> spectrum(nChannels);
-      for (auto channel_no = 0; channel_no < nChannels; ++channel_no) {
+      for (specnum_t channel_no = 0; channel_no < static_cast<specnum_t>(nChannels); ++channel_no) {
         const int dataIndices[3] = {tube_no, pixel_no, channel_no};
         spectrum[channel_no] = data(dataIndices[loadOrder[0]], dataIndices[loadOrder[1]], dataIndices[loadOrder[2]]);
       }
@@ -508,7 +509,7 @@ void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const 
   int nSkipped = 0;
 #pragma omp parallel for if (Kernel::threadSafe(*ws))
   for (specnum_t tube_no = 0; tube_no < static_cast<specnum_t>(nTubes); ++tube_no) {
-    for (specnum_t pixel_no = 0; pixel_no < nPixels; ++pixel_no) {
+    for (specnum_t pixel_no = 0; pixel_no < static_cast<specnum_t>(nPixels); ++pixel_no) {
       specnum_t currentDetector =
           static_cast<specnum_t>(initialSpectrum) + tube_no * static_cast<specnum_t>(nPixels) + pixel_no;
       if (useAcceptedDetectorIDs && std::find(acceptedDetectorIDs.cbegin(), acceptedDetectorIDs.cend(),
@@ -523,7 +524,7 @@ void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const 
       else
         currentSpectrum = currentDetector;
       currentSpectrum *= nScans;
-      for (auto channel_no = 0; channel_no < nScans; ++channel_no) {
+      for (specnum_t channel_no = 0; channel_no < static_cast<specnum_t>(nScans); ++channel_no) {
         auto spectrumValue = data(channel_no, tube_no, pixel_no);
         ws->mutableY(currentSpectrum) = spectrumValue;
         ws->mutableE(currentSpectrum) = sqrt(spectrumValue);

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -500,7 +500,7 @@ void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const 
   const auto useCustomSpectraMap = customDetectorIDs.size() != 0;
   const auto useAcceptedDetectorIDs = acceptedDetectorIDs.size() != 0;
 
-  std::array<int64_t, 3U> dims = {data.dim0(), data.dim1(), data.dim2()};
+  std::array<Nexus::dimsize_t, 3U> dims = {data.dim0(), data.dim1(), data.dim2()};
   const auto nTubes = dims[std::get<0>(axisOrder)];
   const auto nPixels = dims[std::get<1>(axisOrder)];
   const auto nScans = dims[std::get<2>(axisOrder)];

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -49,7 +49,7 @@ constexpr size_t D20_NUMBER_PIXELS = 1600;
 constexpr size_t D20_NUMBER_DEAD_PIXELS = 32;
 // This defines the number of monitors in the instrument. If there are cases
 // where this is no longer one this decleration should be moved.
-constexpr int NUMBER_MONITORS = 1;
+constexpr size_t NUMBER_MONITORS = 1;
 // This is the angular size of a pixel in degrees (in low resolution mode)
 constexpr double D20_PIXEL_SIZE = 0.1;
 // The conversion factor from radian to degree
@@ -452,10 +452,9 @@ void LoadILLDiffraction::fillMovingInstrumentScan(const NXInt &data, const NXDou
   // prepare inputs, dimension orders and list of accepted IDs for exclusion of inactive detectors (D20)
   std::tuple<int, int, int> dimOrder{2, 1, 0}; // scan - tube - pixel
   std::set<int> acceptedIDs;
-  if (static_cast<int>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
-    for (auto index = static_cast<int>(NUMBER_MONITORS);
-         index < static_cast<int>(m_numberDetectorsActual + NUMBER_MONITORS); ++index)
-      acceptedIDs.insert(index);
+  if (static_cast<Nexus::dimsize_t>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
+    for (auto index = NUMBER_MONITORS; index < m_numberDetectorsActual + NUMBER_MONITORS; ++index)
+      acceptedIDs.insert(static_cast<detid_t>(index));
   }
   std::vector<int> customDetectorIDs;
   // Assign detector counts
@@ -476,7 +475,7 @@ void LoadILLDiffraction::fillStaticInstrumentScan(const NXInt &data, const NXDou
   const std::vector<double> axis = getAxis(scan);
   const std::vector<double> monitor = getMonitor(scan);
 
-  int startIndex = static_cast<int>(NUMBER_MONITORS);
+  std::size_t startIndex = NUMBER_MONITORS;
 
   // Assign monitor counts
   m_outWorkspace->mutableX(0) = axis;
@@ -485,10 +484,10 @@ void LoadILLDiffraction::fillStaticInstrumentScan(const NXInt &data, const NXDou
 
   // prepare inputs, dimension orders and list of accepted IDs for exclusion of inactive detectors (D20)
   std::tuple<int, int, int> dimOrder{2, 1, 0}; // scan - tube - pixel
-  std::set<int> acceptedIDs;
-  if (static_cast<int>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
-    for (int i = static_cast<int>(startIndex); i < static_cast<int>(startIndex + m_numberDetectorsActual); ++i)
-      acceptedIDs.insert(i);
+  std::set<detid_t> acceptedIDs;
+  if (static_cast<Nexus::dimsize_t>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
+    for (std::size_t i = startIndex; i < startIndex + m_numberDetectorsActual; ++i)
+      acceptedIDs.insert(static_cast<detid_t>(i));
   }
   // Assign detector counts
   LoadHelper::fillStaticWorkspace(m_outWorkspace, data, axis, startIndex, true, std::vector<int>(), acceptedIDs,

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -452,7 +452,7 @@ void LoadILLDiffraction::fillMovingInstrumentScan(const NXInt &data, const NXDou
   // prepare inputs, dimension orders and list of accepted IDs for exclusion of inactive detectors (D20)
   std::tuple<int, int, int> dimOrder{2, 1, 0}; // scan - tube - pixel
   std::set<int> acceptedIDs;
-  if (static_cast<Nexus::dimsize_t>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
+  if (m_numberDetectorsActual != data.dim1() * data.dim2()) {
     for (auto index = NUMBER_MONITORS; index < m_numberDetectorsActual + NUMBER_MONITORS; ++index)
       acceptedIDs.insert(static_cast<detid_t>(index));
   }
@@ -485,7 +485,7 @@ void LoadILLDiffraction::fillStaticInstrumentScan(const NXInt &data, const NXDou
   // prepare inputs, dimension orders and list of accepted IDs for exclusion of inactive detectors (D20)
   std::tuple<int, int, int> dimOrder{2, 1, 0}; // scan - tube - pixel
   std::set<detid_t> acceptedIDs;
-  if (static_cast<Nexus::dimsize_t>(m_numberDetectorsActual) != data.dim1() * data.dim2()) {
+  if (m_numberDetectorsActual != data.dim1() * data.dim2()) {
     for (std::size_t i = startIndex; i < startIndex + m_numberDetectorsActual; ++i)
       acceptedIDs.insert(static_cast<detid_t>(i));
   }

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -209,11 +209,11 @@ void LoadILLIndirect2::loadDataDetails(const Nexus::NXEntry &entry) {
 
         if (flagSD[0] == 1.0) // is enabled
         {
-          m_activeSDIndices.insert(i);
+          m_activeSDIndices.insert(static_cast<detid_t>(i));
         }
       } catch (...) {
         // if the flags are not present in the file (e.g. old format), load all
-        m_activeSDIndices.insert(i);
+        m_activeSDIndices.insert(static_cast<detid_t>(i));
       }
     }
     m_numberOfSimpleDetectors = m_activeSDIndices.size();
@@ -275,7 +275,7 @@ void LoadILLIndirect2::loadDataIntoWorkspace(const Nexus::NXEntry &entry) {
   int offset = static_cast<int>(m_numberOfTubes * m_numberOfPixelsPerTube + m_numberOfMonitors);
   auto dataSD = LoadHelper::getIntDataset(entry, "dataSD");
   dataSD.load();
-  std::set<int> sdIndices;
+  std::set<detid_t> sdIndices;
   std::transform(m_activeSDIndices.cbegin(), m_activeSDIndices.cend(), std::inserter(sdIndices, sdIndices.begin()),
                  [offset](const auto &index) { return index + offset; });
   LoadHelper::fillStaticWorkspace(m_localWorkspace, dataSD, xAxis, offset, false, std::vector<int>(), sdIndices);

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -201,7 +201,7 @@ void LoadILLIndirect2::loadDataDetails(const Nexus::NXEntry &entry) {
   if (m_loadOption == "Spectrometer") {
     auto dataSD = LoadHelper::getIntDataset(entry, "dataSD");
 
-    for (int i = 0; i < dataSD.dim0(); ++i) {
+    for (Nexus::dimsize_t i = 0; i < dataSD.dim0(); ++i) {
       try {
         std::string entryNameFlagSD = boost::str(boost::format("instrument/SingleD/tubes%i_function") % (i + 1));
         NXFloat flagSD = entry.openNXFloat(entryNameFlagSD);

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -742,7 +742,7 @@ size_t LoadILLSANS::loadDataFromTubes(Nexus::NXInt const &data, const std::vecto
     dimOrder = std::tuple<short, short, short>{0, 1, 2}; // default, tubes-pixels-channels
   }
   LoadHelper::fillStaticWorkspace(m_localWorkspace, data, timeBinning, static_cast<int>(firstIndex), pointData,
-                                  std::vector<int>(), std::set<int>(), dimOrder);
+                                  std::vector<int>(), std::set<detid_t>(), dimOrder);
   return firstIndex + numberOfTubes * numberOfPixelsPerTube;
 }
 

--- a/Framework/DataHandling/src/LoadILLTOF3.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF3.cpp
@@ -338,8 +338,8 @@ std::vector<double> LoadILLTOF3::prepareAxis(const Nexus::NXEntry &entry, bool c
     // read which variable is going to be the axis
     NXInt scannedAxis = entry.openNXInt("data_scan/scanned_variables/variables_names/axis");
     scannedAxis.load();
-    int scannedVarId = 0;
-    for (int index = 0; index < scannedAxis.dim0(); index++) {
+    std::size_t scannedVarId = 0;
+    for (std::size_t index = 0; index < scannedAxis.dim0(); index++) {
       if (scannedAxis[index] == 1) {
         scannedVarId = index;
         break;
@@ -347,7 +347,7 @@ std::vector<double> LoadILLTOF3::prepareAxis(const Nexus::NXEntry &entry, bool c
     }
     auto axis = LoadHelper::getDoubleDataset(entry, "data_scan/scanned_variables/data");
     axis.load();
-    for (int index = 0; index < axis.dim1(); index++) {
+    for (std::size_t index = 0; index < axis.dim1(); index++) {
       xAxis[index] = axis(scannedVarId, index);
     }
   } else {
@@ -439,7 +439,7 @@ void LoadILLTOF3::fillScanWorkspace(const Nexus::NXEntry &entry, const std::vect
   const auto spectrumNo = data.dim1() * data.dim2();
   auto monitorData = LoadHelper::getDoubleDataset(entry, monitorList[0]);
   monitorData.load();
-  for (int index = 0; index < monitorData.dim1(); index++) {
+  for (std::size_t index = 0; index < monitorData.dim1(); index++) {
     // monitor is always the 4th row, if that ever changes, a name search for 'monitor1' would be necessary among
     // scanned_variables
     const auto counts = monitorData(3, index);

--- a/Framework/DataHandling/src/LoadILLTOF3.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF3.cpp
@@ -432,7 +432,7 @@ void LoadILLTOF3::fillScanWorkspace(const Nexus::NXEntry &entry, const std::vect
   // Load scan data
   const std::vector<int> detectorIDs = m_localWorkspace->getInstrument()->getDetectorIDs(false);
   const std::tuple<int, int, int> dimOrder{1, 2, 0};
-  LoadHelper::fillStaticWorkspace(m_localWorkspace, data, xAxis, 0, true, detectorIDs, std::set<int>(), dimOrder);
+  LoadHelper::fillStaticWorkspace(m_localWorkspace, data, xAxis, 0, true, detectorIDs, std::set<detid_t>(), dimOrder);
 
   // Load monitor data, there is only one monitor
   const std::vector<int> monitorIDs = m_localWorkspace->getInstrument()->getMonitors();

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -749,8 +749,8 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadEventEntry(NXData &wksp_cls, N
       else {
         MantidVec x(xbins.dim1());
 
-        for (int i = 0; i < xbins.dim1(); i++)
-          x[i] = xbins(static_cast<int>(wi), i);
+        for (std::size_t i = 0; i < xbins.dim1(); i++)
+          x[i] = xbins(wi, i);
 
         // for ragged workspace we need to remove all NaN value from end of vector
         const auto idx =

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -846,10 +846,10 @@ API::Workspace_sptr LoadNexusProcessed::loadTableEntry(const NXEntry &entry) {
         std::string columnTitle = data.attributes("name");
         if (!columnTitle.empty()) {
           workspace->addColumn("str", columnTitle);
-          nxdimsize_t nRows = info.dims[0];
+          dimsize_t nRows = info.dims[0];
           workspace->setRowCount(nRows);
 
-          nxdimsize_t const maxStr = info.dims[1];
+          dimsize_t const maxStr = info.dims[1];
           data.load();
           for (int64_t iR = 0; iR < nRows; ++iR) {
             auto &cellContents = workspace->cell<std::string>(iR, columnNumber - 1);
@@ -1174,7 +1174,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      nxdimsize_t const maxShapeJSONLength = info.dims[1];
+      dimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
       for (size_t i = 0; i < numberPeaks; ++i) {
 
@@ -1466,7 +1466,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      nxdimsize_t const maxShapeJSONLength = info.dims[1];
+      dimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
       for (size_t i = 0; i < numberPeaks; ++i) {
 

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -851,7 +851,7 @@ API::Workspace_sptr LoadNexusProcessed::loadTableEntry(const NXEntry &entry) {
 
           dimsize_t const maxStr = info.dims[1];
           data.load();
-          for (int64_t iR = 0; iR < nRows; ++iR) {
+          for (dimsize_t iR = 0; iR < nRows; ++iR) {
             auto &cellContents = workspace->cell<std::string>(iR, columnNumber - 1);
             auto startPoint = data() + maxStr * iR;
             cellContents.assign(startPoint, startPoint + maxStr);
@@ -1532,7 +1532,7 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
                                                                 const int64_t xlength, std::string &workspaceType) {
   // Filter the list of spectra to process, applying min/max/list options
   NXDouble data = wksp_cls.openDoubleData();
-  int64_t nchannels = data.dim1();
+  dimsize_t nchannels = data.dim1();
   size_t nspectra = data.dim0();
   // process optional spectrum parameters, if set
   checkOptionalProperties(nspectra);

--- a/Framework/DataHandling/src/SaveNXSPE.cpp
+++ b/Framework/DataHandling/src/SaveNXSPE.cpp
@@ -271,7 +271,7 @@ void SaveNXSPE::exec() {
 
   // Write the data
   Progress progress(this, 0.0, 1.0, nHist);
-  int64_t bufferCounter(0);
+  uint64_t bufferCounter(0);
   const auto &spectrumInfo = inputWS->spectrumInfo();
   for (std::size_t i = 0; i < nHist; ++i) {
     progress.report();

--- a/Framework/DataHandling/src/SaveNXSPE.cpp
+++ b/Framework/DataHandling/src/SaveNXSPE.cpp
@@ -91,9 +91,9 @@ void SaveNXSPE::exec() {
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
 
   // Number of spectra
-  const auto nHist = static_cast<int64_t>(inputWS->getNumberHistograms());
+  const auto nHist = inputWS->getNumberHistograms();
   // Number of energy bins
-  const auto nBins = static_cast<int64_t>(inputWS->blocksize());
+  const auto nBins = inputWS->blocksize();
 
   // Retrieve the filename from the properties
   std::string filename = getPropertyValue("Filename");
@@ -240,10 +240,8 @@ void SaveNXSPE::exec() {
   nxFile.closeData();
 
   // let's create some blank arrays in the nexus file
-  using Dimensions = std::vector<int64_t>;
-  Dimensions arrayDims(2);
-  arrayDims[0] = nHist;
-  arrayDims[1] = nBins;
+  using Dimensions = Nexus::DimVector;
+  Dimensions arrayDims{nHist, nBins};
   nxFile.makeData("data", NXnumtype::FLOAT64, arrayDims, false);
   nxFile.makeData("error", NXnumtype::FLOAT64, arrayDims, false);
 
@@ -275,7 +273,7 @@ void SaveNXSPE::exec() {
   Progress progress(this, 0.0, 1.0, nHist);
   int64_t bufferCounter(0);
   const auto &spectrumInfo = inputWS->spectrumInfo();
-  for (int64_t i = 0; i < nHist; ++i) {
+  for (std::size_t i = 0; i < nHist; ++i) {
     progress.report();
 
     double *signalBufferStart = signalBuffer.get() + bufferCounter * nBins;

--- a/Framework/DataHandling/src/SaveNXSPE.cpp
+++ b/Framework/DataHandling/src/SaveNXSPE.cpp
@@ -330,7 +330,7 @@ void SaveNXSPE::exec() {
   spCalcDetPar->execute();
 
   //
-  auto *pCalcDetPar = dynamic_cast<FindDetectorsPar *>(spCalcDetPar.get());
+  auto const *pCalcDetPar = dynamic_cast<FindDetectorsPar *>(spCalcDetPar.get());
   if (!pCalcDetPar) { // "can not get pointer to FindDetectorsPar algorithm"
     throw(std::bad_cast());
   }

--- a/Framework/DataHandling/src/SaveNXTomo.cpp
+++ b/Framework/DataHandling/src/SaveNXTomo.cpp
@@ -271,8 +271,8 @@ void SaveNXTomo::writeSingleWorkspace(const Workspace2D_sptr &workspace) {
     throw std::runtime_error("Unable to create a valid NXTomo file");
   }
 
-  int numFiles = 0;
-  m_nxFile->getAttr<int>("NumFiles", numFiles);
+  Nexus::dimsize_t numFiles = 0;
+  m_nxFile->getAttr("NumFiles", numFiles);
 
   // Change slab start to after last data position
   m_slabStart[0] = numFiles;
@@ -292,7 +292,7 @@ void SaveNXTomo::writeSingleWorkspace(const Workspace2D_sptr &workspace) {
   }
 
   m_nxFile->openData("rotation_angle");
-  m_nxFile->putSlab(rotValue, static_cast<Nexus::dimsize_t>(numFiles), 1);
+  m_nxFile->putSlab(rotValue, numFiles, 1);
   m_nxFile->closeData();
 
   // Copy data out, remake data with dimension of old size plus new elements.
@@ -303,9 +303,9 @@ void SaveNXTomo::writeSingleWorkspace(const Workspace2D_sptr &workspace) {
 
   // images can be as one-spectrum-per-pixel, or one-spectrum-per-row
   bool spectrumPerPixel = (1 == workspace->y(0).size());
-  for (int64_t i = 0; i < m_dimensions[1]; ++i) {
+  for (Nexus::dimsize_t i = 0; i < m_dimensions[1]; ++i) {
     const auto &Y = workspace->y(i);
-    for (int64_t j = 0; j < m_dimensions[2]; ++j) {
+    for (Nexus::dimsize_t j = 0; j < m_dimensions[2]; ++j) {
       if (spectrumPerPixel) {
         dataArr[i * m_dimensions[1] + j] = workspace->y(i * m_dimensions[1] + j)[0];
       } else {
@@ -329,7 +329,7 @@ void SaveNXTomo::writeSingleWorkspace(const Workspace2D_sptr &workspace) {
   delete[] dataArr;
 }
 
-void SaveNXTomo::writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd) {
+void SaveNXTomo::writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd) {
   // Add ImageKey to instrument/image_key if present, use 0 if not
   try {
     m_nxFile->openAddress("/entry1/tomo_entry/instrument/detector");
@@ -356,7 +356,7 @@ void SaveNXTomo::writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspa
   m_nxFile->closeGroup();
 }
 
-void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd) {
+void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd) {
   // Add Log information (minus special values - Rotation, ImageKey, Intensity)
   // Unable to add multidimensional string data, storing strings as
   // multidimensional data set of uint8 values
@@ -396,7 +396,7 @@ void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, 
   }
 }
 
-void SaveNXTomo::writeIntensityValue(const DataObjects::Workspace2D_sptr &workspace, int thisFileInd) {
+void SaveNXTomo::writeIntensityValue(const DataObjects::Workspace2D_sptr &workspace, std::size_t thisFileInd) {
   // Add Intensity to control if present, use 1 if not
   try {
     m_nxFile->openAddress("/entry1/tomo_entry/control");

--- a/Framework/DataHandling/src/SaveNXTomo.cpp
+++ b/Framework/DataHandling/src/SaveNXTomo.cpp
@@ -350,7 +350,7 @@ void SaveNXTomo::writeImageKeyValue(const DataObjects::Workspace2D_sptr &workspa
   }
 
   m_nxFile->openData("image_key");
-  m_nxFile->putSlab(keyValue, static_cast<Nexus::dimsize_t>(thisFileInd), 1);
+  m_nxFile->putSlab(keyValue, thisFileInd, 1);
   m_nxFile->closeData();
 
   m_nxFile->closeGroup();
@@ -387,7 +387,7 @@ void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, 
       if (strSize > 80)
         strSize = 80;
       const Nexus::DimVector start{thisFileInd, 0};
-      const Nexus::DimVector size{1, static_cast<Nexus::dimsize_t>(strSize)};
+      const Nexus::DimVector size{1, strSize};
       // single item
       m_nxFile->putSlab(valueAsStr.data(), start, size);
 
@@ -417,7 +417,7 @@ void SaveNXTomo::writeIntensityValue(const DataObjects::Workspace2D_sptr &worksp
   }
 
   m_nxFile->openData("data");
-  m_nxFile->putSlab(intensityValue, static_cast<Nexus::dimsize_t>(thisFileInd), 1);
+  m_nxFile->putSlab(intensityValue, thisFileInd, 1);
   m_nxFile->closeData();
 }
 

--- a/Framework/DataHandling/src/SaveNXTomo.cpp
+++ b/Framework/DataHandling/src/SaveNXTomo.cpp
@@ -209,10 +209,7 @@ void SaveNXTomo::setupFile() {
   // {data,distance,image_key,x_pixel_size,y_pixel_size}
   m_nxFile->makeGroup("detector", "NXdetector", true);
 
-  std::vector<int64_t> infDim;
-  infDim.emplace_back(NX_UNLIMITED);
-
-  m_nxFile->makeData("image_key", NXnumtype::FLOAT64, infDim, false);
+  m_nxFile->makeData("image_key", NXnumtype::FLOAT64, NX_UNLIMITED, false);
   m_nxFile->closeGroup(); // detector
 
   // source group // from diamond file contains {current,energy,name,probe,type}
@@ -224,7 +221,7 @@ void SaveNXTomo::setupFile() {
   // NXsample
   m_nxFile->makeGroup("sample", "NXsample", true);
 
-  m_nxFile->makeData("rotation_angle", NXnumtype::FLOAT64, infDim, true);
+  m_nxFile->makeData("rotation_angle", NXnumtype::FLOAT64, NX_UNLIMITED, true);
   // Create a link object for rotation_angle to use later
   NXlink rotationLink = m_nxFile->getDataID();
   m_nxFile->closeData();
@@ -234,7 +231,7 @@ void SaveNXTomo::setupFile() {
   // Make the NXmonitor group - Holds base beam intensity for each image
 
   m_nxFile->makeGroup("control", "NXmonitor", true);
-  m_nxFile->makeData("data", NXnumtype::FLOAT64, infDim, false);
+  m_nxFile->makeData("data", NXnumtype::FLOAT64, NX_UNLIMITED, false);
   m_nxFile->closeGroup(); // NXmonitor
 
   m_nxFile->makeGroup("data", "NXdata", true);
@@ -380,9 +377,7 @@ void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, 
         m_nxFile->openData(prop->name());
       } catch (Nexus::Exception const &) {
         // Create the data entry if it doesn't exist yet, and open.
-        std::vector<int64_t> infDim;
-        infDim.emplace_back(NX_UNLIMITED);
-        infDim.emplace_back(NX_UNLIMITED);
+        Nexus::DimVector infDim{NX_UNLIMITED, NX_UNLIMITED};
         m_nxFile->makeData(prop->name(), NXnumtype::UINT8, infDim, true);
       }
       auto valueAsStr = prop->value();
@@ -391,8 +386,8 @@ void SaveNXTomo::writeLogValues(const DataObjects::Workspace2D_sptr &workspace, 
       // it won't be greater than this. Otherwise Shorten it
       if (strSize > 80)
         strSize = 80;
-      const Nexus::DimVector start = {thisFileInd, 0};
-      const Nexus::DimSizeVector size = {1, static_cast<Nexus::dimsize_t>(strSize)};
+      const Nexus::DimVector start{thisFileInd, 0};
+      const Nexus::DimVector size{1, static_cast<Nexus::dimsize_t>(strSize)};
       // single item
       m_nxFile->putSlab(valueAsStr.data(), start, size);
 

--- a/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
@@ -751,7 +751,7 @@ bool NexusFileIO::writeNexusBinMasking(const API::MatrixWorkspace_const_sptr &ws
     return false;
 
   // save spectra offsets as a 2d array of ints
-  std::vector<int64_t> dimensions = {spectra_count, 2};
+  Nexus::DimVector dimensions{spectra_count, 2};
 
   m_filehandle->makeData("masked_spectra", NXnumtype::INT32, dimensions, true);
   m_filehandle->putAttr("description", "spectra index,offset in masked_bins and mask_weights");
@@ -759,13 +759,13 @@ bool NexusFileIO::writeNexusBinMasking(const API::MatrixWorkspace_const_sptr &ws
   m_filehandle->closeData();
 
   // save masked bin indices
-  dimensions[0] = static_cast<int>(bins.size());
+  dimensions[0] = static_cast<Nexus::dimsize_t>(bins.size());
   m_filehandle->makeData("masked_bins", NXnumtype::UINT64, dimensions, true);
   m_filehandle->putData(bins.data());
   m_filehandle->closeData();
 
   // save masked bin weights
-  dimensions[0] = static_cast<int>(bins.size());
+  dimensions[0] = static_cast<Nexus::dimsize_t>(bins.size());
   m_filehandle->makeData("mask_weights", NXnumtype::FLOAT64, dimensions, true);
   m_filehandle->putData(weights.data());
   m_filehandle->closeData();

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -50,7 +50,7 @@ static const int NUMRANDOM = 7;
 static const int DETECTS[NUMRANDOM] = {4101, 4804, 1323, 1101, 3805, 1323, 3832};
 
 namespace SmallTestDatFile {
-const std::size_t NDETECTS = 6;
+const Mantid::detid_t NDETECTS = 6;
 }
 
 namespace {
@@ -98,7 +98,7 @@ void writeDetNXSfile(const std::string &filename, const std::size_t nDets) {
   int limit(6);
   int ic(0);
   for (std::size_t i = 0; i < nDets; i++) {
-    detID[2 * i] = i;
+    detID[2 * i] = static_cast<Mantid::detid_t>(i);
     detID[2 * i + 1] = boost::lexical_cast<int>(code[ic]);
     timeOffsets[2 * i] = boost::lexical_cast<float>(delta[ic]);
     timeOffsets[2 * i + 1] = 0;
@@ -349,7 +349,7 @@ public:
     const auto &pmap = WS->constInstrumentParameters();
     const auto &detInfo = WS->detectorInfo();
 
-    for (int j = 0; j < SmallTestDatFile::NDETECTS; ++j) {
+    for (Mantid::detid_t j = 0; j < SmallTestDatFile::NDETECTS; ++j) {
 
       const size_t detIndex = detInfo.indexOf(j);
       const IComponent *baseComp = detInfo.detector(detIndex).getComponentID();

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -50,7 +50,7 @@ static const int NUMRANDOM = 7;
 static const int DETECTS[NUMRANDOM] = {4101, 4804, 1323, 1101, 3805, 1323, 3832};
 
 namespace SmallTestDatFile {
-const int NDETECTS = 6;
+const std::size_t NDETECTS = 6;
 }
 
 namespace {
@@ -71,7 +71,7 @@ void writeSmallDatFile(const std::string &filename) {
           "    w_y         w_z         f_x         f_y         f_z         a_x "
           "        a_y         a_z        det_1       det_2       det_3       "
           "det4\n";
-  for (int detector = 0; detector < SmallTestDatFile::NDETECTS; ++detector) {
+  for (std::size_t detector = 0; detector < SmallTestDatFile::NDETECTS; ++detector) {
     file << detector << "\t" << delta[detector] << "\t" << det_l2[detector] << "\t" << code[detector] << "\t"
          << det_theta[detector] << "\t" << det_phi[detector] << "\t" << NOTUSED << "\t" << NOTUSED << "\t" << NOTUSED
          << "\t" << NOTUSED << "\t" << NOTUSED << "\t" << NOTUSED << "\t" << NOTUSED << "\t" << NOTUSED << "\t"
@@ -81,7 +81,7 @@ void writeSmallDatFile(const std::string &filename) {
   file.close();
 }
 
-void writeDetNXSfile(const std::string &filename, const int nDets) {
+void writeDetNXSfile(const std::string &filename, const std::size_t nDets) {
   Mantid::Nexus::File nxsfile(filename, NXaccess::CREATE5);
   nxsfile.makeGroup("detectors.dat", "NXEntry", true);
   nxsfile.putAttr("version", "1.0");
@@ -97,7 +97,7 @@ void writeDetNXSfile(const std::string &filename, const int nDets) {
 
   int limit(6);
   int ic(0);
-  for (int i = 0; i < nDets; i++) {
+  for (std::size_t i = 0; i < nDets; i++) {
     detID[2 * i] = i;
     detID[2 * i + 1] = boost::lexical_cast<int>(code[ic]);
     timeOffsets[2 * i] = boost::lexical_cast<float>(delta[ic]);

--- a/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
@@ -127,10 +127,10 @@ private:
   //------
   /// the start of the current data block to read from. It related to current
   /// physical representation of the data in NeXus file
-  std::vector<int64_t> m_BlockStart;
+  Nexus::DimVector m_BlockStart;
   /// the vector, which describes the event specific data size, namely how many
   /// column an event is composed into and this class reads/writres
-  std::vector<int64_t> m_BlockSize;
+  Nexus::DimVector m_BlockSize;
   /// lock Nexus file operations as Nexus is not thread safe
   mutable std::mutex m_fileMutex;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
@@ -89,7 +89,7 @@ public:
    * @brief Number of data items in Nexus dataset "data_event" associated
    * with the particular event data version.
    */
-  int64_t dataEventCount(void) const;
+  uint64_t dataEventCount(void) const;
 
   /**
    * @brief Insert goniometer info in a block of event data, if necessary

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -237,7 +237,7 @@ void BoxControllerNeXusIO::prepareNxSToWrite_CurVersion() {
 
     // Now the chunk size.
     // m_Blocksize == (number_events_to_write_at_a_time, data_items_per_event)
-    Nexus::DimSizeVector chunk(m_BlockSize);
+    Nexus::DimVector chunk(m_BlockSize);
     chunk[0] = static_cast<Nexus::dimsize_t>(m_dataChunk);
 
     // Make and open the data
@@ -298,7 +298,7 @@ void BoxControllerNeXusIO::getDiskBufferFileData() {
   //    // Get a vector of the free space blocks to save to the file
   Nexus::DimVector free_dims(2, 2);
   free_dims[0] = int64_t(freeSpaceBlocks.size() / 2);
-  Nexus::DimSizeVector free_chunk(2, 2);
+  Nexus::DimVector free_chunk(2, 2);
   free_chunk[0] = int64_t(m_dataChunk);
 
   std::map<std::string, std::string> groupEntries;

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -238,7 +238,7 @@ void BoxControllerNeXusIO::prepareNxSToWrite_CurVersion() {
     // Now the chunk size.
     // m_Blocksize == (number_events_to_write_at_a_time, data_items_per_event)
     Nexus::DimVector chunk(m_BlockSize);
-    chunk[0] = static_cast<Nexus::dimsize_t>(m_dataChunk);
+    chunk[0] = m_dataChunk;
 
     // Make and open the data
     if (m_CoordSize == 4)
@@ -328,7 +328,7 @@ void BoxControllerNeXusIO::saveGenericBlock(const std::vector<Type> &DataBlock, 
   Nexus::DimVector dims(m_BlockSize);
 
   std::lock_guard<std::mutex> _lock(m_fileMutex);
-  start[0] = static_cast<Nexus::dimsize_t>(blockPosition);
+  start[0] = blockPosition;
   dims[0] = Nexus::dimsize_t(DataBlock.size() / this->getNDataColums());
 
   // ugly cast but why would putSlab change the data?. This is NeXus bug which
@@ -504,11 +504,11 @@ void BoxControllerNeXusIO::loadGenericBlock(std::vector<Type> &Block, const uint
     throw Kernel::Exception::FileError("Attemtp to read behind the file end", m_fileName);
 
   Nexus::DimVector start(2, 0);
-  start[0] = static_cast<Nexus::dimsize_t>(blockPosition);
+  start[0] = blockPosition;
 
   Nexus::DimVector size(m_BlockSize);
-  size[0] = static_cast<Nexus::dimsize_t>(nPoints);
-  size[1] = static_cast<Nexus::dimsize_t>(dataEventCount()); // data item count per event in the Nexus file
+  size[0] = nPoints;
+  size[1] = dataEventCount(); // data item count per event in the Nexus file
 
   std::lock_guard<std::mutex> _lock(m_fileMutex);
 

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -392,10 +392,10 @@ void BoxControllerNeXusIO::setEventDataVersion(const size_t &traitsCount) {
   }
 }
 
-int64_t BoxControllerNeXusIO::dataEventCount(void) const {
+uint64_t BoxControllerNeXusIO::dataEventCount(void) const {
   // m_BlockSize[1] is the number of data events associated to an MDLeanEvent
   // or MDEvent object.
-  int64_t size(m_BlockSize[1]);
+  uint64_t size(m_BlockSize[1]);
   switch (m_EventDataVersion) {
   case (EventDataVersion::EDVLean):
     break;                              // no adjusting is necessary
@@ -587,8 +587,8 @@ void BoxControllerNeXusIO::closeFile() {
       std::vector<uint64_t> freeSpaceBlocks;
       this->getFreeSpaceVector(freeSpaceBlocks);
       if (!freeSpaceBlocks.empty()) {
-        std::vector<int64_t> free_dims(2, 2);
-        free_dims[0] = int64_t(freeSpaceBlocks.size() / 2);
+        Nexus::DimVector free_dims(2, 2);
+        free_dims[0] = Nexus::dimsize_t(freeSpaceBlocks.size() / 2);
 
         m_File->writeUpdatedData(g_DBDataName, freeSpaceBlocks, free_dims);
       }

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -323,13 +323,13 @@ void BoxControllerNeXusIO::getDiskBufferFileData() {
  *@param blockPosition -- The starting place to save data to   */
 template <typename Type>
 void BoxControllerNeXusIO::saveGenericBlock(const std::vector<Type> &DataBlock, const uint64_t blockPosition) const {
-  std::vector<int64_t> start(2, 0);
+  Nexus::DimVector start(2, 0);
   // Specify the dimensions
-  std::vector<int64_t> dims(m_BlockSize);
+  Nexus::DimVector dims(m_BlockSize);
 
   std::lock_guard<std::mutex> _lock(m_fileMutex);
-  start[0] = int64_t(blockPosition);
-  dims[0] = int64_t(DataBlock.size() / this->getNDataColums());
+  start[0] = static_cast<Nexus::dimsize_t>(blockPosition);
+  dims[0] = Nexus::dimsize_t(DataBlock.size() / this->getNDataColums());
 
   // ugly cast but why would putSlab change the data?. This is NeXus bug which
   // makes putSlab method non-constant
@@ -503,12 +503,12 @@ void BoxControllerNeXusIO::loadGenericBlock(std::vector<Type> &Block, const uint
   if (blockPosition + nPoints > this->getFileLength())
     throw Kernel::Exception::FileError("Attemtp to read behind the file end", m_fileName);
 
-  std::vector<int64_t> start(2, 0);
-  start[0] = static_cast<int64_t>(blockPosition);
+  Nexus::DimVector start(2, 0);
+  start[0] = static_cast<Nexus::dimsize_t>(blockPosition);
 
-  std::vector<int64_t> size(m_BlockSize);
-  size[0] = static_cast<int64_t>(nPoints);
-  size[1] = dataEventCount(); // data item count per event in the Nexus file
+  Nexus::DimVector size(m_BlockSize);
+  size[0] = static_cast<Nexus::dimsize_t>(nPoints);
+  size[1] = static_cast<Nexus::dimsize_t>(dataEventCount()); // data item count per event in the Nexus file
 
   std::lock_guard<std::mutex> _lock(m_fileMutex);
 

--- a/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
@@ -586,7 +586,7 @@ void LeanElasticPeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->closeData();
 
   // Goniometer Matrix Column
-  const Nexus::DimVector array_dims{static_cast<Nexus::dimsize_t>(m_peaks.size()), 9};
+  const Nexus::DimVector array_dims{m_peaks.size(), 9};
   file->writeData("column_13", goniometerMatrix, array_dims);
   file->openData("column_13");
   file->putAttr("name", "Goniometer Matrix");
@@ -620,7 +620,7 @@ void LeanElasticPeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->closeData();
 
   // Qlab
-  const Nexus::DimVector qlab_dims{static_cast<Nexus::dimsize_t>(m_peaks.size()), 3};
+  const Nexus::DimVector qlab_dims{m_peaks.size(), 3};
   file->writeData("column_15", qlabs, qlab_dims);
   file->openData("column_15");
   file->putAttr("name", "Q LabFrame");

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -862,7 +862,7 @@ void PeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->putAttr("units", "Not known"); // Units may need changing when known
   file->closeData();
 
-  const Nexus::DimVector qlab_dims{static_cast<Nexus::dimsize_t>(m_peaks.size()), 3};
+  const Nexus::DimVector qlab_dims{m_peaks.size(), 3};
 
   // Integer HKL column
   file->writeData("column_19", intHKL, qlab_dims);
@@ -881,7 +881,7 @@ void PeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->closeData();
 
   // Goniometer Matrix Column
-  const Nexus::DimVector array_dims{static_cast<Nexus::dimsize_t>(m_peaks.size()), 9};
+  const Nexus::DimVector array_dims{m_peaks.size(), 9};
   file->writeData("column_15", goniometerMatrix, array_dims);
   file->openData("column_15");
   file->putAttr("name", "Goniometer Matrix");

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -2044,8 +2044,7 @@ template <> void TimeSeriesProperty<std::string>::saveProperty(Nexus::File *file
     index += maxlen;
   }
 
-  const Mantid::Nexus::DimVector dims{static_cast<Mantid::Nexus::dimsize_t>(values.size()),
-                                      static_cast<Mantid::Nexus::dimsize_t>(maxlen)};
+  const Mantid::Nexus::DimVector dims{values.size(), maxlen};
   file->makeData("value", NXnumtype::CHAR, dims, true);
   file->putData(strs.data());
   file->closeData();

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -260,12 +260,12 @@ void LoadMD::loadSlab(const std::string &name, NumT *data, const MDHistoWorkspac
 
   // verify that the number of points is correct
   const auto dataDims = m_file->getInfo().dims;
-  uint64_t nPoints = 1;
+  Nexus::dimsize_t nPoints = 1;
   const size_t numDims = dataDims.size();
   for (size_t d = 0; d < numDims; d++) {
-    nPoints *= static_cast<uint64_t>(dataDims[d]);
+    nPoints *= dataDims[d];
   }
-  if (nPoints != ws->getNPoints())
+  if (nPoints != static_cast<Nexus::dimsize_t>(ws->getNPoints()))
     throw std::runtime_error("Inconsistency between the number of points in '" + name +
                              "' and the number of bins defined by the dimensions.");
 

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -265,7 +265,7 @@ void LoadMD::loadSlab(const std::string &name, NumT *data, const MDHistoWorkspac
   for (size_t d = 0; d < numDims; d++) {
     nPoints *= dataDims[d];
   }
-  if (nPoints != static_cast<Nexus::dimsize_t>(ws->getNPoints()))
+  if (nPoints != ws->getNPoints())
     throw std::runtime_error("Inconsistency between the number of points in '" + name +
                              "' and the number of bins defined by the dimensions.");
 

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -156,7 +156,7 @@ void SaveMD2::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) 
     size[numDims - 1 - d] = int(dim->getNBins());
   }
 
-  Nexus::DimSizeVector chunks = size;
+  Nexus::DimVector chunks = size;
   chunks[0] = 1; // Drop the largest stride for chunking, I don't know
                  // if this is the best but appears to work
 

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -28,8 +28,7 @@ namespace Nexus {
 @date 28/05/2009
 */
 
-typedef int64_t nxdimsize_t;
-typedef std::array<nxdimsize_t, 4> NXDimArray;
+typedef std::array<dimsize_t, 4> NXDimArray;
 
 /**
  * Structure for keeping information about a Nexus data set, such as the dimensions and the type
@@ -138,15 +137,15 @@ public:
   /// Returns the rank (number of dimensions) of the data. The maximum is 4
   std::size_t rank() const { return m_info.rank; }
   /// Returns the number of elements along i-th dimension
-  nxdimsize_t dims(std::size_t i) const { return i < 4 ? m_info.dims[i] : 0; }
+  dimsize_t dims(std::size_t i) const { return i < 4 ? m_info.dims[i] : 0; }
   /// Returns the number of elements along the first dimension
-  nxdimsize_t dim0() const;
+  dimsize_t dim0() const;
   /// Returns the number of elements along the second dimension
-  nxdimsize_t dim1() const;
+  dimsize_t dim1() const;
   /// Returns the number of elements along the third dimension
-  nxdimsize_t dim2() const;
+  dimsize_t dim2() const;
   /// Returns the number of elements along the fourth dimension
-  nxdimsize_t dim3() const;
+  dimsize_t dim3() const;
   /// Returns the name of the data set
   std::string name() const { return m_info.nxname; } // cppcheck-suppress returnByReference
   /// Returns the Nexus type of the data. The types are defined in NexusFile_fwd.h
@@ -177,7 +176,7 @@ protected:
    * size of the array) must be equal to the rank of the data.
    * @throw runtime_error if the operation fails.
    */
-  template <typename NumT> void getSlab(NumT *data, DimSizeVector const &start, DimSizeVector const &size) {
+  template <typename NumT> void getSlab(NumT *data, DimVector const &start, DimVector const &size) {
     m_fileID->openData(name());
     m_fileID->getSlab(data, start, size);
     m_fileID->closeData();
@@ -317,12 +316,12 @@ public:
    * @param j :: Non-negative value makes it read a chunk of dimension rank()-2. i and j are its indeces. The rank of
    * the data must be >= 2
    */
-  void load(nxdimsize_t const blocksize, nxdimsize_t const i = -1, nxdimsize_t const j = -1) {
+  void load(dimsize_t const blocksize, dimsize_t const i = -1, dimsize_t const j = -1) {
     if (rank() > 4) {
       throw std::runtime_error("Cannot load dataset of rank greater than 4");
     }
-    nxdimsize_t n = 0, id(i), jd(j); // cppcheck-suppress variableScope
-    DimSizeVector datastart, datasize;
+    dimsize_t n = 0, id(i), jd(j); // cppcheck-suppress variableScope
+    DimVector datastart, datasize;
     if (rank() == 4) {
       if (i < 0) // load all data
       {
@@ -358,7 +357,7 @@ public:
       } else {
         if (id >= dim0() || jd >= dim1())
           rangeError();
-        nxdimsize_t m = blocksize;
+        dimsize_t m = blocksize;
         if (jd + m > dim1())
           m = dim1() - jd;
         n = dim2() * m;
@@ -374,7 +373,7 @@ public:
       } else if (j < 0) {
         if (id >= dim0())
           rangeError();
-        nxdimsize_t m = blocksize;
+        dimsize_t m = blocksize;
         if (id + m > dim0())
           m = dim0() - id;
         n = dim1() * m;
@@ -411,12 +410,12 @@ private:
    *
    * @param new_size :: The number of elements to allocate.
    */
-  void alloc(nxdimsize_t new_size) {
+  void alloc(dimsize_t new_size) {
     if (new_size <= 0) {
       throw std::runtime_error("Attempt to load from an empty dataset " + address());
     }
     try {
-      if (new_size != static_cast<nxdimsize_t>(m_size)) {
+      if (new_size != static_cast<dimsize_t>(m_size)) {
         m_data.resize(new_size);
         m_size = static_cast<size_t>(new_size);
       }

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -403,9 +403,9 @@ private:
       throw std::runtime_error("Attempt to load from an empty dataset " + address());
     }
     try {
-      if (new_size != static_cast<dimsize_t>(m_size)) {
+      if (new_size != m_size) {
         m_data.resize(new_size);
-        m_size = static_cast<size_t>(new_size);
+        m_size = new_size;
       }
     } catch (...) {
       std::ostringstream ostr;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -47,8 +47,10 @@ private:
   hid_t m_fid;
   // There is no reason to copy or assign a file ID
   FileID(FileID const &f) = delete;
+  FileID(FileID const &&f) = delete;
   FileID &operator=(hid_t const) = delete;
   FileID &operator=(FileID const &) = delete;
+  FileID &operator=(FileID const &&) = delete;
 
 public:
   bool operator==(int const v) const { return static_cast<int>(m_fid) == v; }
@@ -340,7 +342,7 @@ public:
    * \param open_data Whether or not to open the data after creating it.
    */
   void makeCompData(std::string const &name, NXnumtype const type, DimVector const &dims, NXcompression comp,
-                    DimSizeVector const &bufsize, bool open_data = false);
+                    DimVector const &bufsize, bool open_data = false);
 
   /**
    * Insert an array as part of a data in the final file.
@@ -349,7 +351,7 @@ public:
    * \param start The starting index to insert the data.
    * \param size The size of the array to put in the file.
    */
-  template <typename NumT> void putSlab(NumT const *data, DimSizeVector const &start, DimSizeVector const &size);
+  template <typename NumT> void putSlab(NumT const *data, DimVector const &start, DimVector const &size);
 
   /**
    * Insert an array as part of a data in the final file.
@@ -359,8 +361,7 @@ public:
    * \param size The size of the array to put in the file.
    * \tparam NumT numeric data type of \a data
    */
-  template <typename NumT>
-  void putSlab(std::vector<NumT> const &data, DimSizeVector const &start, DimSizeVector const &size);
+  template <typename NumT> void putSlab(std::vector<NumT> const &data, DimVector const &start, DimVector const &size);
 
   /**
    * Insert a number as part of a data in the final file.
@@ -380,7 +381,7 @@ public:
    * from.
    * \param size The size of the block to read from the file.
    */
-  template <typename NumT> void getSlab(NumT *data, DimSizeVector const &start, DimSizeVector const &size);
+  template <typename NumT> void getSlab(NumT *data, DimVector const &start, DimVector const &size);
 
   /** Get data and coerce into an int vector.
    *
@@ -474,7 +475,7 @@ public:
    */
   template <typename NumT>
   void writeExtendibleData(std::string const &name, std::vector<NumT> const &value, DimVector const &dims,
-                           DimSizeVector const &chunk);
+                           DimVector const &chunk);
 
   /** Updates the data written into an already-created
    * data vector. If the data was created as extendible, it will be resized.
@@ -508,7 +509,7 @@ public:
    */
   template <typename NumT>
   void writeCompData(std::string const &name, std::vector<NumT> const &value, DimVector const &dims,
-                     NXcompression const comp, DimSizeVector const &bufsize);
+                     NXcompression const comp, DimVector const &bufsize);
 
   /*----------------------------------------------------------------------*/
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -111,7 +111,7 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression 
 // forward declare
 namespace Mantid::Nexus {
 
-typedef int64_t dimsize_t;
+typedef hsize_t dimsize_t;
 typedef std::vector<dimsize_t> DimVector;
 
 typedef std::pair<std::string, std::string> Entry;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -12,8 +12,7 @@
 #include <string>
 #include <vector>
 
-constexpr int NX_MAXADDRESSLEN = 1024;
-
+// forward declare typedefs from hdf5
 typedef int64_t hid_t;
 typedef uint64_t hsize_t;
 
@@ -112,12 +111,8 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression 
 // forward declare
 namespace Mantid::Nexus {
 
-// TODO change to std::size_t
-typedef std::int64_t dimsize_t;
-// TODO replace all instances with DimArray
-typedef std::vector<dimsize_t> DimVector; ///< use specifically for the dims array
-//  TODO this is probably the same as DimVector
-typedef std::vector<dimsize_t> DimSizeVector; ///< used for start, size, chunk, buffsize, etc.
+typedef int64_t dimsize_t;
+typedef std::vector<dimsize_t> DimVector;
 
 typedef std::pair<std::string, std::string> Entry;
 typedef std::map<std::string, std::string> Entries;

--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -201,8 +201,8 @@ void readNexusVector(std::vector<T> &out, Nexus::File &file, const std::string &
  * readNexusAnySlab via the RUN_NEXUSIOHELPER_FUNCTION macro.
  */
 template <typename T, Narrowing narrow = Narrowing::Prevent>
-std::vector<T> readNexusSlab(Nexus::File &file, const std::string &entry, const std::vector<int64_t> &start,
-                             const std::vector<int64_t> &size) {
+std::vector<T> readNexusSlab(Nexus::File &file, const std::string &entry, DimVector const &start,
+                             DimVector const &size) {
   const auto info_and_close = checkIfOpenAndGetInfo(file, std::move(std::move(entry)));
   RUN_NEXUSIOHELPER_FUNCTION(narrow, (info_and_close.first).type, readNexusAnySlab, file, start, size,
                              info_and_close.second);
@@ -213,8 +213,8 @@ std::vector<T> readNexusSlab(Nexus::File &file, const std::string &entry, const 
  * The provided output buffer is filled.
  */
 template <typename T, Narrowing narrow = Narrowing::Prevent>
-void readNexusSlab(std::vector<T> &out, Nexus::File &file, const std::string &entry, const std::vector<int64_t> &start,
-                   const std::vector<int64_t> &size) {
+void readNexusSlab(std::vector<T> &out, Nexus::File &file, const std::string &entry, DimVector const &start,
+                   DimVector const &size) {
   const auto info_and_close = checkIfOpenAndGetInfo(file, std::move(std::move(entry)));
   RUN_NEXUSIOHELPER_FUNCTION(narrow, (info_and_close.first).type, readNexusAnySlab, out, file, start, size,
                              info_and_close.second);

--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -49,7 +49,7 @@ namespace {
     throw std::runtime_error(msg);                                                                                     \
   }
 
-int64_t vectorVolume(const Nexus::DimSizeVector &size) {
+int64_t vectorVolume(const Nexus::DimVector &size) {
   return std::accumulate(size.cbegin(), size.cend(), int64_t{1}, std::multiplies<>());
 }
 
@@ -109,8 +109,8 @@ void readNexusAnyVector(std::vector<T> &out, Nexus::File &file, const size_t siz
  * another type. If the two types are the same, the conversion is skipped.
  */
 template <typename T, typename U, Narrowing narrow>
-void doReadNexusAnySlab(std::vector<T> &out, Nexus::File &file, const Nexus::DimSizeVector &start,
-                        const Nexus::DimSizeVector &size, const int64_t volume, const bool close_data) {
+void doReadNexusAnySlab(std::vector<T> &out, Nexus::File &file, const Nexus::DimVector &start,
+                        const Nexus::DimVector &size, const int64_t volume, const bool close_data) {
   if constexpr (sizeof(T) < sizeof(U) && narrow == Narrowing::Prevent) {
     if (close_data)
       file.closeData();
@@ -133,7 +133,7 @@ void doReadNexusAnySlab(std::vector<T> &out, Nexus::File &file, const Nexus::Dim
 
 /// Read any type of slab and return it as a new vector.
 template <typename T, typename U, Narrowing narrow>
-std::vector<T> readNexusAnySlab(Nexus::File &file, const Nexus::DimSizeVector &start, const Nexus::DimSizeVector &size,
+std::vector<T> readNexusAnySlab(Nexus::File &file, const Nexus::DimVector &start, const Nexus::DimVector &size,
                                 const bool close_data) {
   const auto volume = vectorVolume(size);
   std::vector<T> vec(volume);
@@ -143,8 +143,8 @@ std::vector<T> readNexusAnySlab(Nexus::File &file, const Nexus::DimSizeVector &s
 
 /// Read any type of slab and store it into the provided buffer vector.
 template <typename T, typename U, Narrowing narrow>
-void readNexusAnySlab(std::vector<T> &out, Nexus::File &file, const Nexus::DimSizeVector &start,
-                      const Nexus::DimSizeVector &size, const bool close_data) {
+void readNexusAnySlab(std::vector<T> &out, Nexus::File &file, const Nexus::DimVector &start,
+                      const Nexus::DimVector &size, const bool close_data) {
   const auto volume = vectorVolume(size);
   if (out.size() < static_cast<size_t>(volume))
     throw std::runtime_error("The output buffer is too small in NeXusIOHelper::readNexusAnySlab");

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -346,11 +346,11 @@ void NXDataSet::openLocal() {
  * @returns An integer indicating the size of the dimension.
  * @throws out_of_range error if requested on an object of rank 0
  */
-nxdimsize_t NXDataSet::dim0() const {
+dimsize_t NXDataSet::dim0() const {
   if (m_info.rank == 0UL) {
     throw std::out_of_range("NXDataSet::dim0() - Requested dimension greater than rank.");
   }
-  return static_cast<int>(m_info.dims[0]);
+  return m_info.dims[0];
 }
 
 /**
@@ -358,11 +358,11 @@ nxdimsize_t NXDataSet::dim0() const {
  * @returns An integer indicating the size of the dimension
  * @throws out_of_range error if requested on an object of rank < 2
  */
-nxdimsize_t NXDataSet::dim1() const {
+dimsize_t NXDataSet::dim1() const {
   if (m_info.rank < 2) {
     throw std::out_of_range("NXDataSet::dim1() - Requested dimension greater than rank.");
   }
-  return static_cast<int>(m_info.dims[1]);
+  return m_info.dims[1];
 }
 
 /**
@@ -370,11 +370,11 @@ nxdimsize_t NXDataSet::dim1() const {
  * @returns An integer indicating the size of the dimension
  * @throws out_of_range error if requested on an object of rank < 3
  */
-nxdimsize_t NXDataSet::dim2() const {
+dimsize_t NXDataSet::dim2() const {
   if (m_info.rank < 3) {
     throw std::out_of_range("NXDataSet::dim2() - Requested dimension greater than rank.");
   }
-  return static_cast<int>(m_info.dims[2]);
+  return m_info.dims[2];
 }
 
 /**
@@ -382,11 +382,11 @@ nxdimsize_t NXDataSet::dim2() const {
  * @returns An integer indicating the size of the dimension
  * @throws out_of_range error if requested on an object of rank < 4
  */
-nxdimsize_t NXDataSet::dim3() const {
+dimsize_t NXDataSet::dim3() const {
   if (m_info.rank < 4) {
     throw std::out_of_range("NXDataSet::dim3() - Requested dimension greater than rank.");
   }
-  return static_cast<int>(m_info.dims[3]);
+  return m_info.dims[3];
 }
 
 //---------------------------------------------------------

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1291,7 +1291,7 @@ void File::writeData(std::string const &name, std::string const &value) {
   // Allow empty strings by defaulting to a space
   if (my_value.empty())
     my_value = " ";
-  const DimVector dims{static_cast<dimsize_t>(my_value.size())};
+  const DimVector dims{my_value.size()};
   this->makeData(name, NXnumtype::CHAR, dims, true);
 
   this->putData(my_value);
@@ -1300,7 +1300,7 @@ void File::writeData(std::string const &name, std::string const &value) {
 }
 
 template <typename NumT> void File::writeData(std::string const &name, vector<NumT> const &value) {
-  DimVector const dims{static_cast<dimsize_t>(value.size())};
+  DimVector const dims{value.size()};
   this->writeData(name, value, dims);
 }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -537,7 +537,7 @@ void File::makeData(const string &name, NXnumtype const type, DimVector const &d
   if (dims.empty()) {
     throw NXEXCEPTION("Supplied empty dimensions");
   }
-  DimSizeVector chunk_size(dims.size());
+  DimVector chunk_size(dims.size());
   for (std::size_t i = 0; i < dims.size(); i++) {
     chunk_size[i] = (dims[i] == NX_UNLIMITED || dims[i] <= 0 ? 1 : dims[i]);
   }
@@ -618,8 +618,8 @@ template <typename NumT> void File::putData(NumT const *data) {
         mySize[i] = static_cast<int64_t>(thedims[i]);
       }
     }
-    DimSizeVector vecStart(myStart.begin(), myStart.end());
-    DimSizeVector vecSize(mySize.begin(), mySize.end());
+    DimVector vecStart(myStart.begin(), myStart.end());
+    DimVector vecSize(mySize.begin(), mySize.end());
 
     return putSlab(data, vecStart, vecSize);
   } else {
@@ -821,7 +821,7 @@ void File::closeData() {
 //------------------------------------------------------------------------------------------------------------------
 
 void File::makeCompData(std::string const &name, NXnumtype const type, DimVector const &dims, NXcompression comp,
-                        DimSizeVector const &chunk, bool open_data) {
+                        DimVector const &chunk, bool open_data) {
   // error check the parameters
   if (name.empty()) {
     throw NXEXCEPTION("Supplied empty name to makeCompData");
@@ -985,7 +985,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
   }
 }
 
-template <typename NumT> void File::putSlab(NumT const *data, DimSizeVector const &start, DimSizeVector const &size) {
+template <typename NumT> void File::putSlab(NumT const *data, DimVector const &start, DimVector const &size) {
   if (data == NULL) {
     throw NXEXCEPTION("Data specified as null");
   }
@@ -1102,8 +1102,7 @@ template <typename NumT> void File::putSlab(NumT const *data, DimSizeVector cons
   }
 }
 
-template <typename NumT>
-void File::putSlab(vector<NumT> const &data, DimSizeVector const &start, DimSizeVector const &size) {
+template <typename NumT> void File::putSlab(vector<NumT> const &data, DimVector const &start, DimVector const &size) {
   if (data.empty()) {
     throw NXEXCEPTION("Supplied empty data to putSlab");
   }
@@ -1111,12 +1110,12 @@ void File::putSlab(vector<NumT> const &data, DimSizeVector const &start, DimSize
 }
 
 template <typename NumT> void File::putSlab(vector<NumT> const &data, dimsize_t const start, dimsize_t const size) {
-  DimSizeVector start_v{start};
-  DimSizeVector size_v{size};
+  DimVector start_v{start};
+  DimVector size_v{size};
   this->putSlab(data, start_v, size_v);
 }
 
-template <typename NumT> void File::getSlab(NumT *data, DimSizeVector const &start, DimSizeVector const &size) {
+template <typename NumT> void File::getSlab(NumT *data, DimVector const &start, DimVector const &size) {
   if (data == NULL) {
     throw NXEXCEPTION("Supplied null pointer to getSlab");
   }
@@ -1320,7 +1319,7 @@ template <typename NumT> void File::writeExtendibleData(std::string const &name,
 template <typename NumT>
 void File::writeExtendibleData(std::string const &name, vector<NumT> const &value, dimsize_t const chunk) {
   DimVector dims{NX_UNLIMITED};
-  DimSizeVector chunk_dims{chunk};
+  DimVector chunk_dims{chunk};
   // Use chunking without using compression
   this->makeCompData(name, getType<NumT>(), dims, NXcompression::NONE, chunk_dims, true);
   this->putSlab(value, dimsize_t(0), dimsize_t(value.size()));
@@ -1329,14 +1328,14 @@ void File::writeExtendibleData(std::string const &name, vector<NumT> const &valu
 
 template <typename NumT>
 void File::writeExtendibleData(std::string const &name, vector<NumT> const &value, DimVector const &dims,
-                               DimSizeVector const &chunk) {
+                               DimVector const &chunk) {
   // Create the data with unlimited 0th dimensions
   DimVector unlim_dims(dims);
   unlim_dims[0] = NX_UNLIMITED;
   // Use chunking without using compression
   this->makeCompData(name, getType<NumT>(), unlim_dims, NXcompression::NONE, chunk, true);
   // And put that slab of that of that given size in there
-  DimSizeVector start(dims.size(), 0);
+  DimVector start(dims.size(), 0);
   this->putSlab(value, start, dims);
   this->closeData();
 }
@@ -1350,14 +1349,14 @@ template <typename NumT> void File::writeUpdatedData(std::string const &name, st
 template <typename NumT>
 void File::writeUpdatedData(std::string const &name, std::vector<NumT> const &value, DimVector const &dims) {
   this->openData(name);
-  DimSizeVector start(dims.size(), 0);
+  DimVector start(dims.size(), 0);
   this->putSlab(value, start, dims);
   this->closeData();
 }
 
 template <typename NumT>
 void File::writeCompData(std::string const &name, vector<NumT> const &value, DimVector const &dims,
-                         NXcompression const comp, DimSizeVector const &bufsize) {
+                         NXcompression const comp, DimVector const &bufsize) {
   this->makeCompData(name, getType<NumT>(), dims, comp, bufsize, true);
   this->putData(value);
   this->closeData();
@@ -2004,27 +2003,27 @@ template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name
                                                          dimsize_t const chunk);
 
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<float> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<double> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<int8_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<uint8_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<int16_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<uint16_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<int32_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<uint32_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<int64_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<uint64_t> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 template MANTID_NEXUS_DLL void File::writeExtendibleData(std::string const &name, std::vector<char> const &value,
-                                                         DimVector const &dims, DimSizeVector const &chunk);
+                                                         DimVector const &dims, DimVector const &chunk);
 
 template MANTID_NEXUS_DLL void File::writeUpdatedData(std::string const &name, vector<float> const &value);
 template MANTID_NEXUS_DLL void File::writeUpdatedData(std::string const &name, vector<double> const &value);
@@ -2063,89 +2062,82 @@ template MANTID_NEXUS_DLL void File::writeUpdatedData(std::string const &name, v
 
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<float> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<double> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<int8_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<uint8_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<int16_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<uint16_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<int32_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<uint32_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<int64_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 template MANTID_NEXUS_DLL void File::writeCompData(std::string const &name, vector<uint64_t> const &value,
                                                    DimVector const &dims, NXcompression const comp,
-                                                   DimSizeVector const &bufsize);
+                                                   DimVector const &bufsize);
 
 // READ / WRITE DATA -- SLAB / EXTENDIBLE
 
-template MANTID_NEXUS_DLL void File::getSlab(float *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(double *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(int8_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(uint8_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(int16_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(uint16_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(int32_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(uint32_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(int64_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(uint64_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(char *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::getSlab(bool *data, const DimSizeVector &start, const DimSizeVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(float *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(double *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(int8_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(uint8_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(int16_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(uint16_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(int32_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(uint32_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(int64_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(uint64_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(char *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::getSlab(bool *data, const DimVector &start, const DimVector &size);
 
-template MANTID_NEXUS_DLL void File::putSlab(const float *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const double *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const int8_t *data, const DimSizeVector &start, const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const uint8_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const int16_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const uint16_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const int32_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const uint32_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const int64_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const uint64_t *data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const char *data, const DimSizeVector &start, const DimSizeVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const float *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const double *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const int8_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const uint8_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const int16_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const uint16_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const int32_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const uint32_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const int64_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const uint64_t *data, const DimVector &start, const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const char *data, const DimVector &start, const DimVector &size);
 
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<float> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<double> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int8_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint8_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int16_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint16_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int32_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint32_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int64_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
-template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint64_t> &data, const DimSizeVector &start,
-                                             const DimSizeVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<float> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<double> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int8_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint8_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int16_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint16_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int32_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint32_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<int64_t> &data, const DimVector &start,
+                                             const DimVector &size);
+template MANTID_NEXUS_DLL void File::putSlab(const std::vector<uint64_t> &data, const DimVector &start,
+                                             const DimVector &size);
 
 template MANTID_NEXUS_DLL void File::putSlab(const std::vector<float> &data, const dimsize_t start,
                                              const dimsize_t size);

--- a/Framework/Nexus/test/NapiUnitTest.h
+++ b/Framework/Nexus/test/NapiUnitTest.h
@@ -87,7 +87,7 @@ public:
     // NOTE: to properly set the DataSpace, should be `dims {in.size(), 1}` and use rank = 2
     // However, that seems to contradict notes inside napi5 about rank for string data
     // Using rank = 1 works, but the DataSpace will register size = 1
-    DimVector dims{static_cast<dimsize_t>(in.size())};
+    DimVector dims{in.size()};
     NX_ASSERT_OKAY(NXmakedata64(fid, name.c_str(), NXnumtype::CHAR, 1, dims), "failed to make data");
     NX_ASSERT_OKAY(NXopendata(fid, name.c_str()), "failed to open data");
     NX_ASSERT_OKAY(NXputdata(fid, in.data()), "failed to put data");
@@ -116,7 +116,7 @@ public:
     // put/get a char array
     char word[] = "silicovolcaniosis";
     char read[30] = {'A'}; // pre-fill with junk data
-    dims = {static_cast<dimsize_t>(strlen(word))};
+    dims = {strlen(word)};
     NX_ASSERT_OKAY(NXmakedata64(fid, "data_char", NXnumtype::CHAR, 1, dims), "failed to make data");
     NX_ASSERT_OKAY(NXopendata(fid, "data_char"), "failed to open data");
     NX_ASSERT_OKAY(NXputdata(fid, word), "failed to put data");

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -92,7 +92,7 @@ public:
           fileid.openGroup(oss2, "NXdata");
           for (int iData = 0; iData < nData; iData++) {
             std::string oss3(strmakef("i2_data_%d", iData));
-            DimVector dims{static_cast<dimsize_t>(i2_array.size())};
+            DimVector dims{i2_array.size()};
             fileid.makeData(oss3, NXnumtype::INT16, dims);
             fileid.openData(oss3);
             fileid.putData(i2_array.data());

--- a/Framework/Nexus/test/NexusFileNapiTest.h
+++ b/Framework/Nexus/test/NexusFileNapiTest.h
@@ -106,7 +106,7 @@ private:
     }
     file.makeData("r8_data", NXnumtype::FLOAT64, array_dims, true);
     DimVector slab_start{4, 0};
-    DimSizeVector slab_size{1, 4};
+    DimVector slab_size{1, 4};
     file.putSlab(&(r8_array[16]), slab_start, slab_size);
     slab_start[0] = 0;
     slab_start[1] = 0;

--- a/Framework/Nexus/test/NexusFileReadWriteTest.h
+++ b/Framework/Nexus/test/NexusFileReadWriteTest.h
@@ -99,7 +99,7 @@ private:
 
     // write
     dimsize_t dimsize = data.size();
-    DimSizeVector const start({0}), size({dimsize});
+    DimVector const start{0}, size{dimsize};
     fileid.makeData(dataname, getType<T>(), dimsize);
     fileid.openData(dataname);
     fileid.putSlab(data, start, size);
@@ -123,7 +123,7 @@ private:
     cout << "Testing slab " << dataname << "\n" << std::flush;
 
     // write
-    DimSizeVector start({0, 0}), size({N, M});
+    DimVector start{0, 0}, size{N, M};
     DimVector const dims({N, M});
     fileid.makeData(dataname, getType<T>(), dims);
     fileid.openData(dataname);
@@ -277,7 +277,7 @@ public:
     // make and open compressed data
     TS_ASSERT_THROWS_NOTHING(fileid.makeCompData("data", NXnumtype::FLOAT64, dims, NXcompression::NONE, dims, true));
 
-    Mantid::Nexus::DimSizeVector slab_start{0, 0}, slab_size{1, DATA_SIZE};
+    Mantid::Nexus::DimVector slab_start{0, 0}, slab_size{1, DATA_SIZE};
     for (Mantid::Nexus::dimsize_t i = 0; i < 2; i++) {
       slab_start[0] = i;
       TS_ASSERT_THROWS_NOTHING(fileid.putSlab(d, slab_start, slab_size));

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -673,8 +673,7 @@ public:
       index += maxlen;
     }
     // write the strings as a flat array, but with dims for a block
-    Mantid::Nexus::DimVector dims{static_cast<Mantid::Nexus::dimsize_t>(numStr),
-                                  static_cast<Mantid::Nexus::dimsize_t>(maxlen)};
+    Mantid::Nexus::DimVector dims{numStr, maxlen};
     file.makeData("value", NXnumtype::CHAR, dims, true);
     file.putData(strs.data());
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -231,7 +231,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS
 uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFocusedXYE.cpp:73
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSS.cpp:432
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSS.cpp:566
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXSPE.cpp:333
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusProcessed.cpp:572
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/CoordinateConversion.h:109
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventWorkspace.cpp:712


### PR DESCRIPTION
### Description of work

Writing data to NeXus files requires specifying the dimensions of the data through an array object.  `NexusFile_fwd.h` defines a helpful typedef, `DimVector`, which is a `std::vector`.  To be compatible with `napi` this had been declared as a vector of `int64_t`; however, dimensions cannot be negative, so this should be a vector of unsigned ints.  Further, the values in this array almost always come from the size of some other container object, with type `std::size_t`, requiring unnecessary static casts.

From the start of the Nexus refactor work, it has been an ambition to change these values to unsigned ints, but has been prohibitively difficult due to the then condition of `napi`.

This finally gets in that bit of cleanup.

Part of #38332

### To test:

Changes are very mechanical.

Ensure all existing tests can pass without regressions.

This does not need release notes because this is entirely internal

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
