### PR TITLE
Enforce python variable naming conventions for workspace names

### DIFF
--- a/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -82,10 +82,6 @@ public:
   //@}
 
 public:
-  /// Return the list of illegal characters as one string
-  const std::string &illegalCharacters() const;
-  /// Set the list of illegal characters
-  void setIllegalCharacterList(const std::string &);
   /// Is the given name a valid name for an object in the ADS
   const std::string isValid(const std::string &name) const;
   /// Overridden add member to attach the name to the workspace when a
@@ -150,9 +146,6 @@ private:
   AnalysisDataServiceImpl &operator=(const AnalysisDataServiceImpl &) = delete;
   /// Private destructor
   ~AnalysisDataServiceImpl() override = default;
-
-  /// The string of illegal characters
-  std::string m_illegalChars;
 };
 
 using AnalysisDataService = Mantid::Kernel::SingletonHolder<AnalysisDataServiceImpl>;

--- a/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -82,8 +82,10 @@ public:
   //@}
 
 public:
-  /// Is the given name a valid name for an object in the ADS
-  const std::string isValid(const std::string &name) const;
+  /// Validate the name and issue a warning in release mode, only return error string in debug mode.
+  const std::string isValid(const std::string &name, const bool printWarning = false) const;
+  //// Check whether the name is a valid python variable name and return an error message if not.
+  const std::string validateName(const std::string &name) const;
   /// Overridden add member to attach the name to the workspace when a
   /// workspace object is added to the service
   void add(const std::string &name, const std::shared_ptr<API::Workspace> &workspace) override;

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -39,15 +39,29 @@ std::shared_ptr<const WorkspaceGroup> AnalysisDataServiceImpl::GroupUpdatedNotif
  */
 const std::string AnalysisDataServiceImpl::isValid(const std::string &name) const {
   std::regex validName("^[a-zA-Z_][\\w]*");
-
   std::string error = "";
 
   if (!std::regex_match(name, validName)) {
     error =
         "Invalid object name '" + name +
         "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
+
+    // Log a warning message to let user know we will stop allowing invalid variable names in the future.
+    const std::string warningMessage =
+        error + "\n"
+                "Currently this is only a warning, but in a future version of Mantid this will raise an exception and "
+                "the operation will fail.\n"
+                "Please update your scripts to use valid Python identifiers for workspace names.";
+    Kernel::Logger log("AnalaysisDataService");
+    log.warning(warningMessage);
   }
+
+  // Fail in debug mode if name is not valid.
+#ifndef NDEBUG
   return error;
+#endif
+
+  return "";
 }
 
 /**

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -35,6 +35,8 @@ std::shared_ptr<const WorkspaceGroup> AnalysisDataServiceImpl::GroupUpdatedNotif
  * Check whether the name is valid for the ADS. In release mode, issue a warning but do not return the error.
  * In debug mode, return the error string.
  * @param name A string containing a possible name for an object in the ADS
+ * @param printWarning Whether to print a warning if the workspace name is invalid. Default is false. Used to
+ *                     avoid the warning printing multiple times per operation.
  * @return An empty string if the name is valid or an error message stating the
  * problem if the name is unacceptable.
  */

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -9,7 +9,6 @@
 #include <iterator>
 #include <random>
 #include <regex>
-#include <sstream>
 
 namespace Mantid::API {
 

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -8,6 +8,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include <iterator>
 #include <random>
+#include <regex>
 #include <sstream>
 
 namespace Mantid::API {
@@ -32,25 +33,20 @@ std::shared_ptr<const WorkspaceGroup> AnalysisDataServiceImpl::GroupUpdatedNotif
 // Public methods
 //-------------------------------------------------------------------------
 /**
- * Is the given name a valid name for an object in the ADS
+ * Is the given name a valid name for an object in the ADS?
  * @param name A string containing a possible name for an object in the ADS
  * @return An empty string if the name is valid or an error message stating the
- * problem
- * if the name is unacceptable.
+ * problem if the name is unacceptable.
  */
 const std::string AnalysisDataServiceImpl::isValid(const std::string &name) const {
-  std::string error;
-  const std::string &illegal = illegalCharacters();
-  if (illegal.empty())
-    return error; // Quick route out.
-  const size_t length = name.size();
-  for (size_t i = 0; i < length; ++i) {
-    if (illegal.find_first_of(name[i]) != std::string::npos) {
-      std::ostringstream strm;
-      strm << "Invalid object name '" << name << "'. Names cannot contain any of the following characters: " << illegal;
-      error = strm.str();
-      break;
-    }
+  std::regex validName("^[a-zA-Z_][\\w]*");
+
+  std::string error = "";
+
+  if (!std::regex_match(name, validName)) {
+    error =
+        "Invalid object name '" + name +
+        "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
   }
   return error;
 }
@@ -386,26 +382,7 @@ std::map<std::string, Workspace_sptr> AnalysisDataServiceImpl::topLevelItems() c
  * Constructor
  */
 AnalysisDataServiceImpl::AnalysisDataServiceImpl()
-    : Mantid::Kernel::DataService<Mantid::API::Workspace>("AnalysisDataService"), m_illegalChars() {}
-
-// The following is commented using /// rather than /** to stop the compiler
-// complaining
-// about the special characters in the comment fields.
-/// Return a string containing the characters not allowed in names objects
-/// within ADS
-/// @returns A n array of c strings containing the following characters: "
-/// +-/*\%<>&|^~=!@()[]{},:.`$?"
-const std::string &AnalysisDataServiceImpl::illegalCharacters() const { return m_illegalChars; }
-
-/**
- * Set the list of illegal characeters
- * @param illegalChars A string containing the characters, as one long string,
- * that are not to be accepted by the ADS
- * NOTE: This only affects further additions to the ADS
- */
-void AnalysisDataServiceImpl::setIllegalCharacterList(const std::string &illegalChars) {
-  m_illegalChars = illegalChars;
-}
+    : Mantid::Kernel::DataService<Mantid::API::Workspace>("AnalysisDataService") {}
 
 /**
  * Checks the name is valid

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -39,10 +39,9 @@ std::shared_ptr<const WorkspaceGroup> AnalysisDataServiceImpl::GroupUpdatedNotif
  */
 const std::string AnalysisDataServiceImpl::isValid(const std::string &name) const {
   std::regex validName("^[a-zA-Z_][\\w]*");
-  std::string error = "";
 
   if (!std::regex_match(name, validName)) {
-    error =
+    const std::string error =
         "Invalid object name '" + name +
         "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
 
@@ -54,12 +53,12 @@ const std::string AnalysisDataServiceImpl::isValid(const std::string &name) cons
                 "Please update your scripts to use valid Python identifiers for workspace names.";
     Kernel::Logger log("AnalaysisDataService");
     log.warning(warningMessage);
-  }
 
-  // Fail in debug mode if name is not valid.
+    // Fail in debug mode if name is not valid.
 #ifndef NDEBUG
-  return error;
+    return error;
 #endif
+  }
 
   return "";
 }

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -42,27 +42,38 @@ public:
 
   void setUp() override { ads.clear(); }
 
-  void test_IsValid_Returns_An_Empty_String_For_A_Valid_Name_When_All_CharsAre_Allowed() {
-    TS_ASSERT_EQUALS(ads.isValid("CamelCase"), "");
-    TS_ASSERT_EQUALS(ads.isValid("_Has_Underscore"), "");
+  void testIsValidReturnsEmptyStringForValidPythonNames() {
+    TS_ASSERT_EQUALS(ads.isValid("a"), "");
+    TS_ASSERT_EQUALS(ads.isValid("Z"), "");
+    TS_ASSERT_EQUALS(ads.isValid("camelCase"), "");
+    TS_ASSERT_EQUALS(ads.isValid("PascalCase"), "");
+    TS_ASSERT_EQUALS(ads.isValid("has_Underscore"), "");
+    TS_ASSERT_EQUALS(ads.isValid("_starts_with_underscore"), "");
+    TS_ASSERT_EQUALS(ads.isValid("ends_with_underscore_"), "");
+    TS_ASSERT_EQUALS(ads.isValid("__l_o_t_s__o_f__u_n_d_e_r_s_c_o_r_e_s__"), "");
     TS_ASSERT_EQUALS(ads.isValid("alllowercase"), "");
     TS_ASSERT_EQUALS(ads.isValid("ALLUPPERCASE"), "");
+    TS_ASSERT_EQUALS(ads.isValid("Numb3rs"), "");
+    TS_ASSERT_EQUALS(ads.isValid("_m0r3_numb3r5"), "");
+    TS_ASSERT_EQUALS(ads.isValid("_"), "");
+    TS_ASSERT_EQUALS(ads.isValid("___"), "");
   }
 
-  void test_IsValid_Returns_An_Error_String_For_A_Invalid_Name() {
+  void testIsValidReturnsErrorStringForNamesContainingIllegalCharacters() {
     const std::string illegalChars = " +-/*\\%<>&|^~=!@()[]{},:.`$'\"?";
-    ads.setIllegalCharacterList(illegalChars);
-    const size_t nchars(illegalChars.size());
-    for (size_t i = 0; i < nchars; ++i) {
-      std::ostringstream name;
-      name << "NotAllowed" << illegalChars[i];
-      std::ostringstream expectedError;
-      expectedError << "Invalid object name '" << name.str()
-                    << "'. Names cannot contain any of the following characters: " << illegalChars;
-      TS_ASSERT_EQUALS(ads.isValid(name.str()), expectedError.str());
+    for (const char &illegalChar : illegalChars) {
+      const std::string illegalName = std::string("variable_name") + illegalChar;
+      std::string expectedError =
+          "Invalid object name '" + illegalName +
+          "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
+      TS_ASSERT_EQUALS(ads.isValid(illegalName), expectedError);
     }
-    // Clean up
-    ads.setIllegalCharacterList("");
+  }
+
+  void testIsValidReturnsErrorStringForNamesStartingWithNumbers() {
+    TS_ASSERT_EQUALS(ads.isValid("7dodgy_name"),
+                     "Invalid object name '7dodgy_name'. Names must start with a letter or underscore and contain only "
+                     "alpha-numeric characters and underscores.");
   }
 
   void test_Retrieve_Case_Insensitive() {
@@ -140,28 +151,12 @@ public:
     TS_ASSERT_THROWS_NOTHING(ads.remove(name));
   }
 
-  void test_Add_With_Name_Containing_Special_Chars_Throws_Invalid_Argument() {
+  void test_Add_With_Name_Containing_Illegal_Characters_Throws_Invalid_Argument() {
     this->doAddingOnInvalidNameTests(false /*Don't use replace*/);
   }
 
-  void test_AddOrReplace_With_Name_Containing_Special_Chars_Throws_Invalid_Argument() {
+  void test_AddOrReplace_With_Name_Containing_Illegal_Characters_Throws_Invalid_Argument() {
     this->doAddingOnInvalidNameTests(true /*Use replace*/);
-  }
-
-  void test_Add_Then_Changing_Illegal_Char_List_Only_Affects_Future_Additions() {
-    // The ADS shouldcurrently accept anything
-    const std::string illegalChar(".");
-    std::string name = "ContainsIllegal" + illegalChar;
-    TS_ASSERT_THROWS_NOTHING(addToADS(name));
-    // Ban period characters
-    ads.setIllegalCharacterList(illegalChar);
-    // Check we still have the original one
-    TS_ASSERT_EQUALS(ads.doesExist(name), true);
-    std::string banned = "Also.Contains.Illegal";
-    // This should not be allowed now.
-    TS_ASSERT_THROWS(addToADS(banned), const std::invalid_argument &);
-    // Clear up
-    ads.setIllegalCharacterList("");
   }
 
   void test_AddOrReplace_Does_Not_Throw_When_Adding_Object_That_Has_A_Name_That_Already_Exists() {
@@ -541,30 +536,25 @@ private:
   /// If replace=true then usea addOrReplace
   void doAddingOnInvalidNameTests(bool replace) {
     const std::string illegalChars = " +-/*\\%<>&|^~=!@()[]{},:.`$'\"?";
-    ads.setIllegalCharacterList(illegalChars);
     const size_t nchars(illegalChars.size());
     const std::string allowed("WsName");
 
-    for (size_t i = 0; i < nchars; ++i) {
+    for (const char &illegalChar : illegalChars) {
       // Build illegal name
-      std::ostringstream name;
-      name << allowed << illegalChars[i] << allowed << illegalChars[i] << allowed;
+      std::string name = std::string("ws") + illegalChar + "name";
       // Add it
-      std::ostringstream errorMsg;
-      errorMsg << "Name containing illegal character " << illegalChars[i] << " is not allowed but ADS did not throw.";
+      std::string errorMsg =
+          std::string("Expected ADS to throw with illegal character ") + illegalChar + " in workspace name.";
       if (replace) {
-        TSM_ASSERT_THROWS(errorMsg.str(), addToADS(name.str()), const std::invalid_argument &);
+        TSM_ASSERT_THROWS(errorMsg, addToADS(name), const std::invalid_argument &);
       } else {
-        TSM_ASSERT_THROWS(errorMsg.str(), addOrReplaceToADS(name.str()), const std::invalid_argument &);
+        TSM_ASSERT_THROWS(errorMsg, addOrReplaceToADS(name), const std::invalid_argument &);
       }
-      bool stored = ads.doesExist(name.str());
+      bool stored = ads.doesExist(name);
       TS_ASSERT_EQUALS(stored, false);
       if (stored)
-        ads.remove(name.str()); // Clear up if the test fails so that it dones't
-                                // impact on others.
+        ads.remove(name); // Clear up if the test fails so that it dones't impact on others.
     }
-    // Clean up
-    ads.setIllegalCharacterList("");
   }
 
   /// Add a ptr to the ADS with the given name

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -42,36 +42,36 @@ public:
 
   void setUp() override { ads.clear(); }
 
-  void testIsValidReturnsEmptyStringForValidPythonNames() {
-    TS_ASSERT_EQUALS(ads.isValid("a"), "");
-    TS_ASSERT_EQUALS(ads.isValid("Z"), "");
-    TS_ASSERT_EQUALS(ads.isValid("camelCase"), "");
-    TS_ASSERT_EQUALS(ads.isValid("PascalCase"), "");
-    TS_ASSERT_EQUALS(ads.isValid("has_Underscore"), "");
-    TS_ASSERT_EQUALS(ads.isValid("_starts_with_underscore"), "");
-    TS_ASSERT_EQUALS(ads.isValid("ends_with_underscore_"), "");
-    TS_ASSERT_EQUALS(ads.isValid("__l_o_t_s__o_f__u_n_d_e_r_s_c_o_r_e_s__"), "");
-    TS_ASSERT_EQUALS(ads.isValid("alllowercase"), "");
-    TS_ASSERT_EQUALS(ads.isValid("ALLUPPERCASE"), "");
-    TS_ASSERT_EQUALS(ads.isValid("Numb3rs"), "");
-    TS_ASSERT_EQUALS(ads.isValid("_m0r3_numb3r5"), "");
-    TS_ASSERT_EQUALS(ads.isValid("_"), "");
-    TS_ASSERT_EQUALS(ads.isValid("___"), "");
+  void testValidateNameReturnsEmptyStringForValidPythonNames() {
+    TS_ASSERT_EQUALS(ads.validateName("a"), "");
+    TS_ASSERT_EQUALS(ads.validateName("Z"), "");
+    TS_ASSERT_EQUALS(ads.validateName("camelCase"), "");
+    TS_ASSERT_EQUALS(ads.validateName("PascalCase"), "");
+    TS_ASSERT_EQUALS(ads.validateName("has_Underscore"), "");
+    TS_ASSERT_EQUALS(ads.validateName("_starts_with_underscore"), "");
+    TS_ASSERT_EQUALS(ads.validateName("ends_with_underscore_"), "");
+    TS_ASSERT_EQUALS(ads.validateName("__l_o_t_s__o_f__u_n_d_e_r_s_c_o_r_e_s__"), "");
+    TS_ASSERT_EQUALS(ads.validateName("alllowercase"), "");
+    TS_ASSERT_EQUALS(ads.validateName("ALLUPPERCASE"), "");
+    TS_ASSERT_EQUALS(ads.validateName("Numb3rs"), "");
+    TS_ASSERT_EQUALS(ads.validateName("_m0r3_numb3r5"), "");
+    TS_ASSERT_EQUALS(ads.validateName("_"), "");
+    TS_ASSERT_EQUALS(ads.validateName("___"), "");
   }
 
-  void testIsValidReturnsErrorStringForNamesContainingIllegalCharacters() {
+  void testValidateNameReturnsErrorStringForNamesContainingIllegalCharacters() {
     const std::string illegalChars = " +-/*\\%<>&|^~=!@()[]{},:.`$'\"?";
     for (const char &illegalChar : illegalChars) {
       const std::string illegalName = std::string("variable_name") + illegalChar;
       std::string expectedError =
           "Invalid object name '" + illegalName +
           "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
-      TS_ASSERT_EQUALS(ads.isValid(illegalName), expectedError);
+      TS_ASSERT_EQUALS(ads.validateName(illegalName), expectedError);
     }
   }
 
-  void testIsValidReturnsErrorStringForNamesStartingWithNumbers() {
-    TS_ASSERT_EQUALS(ads.isValid("7dodgy_name"),
+  void testValidateNameReturnsErrorStringForNamesStartingWithNumbers() {
+    TS_ASSERT_EQUALS(ads.validateName("7dodgy_name"),
                      "Invalid object name '7dodgy_name'. Names must start with a letter or underscore and contain only "
                      "alpha-numeric characters and underscores.");
   }
@@ -151,13 +151,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(ads.remove(name));
   }
 
-  void test_Add_With_Name_Containing_Illegal_Characters_Throws_Invalid_Argument() {
-    this->doAddingOnInvalidNameTests(false /*Don't use replace*/);
-  }
+  void testAddWithInvalidName() { this->doAddingOnInvalidNameTests(false /*Don't use replace*/); }
 
-  void test_AddOrReplace_With_Name_Containing_Illegal_Characters_Throws_Invalid_Argument() {
-    this->doAddingOnInvalidNameTests(true /*Use replace*/);
-  }
+  void testAddOrReplaceWithInvalidName() { this->doAddingOnInvalidNameTests(true /*Use replace*/); }
 
   void test_AddOrReplace_Does_Not_Throw_When_Adding_Object_That_Has_A_Name_That_Already_Exists() {
     const std::string name("MySpaceAddOrReplace");
@@ -542,7 +538,9 @@ private:
     for (const char &illegalChar : illegalChars) {
       // Build illegal name
       std::string name = std::string("ws") + illegalChar + "name";
-      // Add it
+
+#ifndef NDEBUG
+      // In debug mode, illegal workspace names throw exceptions.
       std::string errorMsg =
           std::string("Expected ADS to throw with illegal character ") + illegalChar + " in workspace name.";
       if (replace) {
@@ -550,10 +548,19 @@ private:
       } else {
         TSM_ASSERT_THROWS(errorMsg, addOrReplaceToADS(name), const std::invalid_argument &);
       }
-      bool stored = ads.doesExist(name);
-      TS_ASSERT_EQUALS(stored, false);
-      if (stored)
-        ads.remove(name); // Clear up if the test fails so that it dones't impact on others.
+      TS_ASSERT(!ads.doesExist(name));
+#else
+      // In release mode, a warning is printed but no exception is thrown.
+      std::string errorMsg =
+          std::string("Expected ADS not to throw with illegal character ") + illegalChar + " in workspace name.";
+      if (replace) {
+        TSM_ASSERT_THROWS_NOTHING(errorMsg, addToADS(name));
+      } else {
+        TSM_ASSERT_THROWS_NOTHING(errorMsg, addOrReplaceToADS(name));
+      }
+      TS_ASSERT(ads.doesExist(name));
+#endif
+      ads.remove(name); // Clear up if the test fails so that it dones't impact on others.
     }
   }
 

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -532,7 +532,6 @@ private:
   /// If replace=true then usea addOrReplace
   void doAddingOnInvalidNameTests(bool replace) {
     const std::string illegalChars = " +-/*\\%<>&|^~=!@()[]{},:.`$'\"?";
-    const size_t nchars(illegalChars.size());
     const std::string allowed("WsName");
 
     for (const char &illegalChar : illegalChars) {

--- a/Framework/API/test/WorkspacePropertyTest.h
+++ b/Framework/API/test/WorkspacePropertyTest.h
@@ -122,11 +122,15 @@ public:
     // valid
     TS_ASSERT_EQUALS(wsp2->setValue("ws2"), "");
     TS_ASSERT_EQUALS(wsp2->isValid(), "");
-    // Setting an invalid name should make wsp6 invalid
+
+    // Setting an invalid name should make wsp6 invalid but currently only in debug mode.
     std::string invalidWorkspaceName = "ws6-1";
-    std::string error =
+    std::string error = "";
+#ifndef NDEBUG
+    error =
         "Invalid object name '" + invalidWorkspaceName +
         "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
+#endif
     TS_ASSERT_EQUALS(wsp6->setValue(invalidWorkspaceName), error);
     TS_ASSERT_EQUALS(wsp6->isValid(), error);
 
@@ -351,17 +355,19 @@ public:
   void test_trimmming_off() {
     Workspace_sptr ws = WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
     std::string wsNameWithWhitespace = "  space1\t\n";
-    AnalysisDataService::Instance().add("space1", ws);
+    AnalysisDataService::Instance().add(wsNameWithWhitespace, ws);
     WorkspaceProperty<Workspace> p("workspace1", "", Direction::Input);
     // turn trimming off
     p.setAutoTrim(false);
 
-    std::string expectedError =
+    std::string expectedError = "";
+#ifndef NDEBUG
+    expectedError =
         "Invalid object name '" + wsNameWithWhitespace +
         "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
-
-    // setValue() should return an error string if illegal workspace name is provided.
-    TS_ASSERT_EQUALS(p.setValue(wsNameWithWhitespace), "expectedError");
+#endif
+    // setValue() should return an error string in debug mode if illegal workspace name is provided.
+    TS_ASSERT_EQUALS(p.setValue(wsNameWithWhitespace), expectedError);
 
     AnalysisDataService::Instance().clear();
   }

--- a/Framework/API/test/WorkspacePropertyTest.h
+++ b/Framework/API/test/WorkspacePropertyTest.h
@@ -339,21 +339,29 @@ public:
     TS_ASSERT_EQUALS(p1.value(), "");
   }
 
-  void test_trimmming() {
-    // trimming on
-    Workspace_sptr ws1 = WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
-    AnalysisDataService::Instance().add("space1", ws1);
-    WorkspaceProperty<Workspace> p1("workspace1", "", Direction::Input);
-    p1.setValue("  space1\t\n");
-    TS_ASSERT_EQUALS(p1.value(), "space1");
+  void test_trimmming_on() {
+    Workspace_sptr ws = WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
+    AnalysisDataService::Instance().add("space1", ws);
+    WorkspaceProperty<Workspace> p("workspace1", "", Direction::Input);
+    p.setValue("  space1\t\n");
+    TS_ASSERT_EQUALS(p.value(), "space1");
+    AnalysisDataService::Instance().clear();
+  }
 
+  void test_trimmming_off() {
+    Workspace_sptr ws = WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
+    std::string wsNameWithWhitespace = "  space1\t\n";
+    AnalysisDataService::Instance().add("space1", ws);
+    WorkspaceProperty<Workspace> p("workspace1", "", Direction::Input);
     // turn trimming off
-    Workspace_sptr ws2 = WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
-    AnalysisDataService::Instance().add("  space1\t\n", ws2);
-    WorkspaceProperty<Workspace> p2("workspace1", "", Direction::Input);
-    p2.setAutoTrim(false);
-    p2.setValue("  space1\t\n");
-    TS_ASSERT_EQUALS(p2.value(), "  space1\t\n");
+    p.setAutoTrim(false);
+
+    std::string expectedError =
+        "Invalid object name '" + wsNameWithWhitespace +
+        "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
+
+    // setValue() should return an error string if illegal workspace name is provided.
+    TS_ASSERT_EQUALS(p.setValue(wsNameWithWhitespace), "expectedError");
 
     AnalysisDataService::Instance().clear();
   }

--- a/Framework/API/test/WorkspacePropertyTest.h
+++ b/Framework/API/test/WorkspacePropertyTest.h
@@ -123,14 +123,12 @@ public:
     TS_ASSERT_EQUALS(wsp2->setValue("ws2"), "");
     TS_ASSERT_EQUALS(wsp2->isValid(), "");
     // Setting an invalid name should make wsp6 invalid
-    const std::string illegalChars = " +-/*\\%<>&|^~=!@()[]{},:.`$'\"?";
-    AnalysisDataService::Instance().setIllegalCharacterList(illegalChars);
-    std::string error = "Invalid object name 'ws6-1'. Names cannot contain any "
-                        "of the following characters: " +
-                        illegalChars;
-    TS_ASSERT_EQUALS(wsp6->setValue("ws6-1"), error);
+    std::string invalidWorkspaceName = "ws6-1";
+    std::string error =
+        "Invalid object name '" + invalidWorkspaceName +
+        "'. Names must start with a letter or underscore and contain only alpha-numeric characters and underscores.";
+    TS_ASSERT_EQUALS(wsp6->setValue(invalidWorkspaceName), error);
     TS_ASSERT_EQUALS(wsp6->isValid(), error);
-    AnalysisDataService::Instance().setIllegalCharacterList("");
 
     // The other three need the input workspace to exist in the ADS
     Workspace_sptr space;

--- a/docs/source/release/v6.14.0/Framework/Data_Objects/New_features/39488.rst
+++ b/docs/source/release/v6.14.0/Framework/Data_Objects/New_features/39488.rst
@@ -1,0 +1,5 @@
+- Workspace names that do not conform to python variable naming conventions
+  (must start with letter or underscore, and contain only letters, digits and underscores)
+  will invoke a warning message.
+  In a future version of mantid, invalid workspace names will cause an exception to be raised.
+  Please update your scripts to use valid Python identifiers for workspace names.


### PR DESCRIPTION
### Description of work
A warning message is displayed whenever a workspace is created with a name that doesn't conformt Python variable naming conventions. This will allow us to move to enforcing this standard in the future.

In debug mode, an exception is raised. This will help avoid any new instances of bad workspace names entering the codebase.

### To test:
1. In debug mode, try loading some data using the UI with something invalid in the name field, e.g. with a space in or starting with a number. It should not allow you to load.
2. In release mode, try the same. It should work, but with a warning message in the log. The warning message should appear only once per operation.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
