### PR TITLE
Create `PythonObjectProperty`

### DIFF
--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     src/ErrorHandling.cpp
     src/GlobalInterpreterLock.cpp
     src/NDArray.cpp
+    src/PythonObjectProperty.cpp
     src/ReleaseGlobalInterpreterLock.cpp
     src/UninstallTrace.cpp
     src/PythonLoggingChannel.cpp
@@ -36,6 +37,7 @@ set(INC_FILES
     inc/MantidPythonInterface/core/PropertyWithValueExporter.h
     inc/MantidPythonInterface/core/PythonLoggingChannel.h
     inc/MantidPythonInterface/core/PythonObjectInstantiator.h
+    inc/MantidPythonInterface/core/PythonObjectProperty.h
     inc/MantidPythonInterface/core/PythonStdoutChannel.h
     inc/MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h
     inc/MantidPythonInterface/core/StlExportDefinitions.h

--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRC_FILES
     src/GlobalInterpreterLock.cpp
     src/NDArray.cpp
     src/PythonObjectProperty.cpp
+    src/PythonObjectTypeValidator.cpp
     src/ReleaseGlobalInterpreterLock.cpp
     src/UninstallTrace.cpp
     src/PythonLoggingChannel.cpp

--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -38,6 +38,7 @@ set(INC_FILES
     inc/MantidPythonInterface/core/PythonLoggingChannel.h
     inc/MantidPythonInterface/core/PythonObjectInstantiator.h
     inc/MantidPythonInterface/core/PythonObjectProperty.h
+    inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
     inc/MantidPythonInterface/core/PythonStdoutChannel.h
     inc/MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h
     inc/MantidPythonInterface/core/StlExportDefinitions.h

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
@@ -19,7 +19,7 @@
 // Call the dtype helper function
 template <typename HeldType> std::string dtype(Mantid::Kernel::PropertyWithValue<HeldType> &self) {
   // Check for the special case of a string
-  if (std::is_same<HeldType, std::string>::value) {
+  if constexpr (std::is_same<HeldType, std::string>::value) {
     std::stringstream ss;
     std::string val = self.value();
     ss << "S" << val.size();

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -88,12 +88,6 @@ public:
       : BaseClass(name, PythonObject(), std::make_shared<NullValidator>(), direction) {}
 
   /** Constructor from which you can set the property's values through a string:
-   *
-   * Inherits from the constructor of PropertyWithValue specifically made to
-   * handle a list
-   * of numeric values in a string format so that initial value is set
-   * correctly.
-   *
    *  @param name ::      The name to assign to the property
    *  @param strvalue ::     A string which will set the property being stored
    *  @param validator :: The validator to use for this property, if required

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -107,12 +107,12 @@ public:
 
   // Unhide the base class assignment operator
   using PropertyWithValue<PythonObject>::operator=;
-  PythonObjectProperty &operator=(const PythonObjectProperty &right) = default;
+  PythonObjectProperty &operator=(PythonObjectProperty const &right) = default;
 
   std::string getDefault() const override;
-  std::string setValue(const std::string &value) override;
-  std::string setValueFromJson(const Json::Value &value) override;
-  std::string setDataItem(const std::shared_ptr<Kernel::DataItem> &value) override;
+  std::string setValue(std::string const &value) override;
+  std::string setValueFromJson(Json::Value const &value) override;
+  std::string setDataItem(std::shared_ptr<Kernel::DataItem> const &value) override;
   bool isDefault() const override;
 };
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -112,10 +112,12 @@ public:
   // Unhide the base class assignment operator
   using BaseClass::operator=;
 
+  std::string getDefault() const override;
   std::string setValue(PythonObject const &obj);
   std::string setValue(std::string const &value) override;
   std::string setValueFromJson(Json::Value const &value) override;
   std::string setDataItem(std::shared_ptr<Kernel::DataItem> const &value) override;
+  bool isDefault() const override;
 };
 
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -17,10 +17,17 @@
 
 #include <boost/python/object.hpp>
 
+// forward declare
+namespace Json {
+class Value;
+}
+
 namespace Mantid::Kernel {
 using PythonObject = boost::python::object;
 #ifndef __APPLE__
-// NOTE for Linux builds, it is necessary the DLL export occur here
+// NOTE for Linux builds (and maybe Windows), it is necessary the DLL export occur here.
+// This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
+// not linked in Kernel, this declarationcan only occur in a file inside the PythonInterface layer
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
 template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;
 #endif
@@ -51,7 +58,7 @@ public:
   PythonObjectProperty(std::string const &name, PythonObject const &defaultValue,
                        IValidator_sptr const &validator = std::make_shared<NullValidator>(),
                        unsigned int const direction = Direction::Input)
-      : PropertyWithValue<PythonObject>(name, defaultValue, validator, direction) {}
+      : BaseClass(name, defaultValue, validator, direction) {}
 
   /** Constructor that's useful for output properties or inputs with non-None default and no validator.
    *  @param name ::         The name to assign to the property
@@ -60,7 +67,7 @@ public:
    */
   PythonObjectProperty(std::string const &name, PythonObject const &defaultValue,
                        unsigned int const direction = Direction::Input)
-      : PropertyWithValue<PythonObject>(name, defaultValue, std::make_shared<NullValidator>(), direction) {}
+      : BaseClass(name, defaultValue, std::make_shared<NullValidator>(), direction) {}
 
   /** Constructor
    *  Will lead to the property having default value of None
@@ -70,7 +77,7 @@ public:
    */
   PythonObjectProperty(std::string const &name, IValidator_sptr const &validator,
                        unsigned int const direction = Direction::Input)
-      : PropertyWithValue<PythonObject>(name, PythonObject(), validator, direction) {}
+      : BaseClass(name, PythonObject(), validator, direction) {}
 
   /** Constructor that's useful for output properties or inputs with default value None and no validator.
    *  Will lead to the property having a default initial value of None and no validator
@@ -78,7 +85,7 @@ public:
    *  @param direction :: The direction (Input/Output/InOut) of this property
    */
   PythonObjectProperty(std::string const &name, unsigned int const direction = Direction::Input)
-      : PropertyWithValue<PythonObject>(name, PythonObject(), std::make_shared<NullValidator>(), direction) {}
+      : BaseClass(name, PythonObject(), std::make_shared<NullValidator>(), direction) {}
 
   /** Constructor from which you can set the property's values through a string:
    *
@@ -97,19 +104,19 @@ public:
   PythonObjectProperty(std::string const &name, std::string const &strvalue,
                        IValidator_sptr const &validator = std::make_shared<NullValidator>(),
                        unsigned int const direction = Direction::Input)
-      : PropertyWithValue<PythonObject>(name, PythonObject(), strvalue, validator, direction) {}
+      : BaseClass(name, PythonObject(), strvalue, validator, direction) {}
 
   /** Copy constructor */
-  PythonObjectProperty(PythonObjectProperty const &other) : PropertyWithValue<PythonObject>(other) {}
+  PythonObjectProperty(PythonObjectProperty const &other) : BaseClass(other) {}
 
   /** This is required by Property interface */
   PythonObjectProperty *clone() const override { return new PythonObjectProperty(*this); }
 
   // Unhide the base class assignment operator
-  using PropertyWithValue<PythonObject>::operator=;
-  PythonObjectProperty &operator=(PythonObjectProperty const &right) = default;
+  using BaseClass::operator=;
 
   std::string getDefault() const override;
+  std::string setValue(PythonObject const &obj);
   std::string setValue(std::string const &value) override;
   std::string setValueFromJson(Json::Value const &value) override;
   std::string setDataItem(std::shared_ptr<Kernel::DataItem> const &value) override;

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -1,0 +1,115 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidPythonInterface/core/DllConfig.h"
+
+#include "MantidKernel/IValidator.h"
+#include "MantidKernel/NullValidator.h"
+#include "MantidKernel/PropertyWithValue.h"
+
+#include <boost/python/object.hpp>
+
+namespace Mantid::Kernel {
+using PythonObject = boost::python::object;
+// Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
+template class MANTID_KERNEL_DLL PropertyWithValue<PythonObject>;
+} // namespace Mantid::Kernel
+
+namespace Mantid::PythonInterface {
+
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::IValidator_sptr;
+using Mantid::Kernel::NullValidator;
+using PythonObject = boost::python::object;
+
+class MANTID_PYTHONINTERFACE_CORE_DLL PythonObjectProperty : public Mantid::Kernel::PropertyWithValue<PythonObject> {
+public:
+  // Convenience typedefs
+  using ValueType = PythonObject;
+  using BaseClass = Mantid::Kernel::PropertyWithValue<ValueType>;
+
+  /** No default constructor */
+  PythonObjectProperty() = delete;
+
+  /** Constructor
+   *  @param name ::         The name to assign to the property
+   *  @param defaultValue :: The default python object to assign to the property
+   *  @param validator ::    The validator to use for this property, if required.
+   *  @param direction ::    The direction (Input/Output/InOut) of this property
+   */
+  PythonObjectProperty(std::string const &name, PythonObject const &defaultValue,
+                       IValidator_sptr const &validator = std::make_shared<NullValidator>(),
+                       unsigned int const direction = Direction::Input)
+      : PropertyWithValue<PythonObject>(name, defaultValue, validator, direction) {}
+
+  /** Constructor that's useful for output properties or inputs with non-None default and no validator.
+   *  @param name ::         The name to assign to the property
+   *  @param defaultValue :: The default python object to assign to the property
+   *  @param direction ::    The direction (Input/Output/InOut) of this property
+   */
+  PythonObjectProperty(std::string const &name, PythonObject const &defaultValue,
+                       unsigned int const direction = Direction::Input)
+      : PropertyWithValue<PythonObject>(name, defaultValue, std::make_shared<NullValidator>(), direction) {}
+
+  /** Constructor
+   *  Will lead to the property having default value of None
+   *  @param name ::      The name to assign to the property
+   *  @param validator :: The validator to use for this property, if required
+   *  @param direction :: The direction (Input/Output/InOut) of this property
+   */
+  PythonObjectProperty(std::string const &name, IValidator_sptr const &validator,
+                       unsigned int const direction = Direction::Input)
+      : PropertyWithValue<PythonObject>(name, PythonObject(), validator, direction) {}
+
+  /** Constructor that's useful for output properties or inputs with default value None and no validator.
+   *  Will lead to the property having a default initial value of None and no validator
+   *  @param name ::      The name to assign to the property
+   *  @param direction :: The direction (Input/Output/InOut) of this property
+   */
+  PythonObjectProperty(std::string const &name, unsigned int const direction = Direction::Input)
+      : PropertyWithValue<PythonObject>(name, PythonObject(), std::make_shared<NullValidator>(), direction) {}
+
+  /** Constructor from which you can set the property's values through a string:
+   *
+   * Inherits from the constructor of PropertyWithValue specifically made to
+   * handle a list
+   * of numeric values in a string format so that initial value is set
+   * correctly.
+   *
+   *  @param name ::      The name to assign to the property
+   *  @param strvalue ::     A string which will set the property being stored
+   *  @param validator :: The validator to use for this property, if required
+   *  @param direction :: The direction (Input/Output/InOut) of this property
+   *  @throw std::invalid_argument if the string passed is not compatible with
+   * the array type
+   */
+  PythonObjectProperty(std::string const &name, std::string const &strvalue,
+                       IValidator_sptr const &validator = std::make_shared<NullValidator>(),
+                       unsigned int const direction = Direction::Input)
+      : PropertyWithValue<PythonObject>(name, PythonObject(), strvalue, validator, direction) {}
+
+  /** Copy constructor */
+  PythonObjectProperty(PythonObjectProperty const &other) : PropertyWithValue<PythonObject>(other) {}
+
+  /** This is required by Property interface */
+  PythonObjectProperty *clone() const override { return new PythonObjectProperty(*this); }
+
+  // Unhide the base class assignment operator
+  using PropertyWithValue<PythonObject>::operator=;
+  PythonObjectProperty &operator=(const PythonObjectProperty &right) = default;
+
+  std::string getDefault() const override;
+  std::string setValue(const std::string &value) override;
+  std::string setValueFromJson(const Json::Value &value) override;
+  bool isDefault() const override;
+};
+
+} // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -24,10 +24,14 @@ class Value;
 
 namespace Mantid::Kernel {
 using PythonObject = boost::python::object;
+
 #ifndef __APPLE__
-// NOTE for Linux builds (and maybe Windows), it is necessary the DLL export occur here.
-// This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
-// not linked in Kernel, this declarationcan only occur in a file inside the PythonInterface layer
+/** NOTE:
+ *  For Linux builds (and maybe Windows), it is necessary that the below DLL export occur here.
+ *  This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
+ *  not linked in Kernel, this declaration can only occur inside the PythonInterface layer
+ *  For Linux builds, this MUST be instantiated BEFORE the declaration of PythonObjectProperty
+ */
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
 template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;
 #endif
@@ -92,8 +96,7 @@ public:
    *  @param strvalue ::     A string which will set the property being stored
    *  @param validator :: The validator to use for this property, if required
    *  @param direction :: The direction (Input/Output/InOut) of this property
-   *  @throw std::invalid_argument if the string passed is not compatible with
-   * the array type
+   *  @throw std::invalid_argument if the string passed is not compatible with a python object
    */
   PythonObjectProperty(std::string const &name, std::string const &strvalue,
                        IValidator_sptr const &validator = std::make_shared<NullValidator>(),
@@ -109,12 +112,10 @@ public:
   // Unhide the base class assignment operator
   using BaseClass::operator=;
 
-  std::string getDefault() const override;
   std::string setValue(PythonObject const &obj);
   std::string setValue(std::string const &value) override;
   std::string setValueFromJson(Json::Value const &value) override;
   std::string setDataItem(std::shared_ptr<Kernel::DataItem> const &value) override;
-  bool isDefault() const override;
 };
 
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -19,8 +19,11 @@
 
 namespace Mantid::Kernel {
 using PythonObject = boost::python::object;
+#ifndef __APPLE__
+// NOTE for Linux builds, it is necessary the DLL export occur here
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
-template class MANTID_KERNEL_DLL PropertyWithValue<PythonObject>;
+template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;
+#endif
 } // namespace Mantid::Kernel
 
 namespace Mantid::PythonInterface {
@@ -28,7 +31,7 @@ namespace Mantid::PythonInterface {
 using Mantid::Kernel::Direction;
 using Mantid::Kernel::IValidator_sptr;
 using Mantid::Kernel::NullValidator;
-using PythonObject = boost::python::object;
+using Mantid::Kernel::PythonObject;
 
 class MANTID_PYTHONINTERFACE_CORE_DLL PythonObjectProperty : public Mantid::Kernel::PropertyWithValue<PythonObject> {
 public:
@@ -109,6 +112,7 @@ public:
   std::string getDefault() const override;
   std::string setValue(const std::string &value) override;
   std::string setValueFromJson(const Json::Value &value) override;
+  std::string setDataItem(const std::shared_ptr<Kernel::DataItem> &value) override;
   bool isDefault() const override;
 };
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
@@ -52,26 +52,7 @@ public:
 private:
   object pythonClass;
 
-  std::string check(boost::any const &value) const override {
-    boost::python::object obj;
-    try {
-      obj = *(boost::any_cast<boost::python::object const *>(value));
-    } catch (...) {
-      return "Attempting to run a python type validator on an object that is not a python object";
-    }
-    std::string ret;
-    int check = PyObject_IsInstance(obj.ptr(), pythonClass.ptr());
-    if (check < 0) {
-      // this represents an internal error while checking type
-      PyErr_Clear();
-      ret = "Failed to check instance type";
-    } else if (check == 0) {
-      std::string objclassname = extract<std::string>(obj.attr("__class__").attr("__name__"));
-      std::string classname = extract<std::string>(pythonClass.attr("__name__"));
-      ret = std::string("The passed object is of type ") + objclassname + std::string(" and not of type ") + classname;
-    }
-    return ret;
-  }
+  std::string check(boost::any const &value) const override;
 };
 
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
@@ -1,0 +1,72 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidPythonInterface/core/DllConfig.h"
+
+#include "MantidKernel/IValidator.h"
+
+#include <Python.h>
+#include <boost/python/extract.hpp>
+#include <boost/python/object.hpp>
+
+// forward declare
+namespace Json {
+class Value;
+}
+
+namespace {
+using namespace boost::python;
+object const &validate_python_class(object const &pyclass) {
+  if (PyType_Check(pyclass.ptr())) {
+    return pyclass;
+  } else {
+    throw std::invalid_argument("Attempt to construct validator with an object instead of a class type");
+  }
+}
+} // namespace
+
+namespace Mantid::PythonInterface {
+
+using namespace boost::python;
+using Mantid::Kernel::IValidator_sptr;
+
+class MANTID_PYTHONINTERFACE_CORE_DLL PythonObjectTypeValidator : public Mantid::Kernel::IValidator {
+
+public:
+  PythonObjectTypeValidator() : pythonClass() {};
+
+  PythonObjectTypeValidator(object const &pyclass) : pythonClass(validate_python_class(pyclass)) {}
+
+  ~PythonObjectTypeValidator() = default;
+
+  IValidator_sptr clone() const override { return std::make_shared<PythonObjectTypeValidator>(*this); };
+
+private:
+  object pythonClass;
+
+  std::string check(boost::any const &value) const override {
+    boost::python::object obj;
+    try {
+      obj = *(boost::any_cast<boost::python::object const *>(value));
+    } catch (...) {
+      return "Attempting to run a python type validator on an object that is not a python object";
+    }
+    if (PyObject_IsInstance(obj.ptr(), pythonClass.ptr())) {
+      return "";
+    } else {
+      std::string objclassname = extract<std::string>(obj.attr("__class__").attr("__name__"));
+      std::string classname = extract<std::string>(pythonClass.attr("__name__"));
+      return std::string("The passed object is of type ") + objclassname + std::string(" and not of type ") + classname;
+    }
+  }
+};
+
+} // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
@@ -45,7 +45,7 @@ public:
 
   PythonObjectTypeValidator(object const &pyclass) : pythonClass(validate_python_class(pyclass)) {}
 
-  ~PythonObjectTypeValidator() = default;
+  ~PythonObjectTypeValidator() override = default;
 
   IValidator_sptr clone() const override { return std::make_shared<PythonObjectTypeValidator>(*this); };
 

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectTypeValidator.h
@@ -59,7 +59,7 @@ private:
     } catch (...) {
       return "Attempting to run a python type validator on an object that is not a python object";
     }
-    std::string ret();
+    std::string ret;
     int check = PyObject_IsInstance(obj.ptr(), pythonClass.ptr());
     if (check < 0) {
       // this represents an internal error while checking type

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -21,7 +21,7 @@
 namespace {
 namespace bp = boost::python;
 
-std::set<std::string> jsonAllowedTypes{"int", "float", "str", "dict", "list", "tuple", "NoneType", "bool"};
+std::set<std::string> const jsonAllowedTypes{"int", "float", "str", "dict", "list", "tuple", "NoneType", "bool"};
 
 bp::object iterativeDictDump(bp::object obj) {
   bp::dict d = bp::extract<bp::dict>(obj.attr("__dict__"));
@@ -64,10 +64,10 @@ template <> std::string toString(PythonObject const &obj) {
       rep = json.attr("dumps")(obj);
     }
     // if json doesn't work, then iteratively dump its dict as a json
-    catch (boost::python::error_already_set const &e) {
+    catch (boost::python::error_already_set const &) {
       PyErr_Clear(); // NOTE must clear error registry, or bizarre errors will occur at unexpected lines
       boost::python::object dict = iterativeDictDump(obj);
-      rep = (json.attr("dumps")(dict)).attr("encode")("utf-8");
+      rep = json.attr("dumps")(dict);
     }
   }
   return boost::python::extract<std::string>(rep);
@@ -91,7 +91,7 @@ template <> Json::Value encodeAsJson(PythonObject const &) {
 #ifdef __APPLE__
 // NOTE for mac builds, it is necessary the DLL export occur here.
 // This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
-// not linked in Kernel, this declarationcan only occur in a file inside the PythonInterface layer
+// not linked in Kernel, this declaration can only occur in a file inside the PythonInterface layer
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
 template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;
 #endif
@@ -122,7 +122,7 @@ std::string PythonObjectProperty::setValue(PythonObject const &value) {
   return ret;
 }
 
-/** Set the propety value.
+/** Set the property value.
  *  @param value :: The value of the property as a string.
  *  @return Error message, or "" on success.
  */
@@ -164,7 +164,7 @@ std::string PythonObjectProperty::setValue(std::string const &value) {
  */
 std::string PythonObjectProperty::setValueFromJson(const Json::Value &json) {
   std::string jsonstr = JsonHelpers::jsonToString(json);
-  setValue(jsonstr);
+  return setValue(jsonstr);
 }
 
 std::string PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &) {

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -24,7 +24,7 @@ namespace bp = boost::python;
 /** Atomic types which can be serialized by python's json.dumps */
 std::set<std::string> const jsonAllowedTypes{"int", "float", "str", "NoneType", "bool"};
 
-inline bool isJsonAtomic(bp::object obj) {
+inline bool isJsonAtomic(bp::object const &obj) {
   std::string const objname = bp::extract<std::string>(obj.attr("__class__").attr("__name__"));
   return jsonAllowedTypes.count(objname) > 0;
 }
@@ -40,7 +40,6 @@ inline bool isJsonAtomic(bp::object obj) {
 bp::object recursiveDictDump(bp::object const &obj, unsigned char depth = 0) {
   static unsigned char constexpr max_depth(10);
   bp::object ret;
-  std::string const objname = bp::extract<std::string>(obj.attr("__class__").attr("__name__"));
   // limit recursion depth, to avoid infinity loops or possible segfaults
   if (depth >= max_depth) {
     ret = bp::str("...");

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -29,7 +29,7 @@ template <> std::string toPrettyString(PythonObject const &value, size_t /*maxLe
 /**
  * Creates a Json representation of the object
  */
-Json::Value encodeAsJson(PythonObject const &) {
+template <> Json::Value encodeAsJson(PythonObject const &) {
   throw Exception::NotImplementedError("encodeAsJson(const boost::python::object &value)");
 }
 
@@ -37,7 +37,6 @@ Json::Value encodeAsJson(PythonObject const &) {
 
 namespace Mantid::PythonInterface {
 
-using Kernel::DataItem;
 using Kernel::PropertyWithValue;
 using Kernel::Exception::NotImplementedError;
 

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -1,0 +1,73 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidPythonInterface/core/PythonObjectProperty.h"
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/PropertyWithValue.hxx"
+#include "MantidKernel/PropertyWithValueJSON.h"
+
+namespace Mantid::Kernel {
+
+/**
+ * Creates a string representation of the object
+ */
+template <> std::string toString(PythonObject const &) {
+  throw Exception::NotImplementedError("toString(const boost::python::object &)");
+}
+
+/**
+ * Creates a pretty string representation of the object. In this case it matches
+ * the simple string case.
+ */
+template <> std::string toPrettyString(PythonObject const &value, size_t /*maxLength*/, bool /*collapseLists*/) {
+  return toString(value);
+}
+
+/**
+ * Creates a Json representation of the object
+ */
+Json::Value encodeAsJson(PythonObject const &) {
+  throw Exception::NotImplementedError("encodeAsJson(const boost::python::object &value)");
+}
+
+} // namespace Mantid::Kernel
+
+namespace Mantid::PythonInterface {
+
+using Kernel::DataItem;
+using Kernel::PropertyWithValue;
+using Kernel::Exception::NotImplementedError;
+
+/**
+ *  @return An empty string to indicate a default
+ */
+std::string PythonObjectProperty::getDefault() const { return ""; }
+
+/** Set the function definition.
+ *  Also tries to create the function with FunctionFactory.
+ *  @param value :: The function definition string.
+ *  @return Error message from FunctionFactory or "" on success.
+ */
+std::string PythonObjectProperty::setValue(std::string const &) {
+  throw NotImplementedError("PythonObjectProperty::setValue(const std::string &value)");
+}
+
+/**
+ * Assumes the Json object is a string and parses it to create the function
+ * @param value A Json::Value containing a string
+ * @return An empty string indicating success otherwise the string will contain
+ * the value of the error.
+ */
+std::string PythonObjectProperty::setValueFromJson(const Json::Value &) {
+  throw NotImplementedError("PythonObjectProperty::setValueFromJson(const Json::Value &value)");
+}
+
+/** Indicates if the value matches the default, in this case if the value is None
+ *  @return true if the value is None
+ */
+bool PythonObjectProperty::isDefault() const { return m_value.is_none(); }
+
+} // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -147,6 +147,11 @@ namespace Mantid::PythonInterface {
 using Kernel::PropertyWithValue;
 using Kernel::Exception::NotImplementedError;
 
+/**
+ *  @return A string representati on of the default value
+ */
+std::string PythonObjectProperty::getDefault() const { return Mantid::Kernel::toString(m_initialValue); }
+
 /** Set the property value.
  *  @param value :: The object definition string.
  *  @return Error message, or "" on success.
@@ -209,5 +214,11 @@ std::string PythonObjectProperty::setValueFromJson(const Json::Value &json) {
 std::string PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &) {
   throw NotImplementedError("PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &)");
 }
+
+/** Indicates if the value matches the value None
+ *  @return true if the value is None
+ *  NOTE: For reasons (surely good ones), trying to compare m_value to m_initialValue raises a segfault
+ */
+bool PythonObjectProperty::isDefault() const { return m_value.is_none(); }
 
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -8,14 +8,39 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.hxx"
 #include "MantidKernel/PropertyWithValueJSON.h"
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
+#include "MantidPythonInterface/core/IsNone.h"
+
+#include <boost/python/call_method.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/errors.hpp>
+#include <boost/python/exec.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/import.hpp>
+#include <boost/python/list.hpp>
+
+#include <iostream>
 
 namespace Mantid::Kernel {
 
 /**
  * Creates a string representation of the object
  */
-template <> std::string toString(PythonObject const &) {
-  throw Exception::NotImplementedError("toString(const boost::python::object &)");
+template <> std::string toString(PythonObject const &obj) {
+  Mantid::PythonInterface::GlobalInterpreterLock gil;
+
+  if (Mantid::PythonInterface::isNone(obj)) {
+    throw Exception::NullPointerException("toString", boost::python::call_method<std::string>(obj.ptr(), "name"));
+  } else {
+    std::string ret;
+    try {
+      boost::python::object json = boost::python::import("json");
+      ret = boost::python::extract<std::string>(json.attr("dumps")(obj));
+    } catch (boost::python::error_already_set const &) {
+      ret = boost::python::extract<std::string>(obj.attr("__repr__")());
+    }
+    return ret;
+  }
 }
 
 /**
@@ -56,8 +81,22 @@ std::string PythonObjectProperty::getDefault() const { return ""; }
  *  @param value :: The function definition string.
  *  @return Error message from FunctionFactory or "" on success.
  */
-std::string PythonObjectProperty::setValue(std::string const &) {
-  throw NotImplementedError("PythonObjectProperty::setValue(const std::string &value)");
+std::string PythonObjectProperty::setValue(std::string const &val) {
+  Mantid::PythonInterface::GlobalInterpreterLock gil;
+  try {
+    boost::python::object json = boost::python::import("json");
+    boost::python::str strval(val);
+    m_value = boost::python::extract<PythonObject>(json.attr("loads")(strval));
+  } catch (boost::python::error_already_set const &) {
+    boost::python::str strval(val);
+    try {
+      m_value = boost::python::eval(strval);
+    } catch (boost::python::error_already_set const &) {
+      m_value = strval;
+    }
+    // m_value = PythonObject(val);
+  }
+  return "";
 }
 
 /**

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -33,6 +33,12 @@ template <> Json::Value encodeAsJson(PythonObject const &) {
   throw Exception::NotImplementedError("encodeAsJson(const boost::python::object &value)");
 }
 
+#ifdef __APPLE__
+// NOTE for mac builds, it is necessary the DLL export occur here
+// Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
+template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;
+#endif
+
 } // namespace Mantid::Kernel
 
 namespace Mantid::PythonInterface {
@@ -62,6 +68,10 @@ std::string PythonObjectProperty::setValue(std::string const &) {
  */
 std::string PythonObjectProperty::setValueFromJson(const Json::Value &) {
   throw NotImplementedError("PythonObjectProperty::setValueFromJson(const Json::Value &value)");
+}
+
+std::string PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &) {
+  throw NotImplementedError("PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &)");
 }
 
 /** Indicates if the value matches the default, in this case if the value is None

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -3,23 +3,20 @@
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-// SPDX - License - Identifier: GPL - 3.0 +
+// SPDX - License - Identifier: GPL-3.0 +
 #include "MantidPythonInterface/core/PythonObjectProperty.h"
+#include "MantidJson/Json.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.hxx"
 #include "MantidKernel/PropertyWithValueJSON.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/IsNone.h"
 
-#include <boost/python/call_method.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/errors.hpp>
-#include <boost/python/exec.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/import.hpp>
 #include <boost/python/list.hpp>
-
-#include <iostream>
 
 namespace {
 namespace bp = boost::python;
@@ -112,8 +109,7 @@ using Kernel::Exception::NotImplementedError;
 std::string PythonObjectProperty::getDefault() const { return ""; }
 
 /** Set the property value.
- *  Also tries to create the function with FunctionFactory.
- *  @param value :: The function definition string.
+ *  @param value :: The object definition string.
  *  @return Error message, or "" on success.
  */
 std::string PythonObjectProperty::setValue(PythonObject const &value) {
@@ -126,7 +122,7 @@ std::string PythonObjectProperty::setValue(PythonObject const &value) {
   return ret;
 }
 
-/** Set the propety value..
+/** Set the propety value.
  *  @param value :: The value of the property as a string.
  *  @return Error message, or "" on success.
  */
@@ -154,20 +150,21 @@ std::string PythonObjectProperty::setValue(std::string const &value) {
   // use the assignment operator, which also calls the validator
   try {
     *this = newVal;
-  } catch (std::invalid_argument &except) {
+  } catch (std::invalid_argument const &except) {
     ret = except.what();
   }
   return ret;
 }
 
 /**
- * Assumes the Json object is a string and parses it to create the function
+ * Assumes the Json object is a string and parses it to create the object
  * @param value A Json::Value containing a string
  * @return An empty string indicating success otherwise the string will contain
  * the value of the error.
  */
-std::string PythonObjectProperty::setValueFromJson(const Json::Value &) {
-  throw NotImplementedError("PythonObjectProperty::setValueFromJson(const Json::Value &value)");
+std::string PythonObjectProperty::setValueFromJson(const Json::Value &json) {
+  std::string jsonstr = JsonHelpers::jsonToString(json);
+  setValue(jsonstr);
 }
 
 std::string PythonObjectProperty::setDataItem(const std::shared_ptr<Kernel::DataItem> &) {

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -32,7 +32,7 @@ std::set<std::string> const jsonAllowedTypes{"int", "float", "str", "NoneType", 
  * @param depth the current recursion depth, which is limited to ten; beyond this, ellipses will be printed
  * @return a python object which is a dictionary corresponding to `obj`
  */
-bp::object recursiveDictDump(bp::object obj, unsigned char depth = 0) {
+bp::object recursiveDictDump(bp::object const &obj, unsigned char depth = 0) {
   static unsigned char constexpr max_depth(10);
   bp::object ret;
   std::string const objname = bp::extract<std::string>(obj.attr("__class__").attr("__name__"));

--- a/Framework/PythonInterface/core/src/PythonObjectTypeValidator.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectTypeValidator.cpp
@@ -12,7 +12,7 @@ std::string PythonObjectTypeValidator::check(boost::any const &value) const {
   boost::python::object obj;
   try {
     obj = *(boost::any_cast<boost::python::object const *>(value));
-  } catch (...) {
+  } catch (boost::bad_any_cast const &) {
     return "Attempting to run a python type validator on an object that is not a python object";
   }
   std::string ret;

--- a/Framework/PythonInterface/core/src/PythonObjectTypeValidator.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectTypeValidator.cpp
@@ -1,0 +1,32 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL-3.0 +
+#include "MantidPythonInterface/core/PythonObjectTypeValidator.h"
+
+namespace Mantid::PythonInterface {
+
+std::string PythonObjectTypeValidator::check(boost::any const &value) const {
+  boost::python::object obj;
+  try {
+    obj = *(boost::any_cast<boost::python::object const *>(value));
+  } catch (...) {
+    return "Attempting to run a python type validator on an object that is not a python object";
+  }
+  std::string ret;
+  int check = PyObject_IsInstance(obj.ptr(), pythonClass.ptr());
+  if (check < 0) {
+    // this represents an internal error while checking type
+    PyErr_Clear();
+    ret = "Failed to check instance type";
+  } else if (check == 0) {
+    std::string objclassname = extract<std::string>(obj.attr("__class__").attr("__name__"));
+    std::string classname = extract<std::string>(pythonClass.attr("__name__"));
+    ret = std::string("The passed object is of type ") + objclassname + std::string(" and not of type ") + classname;
+  }
+  return ret;
+}
+
+} // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -84,6 +84,7 @@ set(INC_FILES
     inc/MantidPythonInterface/kernel/Registry/PropertyValueHandler.h
     inc/MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h
     inc/MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h
+    inc/MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h
     inc/MantidPythonInterface/kernel/Registry/SequenceTypeHandler.h
     inc/MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h
     inc/MantidPythonInterface/kernel/Registry/TypeRegistry.h

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -49,6 +49,7 @@ set(EXPORT_FILES
     src/Exports/PropertyManager.cpp
     src/Exports/PropertyManagerDataService.cpp
     src/Exports/PropertyManagerProperty.cpp
+    src/Exports/PythonObjectProperty.cpp
     src/Exports/PropertyHistory.cpp
     src/Exports/Memory.cpp
     src/Exports/ProgressBase.cpp
@@ -74,7 +75,8 @@ create_module(${MODULE_TEMPLATE} ${MODULE_DEFINITION} ${EXPORT_FILES})
 
 set(SRC_FILES
     src/Registry/MappingTypeHandler.cpp src/Registry/PropertyManagerFactory.cpp
-    src/Registry/PropertyWithValueFactory.cpp src/Registry/SequenceTypeHandler.cpp src/Registry/TypeRegistry.cpp
+    src/Registry/PropertyWithValueFactory.cpp src/Registry/PythonObjectTypeHandler.cpp
+    src/Registry/SequenceTypeHandler.cpp src/Registry/TypeRegistry.cpp
 )
 
 set(INC_FILES

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -50,6 +50,7 @@ set(EXPORT_FILES
     src/Exports/PropertyManagerDataService.cpp
     src/Exports/PropertyManagerProperty.cpp
     src/Exports/PythonObjectProperty.cpp
+    src/Exports/PythonObjectTypeValidator.cpp
     src/Exports/PropertyHistory.cpp
     src/Exports/Memory.cpp
     src/Exports/ProgressBase.cpp

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h
@@ -29,7 +29,7 @@ struct DLLExport PythonObjectTypeHandler : public TypedPropertyValueHandler<boos
     alg->setProperty(name, value);
   }
 
-  /// Call to create a name property where the value is some container type
+  /// Call to create a named property where the value is some container type
   std::unique_ptr<Kernel::Property> create(std::string const &name, boost::python::object const &defaultValue,
                                            boost::python::object const &validator,
                                            unsigned int const direction) const override;

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h
@@ -1,0 +1,39 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h"
+
+namespace Mantid {
+namespace PythonInterface {
+namespace Registry {
+/**
+ * A specialisation of PropertyValueHandler to handle passing a python object directly
+ * to a PythonObjectProperty
+ */
+struct DLLExport PythonObjectTypeHandler : public TypedPropertyValueHandler<boost::python::object> {
+
+  /// Call to set a named property where the value is some container type
+  /**
+   * Set function to handle Python -> C++ calls to a property manager and get the
+   * correct type
+   * @param alg :: A pointer to an IPropertyManager
+   * @param name :: The name of the property
+   * @param value :: A boost python object that stores the value
+   */
+  void set(Kernel::IPropertyManager *alg, std::string const &name, boost::python::object const &value) const override {
+    alg->setProperty(name, value);
+  }
+
+  /// Call to create a name property where the value is some container type
+  std::unique_ptr<Kernel::Property> create(std::string const &name, boost::python::object const &defaultValue,
+                                           boost::python::object const &validator,
+                                           unsigned int const direction) const override;
+};
+} // namespace Registry
+} // namespace PythonInterface
+} // namespace Mantid

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
@@ -1,0 +1,38 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidPythonInterface/core/PythonObjectProperty.h"
+
+#include "MantidPythonInterface/core/PropertyWithValueExporter.h"
+#include "MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h"
+#include "MantidPythonInterface/kernel/Registry/TypeRegistry.h"
+
+#include <boost/python/class.hpp>
+
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::PropertyWithValue;
+using Mantid::PythonInterface::PropertyWithValueExporter;
+using Mantid::PythonInterface::PythonObjectProperty;
+namespace Registry = Mantid::PythonInterface::Registry;
+using namespace boost::python;
+
+void export_PythonObjectProperty() {
+  // export base class
+  using BaseValueType = boost::python::object;
+  PropertyWithValueExporter<BaseValueType>::define("PythonObjectPropertyWithValue");
+
+  // leaf class type
+  using BaseClassType = PythonObjectProperty::BaseClass;
+  class_<PythonObjectProperty, bases<BaseClassType>, boost::noncopyable>("PythonObjectProperty", no_init)
+      .def(init<const std::string &, const unsigned int>(
+          (arg("self"), arg("name"), arg("direction") = Direction::Input), "Construct a PythonObjectProperty"))
+      .def(init<const std::string &, const boost::python::object &, const unsigned int>(
+          (arg("self"), arg("name"), arg("defaultValue"), arg("direction") = Direction::Input),
+          "Construct a PythonObjectProperty with a default value"));
+
+  // type handler for alg.setProperty calls
+  Registry::TypeRegistry::subscribe(typeid(BaseValueType), new Registry::PythonObjectTypeHandler);
+}

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidPythonInterface/core/PythonObjectProperty.h"
+#include "MantidKernel/NullValidator.h"
 
 #include "MantidPythonInterface/core/PropertyWithValueExporter.h"
 #include "MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h"
@@ -17,12 +18,25 @@
 #include <boost/python/return_value_policy.hpp>
 #endif
 
+#include <boost/python/default_call_policies.hpp>
+#include <boost/python/make_constructor.hpp>
+
 using Mantid::Kernel::Direction;
+using Mantid::Kernel::IValidator_sptr;
+using Mantid::Kernel::NullValidator;
 using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using Mantid::PythonInterface::PythonObjectProperty;
 namespace Registry = Mantid::PythonInterface::Registry;
 using namespace boost::python;
+
+namespace {
+
+PythonObjectProperty *createPythonObjectProperty(std::string const &name, boost::python::object const &value,
+                                                 IValidator_sptr const &validator, unsigned int const direction) {
+  return new PythonObjectProperty(name, value, validator, direction);
+}
+} // namespace
 
 void export_PythonObjectProperty() {
   // export base class
@@ -32,13 +46,35 @@ void export_PythonObjectProperty() {
   // leaf class type
   using BaseClassType = PythonObjectProperty::BaseClass;
   class_<PythonObjectProperty, bases<BaseClassType>, boost::noncopyable>("PythonObjectProperty", no_init)
+      // name and direction
       .def(init<const std::string &, const unsigned int>(
           (arg("self"), arg("name"), arg("direction") = Direction::Input), "Construct a PythonObjectProperty"))
+
+      // name, validator, and direction
+      .def(init<const std::string &, IValidator_sptr, const unsigned int>(
+          (arg("self"), arg("name"), arg("validator"), arg("direction") = Direction::Input),
+          "Construct a PythonObjectProperty with a validator"))
+
+      // name, default, and direction
       .def(init<const std::string &, const boost::python::object &, const unsigned int>(
           (arg("self"), arg("name"), arg("defaultValue"), arg("direction") = Direction::Input),
           "Construct a PythonObjectProperty with a default value"))
+
+      // name, default, validator, and direction
+      .def(init<const std::string &, const boost::python::object &, IValidator_sptr, const unsigned int>(
+          (arg("self"), arg("name"), arg("defaultValue"), arg("validator") = IValidator_sptr(new NullValidator),
+           arg("direction") = Direction::Input),
+          "Construct a PythonObjectProperty with a default value and validator"))
+
+      .def("__init__",
+           make_constructor(&createPythonObjectProperty, default_call_policies(),
+                            (arg("name"), arg("value"), arg("validator") = IValidator_sptr(new NullValidator),
+                             arg("direction") = Direction::Input)))
+
       .add_property("value", make_function(&PythonObjectProperty::operator(),
-                                           return_value_policy<boost::python::return_by_value>()));
+                                           return_value_policy<boost::python::return_by_value>()))
+      .def("setValue", static_cast<std::string (PythonObjectProperty::*)(boost::python::object const &)>(
+                           &PythonObjectProperty::setValue));
 
   // type handler for alg.setProperty calls
   Registry::TypeRegistry::subscribe(typeid(BaseValueType), new Registry::PythonObjectTypeHandler);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
@@ -10,7 +10,12 @@
 #include "MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h"
 #include "MantidPythonInterface/kernel/Registry/TypeRegistry.h"
 
+#ifndef Q_MOC_RUN
+#include <boost/python/bases.hpp>
 #include <boost/python/class.hpp>
+#include <boost/python/return_by_value.hpp>
+#include <boost/python/return_value_policy.hpp>
+#endif
 
 using Mantid::Kernel::Direction;
 using Mantid::Kernel::PropertyWithValue;
@@ -31,7 +36,9 @@ void export_PythonObjectProperty() {
           (arg("self"), arg("name"), arg("direction") = Direction::Input), "Construct a PythonObjectProperty"))
       .def(init<const std::string &, const boost::python::object &, const unsigned int>(
           (arg("self"), arg("name"), arg("defaultValue"), arg("direction") = Direction::Input),
-          "Construct a PythonObjectProperty with a default value"));
+          "Construct a PythonObjectProperty with a default value"))
+      .add_property("value", make_function(&PythonObjectProperty::operator(),
+                                           return_value_policy<boost::python::return_by_value>()));
 
   // type handler for alg.setProperty calls
   Registry::TypeRegistry::subscribe(typeid(BaseValueType), new Registry::PythonObjectTypeHandler);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectProperty.cpp
@@ -62,7 +62,7 @@ void export_PythonObjectProperty() {
 
       // name, default, validator, and direction
       .def(init<const std::string &, const boost::python::object &, IValidator_sptr, const unsigned int>(
-          (arg("self"), arg("name"), arg("defaultValue"), arg("validator") = IValidator_sptr(new NullValidator),
+          (arg("self"), arg("name"), arg("defaultValue"), arg("validator") = std::make_shared<NullValidator>(),
            arg("direction") = Direction::Input),
           "Construct a PythonObjectProperty with a default value and validator"))
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
@@ -23,5 +23,6 @@ void export_PythonObjectTypeValidator() {
   class_<PythonObjectTypeValidator, bases<IValidator>, boost::noncopyable>("PythonObjectTypeValidator")
       .def("__init__",
            make_constructor(&createPythonObjectTypeValidator, default_call_policies(), (arg("PythonClass"))),
-           "Constructs a validator verifying that objects passed to this property are of the given class");
+           "Constructs a validator verifying that objects passed to this property are of the given class")
+      .def("isValid", &PythonObjectTypeValidator::isValid<boost::python::object>);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
@@ -1,0 +1,27 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidPythonInterface/core/PythonObjectTypeValidator.h"
+#include <boost/python/class.hpp>
+#include <boost/python/default_call_policies.hpp>
+#include <boost/python/make_constructor.hpp>
+
+using Mantid::Kernel::IValidator;
+using Mantid::PythonInterface::PythonObjectTypeValidator;
+using namespace boost::python;
+
+namespace {
+PythonObjectTypeValidator *createPythonObjectTypeValidator(object pythonClass) {
+  return new PythonObjectTypeValidator(pythonClass);
+}
+} // namespace
+
+void export_PythonObjectTypeValidator() {
+  class_<PythonObjectTypeValidator, bases<IValidator>, boost::noncopyable>("PythonObjectTypeValidator")
+      .def("__init__",
+           make_constructor(&createPythonObjectTypeValidator, default_call_policies(), (arg("PythonClass"))),
+           "Constructs a validator verifying that objects passed to this property are of the given class");
+}

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PythonObjectTypeValidator.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PythonObjectTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PythonObjectTypeHandler.cpp
@@ -1,0 +1,45 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+//-----------------------------------------------------------------------------
+// Includes
+//-----------------------------------------------------------------------------
+#include "MantidPythonInterface/kernel/Registry/PythonObjectTypeHandler.h"
+#include "MantidKernel/IPropertyManager.h"
+#include "MantidPythonInterface/core/PythonObjectProperty.h"
+#include <boost/python/extract.hpp>
+
+namespace Mantid::PythonInterface::Registry {
+
+/**
+ * Create a PropertyWithValue from the given python object value
+ * @param name :: The name of the property
+ * @param defaultValue :: The defaultValue of the property. The object attempts
+ * to extract
+ * a value of type ContainerType from the python object
+ * @param validator :: A python object pointing to a validator instance, which
+ * can be None.
+ * @param direction :: The direction of the property
+ * @returns A pointer to a newly constructed property instance
+ */
+std::unique_ptr<Kernel::Property> PythonObjectTypeHandler::create(std::string const &name,
+                                                                  boost::python::object const &defaultValue,
+                                                                  boost::python::object const &validator,
+                                                                  const unsigned int direction) const {
+  using boost::python::extract;
+  using Kernel::IValidator;
+
+  std::unique_ptr<Kernel::Property> valueProp;
+  if (isNone(validator)) {
+    valueProp = std::make_unique<PythonObjectProperty>(name, defaultValue, direction);
+  } else {
+    const IValidator *propValidator = extract<IValidator *>(validator);
+    valueProp = std::make_unique<PythonObjectProperty>(name, defaultValue, propValidator->clone(), direction);
+  }
+  return valueProp;
+}
+
+} // namespace Mantid::PythonInterface::Registry

--- a/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_PY_FILES
     PropertyManagerTest.py
     PropertyManagerDataServiceTest.py
     PropertyManagerPropertyTest.py
+    PythonObjectPropertyTest.py
     PythonPluginsTest.py
     RebinParamsValidatorTest.py
     StatisticsTest.py

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -217,7 +217,8 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.setProperty("PyObject", json.dumps(a_dict))
         self.assertEqual(a_dict, fake.getProperty("PyObject").value)
 
-    def test_value_string(self):
+    # TODO make work
+    def xtest_value_string(self):
         fake = FakeAlgorithm()
         fake.initialize()
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -7,7 +7,7 @@
 """Tests for PythonObjectProperty"""
 
 import unittest
-from mantid.kernel import Direction, PythonObjectProperty
+from mantid.kernel import Direction, PythonObjectProperty, PythonObjectTypeValidator
 from mantid.api import Algorithm
 
 
@@ -19,8 +19,24 @@ class FakeAlgorithm(Algorithm):
         pass
 
 
-def my_serializer():
-    pass
+class NestedClass:
+    def __init__(self, a):
+        self.a = a
+
+
+class FakeClass:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = NestedClass(y)
+
+
+class FakeValidatedAlgorithm(Algorithm):
+    def PyInit(self):
+        validator = PythonObjectTypeValidator(FakeClass)
+        self.declareProperty(PythonObjectProperty("PyObject", None, validator))
+
+    def PyExec(self):
+        pass
 
 
 class PythonObjectPropertyTest(unittest.TestCase):
@@ -52,6 +68,62 @@ class PythonObjectPropertyTest(unittest.TestCase):
         self.assertEqual(prop.direction, Direction.Input)
         self.assertEqual(prop.value, default_value)
 
+    def test_construction_with_validator_int(self):
+        # make sure a validator cannot be created from a non-class-type object
+        x = 7
+        with self.assertRaises(Exception):
+            PythonObjectTypeValidator(x)
+
+        x = {"key": 12, "other": 3.141592}
+        with self.assertRaises(Exception):
+            PythonObjectTypeValidator(x)
+
+        # not create a type validator and init a property with it
+        validator = PythonObjectTypeValidator(int)
+        prop = PythonObjectProperty("PyObjectProperty", None, validator)
+
+        # check for int
+        a_int = 100001000000001
+        res = prop.setValue(a_int)
+        # successful setting will register as an empty string being returned
+        self.assertEqual(res, "")
+        self.assertEqual(a_int, prop.value)
+
+        # try setting with a float
+        a_float = 3.141592
+        res = prop.setValue(a_float)
+        # an error condition will register as a string message being returned
+        self.assertNotEqual(res, "")
+        # make sure the value has not changed and is still valid
+        self.assertEqual(a_int, prop.value)
+
+    def test_construction_with_validator_classes(self):
+        # make sure a validator cannot be created from a non-class-type object
+        class A:
+            pass
+
+        class B:
+            pass
+
+        # not create a type validator and init a property with it
+        validator = PythonObjectTypeValidator(A)
+        prop = PythonObjectProperty("PyObjectProperty", None, validator)
+
+        # check success
+        a = A()
+        res = prop.setValue(a)
+        # successful setting will register as an empty string being returned
+        self.assertEqual(res, "")
+        self.assertEqual(a, prop.value)
+
+        # try setting with a float
+        b = B()
+        res = prop.setValue(b)
+        # an error condition will register as a string message being returned
+        self.assertNotEqual(res, "")
+        # make sure the value has not changed and is still valid
+        self.assertEqual(a, prop.value)
+
     def test_set_property_on_algorithm_PyObject(self):
         fake = FakeAlgorithm()
         fake.initialize()
@@ -69,11 +141,6 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake = FakeAlgorithm()
         fake.initialize()
 
-        class FakeClass:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
         value = FakeClass(16, "NXshorts")
         fake.setProperty("PyObject", value)
 
@@ -86,6 +153,23 @@ class PythonObjectPropertyTest(unittest.TestCase):
         ret = fake.getProperty("PyObject").value
         self.assertEqual(ret.x, value.x)
         self.assertEqual(ret.y, value.y)
+
+    def test_set_property_on_algorithm_class_with_validator(self):
+        fake = FakeValidatedAlgorithm()
+        fake.initialize()
+
+        value = {"not": "correct"}
+        with self.assertRaises(Exception):
+            fake.setProperty("PyObject", value)
+
+        value = FakeClass(16, "NXshorts")
+        fake.setProperty("PyObject", value)
+
+        # It is important that both the value and address match to prove it
+        # is just the same object that we got back
+        self.assertIs(value, fake.getProperty("PyObject").value)
+        self.assertEqual(value, fake.getProperty("PyObject").value)
+        self.assertEqual(id(value), id(fake.getProperty("PyObject").value))
 
     def test_value_int(self):
         fake = FakeAlgorithm()
@@ -133,25 +217,7 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.setProperty("PyObject", json.dumps(a_dict))
         self.assertEqual(a_dict, fake.getProperty("PyObject").value)
 
-    # TODO make work
-    def xtest_value_class(self):
-        fake = FakeAlgorithm()
-        fake.initialize()
-
-        class FakeClass:
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
-        # check for dict
-        a_class = FakeClass(7, "frnakling")
-        fake.setProperty("PyObject", a_class)
-        self.assertEqual(a_class, fake.getPropertyValue("PyObject"))
-        fake.setProperty("PyObject", a_class)
-        self.assertEqual(a_class, fake.getProperty("PyObject").value)
-
-    # TODO make work
-    def xtest_value_string(self):
+    def test_value_string(self):
         fake = FakeAlgorithm()
         fake.initialize()
 
@@ -160,6 +226,21 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.setProperty("PyObject", a_string)
         self.assertEqual(a_string, fake.getPropertyValue("PyObject"))
         self.assertEqual(a_string, fake.getProperty("PyObject").value)
+
+    # TODO make work
+    def xtest_value_class(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for class
+        obj = FakeClass(7, "frnakling")
+        fake.setProperty("PyObject", obj)
+
+        # take the string, set the property from the string, ensure same
+        propVal = fake.getPropertyValue("PyObject")
+        print(propVal)
+        fake.setPropertyValue("PyObject", propVal)
+        self.assertEqual(obj, fake.getProperty("PyObject").value)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -259,6 +259,21 @@ class PythonObjectPropertyTest(unittest.TestCase):
         objAsJson = {"x": 7, "y": {"a": "frnakling"}}
         self.assertEqual(objAsJson, fake.getProperty("PyObject").value)
 
+    def test_value_class_recursion_stops(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # create a self-referential object
+        obj = [1]
+        obj[0] = obj
+        fake.setProperty("PyObject", obj)
+        self.assertIs(obj, fake.getProperty("PyObject").value)
+
+        # take the string, ensure it terminates
+        propVal = fake.getPropertyValue("PyObject")
+        fake.setPropertyValue("PyObject", propVal)
+        self.assertIn("...", fake.getPropertyValue("PyObject"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -217,8 +217,7 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.setProperty("PyObject", json.dumps(a_dict))
         self.assertEqual(a_dict, fake.getProperty("PyObject").value)
 
-    # TODO make work
-    def xtest_value_string(self):
+    def test_value_string(self):
         fake = FakeAlgorithm()
         fake.initialize()
 
@@ -228,20 +227,20 @@ class PythonObjectPropertyTest(unittest.TestCase):
         self.assertEqual(a_string, fake.getPropertyValue("PyObject"))
         self.assertEqual(a_string, fake.getProperty("PyObject").value)
 
-    # TODO make work
-    def xtest_value_class(self):
+    def test_value_class(self):
         fake = FakeAlgorithm()
         fake.initialize()
 
         # check for class
         obj = FakeClass(7, "frnakling")
         fake.setProperty("PyObject", obj)
+        self.assertIs(obj, fake.getProperty("PyObject").value)
 
         # take the string, set the property from the string, ensure same
         propVal = fake.getPropertyValue("PyObject")
-        print(propVal)
         fake.setPropertyValue("PyObject", propVal)
-        self.assertEqual(obj, fake.getProperty("PyObject").value)
+        objAsJson = {"x": 7, "y": {"a": "frnakling"}}
+        self.assertEqual(objAsJson, fake.getProperty("PyObject").value)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -323,8 +323,8 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.initialize()
 
         # create a self-referential object
-        obj = {"key": [FakeClass(1, 2), FakeClass(3, 4)]}
-        obj["key"][1] = obj
+        obj = FakeClass(1, 2)
+        obj.y = obj
         fake.setProperty("PyObject", obj)
         self.assertIs(obj, fake.getProperty("PyObject").value)
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -65,6 +65,102 @@ class PythonObjectPropertyTest(unittest.TestCase):
         self.assertEqual(value, fake.getProperty("PyObject").value)
         self.assertEqual(id(value), id(fake.getProperty("PyObject").value))
 
+    def test_set_property_on_algorithm_class(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        class FakeClass:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        value = FakeClass(16, "NXshorts")
+        fake.setProperty("PyObject", value)
+
+        # It is important that both the value and address match to prove it
+        # is just the same object that we got back
+        self.assertIs(value, fake.getProperty("PyObject").value)
+        self.assertEqual(value, fake.getProperty("PyObject").value)
+        self.assertEqual(id(value), id(fake.getProperty("PyObject").value))
+        # check individual properties
+        ret = fake.getProperty("PyObject").value
+        self.assertEqual(ret.x, value.x)
+        self.assertEqual(ret.y, value.y)
+
+    def test_value_int(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for int
+        a_int = 100001000000001
+        fake.setProperty("PyObject", a_int)
+        self.assertEqual(str(a_int), fake.getPropertyValue("PyObject"))
+        fake.setProperty("PyObject", str(a_int))
+        self.assertEqual(a_int, fake.getProperty("PyObject").value)
+
+    def test_value_float(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for float
+        a_float = 3.141592
+        fake.setProperty("PyObject", a_float)
+        self.assertEqual(str(a_float), fake.getPropertyValue("PyObject"))
+        fake.setProperty("PyObject", str(a_float))
+        self.assertEqual(a_float, fake.getProperty("PyObject").value)
+
+    def test_value_list(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for list
+        a_list = [3.4, 5]
+        fake.setProperty("PyObject", a_list)
+        self.assertEqual(str(a_list), fake.getPropertyValue("PyObject"))
+        fake.setProperty("PyObject", str(a_list))
+        self.assertEqual(a_list, fake.getProperty("PyObject").value)
+
+    def test_value_dict(self):
+        import json
+
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for dict
+        a_dict = {"key1": 12, "key2": -14}
+        fake.setProperty("PyObject", a_dict)
+        self.assertEqual(json.dumps(a_dict), fake.getPropertyValue("PyObject"))
+        fake.setProperty("PyObject", json.dumps(a_dict))
+        self.assertEqual(a_dict, fake.getProperty("PyObject").value)
+
+    # TODO make work
+    def xtest_value_class(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        class FakeClass:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        # check for dict
+        a_class = FakeClass(7, "frnakling")
+        fake.setProperty("PyObject", a_class)
+        self.assertEqual(a_class, fake.getPropertyValue("PyObject"))
+        fake.setProperty("PyObject", a_class)
+        self.assertEqual(a_class, fake.getProperty("PyObject").value)
+
+    # TODO make work
+    def xtest_value_string(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for string
+        a_string = "hello world"
+        fake.setProperty("PyObject", a_string)
+        self.assertEqual(a_string, fake.getPropertyValue("PyObject"))
+        self.assertEqual(a_string, fake.getProperty("PyObject").value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -1,0 +1,69 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Test the exposed PropertyManagerProperty"""
+
+import unittest
+from mantid.kernel import Direction, PythonObjectProperty
+from mantid.api import Algorithm
+
+
+class FakeAlgorithm(Algorithm):
+    def PyInit(self):
+        self.declareProperty(PythonObjectProperty("PyObject"))
+
+    def PyExec(self):
+        pass
+
+
+def my_serializer():
+    pass
+
+
+class PythonObjectPropertyTest(unittest.TestCase):
+    def test_construction_with_no_value_defaults_to_input(self):
+        prop = PythonObjectProperty("MyInputProperty")
+
+        self.assertEqual(prop.direction, Direction.Input)
+
+    def test_construction_with_direction_is_respected(self):
+        prop = PythonObjectProperty("MyOutputProperty", direction=Direction.Output)
+
+        self.assertEqual(prop.direction, Direction.Output)
+
+    def test_construction_with_no_value_defaults_to_None(self):
+        prop = PythonObjectProperty("MyProperty")
+
+        self.assertEqual(
+            "MyProperty",
+            prop.name,
+        )
+        self.assertEqual(Direction.Input, prop.direction)
+        self.assertIs(prop.value, None)
+
+    def test_construction_with_default_value_returns_same_value(self):
+        default_value = 10
+        prop = PythonObjectProperty("MyProperty", default_value)
+
+        self.assertEqual(prop.name, "MyProperty")
+        self.assertEqual(prop.direction, Direction.Input)
+        self.assertEqual(prop.value, default_value)
+
+    def test_set_property_on_algorithm_PyObject(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        value = 5
+        fake.setProperty("PyObject", value)
+
+        # It is important that both the value and address match to prove it
+        # is just the same object that we got back
+        self.assertEqual(value, fake.getProperty("PyObject").value)
+        self.assertEqual(id(value), id(fake.getProperty("PyObject").value))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -205,9 +205,10 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.initialize()
 
         # check for float
-        a_float = 3.141592
+        a_float = 3.141592 / 2.718281828
         fake.setProperty("PyObject", a_float)
         self.assertEqual(str(a_float), fake.getPropertyValue("PyObject"))
+        self.assertEqual("1.1557271095438455", fake.getPropertyValue("PyObject"))  # NOTE 16 digits
         fake.setProperty("PyObject", str(a_float))
         self.assertEqual(a_float, fake.getProperty("PyObject").value)
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-"""Test the exposed PropertyManagerProperty"""
+"""Tests for PythonObjectProperty"""
 
 import unittest
 from mantid.kernel import Direction, PythonObjectProperty
@@ -56,11 +56,12 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake = FakeAlgorithm()
         fake.initialize()
 
-        value = 5
+        value = object()
         fake.setProperty("PyObject", value)
 
         # It is important that both the value and address match to prove it
         # is just the same object that we got back
+        self.assertIs(value, fake.getProperty("PyObject").value)
         self.assertEqual(value, fake.getProperty("PyObject").value)
         self.assertEqual(id(value), id(fake.getProperty("PyObject").value))
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -68,7 +68,7 @@ class PythonObjectPropertyTest(unittest.TestCase):
         self.assertEqual(prop.direction, Direction.Input)
         self.assertEqual(prop.value, default_value)
 
-    def test_construction_with_validator_int(self):
+    def test_python_validator(self):
         # make sure a validator cannot be created from a non-class-type object
         x = 7
         with self.assertRaises(Exception):
@@ -78,7 +78,24 @@ class PythonObjectPropertyTest(unittest.TestCase):
         with self.assertRaises(Exception):
             PythonObjectTypeValidator(x)
 
-        # not create a type validator and init a property with it
+        # make sure it can be created from a standard type
+        intValidator = PythonObjectTypeValidator(int)
+        self.assertEqual(intValidator.isValid(12), "")
+        self.assertEqual(intValidator.isValid(3.141592), "The passed object is of type float and not of type int")
+        self.assertEqual(intValidator.isValid(None), "The passed object is of type NoneType and not of type int")
+
+        # make sure it can be created from a custom type
+        class A:
+            pass
+
+        a = A()
+
+        classValidator = PythonObjectTypeValidator(A)
+        self.assertEqual(classValidator.isValid(a), "")
+        self.assertEqual(classValidator.isValid(12), "The passed object is of type int and not of type A")
+
+    def test_construction_with_validator_int(self):
+        # create a type validator and init a property with it
         validator = PythonObjectTypeValidator(int)
         prop = PythonObjectProperty("PyObjectProperty", None, validator)
 
@@ -98,25 +115,25 @@ class PythonObjectPropertyTest(unittest.TestCase):
         self.assertEqual(a_int, prop.value)
 
     def test_construction_with_validator_classes(self):
-        # make sure a validator cannot be created from a non-class-type object
+        # two stub classes for the check
         class A:
             pass
 
         class B:
             pass
 
-        # not create a type validator and init a property with it
+        # not create a type validator for A and init a property with it
         validator = PythonObjectTypeValidator(A)
         prop = PythonObjectProperty("PyObjectProperty", None, validator)
 
-        # check success
+        # check success with A objects
         a = A()
         res = prop.setValue(a)
         # successful setting will register as an empty string being returned
         self.assertEqual(res, "")
         self.assertEqual(a, prop.value)
 
-        # try setting with a float
+        # check failure with B objects
         b = B()
         res = prop.setValue(b)
         # an error condition will register as a string message being returned

--- a/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PythonObjectPropertyTest.py
@@ -236,6 +236,15 @@ class PythonObjectPropertyTest(unittest.TestCase):
         fake.setProperty("PyObject", json.dumps(a_dict))
         self.assertEqual(a_dict, fake.getProperty("PyObject").value)
 
+    def test_value_failure_tuple_keys(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+
+        # check for list
+        a_dict = {(1, 2): 1, (3, 4): 4}
+        fake.setProperty("PyObject", a_dict)
+        self.assertEqual("<unrepresentable object>", fake.getPropertyValue("PyObject"))
+
     def test_value_string(self):
         fake = FakeAlgorithm()
         fake.initialize()

--- a/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
+++ b/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
@@ -5,7 +5,7 @@
 =======================
 
 This is a Python binding to the C++ class Mantid::PythonInterface::PythonObjectProperty.
-It is meant to hold a generic python object as a property for use in algorithms defined form python.
+It is meant to hold a generic python object as a property for use in algorithms defined from python.
 
 *bases:* :py:obj:`mantid.kernel.PropertyWithValue`
 
@@ -51,6 +51,7 @@ Notes
 -----
 
 When string values are required, this will first attempt to write them using ``json.dumps``.
-If that does not work then serialization will build a json-like object by recursive calls to `__dict__`.
+If that does not work then serialization will recursively build a json-like object, including replacing custom classes with `__dict__` property.
 Note that for very complicated objects, this can result in enormous string outputs.  It is recommended to stick to
-simpler python types, or classes made from simple python types.
+simpler python types, or classes made from simple python types.  This will not work on objects that use python tuples for dictionary keys.
+If the recursive serialization fails, the string value will be set to ``"<unrepresentable object>"``.

--- a/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
+++ b/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
@@ -1,0 +1,54 @@
+=======================
+ PythonObjectProperty
+=======================
+
+This is a Python binding to the C++ class Mantid::PythonInterface::PythonObjectProperty.
+It is meant to hold a generic python object as a property for use in algorithms defined form python.
+
+*bases:* :py:obj:`mantid.kernel.PropertyWithValue`
+
+.. module:`mantid.kernel`
+
+.. autoclass:: mantid.kernel.PythonObjectProperty
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+Example Usage
+------------------
+
+The following example shows how to use this property type, both with and without a ``PythonObjectTypeValidator``.
+
+.. code-block:: python
+
+    from mantid.kernel import PythonObjectProperty, PythonObjectTypeValidator
+    from mantid.api import PythonAlgorithm
+
+    class FakeClass:
+        pass
+
+    class FakeAlgorithm(PythonAlgorithm):
+        def PyInit(self):
+            self.declareProperty(PythonObjectProperty("UnvalidatedPyObject"))
+            self.declareProperty(PythonObjectProperty("ValidatedPyObject", None, PythonObjectTypeValidator(FakeClass)))
+
+        def PyExec(self):
+            pass
+
+    value1 = {"key1": "value one", "key2": ["one", "two", "three"]}
+    value2 = FakeClass()
+
+    # run the algorithm
+    fake = FakeAlgorithm()
+    fake.initialize()
+    fake.setProperty("UnvalidatedPyObject", value1)
+    fake.setProperty("ValidatedPyObject", value2)
+    fake.execute()
+
+Notes
+-----
+
+When string values are required, this will first attempt to write them using ``json.dumps``.
+If that does not work then serialization will build a json-like object by recursive calls to `__dict__`.
+Note that for very complicated objects, this can result in enormous string outputs.  It is recommended to stick to
+simpler python types, or classes made from simple python types.

--- a/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
+++ b/docs/source/api/python/mantid/kernel/PythonObjectProperty.rst
@@ -1,3 +1,5 @@
+.. _PythonObjectProperty:
+
 =======================
  PythonObjectProperty
 =======================

--- a/docs/source/api/python/mantid/kernel/PythonObjectTypeValidator.rst
+++ b/docs/source/api/python/mantid/kernel/PythonObjectTypeValidator.rst
@@ -1,3 +1,5 @@
+.. _PythonObjectTypeValidator:
+
 ===========================
  PythonObjectTypeValidator
 ===========================

--- a/docs/source/api/python/mantid/kernel/PythonObjectTypeValidator.rst
+++ b/docs/source/api/python/mantid/kernel/PythonObjectTypeValidator.rst
@@ -1,0 +1,19 @@
+===========================
+ PythonObjectTypeValidator
+===========================
+
+This is a Python binding to the C++ class Mantid::PythonInterface::PythonObjectTypeValidator.
+
+*bases:* :py:obj:`mantid.kernel.PropertyWithValue`
+
+.. module:`mantid.kernel`
+
+.. autoclass:: mantid.kernel.PythonObjectTypeValidator
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+Example Usage
+------------------
+
+See docs for :ref:`PythonObjectProperty <PythonObjectProperty>`

--- a/docs/source/release/v6.14.0/Workbench/New_features/39880.rst
+++ b/docs/source/release/v6.14.0/Workbench/New_features/39880.rst
@@ -1,0 +1,2 @@
+- Created :ref:`PythonObjectProperty <PythonObjectProperty>` which allows using generic python objects as inputs to algorithms defined through the python API
+- Created :ref:`PythonObjectTypeValidator <PythonObjectTypeValidator>` for use with :ref:`PythonObjectProperty <PythonObjectProperty>`, to enforce correct typing on python objects


### PR DESCRIPTION
### Description of work

This creates a Mantid algorithm property that can hold a generic python object.  This means that algorithms defined entirely within python are not restricted to C++ types, and that properties could hold any kind of value definable within python.

This also creates a validator, `PythonObjectTypeValidator` which can limit the type for these python objects.

These new classes are defined only within the `PythonInterface` layer, as they are not intended for use within C++ code.

The main use case of this new property type is for algorithms defined entirely within python which anticipate property arguments other than primitives or lists of primitives.  In particular for SNAPRed, which heavily uses `pydantic` objects as arguments to algorithms, requiring either string serialization/deserialization, or a [kludge for pointers](https://github.com/neutrons/SNAPRed/blob/2899195bc67331a524d0e27830c3c5e6dd78298c/src/snapred/backend/recipe/algorithm/OffsetStatistics.py#L31C1-L34C10).

### To test:

There are unit tests defined for the property and the validator.

Please check this from within workbench.  In a comment below I will post a script that should check everything we need to verify.

The [comment with the test is here](https://github.com/mantidproject/mantid/pull/39880#issuecomment-3282327834)

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
