### PR TITLE
Add validate() wrapper around validateInputs() to handle group workspaces better

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -212,7 +212,6 @@ public:
   void addTimer(const std::string &name, const Kernel::time_point_ns &begin, const Kernel::time_point_ns &end);
   void executeAsChildAlg() override;
   std::map<std::string, std::string> validate() override;
-  std::map<std::string, std::string> validateInputs() override;
 
   /// Gets the current execution state
   ExecutionState executionState() const override;
@@ -362,6 +361,8 @@ protected:
   virtual void init() = 0;
   /// Virtual method - must be overridden by concrete algorithm
   virtual void exec() = 0;
+  /// Method checking errors on ALL the inputs, before execution. Used internally by validate().
+  virtual std::map<std::string, std::string> validateInputs();
 
   /// Returns a semi-colon separated list of workspace types to attach this
   /// algorithm

--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -211,6 +211,7 @@ public:
   bool execute() override final;
   void addTimer(const std::string &name, const Kernel::time_point_ns &begin, const Kernel::time_point_ns &end);
   void executeAsChildAlg() override;
+  std::map<std::string, std::string> validate() override;
   std::map<std::string, std::string> validateInputs() override;
 
   /// Gets the current execution state

--- a/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -102,10 +102,8 @@ public:
    */
   virtual void initialize() = 0;
 
+  /// Public method to validate inputs which can handle group workspace inputs
   virtual std::map<std::string, std::string> validate() = 0;
-  /// Method checking errors on ALL the inputs, before execution. For use mostly
-  /// in dialogs.
-  virtual std::map<std::string, std::string> validateInputs() = 0;
 
   /// System execution. This method invokes the exec() method of a concrete
   /// algorithm.

--- a/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -102,6 +102,7 @@ public:
    */
   virtual void initialize() = 0;
 
+  virtual std::map<std::string, std::string> validate() = 0;
   /// Method checking errors on ALL the inputs, before execution. For use mostly
   /// in dialogs.
   virtual std::map<std::string, std::string> validateInputs() = 0;

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -323,14 +323,19 @@ void Algorithm::initialize() {
 //---------------------------------------------------------------------------------------------
 /** Perform validation of ALL the input properties of the algorithm.
  * This is to be overridden by specific algorithms.
- * It will be called in dialogs after parsing all inputs and setting the
- * properties, but BEFORE executing.
  *
  * @return a map where: Key = string name of the property;
             Value = string describing the problem with the property.
  */
 std::map<std::string, std::string> Algorithm::validateInputs() { return std::map<std::string, std::string>(); }
 
+//---------------------------------------------------------------------------------------------
+/** Wraps validateInputs() to handle group workspaces in the case that validation is run
+ * in dialogs after parsing all inputs and setting the *properties but BEFORE executing.
+ *
+ * @return a map where: Key = string name of the property;
+           Value = string describing the problem with the property.
+ */
 std::map<std::string, std::string> Algorithm::validate() {
   this->cacheWorkspaceProperties();
 

--- a/Framework/Algorithms/test/ChangeTimeZeroTest.h
+++ b/Framework/Algorithms/test/ChangeTimeZeroTest.h
@@ -365,7 +365,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "group"));
     alg.setPropertyValue("OutputWorkspace", "__NoName");
     alg.setPropertyValue("AbsoluteTimeOffset", absoluteTimeShift.toISO8601String());
-    TS_ASSERT_THROWS_NOTHING(alg.validateInputs());
+    TS_ASSERT_THROWS_NOTHING(alg.validate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Algorithms/test/CombineDiffCalTest.h
+++ b/Framework/Algorithms/test/CombineDiffCalTest.h
@@ -612,7 +612,7 @@ public:
     }
   }
 
-  void test_validateInputs_in_pixel_not_cal() {
+  void test_validate_in_pixel_not_cal() {
     // Ensure the algorithm will fail early if the pixels in the PixelCalibration
     // are not present in the CalibrationWorkspace
     // create workspaces with these detectors:
@@ -650,13 +650,13 @@ public:
     auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
     TS_ASSERT(!alg->isExecuted());
-    auto result = alg->validateInputs();
+    auto result = alg->validate();
     TS_ASSERT(!result.count("GroupedCalibration"));
     TS_ASSERT(result.count("PixelCalibration"));
     TS_ASSERT(result.count("CalibrationWorkspace"));
   }
 
-  void test_validateInputs_in_grouped_not_cal() {
+  void test_validate_in_grouped_not_cal() {
     // Ensure the algorithm will fail early if the pixels in the GroupedCalibration
     // are not present in the CalibrationWorkspace
     // create workspaces with these detectors:
@@ -694,7 +694,7 @@ public:
     auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
     TS_ASSERT(!alg->isExecuted());
-    auto result = alg->validateInputs();
+    auto result = alg->validate();
     TS_ASSERT(result.count("GroupedCalibration"));
     TS_ASSERT(!result.count("PixelCalibration"));
     TS_ASSERT(result.count("CalibrationWorkspace"));

--- a/Framework/Algorithms/test/ConvertToDistributionTest.h
+++ b/Framework/Algorithms/test/ConvertToDistributionTest.h
@@ -18,7 +18,7 @@ using Mantid::Algorithms::ConvertToDistribution;
 
 class TestConvertToDistribution : public ConvertToDistribution {
 public:
-  std::map<std::string, std::string> wrapValidateInputs() { return this->validateInputs(); }
+  std::map<std::string, std::string> wrapValidate() { return this->validate(); }
 };
 
 class ConvertToDistributionTest : public CxxTest::TestSuite {
@@ -80,7 +80,7 @@ public:
     conv.initialize();
     conv.setChild(true);
     TS_ASSERT_THROWS_NOTHING(conv.setPropertyValue("Workspace", "group"));
-    TS_ASSERT_THROWS_NOTHING(conv.wrapValidateInputs());
+    TS_ASSERT_THROWS_NOTHING(conv.wrapValidate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Algorithms/test/CopyDetectorMappingTest.h
+++ b/Framework/Algorithms/test/CopyDetectorMappingTest.h
@@ -73,7 +73,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(copyMapping.setPropertyValue("WorkspaceToMatch", "to_match"));
     TS_ASSERT_THROWS_NOTHING(copyMapping.setPropertyValue("WorkspaceToRemap", "to_remap"));
 
-    auto validationIssues = copyMapping.validateInputs();
+    auto validationIssues = copyMapping.validate();
     TS_ASSERT_DIFFERS(validationIssues.size(), 0);
 
     TS_ASSERT_THROWS_ANYTHING(copyMapping.execute());

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -192,7 +192,7 @@ public:
     alg.setProperty("WorkspaceIndexMax", 1);
     alg.setProperty("XMin", 2.0);
     alg.setProperty("XMax", 2.0);
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.count("XMin"), 1);
     TS_ASSERT_EQUALS(errorMap.count("XMax"), 1);
@@ -206,7 +206,7 @@ public:
     alg.setProperty("WorkspaceIndexMax", 1);
     alg.setProperty("XMin", 3.0);
     alg.setProperty("XMax", 2.0);
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.count("XMin"), 1);
     TS_ASSERT_EQUALS(errorMap.count("XMax"), 1);
@@ -220,7 +220,7 @@ public:
     alg.setProperty("WorkspaceIndexMax", 1);
     alg.setProperty("XMin", 2.0);
     alg.setProperty("XMax", 3.0);
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);
@@ -234,7 +234,7 @@ public:
     alg.setProperty("WorkspaceIndexMax", 1);
     alg.setProperty("XMin", 2.0);
     alg.setProperty("XMax", 3.0);
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);
@@ -249,7 +249,7 @@ public:
     alg.setProperty("WorkspaceIndexMin", 1);
     alg.setProperty("WorkspaceIndexMax", 2);
     alg.setProperty("WorkspaceIndexList", "1,2,3");
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 3);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
     TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);

--- a/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
+++ b/Framework/Algorithms/test/DetermineSpinStateOrderTest.h
@@ -94,7 +94,7 @@ public:
     alg.initialize();
     alg.setProperty("InputWorkspace", wsGroupOsiris);
 
-    auto errors = alg.validateInputs();
+    auto errors = alg.validate();
     TS_ASSERT(!errors.empty())
     TS_ASSERT_EQUALS(errors["InputWorkspace"], "Sub workspaces must be data from either LARMOR or ZOOM when "
                                                "SpinFlipperLogName or SpinFlipperAverageCurrent are not provided")

--- a/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
+++ b/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
@@ -851,8 +851,8 @@ public:
   void test_validateInputsWithInputWorkspaceSetToGroup() {
     // Test motivated by ensuring alg dialog opens in workbench UI in all cases
     // Workbench calls InterfaceManager::createdialogfromname when opening algorithm dialog. This calls
-    // setPropertyValue on all inputs and if they're all OK it then calls validateInputs - this is separate to and
-    // before the call to validateInputs that happens inside alg->execute()
+    // setPropertyValue on all inputs and if they're all OK it then calls validate- this is separate to and
+    // before the call to validate that happens inside alg->execute()
     auto alg = createAlgorithm();
     const double THICKNESS = 0.001; // metres
     auto inputWorkspace = SetupFlatPlateWorkspace(1, 1, 1.0, 1, 0.5, 1.0, 100 * THICKNESS, 100 * THICKNESS, THICKNESS);
@@ -865,9 +865,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("NeutronPathsSingle", "1"));
     TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("NeutronPathsMultiple", "1"));
     std::map<std::string, std::string> errs;
-    // Note: if validateInputs causes an access violation (as opposed to throwing an exception) then
+    // Note: if validate causes an access violation (as opposed to throwing an exception) then
     // TS_ASSERT_THROWS_NOTHING won't catch it
-    TS_ASSERT_THROWS_NOTHING(errs = alg->validateInputs());
+    TS_ASSERT_THROWS_NOTHING(errs = alg->validate());
     TS_ASSERT(!errs.empty());
     Mantid::API::AnalysisDataService::Instance().clear();
   }

--- a/Framework/Algorithms/test/FFTTest.h
+++ b/Framework/Algorithms/test/FFTTest.h
@@ -24,11 +24,11 @@ using namespace Mantid;
 using namespace Mantid::API;
 
 /**
- * This is a test class that exists to test the method validateInputs()
+ * This is a test class that exists to test the method validate()
  */
 class TestFFT : public Mantid::Algorithms::FFT {
 public:
-  std::map<std::string, std::string> wrapValidateInputs() { return this->validateInputs(); }
+  std::map<std::string, std::string> wrapValidate() { return this->validate(); }
 };
 
 class FFTTest : public CxxTest::TestSuite {
@@ -542,7 +542,7 @@ public:
     fft.setPropertyValue("OutputWorkspace", "__NotUsed");
     fft.setPropertyValue("Real", "0");
     fft.setPropertyValue("Imaginary", "0");
-    TS_ASSERT_THROWS_NOTHING(fft.wrapValidateInputs());
+    TS_ASSERT_THROWS_NOTHING(fft.wrapValidate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Algorithms/test/FilterByLogValueTest.h
+++ b/Framework/Algorithms/test/FilterByLogValueTest.h
@@ -70,13 +70,13 @@ public:
 
     // Check protest when non-existent log is set
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "NotThere"));
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "LogName");
 
     // Check protest when single-value log is set
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "SingleValue"));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "LogName");
 
@@ -84,14 +84,14 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "TSP"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MinimumValue", 2.0));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaximumValue", 1.0));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "MaximumValue");
     TS_ASSERT_EQUALS(errorMap.rbegin()->first, "MinimumValue");
 
     // Check it's happy when that's been remedied
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaximumValue", 3.0));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT(errorMap.empty());
   }
 

--- a/Framework/Algorithms/test/FilterByXValueTest.h
+++ b/Framework/Algorithms/test/FilterByXValueTest.h
@@ -31,17 +31,17 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", WorkspaceCreationHelper::createEventWorkspace()));
 
     // At least one of XMin & XMax must be specified
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
     TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");
 
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", 10.0));
-    TS_ASSERT(alg.validateInputs().empty());
+    TS_ASSERT(alg.validate().empty());
 
     // XMax must be > XMin
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", 9.0));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
     TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");

--- a/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
+++ b/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
@@ -79,19 +79,19 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Requires at least 2 input workspaces")
 
     // single input workspace
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1"}));
-    issues = alg.validateInputs();
+    issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Requires at least 2 input workspaces")
 
     // two workspaces should have no issues
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"}));
-    issues = alg.validateInputs();
+    issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 0)
   }
 
@@ -101,7 +101,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "highPC"}));
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Proton charge must not vary more than 1%")
   }
@@ -112,7 +112,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffNumHist"}));
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Number of spectra mismatch.")
   }
@@ -123,7 +123,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffNumBins"}));
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Size mismatch.")
   }
@@ -134,7 +134,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffInstrument"}));
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Instrument name mismatch.")
   }
@@ -145,7 +145,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "histogram"}));
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 1)
     TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Workspace \"histogram\" is not an EventWorkspace")
   }
@@ -158,7 +158,7 @@ public:
     alg.setProperty("PercentMin", 75.);
     alg.setProperty("PercentMax", 25.);
 
-    auto issues = alg.validateInputs();
+    auto issues = alg.validate();
     TS_ASSERT_EQUALS(issues.size(), 2)
     TS_ASSERT_EQUALS(issues["PercentMin"], "PercentMin must be less than PercentMax")
     TS_ASSERT_EQUALS(issues["PercentMax"], "PercentMin must be less than PercentMax")

--- a/Framework/Algorithms/test/GetAllEiTest.h
+++ b/Framework/Algorithms/test/GetAllEiTest.h
@@ -165,11 +165,11 @@ public:
     TSM_ASSERT_THROWS("should throw runtime error on validation as no "
                       "appropriate logs are defined",
                       m_getAllEi.execute(), const std::runtime_error &);
-    auto log_messages = m_getAllEi.validateInputs();
+    auto log_messages = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("Two logs should fail", log_messages.size(), 2);
     // add invalid property type
     ws->mutableRun().addLogData(new Kernel::PropertyWithValue<double>("Chopper_Speed", 10.));
-    auto log_messages2 = m_getAllEi.validateInputs();
+    auto log_messages2 = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("Two logs should fail", log_messages2.size(), 2);
 
     TSM_ASSERT_DIFFERS("should fail for different reason ", log_messages["ChopperSpeedLog"],
@@ -177,18 +177,18 @@ public:
     // add correct property type:
     ws->mutableRun().clearLogs();
     ws->mutableRun().addLogData(new Kernel::TimeSeriesProperty<double>("Chopper_Speed"));
-    log_messages = m_getAllEi.validateInputs();
+    log_messages = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("One log should fail", log_messages.size(), 1);
     TSM_ASSERT("Filter log is not provided ", !m_getAllEi.filterLogProvided());
     ws->mutableRun().addLogData(new Kernel::TimeSeriesProperty<double>("Chopper_Delay"));
     ws->mutableRun().addLogData(new Kernel::TimeSeriesProperty<double>("proton_charge"));
-    log_messages = m_getAllEi.validateInputs();
+    log_messages = m_getAllEi.validate();
 
     TSM_ASSERT_EQUALS("All logs are defined", log_messages.size(), 0);
     TSM_ASSERT("Filter log is provided ", m_getAllEi.filterLogProvided());
 
     m_getAllEi.setProperty("Monitor1SpecID", 3);
-    log_messages = m_getAllEi.validateInputs();
+    log_messages = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("Workspace should not have spectra with ID=3", log_messages.size(), 1);
   }
   //
@@ -258,7 +258,7 @@ public:
 
     // Run validate as this will set up property, which indicates filter log
     // presence
-    auto errors = m_getAllEi.validateInputs();
+    auto errors = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("All logs are defined now", errors.size(), 0);
 
     double chop_speed, chop_delay;
@@ -272,7 +272,7 @@ public:
     }
 
     ws->mutableRun().addProperty(goodFram.release(), true);
-    errors = m_getAllEi.validateInputs();
+    errors = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("All logs are defined now", errors.size(), 0);
 
     m_getAllEi.find_chop_speed_and_delay(ws, chop_speed, chop_delay);
@@ -317,7 +317,7 @@ public:
 
     // Run validate as this will set up property, which indicates filter log
     // presence
-    auto errors = m_getAllEi.validateInputs();
+    auto errors = m_getAllEi.validate();
     TSM_ASSERT_EQUALS("All logs are defined now", errors.size(), 0);
 
     double chop_speed, chop_delay;

--- a/Framework/Algorithms/test/IntegrateEPPTest.h
+++ b/Framework/Algorithms/test/IntegrateEPPTest.h
@@ -181,7 +181,7 @@ public:
 
     // Make sure validateInputs doesn't throw for a WorkspaceGroup input.
     Algorithm &baseAlg = alg;
-    TS_ASSERT_THROWS_NOTHING(baseAlg.validateInputs());
+    TS_ASSERT_THROWS_NOTHING(baseAlg.validate());
 
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());

--- a/Framework/Algorithms/test/LineProfileTest.h
+++ b/Framework/Algorithms/test/LineProfileTest.h
@@ -310,7 +310,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("HalfWidth", 1.0))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Start", 9.0))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("End", 2.0))
-    const auto issues = alg.validateInputs();
+    const auto issues = alg.validate();
     const auto it = issues.find("Start");
     TS_ASSERT_DIFFERS(it, issues.end())
   }

--- a/Framework/Algorithms/test/MaxEntTest.h
+++ b/Framework/Algorithms/test/MaxEntTest.h
@@ -24,11 +24,11 @@ using Mantid::HistogramData::CountStandardDeviations;
 using Mantid::HistogramData::Points;
 
 /**
- * This is a test class that exists to test the method validateInputs()
+ * This is a test class that exists to test the method validate()
  */
 class TestMaxEnt : public Mantid::Algorithms::MaxEnt {
 public:
-  std::map<std::string, std::string> wrapValidateInputs() { return this->validateInputs(); }
+  std::map<std::string, std::string> wrapValidate() { return this->validate(); }
 };
 
 class MaxEntTest : public CxxTest::TestSuite {
@@ -1000,7 +1000,7 @@ public:
     alg.setPropertyValue("ReconstructedData", "data");
     alg.setPropertyValue("EvolChi", "evolChi");
     alg.setPropertyValue("EvolAngle", "evolAngle");
-    TS_ASSERT_THROWS_NOTHING(alg.wrapValidateInputs());
+    TS_ASSERT_THROWS_NOTHING(alg.wrapValidate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -110,7 +110,7 @@ public:
     rebin.initialize();
     rebin.setProperty("Params", std::vector<double>{1.0, -1.0, 10.0});
     rebin.setProperty("Power", 0.5);
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     auto errmsg = errmsgs.find("Params");
     TS_ASSERT(errmsg != errmsgs.end());
     TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
@@ -837,7 +837,7 @@ public:
     rebin.initialize();
     rebin.setProperty("Params", std::vector<double>{1.2, 1.2, 12.22});
     rebin.setPropertyValue("BinningMode", "Power");
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     auto errmsg = errmsgs.find("Power");
     TS_ASSERT(errmsg != errmsgs.end());
     TS_ASSERT(errmsg->second.substr(0, 35) == "The binning mode was set to 'Power'");
@@ -853,7 +853,7 @@ public:
     rebin.setProperty("InputWorkspace", "ws1");
     rebin.setProperty("Params", std::vector<double>{-1.0, 1.0, 1000.0});
     rebin.setProperty("BinningMode", "Logarithmic");
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     TS_ASSERT(!errmsgs.empty());
     auto errmsg = errmsgs.find("Params");
     TS_ASSERT(errmsg != errmsgs.end());
@@ -928,7 +928,7 @@ public:
     rebin.setProperty("BinningMode", binMode);
     if (binMode == "Power")
       rebin.setProperty("Power", 0.5);
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     TS_ASSERT(errmsgs.empty());
     // exactly one of these will be true, the other false
     bool validatedRvrs = rebin.getProperty("UseReverseLogarithmic");
@@ -971,7 +971,7 @@ public:
     rebin.setProperty("Params", std::vector<double>{1.2, -1.2, 12.22});
     rebin.setProperty("UseReverseLogarithmic", true);
     rebin.setProperty("BinningMode", "ReverseLogarithmic");
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     TS_ASSERT(errmsgs.empty());
     // assert this is still true
     TS_ASSERT(bool(rebin.getProperty("UseReverseLogarithmic")));
@@ -1018,7 +1018,7 @@ public:
     rebin.setPropertyValue("BinningMode", binMode);
     if (binMode == "Power")
       rebin.setProperty("Power", 0.5);
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     TS_ASSERT(errmsgs.empty());
 
     std::vector<double> rbParams = rebin.getProperty("Params");
@@ -1065,7 +1065,7 @@ public:
     rebin.setProperty("Params", std::vector<double>{1.0, step, 10.0});
     rebin.setProperty("Power", 0.5);
     rebin.setPropertyValue("BinningMode", binMode);
-    auto errmsgs = rebin.validateInputs();
+    auto errmsgs = rebin.validate();
     TS_ASSERT(errmsgs.empty());
     // ensure that power was unset
     TS_ASSERT(double(rebin.getProperty("Power")) == 0.0);
@@ -1443,7 +1443,7 @@ public:
     rebin.setProperty("InputWorkspace", groupWsName);
     rebin.setPropertyValue("OutputWorkspace", "output");
     rebin.setProperty("Params", "1,1,10");
-    auto errors = rebin.validateInputs();
+    auto errors = rebin.validate();
     TS_ASSERT_EQUALS(0, errors.size());
     TS_ASSERT(rebin.execute());
     TS_ASSERT(rebin.isExecuted());

--- a/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
+++ b/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
@@ -386,7 +386,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms()));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"], "DetectorTwoThetaRanges requires 3 columns");
   }
 
@@ -395,7 +395,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms()));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"], "DetectorTwoThetaRanges requires 3 columns");
   }
 
@@ -404,7 +404,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms()));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"],
                      "The first column of DetectorTwoThetaRanges should be of type int");
   }
@@ -414,7 +414,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms()));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"],
                      "The second column of DetectorTwoThetaRanges should be of type double");
   }
@@ -424,7 +424,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms()));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"],
                      "The third column of DetectorTwoThetaRanges should be of type double");
   }
@@ -434,7 +434,7 @@ public:
     auto inputWS = SofQWTest::loadTestFile();
     const auto twoThetaRanges = createTableWorkspace(dataTypes, static_cast<int>(inputWS->getNumberHistograms() + 1));
     const IAlgorithm_sptr alg = setUpAlg(inputWS, twoThetaRanges);
-    auto results = alg->validateInputs();
+    auto results = alg->validate();
     TS_ASSERT_EQUALS(results["DetectorTwoThetaRanges"],
                      "The table and workspace do not have the same number of detectors");
   }

--- a/Framework/Algorithms/test/SumEventsByLogValueTest.h
+++ b/Framework/Algorithms/test/SumEventsByLogValueTest.h
@@ -59,25 +59,25 @@ public:
 
     // Check protest when non-existent log is set
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "NotThere"));
-    auto errorMap = alg.validateInputs();
+    auto errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "LogName");
 
     // Check protest when single-value log is set
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "SingleValue"));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "LogName");
 
     // Check protest when empty tsp log given
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "emptyTSP"));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
     TS_ASSERT_EQUALS(errorMap.begin()->first, "LogName");
 
     // Check it's happy when a non-empty tsp is given
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogName", "TSP"));
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT(errorMap.empty());
   }
 

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -44,7 +44,7 @@ public:
   void testValidateInputsWithDefaultsPasses() {
     Mantid::Algorithms::SumSpectra runner;
     runner.initialize();
-    auto validationErrors = runner.validateInputs();
+    auto validationErrors = runner.validate();
     TS_ASSERT(validationErrors.empty());
   }
 
@@ -53,7 +53,7 @@ public:
     runner.initialize();
     runner.setProperty("StartWorkspaceIndex", 10);
     runner.setProperty("EndWorkspaceIndex", 9);
-    auto validationErrors = runner.validateInputs();
+    auto validationErrors = runner.validate();
     TS_ASSERT_EQUALS(2, validationErrors.size());
     TSM_ASSERT_THROWS_NOTHING("Validation errors should contain a StartWorkspaceIndex entry",
                               validationErrors["StartWorkspaceIndex"]);
@@ -70,7 +70,7 @@ public:
     // bad start workspace index
     runner.setProperty("InputWorkspace", testWS);
     runner.setProperty("StartWorkspaceIndex", 3);
-    auto validationErrors = runner.validateInputs();
+    auto validationErrors = runner.validate();
     TS_ASSERT_EQUALS(1, validationErrors.size());
     TSM_ASSERT_THROWS_NOTHING("Validation errors should contain a StartWorkspaceIndex entry",
                               validationErrors["StartWorkspaceIndex"]);
@@ -78,7 +78,7 @@ public:
     // bad end workspace index
     runner.setProperty("StartWorkspaceIndex", 0);
     runner.setProperty("EndWorkspaceIndex", 5);
-    validationErrors = runner.validateInputs();
+    validationErrors = runner.validate();
     TS_ASSERT_EQUALS(1, validationErrors.size());
     TSM_ASSERT_THROWS_NOTHING("Validation errors should contain a EndWorkspaceIndex entry",
                               validationErrors["EndWorkspaceIndex"]);
@@ -92,7 +92,7 @@ public:
     auto testGroup = WorkspaceCreationHelper::createWorkspaceGroup(2, 1, 1, nameStem);
     runner.setProperty("InputWorkspace", nameStem);
 
-    auto validationErrors = runner.validateInputs();
+    auto validationErrors = runner.validate();
     TS_ASSERT(validationErrors.empty());
 
     Mantid::API::AnalysisDataService::Instance().remove(nameStem);
@@ -107,7 +107,7 @@ public:
     runner.setPropertyValue("InputWorkspace", nameStem);
     runner.setProperty("StartWorkspaceIndex", 11);
 
-    auto validationErrors = runner.validateInputs();
+    auto validationErrors = runner.validate();
     TS_ASSERT_EQUALS(1, validationErrors.size());
     TSM_ASSERT_THROWS_NOTHING("Validation errors should contain StartWorkspaceIndex",
                               validationErrors["StartWorkspaceIndex"]);

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -510,7 +510,7 @@ public:
 
   void assert_helpmsgs_error_from_validate_inputs(std::shared_ptr<IndexPeaks> alg, std::string prop,
                                                   std::string err_substring) {
-    auto helpMsgs = alg->validateInputs();
+    auto helpMsgs = alg->validate();
 
     const auto valueIter = helpMsgs.find(prop);
     TS_ASSERT(valueIter != helpMsgs.cend())

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -285,7 +285,7 @@ public:
     alg.initialize();
     alg.setProperty("Peaks", WorkspaceCreationHelper::createPeaksWorkspace(0));
 
-    auto helpMsgs = alg.validateInputs();
+    auto helpMsgs = alg.validate();
 
     const auto valueIter = helpMsgs.find("Peaks");
     TS_ASSERT(valueIter != helpMsgs.cend())
@@ -303,7 +303,7 @@ public:
     alg.setProperty("Peaks", WorkspaceCreationHelper::createPeaksWorkspace(0));
     alg.setProperty("ModVector1", "0.5,0,0.5");
 
-    auto helpMsgs = alg.validateInputs();
+    auto helpMsgs = alg.validate();
 
     TS_ASSERT(helpMsgs.find("MaxOrder") != helpMsgs.cend())
   }
@@ -316,7 +316,7 @@ private:
     alg.setProperty(minName, 8.0);
     alg.setProperty(maxName, -8.0);
 
-    auto helpMsgs = alg.validateInputs();
+    auto helpMsgs = alg.validate();
 
     const auto minError = helpMsgs.find(minName);
     TS_ASSERT(minError != helpMsgs.cend())

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -857,7 +857,7 @@ public:
     groupAlg.setPropertyValue("OutputWorkspace", outputWSNameBase);
     groupAlg.setPropertyValue("GroupingPattern", "-1, 0");
     // Check that the GroupingPattern was recognised as invalid
-    TS_ASSERT(!groupAlg.validateInputs()["GroupingPattern"].empty());
+    TS_ASSERT(!groupAlg.validate()["GroupingPattern"].empty());
     // And that we're not allowed to run
     TS_ASSERT_THROWS(groupAlg.execute(), const std::runtime_error &);
   }

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -882,7 +882,7 @@ public:
     using Mantid::DataObjects::TableWorkspace;
     auto alg = createAlgorithm(std::make_shared<TableWorkspace>(0));
 
-    auto helpMessages = alg->validateInputs();
+    auto helpMessages = alg->validate();
     TS_ASSERT(helpMessages.find("InputWorkspace") != helpMessages.cend());
   }
 
@@ -1064,7 +1064,7 @@ private:
   }
 
   bool validateErrorProduced(Mantid::API::IAlgorithm &alg, const std::string &name) {
-    const auto errors = alg.validateInputs();
+    const auto errors = alg.validate();
     if (errors.find(name) != errors.end())
       return true;
     else

--- a/Framework/LiveData/test/LiveDataAlgorithmTest.h
+++ b/Framework/LiveData/test/LiveDataAlgorithmTest.h
@@ -62,7 +62,7 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
-  void test_validateInputs() {
+  void test_validate() {
     FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilities.xml", "TEST");
 
     LiveDataAlgorithmImpl alg;
@@ -72,23 +72,23 @@ public:
 
     alg.setPropertyValue("Instrument", "FakeEventDataListener");
 
-    TSM_ASSERT("No OutputWorkspace", !alg.validateInputs()["OutputWorkspace"].empty());
+    TSM_ASSERT("No OutputWorkspace", !alg.validate()["OutputWorkspace"].empty());
     alg.setPropertyValue("OutputWorkspace", "out_ws");
-    TSM_ASSERT("Is OK now", alg.validateInputs().empty());
+    TSM_ASSERT("Is OK now", alg.validate().empty());
 
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("PostProcessingScript", "Pause(1)"));
     TS_ASSERT(alg.hasPostProcessing());
 
-    TSM_ASSERT("No AccumulationWorkspace", !alg.validateInputs()["AccumulationWorkspace"].empty());
+    TSM_ASSERT("No AccumulationWorkspace", !alg.validate()["AccumulationWorkspace"].empty());
     alg.setPropertyValue("AccumulationWorkspace", "accum_ws");
-    TSM_ASSERT("Is OK now", alg.validateInputs().empty());
+    TSM_ASSERT("Is OK now", alg.validate().empty());
 
     alg.setPropertyValue("AccumulationWorkspace", "out_ws");
-    TSM_ASSERT("AccumulationWorkspace == OutputWorkspace", !alg.validateInputs()["AccumulationWorkspace"].empty());
+    TSM_ASSERT("AccumulationWorkspace == OutputWorkspace", !alg.validate()["AccumulationWorkspace"].empty());
 
     alg.setPropertyValue("Instrument", "TESTHISTOLISTENER");
     alg.setPropertyValue("AccumulationMethod", "Add");
-    TSM_ASSERT("Shouldn't add histograms", !alg.validateInputs()["AccumulationMethod"].empty());
+    TSM_ASSERT("Shouldn't add histograms", !alg.validate()["AccumulationMethod"].empty());
   }
 
   /** Test creating the processing algorithm.

--- a/Framework/LiveData/test/MonitorLiveDataTest.h
+++ b/Framework/LiveData/test/MonitorLiveDataTest.h
@@ -80,7 +80,7 @@ public:
 
     // This algorithm dies because another thread has the same output
     std::shared_ptr<MonitorLiveData> alg2 = makeAlgo("fake1");
-    TSM_ASSERT("validateInputs should complaing (return a non-empty map)", !alg2->validateInputs().empty());
+    TSM_ASSERT("validate should complaing (return a non-empty map)", !alg2->validate().empty());
 
     // Abort the thread.
     alg1->cancel();
@@ -98,7 +98,7 @@ public:
 
     // This algorithm dies because another thread has the same output
     std::shared_ptr<MonitorLiveData> alg2 = makeAlgo("fake2", "accum1");
-    TSM_ASSERT("validateInputs should complaing (return a non-empty map)", !alg2->validateInputs().empty());
+    TSM_ASSERT("validate should complaing (return a non-empty map)", !alg2->validate().empty());
 
     // Abort the thread.
     alg1->cancel();
@@ -118,7 +118,7 @@ public:
 
     // This algorithm if OK because the other is not still running
     IAlgorithm_sptr alg2 = makeAlgo("fake1");
-    TSM_ASSERT("validateInputs should give the all clear (an empty map)", alg2->validateInputs().empty());
+    TSM_ASSERT("validate should give the all clear (an empty map)", alg2->validate().empty());
   }
 
   //--------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -56,7 +56,7 @@ public:
     std::vector<double> p1BinVec = {(0.0), (step), (1.0)};
     alg.setProperty("P1Bin", p1BinVec);
     alg.setPropertyValue("OutputWorkspace", "dummy");
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("No new steps allowed", alg.execute(), std::runtime_error &);
   }
 
@@ -77,14 +77,14 @@ public:
     double max = min;
     std::vector<double> p1BinVec = {min, max};
     alg.setProperty("P1Bin", p1BinVec);
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("Incorrect limits", alg.execute(), std::runtime_error &);
 
     // Test less than
     max = min - 0.01;
     p1BinVec = {min, max};
     alg.setProperty("P1Bin", p1BinVec);
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("Incorrect limits", alg.execute(), std::runtime_error &);
   }
 
@@ -105,21 +105,21 @@ public:
     double max = min;
     std::vector<double> p1BinVec = {min, step, max};
     alg.setProperty("P1Bin", p1BinVec);
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("Incorrect limits", alg.execute(), std::runtime_error &);
 
     // Test less than
     max = min - 0.01;
     p1BinVec = {min, max};
     alg.setProperty("P1Bin", p1BinVec);
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("Incorrect limits", alg.execute(), std::runtime_error &);
 
     // Test non-zero step. ZERO means copy!
     max = min - 0.01;
     p1BinVec = {min, max};
     alg.setProperty("P1Bin", p1BinVec);
-    TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
+    TSM_ASSERT("Expect validation errors", alg.validate().size() > 0);
     TSM_ASSERT_THROWS("Step has been specified", alg.execute(), std::runtime_error &);
   }
 

--- a/Framework/MDAlgorithms/test/ReplicateMDTest.h
+++ b/Framework/MDAlgorithms/test/ReplicateMDTest.h
@@ -140,11 +140,11 @@ public:
     alg.initialize();
     alg.setProperty("DataWorkspace", dataWSBad);
     alg.setProperty("ShapeWorkspace", shapeWS);
-    TSM_ASSERT_EQUALS("Shape and data are the same size. Should fail.", 1, alg.validateInputs().size());
+    TSM_ASSERT_EQUALS("Shape and data are the same size. Should fail.", 1, alg.validate().size());
 
     // Try again with different property value
     alg.setProperty("DataWorkspace", dataWSGood);
-    TSM_ASSERT_EQUALS("Interated dim should not be counted.", 0, alg.validateInputs().size());
+    TSM_ASSERT_EQUALS("Interated dim should not be counted.", 0, alg.validate().size());
   }
 
   void test_basic_shape_check() {
@@ -162,7 +162,7 @@ public:
     alg.initialize();
     alg.setProperty("DataWorkspace", dataWS);
     alg.setProperty("ShapeWorkspace", shapeWS);
-    TSM_ASSERT_EQUALS("Shape and data are different shapes. Should fail.", 1, alg.validateInputs().size());
+    TSM_ASSERT_EQUALS("Shape and data are different shapes. Should fail.", 1, alg.validate().size());
   }
 
   void test_very_simple_exec() {

--- a/Framework/Muon/test/AsymmetryCalcTest.h
+++ b/Framework/Muon/test/AsymmetryCalcTest.h
@@ -25,11 +25,11 @@ using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
 /**
- * This is a test class that exists to test the method validateInputs()
+ * This is a test class that exists to test the method validate()
  */
 class TestAsymmetryCalc : public Mantid::Algorithms::AsymmetryCalc {
 public:
-  std::map<std::string, std::string> wrapValidateInputs() { return this->validateInputs(); }
+  std::map<std::string, std::string> wrapValidate() { return this->validate(); }
 };
 
 class AsymmetryCalcTest : public CxxTest::TestSuite {
@@ -158,7 +158,7 @@ public:
     calc.setPropertyValue("OutputWorkspace", "__Unused");
     calc.setPropertyValue("ForwardSpectra", "1");
     calc.setPropertyValue("BackwardSpectra", "2");
-    TS_ASSERT_THROWS_NOTHING(calc.wrapValidateInputs());
+    TS_ASSERT_THROWS_NOTHING(calc.wrapValidate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Muon/test/CalMuonDetectorPhasesTest.h
+++ b/Framework/Muon/test/CalMuonDetectorPhasesTest.h
@@ -27,11 +27,11 @@ using Mantid::MantidVec;
 const std::string outputName = "MuonRemoveExpDecay_Output";
 
 /**
- * This is a test class that exists to test the method validateInputs()
+ * This is a test class that exists to test the method validate()
  */
 class TestCalMuonDetectorPhases : public Mantid::Algorithms::CalMuonDetectorPhases {
 public:
-  std::map<std::string, std::string> wrapValidateInputs() { return this->validateInputs(); }
+  std::map<std::string, std::string> wrapValidate() { return this->validate(); }
 };
 
 class CalMuonDetectorPhasesTest : public CxxTest::TestSuite {
@@ -109,7 +109,7 @@ public:
     calc.setPropertyValue("DetectorTable", "tab");
     calc.setProperty("ForwardSpectra", std::vector<int>{1});
     calc.setProperty("BackwardSpectra", std::vector<int>{2});
-    TS_ASSERT_THROWS_NOTHING(calc.wrapValidateInputs());
+    TS_ASSERT_THROWS_NOTHING(calc.wrapValidate());
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/Muon/test/MuonPreProcessTest.h
+++ b/Framework/Muon/test/MuonPreProcessTest.h
@@ -225,7 +225,7 @@ public:
     ITableWorkspace_sptr timeZeroTable = createTimeZeroTable(5, timeZeros);
 
     auto alg = setUpAlgorithmWithTimeZeroTable(ws, timeZeroTable);
-    auto errors = alg->validateInputs();
+    auto errors = alg->validate();
     const auto expected = "TimeZeroTable must have as many rows as there are "
                           "spectra in InputWorkspace. Use TimeOffset to apply "
                           "same time correcton to all data";

--- a/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
+++ b/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
@@ -598,7 +598,7 @@ public:
   void test_validate_inputs_fails_if_neither_first_and_last_or_workspacenames_is_defined() {
     PlotAsymmetryByLogValue alg;
     alg.initialize();
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     const auto expected = "Must either supply WorkspaceNames or FirstRun and "
                           "LastRun";
     TS_ASSERT_EQUALS(result["FirstRun"], expected);
@@ -611,7 +611,7 @@ public:
     alg.initialize();
     alg.setProperty("FirstRun", firstRun);
     alg.setProperty("LastRun", lastRun);
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     TS_ASSERT(result.empty());
   }
 
@@ -620,7 +620,7 @@ public:
     alg.initialize();
     std::vector<std::string> input{firstRun, lastRun};
     alg.setProperty("WorkspaceNames", input);
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     std::vector<std::string> propertyValue = alg.getProperty("WorkspaceNames");
     TS_ASSERT(result.empty());
     TS_ASSERT_EQUALS(input, propertyValue);
@@ -633,7 +633,7 @@ public:
     alg.setProperty("WorkspaceNames", input);
     alg.setProperty("FirstRun", firstRun);
     alg.setProperty("LastRun", lastRun);
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     TS_ASSERT(result.empty());
   }
 
@@ -641,7 +641,7 @@ public:
     PlotAsymmetryByLogValue alg;
     alg.initialize();
     alg.setProperty("FirstRun", firstRun);
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     const auto expected = "Must supply both FirstRun and LastRun";
     TS_ASSERT_EQUALS(result["FirstRun"], expected);
     TS_ASSERT_EQUALS(result["LastRun"], expected);
@@ -651,7 +651,7 @@ public:
     PlotAsymmetryByLogValue alg;
     alg.initialize();
     alg.setProperty("LastRun", lastRun);
-    auto result = alg.validateInputs();
+    auto result = alg.validate();
     const auto expected = "Must supply both FirstRun and LastRun";
     TS_ASSERT_EQUALS(result["FirstRun"], expected);
     TS_ASSERT_EQUALS(result["LastRun"], expected);

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
@@ -68,8 +68,6 @@ public:
   void cancel() override;
   /// A return of false will allow processing workspace groups as a whole
   bool checkGroups() override;
-  /// Returns the validateInputs result of the algorithm.
-  std::map<std::string, std::string> validateInputs() override;
   ///@}
 
   // -- Deprecated methods --
@@ -113,6 +111,8 @@ private:
   void init() override;
   /// Private exec for this algorithm
   void exec() override;
+  /// Returns the validateInputs result of the algorithm.
+  std::map<std::string, std::string> validateInputs() override;
 
   /// We don't want the base class versions
   using SuperClass::declareProperty;

--- a/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -343,8 +343,8 @@ std::string getWikiSummary(const IAlgorithm &self) {
  * @param self Reference to the calling object
  * @return validation error dictionary
  */
-boost::python::dict validateInputs(IAlgorithm &self) {
-  auto map = self.validateInputs();
+boost::python::dict validate(IAlgorithm &self) {
+  auto map = self.validate();
   using MapToPyDictionary = Mantid::PythonInterface::Converters::MapToPyDictionary<std::string, std::string>;
   return MapToPyDictionary(map)();
 }
@@ -441,8 +441,7 @@ void export_ialgorithm() {
            "should rethrow exceptions when "
            "executing.")
       .def("initialize", &initializeProxy, arg("self"), "Initializes the algorithm")
-      .def("validateInputs", &validateInputs, arg("self"),
-           "Cross-check all inputs and return any errors as a dictionary")
+      .def("validate", &validate, arg("self"), "Cross-check all inputs and return any errors as a dictionary")
       .def("execute", &executeProxy, arg("self"), "Runs the algorithm and returns whether it has been successful")
       .def("executeAsync", &executeAsync, arg("self"),
            "Starts the algorithm in a separate thread and returns immediately")

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -182,41 +182,6 @@ template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::cancel()
   }
 }
 
-/**
- * @copydoc Mantid::API::Algorithm::validateInputs
- */
-template <typename BaseAlgorithm> std::map<std::string, std::string> AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
-  using boost::python::dict;
-  std::map<std::string, std::string> resultMap;
-
-  try {
-    GlobalInterpreterLock gil;
-    dict resultDict = callMethod<dict>(getSelf(), "validateInputs");
-    // convert to a map<string,string>
-    boost::python::list keys = resultDict.keys();
-    size_t numItems = boost::python::len(keys);
-    for (size_t i = 0; i < numItems; ++i) {
-      boost::python::object key = keys[i];
-      boost::python::object value = resultDict[key];
-      if (value) {
-        try {
-          std::string keyAsString = boost::python::extract<std::string>(key);
-          std::string valueAsString = boost::python::extract<std::string>(value);
-          resultMap[std::move(keyAsString)] = std::move(valueAsString);
-        } catch (boost::python::error_already_set &) {
-          this->getLogger().error() << "In validateInputs(self): Invalid type for key/value pair "
-                                    << "detected in dict.\n"
-                                    << "All keys and values must be strings\n";
-        }
-      }
-    }
-  } catch (UndefinedAttributeError &) {
-    return resultMap;
-  }
-
-  return resultMap;
-}
-
 /// Set the summary text
 /// @param summary Wiki text
 template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::setWikiSummary(const std::string &summary) {
@@ -332,6 +297,41 @@ template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::exec() {
     else
       throw;
   }
+}
+
+/**
+ * @copydoc Mantid::API::Algorithm::validateInputs
+ */
+template <typename BaseAlgorithm> std::map<std::string, std::string> AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
+  using boost::python::dict;
+  std::map<std::string, std::string> resultMap;
+
+  try {
+    GlobalInterpreterLock gil;
+    dict resultDict = callMethod<dict>(getSelf(), "validateInputs");
+    // convert to a map<string,string>
+    boost::python::list keys = resultDict.keys();
+    size_t numItems = boost::python::len(keys);
+    for (size_t i = 0; i < numItems; ++i) {
+      boost::python::object key = keys[i];
+      boost::python::object value = resultDict[key];
+      if (value) {
+        try {
+          std::string keyAsString = boost::python::extract<std::string>(key);
+          std::string valueAsString = boost::python::extract<std::string>(value);
+          resultMap[std::move(keyAsString)] = std::move(valueAsString);
+        } catch (boost::python::error_already_set &) {
+          this->getLogger().error() << "In validateInputs(self): Invalid type for key/value pair "
+                                    << "detected in dict.\n"
+                                    << "All keys and values must be strings\n";
+        }
+      }
+    }
+  } catch (UndefinedAttributeError &) {
+    return resultMap;
+  }
+
+  return resultMap;
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CreatePoleFigureTableWorkspaceTest.py
@@ -85,7 +85,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
         alg.setProperty("PeakParameterWorkspace", peak_param_table)
         alg.setProperty("OutputWorkspace", "outws")
         alg.setProperty("ReadoutColumn", readout)
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["PeakParameterWorkspace"], f"PeakParameterWorkspace must have column: '{column_name}'")
 
@@ -367,7 +367,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             OutputWorkspace="outws",
             Chi2Threshold=0.0,
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 0)
 
     def test_x0_not_required_if_threshold_is_set_to_zero(self):
@@ -380,7 +380,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             OutputWorkspace="outws",
             PeakPositionThreshold=0.0,
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 0)
 
     def test_suitable_hkl_can_be_parsed(self):
@@ -392,7 +392,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
                 OutputWorkspace="outws",
                 Reflection=hkl,
             )
-            issues = alg.validateInputs()
+            issues = alg.validate()
             self.assertEqual(len(issues), 0)
 
     def _setup_offset_rod(self, offset):
@@ -474,7 +474,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             PeakParameterWorkspace=AnalysisDataService.retrieve("BadPeakParameterWS"),
             OutputWorkspace="outws",
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(
             issues["PeakParameterWorkspace"], "PeakParameterWorkspace must have same number of rows as Input Workspace has spectra"
@@ -498,7 +498,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             OutputWorkspace="outws",
             Reflection=(1, 1, 1),
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "If reflection is specified: InputWorkspace must have a sample")
 
@@ -520,7 +520,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             OutputWorkspace="outws",
             Reflection=(1, 1, 1),
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "If reflection is specified: InputWorkspace sample must have a CrystalStructure")
 
@@ -531,7 +531,7 @@ class CreatePoleFigureTableTest(unittest.TestCase):
             OutputWorkspace="outws",
             AxesTransform=np.ones(9),
         )
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(
             issues["AxesTransform"],

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadElementalAnalysisRunTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadElementalAnalysisRunTest.py
@@ -17,7 +17,7 @@ class LoadElementalAnalysisRunTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("Run", 1)
         alg.setProperty("GroupWorkspace", "1")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("Run" in errors)
         self.assertEqual(len(errors), 1)
         self.assertFalse(AnalysisDataService.doesExist("1"))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -53,7 +53,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
     def test_no_elements(self):
         alg = self.set_up_alg()
         alg.setProperty("Spectra", [135, 182])
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ComptonProfile" in errors)
         self.assertEqual(len(errors), 1)
 
@@ -75,7 +75,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg = self.set_up_alg()
         alg.setProperty("Spectra", [135, 182])
         alg.setProperty("ComptonProfile", table)
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ComptonProfile" in errors)
         self.assertEqual(len(errors), 1)
 
@@ -89,7 +89,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg.setProperty("Spectra", [135, 182])
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("ConstraintsProfile", constraints)
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ConstraintsProfile" in errors)
         self.assertEqual(len(errors), 1)
 
@@ -112,7 +112,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg = self.set_up_alg()
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [135, 182])
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 0)
 
     def test_case_insensitive_constraints_table(self):
@@ -130,7 +130,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [135, 182])
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 1)
         self.assertTrue("TOFRangeVector" in errors)
 
@@ -141,7 +141,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [135, 182])
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 1)
         self.assertTrue("TOFRangeVector" in errors)
 
@@ -152,7 +152,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [135, 182])
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 1)
         self.assertTrue("TOFRangeVector" in errors)
 
@@ -166,7 +166,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
             alg.setProperty("ConstraintsProfile", constraints)
             alg.setProperty("ComptonProfile", table)
             alg.setProperty("Spectra", [135, 182])
-            errors = alg.validateInputs()
+            errors = alg.validate()
             self.assertEqual(len(errors), 1)
             self.assertTrue("ConstraintsProfile" in errors)
 
@@ -180,7 +180,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
             alg.setProperty("ConstraintsProfile", constraints)
             alg.setProperty("ComptonProfile", table)
             alg.setProperty("Spectra", [135, 182])
-            errors = alg.validateInputs()
+            errors = alg.validate()
             self.assertEqual(len(errors), 0)
 
     def test_run_string_correct(self):
@@ -191,7 +191,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
             alg.setProperty("ComptonProfile", table)
             alg.setProperty("Spectra", [135, 182])
             alg.setProperty("Runs", run)
-            errors = alg.validateInputs()
+            errors = alg.validate()
             self.assertEqual(len(errors), 0)
 
     def test_run_string_incorrect(self):
@@ -202,7 +202,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
             alg.setProperty("ComptonProfile", table)
             alg.setProperty("Spectra", [135, 182])
             alg.setProperty("Runs", run)
-            errors = alg.validateInputs()
+            errors = alg.validate()
             self.assertEqual(len(errors), 1)
             self.assertTrue("Runs" in errors)
 
@@ -211,7 +211,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg = self.set_up_alg()
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [3, 134])
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 1)
         self.assertTrue("Spectra" in errors)
 
@@ -221,7 +221,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg.setProperty("ComptonProfile", table)
         alg.setProperty("Spectra", [135, 182])
         alg.setProperty("SpectraToBeMasked", [135, 165, 182])
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(len(errors), 0)
 
     def test_masked_sapectra_incorrect(self):
@@ -232,7 +232,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
             alg.setProperty("ComptonProfile", table)
             alg.setProperty("Spectra", [135, 182])
             alg.setProperty("SpectraToBeMasked", spec)
-            errors = alg.validateInputs()
+            errors = alg.validate()
             self.assertEqual(len(errors), 1)
             self.assertTrue("SpectraToBeMasked" in errors)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/QuickBayesHelperTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/QuickBayesHelperTest.py
@@ -115,7 +115,7 @@ class QuickBayesHelperTest(unittest.TestCase):
         self._alg.setProperty("EMin", 10)
         self._alg.setProperty("EMax", 0.2)
         self._alg.setProperty("SampleWorkspace", self._sample_ws)
-        issues = self._alg.validateInputs()
+        issues = self._alg.validate()
         keys = list(issues.keys())
         self.assertEqual(len(keys), 1)
         self.assertEqual(keys[0], "EMax")
@@ -124,7 +124,7 @@ class QuickBayesHelperTest(unittest.TestCase):
         self._alg.setProperty("EMin", -100)
         self._alg.setProperty("EMax", 0.2)
         self._alg.setProperty("SampleWorkspace", self._sample_ws)
-        issues = self._alg.validateInputs()
+        issues = self._alg.validate()
 
         keys = list(issues.keys())
         self.assertEqual(len(keys), 1)
@@ -134,7 +134,7 @@ class QuickBayesHelperTest(unittest.TestCase):
         self._alg.setProperty("EMin", -0.2)
         self._alg.setProperty("EMax", 200.0)
         self._alg.setProperty("SampleWorkspace", self._sample_ws)
-        issues = self._alg.validateInputs()
+        issues = self._alg.validate()
 
         keys = list(issues.keys())
         self.assertEqual(len(keys), 1)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
@@ -24,7 +24,7 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("InputWorkspace", test_ws)
 
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 0)
 
     def test_validate_inputs_fails_if_no_instrument(self):
@@ -34,7 +34,7 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("InputWorkspace", test_ws)
 
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "The input workspace must have an instrument")
 
@@ -45,7 +45,7 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("InputWorkspace", test_ws)
 
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "The input workspace must only contain one rectangular detector: multiple were found")
 
@@ -56,7 +56,7 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("InputWorkspace", test_ws)
 
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues["InputWorkspace"], "The input workspace must contain a rectangular detector")
 
@@ -67,7 +67,7 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         alg.initialize()
         alg.setProperty("InputWorkspace", test_ws)
 
-        issues = alg.validateInputs()
+        issues = alg.validate()
         self.assertEqual(len(issues), 0)
 
     def test_no_summing_done_on_single_bank(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSFitShiftScaleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSFitShiftScaleTest.py
@@ -34,7 +34,7 @@ class SANSFitShiftScaleTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "None")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ScaleFactor" in errors)
         self.assertTrue("ShiftFactor" in errors)
 
@@ -43,7 +43,7 @@ class SANSFitShiftScaleTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "ScaleOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ShiftFactor" in errors)
 
     def test_fit_shift_requires_scale_factor(self):
@@ -51,7 +51,7 @@ class SANSFitShiftScaleTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "ShiftOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ScaleFactor" in errors)
 
     def test_workspace_entries_must_be_q1d(self):
@@ -74,7 +74,7 @@ class SANSFitShiftScaleTest(unittest.TestCase):
         alg.setProperty("HABWorkspace", multi_spectra_input)
         alg.setProperty("LABWorkspace", multi_spectra_input)
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABWorkspace" in errors)
         self.assertTrue("LABWorkspace" in errors)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSStitchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSStitchTest.py
@@ -35,7 +35,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "None")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ScaleFactor" in errors)
         self.assertTrue("ShiftFactor" in errors)
 
@@ -44,7 +44,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "ScaleOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ShiftFactor" in errors)
 
     def test_fit_shift_requires_scale_factor(self):
@@ -52,7 +52,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setChild(True)
         alg.initialize()
         alg.setProperty("Mode", "ShiftOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("ScaleFactor" in errors)
 
     def test_workspace_entries_must_be_q1d_if_fitting_is_enabled(self):
@@ -77,7 +77,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setProperty("HABNormSample", multi_spectra_input)
         alg.setProperty("LABNormSample", multi_spectra_input)
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABCountsSample" in errors)
         self.assertTrue("LABCountsSample" in errors)
         self.assertTrue("HABNormSample" in errors)
@@ -106,7 +106,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setProperty("LABNormSample", single_spectra_input)
         alg.setProperty("ProcessCan", True)  # Now can workspaces should be provided
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABCountsCan" in errors)
         self.assertTrue("LABCountsCan" in errors)
         self.assertTrue("HABNormCan" in errors)
@@ -139,7 +139,7 @@ class SANSStitchTest(unittest.TestCase):
 
         # 2D inputs Should not be allowed for mode Both
         alg.setProperty("Mode", "Both")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABCountsSample" in errors)
         self.assertTrue("LABCountsSample" in errors)
         self.assertTrue("HABNormSample" in errors)
@@ -147,7 +147,7 @@ class SANSStitchTest(unittest.TestCase):
 
         # 2D inputs Should not be allowed for mode ScaleOnly
         alg.setProperty("Mode", "ScaleOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABCountsSample" in errors)
         self.assertTrue("LABCountsSample" in errors)
         self.assertTrue("HABNormSample" in errors)
@@ -155,7 +155,7 @@ class SANSStitchTest(unittest.TestCase):
 
         # 2D inputs Should not be allowed for mode ShiftOnly
         alg.setProperty("Mode", "ShiftOnly")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertTrue("HABCountsSample" in errors)
         self.assertTrue("LABCountsSample" in errors)
         self.assertTrue("HABNormSample" in errors)
@@ -163,7 +163,7 @@ class SANSStitchTest(unittest.TestCase):
 
         # With no fitting 2D inputs are allowed
         alg.setProperty("Mode", "None")
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(0, len(errors))
 
     def test_scale_none(self):
@@ -756,7 +756,7 @@ class SANSStitchTest(unittest.TestCase):
         alg.setProperty("Mode", "None")
         alg.setProperty("OutputWorkspace", "dummy_name")
 
-        errors = alg.validateInputs()
+        errors = alg.validate()
         self.assertEqual(0, len(errors))
 
         alg.execute()

--- a/Framework/Reflectometry/test/ReflectometryBackgroundSubtractionTest.py
+++ b/Framework/Reflectometry/test/ReflectometryBackgroundSubtractionTest.py
@@ -164,7 +164,7 @@ class ReflectometryBackgroundSubtractionTest(unittest.TestCase):
         mtd["group"] = group
         args = {"InputWorkspace": "group", "BackgroundCalculationMethod": "PerDetectorAverage", "OutputWorkspace": "output"}
         alg = create_algorithm("ReflectometryBackgroundSubtraction", **args)
-        error_map = alg.validateInputs()
+        error_map = alg.validate()
         self.assertEqual(len(error_map), 1)
         self.assertEqual(
             error_map["InputWorkspace"], "Invalid workspace type provided to IndexProperty. Must be convertible to MatrixWorkspace."

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto2Test.h
@@ -203,7 +203,7 @@ public:
     alg.setPropertyValue("InputWorkspace", "input");
     alg.setPropertyValue("FirstTransmissionRun", "trans");
     alg.setPropertyValue("PolarizationAnalysis", "None");
-    auto results = alg.validateInputs();
+    auto results = alg.validate();
     TS_ASSERT(results.count("FirstTransmissionRun"));
 
     AnalysisDataService::Instance().remove("input");
@@ -237,7 +237,7 @@ public:
     alg.setPropertyValue("FirstTransmissionRun", "first_trans");
     alg.setPropertyValue("SecondTransmissionRun", "second_trans");
     alg.setPropertyValue("PolarizationAnalysis", "None");
-    const auto results = alg.validateInputs();
+    const auto results = alg.validate();
     TS_ASSERT(!results.count("FirstTransmissionRun"));
     TS_ASSERT(results.count("SecondTransmissionRun"));
 

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -176,7 +176,7 @@ public:
     alg.setPropertyValue("InputWorkspace", "input");
     alg.setPropertyValue("FirstTransmissionRun", "trans");
     alg.setProperty("PolarizationAnalysis", false);
-    auto results = alg.validateInputs();
+    auto results = alg.validate();
     TS_ASSERT(results.count("FirstTransmissionRun"));
 
     AnalysisDataService::Instance().remove("input");
@@ -210,7 +210,7 @@ public:
     alg.setPropertyValue("FirstTransmissionRun", "first_trans");
     alg.setPropertyValue("SecondTransmissionRun", "second_trans");
     alg.setProperty("PolarizationAnalysis", false);
-    const auto results = alg.validateInputs();
+    const auto results = alg.validate();
     TS_ASSERT(!results.count("FirstTransmissionRun"));
     TS_ASSERT(results.count("SecondTransmissionRun"));
 

--- a/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
+++ b/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
@@ -71,18 +71,18 @@ public:
     alg.setPropertyValue("LatticeSpacingMax", "2.0");
 
     // dMax is larger than dMin
-    std::map<std::string, std::string> errorMap = alg.validateInputs();
+    std::map<std::string, std::string> errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 0);
 
     alg.setPropertyValue("LatticeSpacingMax", "0.5");
     // now it's smaller - not allowed
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1);
 
     errorMap.clear();
 
     alg.setPropertyValue("LatticeSpacingMax", "-0.5");
-    errorMap = alg.validateInputs();
+    errorMap = alg.validate();
     TS_ASSERT_EQUALS(errorMap.size(), 1)
   }
 

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockAlgorithm.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockAlgorithm.h
@@ -40,7 +40,7 @@ public:
   MOCK_CONST_METHOD0(getAlgorithmID, AlgorithmID());
 
   MOCK_METHOD0(initialize, void());
-  MOCK_METHOD0(validateInputs, std::map<std::string, std::string>());
+  MOCK_METHOD0(validate, std::map<std::string, std::string>());
   MOCK_METHOD0(execute, bool());
   MOCK_METHOD0(executeAsync, Poco::ActiveResult<bool>());
   MOCK_METHOD0(executeAsChildAlg, void());

--- a/Testing/SystemTests/tests/framework/AlgorithmValidateInputsTestBase.py
+++ b/Testing/SystemTests/tests/framework/AlgorithmValidateInputsTestBase.py
@@ -52,7 +52,7 @@ class AlgorithmValidateInputsTestBase(MantidSystemTest, metaclass=ABCMeta):
 
         try:
             # This is the real test - does the validateInputs function run successfully
-            algorithm.validateInputs()
+            algorithm.validate()
         except Exception as ex:
             # Makes sure that an exception gets printed if it fails, and then re-raises the exception
             print(ex)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -48,8 +48,8 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IPowder
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/ParameterTie.h:42
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Run.h:39
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Workspace.h:32
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:405
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:1182
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:472
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:1249
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHasProperty.cpp:36
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoxControllerSettingsAlgorithm.cpp:78
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/CatalogManager.cpp:54

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/validate_errors.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/validate_errors.py
@@ -7,7 +7,7 @@
 
 
 def validateToErrors(alg):
-    errors = alg.validateInputs()
+    errors = alg.validate()
     if not errors:
         return
     message = "Invalid properties found: \n"

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -150,7 +150,7 @@ void StepScan::startLiveListener() {
   startLiveData->setProperty("Instrument", m_instrument);
   m_inputWSName = "__live";
   startLiveData->setProperty("OutputWorkspace", m_inputWSName);
-  if (!startLiveData->validateInputs().empty()) {
+  if (!startLiveData->validate().empty()) {
     QMessageBox::critical(this, "StartLiveData failed", "Unable to start live data collection");
     m_uiForm.mWRunFiles->liveButtonSetChecked(false);
     return;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -544,7 +544,7 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
   alg->setProperty("PostProcessingProperties", liveDataReductionOptions(inputWorkspace, instrument));
   alg->setProperty("RunTransitionBehavior", "Restart");
-  auto errorMap = alg->validateInputs();
+  auto errorMap = alg->validate();
   if (!errorMap.empty()) {
     std::string errorString;
     for (auto const &kvp : errorMap)

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -363,7 +363,7 @@ bool AlgorithmDialog::setPropertyValues(const QStringList &skipList) {
   // Do additional validation on the WHOLE set of properties
   // But only if the individual validation passed
   if (allValid) {
-    std::map<std::string, std::string> errs = m_algorithm->validateInputs();
+    std::map<std::string, std::string> errs = m_algorithm->validate();
     for (auto &err : errs) {
       // only count as an error if the named property exists
       if (m_algorithm->existsProperty(err.first)) {


### PR DESCRIPTION
### Description of work

under construction

Closes #39801 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
