### PR TITLE
Added a chopper to PyChop

### DIFF
--- a/docs/source/release/v6.14.0/Direct_Geometry/General/New_features/pychop.rst
+++ b/docs/source/release/v6.14.0/Direct_Geometry/General/New_features/pychop.rst
@@ -1,0 +1,1 @@
+- Extended PyChop calculations by adding a chopper for SEQUOIA spectrometer.

--- a/scripts/pychop/sequoia.yaml
+++ b/scripts/pychop/sequoia.yaml
@@ -49,6 +49,15 @@ chopper_system:
           tjit: 0.0             # Jitter time (us)
           fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
           isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+        SEQ-1000-1.5-AST:
+          name: SEQUOIA 1000 meV Fine resolution
+          pslit: 1.524           # Neutron transparent slit width (mm)
+          pslat: 0.356           # Neutron absorbing slat width (mm)
+          radius: 50.0          # Chopper package radius (mm)
+          rho: 1834.5           # Chopper package curvature (mm)
+          tjit: 0.0             # Jitter time (us)
+          fluxcorr: 3.0         # (Empirical/Fudge) factor to scale calculated flux by
+          isPi: False           # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
         ARCS-100-1.5-AST:
           name: ARCS 100 meV Sloppy
           pslit: 1.52           # Neutron transparent slit width (mm)


### PR DESCRIPTION
### Description of work

Added a new chopper to PyChop
**Report to:** Matt Stone

### To test:

Run pychop by going to Interfaces->Direct->PyChop. Select SEQUOIA instrument. When compared to SEQ700, the new chopper has better resolution but lower flux.

<img width="1902" height="1278" alt="Screenshot from 2025-09-05 17-06-58" src="https://github.com/user-attachments/assets/f239ab01-df90-45b1-8ba0-7fdc39388f0e" />
<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->

