### PR TITLE
Update nbins in PoldiAutoCorrelation doc test

### DIFF
--- a/docs/source/algorithms/PoldiAutoCorrelation-v6.rst
+++ b/docs/source/algorithms/PoldiAutoCorrelation-v6.rst
@@ -78,7 +78,7 @@ Output:
 .. testoutput:: POLDI_silicon_autocorr
 
     The workspace contains 448 spectra.
-    The correlation spectrum has 2460 bins.
+    The correlation spectrum has 2833 bins.
 
 References
 ----------


### PR DESCRIPTION
### Description of work

Doc test was failing
```
document: algorithms/PoldiAutoCorrelation-v6
--------------------------------------------
# stuff...
Expected:
    The workspace contains 448 spectra.
    The correlation spectrum has 2460 bins.
Got:
    The workspace contains 448 spectra.
    The correlation spectrum has 2833 bins.
**********************************************************************
1 items had failures:
   1 of   1 in POLDI_silicon_autocorr
1 tests in 1 items.
0 passed and 1 failed.
***Test Failed*** 1 failures.
```

This is after a bug was fixed in max arrival time calculation in PR #39912 in commit 704e68a1d53a8b71a95a013978b96c7d933cb027
The value now matches the unit test value.

### To test:

(1) Run doc tests locally

No release note required as not user facing change

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
