### PR TITLE
Fix typo in main docs index page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Mantid can be used though several Graphical User Interfaces (GUI) and programmin
 
 * :ref:`MantidWorkbench <workbench>`, A modern general-purpose interface supporting a wide range of techniques and visualisation approaches.
 * Autoreduction services at specific facilities, including ISIS and the `SNS <https://monitor.sns.gov>`_.
-* API's for :ref:`Python <pythonapi>` and `C++ <http://doxygen.mantidproject.org/>`_.
+* APIs for :ref:`Python <pythonapi>` and `C++ <http://doxygen.mantidproject.org/>`_.
 
 Documentation
 =============
@@ -62,7 +62,7 @@ This is the documentation for Mantid |release|.
   * :ref:`interfaces contents`, descriptions of the bespoke technique interfaces available.
   * :ref:`fitting contents`, details of all the supported fitting functions and minimization approaches.
   * :ref:`techniques contents`, with further information relevant to some of the specific scientific techniques.
-  * API's for :ref:`Python <pythonapi>` and `C++ <http://doxygen.mantidproject.org/>`_.
+  * APIs for :ref:`Python <pythonapi>` and `C++ <http://doxygen.mantidproject.org/>`_.
   * :ref:`release_notes`, a catalog of all of the release notes since v3.5.2.
   * :ref:`deprecation_policy`, our current policy for deprecating algorithms, interfaces and other parts of Mantid.
 


### PR DESCRIPTION
Just spotted this typo on our main docs page. `APIs` is plural, not possessive.

### To test:
No testing required.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
