### PR TITLE
Fix export to ADS bug new IV

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -232,7 +232,8 @@ class FullInstrumentViewPresenter:
         self._view.close()
 
     def replace_workspace_callback(self, ws_name, ws):
-        self._view.close()
+        if ws_name == self._model.workspace.name():
+            self._view.close()
 
     def handle_close(self):
         # The observers are unsubscribed on object deletion, it's safer to manually

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -156,3 +156,15 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         units = self._presenter.available_unit_options()
         mock_has_unit.assert_called_once()
         self.assertEquals(self._presenter._UNIT_OPTIONS, units)
+
+    def test_only_close_on_correct_ws_replace(self):
+        ws_name = self._model.workspace.name()
+        self._presenter.replace_workspace_callback(ws_name, None)
+        self._mock_view.close.assert_called_once()
+        self._mock_view.close.reset_mock()
+        self._presenter.replace_workspace_callback("not_my_workspace", None)
+        self._mock_view.close.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Only close the interface if the workspace that's replaced is the one open in the IV. Otherwise if you click `Export to ADS` more than once it will close, because the export workspace is getting replaced.

### To test:

Open new IV, export selected spectra to the ADS, change selection or units, export again. Interface shouldn't close.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
