### PR TITLE
Remove conda packages from previous builds before archiving to github

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -484,6 +484,7 @@ pipeline {
           target: 'standalone-packages',
           flatten: true
         // Copy conda packages and create a tarball to upload to the github release for backup.
+        sh 'rm -fr ${WORKSPACE}/conda-packages'
         copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
           fingerprintArtifacts: true,
           projectName: '${JOB_NAME}',


### PR DESCRIPTION
### Description of work
Ensures that only the conda packages associated with the current build are uploaded to GitHub.

During the GitHub publishing stage of the nightly/release pipeline, we tar all of the conda packages (mantid-developer, mantid, mantidqt, mantiddocs, mantidworkbench) and upload them to the GitHub release, primarily as a backup in case we lose them from our anaconda channel. We hadn't noticed that it was uploading extra packages left over from previous builds, depending on which agent was running the stage.

Closes #39626

### To test:
[This test Linux build](https://builds.mantidproject.org/job/build_packages_from_branch/1305/) should upload only the conda packages associated with the build. You can download the conda-packages.tar file from the [draft release](https://github.com/mantidproject/mantid/releases/tag/untagged-706392f68e4e38540cf8) that was created by that build. Unpack it and make sure the contents are correct (should be only five conda packages with the correct version number).


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
