### PR TITLE
Add parallel for loops to PolarizationCorrectionWildes

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -659,6 +659,7 @@ PolarizationCorrectionWildes::directBeamCorrections(const WorkspaceMap &inputs, 
   WorkspaceMap outputs;
   outputs.ppWS = createWorkspaceWithHistory(inputs.ppWS);
   const size_t nHisto = inputs.ppWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.ppWS, *outputs.ppWS);
   PARALLEL_FOR_IF(threadSafe)
   for (int wsIndex = 0; wsIndex < static_cast<int>(nHisto); ++wsIndex) {
@@ -704,6 +705,7 @@ PolarizationCorrectionWildes::analyzerlessCorrections(const WorkspaceMap &inputs
   outputs.mmWS = createWorkspaceWithHistory(inputs.mmWS);
   outputs.ppWS = createWorkspaceWithHistory(inputs.ppWS);
   const size_t nHisto = inputs.mmWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.mmWS, *inputs.ppWS, *outputs.mmWS, *outputs.ppWS);
   PARALLEL_FOR_IF(threadSafe)
   for (int wsIndex = 0; wsIndex < static_cast<int>(nHisto); ++wsIndex) {
@@ -830,6 +832,7 @@ PolarizationCorrectionWildes::fullCorrections(const WorkspaceMap &inputs, const 
   const auto P2 = efficiencies.P2->y();
   const auto P2E = efficiencies.P2->e();
   const size_t nHisto = inputs.mmWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.mmWS, *inputs.mpWS, *inputs.pmWS, *inputs.ppWS, *outputs.mmWS,
                                              *outputs.mpWS, *outputs.pmWS, *outputs.ppWS);
   PARALLEL_FOR_IF(threadSafe)
@@ -917,6 +920,7 @@ void PolarizationCorrectionWildes::threeInputsSolve01(WorkspaceMap &inputs, cons
   const auto &P1 = efficiencies.P1->y();
   const auto &P2 = efficiencies.P2->y();
   const auto nHisto = inputs.pmWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.mmWS, *inputs.mpWS, *inputs.pmWS, *inputs.ppWS);
   PARALLEL_FOR_IF(threadSafe)
   for (int wsIndex = 0; wsIndex < static_cast<int>(nHisto); ++wsIndex) {
@@ -957,6 +961,7 @@ void PolarizationCorrectionWildes::threeInputsSolve10(WorkspaceMap &inputs, cons
   const auto &P1 = efficiencies.P1->y();
   const auto &P2 = efficiencies.P2->y();
   const auto nHisto = inputs.mpWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.mmWS, *inputs.mpWS, *inputs.pmWS, *inputs.ppWS);
   PARALLEL_FOR_IF(threadSafe)
   for (int wsIndex = 0; wsIndex < static_cast<int>(nHisto); ++wsIndex) {
@@ -1003,6 +1008,7 @@ void PolarizationCorrectionWildes::twoInputsSolve01And10(WorkspaceMap &fullInput
   const auto &P2 = efficiencies.P2->y();
   const auto &P2E = efficiencies.P2->e();
   const auto nHisto = inputs.mmWS->getNumberHistograms();
+  // cppcheck-suppress unreadVariable
   const bool threadSafe = Kernel::threadSafe(*inputs.mmWS, *inputs.ppWS, *fullInputs.pmWS, *fullInputs.mpWS);
   PARALLEL_FOR_IF(threadSafe)
   for (int wsIndex = 0; wsIndex < static_cast<int>(nHisto); ++wsIndex) {

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -22,8 +22,6 @@
 #include <Eigen/Dense>
 #include <boost/math/special_functions/pow.hpp>
 
-#include <execution>
-
 namespace {
 /// Property names.
 namespace Prop {

--- a/docs/source/release/v6.14.0/SANS/New_features/39850.rst
+++ b/docs/source/release/v6.14.0/SANS/New_features/39850.rst
@@ -1,0 +1,1 @@
+- Added parallelisation to :ref:`algm-PolarizationCorrectionWildes` to reduce computation time by a factor of 4.


### PR DESCRIPTION
### Description of work

I tried for a while to use the new `std::for_each` in parallel execution mode but apparently it's still a bit funny on some compilers, so just stuck to the tried and true OpenMP.
Changing both inner and outer loops to parallel didn't seem to add much overhead at all, also this way there is still a speed up for workspaces with a low histogram number.

Closes #39850 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Compare [this package build](https://builds.mantidproject.org/job/build_packages_from_branch/1342/) (windows only, sorry) with the nightly.

```
PolarizationEfficiencyCor(
        InputWorkspaceGroup=scattering,
        OutputWorkspace='out',
        Efficiencies=efficiencies,
        Flippers="11,10,01,00")
```
I can send data to whoever is testing.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
