### PR TITLE
Add ability to turn off some of the local repository mirrors

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -19,6 +19,18 @@ if(NOT MANTID_DATA_STORE)
   message(FATAL_ERROR "MANTID_DATA_STORE not set. It is required for external data")
 endif()
 
+# add options for selecting which data mirrors to use
+set(_data_store_mirror_options all ral ornl none)
+set(DATA_STORE_MIRROR
+    all
+    CACHE STRING "Local data mirror to enable"
+)
+set_property(CACHE DATA_STORE_MIRROR PROPERTY STRINGS ${_data_store_mirror_options})
+list(FIND _data_store_mirror_options ${DATA_STORE_MIRROR} index)
+if(index EQUAL -1)
+  message(FATAL_ERROR "DATA_STORE_MIRROR must be one of ${_data_store_mirror_options}")
+endif()
+
 # Tell ExternalData module about selected object stores.
 list(APPEND ExternalData_OBJECT_STORES
      # Store selected by Mantid-specific configuration above.
@@ -41,9 +53,17 @@ mark_as_advanced(ExternalData_URL_TEMPLATES)
 list(APPEND ExternalData_URL_TEMPLATES "file:///home/builder/MantidExternalData-readonly/%(algo)/%(hash)")
 list(APPEND ExternalData_URL_TEMPLATES "file:///Users/mantidbuilder/MantidExternalData/%(algo)/%(hash)") # macOS
 list(APPEND ExternalData_URL_TEMPLATES "file:///mantid_data/%(algo)/%(hash)") # ISIS Linux
+
 # facility based mirrors
-list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") # RAL
-list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL
+if((${DATA_STORE_MIRROR} STREQUAL all) OR (${DATA_STORE_MIRROR} STREQUAL ral))
+  message(STATUS "Adding ral data mirror")
+  list(APPEND ExternalData_URL_TEMPLATES "http://130.246.80.136/external-data/%(algo)/%(hash)") # RAL
+endif()
+if((${DATA_STORE_MIRROR} STREQUAL all) OR (${DATA_STORE_MIRROR} STREQUAL ornl))
+  message(STATUS "Adding ornl data mirror")
+  list(APPEND ExternalData_URL_TEMPLATES "https://mantid-cache.sns.gov/testdata/%(algo)/%(hash)") # ORNL
+endif()
+
 # This should always be last as it's the main read/write cache
 list(APPEND ExternalData_URL_TEMPLATES "https://testdata.mantidproject.org/ftp/external-data/%(algo)/%(hash)")
 

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -25,6 +25,7 @@ ENABLE_SYSTEM_TESTS=$7
 ENABLE_DOC_TESTS=$8
 ENABLE_COVERITY=$9
 EXTRA_CMAKE_FLAGS=${10}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Only pass MANTID_DATA_STORE to CMake if present in the environment otherwise rely on CMake default
 if [[ -n "${MANTID_DATA_STORE}" ]]; then
@@ -40,7 +41,9 @@ if [[ ${JOB_NAME} == *pull_requests* ]]; then
 fi
 
 # Run CMake using preset and variables
-cmake --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $WORKSPACE
+cmake --preset=${CMAKE_PRESET} \
+      ${MANTID_DATA_STORE_CMAKE} -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors") \
+      ${EXTRA_CMAKE_FLAGS} $WORKSPACE
 
 # Run the actual builds for the code, unit tests, and system tests.
 cd $WORKSPACE/build

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -26,6 +26,7 @@ ENABLE_DOC_TESTS=$8
 ENABLE_COVERITY=$9
 EXTRA_CMAKE_FLAGS=${10}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_MIRROR="$("${SCRIPT_DIR}/../data_mirrors")"
 
 # Only pass MANTID_DATA_STORE to CMake if present in the environment otherwise rely on CMake default
 if [[ -n "${MANTID_DATA_STORE}" ]]; then
@@ -42,7 +43,7 @@ fi
 
 # Run CMake using preset and variables
 cmake --preset=${CMAKE_PRESET} \
-      ${MANTID_DATA_STORE_CMAKE} -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors") \
+      ${MANTID_DATA_STORE_CMAKE} -DDATA_STORE_MIRROR=${DATA_MIRROR} \
       ${EXTRA_CMAKE_FLAGS} $WORKSPACE
 
 # Run the actual builds for the code, unit tests, and system tests.

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -7,6 +7,7 @@ DOCS_GIT_REPOSITORY=https://github.com/mantidproject/docs-nightly
 GIT_USER_NAME=mantid-builder
 GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_MIRROR="$("${SCRIPT_DIR}/data_mirrors")"
 
 # source util functions
 . source/buildconfig/Jenkins/Conda/mamba-utils
@@ -23,7 +24,7 @@ mkdir build && cd build
 LD_PRELOAD="" \
 # Generate build files
 cmake -G Ninja \
-  -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors")
+  -DDATA_STORE_MIRROR=${DATA_MIRROR} \
   -DMANTID_FRAMEWORK_LIB=SYSTEM \
   -DMANTID_QT_LIB=SYSTEM \
   -DENABLE_WORKBENCH=OFF \

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -6,6 +6,7 @@ CONDA_LABEL=mantid/label/nightly
 DOCS_GIT_REPOSITORY=https://github.com/mantidproject/docs-nightly
 GIT_USER_NAME=mantid-builder
 GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # source util functions
 . source/buildconfig/Jenkins/Conda/mamba-utils
@@ -22,6 +23,7 @@ mkdir build && cd build
 LD_PRELOAD="" \
 # Generate build files
 cmake -G Ninja \
+  -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors")
   -DMANTID_FRAMEWORK_LIB=SYSTEM \
   -DMANTID_QT_LIB=SYSTEM \
   -DENABLE_WORKBENCH=OFF \

--- a/buildconfig/Jenkins/data_mirrors
+++ b/buildconfig/Jenkins/data_mirrors
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# inspects the JENKINS_AGENT_NAME environment variable to decide which data mirrors to enable using the DATA_STORE_MIRROR property in cmake. This returns
+# ral - when agent starts with isis
+# ornl - when agent starts with ornl
+# all - for any other case, including the variable not existing
+case "${JENKINS_AGENT_NAME}" in
+    ornl*)
+	echo "ornl"
+    ;;
+    isis*)
+	echo "ral"
+    ;;
+    *)
+	echo "all"
+    ;;
+esac

--- a/buildconfig/Jenkins/performancetests
+++ b/buildconfig/Jenkins/performancetests
@@ -12,6 +12,7 @@ if [[ $CLEAN_DB == true ]]; then
   rm -f $DB_FILENAME
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Clean buld if required
 BUILD_DIR=$WORKSPACE/build
 
@@ -35,7 +36,7 @@ touch $userconfig_dir/Mantid.user.properties
 
 # TODO: Remove -DENABLE_WORKBENCH=FALSE when the perfomance test machine has Qt5
 cd $BUILD_DIR
-cmake -G 'Ninja' -DCMAKE_BUILD_TYPE=Release -DTESTING_TIMEOUT=600 -DCXXTEST_ADD_PERFORMANCE=TRUE -DENABLE_WORKBENCH=FALSE $WORKSPACE
+cmake -G 'Ninja' -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors") -DCMAKE_BUILD_TYPE=Release -DTESTING_TIMEOUT=600 -DCXXTEST_ADD_PERFORMANCE=TRUE -DENABLE_WORKBENCH=FALSE $WORKSPACE
 ninja -j$BUILD_THREADS
 ninja -j$BUILD_THREADS AllTests
 

--- a/buildconfig/Jenkins/performancetests
+++ b/buildconfig/Jenkins/performancetests
@@ -13,6 +13,7 @@ if [[ $CLEAN_DB == true ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_MIRROR="$("${SCRIPT_DIR}/data_mirrors")"
 # Clean buld if required
 BUILD_DIR=$WORKSPACE/build
 
@@ -36,7 +37,7 @@ touch $userconfig_dir/Mantid.user.properties
 
 # TODO: Remove -DENABLE_WORKBENCH=FALSE when the perfomance test machine has Qt5
 cd $BUILD_DIR
-cmake -G 'Ninja' -DDATA_STORE_MIRROR=$("${SCRIPT_DIR}/data_mirrors") -DCMAKE_BUILD_TYPE=Release -DTESTING_TIMEOUT=600 -DCXXTEST_ADD_PERFORMANCE=TRUE -DENABLE_WORKBENCH=FALSE $WORKSPACE
+cmake -G 'Ninja' -DDATA_STORE_MIRROR=${DATA_MIRROR} -DCMAKE_BUILD_TYPE=Release -DTESTING_TIMEOUT=600 -DCXXTEST_ADD_PERFORMANCE=TRUE -DENABLE_WORKBENCH=FALSE $WORKSPACE
 ninja -j$BUILD_THREADS
 ninja -j$BUILD_THREADS AllTests
 

--- a/dev-docs/source/DataFilesForTesting.rst
+++ b/dev-docs/source/DataFilesForTesting.rst
@@ -194,6 +194,11 @@ it is recommended that it be placed on a disk with a large amount of
 space. CMake uses the ``MANTID_DATA_STORE`` variable to define where the
 data is stored.
 
+The data itself can be downloaded from a local mirror as well to decrease build times.
+This is controlled by the ``DATA_STORE_MIRROR`` variable which can be "all" (default), "none", "ornl", or "ral".
+The variable will insert additional data mirrors that facilities have created.
+If the data is not found in a local mirror, it will be downloaded from the central data repository.
+
 Example cmake command:
 ----------------------
 

--- a/docs/source/release/v6.15.0/Framework/Dependencies/New_features/39957.rst
+++ b/docs/source/release/v6.15.0/Framework/Dependencies/New_features/39957.rst
@@ -1,0 +1,1 @@
+- Add the ability to select mirrors for test data in builds using the ``DATA_STORE_MIRROR`` cmake variable. See :doc:`data files for testing <mantid-dev:DataFilesForTesting>`


### PR DESCRIPTION
Rather than relying on network and such to fail quickly from servers that cannot be seen, add options to only include selected local mirrors. Since this happens at the cmake configuration stage, only the desired mirrors will be added to the list to search. The new mechanism defaults to using all mirrors.

Nothing was changed in buildscripts because it requires a mechanism to determine which build server is being used.

There is no associated issue, but it is associated with [EWM13274](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13274)

### To test:

Try the various options `all`, `none`, `ornl`, and `ral` and look for the cmake message about which mirrors are used. One can also search the `CMakeCache.txt` for the value of `ExternalData_URL`.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
