### PR TITLE
Fix ZOOM NormaliseByCurrent bug - Ensure period logs are added to monitor workspaces in line with Event workspaces

### DIFF
--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -203,8 +203,10 @@ void LoadNexusMonitors2::exec() {
   // this gets the ids from the "isis_vms_compat" group
   fixUDets(file);
 
-  m_multiPeriodCounts.resize(m_monitor_count);
-  m_multiPeriodBinEdges.resize(m_monitor_count);
+  if (numPeriods > 0) {
+    m_multiPeriodCounts.resize(m_monitor_count);
+    m_multiPeriodBinEdges.resize(m_monitor_count);
+  }
 
   // Nothing to do
   if (0 == m_monitor_count) {
@@ -347,7 +349,7 @@ void LoadNexusMonitors2::exec() {
   // add filename
   m_workspace->mutableRun().addProperty("Filename", m_filename);
 
-  if (!useEventMon) {
+  if ((numPeriods > 0) && (!useEventMon)) {
     splitMutiPeriodHistrogramData(numPeriods);
   } else {
     this->setProperty("OutputWorkspace", m_workspace);
@@ -738,8 +740,12 @@ void LoadNexusMonitors2::readHistoMonitorEntry(Nexus::File &file, size_t ws_inde
   file.getDataCoerce(tof);
   file.closeData();
 
-  m_multiPeriodBinEdges[ws_index] = std::move(tof);
-  m_multiPeriodCounts[ws_index] = std::move(data);
+  if (numPeriods > 0) {
+    m_multiPeriodBinEdges[ws_index] = std::move(tof);
+    m_multiPeriodCounts[ws_index] = std::move(data);
+  } else {
+    m_workspace->setHistogram(ws_index, Histogram(BinEdges(std::move(tof)), Counts(std::move(data))));
+  }
 }
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -498,10 +498,10 @@ void LoadNexusMonitors2::splitMutiPeriodHistrogramData(const size_t numPeriods) 
     monLogCreator.addStatusLog(wsPeriod->mutableRun());
     monLogCreator.addPeriodLogs(static_cast<int>(i + 1), wsPeriod->mutableRun());
 
-    // add to workspace group if multi period and set the output property
     outputWorkspaces.push_back(wsPeriod);
   }
 
+  // set output workspace to either single period ws, or group ws.
   if (outputWorkspaces.size() > 1) {
     WorkspaceGroup_sptr wsGroup(new WorkspaceGroup);
     for (const auto ws : outputWorkspaces) {

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -504,7 +504,7 @@ void LoadNexusMonitors2::splitMutiPeriodHistrogramData(const size_t numPeriods) 
   // set output workspace to either single period ws, or group ws.
   if (outputWorkspaces.size() > 1) {
     WorkspaceGroup_sptr wsGroup(new WorkspaceGroup);
-    for (const auto ws : outputWorkspaces) {
+    for (const auto &ws : outputWorkspaces) {
       wsGroup->addWorkspace(ws);
     }
     this->setProperty("OutputWorkspace", wsGroup);

--- a/docs/source/release/v6.14.0/Framework/Data_Objects/Bugfixes/39831.rst
+++ b/docs/source/release/v6.14.0/Framework/Data_Objects/Bugfixes/39831.rst
@@ -1,0 +1,1 @@
+- When loading monitors with period data (``LoadNexusMonitors2``), period sample logs are now added to the resultant workspace; This is in line with the creation of Event Workspaces. This fixes a bug that occurred when ``NormaliseByCurrent`` was used on the monitor workspace.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

A change was made in https://github.com/mantidproject/mantid/pull/39322 that uses the `current_period` log to calculate the proton charge.

This `current_period` log is added to all event workspaces that have certain logs associated with period data, even if the data only has one period:https://github.com/mantidproject/mantid/blob/583bca96a8f7b721c2efb5a024b0832f0d60d8e5/Framework/DataHandling/src/LoadEventNexus.cpp#L958

When loading monitors into a separate workspace as part of `LoadEventNexus`, `LoadNexusMonitors` in contrast does NOT add this property for workspaces that have only 1 period. This PR changes this so that the function enabling the `splitMutiPeriodHistrogramData` function to operates on all workspaces with periods of >0.

Closes #39831. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run the following user-provided script. Ensure no exception is thrown:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as n


def loadandSum(rnum):

    Load(Filename='//isis/inst$/NDXZOOM/Instrument/data/cycle_22_4/ZOOM000'+str(rnum)+'.nxs', OutputWorkspace='ZOOM000'+str(rnum), LoadMonitors=True)

    NormaliseByCurrent('ZOOM000'+str(rnum),OutputWorkspace='ZOOM000'+str(rnum))

    NormaliseByCurrent('ZOOM000'+str(rnum)+'_monitors',OutputWorkspace='ZOOM000'+str(rnum)+'_monitors')


for i in range(26373,26400,2):

        loadandSum(i)
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
