### PR TITLE
Cleanup load tasks and use of shared pointers

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -57,8 +57,7 @@ private:
   DefaultEventLoader &m_loader;
   /// NXS address to bank
   std::string entry_name;
-  /// Vector where (index = pixel ID+pixelID_to_wi_offset), value = workspace
-  /// index)
+  /// Vector where (index = pixel ID+pixelID_to_wi_offset), value = workspace index)
   const std::vector<size_t> &pixelID_to_wi_vector;
   /// Offset in the pixelID_to_wi_vector to use.
   detid_t pixelID_to_wi_offset;

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -41,11 +41,11 @@ public:
    * @param max_event_id :: maximum detector ID to load
    */
   ProcessBankData(DefaultEventLoader &loader, const std::string &entry_name, API::Progress *prog,
-                  std::shared_ptr<std::vector<uint32_t>> event_id,
-                  std::shared_ptr<std::vector<float>> event_time_of_flight, size_t numEvents, size_t startAt,
-                  std::shared_ptr<std::vector<uint64_t>> event_index,
-                  std::shared_ptr<BankPulseTimes> thisBankPulseTimes, bool have_weight,
-                  std::shared_ptr<std::vector<float>> event_weight, detid_t min_event_id, detid_t max_event_id);
+                  std::shared_ptr<std::vector<uint32_t>> const &event_id,
+                  std::shared_ptr<std::vector<float>> const &event_time_of_flight, size_t numEvents, size_t startAt,
+                  std::shared_ptr<std::vector<uint64_t>> const &event_index,
+                  std::shared_ptr<BankPulseTimes> const &thisBankPulseTimes, bool have_weight,
+                  std::shared_ptr<std::vector<float>> const &event_weight, detid_t min_event_id, detid_t max_event_id);
 
   void run() override;
 
@@ -64,21 +64,21 @@ private:
   /// Progress reporting
   API::Progress *prog;
   /// event pixel ID array
-  const std::shared_ptr<std::vector<uint32_t>> event_detid;
+  std::shared_ptr<std::vector<uint32_t> const> event_detid;
   /// event TOF array
-  const std::shared_ptr<std::vector<float>> event_time_of_flight;
+  std::shared_ptr<std::vector<float> const> event_time_of_flight;
   /// # of events in arrays
   size_t numEvents;
   /// index of the first event from event_index
   size_t startAt;
   /// vector of event index (length of # of pulses)
-  const std::shared_ptr<std::vector<uint64_t>> event_index;
+  std::shared_ptr<std::vector<uint64_t> const> event_index;
   /// Pulse times for this bank
-  const std::shared_ptr<BankPulseTimes> thisBankPulseTimes;
+  std::shared_ptr<BankPulseTimes const> thisBankPulseTimes;
   /// Flag for simulated data
   bool have_weight;
   /// event weights array
-  const std::shared_ptr<std::vector<float>> event_weight;
+  std::shared_ptr<std::vector<float> const> event_weight;
   /// Minimum pixel id (inclusive)
   detid_t m_min_detid;
   /// Maximum pixel id (inclusive)

--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -69,7 +69,7 @@ public:
   };
 
   // ----------------------------------------- pulse indexer class start
-  PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, const std::size_t firstEventIndex,
+  PulseIndexer(std::shared_ptr<std::vector<uint64_t> const> const &event_index, const std::size_t firstEventIndex,
                const std::size_t numEvents, const std::string &entry_name, const std::vector<size_t> &pulse_roi);
 
   /// Which element in the event_index array is the first one to use
@@ -104,7 +104,7 @@ private:
   bool includedPulse(const size_t pulseIndex) const;
 
   /// vector of indices (length of # of pulses) into the event arrays
-  const std::shared_ptr<std::vector<uint64_t>> m_event_index;
+  const std::shared_ptr<std::vector<uint64_t> const> m_event_index;
 
   /**
    * How far into the array of events the tof/detid are already. This is used when data is read in chunks.

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -59,9 +59,8 @@ LoadBankFromDiskTask::LoadBankFromDiskTask(DefaultEventLoader &loader, std::stri
   m_max_id = 0;
 }
 
-/** Load the pulse times, if needed. This sets
- * thisBankPulseTimes to the right pointer.
- * */
+/** Load the pulse times, if needed. This sets thisBankPulseTimes to the right pointer.
+ */
 void LoadBankFromDiskTask::loadPulseTimes(Nexus::File &file) {
   try {
     // First, get info about the event_time_zero field in this bank
@@ -102,8 +101,7 @@ void LoadBankFromDiskTask::loadPulseTimes(Nexus::File &file) {
 }
 
 /** Load the event_index field
- * (a list of size of # of pulses giving the index in the event list for that
-    pulse)
+ * (a list of size of # of pulses giving the index in the event list for that pulse)
  * @param file :: File handle for the NeXus file
  */
 std::unique_ptr<std::vector<uint64_t>> LoadBankFromDiskTask::loadEventIndex(Nexus::File &file) {

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -317,10 +317,10 @@ void LoadBankFromDiskTask::run() {
   prog->report(entry_name + ": load from disk");
 
   // arrays to load into
-  std::unique_ptr<std::vector<uint32_t>> event_id;
-  std::unique_ptr<std::vector<float>> event_time_of_flight;
-  std::unique_ptr<std::vector<float>> event_weight;
-  std::unique_ptr<std::vector<uint64_t>> event_index;
+  std::shared_ptr<std::vector<uint32_t>> event_id;
+  std::shared_ptr<std::vector<float>> event_time_of_flight;
+  std::shared_ptr<std::vector<float>> event_weight;
+  std::shared_ptr<std::vector<uint64_t>> event_index;
 
   // Open the file
   Nexus::File file(m_loader.alg->m_filename);
@@ -458,17 +458,11 @@ void LoadBankFromDiskTask::run() {
   const auto numEvents = static_cast<size_t>(m_loadSize[0]);
   const auto startAt = static_cast<size_t>(m_loadStart[0]);
 
-  // convert things to shared_arrays to share between tasks
-  std::shared_ptr<std::vector<uint32_t>> event_id_shrd(std::move(event_id));
-  std::shared_ptr<std::vector<float>> event_time_of_flight_shrd(std::move(event_time_of_flight));
-  std::shared_ptr<std::vector<float>> event_weight_shrd(std::move(event_weight));
-  std::shared_ptr<std::vector<uint64_t>> event_index_shrd(std::move(event_index));
-
-  if ((m_loader.alg->compressEvents) && (!event_weight_shrd) && (m_loader.alg->compressTolerance != 0)) {
+  if ((m_loader.alg->compressEvents) && (!event_weight) && (m_loader.alg->compressTolerance != 0)) {
     // this method is for unweighted events that the user wants compressed on load
 
     // TODO should this be created elsewhere?
-    const auto [tof_min, tof_max] = Mantid::Kernel::parallel_minmax(event_time_of_flight_shrd);
+    const auto [tof_min, tof_max] = Mantid::Kernel::parallel_minmax(event_time_of_flight);
 
     const bool log_compression = (m_loader.alg->compressTolerance < 0);
 
@@ -512,25 +506,25 @@ void LoadBankFromDiskTask::run() {
 
     // create the tasks
     std::shared_ptr<Task> newTask1 = std::make_shared<ProcessBankCompressed>(
-        m_loader, entry_name, prog, event_id_shrd, event_time_of_flight_shrd, startAt, event_index_shrd,
-        thisBankPulseTimes, m_min_id, mid_id, histogram_bin_edges, m_loader.alg->compressTolerance);
+        m_loader, entry_name, prog, event_id, event_time_of_flight, startAt, event_index, thisBankPulseTimes, m_min_id,
+        mid_id, histogram_bin_edges, m_loader.alg->compressTolerance);
     scheduler.push(newTask1);
     if (m_loader.splitProcessing && (mid_id < m_max_id)) {
       std::shared_ptr<Task> newTask2 = std::make_shared<ProcessBankCompressed>(
-          m_loader, entry_name, prog, event_id_shrd, event_time_of_flight_shrd, startAt, event_index_shrd,
-          thisBankPulseTimes, (mid_id + 1), m_max_id, histogram_bin_edges, m_loader.alg->compressTolerance);
+          m_loader, entry_name, prog, event_id, event_time_of_flight, startAt, event_index, thisBankPulseTimes,
+          (mid_id + 1), m_max_id, histogram_bin_edges, m_loader.alg->compressTolerance);
       scheduler.push(newTask2);
     }
   } else {
     // create all events using traditional method
     std::shared_ptr<Task> newTask1 = std::make_shared<ProcessBankData>(
-        m_loader, entry_name, prog, event_id_shrd, event_time_of_flight_shrd, numEvents, startAt, event_index_shrd,
-        thisBankPulseTimes, m_have_weight, event_weight_shrd, m_min_id, mid_id);
+        m_loader, entry_name, prog, event_id, event_time_of_flight, numEvents, startAt, event_index, thisBankPulseTimes,
+        m_have_weight, event_weight, m_min_id, mid_id);
     scheduler.push(newTask1);
     if (m_loader.splitProcessing && (mid_id < m_max_id)) {
       std::shared_ptr<Task> newTask2 = std::make_shared<ProcessBankData>(
-          m_loader, entry_name, prog, event_id_shrd, event_time_of_flight_shrd, numEvents, startAt, event_index_shrd,
-          thisBankPulseTimes, m_have_weight, event_weight_shrd, (mid_id + 1), m_max_id);
+          m_loader, entry_name, prog, event_id, event_time_of_flight, numEvents, startAt, event_index,
+          thisBankPulseTimes, m_have_weight, event_weight, (mid_id + 1), m_max_id);
       scheduler.push(newTask2);
     }
   }
@@ -539,6 +533,7 @@ void LoadBankFromDiskTask::run() {
   if (m_loader.alg->getLogger().isDebug())
     m_loader.alg->getLogger().debug() << "Time to LoadBankFromDisk " << entry_name << " " << timer << "\n";
 #endif
+  thisBankPulseTimes.reset();
 }
 
 /**

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -51,8 +51,7 @@ void ProcessBankData::preCountAndReserveMem() {
       counts[thisId - m_min_detid]++;
   }
 
-  // Now we pre-allocate (reserve) the vectors of events in each pixel
-  // counted
+  // Now we pre-allocate (reserve) the vectors of events in each pixel counted
   auto &outputWS = m_loader.m_ws;
   const auto *alg = m_loader.alg;
   const size_t numEventLists = outputWS.getNumberHistograms();

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -17,18 +17,17 @@ using namespace Mantid::DataObjects;
 namespace Mantid::DataHandling {
 
 ProcessBankData::ProcessBankData(DefaultEventLoader &m_loader, const std::string &entry_name, API::Progress *prog,
-                                 std::shared_ptr<std::vector<uint32_t>> event_id,
-                                 std::shared_ptr<std::vector<float>> event_time_of_flight, size_t numEvents,
-                                 size_t startAt, std::shared_ptr<std::vector<uint64_t>> event_index,
-                                 std::shared_ptr<BankPulseTimes> thisBankPulseTimes, bool have_weight,
-                                 std::shared_ptr<std::vector<float>> event_weight, detid_t min_event_id,
+                                 std::shared_ptr<std::vector<uint32_t>> const &event_id,
+                                 std::shared_ptr<std::vector<float>> const &event_time_of_flight, size_t numEvents,
+                                 size_t startAt, std::shared_ptr<std::vector<uint64_t>> const &event_index,
+                                 std::shared_ptr<BankPulseTimes> const &thisBankPulseTimes, bool have_weight,
+                                 std::shared_ptr<std::vector<float>> const &event_weight, detid_t min_event_id,
                                  detid_t max_event_id)
     : Task(), m_loader(m_loader), entry_name(std::move(entry_name)),
       pixelID_to_wi_vector(m_loader.pixelID_to_wi_vector), pixelID_to_wi_offset(m_loader.pixelID_to_wi_offset),
-      prog(prog), event_detid(std::move(event_id)), event_time_of_flight(std::move(event_time_of_flight)),
-      numEvents(numEvents), startAt(startAt), event_index(std::move(event_index)),
-      thisBankPulseTimes(std::move(thisBankPulseTimes)), have_weight(have_weight),
-      event_weight(std::move(event_weight)), m_min_detid(min_event_id), m_max_detid(max_event_id) {
+      prog(prog), event_detid(event_id), event_time_of_flight(event_time_of_flight), numEvents(numEvents),
+      startAt(startAt), event_index(event_index), thisBankPulseTimes(thisBankPulseTimes), have_weight(have_weight),
+      event_weight(event_weight), m_min_detid(min_event_id), m_max_detid(max_event_id) {
   // Cost is approximately proportional to the number of events to process.
   m_cost = static_cast<double>(numEvents);
 
@@ -234,6 +233,11 @@ void ProcessBankData::run() {
   if (alg->getLogger().isDebug())
     alg->getLogger().debug() << "Time to ProcessBankData " << entry_name << " " << timer << "\n";
 #endif
+  event_detid.reset();
+  event_time_of_flight.reset();
+  event_index.reset();
+  event_weight.reset();
+  thisBankPulseTimes.reset();
 } // END-OF-RUN()
 
 /**

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -18,16 +18,16 @@ namespace Mantid::DataHandling {
 
 ProcessBankData::ProcessBankData(DefaultEventLoader &m_loader, const std::string &entry_name, API::Progress *prog,
                                  std::shared_ptr<std::vector<uint32_t>> const &event_id,
-                                 std::shared_ptr<std::vector<float>> const &event_time_of_flight, size_t numEvents,
-                                 size_t startAt, std::shared_ptr<std::vector<uint64_t>> const &event_index,
+                                 std::shared_ptr<std::vector<float>> const &tevent_time_of_flight, size_t numEvents,
+                                 size_t startAt, std::shared_ptr<std::vector<uint64_t>> const &tevent_index,
                                  std::shared_ptr<BankPulseTimes> const &thisBankPulseTimes, bool have_weight,
-                                 std::shared_ptr<std::vector<float>> const &event_weight, detid_t min_event_id,
+                                 std::shared_ptr<std::vector<float>> const &tevent_weight, detid_t min_event_id,
                                  detid_t max_event_id)
     : Task(), m_loader(m_loader), entry_name(std::move(entry_name)),
       pixelID_to_wi_vector(m_loader.pixelID_to_wi_vector), pixelID_to_wi_offset(m_loader.pixelID_to_wi_offset),
-      prog(prog), event_detid(event_id), event_time_of_flight(event_time_of_flight), numEvents(numEvents),
-      startAt(startAt), event_index(event_index), thisBankPulseTimes(thisBankPulseTimes), have_weight(have_weight),
-      event_weight(event_weight), m_min_detid(min_event_id), m_max_detid(max_event_id) {
+      prog(prog), event_detid(event_id), event_time_of_flight(tevent_time_of_flight), numEvents(numEvents),
+      startAt(startAt), event_index(tevent_index), thisBankPulseTimes(thisBankPulseTimes), have_weight(have_weight),
+      event_weight(tevent_weight), m_min_detid(min_event_id), m_max_detid(max_event_id) {
   // Cost is approximately proportional to the number of events to process.
   m_cost = static_cast<double>(numEvents);
 

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -11,9 +11,9 @@
 #include <utility>
 
 namespace Mantid::DataHandling {
-PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, const std::size_t firstEventIndex,
-                           const std::size_t numEvents, const std::string &entry_name,
-                           const std::vector<size_t> &pulse_roi)
+PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t> const> const &event_index,
+                           const std::size_t firstEventIndex, const std::size_t numEvents,
+                           const std::string &entry_name, const std::vector<size_t> &pulse_roi)
     : m_event_index(std::move(event_index)), m_firstEventIndex(firstEventIndex), m_numEvents(numEvents),
       m_roi_complex(false), m_entry_name(entry_name) {
   // cache the number of pulses


### PR DESCRIPTION
### Description of work

In an attempt at some possible speedups or memory efficiencies, this plays around with the use of pointers inside the tasks used in `LoadEventNexus`.

### To test:

A script to use for benchmark testing is posted in the comments below.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
