### PR TITLE
Output merged S(Q)-1 before the Fourier filter has been applied to the PDF in POLARIS reduction

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -13,6 +13,7 @@ import mantid.simpleapi as mantid
 from mantid import config
 
 from isis_powder import Polaris, SampleDetails
+from mantid.api import AnalysisDataService
 
 DIRS = config["datasearch.directories"].split(";")
 
@@ -462,6 +463,7 @@ class TotalScatteringMergedRebinTest(systemtesting.MantidSystemTest):
         # to be updated very frequently. In the meantime, the rebin test will be done by testing the histogram size in
         # a truncated WS
         self.assertAlmostEqual(self.pdf_output.dataX(0).size, 255, places=3)
+        self.assertTrue(AnalysisDataService.retrieve("merged S(Q)-1") is not None)
 
 
 class TotalScatteringPdfTypeTest(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -463,7 +463,7 @@ class TotalScatteringMergedRebinTest(systemtesting.MantidSystemTest):
         # to be updated very frequently. In the meantime, the rebin test will be done by testing the histogram size in
         # a truncated WS
         self.assertAlmostEqual(self.pdf_output.dataX(0).size, 255, places=3)
-        self.assertTrue(AnalysisDataService.retrieve("merged S(Q)-1") is not None)
+        self.assertTrue(AnalysisDataService.doesExist("merged_S_of_Q_minus_one"))
 
 
 class TotalScatteringPdfTypeTest(systemtesting.MantidSystemTest):

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39902.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39902.rst
@@ -1,0 +1,1 @@
+- In Polaris reduction, output `Merged S(Q)-1` workspace before applying Fourier filter to the PDF. To differntiate this from resultant workspace after applying the Fourier filter and reverse transformed, the corresponding workspace was renamed from `*_merged_Q` to `*_merged_Q_r-FT`.

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39902.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39902.rst
@@ -1,1 +1,1 @@
-- In Polaris reduction, output `Merged S(Q)-1` workspace before applying Fourier filter to the PDF. To differntiate this from resultant workspace after applying the Fourier filter and reverse transformed, the corresponding workspace was renamed from `*_merged_Q` to `*_merged_Q_r-FT`.
+- In Polaris reduction, output `merged_S_of_Q_minus_one` workspace before applying Fourier filter to the PDF. To differntiate this from resultant workspace after applying the Fourier filter and reverse transformed, the corresponding workspace was renamed from `*_merged_Q` to `*_merged_Q_r_FT`.

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -118,7 +118,9 @@ def generate_ts_pdf(
     if merge_banks:
         q_min, q_max = _load_qlims(q_lims)
         merged_ws = mantid.MatchAndMergeWorkspaces(InputWorkspaces=focused_ws, XMin=q_min, XMax=q_max, CalculateScale=False)
-        mantid.CloneWorkspace(InputWorkspace=merged_ws, OutputWorkspace="merged S(Q)-1")  # merged S(Q)-1 before applying Fourier filter
+        mantid.CloneWorkspace(
+            InputWorkspace=merged_ws, OutputWorkspace="merged_S_of_Q_minus_one"
+        )  # merged S(Q)-1 before applying Fourier filter
         fast_fourier_filter(merged_ws, rho0=sample_details.material_object.number_density, freq_params=freq_params)
         pdf_output = mantid.PDFFourierTransform(
             Inputworkspace="merged_ws",
@@ -144,7 +146,7 @@ def generate_ts_pdf(
         common.remove_intermediate_workspace("self_scattering_correction")
     # Rename output ws
     if "merged_ws" in locals():
-        mantid.RenameWorkspace(InputWorkspace="merged_ws", OutputWorkspace=run_number + "_merged_Q_r-FT")
+        mantid.RenameWorkspace(InputWorkspace="merged_ws", OutputWorkspace=run_number + "_merged_Q_r_FT")
 
     mantid.RenameWorkspace(InputWorkspace="focused_ws", OutputWorkspace=run_number + "_focused_Q")
     if isinstance(focused_ws, WorkspaceGroup):

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -118,6 +118,7 @@ def generate_ts_pdf(
     if merge_banks:
         q_min, q_max = _load_qlims(q_lims)
         merged_ws = mantid.MatchAndMergeWorkspaces(InputWorkspaces=focused_ws, XMin=q_min, XMax=q_max, CalculateScale=False)
+        mantid.CloneWorkspace(InputWorkspace=merged_ws, OutputWorkspace="merged S(Q)-1")  # merged S(Q)-1 before applying Fourier filter
         fast_fourier_filter(merged_ws, rho0=sample_details.material_object.number_density, freq_params=freq_params)
         pdf_output = mantid.PDFFourierTransform(
             Inputworkspace="merged_ws",
@@ -143,7 +144,7 @@ def generate_ts_pdf(
         common.remove_intermediate_workspace("self_scattering_correction")
     # Rename output ws
     if "merged_ws" in locals():
-        mantid.RenameWorkspace(InputWorkspace="merged_ws", OutputWorkspace=run_number + "_merged_Q")
+        mantid.RenameWorkspace(InputWorkspace="merged_ws", OutputWorkspace=run_number + "_merged_Q_r-FT")
 
     mantid.RenameWorkspace(InputWorkspace="focused_ws", OutputWorkspace=run_number + "_focused_Q")
     if isinstance(focused_ws, WorkspaceGroup):


### PR DESCRIPTION
### Description of work
POLARIS find it useful to look at the `merged S(Q)-1` before the Fourier filter has been applied to the PDF and then reversed transformed and hence output that workspace.

To differentiate it from the merged S(Q)-1 after the Fourier filter has been applied to the PDF and reversed transformed (which is already created), the corresponding workspace was renamed from `*_merged_Q` to `*_merged_Q_r-FT`

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39902. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

 1. code review
 2. `ISIS_PowderPolarisTest` system tests should pass.
 
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
