### PR TITLE
update ornl externaldata mirror

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -42,7 +42,7 @@ list(APPEND ExternalData_URL_TEMPLATES "file:///home/builder/MantidExternalData-
 list(APPEND ExternalData_URL_TEMPLATES "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)")
 # facility based mirrors
 list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") # RAL
-list(APPEND ExternalData_URL_TEMPLATES "https://mantid-ilm.sns.gov/testdata/%(algo)/%(hash)") # ORNL
+list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL
 # This should always be last as it's the main read/write cache
 list(APPEND ExternalData_URL_TEMPLATES "https://testdata.mantidproject.org/ftp/external-data/%(algo)/%(hash)")
 


### PR DESCRIPTION
### Description of work

Change the ORNL mantid external data mirror from mantid-ilm.sns.gov to mantid-cache.sns.gov

### To test:


Kick off a mantid nightly build using Core_Team_test_pipeline, with tag targeting ORNL mantid builders.
The new https://mantid-cache.sns.gov mirror is only visible to ORNL mantid builders.

Test pipeline using new mirror: https://builds.mantidproject.org/job/Core_Team_test_pipeline/295/console

---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
