### PR TITLE
Depend on matplotlib-base instead of matplotlib

### DIFF
--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -80,7 +80,7 @@ requirements:
     - zlib
 
   run_constrained:
-    - matplotlib {{ matplotlib }}
+    - matplotlib-base {{ matplotlib }}
 
 test:
   imports:


### PR DESCRIPTION
This is a version of #39780 into `ornl-next`