### PR TITLE
Pattern argument to log_to_python( )

### DIFF
--- a/Framework/LiveData/src/ADARA/ADARAParser.cpp
+++ b/Framework/LiveData/src/ADARA/ADARAParser.cpp
@@ -63,7 +63,7 @@ void Parser::reset() {
   m_len = 0;
   m_oversize_len = 0;
   m_restart_offset = 0;
-
+  m_oversize_offset = 0;
   m_discarded_packets.clear();
 }
 
@@ -314,38 +314,38 @@ bool Parser::rxOversizePkt(const PacketHeader *hdr, const uint8_t * /*unused*/, 
     return false;                                                                                                      \
   }
 
-EXPAND_HANDLER(RawDataPkt)
-EXPAND_HANDLER(MappedDataPkt)
-EXPAND_HANDLER(RTDLPkt)
-EXPAND_HANDLER(SourceListPkt)
+EXPAND_HANDLER(AnnotationPkt)
 EXPAND_HANDLER(BankedEventPkt)
 EXPAND_HANDLER(BankedEventStatePkt)
-EXPAND_HANDLER(BeamMonitorPkt)
-EXPAND_HANDLER(PixelMappingPkt)
-EXPAND_HANDLER(PixelMappingAltPkt)
-EXPAND_HANDLER(RunStatusPkt)
-EXPAND_HANDLER(RunInfoPkt)
-EXPAND_HANDLER(TransCompletePkt)
-EXPAND_HANDLER(ClientHelloPkt)
-EXPAND_HANDLER(AnnotationPkt)
-EXPAND_HANDLER(SyncPkt)
-EXPAND_HANDLER(HeartbeatPkt)
-EXPAND_HANDLER(GeometryPkt)
 EXPAND_HANDLER(BeamlineInfoPkt)
 EXPAND_HANDLER(BeamMonitorConfigPkt)
-EXPAND_HANDLER(DetectorBankSetsPkt)
+EXPAND_HANDLER(BeamMonitorPkt)
+EXPAND_HANDLER(ClientHelloPkt)
 EXPAND_HANDLER(DataDonePkt)
+EXPAND_HANDLER(DetectorBankSetsPkt)
 EXPAND_HANDLER(DeviceDescriptorPkt)
-EXPAND_HANDLER(VariableU32Pkt)
-EXPAND_HANDLER(VariableDoublePkt)
-EXPAND_HANDLER(VariableStringPkt)
-EXPAND_HANDLER(VariableU32ArrayPkt)
-EXPAND_HANDLER(VariableDoubleArrayPkt)
-EXPAND_HANDLER(MultVariableU32Pkt)
+EXPAND_HANDLER(GeometryPkt)
+EXPAND_HANDLER(HeartbeatPkt)
+EXPAND_HANDLER(MappedDataPkt)
 EXPAND_HANDLER(MultVariableDoublePkt)
+EXPAND_HANDLER(MultVariableDoubleArrayPkt)
 EXPAND_HANDLER(MultVariableStringPkt)
 EXPAND_HANDLER(MultVariableU32ArrayPkt)
-EXPAND_HANDLER(MultVariableDoubleArrayPkt)
+EXPAND_HANDLER(MultVariableU32Pkt)
+EXPAND_HANDLER(PixelMappingAltPkt)
+EXPAND_HANDLER(PixelMappingPkt)
+EXPAND_HANDLER(RawDataPkt)
+EXPAND_HANDLER(RTDLPkt)
+EXPAND_HANDLER(RunInfoPkt)
+EXPAND_HANDLER(RunStatusPkt)
+EXPAND_HANDLER(SourceListPkt)
+EXPAND_HANDLER(SyncPkt)
+EXPAND_HANDLER(TransCompletePkt)
+EXPAND_HANDLER(VariableDoublePkt)
+EXPAND_HANDLER(VariableDoubleArrayPkt)
+EXPAND_HANDLER(VariableStringPkt)
+EXPAND_HANDLER(VariableU32ArrayPkt)
+EXPAND_HANDLER(VariableU32Pkt)
 
 void Parser::getDiscardedPacketsLogString(std::string &log_info) {
   log_info = "Discarded ADARA Packet/Counts: ";

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -442,13 +442,12 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::BankedEventPkt &pkt) {
 /// Parse a beam monitor event packet
 
 /** Overrides the default function defined in ADARA::Parser and processes data from ADARA::BeamMonitorPkt packets.
- * Parsed events are counted and the counts are accumulated in the temporary workspace until the forground thread
+ * Parsed events are counted and the counts are accumulated in the temporary workspace until the foreground thread
  * retrieves them.
  *
  * @see extractData()
  * @param pkt The packet to be parsed
- * @return Returns false if there were no problems.  Returns true if there was an error and packet parsing should be
- * interrupted
+ * @return false if no problems, true if error occurred and packet parsing should be interrupted
  */
 bool SNSLiveEventDataListener::rxPacket(const ADARA::BeamMonitorPkt &pkt) {
   // Check to see if we should process this packet (depending on what the user selected for start up options, the SMS
@@ -1517,20 +1516,16 @@ ILiveListener::RunStatus SNSLiveEventDataListener::runStatus() {
   return rv;
 }
 
-// Called by the rxPacket() functions to determine if the packet should be
-// processed
-// (Depending on when it last indexed its data, SMS might send us packets that
-// are
-// older than we requested.)
-// Returns false if the packet should be processed, true if is should be ignored
+// Called by the rxPacket() functions to determine if the packet should be processed
+// (Depending on when it last indexed its data, SNS might send us packets that are older than we requested)
+// Returns false if the packet should be processed, true if it should be ignored
 bool SNSLiveEventDataListener::ignorePacket(const ADARA::PacketHeader &hdr, const ADARA::RunStatus::Enum status) {
-  // Since we're filtering based on time (either the absolute timestamp or
-  // nothing
-  // before the start of the most recent run), once we've determined a given
-  // packet should be processed, we know all packets after that should also be
-  // processed.  Thus, we can reduce most calls to this function to a simple
-  // boolean test...
-  if (!m_ignorePackets)
+  // Since we're filtering based on time (either the absolute timestamp or nothing
+  // before the start of the most recent run),
+  // once we've determined a given packet should be processed,
+  // we know all packets after that should also be processed.
+  // Thus, we can reduce most calls to this function to a simple boolean test
+  if (!m_ignorePackets) // don't ignore
     return false;
 
   // Are we looking for the start of the run?
@@ -1548,7 +1543,7 @@ bool SNSLiveEventDataListener::ignorePacket(const ADARA::PacketHeader &hdr, cons
 
   // If we've just hit our start-up condition, then process
   // all the variable value packets we've been hanging on to.
-  if (!m_ignorePackets) {
+  if (!m_ignorePackets) { // don't ignore
     replayVariableCache();
   }
 
@@ -1557,12 +1552,9 @@ bool SNSLiveEventDataListener::ignorePacket(const ADARA::PacketHeader &hdr, cons
 
 // Process all the variable value packets stored in m_variableMap
 void SNSLiveEventDataListener::replayVariableCache() {
-  auto it = m_variableMap.begin();
-  while (it != m_variableMap.end()) {
-    rxPacket(*(*it).second); // call rxPacket() on the stored packet
-    it++;
+  for (const auto &varPacketPair : m_variableMap) {
+    rxPacket(*varPacketPair.second); // call rxPacket() on the stored packet
   }
-
   m_variableMap.clear(); // empty the map to save a little ram
 }
 

--- a/Framework/PythonInterface/mantid/utils/logging.py
+++ b/Framework/PythonInterface/mantid/utils/logging.py
@@ -60,7 +60,7 @@ def capture_logs(level=None) -> io.StringIO:
         sys.stdout = backup["stdout"]
 
 
-def log_to_python(level="debug"):
+def log_to_python(level=None, pattern=None) -> None:
     r"""
     Modify Mantid's logger to forward messages to Python's logging framework instead
     of outputting them itself. This allows users to configure the logger from Python
@@ -70,14 +70,18 @@ def log_to_python(level="debug"):
 
     @param str level: Logging level for the *Mantid* logger. Should be set to a low value
         to forward all potentially relevant messages to Python and let *Python's* logger
-        filter out undesired messages. Possible values: 'trace', 'debug' (default),
+        filter out undesired messages. Possible values: 'trace', 'debug',
         'information', 'notice', 'warning', 'error', 'critical', 'fatal'.
+    @param str pattern: A logging pattern to format messages before forwarding them (example: %t)
+        See https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders
     """
     config = ConfigService.Instance()
-    config["logging.loggers.root.level"] = level
-    config["logging.channels.consoleChannel.formatter"] = "f1"
-    # Output only the message text and let Python take care of formatting.
-    config["logging.formatters.f1.class"] = "PatternFormatter"
-    config["logging.formatters.f1.pattern"] = "%t"
+    if level is not None:
+        config["logging.loggers.root.level"] = level
+    if pattern is not None:
+        config["logging.channels.consoleChannel.formatter"] = "f1"
+        # Output only the message text and let Python take care of formatting.
+        config["logging.formatters.f1.class"] = "PatternFormatter"
+        config["logging.formatters.f1.pattern"] = pattern
     # Important: Do this one last because it triggers re-init of logging system!
     config["logging.channels.consoleChannel.class"] = "PythonLoggingChannel"

--- a/Framework/PythonInterface/mantid/utils/logging.py
+++ b/Framework/PythonInterface/mantid/utils/logging.py
@@ -72,7 +72,7 @@ def log_to_python(level=None, pattern=None) -> None:
         to forward all potentially relevant messages to Python and let *Python's* logger
         filter out undesired messages. Possible values: 'trace', 'debug',
         'information', 'notice', 'warning', 'error', 'critical', 'fatal'.
-    @param str pattern: A logging pattern to format messages before forwarding them (example: %t)
+    @param str pattern: A logging pattern to format messages before forwarding them (example: '[%s] %t')
         See https://github.com/pocoproject/poco/wiki/Poco::Util::Application-Logging-Configuration#logging-format-placeholders
     """
     config = ConfigService.Instance()
@@ -80,7 +80,6 @@ def log_to_python(level=None, pattern=None) -> None:
         config["logging.loggers.root.level"] = level
     if pattern is not None:
         config["logging.channels.consoleChannel.formatter"] = "f1"
-        # Output only the message text and let Python take care of formatting.
         config["logging.formatters.f1.class"] = "PatternFormatter"
         config["logging.formatters.f1.pattern"] = pattern
     # Important: Do this one last because it triggers re-init of logging system!

--- a/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
@@ -51,7 +51,7 @@ class loggingTest(unittest.TestCase):
         py_logger.addHandler(handler)
 
         with temporary_config():
-            log_to_python()
+            log_to_python(level="%t")
             logger.information("[[info]]")
             logger.warning("[[warning]]")
             logger.error("[[error]]")

--- a/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
@@ -51,7 +51,7 @@ class loggingTest(unittest.TestCase):
         py_logger.addHandler(handler)
 
         with temporary_config():
-            log_to_python(level="%t")
+            log_to_python(level="information", pattern="%t")
             logger.information("[[info]]")
             logger.warning("[[warning]]")
             logger.error("[[error]]")

--- a/docs/source/release/v6.14.0/Framework/LiveData/New_features/39186.rst
+++ b/docs/source/release/v6.14.0/Framework/LiveData/New_features/39186.rst
@@ -1,0 +1,1 @@
+- updated header and source files for ADARA packets from v1.5.1 to v1.10.3

--- a/docs/source/release/v6.14.0/Framework/LiveData/New_features/39186.rst
+++ b/docs/source/release/v6.14.0/Framework/LiveData/New_features/39186.rst
@@ -1,1 +1,0 @@
-- updated header and source files for ADARA packets from v1.5.1 to v1.10.3


### PR DESCRIPTION
### Description of work

This PR enhances the log_to_python() function in the Python logging utility to accept an optional pattern argument for formatting log messages. The change allows users to specify custom formatting patterns when forwarding Mantid log messages to Python's logging framework.

Key Changes
Added optional pattern parameter to log_to_python() function with default value None
Updated function to only apply pattern configuration when a pattern is provided
Removed the hard-coded "%t" pattern and made it configurable

This does not require release notes. The change is limited to internal API functionality, with no impact on user-facing features, GUI interfaces, or workflows.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

EWM [11991](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11991)  
PR against `ornl-next`: #40020 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
In an environment such as `mantid-developer`, run script:
```python
import logging

from mantid.simpleapi import *
from mantid.utils.logging import log_to_python 

log_to_python(level="information", pattern="Hello [%s] %t")  # creates python standard logger with the name of "Mantid"
logging.getLogger("Mantid").setLevel(logging.INFO)

# create a file handler
fileHandler = logging.FileHandler("/tmp/test_40019.log")
fileHandler.setLevel(logging.INFO)
fileHandler.setFormatter(logging.Formatter("%(message)s"))
logging.getLogger("Mantid").addHandler(fileHandler)

# Ouptut INFO messages created by algorithm CreateEmptyTableWorkspace
ws = CreateEmptyTableWorkspace()
```
Then verify the contents of `"/tmp/test_40019.log"`:
```bash
Hello [CreateEmptyTableWorkspace] CreateEmptyTableWorkspace started
....
```
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
