### PR TITLE
remove double test

### DIFF
--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -1495,37 +1495,6 @@ public:
     TZSET();
   }
 
-  void test_data_existing_time_string() {
-    cout << "\ntest dataset read existing -- time string attr\n";
-
-    // open an existing file
-    std::string filename = getFullPath("HB2C_7000.nxs.h5");
-    Mantid::Nexus::File file(filename, NXaccess::READ);
-
-    std::string time_str;
-    file.getAttr("file_time", time_str);
-    file.close();
-
-    std::tm tm = {};
-    char sign;
-    int offsetHours, offsetMinutes;
-
-    sscanf(time_str.c_str(), "%4d-%2d-%2dT%2d:%2d:%2d%c%2d:%2d", &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour,
-           &tm.tm_min, &tm.tm_sec, &sign, &offsetHours, &offsetMinutes);
-
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
-
-    std::time_t local = std::mktime(&tm);
-
-    std::string expected = Mantid::Types::Core::DateAndTime::getLocalTimeISO8601String(local);
-    TS_ASSERT_EQUALS(time_str.substr(0, time_str.find_last_of("+-")), expected.substr(0, expected.find_last_of("+-")));
-    std::regex iso8601_regex(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$)");
-
-    TS_ASSERT(std::regex_match(time_str, iso8601_regex));
-    TS_ASSERT(std::regex_match(expected, iso8601_regex));
-  }
-
   // ##################################################################################################################
   // TEST LINK METHODS
   // ################################################################################################################


### PR DESCRIPTION
### Description of work

An accidental mis-order or PR merging left `NexusFileTest` with two different tests with the same name.

The second test is not needed, so can be deleted.  Leaving it will cause errors building the unit tests.

### To test:

Pull this branch, run
``` bash
ninja NexusTest && ctest -R ^NexusTest
```

If this passes, then the issue is fixed.

I think this can be directly merged without waiting for the usual CI/CD

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
