### PR TITLE
Warn macOS Arm users who install the Intel package

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1027,7 +1027,8 @@ std::string ConfigServiceImpl::getOSArchitecture() {
     if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1 && ret == 1) {
       osArch = "arm64_(x86_64)";
       g_log.warning("You are running an Intel build of Mantid on Apple silicon, which will be significantly slower and "
-                    "use more power. For best performance, install the Arm version of Mantid.");
+                    "use more power. For best performance, install the Arm version of Mantid. This version is "
+                    "available here: https://downloads.mantidproject.org");
     } else {
       // TODO this can be removed after the v6.14 code freeze because the feature will be dropped
       g_log.warning("Mantid v6.14 is the last version that will support Intel macOS.");

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1026,6 +1026,8 @@ std::string ConfigServiceImpl::getOSArchitecture() {
     size_t size = sizeof(ret);
     if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1 && ret == 1) {
       osArch = "arm64_(x86_64)";
+      g_log.warning("You are running an Intel build of Mantid on Apple silicon, which will be significantly slower and "
+                    "use more power. For best performance, install the Arm version of Mantid.");
     } else {
       // TODO this can be removed after the v6.14 code freeze because the feature will be dropped
       g_log.warning("Mantid v6.14 is the last version that will support Intel macOS.");

--- a/docs/source/release/v6.14.0/Framework/Python/New_features/39763.rst
+++ b/docs/source/release/v6.14.0/Framework/Python/New_features/39763.rst
@@ -1,0 +1,1 @@
+- macOS users with Apple silicon (Arm-based architecture) are now warned if they have installed the Intel-based Mantid package.


### PR DESCRIPTION
### Description of work
Warn macOS users who install an Intel build on an Arm machine.

Closes #39763 


### To test:
Install the package from this build:
x86: [![Build Status](https://builds.mantidproject.org/job/build_packages_from_branch/1329/badge/icon)](https://builds.mantidproject.org/job/build_packages_from_branch/1329/)
ARM: [![Build Status](https://builds.mantidproject.org/job/build_packages_from_branch/1331/badge/icon)](https://builds.mantidproject.org/job/build_packages_from_branch/1331/)
- on Arm macOS machine - check there is a warning
- on Intel macOS machine - check there is **no** warning.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
