### PR TITLE
Add section for missing release notes.

### DIFF
--- a/docs/source/release/v6.14.0/framework.rst
+++ b/docs/source/release/v6.14.0/framework.rst
@@ -55,6 +55,12 @@ Bugfixes
 ############
 .. amalgamate:: Framework/Data_Objects/Bugfixes
 
+Live Data
+---------
+
+New features
+############
+.. amalgamate:: Framework/LiveData/New_features
 
 Python
 ------


### PR DESCRIPTION
### Description of work
A new directory was added at some point for some release notes. The directory wasn't included in the framework index. This adds it so that the release notes are not lost.

### To test:
Build docs and check that the release notes are present. I've done it for you so you don't have to:
<img width="524" height="394" alt="image" src="https://github.com/user-attachments/assets/a58a8846-b51c-458d-971e-22f91fdc34ca" />


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
