### PR TITLE
Move `PropertyHelper` functions outside of anonymous namespace -- `ornl-next`

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SRC_FILES
     src/SpinStateHelpers.cpp
     src/ProgressBase.cpp
     src/Property.cpp
+    src/PropertyHelper.cpp
     src/PropertyHistory.cpp
     src/PropertyManager.cpp
     src/PropertyManagerDataService.cpp

--- a/Framework/Kernel/src/PropertyHelper.cpp
+++ b/Framework/Kernel/src/PropertyHelper.cpp
@@ -1,0 +1,25 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidKernel/PropertyHelper.h"
+#include "MantidKernel/Strings.h"
+
+namespace Mantid::Kernel {
+
+/** Helper functions for setting the value of an OptionalBool property */
+template <> void MANTID_KERNEL_DLL toValue(const std::string &strValue, OptionalBool &value) {
+  const auto normalizedStr = Mantid::Kernel::Strings::toLower(strValue);
+  if (normalizedStr == "0" || normalizedStr == "false") {
+    value = OptionalBool::False;
+  } else if (normalizedStr == "1" || normalizedStr == "true") {
+    value = OptionalBool::True;
+  } else {
+    value = strValue;
+  }
+}
+
+} // namespace Mantid::Kernel


### PR DESCRIPTION
Sister to PR #39856 