### PR TITLE
Fix for embedded plot warning in inelastic/indirect interfaces

### DIFF
--- a/docs/source/release/v6.14.0/Workbench/Bugfixes/39446.rst
+++ b/docs/source/release/v6.14.0/Workbench/Bugfixes/39446.rst
@@ -1,0 +1,1 @@
+- Python warning for `np.bool` scalars interpreted as index is no longer present when using the MantidPlot widget.

--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -141,7 +141,7 @@ class HorizontalMarker(QObject):
             return False
         if self.x1 is not None and x > self.x1:
             return False
-        return abs(self.get_y_in_pixels() - y_pixels) < MARKER_SENSITIVITY
+        return True if abs(self.get_y_in_pixels() - y_pixels) < MARKER_SENSITIVITY else False
 
     def mouse_move_start(self, x, y):
         """
@@ -319,12 +319,11 @@ class VerticalMarker(QObject):
         :return: True or False.
         """
         x_pixels, _ = self.patch.get_transform().transform((x, y))
-
         if self.y0 is not None and y < self.y0:
             return False
         if self.y1 is not None and y > self.y1:
             return False
-        return abs(self.get_x_in_pixels() - x_pixels) < MARKER_SENSITIVITY
+        return True if abs(self.get_x_in_pixels() - x_pixels) < MARKER_SENSITIVITY else False
 
     def mouse_move_start(self, x, y):
         """
@@ -991,10 +990,7 @@ class SingleMarker(QObject):
 
     def is_above(self, x, y):
         """Check if the cursor is above the marker"""
-        if self.marker.is_above(x, y):
-            return True
-        else:
-            return False
+        return self.marker.is_above(x, y)
 
     def relative(self, value, lower, upper):
         if not lower <= value <= upper:


### PR DESCRIPTION
### Description of work

This issue fixes #39446 warning. 
This bug is quite sneaky. The problem seems to appear when clicking down horizontal or vertical markers of embedded plots (for example the ones in the symmetrise interface).  This in fact tries to determine if the mouse position is above the marker by making a data transform using matplotlib. The returned transformed position and the marker position are compared within a sensitivity margin. This has a np.bool return type.  Now, I don't know how the boost python api takes this np.bool and produces the warning exactly, but that seems to be the problem. I have modified the return type of the function to be just a python native boolean type. In any case is probably better to not have mixed return types in the boost python call from cpp. The warning does not appear anymore. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39446. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- I have tested this in a macos with the latest build (rebased from this morning). 
- Add the line ``warnings.simplefilter("always")`` in line 417 of https://github.com/mantidproject/mantid/blob/94f669e8f395a7a4d582bcfefff99206936459b1/qt/applications/workbench/workbench/app/mainwindow.py#L418 , this makes the warning appear each time the offending method is called and make easier to track the warning origin. 
- Check that the warning does not appear in this branch when clicking down on either the vertical or horizontal markers of the symmetrise interface (or any embedded plot with markers)
<img width="553" height="281" alt="image" src="https://github.com/user-attachments/assets/e270977d-b7d3-4b6c-a748-413b24f30081" />


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
