### PR TITLE
Use vcvarsall.bat in build and test stage to locate c compilers

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,15 +75,6 @@
     },
     {
       "name": "win-64-ci",
-      "description": "Build options for a CI build on windows",
-      "inherits": [
-        "ci-default",
-        "conda"
-      ],
-      "generator": "Visual Studio 17 2022"
-    },
-    {
-      "name": "win-64-ci-ninja",
       "description": "Build options for a CI build on windows with Ninja",
       "inherits": [
         "ci-default",

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -31,6 +31,10 @@ if [[ -n "${MANTID_DATA_STORE}" ]]; then
     MANTID_DATA_STORE_CMAKE="-DMANTID_DATA_STORE=${MANTID_DATA_STORE}"
 fi
 
+if [[ $OSTYPE == "msys"* ]]; then
+    eval "$(./vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
+fi
+
 # Run CMake using preset and variables
 cmake --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $WORKSPACE
 
@@ -51,10 +55,6 @@ if [[ $ENABLE_COVERITY == true ]]; then
     curl -f -X PUT -d token=$COVERITY_TOKEN https://scan.coverity.com/projects/335/builds/$build_id/enqueue
 
     exit 0
-fi
-
-if [[ $OSTYPE == "msys"* ]]; then
-    eval "$(./vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
 fi
 
 if [[ $ENABLE_BUILD_CODE == true ]]; then

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -32,7 +32,7 @@ if [[ -n "${MANTID_DATA_STORE}" ]]; then
 fi
 
 if [[ $OSTYPE == "msys"* ]]; then
-    eval "$(./vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
+    eval "$($WORKSPACE/buildconfig/Jenkins/Conda/vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
 fi
 
 # Run CMake using preset and variables

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -14,7 +14,6 @@
 #   8. ENABLE_DOC_TESTS: whether or not to build the test data for doc tests
 #   9. ENABLE_COVERITY: enables the coverity scan static analysis
 #   10. EXTRA_CMAKE_FLAGS: Extra flags to pass directly to cmake, enclose in "".
-#   11. BUILD_THREADS: Pass the number of threads that can be used to build with
 
 WORKSPACE=$1
 CMAKE_PRESET=$2
@@ -26,16 +25,10 @@ ENABLE_SYSTEM_TESTS=$7
 ENABLE_DOC_TESTS=$8
 ENABLE_COVERITY=$9
 EXTRA_CMAKE_FLAGS=${10}
-BUILD_THREADS=${11}
 
 # Only pass MANTID_DATA_STORE to CMake if present in the environment otherwise rely on CMake default
 if [[ -n "${MANTID_DATA_STORE}" ]]; then
     MANTID_DATA_STORE_CMAKE="-DMANTID_DATA_STORE=${MANTID_DATA_STORE}"
-fi
-
-BUILD_OPTIONS=""
-if [[ $OSTYPE == "msys"* ]]; then
-    BUILD_OPTIONS="$BUILD_OPTIONS --config Release"
 fi
 
 # Run CMake using preset and variables
@@ -44,18 +37,10 @@ cmake --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $
 # Run the actual builds for the code, unit tests, and system tests.
 cd $WORKSPACE/build
 
-if [ -f build.ninja ]; then
-    # if using ninja let ninja control compiling threads
-    echo "ninja will control number of threads"
-else
-    # prepend number of threads to build with
-    BUILD_OPTIONS="-j$BUILD_THREADS $BUILD_OPTIONS"
-fi
-
 if [[ $ENABLE_COVERITY == true ]]; then
     conda install -y jq curl
 
-    ${COVERITY_DIR}/cov-build --dir cov-int cmake --build . $BUILD_OPTIONS
+    ${COVERITY_DIR}/cov-build --dir cov-int cmake --build .
     tar czvf mantid.tgz cov-int
 
     curl --fail-with-body -X POST -d version=$GIT_COMMIT -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="mantid.tgz" https://scan.coverity.com/projects/335/builds/init > response
@@ -68,8 +53,12 @@ if [[ $ENABLE_COVERITY == true ]]; then
     exit 0
 fi
 
+if [[ $OSTYPE == "msys"* ]]; then
+    eval "$(./vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
+fi
+
 if [[ $ENABLE_BUILD_CODE == true ]]; then
-    cmake --build . $BUILD_OPTIONS
+    cmake --build .
 fi
 
 # create a collection of targets to run all at once during main build

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -126,7 +126,7 @@ fi
 git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
 
 # Mamba
-setup_mamba $WORKSPACE/miniforge "" $CLEAN_BUILD $PLATFORM
+setup_mamba $WORKSPACE/miniforge "" $CLEAN_BUILD
 create_and_activate_mantid_developer_env $WORKSPACE $PLATFORM
 
 # Check whether this is an incremental build that only changes rst files
@@ -169,7 +169,7 @@ fi
 set -o pipefail
 
 # Run the script that handles the build
-$SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
+$SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
 
 # Return to original behaviour.
 set +o pipefail

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -571,7 +571,6 @@ def build_and_test(platform) {
   common_args = '--clean-build --clean-external-projects --enable-systemtests'
   cmake_preset = "${platform}-ci"
   if(platform.startsWith('win')) {
-    cmake_preset += "-ninja"
     workspace_unix_style = toUnixStylePath("${WORKSPACE}")
     bat "\"${WIN_BASH}\" -ex -c \"${buildscript_path}\
       ${workspace_unix_style}/${CHECKOUT_DIR} ${cmake_preset} ${common_args}\""

--- a/buildconfig/Jenkins/Conda/vcvarsall.sh
+++ b/buildconfig/Jenkins/Conda/vcvarsall.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+#
+# Source: https://github.com/nathan818fr/vcvars-bash
+# Author: Nathan Poirier <nathan@poirier.io>
+#
+set -Eeuo pipefail
+shopt -s inherit_errexit
+
+declare -r VERSION='2025-07-09.1'
+
+function detect_platform() {
+  case "${OSTYPE:-}" in
+  cygwin* | msys* | win32)
+    declare -gr bash_platform='win_cyg'
+    ;;
+  *)
+    if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+      declare -gr bash_platform='win_wsl'
+    else
+      printf 'error: Unsupported platform (%s)\n' "${OSTYPE:-}" >&2
+      printf 'hint: This script only supports Bash on Windows (Git Bash, WSL, etc.)\n' >&2
+      return 1
+    fi
+    ;;
+  esac
+}
+
+function detect_mode() {
+  # Detect the mode depending on the name called
+  if [[ "$(basename -- "$0")" == vcvarsrun* ]]; then
+    declare -gr script_mode='run' # vcvarsrun.sh
+  else
+    declare -gr script_mode='default' # vcvarsall.sh
+  fi
+}
+
+function print_usage() {
+  case "$script_mode" in
+  default)
+    cat <<EOF
+Usage: eval "\$(vcvarsall.sh [vcvarsall.bat arguments])"
+Script version: $VERSION
+
+Load MSVC environment variables using vcvarsall.bat and export them.
+The script writes a list of export commands to stdout, to be evaluated by a
+POSIX-compliant shell.
+
+Example: eval "\$(vcvarsall.sh x86)"
+EOF
+    ;;
+  run)
+    cat <<EOF
+Usage: vcvarsrun.sh [vcvarsall.bat arguments] -- command [arguments...]
+Script version: $VERSION
+
+Load MSVC environment variables using vcvarsall.bat and execute a command with
+them.
+
+Example: vcvarsrun.sh x64 -- cl /nologo /EHsc /Fe:hello.exe hello.cpp
+EOF
+    ;;
+  esac
+  cat <<EOF
+
+Environment variables:
+  VSINSTALLDIR
+    The path to the Visual Studio installation directory.
+    Example: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community"
+    Default: The latest Visual Studio installation directory found by
+             vswhere.exe
+
+  VSWHEREPATH
+    The path to the vswhere.exe executable.
+    Example: "C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe"
+    Default: Automatically detected (in the PATH or well-known locations)
+
+  VSWHEREARGS
+    The arguments to pass to vswhere.exe.
+    This value is always automatically prefixed with "-latest -property installationPath".
+    Default: "-products *"
+EOF
+  local vcvarsall
+  vcvarsall=$(find_vcvarsall)
+  printf '\nvcvarsall.bat arguments: %s\n' "$({ cmd "$(cmdesc "$vcvarsall")" -help </dev/null 2>/dev/null || true; } | fix_crlf | sed '/^Syntax:/d; s/^    vcvarsall.bat //')"
+}
+
+function main() {
+  detect_platform
+  detect_mode
+
+  # Parse arguments
+  if [[ $# -eq 0 ]]; then
+    print_usage >&2
+    return 1
+  fi
+
+  local arg vcvarsall_args=()
+  for arg in "$@"; do
+    shift
+    if [[ "$arg" == '--' ]]; then
+      if [[ "$script_mode" == 'default' ]]; then
+        printf 'error: Unexpected argument: --\n' >&2
+        printf 'hint: Use vcvarsrun to run a command\n' >&2
+        return 1
+      fi
+      break
+    fi
+    vcvarsall_args+=("$(cmdesc "$arg")")
+  done
+
+  if [[ "$script_mode" == 'run' && $# -eq 0 ]]; then
+    printf 'error: No command specified\n' >&2
+    return 1
+  fi
+
+  # Get MSVC environment variables from vcvarsall.bat
+  local vcvarsall vcvarsall_env
+  vcvarsall=$(find_vcvarsall)
+  vcvarsall_env=$({ cmd "$(cmdesc "$vcvarsall")" "${vcvarsall_args[@]}" '&&' 'set' </dev/null || true; } | fix_crlf)
+
+  # Filter MSVC environment variables and export them.
+  # The list of variables to export was based on a comparison between a clean environment and the vcvarsall.bat
+  # environment (on different MSVC versions, tools and architectures).
+  #
+  # Windows environment variables are case-insensitive while Unix-like environment variables are case-sensitive, so:
+  # - we always use uppercase names to prevent duplicates environment variables on the Unix-like side
+  # - we also ensure that only the first occurrence of a variable is exported (see below)
+  #
+  # While Windows environment variables are case-insensitive, it is possible to have duplicates in some edge cases.
+  # e.g. using Git Bash:
+  #  export xxx=1; export XXX=2; export xXx=3; cmd.exe //c set XxX=4 '&&' set
+  # will output:
+  #  XXX=4
+  #  xXx=3
+  #  xxx=1
+
+  declare -A seen_vars
+  function export_env() {
+    local name=${1^^}
+    local value=$2
+    if [[ ! "$name" =~ ^[A-Z0-9_]+$ ]]; then return; fi
+    if [[ -n "${seen_vars[$name]:-}" ]]; then return; fi
+    seen_vars[$name]=1
+    if [[ "$script_mode" == 'run' ]]; then
+      export "${name}=${value}"
+    else
+      printf "export %s='%s'\n" "$name" "${value//\'/\'\\\'\'}"
+    fi
+  }
+
+  local name value initialized=false
+  while IFS='=' read -r name value; do
+    if [[ "$initialized" == 'false' ]]; then
+      if [[ -n "$value" ]]; then name+="=$value"; fi
+      if [[ "$name" == *' Environment initialized for: '* ]]; then initialized=true; fi
+      printf '%s\n' "$name" >&2
+      continue
+    fi
+
+    case "${name^^}" in
+    LIB | LIBPATH | INCLUDE | EXTERNAL_INCLUDE | COMMANDPROMPTTYPE | DEVENVDIR | EXTENSIONSDKDIR | FRAMEWORK* | \
+      PLATFORM | PREFERREDTOOLARCHITECTURE | UCRT* | UNIVERSALCRTSDK* | VCIDE* | VCINSTALL* | VCPKG* | VCTOOLS* | \
+      VSCMD* | VSINSTALL* | VS[0-9]* | VISUALSTUDIO* | WINDOWSLIB* | WINDOWSSDK*)
+      export_env "$name" "$value"
+      ;;
+    PATH)
+      # PATH is a special case, requiring special handling
+      local new_paths
+      new_paths=$(pathlist_win_to_unix "$value")             # Convert to unix-style path list
+      new_paths=$(pathlist_normalize "${PATH}:${new_paths}") # Prepend the current PATH
+      export_env 'WINDOWS_PATH' "$value"
+      export_env 'PATH' "$new_paths"
+      ;;
+    esac
+  done <<<"$vcvarsall_env"
+
+  if [[ "$initialized" == 'false' ]]; then
+    printf 'error: vcvarsall.bat failed' >&2
+    return 1
+  fi
+
+  # Execute command if needed
+  if [[ "$script_mode" == 'run' ]]; then
+    exec "$@"
+  fi
+}
+
+# Locate vcvarsall.bat
+# Inputs:
+#   VSINSTALLDIR: The path to the Visual Studio installation directory (optional)
+#   VSWHEREPATH: The path to the vswhere.exe executable (optional)
+#   VSWHEREARGS: The arguments to pass to vswhere.exe (optional)
+# Outputs:
+#   stdout: The windows-style path to vcvarsall.bat
+function find_vcvarsall() {
+  local vsinstalldir
+  if [[ -n "${VSINSTALLDIR:-}" ]]; then
+    vsinstalldir="$VSINSTALLDIR"
+  else
+    local vswhere
+    if [[ -n "${VSWHEREPATH:-}" ]]; then
+      vswhere=$(unixpath "$VSWHEREPATH")
+    else
+      vswhere=$(command -v 'vswhere' 2>/dev/null || unixpath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe')
+    fi
+
+    local vswhereargs=(-latest -property installationPath)
+    if [[ -n "${VSWHEREARGS:-}" ]]; then
+      parse_args_simple "$VSWHEREARGS"
+      vswhereargs+=("${result[@]}")
+    else
+      vswhereargs+=(-products '*')
+    fi
+
+    if [[ "${VCVARSBASH_DEBUG:-}" == 1 ]]; then
+      printf 'debug: vswhere path: %s\n' "$vswhere" >&2
+      printf 'debug: vswhere args:\n' >&2
+      printf 'debug:  [ %s ]\n' "${vswhereargs[@]}" >&2
+    fi
+
+    vsinstalldir=$("$vswhere" "${vswhereargs[@]}" </dev/null | fix_crlf)
+    if [[ -z "$vsinstalldir" ]]; then
+      printf 'error: vswhere returned an empty installation path\n' >&2
+      return 1
+    fi
+  fi
+
+  printf '%s\n' "$(winpath "$vsinstalldir")\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+}
+
+# Split command arguments into an array, with a simple logic
+# - Arguments are separated by whitespace (space, tab, newline, carriage return)
+# - To include whitespace in an argument, it must be enclosed in double quotes (")
+# - When inside a double-quoted argument, quotes can be escaped by doubling them ("")
+# Inputs:
+#   $1: The string to parse
+# Outputs:
+#   result: An array of parsed arguments
+function parse_args_simple() {
+  declare -g result=()
+  local str="$1 " # add a trailing space to simplify the last argument handling
+  local args=()
+  local current_type=none # none = waiting for next arg, normal = inside normal arg, quoted = inside quoted arg
+  local current_value=''
+  local i=0 len=${#str}
+  while ((i < len)); do
+    local c=${str:i:1}
+    case "$current_type" in
+    none)
+      case "$c" in
+      ' ' | $'\t' | $'\n' | $'\r')
+        # Ignore whitespace
+        ;;
+      '"')
+        # Start a quoted argument
+        current_type=quoted
+        current_value=''
+        ;;
+      *)
+        # Start a normal argument
+        current_type=normal
+        current_value="$c"
+        ;;
+      esac
+      ;;
+    normal)
+      case "$c" in
+      ' ' | $'\t' | $'\n' | $'\r')
+        # End of normal argument, add it to the list
+        args+=("$current_value")
+        current_type=none
+        current_value=''
+        ;;
+      *)
+        # Continue building the normal argument
+        current_value+="$c"
+        ;;
+      esac
+      ;;
+    quoted)
+      case "$c" in
+      '"')
+        if [[ "${str:i+1:1}" != '"' ]]; then
+          # End of quoted argument, add it to the list
+          args+=("$current_value")
+          current_type=none
+          current_value=''
+        else
+          # Escaped quote, add a single quote to the current value
+          current_value+='"'
+          ((++i)) # Skip the next quote
+        fi
+        ;;
+      *)
+        # Continue building the quoted argument
+        current_value+="$c"
+        ;;
+      esac
+      ;;
+    esac
+    ((++i))
+  done
+  if [[ "$current_type" != none ]]; then
+    printf 'error: Unfinished %s argument: %s\n' "$current_type" "$current_value" >&2
+    return 1
+  fi
+  declare -g result=("${args[@]}")
+}
+
+# Run a command with cmd.exe
+# Inputs:
+#   $@: The command string to run (use cmdesc to escape arguments when needed)
+# Outputs:
+#   stdout: The cmd.exe standard output
+#   stderr: The cmd.exe error output
+function cmd() {
+  # This seems to work fine on all supported platforms
+  # (even with all the weird path and argument conversions on MSYS-like)
+  MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' cmd.exe /s /c " ; $* "
+}
+
+# Escape a cmd.exe command argument
+# Inputs:
+#   $1: The argument to escape
+# Outputs:
+#   stdout: The escaped argument
+function cmdesc() {
+  # shellcheck disable=SC2001
+  sed 's/[^0-9A-Za-z]/^\0/g' <<<"$1"
+}
+
+# Convert path to an absolute unix-style path
+# Inputs:
+#   $1: The path to convert
+# Outputs:
+#   stdout: The converted path
+function unixpath() {
+  local path=$1
+  case "$bash_platform" in
+  win_wsl)
+    case "$path" in
+    [a-zA-Z]:\\* | [a-zA-Z]:/* | \\\\* | //*)
+      # Convert windows path using wslpath (unix mode, absolute path)
+      wslpath -u -a -- "$path"
+      ;;
+    *)
+      # Convert unix path using realpath
+      realpath -m -- "$path"
+      ;;
+    esac
+    ;;
+  *)
+    cygpath -u -a -- "$path"
+    ;;
+  esac
+}
+
+# Convert path to an absolute windows-style path
+# Inputs:
+#   $1: The path to convert
+# Outputs:
+#   stdout: The converted path
+function winpath() {
+  local path=$1
+  case "$bash_platform" in
+  win_wsl)
+    case "$path" in
+    [a-zA-Z]:\\* | [a-zA-Z]:/* | \\\\* | //*)
+      # Already a windows path
+      printf '%s' "$path"
+      ;;
+    *)
+      # Convert using wslpath (windows mode, absolute path)
+      wslpath -w -a -- "$path"
+      ;;
+    esac
+    ;;
+  *)
+    # Convert using cygpath (windows mode, absolute path, long form)
+    cygpath -w -a -l -- "$path"
+    ;;
+  esac
+}
+
+# Convert a windows-style path list to a unix-style path list
+# Inputs:
+#   $1: The windows-style path list to convert
+# Outputs:
+#   stdout: The converted unix-style path list
+function pathlist_win_to_unix() {
+  local win_paths=$1
+
+  local path_dir first=true
+  while IFS= read -r -d';' path_dir; do
+    if [[ -z "$path_dir" ]]; then continue; fi
+
+    if [[ "$first" == 'true' ]]; then first=false; else printf ':'; fi
+    printf '%s' "$(unixpath "$path_dir")"
+  done <<<"${win_paths};"
+}
+
+# Normalize a unix-style path list, removing duplicates and empty entries
+# Inputs:
+#   $1: The list to normalize
+# Outputs:
+#   stdout: The normalized path list
+function pathlist_normalize() {
+  local unix_paths=$1
+
+  declare -A seen_paths
+  local path_dir first=true
+  while IFS= read -r -d ':' path_dir; do
+    if [[ -z "$path_dir" ]]; then continue; fi
+    if [[ -n "${seen_paths[$path_dir]:-}" ]]; then continue; fi
+    seen_paths[$path_dir]=1
+
+    if [[ "$first" == 'true' ]]; then first=false; else printf ':'; fi
+    printf '%s' "$path_dir"
+  done <<<"${unix_paths}:"
+}
+
+# Convert CRLF to LF
+# Inputs:
+#   stdin: The input to convert
+# Outputs:
+#   stdout: The converted input
+function fix_crlf() {
+  sed 's/\r$//'
+}
+
+eval 'main "$@";exit "$?"'


### PR DESCRIPTION
NOTE: Failing on Windows is expected as the `win-64-ci-ninja` preset has been removed. After this PR has been merged, we will change over the preset in the jenkins config.

Build and test run: https://builds.mantidproject.org/job/build_packages_from_branch/1261

### Description of work

This PR:
- Adds a `vcvarsall.sh` script which allows us to add the MSVC compilers to the path from a bash shell.
- Changes the`win-64-ci` cmake preset to use ninja.
- Removes some code from the build scripts related to using VS as a generator on windows, which we will not do after this.

### To test:



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
