### PR TITLE
Check for none when building child algorithms from dicts in python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -180,6 +180,13 @@ object createChildWithProps(tuple args, dict kwargs) {
   auto childAlg = parentAlg->createChildAlgorithm(name.value(), startProgress.value_or(-1), endProgress.value_or(-1),
                                                   enableLogging.value_or(true), version.value_or(-1));
 
+  if (kwargs.has_key(reservedNames[5])) {
+    // We set StoreInADS here if it hasn't been set before and it is present in kwargs
+    std::optional<bool> storeADS = std::nullopt;
+    extractKwargs<bool>(kwargs, reservedNames[5], storeADS);
+    childAlg->setAlwaysStoreInADS(storeADS.value_or(false));
+  }
+
   const list keys = kwargs.keys();
   for (int i = 0; i < len(keys); ++i) {
     const std::string propName = extract<std::string>(keys[i]);

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -187,7 +187,7 @@ object createChildWithProps(tuple args, dict kwargs) {
       continue;
 
     object curArg = kwargs[keys[i]];
-    if (!curArg)
+    if (curArg.is_none())
       continue;
 
     using Mantid::PythonInterface::PyNativeTypeExtractor;

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -165,7 +165,8 @@ object createChildWithProps(tuple args, dict kwargs) {
   auto enableLogging = extractArg<bool>(4, args);
   auto version = extractArg<int>(5, args);
 
-  const std::array<std::string, 5> reservedNames = {"name", "startProgress", "endProgress", "enableLogging", "version"};
+  const std::array<std::string, 6> reservedNames = {"name",          "startProgress", "endProgress",
+                                                    "enableLogging", "version",       "StoreInADS"};
 
   extractKwargs<std::string>(kwargs, reservedNames[0], name);
   extractKwargs<double>(kwargs, reservedNames[1], startProgress);

--- a/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
@@ -170,6 +170,15 @@ class AlgorithmTest(unittest.TestCase):
 
         self.assertEqual("Wavelength", ws.getAxis(0).getUnit().unitID())
 
+    def test_createChildAlgorithm_allows_to_set_numeric_properties_to_zero(self):
+        parent_alg = AlgorithmManager.createUnmanaged("Load")
+        child_alg = parent_alg.createChildAlgorithm("CreateSampleWorkspace", **{"XMax": 0.0})
+
+        self.assertTrue(child_alg.isChild())
+        xmax = child_alg.getProperty("XMax").value
+
+        self.assertEqual(xmax, 0.0)
+
     def test_createChildAlgorithm_with_named_args(self):
         parent_alg = AlgorithmManager.createUnmanaged("Load")
         child_alg = parent_alg.createChildAlgorithm("CreateSampleWorkspace", XUnit="Wavelength")


### PR DESCRIPTION
### Description of work
When trying to execute a child algorithm from a python algorithm, without using the simpleapi, it is possible to pass a dictionary of kwargs to the method 'createChildAlgorithm' , which is interfaced from the algorithm class. 
The translation from the python properties to the cpp property types is done in the algorithm exports definition file. Before assigning the property, there is a check with the not(!) cpp operator, I guess to assess whether there is some error on exporting the python object or if the property has been declared as none, and continues iterating over other properties if that's the case. But boost::python api checks for truthiness of the contained boost::python object and as a result some perfectly valid properties (like `WorkspaceIndex`=0) are not set in the algorithm, as they are evaluated to be false before assigning. 
An example may illustrate better: 
```
from mantid.simpleapi import *
from mantid.api import AlgorithmFactory, PythonAlgorithm, AlgorithmManager

class TestChild(PythonAlgorithm):

    def category(self):
        return "Utility"

    def name(self):
        return "TestChild"
    
    def PyInit(self):
        pass

    def PyExec(self):
        alg =self.createChildAlgorithm("CreateSampleWorkspace", XMax=0.0)
        alg.initialize()
        print("Is it 0? ->",alg.getPropertyValue("XMax"))

AlgorithmFactory.subscribe(TestChild)

asChildAlg = AlgorithmManager.createUnmanaged("TestChild")
asChildAlg.initialize()
asChildAlg.execute()

testAlg = AlgorithmManager.createUnmanaged("CreateSampleWorkspace")
testAlg.initialize()
testAlg.setProperty("XMax", 0.0)
print("Is it 0? ->",testAlg.getPropertyValue("XMax"))
```
A test python algorithm is created and within it, a child algorithm for `CreateSampleWorkspace` is called with the property `XMax` set to 0. The same is done calling directly the algorithm. In the first case, the property is not set, so we retrieve the default value for this property (2000), while in the second case we get 0. 

To fix this, I have changed to just check whether the property is equal to none, just being careful that `StoreInADS` is handled before reaching this point (which shouldn't be a concern when calling a child algorithm from simpleapi anyway)



<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Build the branch and check the example of the pr, now the result should be similar in both the child algorithm and the main algorithm. (0)

_No release notes as it is an internal change, very unlikely to have impacted the user_




### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
