### PR TITLE
Pin to newer seekpath that doesn't depend on future package

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -89,7 +89,7 @@ done
 # Mamba
 setup_mamba $WORKSPACE/miniforge "" true $PLATFORM
 mamba activate base
-mamba install --yes boa conda-verify versioningit python=3.11
+mamba install --yes boa versioningit python=3.11
 
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -156,6 +156,9 @@ gsl:
 libopenblas:
   - 0.3.27
 
+# currently pinning seekpath in mantid-developer and mantid to use v2.1.0 build 2
+# which does not require future https://github.com/conda-forge/seekpath-feedstock/pull/15/
+# please remove this comment and the pins in those recipes when euphonic and seekpath release new versions
 euphonic:
   - '>=1.4.3,<2.0'
 

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -13,6 +13,8 @@ requirements:
     - doxygen {{ doxygen }}
     - eigen {{ eigen }}
     - euphonic {{ euphonic }}
+    # remove seekpath altogether once newer euphonic is released
+    - seekpath=2.1.0=*2
     - graphviz {{ graphviz }}
     - gsl {{ gsl }}
     - h5py

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -8,7 +8,6 @@ requirements:
   run:
     - ccache
     - cmake {{ cmake }}
-    - conda-verify
     - conda-wrappers # [win]
     - doxygen {{ doxygen }}
     - eigen {{ eigen }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -72,6 +72,8 @@ requirements:
     - pyyaml {{ pyyaml }}
     - scipy {{ scipy }}
     - euphonic {{ euphonic }}
+    # remove seekpath altogether once newer euphonic is released
+    - seekpath=2.1.0=*2
     - toml {{ toml }}
     - libglu {{ libglu }}  # [linux]
     - joblib

--- a/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
+++ b/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
@@ -1,0 +1,1 @@
+- Pin build 2 of ``seekpath`` v2.1.0 which removes an eroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonics``. ``future`` is not used had has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .

--- a/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
+++ b/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
@@ -1,1 +1,1 @@
-- Pin build 2 of ``seekpath`` v2.1.0 which removes an eroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonics``. ``future`` is not used had has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .
+- Pin build 2 of ``seekpath`` v2.1.0 which removes an erroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonic``. ``future`` is not used and has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .


### PR DESCRIPTION
Mantid is currently showing vulnerability [CVE-2025-50817](https://github.com/advisories/GHSA-xqrq-4mgf-ff32) which is related to using the `future` package. Deeper analysis found that `future` is a dependency from
```sh
$ pixi tree -i future

future 1.0.0
└── seekpath 2.1.0
    └── euphonic 1.4.4
        └── mantid 6.13.1.1
```
From there, a [new build of seekpath was made](https://github.com/conda-forge/seekpath-feedstock/pull/15), but [euphonic has not released a new package](https://github.com/conda-forge/euphonic-feedstock/blob/main/recipe/meta.yaml) to update the dependency to continue a large compatibility range. To get the newer seekpath, this PR adds in the constraint in our conda recipes.

A comment was added in the recipes to remove this pin once a new euphonic package is released.

This also removes [conda-verify](https://github.com/conda/conda-verify) which isn't in the buildscripts and has not released a version for a long time even with [a request](https://github.com/conda/conda-verify/issues/135).

This has no associated issue but is related to [EWM12761](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12761)


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Look at the build logs to see that seekpath version 2.1.0 build pyhd8ed1ab_2 was used. The `future` package should no longer be listed.

You will find `future` is still installed in the developer environment, but that is because it is required by `conda-verify`, which is developer dependency and not a dependency for the mantid install.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
