### PR TITLE
Increase the external data timeout duration

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -48,7 +48,8 @@ list(APPEND ExternalData_URL_TEMPLATES "https://testdata.mantidproject.org/ftp/e
 
 # Increase network timeout defaults to avoid our slow server connection but don't override what a user provides
 if(NOT ExternalData_TIMEOUT_INACTIVITY)
-  set(ExternalData_TIMEOUT_INACTIVITY 120)
+  # Temporary increase the timeout duration to resolve an issue with the packaging pipeline
+  set(ExternalData_TIMEOUT_INACTIVITY 1200)
 endif()
 if(NOT ExternalData_TIMEOUT_ABSOLUTE)
   set(ExternalData_TIMEOUT_ABSOLUTE 1200)


### PR DESCRIPTION
This pulls #39911 into `ornl-next`