### PR TITLE
Fix coverity defects on HeliumAnalyserEffTime algorithm

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiencyTime.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiencyTime.cpp
@@ -227,7 +227,8 @@ std::vector<MatrixWorkspace_sptr> HeliumAnalyserEfficiencyTime::calculateOutputs
     }
   }
 
-  const auto outputVec = std::vector({efficiency, efficiencyErrors, unpolTransmission, unpolTransmissionErrors});
+  const auto outputVec = std::vector({std::move(efficiency), std::move(efficiencyErrors), std::move(unpolTransmission),
+                                      std::move(unpolTransmissionErrors)});
   std::vector<MatrixWorkspace_sptr> wsOut;
   for (size_t index = 0; index < outputVec.size(); index += 2) {
     if (outputVec.at(index).size() > 0) {
@@ -265,7 +266,7 @@ std::pair<double, double> HeliumAnalyserEfficiencyTime::getTimeDifference() {
   } else {
     // Here we can only take the time stamp of the input workspace from the table
     const auto colTimeStamps = table->getColumn(COLUMN_STAMPS);
-    const auto expTimeStamp = colTimeStamps->cell<std::string>(indexRow);
+    const auto &expTimeStamp = colTimeStamps->cell<std::string>(indexRow);
     const auto duration = Types::Core::DateAndTime(expTimeStamp) - Types::Core::DateAndTime(refTimeStamp);
     tHours = static_cast<double>(duration.total_seconds() / 3600);
   }


### PR DESCRIPTION
### Description of work

On HeliumAnalyserEfficiencyTime.cpp:
- In line 269: use const auto reference to avoid copying the string. 
- In line 230-231: Use std::move with the output workspace in the initializer list of the output vector.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->



<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- CI passes everything. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

_Release notes are not necessary_

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
