### PR TITLE
Fix Plot legend defect for workspaces starting with _

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -240,7 +240,17 @@ def plot(axes, workspace, *args, **kwargs):
     roi = kwargs.pop("roi", np.zeros(0, dtype=bool))
     if roi.size > 0:
         axes.fill_between(x, min(y), max(y), where=roi, color="grey", alpha=0.5)
-    return axes.plot(x, y, *args, **kwargs)
+    p = axes.plot(x, y, *args, **kwargs)
+
+    # set artist label for workspace
+    for artist in p:
+        # matplotlib does not display legends starting with _
+        # so we add a hidden character to the start U+206A
+        hiddenChar = "⁪"
+        if workspace.name().startswith("_"):
+            artist.set_label(hiddenChar + workspace.name())
+
+    return p
 
 
 def errorbar(axes, workspace, *args, **kwargs):

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1743,4 +1743,9 @@ class _WorkspaceArtists(object):
         for artist in self._artists:
             old_workspace_name = self.workspace_name
             prev_label = artist.get_label()
+            if new_workspace_name.startswith("_"):
+                # matplotlib does not display legends starting with _
+                # so we add a hidden character to the start U+206A
+                hiddenChar = "⁪"
+                new_workspace_name = hiddenChar + new_workspace_name
             artist.set_label(re.sub(rf"\b{old_workspace_name}\b", new_workspace_name, prev_label))

--- a/docs/source/release/v6.14.0/Workbench/Bugfixes/39953.rst
+++ b/docs/source/release/v6.14.0/Workbench/Bugfixes/39953.rst
@@ -1,0 +1,1 @@
+- Fixed workspaces starting with "_" not populating the legend of plots.


### PR DESCRIPTION


### Description of work

This pr just adds a hidden character to the start of legends for workspaces that start with "_" because matplot currently hides those.

Before:
<img width="653" height="484" alt="ClipboardImage_20250820103555(1)" src="https://github.com/user-attachments/assets/f2ed8b50-aa37-4cd7-99de-92c12e2c0d61" />
After:
<img width="629" height="563" alt="image" src="https://github.com/user-attachments/assets/c33c53ff-7df4-4209-a237-128fe9fb28b7" />
(please ignore the difference in plot data, one was from the reported issue, the second is my test case)


### To test:

Run the following script in workbench:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

CreateWorkspace(OutputWorkspace="test", DataX=[0,1,2], DataY=[1, 1])
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot(mtd['test'], 'go-', specNum=1)
ax.legend()
fig.show()
hiddenChar="⁪"
RenameWorkspace(InputWorkspace="test", OutputWorkspace="⁪__test")
```
Without this change the legend will be an unpopulated square, with the changes it will look as if the `_` workspaces are treated like any other.

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
