### PR TITLE
Increase the external data timeout duration

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -40,14 +40,16 @@ mark_as_advanced(ExternalData_URL_TEMPLATES)
 # places on local disk
 list(APPEND ExternalData_URL_TEMPLATES "file:///home/builder/MantidExternalData-readonly/%(algo)/%(hash)")
 list(APPEND ExternalData_URL_TEMPLATES "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)")
-# facility based mirrors list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") #
-# RAL list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL This should
-# always be last as it's the main read/write cache
+# facility based mirrors
+list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") # RAL
+list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL
+# This should always be last as it's the main read/write cache
 list(APPEND ExternalData_URL_TEMPLATES "https://testdata.mantidproject.org/ftp/external-data/%(algo)/%(hash)")
 
 # Increase network timeout defaults to avoid our slow server connection but don't override what a user provides
 if(NOT ExternalData_TIMEOUT_INACTIVITY)
-  set(ExternalData_TIMEOUT_INACTIVITY 120)
+  # Temporary increase the timeout duration to resolve an issue with the packaging pipeline
+  set(ExternalData_TIMEOUT_INACTIVITY 1200)
 endif()
 if(NOT ExternalData_TIMEOUT_ABSOLUTE)
   set(ExternalData_TIMEOUT_ABSOLUTE 1200)

--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -40,10 +40,9 @@ mark_as_advanced(ExternalData_URL_TEMPLATES)
 # places on local disk
 list(APPEND ExternalData_URL_TEMPLATES "file:///home/builder/MantidExternalData-readonly/%(algo)/%(hash)")
 list(APPEND ExternalData_URL_TEMPLATES "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)")
-# facility based mirrors
-list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") # RAL
-list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL
-# This should always be last as it's the main read/write cache
+# facility based mirrors list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") #
+# RAL list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL This should
+# always be last as it's the main read/write cache
 list(APPEND ExternalData_URL_TEMPLATES "https://testdata.mantidproject.org/ftp/external-data/%(algo)/%(hash)")
 
 # Increase network timeout defaults to avoid our slow server connection but don't override what a user provides


### PR DESCRIPTION
### Description of work
This PR increases the timeout duration of the external data fetching to resolve failures in the conda packaging pipeline. The error log was:
```
[10:07](https://mantid.slack.com/archives/C0383JFJEKH/p1757408861861609)
[1/1304] Generating /jenkins_workdir/workspace/pull_requests-conda-packaging/conda-bld/mantiddocs_1757080678716/work/build/ExternalData/Testing/Data/UnitTest/Al_LoadPhonopy_atomic_displacements_data_0.txt
15:02:11 FAILED: [code=139] ExternalData/Testing/Data/UnitTest/Al_LoadPhonopy_atomic_displacements_data_0.txt-hash-stamp ExternalData/Testing/Data/UnitTest/Al_LoadPhonopy_atomic_displacements_data_0.txt /jenkins_workdir/workspace/pull_requests-conda-packaging/conda-bld/mantiddocs_1757080678716/work/build/ExternalData/Testing/Data/UnitTest/Al_LoadPhonopy_atomic_displacements_data_0.txt-hash-stamp /jenkins_workdir/workspace/pull_requests-conda-packaging/conda-bld/mantiddocs_1757080678716/work/build/ExternalData/Testing/Data/UnitTest/Al_LoadPhonopy_atomic_displacements_data_0.txt
```
An invistgation issue is raised here: #39916


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Make sure the CI tests pass
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
