### PR TITLE
Fix for diffraction focussing crash when run on a group workspace from an algorithm dialogue 

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
@@ -97,6 +97,7 @@ private:
   void determineRebinParameters(const std::vector<int> &udet2group);
   void determineRebinParametersFromParameters(const std::vector<int> &udet2group);
   int validateSpectrumInGroup(const std::vector<int> &udet2group, size_t wi);
+  void validateInputWorkspaceUnit(API::MatrixWorkspace_const_sptr inputWS, std::map<std::string, std::string> &issues);
 
   /// Shared pointer to the input workspace
   API::MatrixWorkspace_const_sptr m_matrixInputW;

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -94,13 +94,14 @@ std::map<std::string, std::string> DiffractionFocussing2::validateInputs() {
   API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
   if (!inputWS) {
     // Could be a workspace group
-    const auto inputProp = dynamic_cast<WorkspaceProperty<MatrixWorkspace> *>(getPointerToProperty("InputWorkspace"));
+    const auto inputProp =
+        dynamic_cast<const WorkspaceProperty<MatrixWorkspace> *>(getPointerToProperty("InputWorkspace"));
     API::WorkspaceGroup_const_sptr wsGroup =
         std::dynamic_pointer_cast<WorkspaceGroup>(AnalysisDataService::Instance().retrieve(inputProp->value()));
     if (!wsGroup) {
       issues["InputWorkspace"] = "InputWorksapce must be a matrix workspace or workspace group.";
     } else {
-      for (const Workspace_sptr ws : wsGroup->getAllItems()) {
+      for (const Workspace_sptr &ws : wsGroup->getAllItems()) {
         inputWS = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
         validateInputWorkspaceUnit(inputWS, issues);
       }

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -48,7 +48,7 @@ void DiffractionFocussing2::init() {
   auto wsValidator = std::make_shared<API::RawCountValidator>();
   declareProperty(
       std::make_unique<API::WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input, wsValidator),
-      "A 2D workspace with X values of d-spacing, Q or TOF (TOF support deprecated on 29/04/21)");
+      "A 2D workspace with X values of d-spacing or Q");
   declareProperty(std::make_unique<API::WorkspaceProperty<>>("OutputWorkspace", "", Direction::Output),
                   "The result of diffraction focussing of InputWorkspace");
 
@@ -169,10 +169,7 @@ void DiffractionFocussing2::validateInputWorkspaceUnit(API::MatrixWorkspace_cons
                                                        std::map<std::string, std::string> &issues) {
   // Validate UnitID (spacing)
   const std::string unitid = inputWS->getAxis(0)->unit()->unitID();
-  if (unitid == "TOF") {
-    g_log.error(
-        "Support for TOF data in DiffractionFocussing is deprecated (on 29/04/21) - use GroupDetectors instead)");
-  } else if (unitid != "dSpacing" && unitid != "MomentumTransfer") {
+  if (unitid != "dSpacing" && unitid != "MomentumTransfer") {
     std::stringstream msg;
     msg << "UnitID " << unitid << " is not a supported spacing";
     issues["InputWorkspace"] = msg.str();

--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -554,36 +554,6 @@ public:
     return output;
   }
 
-  void test_tof_deprecation_error_thrown() {
-    // Simple test to be removed when TOF support is removed
-    std::string nxsWSname("DiffractionFocussing2Test_ws");
-    // Create the fake event workspace
-    EventWorkspace_sptr inputW = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(3, 1);
-    AnalysisDataService::Instance().addOrReplace(nxsWSname, inputW);
-    // Set xunit TOF
-    inputW->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
-    // Create a grouping workspace
-    std::string GroupNames = "bank3";
-    std::string groupWSName("DiffractionFocussing2Test_group");
-    FrameworkManager::Instance().exec("CreateGroupingWorkspace", 6, "InputWorkspace", nxsWSname.c_str(), "GroupNames",
-                                      GroupNames.c_str(), "OutputWorkspace", groupWSName.c_str());
-    // Run algorithm
-    DiffractionFocussing2 focus;
-    focus.initialize();
-    TS_ASSERT_THROWS_NOTHING(focus.setPropertyValue("InputWorkspace", nxsWSname));
-    TS_ASSERT_THROWS_NOTHING(focus.setPropertyValue("OutputWorkspace", nxsWSname));
-    TS_ASSERT_THROWS_NOTHING(focus.setPropertyValue("GroupingWorkspace", groupWSName));
-    TS_ASSERT_THROWS_NOTHING(focus.setProperty("PreserveEvents", false));
-    // setup poco stream to catch log output
-    std::ostringstream oss;
-    auto psc = new Poco::StreamChannel(oss);
-    Poco::Logger::setChannel("DiffractionFocussing", psc);
-    TS_ASSERT_THROWS_NOTHING(focus.execute(););
-    // assert output contains deprecation message
-    const auto logMsg = oss.str();
-    TS_ASSERT(logMsg.find("Support for TOF data in DiffractionFocussing is deprecated") != std::string::npos)
-  }
-
   void dotestEventWorkspace(bool inplace, size_t numgroups, bool preserveEvents = true, int bankWidthInPixels = 16) {
     std::string nxsWSname("DiffractionFocussing2Test_ws");
 

--- a/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39680.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39680.rst
@@ -1,0 +1,1 @@
+- Fixed a potential crash when running :ref:`DiffractionFocussing <algm-DiffractionFocussing>` from the algorithm dialogue and setting ``InputWorkspace`` to a workspace group.

--- a/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39680.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/Bugfixes/39680.rst
@@ -1,1 +1,2 @@
 - Fixed a potential crash when running :ref:`DiffractionFocussing <algm-DiffractionFocussing>` from the algorithm dialogue and setting ``InputWorkspace`` to a workspace group.
+- The ``InputWorkspace`` property of :ref:`DiffractionFocussing <algm-DiffractionFocussing>` can no longer take workspaces in TOF (deprecated 29/04/21).


### PR DESCRIPTION
### Description of work

The `validateInputs` method of `DiffractionFocussing2` did not consider that `InputWorkspace` could be a workspace group.
In general this is quite confusing because the input workspace property is of the type `MatrixWorkspace`.
Mantid has an exception in the workspace property to allow a group to be passed to such a property. When running the algorithm from python (or C++) this isn't a problem, `Algorithm`'s `executeInternal` method checks for workspace groups, and if they're found, runs the algorithm on each of the child workspaces from the group.
However, when running from a dialogue, the `AlgorithmDialogue` class makes an early call to `validateInputs` before the algorithm has been executed. At this point `InputWorkspace` will still be a workspace group, which can lead to problems if `validateInputs` doesn't consider this possibility.

I'd like to change `Algorithm` to wrap `validateInputs` similarly to how `execute` works when checking for groups. I'll wirte this up in a separate issue. (https://github.com/mantidproject/mantid/issues/39801)

Closes #39680

### To test:

Follow instructions from the issue, you will get an error if you don't provide `GroupingFileName` or `GroupingWorkspace`, but no crash.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
