### PR TITLE
Fix help window for conda installs on Windows

### DIFF
--- a/docs/source/release/v6.14.0/Workbench/Bugfixes/34739.rst
+++ b/docs/source/release/v6.14.0/Workbench/Bugfixes/34739.rst
@@ -1,0 +1,1 @@
+- Opening the help window will no longer cause a crash in Windows conda installs of mantidworkbench.

--- a/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
+++ b/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
@@ -28,7 +28,7 @@ def _patch_qtwebengine_files(prefix: str):
     if src_exe.exists() and not dst_exe.exists():
         shutil.copy2(src_exe, dst_exe)
 
-    # Copy resources directory
+    # Copy the contents of the resources directory
     src_resources = library / "resources"
     for f in src_resources.glob("*"):
         dst = env_root / f.name

--- a/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
+++ b/qt/applications/workbench/workbench/app/mantidworkbench_launch_wrapper.py
@@ -6,10 +6,40 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import os
+from pathlib import Path
+import shutil
 import subprocess
 import sys
 
 from workbench.app.main import main
+
+
+def _patch_qtwebengine_files(prefix: str):
+    """
+    Copy Qt WebEngine executable, resources, locales, and ICU data into the environment
+    root so Qt can find them when launching from a conda environment on Windows.
+    """
+    env_root = Path(prefix)  # Python executable directory
+    library = env_root / "Library"
+
+    # Copy QtWebEngineProcess.exe
+    src_exe = library / "bin" / "QtWebEngineProcess.exe"
+    dst_exe = env_root / "QtWebEngineProcess.exe"
+    if src_exe.exists() and not dst_exe.exists():
+        shutil.copy2(src_exe, dst_exe)
+
+    # Copy resources directory
+    src_resources = library / "resources"
+    for f in src_resources.glob("*"):
+        dst = env_root / f.name
+        if not dst.exists():
+            shutil.copy2(f, dst)
+
+    # Copy locales directory
+    src_locales = library / "translations" / "qtwebengine_locales"
+    dst_locales = env_root / "qtwebengine_locales"
+    if src_locales.exists() and not dst_locales.exists():
+        shutil.copytree(src_locales, dst_locales)
 
 
 def launch(args=None):
@@ -20,9 +50,12 @@ def launch(args=None):
         subprocess.run(command)
     else:
         if sys.platform.startswith("win"):
-            # Windows conda installs require us to set the QT_PLUGIN_PATH variable.
+            # Windows conda installs require us to set the QT_PLUGIN_PATH variable and copy QtWebEngine files
+            # to the root directory of the conda environment.
             if "CONDA_PREFIX" in os.environ:
-                os.environ["QT_PLUGIN_PATH"] = f"{os.environ.get('CONDA_PREFIX')}\\Library\\plugins"
+                prefix = os.environ.get("CONDA_PREFIX")
+                os.environ["QT_PLUGIN_PATH"] = f"{prefix}\\Library\\plugins"
+                _patch_qtwebengine_files(prefix)
         main(args[1:])
 
 


### PR DESCRIPTION
### Description of work
Since the dawn of the `mantidworkbench` conda package, attempting to open the help window in a conda install on Windows would cause the application to crash. This change fixes the issue by ensuring that the files required by Qt WebEngine (such as `QtWebEngineProcess.exe`, `.pak` resource files, and `icudtl.dat`) are placed alongside the conda environment’s `python.exe`, which is where Qt expects them.

Other approaches were tested - including providing `qt.conf` files and setting environment variables for the resources and `QtWebEngineProcess.exe` - but these had no effect. From the observed behavior, the relevant search paths appear to be hard-coded within Qt WebEngine and cannot be overridden by configuration alone.

The fix here is essentially mimicking what we do with the [standalone packaging](https://github.com/mantidproject/mantid/blob/fc33ef8f68b3276f970e12ab3bc1131dc8009853/installers/conda/win/create_package.sh#L128), except in that case the `mantidworkbench.exe` is in a more friendly location from the perspective of Qt WebEngine (inside `<install_root>/bin`, rather than just `<env_root>` as with the conda installation). The fallback search paths appear to be relative to the .exe and are:
- `../qt5/resources`
- `../resources`
- and the `.exe` location iself.

In the standalone install, because the `.exe` is nested inside `bin`, we could move the resources to `../lib/qt5`. However, for the conda installation, that path would take us outside of the conda environment location because the `python.exe` sits in the root of the conda prefix. Taht is why we have to copy the files into the environment prefix.

Closes #34739 


### To test:
1. Install the Windows standalone from this build and ensure that the help window opens as expected:
https://builds.mantidproject.org/job/build_packages_from_branch/1350/
2. Install the mantidworkbench package from conda and ensure that the help window opens as expected (previously would crash):
`mamba install -c mantid/label/windows-help-fix mantidworkbench`

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
