### PR TITLE
Performance improvement for poldi autocorrelation and simulation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
+++ b/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm, Progress
-from mantid.kernel import Direction, FloatBoundedValidator, UnitConversion, DeltaEModeType, UnitParams, UnitParametersMap
+from mantid.kernel import Direction, FloatBoundedValidator, UnitParams, StringListValidator
 import numpy as np
 from plugins.algorithms.poldi_utils import (
     get_instrument_settings_from_log,
@@ -13,6 +13,9 @@ from plugins.algorithms.poldi_utils import (
     get_dspac_limits,
     get_final_dspac_array,
 )
+from joblib import Parallel, delayed
+from functools import reduce
+from operator import iadd
 
 
 class PoldiAutoCorrelation(PythonAlgorithm):
@@ -51,6 +54,14 @@ class PoldiAutoCorrelation(PythonAlgorithm):
             validator=positive_float_validator,
             doc="Maximum wavelength to consider.",
         )
+        self.declareProperty(
+            "InterpolationMethod",
+            defaultValue="Linear",
+            direction=Direction.Input,
+            validator=StringListValidator(["Linear", "Nearest"]),
+            doc="Interpolation used when adding intensity to a given bin in correlation function - "
+            "'Nearest' is quicker but potentially less accurate.",
+        )
 
     def validateInputs(self):
         issues = dict()
@@ -80,7 +91,7 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         # get detector positions from IDF
         si = ws.spectrumInfo()
         tths = np.array([si.twoTheta(ispec) for ispec in range(ws.getNumberHistograms())])
-        l2s = [si.l2(ispec) for ispec in range(ws.getNumberHistograms())]
+        l2s = np.asarray([si.l2(ispec) for ispec in range(ws.getNumberHistograms())])
         l1 = si.l1()
         # determine npulses to include in calc
         time_max = get_max_tof_from_chopper(l1, l1_chop, l2s, tths, lambda_max) + slit_offsets[0]
@@ -90,32 +101,26 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         # but this is a small effect as detector doesn't cover much two-theta range
         dspac_min, dspac_max = get_dspac_limits(tths.min(), tths.max(), lambda_min, lambda_max)
         bin_width = ws.readX(0)[1] - ws.readX(0)[0]
-        dspacs = get_final_dspac_array(bin_width, dspac_min, dspac_max, time_max)
+        dspacs = get_final_dspac_array(bin_width, dspac_min, dspac_max, time_max)[:, None]
         # perform auto-correlation (Eq. 7 in POLDI concept paper)
         ipulses = np.arange(npulses)[:, None]
-        offsets = (ipulses * cycle_time + slit_offsets).flatten()
-        inter_corr = np.zeros((len(dspacs), len(offsets)), dtype=float)  # npulses*nslits
-        # sum over all spectra
-        params = UnitParametersMap()
+        offsets = (ipulses * cycle_time + slit_offsets).flatten() + t0_const
+        # get time-of-flight from chopper to detector for neutron corresponding to d=1Ang
         nspec = ws.getNumberHistograms()
+        path_length_ratio = (l2s + l1 - l1_chop) / (l2s + l1)
+        tof_d1Ang = np.asarray([si.diffractometerConstants(ispec)[UnitParams.difc] * path_length_ratio[ispec] for ispec in range(nspec)])
+        # loop over spectra and add to intermediate correlation
         progress = Progress(self, start=0.0, end=1.0, nreports=nspec)
-        for ispec in range(nspec):
-            params[UnitParams.l2] = l2s[ispec]
-            params[UnitParams.twoTheta] = tths[ispec]
-            # TOF from chopper to detector for wavelength corresponding to d=1Ang
-            # equivalent to DIFC * (Ltot - L1_source-chop) / Ltot
-            tof_d1Ang = UnitConversion.run("dSpacing", "TOF", 1.0, l1 - l1_chop, DeltaEModeType.Elastic, params)
-            arrival_time = tof_d1Ang * dspacs[:, None] + offsets + t0_const
-            # detector clock reset for each pulse
-            # equivalent to np.mod(arrival_time, cycle_time) but order of magnitude quicker
-            time_in_cycle_period = arrival_time - cycle_time * np.floor(arrival_time / cycle_time)
-            itimes = (time_in_cycle_period / bin_width) - 0.5  # correct for first time bin center at bin_width / 2
-            ibins = np.floor(itimes).astype(int)
-            ibins_plus = ibins + 1
-            ibins_plus[ibins_plus > ws.blocksize() - 1] = 0
-            y = ws.readY(ispec)
-            inter_corr += (ibins + 1 - itimes) * y[ibins] + (itimes - ibins) * y[ibins_plus]
-            progress.report()
+        if self.getProperty("InterpolationMethod").value == "Linear":
+            do_autocorr = _autocorr_spec_linear
+        else:
+            do_autocorr = _autocorr_spec_nearest
+        inter_corr = reduce(
+            iadd,
+            Parallel(n_jobs=-2, prefer="threads", return_as="generator_unordered")(
+                delayed(do_autocorr)(ws.readY(ispec), tof_d1Ang[ispec], dspacs, offsets, bin_width, progress) for ispec in range(nspec)
+            ),
+        )  # npulses*nslits
         # average of inverse intermediate correlation func (Eq.8 in POLDI concept paper)
         with np.errstate(divide="ignore", invalid="ignore"):
             corr = 1 / np.sum(1 / inter_corr, axis=1)
@@ -131,6 +136,25 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         alg.execute()
         out_props = tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
         return out_props[0] if len(out_props) == 1 else out_props
+
+
+def _autocorr_spec_linear(y, tof_d1Ang, dspacs, offsets, bin_width, progress):
+    arrival_time = tof_d1Ang * dspacs + offsets
+    itimes = (arrival_time / bin_width) - 0.5  # correct for first time bin center at bin_width / 2
+    ibins = itimes.astype(int)  # quicker than np.floor
+    frac_bin = ibins + 1 - itimes
+    progress.report()
+    return frac_bin * np.take(y, ibins, mode="wrap") + (1 - frac_bin) * np.take(y, ibins + 1, mode="wrap")
+
+
+def _autocorr_spec_nearest(y, tof_d1Ang, dspacs, offsets, bin_width, progress):
+    arrival_time = tof_d1Ang * dspacs + offsets
+    # round to nearest bin - note this truncation is not equivalent to floor as
+    # implicitly subtracting -0.5 as first time bin center at bin_width / 2 then
+    # add 0.5 so that truncation results in rounding of input
+    ibins = (arrival_time / bin_width).astype(int)
+    progress.report()
+    return np.take(y, ibins, mode="wrap")
 
 
 AlgorithmFactory.subscribe(PoldiAutoCorrelation)

--- a/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
+++ b/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
@@ -123,7 +123,7 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         )  # npulses*nslits
         # average of inverse intermediate correlation func (Eq.8 in POLDI concept paper)
         with np.errstate(divide="ignore", invalid="ignore"):
-            corr = 1 / np.sum(1 / inter_corr, axis=1)
+            corr = 1 / np.nansum(1 / inter_corr, axis=1)
         ws_corr = self.exec_child_alg("CreateWorkspace", DataX=dspacs, DataY=corr, UnitX="dSpacing", YUnitLabel="Intensity (a.u.)")
         ws_corr = self.exec_child_alg("ConvertUnits", InputWorkspace=ws_corr, Target="MomentumTransfer")
         self.setProperty("OutputWorkspace", ws_corr)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
@@ -26,15 +26,11 @@ class PoldiAutoCorrelation6Test(unittest.TestCase):
 
     def test_exec_default_wavelength_range(self):
         ws_corr = PoldiAutoCorrelation(InputWorkspace=self.ws, OutputWorkspace="ws_corr", Version=6)
+        self._assert_auto_corr_workspace(ws_corr)
 
-        # assert min/max Q
-        self.assertAlmostEqual(ws_corr.readX(0)[0], 1.5144, delta=1e-3)
-        self.assertAlmostEqual(ws_corr.readX(0)[-1], 9.0832, delta=1e-3)
-        # assert bin width/number bins
-        self.assertEqual(ws_corr.blocksize(), 2460)
-        # assert max y-value at Bragg peak Q
-        _, imax = ws_corr.findY(ws_corr.readY(0).max())
-        self.assertAlmostEqual(ws_corr.readX(0)[imax], 3.272, delta=1e-2)  # (220) peak @ d = 1.920 Ang
+    def test_exec_nearest_interpolation(self):
+        ws_corr = PoldiAutoCorrelation(InputWorkspace=self.ws, OutputWorkspace="ws_corr_nearest", InterpolationMethod="Nearest", Version=6)
+        self._assert_auto_corr_workspace(ws_corr)
 
     def test_exec_cropped_wavelength_range(self):
         ws_corr = PoldiAutoCorrelation(InputWorkspace=self.ws, OutputWorkspace="ws_corr", WavelengthMin=2, WavelengthMax=4, Version=6)
@@ -44,6 +40,16 @@ class PoldiAutoCorrelation6Test(unittest.TestCase):
         self.assertAlmostEqual(ws_corr.readX(0)[-1], 4.9958, delta=1e-3)
         # assert bin width/number bins
         self.assertEqual(ws_corr.blocksize(), 1470)
+
+    def _assert_auto_corr_workspace(self, ws_corr):
+        # assert min/max Q
+        self.assertAlmostEqual(ws_corr.readX(0)[0], 1.5144, delta=1e-3)
+        self.assertAlmostEqual(ws_corr.readX(0)[-1], 9.0832, delta=1e-3)
+        # assert bin width/number bins
+        self.assertEqual(ws_corr.blocksize(), 2460)
+        # assert max y-value at Bragg peak Q
+        _, imax = ws_corr.findY(ws_corr.readY(0).max())
+        self.assertAlmostEqual(ws_corr.readX(0)[imax], 3.272, delta=1e-2)  # (220) peak @ d = 1.920 Ang
 
 
 if __name__ == "__main__":

--- a/docs/source/algorithms/PoldiAutoCorrelation-v6.rst
+++ b/docs/source/algorithms/PoldiAutoCorrelation-v6.rst
@@ -34,6 +34,11 @@ d-spacing is the inverse of the sum of the inverse intensities at each possible 
 A high correlation intensity implies a consistently high intensity was measured at all arrival times due to all
 possible chopper openings/pulses.
 
+In general the arrival time of a neutron for a given d-spacing will not coincide with a bin-center in the data -
+some interpolation is required. There are two interpolation methods which can be specified with the
+``InterpolationMethod`` parameter: ``Linear`` (default - as in [1]_) and ``Nearest``. The ``Nearest`` method is a
+roughly a factor of 2-3 quicker but is potentially less accurate.
+
 Note by convention the correlation spectrum is converted from d-spacing into momentum transfer.
 
 Further details of the POLDI instrument and the reduction can be found in [1]_.

--- a/docs/source/release/v6.14.0/Diffraction/Engineering/New_features/39776.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Engineering/New_features/39776.rst
@@ -1,0 +1,2 @@
+- Performance improvements to :ref:`algm-PoldiAutoCorrelation-v6` and function to simulate POLDI 2D workspace.
+- New parameter ``InterpolationMethod`` in :ref:`algm-PoldiAutoCorrelation-v6`. The default value ``Linear`` preserves existing behaviour (linear interpolation), an additonal option method ``Nearest`` has been added for faster execution.


### PR DESCRIPTION
### Description of work

Performance improvements required for when POLDI gets an additional detector bank and starts measuring (both banks) with x10 more detector channels.

Joblib multithreading has been used in `PoldiAutoCorrelation` and the code to simulate the 2D POLDI workspace.
A  further speed up in `PoldiAutoCorrelation` is provided by adding an option to use nearest interpolation - the existing behaviour (linear interpolation) in the default. Smaller improvements have also been made by e.g. using `np.take` with `mode='wrap'` to avoid taking the modulus with cycle time etc.

The nearest interpolation provides a speed up of ~2-3, in principle it could be less accurate but in practice it seems to average out over all the spectra and tyhe peak positions agree for both interpolation methods. The only noticeable difference is that the low-Q part of the spectrum in slightly noisier.

<img width="1125" height="441" alt="image" src="https://github.com/user-attachments/assets/bbcad60f-ad28-4d8f-8292-ec084ace958e" />

Here are the results of some benchmarking on Si data taken with chopper speed 1e4 rpm and 7200 spectra (to approximate final workspace size)

<html xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
xmlns="http://www.w3.org/TR/REC-html40">



<body>
<!--StartFragment-->

  | Interp. | Threaded | Time (s)
-- | -- | -- | --
MAIN | Linear | N | 142
LATEST | Linear | N | 125
_ |Nearest | N | 45
 _ |Linear | Y | 31
 _ |Nearest | Y | 12


<!--EndFragment-->
</body>

</html>


**Report to:** Florencia (POLDI,PSI)

### To test:

(1) Run this script

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid.api import FileFinder
from plugins.algorithms.poldi_utils import load_poldi, simulate_2d_data
from time import time

fpath_data = FileFinder.getFullPath("poldi_448x500_chopper5k_silicon.txt")
fpath_idf = FileFinder.getFullPath("POLDI_Definition_448_calibrated.xml")

# load the raw data
ws = load_poldi(fpath_data, fpath_idf, chopper_speed=5000, t0=5.855e-02, t0_const=-9.00)

ws_corr_linear = PoldiAutoCorrelation(InputWorkspace=ws, OutputWorkspace='ws_corr_linear')
ws_corr_near = PoldiAutoCorrelation(InputWorkspace=ws, OutputWorkspace='ws_corr_nearest', InterpolationMethod="Nearest")

start = time()
ws_sim = simulate_2d_data(ws, ws_corr_linear, output_workspace="ws_sim")
print("Elapsed = ", time() - start)
```

(2) Check the `ws_corr_linear` and `ws_corr_near` agree

(3) If you can be bothered run this on main to see the speedup agrees with the benchmarking I did.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
