### PR TITLE
Depend on matplotlib-base instead of matplotlib

### DIFF
--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -80,7 +80,7 @@ requirements:
     - zlib
 
   run_constrained:
-    - matplotlib {{ matplotlib }}
+    - matplotlib-base {{ matplotlib }}
 
 test:
   imports:


### PR DESCRIPTION
According to various advice, and an example from https://github.com/conda-forge/arm_pyart-feedstock/pull/31, one should use `-base` if not directly requiring pyqt. Since Framework doesn't directly plot, it doesn't require any particular backend. This will reduce dependencies for software using `mantid` (framework) package.

### To test:

The packages should continue to build, but the `mantid` package should install less dependencies.

*This does not require release notes* because ??? <fill in an explanation of why>

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
