### PR TITLE
Add usage example for changing the log name

### DIFF
--- a/docs/source/api/python/mantid/kernel/Logger.rst
+++ b/docs/source/api/python/mantid/kernel/Logger.rst
@@ -4,6 +4,18 @@
 
 This is a Python binding to the C++ class Mantid::Kernel::Logger.
 
+By default, ``Logger.notice()`` will log at the root level (mantid).
+To get a named ``Logger`` you must create an instance with the name
+
+.. code-block:: python
+
+    from Mantid.kernel import Logger
+    mylogger = Logger("mine")
+    mylogger.notice("this is a test")
+
+will generate the text ``this is a test`` in the logging console and ``mine-[Notice] this is a test`` in the terminal.
+This assumes you are using the default settings.
+
 
 .. module:`mantid.kernel`
 


### PR DESCRIPTION
After explaining how to do this too many times.... This adds a usage example to the docs for people to refer to for this task.

### To test:

`ninja docs-html` and look at the new text at the top of the page.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
