### PR TITLE
Update numpy pinning strategy

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -62,10 +62,8 @@ muparser:
   - '>=2.3.2, <2.3.5'
 
 # Aim to build using the latest minor version, and rely on numpy's generous backward compatibility.
-# Keep the >=2.0.0, and try to increment the upper bound as early as possible.
-# When incrementing the upper bound, make sure to also set the upper_bound in the mantid recipe run requirements.
 numpy:
-  - '>=2.0.0,<2.2'
+  - 2.1.*
 
 matplotlib:
   - 3.9.*

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -62,9 +62,11 @@ libglu:
 muparser:
   - '>=2.3.2, <2.3.5'
 
-# We follow conda-forge and build with the lowest supported version of numpy for forward compatibility.
+# Aim to build using the latest minor version, and rely on numpy's generous backward compatibility.
+# Keep the >=2.0.0, and try to increment the upper bound as early as possible.
+# When incrementing the upper bound, make sure to also set the upper_bound in the mantid recipe run requirements.
 numpy:
-  - 2.0.*
+  - '>=2.0.0,<2.2'
 
 matplotlib:
   - 3.9.*

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -47,7 +47,6 @@ hdf5: # this is to move to libcurl>=8.4
 graphviz:
   - '>=2.47.0'
 
-# this must match the version in the developer dependencies
 jemalloc:
   - 5.2.0 # [linux]
   - 5.2.* # [osx]
@@ -58,7 +57,7 @@ jsoncpp:
 libglu:
   - '>=9.0'
 
-#v2.8.5 caused seg faults on Mantid conda versions and large numbers of tests failing
+#v2.3.5 caused seg faults on Mantid conda versions and large numbers of tests failing
 muparser:
   - '>=2.3.2, <2.3.5'
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -165,5 +165,8 @@ versioningit:
   - '>=2.1'
 
 pin_run_as_build:
-    boost:
-      max_pin: x.x
+  boost:
+    max_pin: x.x
+  numpy:
+    min_pin: x
+    max_pin: x.x

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - matplotlib {{ matplotlib }}
     - muparser {{ muparser }}
     - ninja {{ ninja }}
-    - numpy>=2.0,<2.2 # This is intentionally different to conda_build_config.yaml, will address later.
+    - numpy {{ numpy }}
     - occt {{ occt }}
     - pip {{ pip }}
     - poco {{ poco }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - jemalloc {{ jemalloc }}  # [osx or linux]
     - lib3mf  # [win]
     - muparser {{ muparser }}
-    - {{ pin_compatible("numpy", upper_bound="2.2") }}
+    - {{ pin_compatible("numpy", min_pin="x", max_pin="x.x") }}
     - occt {{ occt }}
     - pycifrw
     - pydantic {{ pydantic }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -63,7 +63,6 @@ requirements:
     - jemalloc {{ jemalloc }}  # [osx or linux]
     - lib3mf  # [win]
     - muparser {{ muparser }}
-    - {{ pin_compatible("numpy", min_pin="x", max_pin="x.x") }}
     - occt {{ occt }}
     - pycifrw
     - pydantic {{ pydantic }}


### PR DESCRIPTION
### Description of work
The difference is subtle but more maintainable, since the version number is only in one place now. The following two things have been done:
- Provide a single version number in `conda_build_config.yaml`, which is the version of numpy we build against. We should aim to build against the newest possible numpy, and make use of numpy's generous backward compatibility (we are currently 2 minor releases behind, which can be dealt with in a follow up PR).
- Allow numpy to float in the mantid runtime environment between 2.0 and the version we build against. I'm not sure that we can simply rely on the [run export defined in the numpy feedstock](https://github.com/conda-forge/numpy-feedstock/blob/5ff53c6b92716105f79932d625e14abebf531531/recipe/recipe.yaml#L88). We do this using the `pin_run_as_build` dictionary.

Closes #39516 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Verify via the build logs that numpy v2.1 was installed in the:
  - mantid-developer environments in the build and test PR jobs
  - mantid conda package in the packaging PR job
- Verify the mantid runtime pin by installing the mantid conda package and attempting to install different versions of numpy.
You should be able to install numpy=2.0 and numpy=2.1, but not numpy=1.9 or numpy=2.2. The packages can be installed on linux with with
`mamba install -c thomashampson/label/numpytest mantidworkbench`

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
