### PR TITLE
Add additional cropping options for Polaris total scattering reduction

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -422,7 +422,7 @@ class TotalScatteringMergedPerDetTest(systemtesting.MantidSystemTest):
         # Load Focused ws
         mantid.LoadNexus(Filename=total_scattering_input_file_per_det, OutputWorkspace="98533-ResultTOF")
         q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
-        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, per_detector=True)
+        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, per_detector_vanadium=True)
 
     def validate(self):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
@@ -575,7 +575,7 @@ class TotalScatteringTestRLimits(systemtesting.MantidSystemTest):
 
 
 def run_total_scattering(run_number, merge_banks, **kwargs):
-    default_kwargs = {"pdf_type": "G(r)", "lorch_filter": True, "per_detector": False}
+    default_kwargs = {"pdf_type": "G(r)", "lorch_filter": True, "per_detector_vanadium": False}
     kwargs = {**default_kwargs, **kwargs}  # overwrite defaults with kwargs passed
     pdf_inst_obj = setup_inst_object(mode="PDF")
     return pdf_inst_obj.create_total_scattering_pdf(run_number=run_number, merge_banks=merge_banks, **kwargs)

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -574,35 +574,11 @@ class TotalScatteringTestRLimits(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(self.pdf_output.dataX(0)[-1], self.r_lims[-1], delta=2e-2)
 
 
-def run_total_scattering(
-    run_number,
-    merge_banks,
-    q_lims=None,
-    delta_q=None,
-    delta_r=None,
-    pdf_type="G(r)",
-    freq_params=None,
-    lorch_filter=True,
-    per_detector=False,
-    pdf_output_name=None,
-    wavelength_lims=None,
-    r_lims=None,
-):
+def run_total_scattering(run_number, merge_banks, **kwargs):
+    default_kwargs = {"pdf_type": "G(r)", "lorch_filter": True, "per_detector": False}
+    kwargs = {**default_kwargs, **kwargs}  # overwrite defaults with kwargs passed
     pdf_inst_obj = setup_inst_object(mode="PDF")
-    return pdf_inst_obj.create_total_scattering_pdf(
-        run_number=run_number,
-        merge_banks=merge_banks,
-        q_lims=q_lims,
-        delta_q=delta_q,
-        delta_r=delta_r,
-        pdf_type=pdf_type,
-        lorch_filter=lorch_filter,
-        freq_params=freq_params,
-        per_detector_vanadium=per_detector,
-        pdf_output_name=pdf_output_name,
-        wavelength_lims=wavelength_lims,
-        r_lims=r_lims,
-    )
+    return pdf_inst_obj.create_total_scattering_pdf(run_number=run_number, merge_banks=merge_banks, **kwargs)
 
 
 def _gen_required_files():

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -538,6 +538,23 @@ class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 8.7571, places=3)
 
 
+class TotalScatteringTestWavelengthLimits(systemtesting.MantidSystemTest):
+    pdf_output = None
+
+    def runTest(self):
+        setup_mantid_paths()
+        # Load Focused ws
+        mantid.LoadNexus(Filename=total_scattering_input_file, OutputWorkspace="98533-ResultTOF")
+        q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
+        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, lorch_filter=False, wavelength_lims=[1, 6])
+
+    def validate(self):
+        # Whilst total scattering is in development, the validation will avoid using reference files as they will have
+        # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.85 Angstrom will be checked.
+        idx = get_bin_number_at_given_r(self.pdf_output.dataX(0), 3.85)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 4.10094, places=3)  # less than in TotalScatteringLorchFilterTest
+
+
 def run_total_scattering(
     run_number,
     merge_banks,
@@ -549,6 +566,7 @@ def run_total_scattering(
     lorch_filter=True,
     per_detector=False,
     pdf_output_name=None,
+    wavelength_lims=None,
 ):
     pdf_inst_obj = setup_inst_object(mode="PDF")
     return pdf_inst_obj.create_total_scattering_pdf(
@@ -562,6 +580,7 @@ def run_total_scattering(
         freq_params=freq_params,
         per_detector_vanadium=per_detector,
         pdf_output_name=pdf_output_name,
+        wavelength_lims=wavelength_lims,
     )
 
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -555,6 +555,25 @@ class TotalScatteringTestWavelengthLimits(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 4.10094, places=3)  # less than in TotalScatteringLorchFilterTest
 
 
+class TotalScatteringTestRLimits(systemtesting.MantidSystemTest):
+    pdf_output = None
+    r_lims = [None, 10]
+
+    def runTest(self):
+        setup_mantid_paths()
+        # Load Focused ws
+        mantid.LoadNexus(Filename=total_scattering_input_file, OutputWorkspace="98533-ResultTOF")
+        q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
+        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, lorch_filter=False, r_lims=self.r_lims)
+
+    def validate(self):
+        # Whilst total scattering is in development, the validation will avoid using reference files as they will have
+        # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.85 Angstrom will be checked.
+        idx = get_bin_number_at_given_r(self.pdf_output.dataX(0), 3.85)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 8.7571, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataX(0)[-1], self.r_lims[-1], delta=2e-2)
+
+
 def run_total_scattering(
     run_number,
     merge_banks,
@@ -567,6 +586,7 @@ def run_total_scattering(
     per_detector=False,
     pdf_output_name=None,
     wavelength_lims=None,
+    r_lims=None,
 ):
     pdf_inst_obj = setup_inst_object(mode="PDF")
     return pdf_inst_obj.create_total_scattering_pdf(
@@ -581,6 +601,7 @@ def run_total_scattering(
         per_detector_vanadium=per_detector,
         pdf_output_name=pdf_output_name,
         wavelength_lims=wavelength_lims,
+        r_lims=r_lims,
     )
 
 

--- a/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39973.rst
+++ b/docs/source/release/v6.14.0/Diffraction/Powder/New_features/39973.rst
@@ -1,0 +1,2 @@
+- Add parameter ``wavelength_lims`` to :ref:`Polaris diffraction <isis-powder-diffraction-polaris-ref>`) to crop focussed data by wavelength before calculating the pair distribution function (pdf).
+- Add parameter ``r_lims`` to :ref:`Polaris diffraction <isis-powder-diffraction-polaris-ref>`) to specify min and max r-value in output pdf.

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -224,6 +224,8 @@ The output PDF can be customized with the following parameters:
 - By calling with `placzek_order` the Placzek correction order can be specified, with the option of 1 or 2 (defaults to 1).
 - By calling with `sample_temp` the user can override the sample temperature provided in the logs. It defaults to using values from the logs if available.
 - By calling with `pdf_output_name`, the name of the output PDF will be set to the user-provided name. If not specified, the output will be the run number suffixed with the PDF type.
+- By calling with `wavelength_lims = [min, max]` the focussed data in all banks will be cropped to include only wavelengths between `min `and `max`.
+- By calling with `r_lims=[min, max]` to specify the r-range of the output pdf (corresponds to `RMin and `Rmax` parameters in :ref:`algm-PDFFourierTransform-v2`).
 
 Example
 =======

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -224,8 +224,8 @@ The output PDF can be customized with the following parameters:
 - By calling with `placzek_order` the Placzek correction order can be specified, with the option of 1 or 2 (defaults to 1).
 - By calling with `sample_temp` the user can override the sample temperature provided in the logs. It defaults to using values from the logs if available.
 - By calling with `pdf_output_name`, the name of the output PDF will be set to the user-provided name. If not specified, the output will be the run number suffixed with the PDF type.
-- By calling with `wavelength_lims = [min, max]` the focussed data in all banks will be cropped to include only wavelengths between `min `and `max`.
-- By calling with `r_lims=[min, max]` to specify the r-range of the output pdf (corresponds to `RMin and `Rmax` parameters in :ref:`algm-PDFFourierTransform-v2`).
+- By calling with `wavelength_lims = [min, max]` the focussed data in all banks will be cropped to include only wavelengths between `min` and `max`.
+- By calling with `r_lims=[min, max]` to specify the r-range of the output pdf (corresponds to `RMin` and `Rmax` parameters in :ref:`algm-PDFFourierTransform-v2`).
 
 Example
 =======

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -109,6 +109,7 @@ class Polaris(AbstractInst):
             per_detector=self._inst_settings.per_detector_vanadium,
             debug=self._inst_settings.debug,
             pdf_output_name=self._inst_settings.pdf_output_name,
+            wavelength_lims=self._inst_settings.wavelength_lims,
         )
         return pdf_output
 

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -110,6 +110,7 @@ class Polaris(AbstractInst):
             debug=self._inst_settings.debug,
             pdf_output_name=self._inst_settings.pdf_output_name,
             wavelength_lims=self._inst_settings.wavelength_lims,
+            r_lims=self._inst_settings.r_lims,
         )
         return pdf_output
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -86,6 +86,7 @@ def generate_ts_pdf(
     per_detector=False,
     debug=False,
     pdf_output_name=None,
+    wavelength_lims=None,
 ):
     if sample_details is None:
         raise RuntimeError(
@@ -115,6 +116,12 @@ def generate_ts_pdf(
 
     if delta_q:
         focused_ws = mantid.Rebin(InputWorkspace=focused_ws, Params=delta_q)
+
+    if wavelength_lims is not None:
+        focused_ws = mantid.ConvertUnits(InputWorkspace=focused_ws, Target="Wavelength", EMode="Elastic")
+        focused_ws = mantid.CropWorkspaceRagged(InputWorkspace=focused_ws, XMin=wavelength_lims[0], XMax=wavelength_lims[1])
+        focused_ws = mantid.ConvertUnits(InputWorkspace=focused_ws, Target="MomentumTransfer", EMode="Elastic")
+
     if merge_banks:
         q_min, q_max = _load_qlims(q_lims)
         merged_ws = mantid.MatchAndMergeWorkspaces(InputWorkspaces=focused_ws, XMin=q_min, XMax=q_max, CalculateScale=False)

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -63,5 +63,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="mayers_mult_scat_events", int_name="mayers_mult_scat_events", optional=True),
     ParamMapEntry(ext_name="pdf_output_name", int_name="pdf_output_name", optional=True),
     ParamMapEntry(ext_name="wavelength_lims", int_name="wavelength_lims", optional=True),
+    ParamMapEntry(ext_name="r_lims", int_name="r_lims", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -62,5 +62,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
     ParamMapEntry(ext_name="mayers_mult_scat_events", int_name="mayers_mult_scat_events", optional=True),
     ParamMapEntry(ext_name="pdf_output_name", int_name="pdf_output_name", optional=True),
+    ParamMapEntry(ext_name="wavelength_lims", int_name="wavelength_lims", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #38957

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

(1) Unzip these files somewhere and update the script below with the path. Also update the paths in the file polaris_config_example.yaml [PR34144Files.zip](https://github.com/mantidproject/mantid/files/8968124/PR34144Files.zip)
(2) Run this script without error
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from isis_powder import polaris, SampleDetails


config_file_path = r"C:\Total Scattering\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sam = SampleDetails(height=4.6,radius=0.29855,center=[0,0,0],shape='cylinder')
sam.set_container(radius=0.3175,chemical_formula='V')
sam.set_material(chemical_formula='Pb-Sn-F4',
number_density=0.059, packing_fraction=0.5)
polaris.set_sample_details(sample=sam)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=True, do_absorb_corrections=True, mayers_mult_scat_events=1)
polaris.focus(run_number="98533", input_mode='Summed', do_absorb_corrections=True,multiple_scattering=False,
              do_van_normalisation=True, van_normalisation_method="Absolute",
              keep_raw_workspace=False, mayers_mult_scat_events=1)

q_lim =[[-1, 0.5, 0.5, 0.5, 0.5],[-1, 30, 30, 30, 30]]
polaris.create_total_scattering_pdf(run_number="98533", merge_banks=False, q_lims=q_lim, 
                                    r_lims=[None,20], wavelength_lims=[2,5], pdf_type="g(r)")
```
(3) Check max r of `pdf_g(r)` workspace is 20 Ang
(4) Convert focussed data in `_focussed_Q` workspace to wavelength - and check between wavelength limits

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
