### PR TITLE
Move `PropertyHelper` functions outside of anonymous namespace, specializations to separate file

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SRC_FILES
     src/SpinStateHelpers.cpp
     src/ProgressBase.cpp
     src/Property.cpp
+    src/PropertyHelper.cpp
     src/PropertyHistory.cpp
     src/PropertyManager.cpp
     src/PropertyManagerDataService.cpp

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -11,6 +11,7 @@
 #include <memory>
 #endif
 
+#include "MantidKernel/IValidator.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/Strings.h"

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -22,15 +22,11 @@ namespace Mantid {
 namespace Kernel {
 
 // --------------------- convert values to strings
-namespace {
 /// Convert values to strings.
 template <typename T> std::string toString(const T &value) { return boost::lexical_cast<std::string>(value); }
 
 /// Throw an exception if a shared pointer is converted to a string.
-template <typename T> std::string toString(const std::shared_ptr<T> &value) {
-  UNUSED_ARG(value);
-  throw boost::bad_lexical_cast();
-}
+template <typename T> std::string toString(const std::shared_ptr<T> &) { throw boost::bad_lexical_cast(); }
 
 /// Specialization for a property of type std::vector.
 template <typename T> std::string toString(const std::vector<T> &value, const std::string &delimiter = ",") {
@@ -115,14 +111,13 @@ toPrettyString(const std::vector<T> &value, size_t maxLength = 0, bool collapseL
   return Strings::shorten(retVal, maxLength);
 }
 
-GNU_DIAG_OFF("unused-function")
-
 /** Explicit specialization for a property of type std::vector<bool>.
  *   This will catch Vectors of char, double, float etc.
  *   This simply concatenates the values using a delimiter
  */
 
 template <>
+[[maybe_unused]]
 inline std::string toPrettyString(const std::vector<bool> &value, size_t maxLength, bool collapseLists,
                                   const std::string &delimiter, const std::string &unusedDelimiter,
                                   typename std::enable_if<std::is_same<bool, bool>::value>::type *) {
@@ -130,8 +125,6 @@ inline std::string toPrettyString(const std::vector<bool> &value, size_t maxLeng
   UNUSED_ARG(collapseLists);
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter), maxLength);
 }
-
-GNU_DIAG_ON("unused-function")
 
 /// Specialization for a property of type std::vector<std::vector>.
 template <typename T>
@@ -205,20 +198,12 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
   }
 }
 
-template <typename T> void toValue(const std::string &strvalue, T &value) { value = boost::lexical_cast<T>(strvalue); }
+template <typename T> void inline toValue(const std::string &strvalue, T &value) {
+  value = boost::lexical_cast<T>(strvalue);
+}
 
-template <typename T> void toValue(const std::string &, std::shared_ptr<T> &) { throw boost::bad_lexical_cast(); }
-
-/** Helper functions for setting the value of an OptionalBool property */
-template <> [[maybe_unused]] void toValue(const std::string &strValue, OptionalBool &value) {
-  const auto normalizedStr = Mantid::Kernel::Strings::toLower(strValue);
-  if (normalizedStr == "0" || normalizedStr == "false") {
-    value = OptionalBool::False;
-  } else if (normalizedStr == "1" || normalizedStr == "true") {
-    value = OptionalBool::True;
-  } else {
-    value = strValue;
-  }
+template <typename T> void inline toValue(const std::string &, std::shared_ptr<T> &) {
+  throw boost::bad_lexical_cast();
 }
 
 namespace detail {
@@ -339,7 +324,6 @@ template <> inline std::vector<std::string> determineAllowedValues(const Optiona
                  [](const std::pair<OptionalBool::Value, std::string> &str) { return str.second; });
   return values;
 }
-} // namespace
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -199,13 +199,16 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
   }
 }
 
-template <typename T> void inline toValue(const std::string &strvalue, T &value) {
+template <typename T> inline void toValue(const std::string &strvalue, T &value) {
   value = boost::lexical_cast<T>(strvalue);
 }
 
-template <typename T> void inline toValue(const std::string &, std::shared_ptr<T> &) {
+template <typename T> inline void toValue(const std::string &, std::shared_ptr<T> &) {
   throw boost::bad_lexical_cast();
 }
+
+// explicit instantiation for OptionalBool
+template <> MANTID_KERNEL_DLL void toValue(const std::string &strValue, OptionalBool &value);
 
 namespace detail {
 // vector<int> specializations

--- a/Framework/Kernel/src/PropertyHelper.cpp
+++ b/Framework/Kernel/src/PropertyHelper.cpp
@@ -6,12 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidKernel/PropertyHelper.h"
-#include "MantidKernel/IValidator.h"
+#include "MantidKernel/Strings.h"
 
 namespace Mantid::Kernel {
 
 /** Helper functions for setting the value of an OptionalBool property */
-template <> inline void MANTID_KERNEL_DLL toValue(const std::string &strValue, OptionalBool &value) {
+template <> void MANTID_KERNEL_DLL toValue(const std::string &strValue, OptionalBool &value) {
   const auto normalizedStr = Mantid::Kernel::Strings::toLower(strValue);
   if (normalizedStr == "0" || normalizedStr == "false") {
     value = OptionalBool::False;

--- a/Framework/Kernel/src/PropertyHelper.cpp
+++ b/Framework/Kernel/src/PropertyHelper.cpp
@@ -1,0 +1,25 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidKernel/PropertyHelper.h"
+#include "MantidKernel/IValidator.h"
+
+namespace Mantid::Kernel {
+
+/** Helper functions for setting the value of an OptionalBool property */
+template <> inline void MANTID_KERNEL_DLL toValue(const std::string &strValue, OptionalBool &value) {
+  const auto normalizedStr = Mantid::Kernel::Strings::toLower(strValue);
+  if (normalizedStr == "0" || normalizedStr == "false") {
+    value = OptionalBool::False;
+  } else if (normalizedStr == "1" || normalizedStr == "true") {
+    value = OptionalBool::True;
+  } else {
+    value = strValue;
+  }
+}
+
+} // namespace Mantid::Kernel


### PR DESCRIPTION
### Description of work

Part of creating Python Object Properties.  Inside `PropertyHelper`, several template functions are defined to do things like converting properties to strings.

All of these methods were wrapped in an anonymous namespace.  However, to specialize the output for different objects (like `PythonObjectProperty`), it is necessary to remove this anonymous namespace so the methods are more generally available.  However, the `toValue<OptionalBool>` which was defined here was being implemented multiple times.

The solution is to put specializations into a separate file.

### To test:

This is a refactor.  Check code quality and ensure unit tests pass.

*This does not require release notes* because this is an internal issue that does not impact users.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
