### PR TITLE
Removed boost optional in FallbackBoostOptionallO.h

### DIFF
--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
@@ -4,7 +4,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <boost/optional.hpp>
 #include <optional>
 #include <ostream>
 
@@ -21,11 +20,4 @@ inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<Ch
   return (os << "std::optional @ " << reinterpret_cast<const void *>(&value));
 }
 
-/// Simple prints the address of the optional object - this can be removed once boost::optional is converted to
-/// std::optional
-template <class CharType, class CharTrait, class OptionalValueType>
-inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &os,
-                                                           boost::optional<OptionalValueType> const &value) {
-  return (os << "boost::optional @ " << reinterpret_cast<const void *>(&value));
-}
 } // namespace boost


### PR DESCRIPTION
This is a version of #39619 into `ornl-next`