### PR TITLE
Expose SpinStateValidator to python and use in AssertSpinStateOrder

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ADSValidator.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ADSValidator.cpp
@@ -16,7 +16,7 @@ using namespace boost::python;
 
 /// This is the base TypedValidator for most of the WorkspaceValidators
 void export_ADSValidator() {
-  TypedValidatorExporter<std::vector<std::string>>::define("StringTypedValidator");
+  TypedValidatorExporter<std::vector<std::string>>::define("StringVectorTypedValidator");
 
   class_<ADSValidator, bases<TypedValidator<std::vector<std::string>>>, boost::noncopyable>(
       "ADSValidator", init<>("Default constructor"))

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -64,6 +64,7 @@ set(EXPORT_FILES
     src/Exports/RebinParamsValidator.cpp
     src/Exports/PhysicalConstants.cpp
     src/Exports/SpecialCoordinateSystem.cpp
+    src/Exports/SpinStateValidator.cpp
 )
 
 set(MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/kernel.cpp)

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/SpinStateValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/SpinStateValidator.cpp
@@ -1,0 +1,47 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidKernel/SpinStateValidator.h"
+#include "MantidKernel/TypedValidator.h"
+#include "MantidPythonInterface/core/TypedValidatorExporter.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/default_call_policies.hpp>
+#include <boost/python/list.hpp>
+#include <boost/python/make_constructor.hpp>
+
+using Mantid::Kernel::SpinStateValidator;
+using Mantid::Kernel::TypedValidator;
+using Mantid::PythonInterface::TypedValidatorExporter;
+using namespace boost::python;
+
+std::shared_ptr<SpinStateValidator>
+createSpinStateValidator(list allowedNumberOfSpins, const bool acceptSingleStates = false,
+                         const std::string &paraIndicator = "0", const std::string &antiIndicator = "1",
+                         const bool optional = false, const std::string &extraIndicator = "") {
+
+  std::unordered_set<int> allowedNumberOfSpinsSet;
+  for (int i = 0; i < len(allowedNumberOfSpins); i++) {
+    int spinN = extract<int>(allowedNumberOfSpins[i]);
+    allowedNumberOfSpinsSet.insert(spinN);
+  }
+
+  return std::make_shared<SpinStateValidator>(allowedNumberOfSpinsSet, acceptSingleStates, paraIndicator, antiIndicator,
+                                              optional, extraIndicator);
+}
+
+void export_SpinStateValidator() {
+  TypedValidatorExporter<std::string>::define("StringTypedValidator");
+
+  class_<SpinStateValidator, bases<TypedValidator<std::string>>, std::shared_ptr<SpinStateValidator>,
+         boost::noncopyable>("SpinStateValidator", no_init)
+      .def("__init__",
+           make_constructor(&createSpinStateValidator, default_call_policies(),
+                            (arg("allowedNumberOfSpins"), arg("acceptSingleStates") = false, arg("paraIndicator") = "0",
+                             arg("antiIndicator") = "1", arg("optional") = false, arg("extraIndicator") = "")),
+           "Will check that a string matches the form 01,00 or 00,10,11,01, for example. This is used for specifying "
+           "the order of input workspaces relative to spin states.");
+}

--- a/Framework/PythonInterface/plugins/algorithms/AssertSpinStateOrder.py
+++ b/Framework/PythonInterface/plugins/algorithms/AssertSpinStateOrder.py
@@ -8,7 +8,7 @@
 
 from mantid.api import AlgorithmFactory, PolSANSWorkspaceValidator, PythonAlgorithm, WorkspaceGroupProperty
 from mantid.simpleapi import DetermineSpinStateOrder
-from mantid.kernel import logger, Direction
+from mantid.kernel import logger, Direction, SpinStateValidator
 
 
 class AssertSpinStateOrder(PythonAlgorithm):
@@ -35,6 +35,7 @@ class AssertSpinStateOrder(PythonAlgorithm):
         self.declareProperty(
             name="ExpectedSpinStates",
             defaultValue="",
+            validator=SpinStateValidator(allowedNumberOfSpins=[4]),
             direction=Direction.Input,
             doc='Comma separate list of spin states (e.g "00,01,10,11") in the expected order of the group workspace periods.',
         )
@@ -52,18 +53,6 @@ class AssertSpinStateOrder(PythonAlgorithm):
             direction=Direction.Output,
             doc="Bool value stating whether the input workspace was found to have the same ordering as the ExpectSpinStates string",
         )
-
-    def validateInputs(self):
-        issues = {}
-
-        expected_spin_states = self.getProperty("ExpectedSpinStates").value
-        if len(expected_spin_states.split(",")) != 4:
-            issues["ExpectedSpinStates"] = "ExpectedSpinStates should have 4 values."
-
-        if expected_spin_states.replace("0", "").replace("1", "").replace(",", "") != "":
-            issues["ExpectedSpinStates"] = "ExpectedSpinStates should be in Wildes notation (e.g '00,01,10,11')."
-
-        return issues
 
     def PyExec(self):
         group_ws = self.getProperty("InputWorkspace").value


### PR DESCRIPTION
### Description of work

Exposes the SpinStateValidator class to python.

### To test:

Use this script to get an example workspace

```
from mantid.simpleapi import *
from mantid.api import WorkspaceGroup

wsGroup = WorkspaceGroup()
mtd.add("group", wsGroup)
y_values = [10, 80, 20, 90]
flipper_current_values = [3, 3.5, 5.5, 5.8]

for i in range(4):
   ws_name = f"ws_{i}"
   CreateSampleWorkspace("Histogram", "Flat background", XUnit="Wavelength", XMin=0, XMax=10, BinWidth=1, NumEvents=10, InstrumentName="LARMOR", OutputWorkspace=ws_name)
   CropWorkspace(ws_name, StartWorkspaceIndex=1, EndWorkspaceIndex=1, OutputWorkspace=ws_name)
   mtd[ws_name] *= y_values[i]
   AddTimeSeriesLog(ws_name, "FlipperCurrent", "2010-01-01T00:00:00", flipper_current_values[i])
   wsGroup.addWorkspace(mtd[ws_name])

ConvertToHistogram(wsGroup, OutputWorkspace=wsGroup)
result = DetermineSpinStateOrder(wsGroup)
print(f"Spin state order from wsGroup is {result}")
```
In the iPython console, test `AssertSpinStateOrder(mtd['group'], <spin state string here>)` with different incorrect spin state strings to check the input is being properly validated. Example strings:
 - '00,01,10' (too short)
 - '00,02,10,11' (contains a 2)
 - '00,00,11,10' (duplicate values)

Also check using the algorithm dialogue.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
