### PR TITLE
Replaced uses of getNumberBins() with blocksize()

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/LagrangeILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/LagrangeILLReductionTest.py
@@ -148,7 +148,7 @@ class LagrangeILLReductionTest(unittest.TestCase):
 
     def check_result(self, ws, expected_unit, expected_bins, first_bin, last_bin):
         self.assertEqual(ws.getNumberHistograms(), 1)
-        self.assertEqual(ws.getNumberBins(), expected_bins)
+        self.assertEqual(ws.blocksize(), expected_bins)
         self.assertEqual(ws.getAxis(0).getUnit().unitID(), expected_unit)
         self.assertAlmostEqual(ws.getAxis(0).extractValues()[0], first_bin, 4)
         self.assertAlmostEqual(ws.getAxis(0).extractValues()[-1], last_bin, 4)

--- a/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/39987.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/39987.rst
@@ -1,0 +1,1 @@
+- Removed uses of `MatrixWorkspace::getNumberBins()`, which is deprecated, and replaced those uses with `MatrixWorkspace::blocksize()`.

--- a/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/39987.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/39987.rst
@@ -1,1 +1,1 @@
-- Removed uses of `MatrixWorkspace::getNumberBins()`, which is deprecated, and replaced those uses with `MatrixWorkspace::blocksize()`.
+- Removed uses of ``MatrixWorkspace::getNumberBins()``, which is deprecated, and replaced those uses with ``MatrixWorkspace::blocksize()``.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -838,7 +838,7 @@ class BasicFittingModel:
         """Evaluate the plot guess fit function and returns the name of the resulting guess workspace."""
         if self.fitting_context.plot_guess_type == X_FROM_FIT_RANGE:
             data_ws = retrieve_ws(self.current_dataset_name)
-            data = np.linspace(self.current_start_x, self.current_end_x, data_ws.getNumberBins())
+            data = np.linspace(self.current_start_x, self.current_end_x, data_ws.blocksize())
         elif self.fitting_context.plot_guess_type == X_FROM_DATA_RANGE:
             data_ws = retrieve_ws(self.current_dataset_name)
             data = np.linspace(data_ws.dataX(0)[0], data_ws.dataX(0)[-1], self.fitting_context.plot_guess_points)

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1588,7 +1588,7 @@ class RunDescriptor(PropDescriptor):
         bg_name = ebg_ws.name()
         ebg_local_name = bg_name
 
-        if ebg_ws.getNumberBins() != ws.getNumberBins() or ebg_ws.getNumberHistograms() != ws.getNumberHistograms():
+        if ebg_ws.blocksize() != ws.blocksize() or ebg_ws.getNumberHistograms() != ws.getNumberHistograms():
             # The RD and background workspaces are different if it is just binning or difference is in monitors
             # we can deal with the issue
             preserve_events = False


### PR DESCRIPTION
`MatrixWorkspace::getNumberBins` has been deprecated, replaced uses with `MatrixWorkspace::blocksize`

See https://github.com/mantidproject/mantid/issues/39987#issuecomment-3347444053

Found during manual testing for 6.14

### To test:

See https://github.com/mantidproject/mantid/issues/39987#issuecomment-3347444053 for testing instructions.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
