### PR TITLE
Rename TOF methods in new Instrument View

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -60,20 +60,20 @@ class FullInstrumentViewModel:
         self._detector_projection_positions = np.zeros_like(self._detector_positions)
         self._detector_is_picked = np.full(len(self._detector_ids[self._is_valid]), False)
 
-        # Get min and max tof values
+        # Get min and max integration values
         if self._workspace.isRaggedWorkspace():
             first_last = np.array([self._workspace.readX(i)[[0, -1]] for i in self._workspace_indices[self._is_valid]])
-            self._tof_limits = (np.min(first_last[:, 0]), np.max(first_last[:, 1]))
+            self._integration_limits = (np.min(first_last[:, 0]), np.max(first_last[:, 1]))
 
         elif self._workspace.isCommonBins():
-            self._tof_limits = tuple(self._workspace.dataX(0)[[0, -1]])
+            self._integration_limits = tuple(self._workspace.dataX(0)[[0, -1]])
 
         else:
             data_x = self._workspace.extractX()[self._is_valid]
-            self._tof_limits = (np.min(data_x[:, 0]), np.max(data_x[:, -1]))
+            self._integration_limits = (np.min(data_x[:, 0]), np.max(data_x[:, -1]))
 
         # Update counts with default total range
-        self.update_time_of_flight_range(self._tof_limits, True)
+        self.update_integration_range(self._integration_limits, True)
 
     @property
     def workspace(self) -> Workspace2D:
@@ -145,26 +145,26 @@ class FullInstrumentViewModel:
         self._counts_limits = limits
 
     @property
-    def tof_limits(self) -> tuple[float, float]:
-        return self._tof_limits
+    def integration_limits(self) -> tuple[float, float]:
+        return self._integration_limits
 
-    @tof_limits.setter
-    def tof_limits(self, limits) -> None:
+    @integration_limits.setter
+    def integration_limits(self, limits) -> None:
         try:
             min, max = limits
             assert float(max) > float(min)
         except (ValueError, AssertionError):
             return
-        self._tof_limits = limits
+        self._integration_limits = limits
         # Update the counts
-        self.update_time_of_flight_range(self._tof_limits)
+        self.update_integration_range(self._integration_limits)
 
-    def update_time_of_flight_range(self, tof_limits: tuple[float, float], entire_range: bool = False) -> None:
-        tof_min, tof_max = tof_limits
+    def update_integration_range(self, integration_limits: tuple[float, float], entire_range: bool = False) -> None:
+        integration_min, integration_max = integration_limits
         workspace_indices = self._workspace_indices[self._is_valid]
         new_detector_counts = np.array(
             self._workspace.getIntegratedCountsForWorkspaceIndices(
-                workspace_indices, len(workspace_indices), float(tof_min), float(tof_max), entire_range
+                workspace_indices, len(workspace_indices), float(integration_min), float(integration_max), entire_range
             ),
             dtype=int,
         )

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -48,7 +48,7 @@ class FullInstrumentViewPresenter:
         self._view.set_projection_combo_options(default_index, options)
         self._view.setup_connections_to_presenter()
         self._view.set_contour_range_limits(self._model.counts_limits)
-        self._view.set_tof_range_limits(self._model.tof_limits)
+        self._view.set_integration_range_limits(self._model.integration_limits)
 
         if len(self._model.monitor_positions) > 0:
             monitor_point_cloud = self.create_poly_data_mesh(self._model.monitor_positions)
@@ -100,12 +100,12 @@ class FullInstrumentViewPresenter:
             return self._model.workspace_x_unit_display
         return ""
 
-    def on_tof_limits_updated(self) -> None:
-        """When TOF limits are changed, read the new limits and tell the presenter to update the colours accordingly"""
-        self._model.tof_limits = self._view.get_tof_limits()
-        self.set_view_tof_limits()
+    def on_integration_limits_updated(self) -> None:
+        """When integration limits are changed, read the new limits and tell the presenter to update the colours accordingly"""
+        self._model.integration_limits = self._view.get_integration_limits()
+        self.set_view_integration_limits()
 
-    def set_view_tof_limits(self) -> None:
+    def set_view_integration_limits(self) -> None:
         self._detector_mesh[self._counts_label] = self._model.detector_counts
 
     def on_contour_limits_updated(self) -> None:
@@ -160,7 +160,7 @@ class FullInstrumentViewPresenter:
 
         self._view.enable_point_picking(callback=self.point_picked)
         self.set_view_contour_limits()
-        self.set_view_tof_limits()
+        self.set_view_integration_limits()
         self._view.reset_camera()
 
     def on_multi_select_detectors_clicked(self, state: int) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -101,8 +101,10 @@ class FullInstrumentViewWindow(QMainWindow):
         self._detector_spherical_position_edit = self._add_detector_info_boxes(detector_info_layout, "Spherical Position")
         self._detector_pixel_counts_edit = self._add_detector_info_boxes(detector_info_layout, "Pixel Counts")
 
-        self._time_of_flight_group_box = QGroupBox("Time of Flight")
-        self._tof_min_edit, self._tof_max_edit, self._tof_slider = self._add_min_max_group_box(self._time_of_flight_group_box)
+        self._integration_limit_group_box = QGroupBox("Time of Flight")
+        self._integration_limit_min_edit, self._integration_limit_max_edit, self._integration_limit_slider = self._add_min_max_group_box(
+            self._integration_limit_group_box
+        )
         self._contour_range_group_box = QGroupBox("Contour Range")
         self._contour_range_min_edit, self._contour_range_max_edit, self._contour_range_slider = self._add_min_max_group_box(
             self._contour_range_group_box
@@ -144,7 +146,7 @@ class FullInstrumentViewWindow(QMainWindow):
         options_vertical_widget = QWidget()
         options_vertical_layout = QVBoxLayout(options_vertical_widget)
         options_vertical_layout.addWidget(detector_group_box)
-        options_vertical_layout.addWidget(self._time_of_flight_group_box)
+        options_vertical_layout.addWidget(self._integration_limit_group_box)
         options_vertical_layout.addWidget(self._contour_range_group_box)
         options_vertical_layout.addWidget(multi_select_group_box)
         options_vertical_layout.addWidget(projection_group_box)
@@ -258,7 +260,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self._presenter = presenter
         for unit in self._presenter.available_unit_options():
             self._units_combo_box.addItem(unit)
-        self._time_of_flight_group_box.setTitle(self._presenter.workspace_display_unit)
+        self._integration_limit_group_box.setTitle(self._presenter.workspace_display_unit)
 
     def setup_connections_to_presenter(self) -> None:
         self._projection_combo_box.currentIndexChanged.connect(self._presenter.on_projection_option_selected)
@@ -266,7 +268,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self._multi_select_check.clicked.connect(self._cleanup_rectangle_picking)
         self._clear_selection_button.clicked.connect(self._presenter.on_clear_selected_detectors_clicked)
         self._contour_range_slider.sliderReleased.connect(self._presenter.on_contour_limits_updated)
-        self._tof_slider.sliderReleased.connect(self._presenter.on_tof_limits_updated)
+        self._integration_limit_slider.sliderReleased.connect(self._presenter.on_integration_limits_updated)
         self._units_combo_box.currentIndexChanged.connect(self._presenter.on_unit_option_selected)
         self._export_workspace_button.clicked.connect(self._presenter.on_export_workspace_clicked)
         self._sum_spectra_checkbox.clicked.connect(self._presenter.on_sum_spectra_checkbox_clicked)
@@ -278,7 +280,10 @@ class FullInstrumentViewWindow(QMainWindow):
             self._presenter.on_contour_limits_updated,
         )
         self._add_connections_to_edits_and_slider(
-            self._tof_min_edit, self._tof_max_edit, self._tof_slider, self._presenter.on_tof_limits_updated
+            self._integration_limit_min_edit,
+            self._integration_limit_max_edit,
+            self._integration_limit_slider,
+            self._presenter.on_integration_limits_updated,
         )
 
     def _cleanup_rectangle_picking(self, is_clicked: bool) -> None:
@@ -318,17 +323,17 @@ class FullInstrumentViewWindow(QMainWindow):
     def sum_spectra_selected(self) -> bool:
         return self._sum_spectra_checkbox.isChecked()
 
-    def get_tof_limits(self) -> tuple[float, float]:
-        return self._tof_slider.value()
+    def get_integration_limits(self) -> tuple[float, float]:
+        return self._integration_limit_slider.value()
 
-    def set_tof_range_limits(self, tof_limits: tuple[float, float]) -> None:
-        """Update the TOF edit boxes with formatted text"""
-        lower, upper = tof_limits
+    def set_integration_range_limits(self, integration_limits: tuple[float, float]) -> None:
+        """Update the integration limit edit boxes with formatted text"""
+        lower, upper = integration_limits
         if upper <= lower:
-            self._time_of_flight_group_box.hide()
+            self._integration_limit_group_box.hide()
             return
-        self._tof_slider.setRange(*tof_limits)
-        self._tof_slider.setValue(tof_limits)
+        self._integration_limit_slider.setRange(*integration_limits)
+        self._integration_limit_slider.setValue(integration_limits)
         return
 
     def get_contour_limits(self) -> tuple[float, float]:

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -63,7 +63,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = [100 * i for i in detector_ids]
         return mock_workspace
 
-    def test_update_time_of_flight_range(self):
+    def test_update_integration_range(self):
         self._mock_detector_table(list(range(self._ws.getNumberHistograms())))
         model = FullInstrumentViewModel(self._ws)
         model.setup()
@@ -71,7 +71,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_workspace = mock.MagicMock()
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = integrated_spectra
         model._workspace = mock_workspace
-        model.update_time_of_flight_range((200, 10000), False)
+        model.update_integration_range((200, 10000), False)
         model._workspace.getIntegratedCountsForWorkspaceIndices.assert_called_once()
         self.assertEqual(min(integrated_spectra), model._counts_limits[0])
         self.assertEqual(max(integrated_spectra), model._counts_limits[1])
@@ -214,16 +214,16 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         self.assertEqual(model.counts_limits[0], 100)
         self.assertEqual(model.counts_limits[1], 300)
 
-    def test_tof_limits_ws_with_common_bins(self):
+    def test_integration_limits_ws_with_common_bins(self):
         self._mock_detector_table([1, 2, 3])
         mock_workspace = self._create_mock_workspace([1, 2, 3])
         mock_workspace.isCommonBins.return_value = True
         mock_workspace.dataX.return_value = np.array([1, 2, 3])
         model = FullInstrumentViewModel(mock_workspace)
         model.setup()
-        self.assertEqual(model.tof_limits, (1, 3))
+        self.assertEqual(model.integration_limits, (1, 3))
 
-    def test_tof_limits_on_ragged_workspace(self):
+    def test_integration_limits_on_ragged_workspace(self):
         self._mock_detector_table([1, 2, 3])
         mock_workspace = self._create_mock_workspace([1, 2, 3])
         mock_workspace.isRaggedWorkspace.return_value = True
@@ -231,16 +231,16 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_workspace.readX.side_effect = lambda i: data_x[i]
         model = FullInstrumentViewModel(mock_workspace)
         model.setup()
-        self.assertEqual(model.tof_limits, (1, 50))
+        self.assertEqual(model.integration_limits, (1, 50))
 
-    def test_tof_limits_on_non_ragged_workspace(self):
+    def test_integration_limits_on_non_ragged_workspace(self):
         self._mock_detector_table([1, 2, 3])
         mock_workspace = self._create_mock_workspace([1, 2, 3])
         mock_workspace.isRaggedWorkspace.return_value = False
         mock_workspace.extractX.return_value = np.array([[1, 2, 3], [10, 20, 30], [10, 20, 50]])
         model = FullInstrumentViewModel(mock_workspace)
         model.setup()
-        self.assertEqual(model.tof_limits, (1, 50))
+        self.assertEqual(model.integration_limits, (1, 50))
 
     def test_monitor_positions(self):
         self._mock_detector_table([1, 2, 3], monitors=["yes", "no", "yes"])

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -55,13 +55,13 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
             mock_calculate_projection.reset_mock()
             mock_create_poly_data_mesh.reset_mock()
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.update_time_of_flight_range")
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.set_view_tof_limits")
-    def test_on_tof_limits_updated_true(self, mock_set_view_tof_limits, mock_update_tof_range):
-        self._mock_view.get_tof_limits.return_value = (0, 100)
-        self._presenter.on_tof_limits_updated()
-        mock_update_tof_range.assert_called_with((0, 100))
-        mock_set_view_tof_limits.assert_called_once()
+    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.update_integration_range")
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.set_view_integration_limits")
+    def test_on_integration_limits_updated_true(self, mock_set_view_integration_limits, mock_update_integration_range):
+        self._mock_view.get_integration_limits.return_value = (0, 100)
+        self._presenter.on_integration_limits_updated()
+        mock_update_integration_range.assert_called_with((0, 100))
+        mock_set_view_integration_limits.assert_called_once()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.set_view_contour_limits")
     def test_on_contour_limits_updated_true(self, mock_set_view_contour_limits):
@@ -75,10 +75,10 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.set_view_contour_limits()
         self._mock_view.set_plotter_scalar_bar_range.assert_called_once_with((0, 100), self._presenter._counts_label)
 
-    def test_set_view_tof_limits(self):
+    def test_set_view_integration_limits(self):
         self._model._counts = np.zeros(200)
         self._presenter._detector_mesh = {}
-        self._presenter.set_view_tof_limits()
+        self._presenter.set_view_integration_limits()
         np.testing.assert_allclose(self._presenter._detector_mesh[self._presenter._counts_label], self._model.detector_counts)
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_picked_detectors")


### PR DESCRIPTION
The workspace may not be in time-of-flight, so we shouldn't reference TOF in the names of the methods and properties in the new instrument view.

This is a maintenance issue, it won't affect the user.

### To test:

Give the new Instrument View a whirl, see if everything still works

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
