### PR TITLE
Pin to newer seekpath that doesn't depend on future package

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -89,7 +89,7 @@ done
 # Mamba
 setup_mamba $WORKSPACE/miniforge "" true $PLATFORM
 mamba activate base
-mamba install --yes boa conda-verify versioningit python=3.11
+mamba install --yes boa versioningit python=3.11
 
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -156,6 +156,9 @@ gsl:
 libopenblas:
   - 0.3.27
 
+# currently pinning seekpath in mantid-developer and mantid to use v2.1.0 build 2
+# which does not require future https://github.com/conda-forge/seekpath-feedstock/pull/15/
+# please remove this comment and the pins in those recipes when euphonic and seekpath release new versions
 euphonic:
   - '>=1.4.3,<2.0'
 

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -13,6 +13,8 @@ requirements:
     - doxygen {{ doxygen }}
     - eigen {{ eigen }}
     - euphonic {{ euphonic }}
+    # remove seekpath altogether once newer euphonic is released
+    - seekpath=2.1.0=*2
     - graphviz {{ graphviz }}
     - gsl {{ gsl }}
     - h5py

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -8,7 +8,6 @@ requirements:
   run:
     - ccache
     - cmake {{ cmake }}
-    - conda-verify
     - conda-wrappers # [win]
     - doxygen {{ doxygen }}
     - eigen {{ eigen }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -72,6 +72,8 @@ requirements:
     - pyyaml {{ pyyaml }}
     - scipy {{ scipy }}
     - euphonic {{ euphonic }}
+    # remove seekpath altogether once newer euphonic is released
+    - seekpath=2.1.0=*2
     - toml {{ toml }}
     - libglu {{ libglu }}  # [linux]
     - joblib

--- a/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
+++ b/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
@@ -1,0 +1,1 @@
+- Pin build 2 of ``seekpath`` v2.1.0 which removes an eroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonics``. ``future`` is not used had has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .

--- a/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
+++ b/docs/source/release/v6.14.0/Framework/Dependencies/New_features/39866.rst
@@ -1,1 +1,1 @@
-- Pin build 2 of ``seekpath`` v2.1.0 which removes an eroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonics``. ``future`` is not used had has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .
+- Pin build 2 of ``seekpath`` v2.1.0 which removes an erroneous dependency on the ``future`` package. ``seekpath`` is a dependency of ``euphonic``. ``future`` is not used and has a known vulnerability `CVE-2025-50817 <https://github.com/advisories/GHSA-xqrq-4mgf-ff32>`_ .


### PR DESCRIPTION
This is a version of #39866 into `ornl-next`