### PR TITLE
Dgsplanner updates

### DIFF
--- a/docs/source/release/v6.14.0/Direct_Geometry/General/Bugfixes/dgsplanner.rst
+++ b/docs/source/release/v6.14.0/Direct_Geometry/General/Bugfixes/dgsplanner.rst
@@ -1,0 +1,2 @@
+- Minor bug fix to increase the speed of masking in DGSPlanner
+- DGSPlanner will now warn if the crystallographic convention is used


### PR DESCRIPTION
### Description of work
The following issues are addressed in this PR:

1. If crystallographic convention is used, it prints it as a title to the plot
2. Masking an empty instrument with a workspace2d from real data (without monitors) causes MaskDetectors to be slow


**Report to:** Matt Stone


### To test:

Start Mantid. Use a processed vanadium file (say from SEQUOIA) as a mask file. Just click plot. The main branch is extremely slow, this one is less than 1 second. Change the Q convention to "Crytallography" in settings. A title should show up in the plot, warning about the change

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
