### PR TITLE
Fix to LoadNexusProcessed to stop occasional file handle error

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -505,6 +505,7 @@ void LoadNexusProcessed::execLoader() {
     }
 
     root.close();
+    m_nexusFile->close();
   }
 
   // All file resources should be scoped to here. All previous file handles

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -206,7 +206,7 @@ File::File(File const &f)
       m_current_data_id(0), m_current_type_id(0), m_current_space_id(0), m_gid_stack{0}, m_descriptor(f.m_descriptor) {
   // NOTE warning to future devs
   // if you change this method, please run the systemtest VanadiumAndFocusWithSolidAngleTest
-  if (m_pfile <= 0)
+  if (m_pfile->getId() <= 0)
     throw Mantid::Nexus::Exception("Error reopening file");
 }
 
@@ -238,20 +238,15 @@ File::~File() {
   // NOTE warning to future devs
   // if you change this part of method, please run the systemtest VanadiumAndFocusWithSolidAngleTest
   // decrease reference counts to this file
-  m_pfile.reset();
+  close();
   H5garbage_collect();
 }
 
 void File::close() {
   // NOTE warning to future devs
   // if you change this method, please run the systemtest VanadiumAndFocusWithSolidAngleTest
-  /* close the file handle */
   if (m_pfile != nullptr) {
-    if (m_pfile.use_count() > 1) {
-      g_log->warning("WARNING: closing file " + m_filename + " which still has open references.");
-    }
-    H5Fclose(m_pfile->getId());
-    H5garbage_collect();
+    // decrease reference counts to this file
     m_pfile.reset();
   }
 }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -207,7 +207,7 @@ File::File(File const &f)
   // NOTE warning to future devs
   // if you change this method, please run the systemtest VanadiumAndFocusWithSolidAngleTest
   if (m_pfile->getId() <= 0)
-    throw Mantid::Nexus::Exception("Error reopening file");
+    throw NXEXCEPTION("Error reopening file");
 }
 
 // deconstructor


### PR DESCRIPTION
### Description of work

Forces a close of the Nexus File handle (dropping reference counts) inside LoadNexusProcessed before the NexusGeometry portions.  This, for some reason, prevents errors that otherwise occur inside the system test `VanadiumAndFocusWithSolidAngleTest`.

I still could not create a unit test that would fail in the same circumstances as the system test.

Related to Plan #38332
Partial fix to Issue #39743

### To test:

Just check that the particular system test, `VanadiumAndFocusWithSolidAngleTest`, completed.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
