### PR TITLE
Do not download all data to run system tests

### DIFF
--- a/Testing/SystemTests/scripts/systemtest.bat.in
+++ b/Testing/SystemTests/scripts/systemtest.bat.in
@@ -53,13 +53,9 @@ if "%MULTI_CONFIG_GENERATOR%" == "true" (
 :: Update testing data
 echo Updating testing data...
 if "%MULTI_CONFIG_GENERATOR%" == "true" (
-  cmake --build . --target StandardTestData --config %2
-  if ERRORLEVEL 1 exit /b %ERRORLEVEL%
   cmake --build . --target SystemTestData --config %2
   if ERRORLEVEL 1 exit /b %ERRORLEVEL%
 ) else (
-  cmake --build . --target StandardTestData
-  if ERRORLEVEL 1 exit /b %ERRORLEVEL%
   cmake --build . --target SystemTestData
   if ERRORLEVEL 1 exit /b %ERRORLEVEL%
 )

--- a/Testing/SystemTests/scripts/systemtest.in
+++ b/Testing/SystemTests/scripts/systemtest.in
@@ -73,7 +73,6 @@ if [ $(command -v cmake3) ]; then
 else
     CMAKE_EXE=cmake
 fi
-$CMAKE_EXE --build . $CMAKE_TARGET_ARG -- StandardTestData
 $CMAKE_EXE --build . $CMAKE_TARGET_ARG -- SystemTestData
 
 # Execute

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -108,6 +108,7 @@ endfunction()
 
 # Documentation types
 add_sphinx_build_target(html "sphinx.ext.mathjax")
+add_dependencies(docs-html DocTestData)
 add_sphinx_build_target(doctest "sphinx.ext.mathjax")
 add_dependencies(docs-doctest DocTestData)
 


### PR DESCRIPTION
For developers that haven't already pulled down the unit test data, it is very slow to download the data. Since system tests should only depend on system test data, modify the launch scripts to only build that target.

Also add a dependency that docs-html on DocTestData.

There is no associated issue. Part of [EWM13216](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13216).

This is originally split off from #39154.

### To test:

A proper test is
```sh
ninja clean && ninja
./systemtest
```
but you might be happier just looking through the changeset.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
