### PR TITLE
Added troubleshooting section for WSL developer documentation

### DIFF
--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -105,3 +105,12 @@ Tips
 
 * Make sure you install `devtoolset-7 <https://developer.mantidproject.org/BuildingWithCMake.html#from-the-command-line>`_ for Centos 7 as described in the provided link before CMake and build.
 * It might also be necessary to install some addition packages for Ubuntu 18.04, including `libnexus0-dev`.
+
+Troubleshooting
+###############
+
+If your WSL stops responding to commands, disabling and re-enabling it might be the best solution. To do this, go to ‘Control Panel’, then ‘Programs’, then ‘Turn Windows features on or off,’ and request
+administrator access for your laptop. Uncheck ‘Windows Subsystem for Linux’ and ‘Virtual Machine Platform’. Restart your laptop after clicking ‘Finish’ in the administrator access app. Request administrator access again,
+then re-check both ‘Windows Subsystem for Linux’ and ‘Virtual Machine Platform’.
+
+Be aware that if you maintain administrative access through a reboot, the session will remain active, but you will not be able to execute programs in administrator mode.


### PR DESCRIPTION
### Description of work

After fixing a problem with my local WSL, I've added a troubleshooting section in the developer documentation.

### To test:

Sense-check the new section and ensure correct grammar and spelling.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
