### PR TITLE
Add note for workbench that osx-64 is no longer going to be supported

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1028,7 +1028,7 @@ std::string ConfigServiceImpl::getOSArchitecture() {
       osArch = "arm64_(x86_64)";
     } else {
       // TODO this can be removed after the v6.14 code freeze because the feature will be dropped
-      g_log.warning("mantid v6.14 is the last version that will support intel osx");
+      g_log.warning("Mantid v6.14 is the last version that will support Intel macOS.");
     }
   }
 #endif

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1026,6 +1026,9 @@ std::string ConfigServiceImpl::getOSArchitecture() {
     size_t size = sizeof(ret);
     if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1 && ret == 1) {
       osArch = "arm64_(x86_64)";
+    } else {
+      // TODO this can be removed after the v6.14 code freeze because the feature will be dropped
+      g_log.warn("mantid v6.14 is the last version that will support intel osx");
     }
   }
 #endif

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1028,7 +1028,7 @@ std::string ConfigServiceImpl::getOSArchitecture() {
       osArch = "arm64_(x86_64)";
     } else {
       // TODO this can be removed after the v6.14 code freeze because the feature will be dropped
-      g_log.warn("mantid v6.14 is the last version that will support intel osx");
+      g_log.warning("mantid v6.14 is the last version that will support intel osx");
     }
   }
 #endif

--- a/docs/source/release/v6.14.0/Workbench/Deprecated/123456789.rst
+++ b/docs/source/release/v6.14.0/Workbench/Deprecated/123456789.rst
@@ -1,0 +1,1 @@
+- This is the last version that will support intel osx

--- a/docs/source/release/v6.14.0/Workbench/Deprecated/123456789.rst
+++ b/docs/source/release/v6.14.0/Workbench/Deprecated/123456789.rst
@@ -1,1 +1,1 @@
-- This is the last version that will support intel osx
+- This is the last version that will support Intel macOS devices.


### PR DESCRIPTION
During the [2025-08-19 Technical Working Group (TWG) meeting](https://github.com/mantidproject/governance/blob/main/technical-working-group/minutes/2025/2025-08-19.md) it was decided that 6.14.0 is the last version to support intel osx. This release note is to let users know.

### To test:

This is adding a release note so there is nothing to test other than looking at the note

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
