### PR TITLE
Small refactors to properties

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -123,9 +123,9 @@ GNU_DIAG_OFF("unused-function")
  */
 
 template <>
-std::string toPrettyString(const std::vector<bool> &value, size_t maxLength, bool collapseLists,
-                           const std::string &delimiter, const std::string &unusedDelimiter,
-                           typename std::enable_if<std::is_same<bool, bool>::value>::type *) {
+inline std::string toPrettyString(const std::vector<bool> &value, size_t maxLength, bool collapseLists,
+                                  const std::string &delimiter, const std::string &unusedDelimiter,
+                                  typename std::enable_if<std::is_same<bool, bool>::value>::type *) {
   UNUSED_ARG(unusedDelimiter);
   UNUSED_ARG(collapseLists);
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter), maxLength);

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.hxx
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.hxx
@@ -260,7 +260,7 @@ template <typename TYPE> PropertyWithValue<TYPE> &PropertyWithValue<TYPE>::opera
  */
 template <typename TYPE> PropertyWithValue<TYPE> &PropertyWithValue<TYPE>::operator=(const TYPE &value) {
   TYPE oldValue = m_value;
-  if (std::is_same<TYPE, std::string>::value) {
+  if constexpr (std::is_same<TYPE, std::string>::value) {
     std::string valueCopy = toString(value);
     if (autoTrim()) {
       boost::trim(valueCopy);


### PR DESCRIPTION
### Description of work

These are two small refactors that were included in the branch `implement_PythonObjectProperty` (authored by @martyngigg ) that are not related to the python object properties strictly.  They are separated out to try to eliminate variables.

### To test:

This is a pure refactor.  Make sure tests pass.

 *This does not require release notes* because this refactor will not affect users.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
