### PR TITLE
Update getting started dev-docs for VS2022 install

### DIFF
--- a/dev-docs/source/GettingStarted/CloningMantid.rst
+++ b/dev-docs/source/GettingStarted/CloningMantid.rst
@@ -1,0 +1,9 @@
+Clone the mantid source code
+----------------------------
+* **Important**: If you have any existing non-conda mantid development environments, do not re-use the source and build directories for your conda environment.
+  We recommend that you clone a new instance of the source and keep separate build directories to avoid any cmake configuration problems.
+* Obtain the mantid source code by either:
+    * Using git in a terminal and cloning the codebase by calling ``git clone git@github.com:mantidproject/mantid.git`` in the directory you want the code to clone to.
+      You will need to follow this `Github guide <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_ to configure SSH access.
+      You may want to follow this `Git setup guide <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_ to configure your git environment.
+    * Or using `GitKraken <https://www.gitkraken.com/>`_.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
@@ -11,12 +11,7 @@ Install Git
     * On Debian based systems (Ubuntu) install using apt with the following command: ``sudo apt install git``
     * On CentOS based systems (RHEL) install using yum with the following command: ``sudo yum install git``
 
-Clone the mantid source code
-----------------------------
-* There are 2 common ways developers have been doing this.
-
-    * Using git in the terminal and cloning the codebase by calling ``git clone git@github.com:mantidproject/mantid.git`` in the directory you want the code to clone to. This sets you up with accessing the remote repository via SSH so make sure to setup git properly using this `startup guide <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_ and ensure your ssh key is setup using this `guide to Github with SSH <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_.
-    * Or by using `GitKraken <https://www.gitkraken.com/>`_.
+.. include:: ./CloningMantid.rst
 
 Install `Miniforge <https://github.com/conda-forge/miniforge/releases>`_
 -------------------------------------------------------------------------

--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
@@ -40,7 +40,6 @@ Configure CMake and generate build files
 * If not already activated in the previous step, run ``conda activate mantid-developer`` to activate your conda environment.
 * Navigate back to your mantid source directory using ``cd mantid`` if you used the default name during cloning from git.
 * Inside of your mantid source directory run ``cmake --preset=linux``
-
     * Alternatively if you don't want to have your build folder in your mantid source then pass the ``-B`` argument, overriding the preset, to cmake: ``cmake {PATH_TO_SOURCE} --preset=linux -B {BUILD_DIR}``
 
 How to build

--- a/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
@@ -27,7 +27,6 @@ Configure CMake and generate build files
 * If not already activated in the previous step, run ``conda activate mantid-developer`` to activate your conda environment.
 * Navigate back to your mantid source directory using ``cd mantid`` if you used the default name during cloning from git.
 * Inside of your mantid source directory run ``cmake --preset=osx``
-
     * Alternatively if you don't want to have your build folder in your mantid source then pass the ``-B`` argument, overriding the preset, to cmake: ``cmake {PATH_TO_SOURCE} --preset=osx -B {BUILD_DIR}``
 
 How to build

--- a/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
@@ -8,13 +8,7 @@ Install `Git <https://git-scm.com/>`_
 -------------------------------------
 * On MacOS install using brew with the following command: ``brew install git``
 
-Clone the mantid source code
-----------------------------
-* There are 2 common ways developers have been doing this.
-
-    * Using git in the terminal and cloning the codebase by calling ``git clone git@github.com:mantidproject/mantid.git`` in the directory you want the code to clone to.
-      This sets you up with accessing the remote repository via SSH so make sure to setup git properly using this `startup guide <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_ and ensure your ssh key is setup using this `guide to Github with SSH <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_.
-    * Or by using `GitKraken <https://www.gitkraken.com/>`_.
+.. include:: ./CloningMantid.rst
 
 Install `Miniforge <https://github.com/conda-forge/miniforge/releases>`_
 -------------------------------------------------------------------------

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -25,13 +25,7 @@ Turn off Python association in Windows
 * Because of the way Windows associates Python files with it's Windows Store version of python we need to turn off this association. If you don't turn this off you will have issues when running the pre-commit framework.
 * Navigate to your Settings -> Manage App Execution Aliases, and turn off all Python Aliases.
 
-Clone the mantid source code
-----------------------------
-* **Important**: If you have any existing non-conda mantid development environments, do not re-use the source and build directories for your conda environment. We recommend that you clone a new instance of the source and keep separate build directories to avoid any cmake configuration problems.
-* Clone the mantid source code by either:
-
-    * Using git bash and cloning the codebase by calling ``git clone git@github.com:mantidproject/mantid.git`` in the directory you want the code to clone to. This sets you up with accessing the remote repository via SSH so make sure to setup git properly using this `startup guide <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_ and ensure your ssh key is setup using this `guide to Github with SSH <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_.
-    * Or using `GitKraken <https://www.gitkraken.com/>`_.
+.. include:: ./CloningMantid.rst
 
 Install `Miniforge <https://github.com/conda-forge/miniforge/releases>`_
 -------------------------------------------------------------------------

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -8,11 +8,9 @@ Install `Visual Studio 2022 Community Edition <https://visualstudio.microsoft.co
 -----------------------------------------------------------------------------------------------
 
 * When asked about installation workloads choose ``Desktop development with C++``
-* Under the "Installation details" section verify that the following are checked:
-
-    * ``Windows Universal CRT SDK``
-    * The latest ``Windows 10 SDK``
-    * ``MSVC v142 - VS 2019 C++ x64/x86 build tools``
+* Under the "Installation details" section verify that the following are checked (they should already be checked by default):
+    * The latest ``Windows 11 SDK``
+    * ``MSVC v143 - VS 2022 C++ x64/x86 build tools (latest)``
 
 * If your machine has less than 32GB of memory Mantid may not build. If you have problems change the maximum number of parallel project builds to 1 in Visual Studio in Tools -> Options -> Projects and Solutions -> Build And Run.
 
@@ -77,6 +75,8 @@ Compile and Build using MS Visual Studio
 * Open visual studio with ``visual-studio.bat``, which is found in the build folder, and then click build.
 * It's not possible to compile in Debug on Windows with conda libraries, however Release, RelWithDebInfo, and DebugWithRelRuntime for Debugging will compile fine.
 * Once in visual studio, the correct target to use as a startup project in visual studio is ``workbench``, not ``MantidWorkbench``. You can then press F5 to start workbench.
+* If you want to use your computer while Mantid is compiling, you can enable the following option:
+  ``Tools > Options > Projects and Solutions > Build And Run > Run build at low process priority``.
 
 Compile and Build using Ninja
 -----------------------------

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -6,7 +6,6 @@ Develop with conda on Windows
 
 Install `Visual Studio 2022 Community Edition <https://visualstudio.microsoft.com/downloads/>`_
 -----------------------------------------------------------------------------------------------
-
 * When asked about installation workloads choose ``Desktop development with C++``
 * Under the "Installation details" section verify that the following are checked (they should already be checked by default):
     * The latest ``Windows 11 SDK``
@@ -16,7 +15,6 @@ Install `Visual Studio 2022 Community Edition <https://visualstudio.microsoft.co
 
 Install `Git <https://git-scm.com/>`_
 -------------------------------------
-
 * Install the latest version of Git, and ensure git bash was installed and the git executable location was added to your PATH, if you didn't do this as part of your installation you can do this `manually <https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)#to-add-a-path-to-the-path-environment-variable>`_.
 * We no longer need Git LFS as conda handles the dependencies that used to be in the third party directory.
 
@@ -29,13 +27,11 @@ Turn off Python association in Windows
 
 Install `Miniforge <https://github.com/conda-forge/miniforge/releases>`_
 -------------------------------------------------------------------------
-
 * Choose the latest version of ``Miniforge3-Windows-x86_64.exe``
 * Run your downloaded ``Miniforge3-Windows-x86_64.exe`` and work through the installer until it finishes. In order to make it easier later on, check the box that adds conda to your path.
 
 Setup the mantid conda environment
 ----------------------------------
-
 Open a terminal or powershell with conda enabled. Here are two ways to do this:
 
 * Open an Anaconda prompt (Miniforge).
@@ -45,7 +41,6 @@ Open a terminal or powershell with conda enabled. Here are two ways to do this:
 
 Configure CMake and generate build files
 ----------------------------------------
-
 * You can configure CMake using an MS Visual Studio or Ninja generator. Choose one of the following:
     * For MS Visual Studio, use the terminal or powershell prompt from the last step.
     * For Ninja, open the ``x64 Native Tools Command Prompt for VS 2019`` or ``x64 Native Tools Command Prompt for VS 2022`` from your search bar.
@@ -53,7 +48,6 @@ Configure CMake and generate build files
 * Navigate to your mantid source directory.
 * If not already activated in the previous step, run ``conda activate mantid-developer`` to activate your conda environment.
 * If you want your build directory inside your source directory, run either:
-
     * ``cmake --preset=win-vs`` for configuring with Visual Studio 2022, or
     * ``cmake --preset=win-vs-2019`` for configuring with Visual Studio 2019, or
     * ``cmake --preset=win-ninja`` for configuring with Ninja.
@@ -65,7 +59,6 @@ Configure CMake and generate build files
 
 Compile and Build using MS Visual Studio
 ----------------------------------------
-
 * Open visual studio with ``visual-studio.bat``, which is found in the build folder, and then click build.
 * It's not possible to compile in Debug on Windows with conda libraries, however Release, RelWithDebInfo, and DebugWithRelRuntime for Debugging will compile fine.
 * Once in visual studio, the correct target to use as a startup project in visual studio is ``workbench``, not ``MantidWorkbench``. You can then press F5 to start workbench.


### PR DESCRIPTION
### Description of work
While installing a fresh instance of Visual Studio 2022, I thought that the docs were a bit out of date. They were asking the developer to install unnecessary optional components. I tried without them and have successfully built and run Mantid Workbench:
- There is no need to install v142 of the toolset - the [cmake preset for win-vs uses v143](https://github.com/mantidproject/mantid/blob/6ce2f9ee1b9be8b506c28ad144adb1e41bf76982/CMakePresets.json#L140), which is installed by default.
- There is also no need to install the Windows 10 or Universal SDK components. It worked fine without either of those. Only the Windows 11 SDK is required (also selected by default).

I also noticed that the git cloning section could be pulled out into a separate file, since it is common to all OS.

I've also fixed some nested bullet formatting by removing extra new lines.

### To test:
Check dev-docs build without warnings and check the getting started docs to ensure it's formatted correctly and reads well.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
