### PR TITLE
Fix crash in PolarizationEfficiencyCor algorithm for wrong input

### DIFF
--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -227,6 +227,9 @@ void PolarizationEfficiencyCor::checkWorkspaces() const {
     throw std::invalid_argument("Input workspaces must be given either as a "
                                 "workspace group or a list of names.");
   }
+
+  if (!isDefault(Prop::INPUT_WORKSPACES) && isDefault(Prop::INPUT_WORKSPACE_GROUP)) {
+  }
 }
 
 //----------------------------------------------------------------------------------------------
@@ -269,6 +272,14 @@ std::vector<std::string> PolarizationEfficiencyCor::getWorkspaceNameList() const
   std::vector<std::string> wsNames;
   if (!isDefault(Prop::INPUT_WORKSPACES)) {
     wsNames = getProperty(Prop::INPUT_WORKSPACES);
+    const auto wsVec = AnalysisDataService::Instance().retrieveWorkspaces(wsNames);
+    if (std::any_of(wsNames.cbegin(), wsNames.cend(), [](const auto &wsName) {
+          return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName) == nullptr;
+        })) {
+      throw std::invalid_argument(
+          "Only Matrix Workspaces can be added in InputWorkspace property list. If the input is a group, "
+          "use the InputWorkspaceGroup property");
+    }
   } else {
     WorkspaceGroup_sptr group = getProperty(Prop::INPUT_WORKSPACE_GROUP);
     auto const n = group->size();

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -227,9 +227,6 @@ void PolarizationEfficiencyCor::checkWorkspaces() const {
     throw std::invalid_argument("Input workspaces must be given either as a "
                                 "workspace group or a list of names.");
   }
-
-  if (!isDefault(Prop::INPUT_WORKSPACES) && isDefault(Prop::INPUT_WORKSPACE_GROUP)) {
-  }
 }
 
 //----------------------------------------------------------------------------------------------
@@ -272,7 +269,6 @@ std::vector<std::string> PolarizationEfficiencyCor::getWorkspaceNameList() const
   std::vector<std::string> wsNames;
   if (!isDefault(Prop::INPUT_WORKSPACES)) {
     wsNames = getProperty(Prop::INPUT_WORKSPACES);
-    const auto wsVec = AnalysisDataService::Instance().retrieveWorkspaces(wsNames);
     if (std::any_of(wsNames.cbegin(), wsNames.cend(), [](const auto &wsName) {
           return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName) == nullptr;
         })) {

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -95,6 +95,15 @@ public:
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
+
+  void test_input_ws_wildes_list_with_group_throws_error() {
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
+    (void)createWorkspaceGroup(4);
+    alg->setProperty("InputWorkspaces", "WS_GROUP_1");
+    // Error: InputWorkspaces property does not accept groups
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
+  }
+
   void test_input_ws_frederikze_needs_group() {
     auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));

--- a/docs/source/release/v6.14.0/SANS/Bugfixes/39832.rst
+++ b/docs/source/release/v6.14.0/SANS/Bugfixes/39832.rst
@@ -1,0 +1,1 @@
+- Algorithm :ref:`algm-PolarizationEfficiencyCor` no longer crashes Mantid when using workspace groups in the ``InputWorkspaces`` property list.


### PR DESCRIPTION
### Description of work
Details in issue #39832 
<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39832. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Build the branch and check that this script throws an error but doesn't crash Mantid ( while in the nightly does):

```
from mantid.simpleapi import *

names = []
for i in range(4):
    names.append(f'group_{i}')
    CreateWorkspace(DataX=np.linspace(0,5,6), DataY=[1]*5, OutputWorkspace=names[-1],Distribution=False, UnitX='Wavelength')
group = GroupWorkspaces(names)
ws=names[-1]
efficiencies= JoinISISPolarizationEfficiencies(F1=ws,F2=ws,P1=ws,P2=ws)
PolarizationEfficiencyCor(InputWorkspaces='group', OutputWorkspace='corr', Efficiencies=efficiencies)
```
_Added release notes_

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
