### PR TITLE
AlignAndFocusPowderSlim selective sample log loading

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -51,4 +51,28 @@ private:
   std::vector<int64_t> loadSize;
   std::vector<std::pair<size_t, size_t>> pulse_indices;
 };
+
+// these properties are public to simplify testing - do not make them public
+namespace PropertyNames {
+const std::string FILENAME("Filename");
+const std::string CAL_FILE("CalFileName");
+const std::string FILTER_TIMESTART("FilterByTimeStart");
+const std::string FILTER_TIMESTOP("FilterByTimeStop");
+const std::string SPLITTER_WS("SplitterWorkspace");
+const std::string SPLITTER_RELATIVE("RelativeTime");
+const std::string SPLITTER_TARGET("SplitterTarget");
+const std::string FILTER_BAD_PULSES("FilterBadPulses");
+const std::string FILTER_BAD_PULSES_LOWER_CUTOFF("BadPulsesLowerCutoff");
+const std::string X_MIN("XMin");
+const std::string X_MAX("XMax");
+const std::string X_DELTA("XDelta");
+const std::string BIN_UNITS("BinningUnits");
+const std::string BINMODE("BinningMode");
+const std::string OUTPUT_WKSP("OutputWorkspace");
+const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
+const std::string EVENTS_PER_THREAD("EventsPerThread");
+const std::string ALLOW_LOGS("LogAllowList");
+const std::string BLOCK_LOGS("LogBlockList");
+} // namespace PropertyNames
+
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -52,7 +52,7 @@ private:
   std::vector<std::pair<size_t, size_t>> pulse_indices;
 };
 
-// these properties are public to simplify testing - do not make them public
+// these properties are public to simplify testing and calling from other code
 namespace PropertyNames {
 const std::string FILENAME("Filename");
 const std::string CAL_FILE("CalFileName");

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -35,6 +35,7 @@
 #include <H5Cpp.h>
 #include <numbers>
 #include <regex>
+#include <vector>
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 using Mantid::API::FileProperty;
@@ -70,6 +71,8 @@ const std::string BINMODE("BinningMode");
 const std::string OUTPUT_WKSP("OutputWorkspace");
 const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
 const std::string EVENTS_PER_THREAD("EventsPerThread");
+const std::string ALLOW_LOGS("LogAllowList");
+const std::string BLOCK_LOGS("LogBlockList");
 } // namespace PropertyNames
 
 const std::string LOG_CHARGE_NAME("proton_charge");
@@ -194,6 +197,10 @@ void AlignAndFocusPowderSlim::init() {
                   "The units of the input X min, max and delta values. Output will always be TOF");
   declareProperty(std::make_unique<EnumeratedStringProperty<BinningMode, &binningModeNames>>(PropertyNames::BINMODE),
                   "Specify binning behavior ('Logarithmic')");
+  declareProperty(std::make_unique<ArrayProperty<std::string>>(PropertyNames::ALLOW_LOGS),
+                  "If specified, only these logs will be loaded from the file");
+  declareProperty(std::make_unique<ArrayProperty<std::string>>(PropertyNames::BLOCK_LOGS),
+                  "If specified, these logs will not be loaded from the file");
   declareProperty(
       std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(PropertyNames::OUTPUT_WKSP, "", Direction::Output),
       "An output workspace.");
@@ -225,6 +232,7 @@ std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {
     errors[PropertyNames::EVENTS_PER_THREAD] = msg;
   }
 
+  // validate binning information is consistent with each other
   const std::vector<double> xmins = getProperty(PropertyNames::X_MIN);
   const std::vector<double> xmaxs = getProperty(PropertyNames::X_MAX);
   const std::vector<double> deltas = getProperty(PropertyNames::X_DELTA);
@@ -243,6 +251,12 @@ std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {
 
   if (!(numMax == 1 || numMax == NUM_HIST))
     errors[PropertyNames::X_MAX] = "Must have 1 or 6 values";
+
+  // only specify allow or block list for logs
+  if ((!isDefault(PropertyNames::ALLOW_LOGS)) && (!isDefault(PropertyNames::BLOCK_LOGS))) {
+    errors[PropertyNames::ALLOW_LOGS] = "Cannot specify both allow and block lists";
+    errors[PropertyNames::BLOCK_LOGS] = "Cannot specify both allow and block lists";
+  }
 
   return errors;
 }
@@ -320,8 +334,11 @@ void AlignAndFocusPowderSlim::exec() {
   // load logs
   this->progress(.12, "Loading logs");
   auto periodLog = std::make_unique<const TimeSeriesProperty<int>>("period_log"); // not used
+  const std::vector<std::string> &allow_logs = getProperty(PropertyNames::ALLOW_LOGS);
+  const std::vector<std::string> &block_logs = getProperty(PropertyNames::BLOCK_LOGS);
   int nPeriods{1};
-  LoadEventNexus::runLoadNexusLogs<MatrixWorkspace_sptr>(filename, wksp, *this, false, nPeriods, periodLog);
+  LoadEventNexus::runLoadNexusLogs<MatrixWorkspace_sptr>(filename, wksp, *this, false, nPeriods, periodLog, allow_logs,
+                                                         block_logs);
 
   // determine the pulse indices from the time and splitter workspace
   this->progress(.15, "Determining pulse indices");

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -53,27 +53,6 @@ using Mantid::Kernel::TimeROI;
 using Mantid::Kernel::TimeSeriesProperty;
 
 namespace { // anonymous namespace
-namespace PropertyNames {
-const std::string FILENAME("Filename");
-const std::string CAL_FILE("CalFileName");
-const std::string FILTER_TIMESTART("FilterByTimeStart");
-const std::string FILTER_TIMESTOP("FilterByTimeStop");
-const std::string SPLITTER_WS("SplitterWorkspace");
-const std::string SPLITTER_RELATIVE("RelativeTime");
-const std::string SPLITTER_TARGET("SplitterTarget");
-const std::string FILTER_BAD_PULSES("FilterBadPulses");
-const std::string FILTER_BAD_PULSES_LOWER_CUTOFF("BadPulsesLowerCutoff");
-const std::string X_MIN("XMin");
-const std::string X_MAX("XMax");
-const std::string X_DELTA("XDelta");
-const std::string BIN_UNITS("BinningUnits");
-const std::string BINMODE("BinningMode");
-const std::string OUTPUT_WKSP("OutputWorkspace");
-const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
-const std::string EVENTS_PER_THREAD("EventsPerThread");
-const std::string ALLOW_LOGS("LogAllowList");
-const std::string BLOCK_LOGS("LogBlockList");
-} // namespace PropertyNames
 
 const std::string LOG_CHARGE_NAME("proton_charge");
 

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -45,6 +45,9 @@ public:
                                      TableWorkspace_sptr tablesplitter = nullptr, const bool relativeTime = false,
                                      const int splitterTarget = -1, const bool filterBadPulses = false,
                                      const std::string blockLogList = "") {
+    // simplify setting property names
+    using namespace Mantid::DataHandling::AlignAndFocusPowderSlim::PropertyNames;
+
     const std::string wksp_name("VULCAN");
 
     std::cout << "==================> " << filename << '\n';
@@ -54,30 +57,30 @@ public:
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", filename));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", wksp_name));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("BinningMode", binning));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BinningUnits", binningUnits));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(FILENAME, filename));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(OUTPUT_WKSP, wksp_name));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(BINMODE, binning));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(BIN_UNITS, binningUnits));
     if (!xmin.empty())
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmin));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(X_MIN, xmin));
     if (!xmax.empty())
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmax));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(X_MAX, xmax));
     if (!xdelta.empty())
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("XDelta", xdelta));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(X_DELTA, xdelta));
     if (!blockLogList.empty())
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogBlockList", blockLogList));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(BLOCK_LOGS, blockLogList));
     if (timeMin > 0.)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStart", timeMin));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(FILTER_TIMESTART, timeMin));
     if (timeMax > 0.)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterByTimeStop", timeMax));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(FILTER_TIMESTOP, timeMax));
     if (tablesplitter != nullptr) {
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("SplitterWorkspace", tablesplitter));
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("RelativeTime", relativeTime));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_WS, tablesplitter));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_RELATIVE, relativeTime));
     }
     if (splitterTarget >= 0)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("SplitterTarget", splitterTarget));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_TARGET, splitterTarget));
     if (filterBadPulses) {
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("FilterBadPulses", filterBadPulses));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(FILTER_BAD_PULSES, filterBadPulses));
     }
 
     if (should_throw) {
@@ -89,7 +92,7 @@ public:
     TS_ASSERT(alg.isExecuted());
     std::cout << "==================> " << timer << '\n';
 
-    MatrixWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr outputWS = alg.getProperty(OUTPUT_WKSP);
     TS_ASSERT(outputWS);
     return outputWS;
   }

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39934.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39934.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` can skip loading particular logs using the (mutually exclisive) ``LogAllowList`` and ``LogBlockList`` properties


### PR DESCRIPTION
To follow behavior from [AlignAndFocusPowderFromFiles](https://docs.mantidproject.org/nightly/algorithms/AlignAndFocusPowderFromFiles-v1.html), this adds the mutually exclusive ``LogAllowList`` and ``LogBlockList`` parameters. Fortunately, the underlying code for loading logs already had an entrypoint for the feature.

Separately, the unit test was refactored to make the settings for an individual run of the algorithm much clearer. The `TestConfig` object was introduced rather than an increasing list of options to a function.

There is no associated issue, but this is for [EWM12971](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12971).

### To test:

Use an existing VULCAN file and supply the `LogBlockList` property to skip `*skf*` logs. In the "view sample logs" those logs should be missing.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
