### PR TITLE
Exposed a few methods from Instrumentviewer into python using SIP

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -180,6 +180,17 @@ public:
 
 %End
 
+  // get Mask Tab
+  InstrumentWidgetMaskTab *getMaskTab();
+%Docstring
+  Get the handler to the 'MASK' tab inside instrument view
+
+  Returns:
+    a pointer to the InstrumentWidgetMaskTab object.
+
+%End
+
+
   // select tab
   void selectTab(Tab tab);
 %Docstring
@@ -218,9 +229,9 @@ public:
       newInstrumentWindowName The new title of the window
 %End
 
-  bool isThreadRunning();
+  bool isThreadRunning() const;
 %Docstring
-  bool isThreadRunning()
+  bool isThreadRunning() const
   ----------------------
   Return whether the instrument loading thread is still executing.
 %End
@@ -238,7 +249,6 @@ public:
   --------------------------------
   Saves the current scene as a png image to a file.
 %End
-
 };
 
 class InstrumentWidgetEncoder {
@@ -394,4 +404,39 @@ class InstrumentWidgetPickTab: InstrumentWidgetTab
         InstrumentWidgetPickTab();
         InstrumentWidgetPickTab(const InstrumentWidgetPickTab &);
 
+};
+
+
+//InstrumentWidgetMaskTab
+class InstrumentWidgetMaskTab: InstrumentWidgetTab
+{
+  %TypeHeaderCode
+#include "MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h"
+  %End
+
+  public:
+    enum Activity {
+      Move,
+      Select,
+      DrawEllipse,
+      DrawRectangle,
+      DrawEllipticalRing,
+      DrawRectangularRing,
+      DrawSector,
+      Pixel,
+      Tube,
+      DrawFree
+    };
+
+    void selectTool(Activity tool);
+%Docstring
+    void selectTool(Activity tool)
+    --------------------------------------------------------------
+    Select the tool in Mask tab according to the selected Activity
+%End
+
+  private:
+    // constructors made private
+    InstrumentWidgetMaskTab();
+    InstrumentWidgetMaskTab(const InstrumentWidgetMaskTab &);
 };

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -415,6 +415,12 @@ class InstrumentWidgetMaskTab: InstrumentWidgetTab
   %End
 
   public:
+    enum Mode {
+      Mask,
+      Group,
+      ROI
+    };
+
     enum Activity {
       Move,
       Select,
@@ -427,6 +433,13 @@ class InstrumentWidgetMaskTab: InstrumentWidgetTab
       Tube,
       DrawFree
     };
+
+    void setMode(Mode mode);
+%Docstring
+    void setMode(Mode mode)
+    -----------------------------------------
+    Selects between Mask, Group, or ROI modes
+%End
 
     void selectTool(Activity tool);
 %Docstring

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
@@ -50,6 +50,7 @@ class InstrumentViewPresenter(ObservingPresenter):
         # TODO FIXME - this may not be a good design.  It violates the OO principles
         # Update the instrument view manager
         InstrumentViewManager.register(self, self.ws_name)
+        self._is_view_closed = False
 
     def current_workspace_equals(self, name):
         return self.ws_name == name
@@ -111,6 +112,10 @@ class InstrumentViewPresenter(ObservingPresenter):
         if workspace_name == self.ws_name:
             super(InstrumentViewPresenter, self).close(self.ws_name)
             InstrumentViewManager.remove(self, self.ws_name)
+            self._is_view_closed = True
+
+    def is_view_closed(self):
+        return self._is_view_closed
 
 
 class InstrumentViewManager:

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
@@ -152,6 +152,7 @@ class InstrumentViewPresenterTest(unittest.TestCase):
         self.presenter.close(ws_name)
         mocked_super_close.assert_called_once_with(ws_name)
         mocked_manager.remove.assert_called_once_with(self.presenter, ws_name)
+        self.assertEqual(self.presenter.is_view_closed(), True)
 
     @mock.patch("mantidqt.widgets.instrumentview.presenter.ObservingPresenter.close")
     @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentViewManager")
@@ -160,6 +161,9 @@ class InstrumentViewPresenterTest(unittest.TestCase):
         self.presenter.close(ws_name)
         mocked_super_close.assert_not_called()
         mocked_manager.assert_not_called()
+
+    def test_is_view_closed(self):
+        self.assertEqual(self.presenter.is_view_closed(), False)
 
 
 if __name__ == "__main__":

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -212,6 +212,8 @@ public:
 
   IInstrumentDisplay *getInstrumentDisplay() const { return m_instrumentDisplay.get(); };
 
+  InstrumentWidgetMaskTab *getMaskTab() { return m_maskTab; }
+
 signals:
   void enableLighting(bool /*_t1*/);
   void plot1D(const QString & /*_t1*/, const std::set<int> & /*_t2*/, bool /*_t3*/);


### PR DESCRIPTION
### Description of work

This PR is to expose a few methods from Intrumentviewer into python using SIP. The changes captures below
1. `InstrumentWidgetMaskTab` class, its `Activity` enum, and void `selectTool(Activity tool)` method
2. A new method `is_view_closed` was added to `InstrumentViewPresenter` python class to reflect whether the Intrumentviewer is closed
3. A new method `getMaskTab` was added to `InstrumentWidget.cpp` to get the instance of `MaskTab` and was exposed to python via SIP
4. exposed `setMode(Mode)` method and `Mode` enum of `InstrumentWidgetMaskTab`

Closes #39810. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Test whether the above exposed Python methods work as expected.
2. Run below code and it should show the InstrumentViewer as expected with the options as set in the code below
3. Instrumentviewer should exit gracefully once closed without any errors

```
from mantid.simpleapi import *
import time
from mantid.api import AnalysisDataService as mtd
from mantidqt.widgets.instrumentview.api import get_instrumentview

InstrumentWidget = import_qt("._instrumentview", "mantidqt.widgets.instrumentview", "InstrumentWidget")
InstrumentWidgetMaskTab = import_qt("._instrumentview", "mantidqt.widgets.instrumentview", "InstrumentWidgetMaskTab")

ws = Load('SXD34762')
peaks = FindSXPeaks(InputWorkspace=ws, PeakFindingStrategy="AllPeaksNSigma", NSigma=10)

iv = get_instrumentview(ws)
iv.select_pick_tab() 
iv.container.widget.overlay(peaks.name()) # peaks should be overlayed

iv.container.select_tab(InstrumentWidget.Tab.MASK)
iv.container.widget.getMaskTab().selectTool(InstrumentWidgetMaskTab.Activity.DrawEllipse)
iv.container.widget.getMaskTab().setMode(InstrumentWidgetMaskTab.Mode.Mask)
iv.show_view() # DrawEllipse tool should be selected

while True:
    time.sleep(0.5)
    if iv.is_view_closed():
        break
print("Instrument view closed")

```


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
