### PR TITLE
Add security policy document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+We take security bugs in our projects seriously.
+We appreciate your efforts to responsibly disclose your findings,
+and will make every effort to acknowledge your contributions.
+
+# Reporting Security Issues
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/mantidproject/mantid/security/advisories/new) tab. **DO NOT REPORT SECURITY VULNERABILITIES THROUGH PUBLIC GITHUB ISSUES.**
+
+We will send a response indicating the next steps in handling your report and may ask for additional information or guidance.
+After the initial reply to your report we will keep you informed and make an announcement in the release notes.


### PR DESCRIPTION
While it is unlikely that mantid will have a direct security issue, it is useful to publicly display a policy for how to report issues and how they will be handled. This wording borrows ideas from [prefix-dev/rattler-build](https://github.com/prefix-dev/rattler-build/blob/main/SECURITY.md) and [microsoft/repo-templates](https://github.com/microsoft/repo-templates/blob/main/shared/SECURITY.md).

This is suggested in the [openssf best practices badge](https://www.bestpractices.dev/en/projects/4316). Once merged, it will be an additional tab on the mantid repository frontpage along with the README and LICENSE.

The policy document cannot be tested.

*This does not require release notes* because it will show up as a separate tab in the repository.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
