### PR TITLE
Use a stamp file to prevent multiple installs of the same pip package

### DIFF
--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -48,16 +48,26 @@ function(add_python_package pkg_name)
     set(_startup_exe ${_egg_link_dir}/${_executable_name})
   endif()
 
+  if(WIN32)
+    set(_path_sep ";")
+  else()
+    set(_path_sep ":")
+  endif()
+
   # create the developer setup which just creates a pth file rather than copying things over
+  set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}.pip.stamp")
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
   set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})
   add_custom_command(
-    OUTPUT ${_outputs}
+    OUTPUT ${_stamp}
     COMMAND
-      ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir} PATH=${_egg_link_dir}:$PATH
-      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --editable .
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir}
+      PATH=${_egg_link_dir}${_path_sep}$PATH MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install
+      --editable .
+    COMMAND ${CMAKE_COMMAND} -E touch ${_stamp}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${_setup_py}
+    BYPRODUCTS ${_outputs}
   )
 
   # Generate a sitecustomize.py file in the egg link directory as setuptools no longer generates site.py for v>=49.0.0

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -72,10 +72,12 @@ function(add_python_package pkg_name)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       DEPENDS ${_setup_py} ${CMAKE_MODULE_PATH}/WriteSiteCustomize.cmake
     )
-    list(APPEND _outputs ${_egg_link_dir}/sitecustomize.py)
+    set(_pkg_depends ${_stamp} ${_egg_link_dir}/sitecustomize.py)
+  else()
+    set(_pkg_depends ${_stamp})
   endif()
 
-  add_custom_target(${pkg_name} ALL DEPENDS ${_stamp})
+  add_custom_target(${pkg_name} ALL DEPENDS ${_pkg_depends} ${_egg_link_dir}/sitecustomize.py)
 
   # When running the install target, run the following code instead that defers to the `pip install` command. It assumes
   # the `${CMAKE_CURRENT_SOURCE_DIR}`, the directory where `add_python_package` was called from, contains either a

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -48,12 +48,6 @@ function(add_python_package pkg_name)
     set(_startup_exe ${_egg_link_dir}/${_executable_name})
   endif()
 
-  if(WIN32)
-    set(_path_sep ";")
-  else()
-    set(_path_sep ":")
-  endif()
-
   # create the developer setup which just creates a pth file rather than copying things over
   set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}.pip.stamp")
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
@@ -61,9 +55,8 @@ function(add_python_package pkg_name)
   add_custom_command(
     OUTPUT ${_stamp}
     COMMAND
-      ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir}
-      PATH=${_egg_link_dir}${_path_sep}$PATH MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install
-      --editable .
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir} PATH=${_egg_link_dir}:$PATH
+      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --editable .
     COMMAND ${CMAKE_COMMAND} -E touch ${_stamp}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${_setup_py}

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -77,7 +77,7 @@ function(add_python_package pkg_name)
     set(_pkg_depends ${_stamp})
   endif()
 
-  add_custom_target(${pkg_name} ALL DEPENDS ${_pkg_depends} ${_egg_link_dir}/sitecustomize.py)
+  add_custom_target(${pkg_name} ALL DEPENDS ${_pkg_depends})
 
   # When running the install target, run the following code instead that defers to the `pip install` command. It assumes
   # the `${CMAKE_CURRENT_SOURCE_DIR}`, the directory where `add_python_package` was called from, contains either a

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -75,7 +75,7 @@ function(add_python_package pkg_name)
     list(APPEND _outputs ${_egg_link_dir}/sitecustomize.py)
   endif()
 
-  add_custom_target(${pkg_name} ALL DEPENDS ${_outputs})
+  add_custom_target(${pkg_name} ALL DEPENDS ${_stamp})
 
   # When running the install target, run the following code instead that defers to the `pip install` command. It assumes
   # the `${CMAKE_CURRENT_SOURCE_DIR}`, the directory where `add_python_package` was called from, contains either a

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -48,7 +48,8 @@ function(add_python_package pkg_name)
     set(_startup_exe ${_egg_link_dir}/${_executable_name})
   endif()
 
-  # create the developer setup which just creates a pth file rather than copying things over
+  # create the developer setup which just creates a pth file rather than copying things over outputs a stamp file,
+  # preventing subsequent installs of the same package unless dependencies change
   set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}.pip.stamp")
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
   set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})


### PR DESCRIPTION
### Description of work

This prevents our build process continually installing/uninstalling editable python packages.

The custom command we add to create packages should not run if the packages already exist. This is however not working/is brittle. This is currently leading now failures in the windows build and test stage of the nightly pipeline due to ninja parallelisation.

This PR changes the output of the cmake command to a simple stamp file, with the previous outputs listed as byproducts. If the stamp file exists, the install function will not run again.

### To test:
- CI tests pass
- Linux build and test passes: https://builds.mantidproject.org/job/build_packages_from_branch/1335/

I intended to run a windows build and test but didn't. I propose we merge this regardless, as the worst that can occur is that we break the already broken windows build. Windows b&t: https://builds.mantidproject.org/job/build_packages_from_branch/1339/

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
