### PR TITLE
Removed deprecated option from Filter Events GUI

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/39993.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/39993.rst
@@ -1,0 +1,1 @@
+- Removed `Split Sample Logs` checkbox from the `Filter Events` interface, since that option is deprecated, and all logs will be split.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -1242,13 +1242,6 @@
                     </property>
                    </widget>
                   </item>
-                  <item>
-                   <widget class="QCheckBox" name="checkBox_splitLog">
-                    <property name="text">
-                     <string>Split Sample Logs</string>
-                    </property>
-                   </widget>
-                  </item>
                  </layout>
                 </item>
                </layout>
@@ -1346,7 +1339,6 @@
   <tabstop>checkBox_filterByPulse</tabstop>
   <tabstop>checkBox_from1</tabstop>
   <tabstop>checkBox_groupWS</tabstop>
-  <tabstop>checkBox_splitLog</tabstop>
   <tabstop>lineEdit</tabstop>
  </tabstops>
  <resources/>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/eventFilterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/eventFilterGUI.py
@@ -932,7 +932,6 @@ class MainWindow(QMainWindow):
         dogroupws = self.ui.checkBox_groupWS.isChecked()
         filterbypulse = self.ui.checkBox_filterByPulse.isChecked()
         startfrom1 = self.ui.checkBox_from1.isChecked()
-        splitsamplelog = self.ui.checkBox_splitLog.isChecked()
 
         corr2sample = str(self.ui.comboBox_tofCorr.currentText())
         how2skip = str(self.ui.comboBox_skipSpectrum.currentText())
@@ -962,7 +961,6 @@ class MainWindow(QMainWindow):
             FilterByPulseTime=filterbypulse,
             CorrectionToSample=corr2sample,
             SpectrumWithoutDetector=how2skip,
-            SplitSampleLogs=splitsamplelog,
             OutputWorkspaceIndexedFrom1=startfrom1,
             OutputTOFCorrectionWorkspace="TOFCorrTable",
             **kwargs,
@@ -1081,6 +1079,5 @@ class MainWindow(QMainWindow):
         self.ui.checkBox_filterByPulse.setCheckState(False)
         self.ui.checkBox_from1.setCheckState(False)
         self.ui.checkBox_groupWS.setCheckState(True)
-        self.ui.checkBox_splitLog.setCheckState(False)
 
         self.canvas.draw()


### PR DESCRIPTION
Removed `Split Sample Logs` checkbox from the `Filter Events` interface, since that option is deprecated, and all logs will be split.

Otherwise, if it is checked you will see this warning in the logs:

`Option SplitSampleLogs is deprecated and ignored. All logs will be split.`

Found during manual testing for 6.14, see https://github.com/mantidproject/mantid/issues/39993#issuecomment-3355597466

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

6.13.1:

<img width="1777" height="1173" alt="image" src="https://github.com/user-attachments/assets/2c05f7cb-4f8c-45aa-b625-08f20cb31b52" />




### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
