### PR TITLE
Fix Windows packaging script after parallel event loader removal

### DIFF
--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -115,7 +115,6 @@ mv $CONDA_ENV_PATH/Library/mingw-w64/bin/libgcc_s_seh*.dll $COPY_DIR/bin/
 
 echo "Copy Mantid specific files from env/Library/bin to package/bin"
 mv $CONDA_ENV_PATH/Library/bin/Mantid.properties $COPY_DIR/bin/
-mv $CONDA_ENV_PATH/Library/bin/MantidNexusParallelLoader.exe $COPY_DIR/bin/
 mv $CONDA_ENV_PATH/Library/bin/mantid-scripts.pth $COPY_DIR/bin/
 
 echo "Copy Mantid icon files from source to package/bin"


### PR DESCRIPTION
### Description of work
A `mv` line needs to be removed from the Windows packaging script because the file no longer exists after the [parallel event loader was removed](https://github.com/mantidproject/mantid/pull/39830).

**I have intentionally cancelled the PR builds because they do not touch the line that was removed, and it would be a waste of resource.**

### To test:
This Windows packaging build should pass:
 [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1327)](https://builds.mantidproject.org/job/build_packages_from_branch/1327/) 

*This does not require release notes* because they were already added [here](https://github.com/mantidproject/mantid/pull/39830).


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
