### PR TITLE
Add option to update UB matrix when CommonUBForAll=False and table contains only peaks from one run

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -49,6 +49,7 @@ const std::string MAIN_NUM_INDEXED{"MainNumIndexed"};
 const std::string SATE_NUM_INDEXED{"SateNumIndexed"};
 const std::string MAIN_ERR{"MainError"};
 const std::string SATE_ERR{"SatelliteError"};
+const std::string UPDATE_UB{"UpdateUB"};
 
 struct SatelliteIndexingArgs {
   const double tolerance;
@@ -108,7 +109,8 @@ struct IndexPeaksArgs {
             alg.getProperty(ROUNDHKLS),
             alg.getProperty(COMMONUB),
             alg.getProperty(SAVEMODINFO),
-            SatelliteIndexingArgs{alg.getProperty(SATE_TOLERANCE), maxOrderToUse, modVectorsToUse, crossTermToUse}};
+            SatelliteIndexingArgs{alg.getProperty(SATE_TOLERANCE), maxOrderToUse, modVectorsToUse, crossTermToUse},
+            alg.getProperty(UPDATE_UB)};
   }
 
   IPeaksWorkspace_sptr workspace;
@@ -117,6 +119,7 @@ struct IndexPeaksArgs {
   const bool commonUB;
   const bool storeModulationInfo;
   const SatelliteIndexingArgs satellites;
+  const bool updateUB;
 };
 } // namespace Prop
 
@@ -382,6 +385,9 @@ void IndexPeaks::init() {
   this->declareProperty(Prop::SAVEMODINFO, false,
                         "If true, update the OrientedLattice with the maxOrder, "
                         "modulation vectors & cross terms values input to the algorithm");
+  this->declareProperty(Prop::UPDATE_UB, false,
+                        "Saves the optimized UB matrix to the workspace if CommonUBForAll=False. This option works "
+                        "only when the peak workspace contains a single run.");
 
   // -- outputs --
   this->declareProperty(Prop::NUM_INDEXED, 0, "Gets set with the number of indexed peaks.", Direction::Output);
@@ -500,9 +506,26 @@ void IndexPeaks::exec() {
     std::unordered_map<int, std::vector<IPeak *>> peaksPerRun;
     for (int i = 0; i < args.workspace->getNumberPeaks(); i++)
       peaksPerRun[args.workspace->getPeak(i).getRunNumber()].emplace_back(args.workspace->getPeakPtr(i));
-    if (peaksPerRun.size() < 2) {
-      g_log.warning("Peaks from only one run exist but CommonUBForAll=True so peaks will be indexed with an optimised "
-                    "UB which will not be saved in the workspace.");
+    if (peaksPerRun.size() == 1) {
+      if (args.updateUB) {
+        // Save the optimized UB to the workspace
+        auto peaks = peaksPerRun.begin()->second;
+        std::vector<V3D> qSample(peaks.size());
+        std::generate(std::begin(qSample), std::end(qSample),
+                      [&peaks, i = 0u]() mutable { return peaks[i++]->getQSampleFrame(); });
+
+        DblMatrix optimizedUB = optimizeUBMatrix(sampleUB, qSample, args.mainTolerance);
+        if (optimizedUB != sampleUB) {
+          args.workspace->mutableSample().getOrientedLattice().setUB(optimizedUB);
+          g_log.notice() << "Updating the UB matrix with an improved optimized version.\n";
+        } else {
+          g_log.notice() << "No improved UB matrix was found, so retaining the original UB.\n";
+        }
+      } else {
+        g_log.warning(
+            "Peaks from only one run exist but CommonUBForAll=False so peaks will be indexed with an optimised "
+            "UB which will not be saved in the workspace. Use UpdateUB=True to save the optimized UB matrix.\n");
+      }
     }
     const bool optimizeUB{true};
     for (const auto &runPeaks : peaksPerRun) {

--- a/docs/source/release/v6.14.0/Framework/Algorithms/New_features/38964.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/New_features/38964.rst
@@ -1,0 +1,1 @@
+- Add UpdateUB option to :ref:`algm-IndexPeaks` that enables saving the optimized UB matrix in the case where there is a single run and CommonUBForAll=False.


### PR DESCRIPTION
This is a version of #39541 into `ornl-next`