### PR TITLE
Fix `SaveMD` performance regression caused by unlimited data chunk dimensions

### DIFF
--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -154,8 +154,7 @@ bool BoxControllerNeXusIO::openFile(const std::string &fileName, const std::stri
     CreateEventGroup();
   // we are in MDEvent group now (either created or opened)
 
-  // read if exist and create if not the group, which is responsible for saving
-  // DiskBuffer information;
+  // read if exist and create if not the group, which is responsible for saving DiskBuffer information;
   getDiskBufferFileData();
 
   if (m_ReadOnly)

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -32,11 +32,9 @@ namespace {
 template <typename MDE, size_t nd>
 void prepareUpdate(MDBoxFlatTree &BoxFlatStruct, BoxController *bc, typename MDEventWorkspace<MDE, nd>::sptr ws,
                    const std::string &filename) {
-  // remove all boxes from the DiskBuffer. DB will calculate boxes positions
-  // on HDD.
+  // remove all boxes from the DiskBuffer. DB will calculate boxes positions on HDD.
   bc->getFileIO()->flushCache();
-  // flatten the box structure; this will remember boxes file positions in the
-  // box structure
+  // flatten the box structure; this will remember boxes file positions in the box structure
   BoxFlatStruct.initFlatStructure(ws, filename);
 }
 } // namespace
@@ -74,8 +72,7 @@ void SaveMD::init() {
 
 //----------------------------------------------------------------------------------------------
 /** Save the MDEventWorskpace to a file.
- * Based on the Intermediate Data Format Detailed Design Document, v.1.R3 found
- *in SVN.
+ * Based on the Intermediate Data Format Detailed Design Document, v.1.R3 found in SVN.
  *
  * @param ws :: MDEventWorkspace of the given type
  */
@@ -106,9 +103,7 @@ template <typename MDE, size_t nd> void SaveMD::doSaveEvents(typename MDEventWor
   }
 
   auto prog = std::make_unique<Progress>(this, 0.0, 0.05, 1);
-  if (updateFileBackend) // workspace has its own file and ignores any changes
-                         // to the
-                         // algorithm parameters
+  if (updateFileBackend) // workspace has its own file and ignores any changes to the algorithm parameters
   {
     if (!ws->isFileBacked())
       throw std::runtime_error(" attempt to update non-file backed workspace");
@@ -116,8 +111,7 @@ template <typename MDE, size_t nd> void SaveMD::doSaveEvents(typename MDEventWor
   }
 
   //-----------------------------------------------------------------------------------------------------
-  // create or open WS group and put there additional information about WS and
-  // its dimensions
+  // create or open WS group and put there additional information about WS and its dimensions
   auto nDims = static_cast<int>(nd);
   bool data_exist;
   auto file =
@@ -166,8 +160,7 @@ template <typename MDE, size_t nd> void SaveMD::doSaveEvents(typename MDEventWor
           // do not spend time on empty or masked boxes
           if (boxe->getDataInMemorySize() == 0 || boxe->getIsMasked())
             continue;
-          // save boxes directly using the boxes file postion, precalculated in
-          // boxFlatStructure.
+          // save boxes directly using the boxes file postion, precalculated in boxFlatStructure.
           saveableTag->save();
           // remove boxes data from memory. This will actually correctly set the
           // tag indicatin that data were not loaded.

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -153,7 +153,7 @@ void SaveMD2::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) 
   for (size_t d = 0; d < numDims; d++) {
     IMDDimension_const_sptr dim = ws->getDimension(d);
     // Size in each dimension (reverse order for RANK)
-    size[numDims - 1 - d] = int(dim->getNBins());
+    size[numDims - 1 - d] = dim->getNBins();
   }
 
   Nexus::DimVector chunks = size;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -148,4 +148,4 @@ class File;
 } // namespace Mantid::Nexus
 
 constexpr std::size_t NX_MAXRANK(32);
-constexpr Mantid::Nexus::dimsize_t NX_UNLIMITED(-1); // 0xffffffffffffffffUL; // AKA max of unsigned long
+constexpr Mantid::Nexus::dimsize_t NX_UNLIMITED(-1); // AKA max of unsigned long, equivalent to H5S_UNLIMITED

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -872,7 +872,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     for (int i = 0; i < rank; i++) {
       if (dims[i] <= 0 || dims[i] == NX_UNLIMITED) {
         mydim[i] = 1;
-        chunkdims[i] = 1;
         maxdims[i] = H5S_UNLIMITED;
       }
     }

--- a/Framework/Nexus/test/NexusFileReadWriteTest.h
+++ b/Framework/Nexus/test/NexusFileReadWriteTest.h
@@ -268,14 +268,14 @@ public:
     // see https://github.com/nexusformat/code/blob/master/test/test_nxunlimited.c
     constexpr std::size_t DATA_SIZE(200);
     double d[DATA_SIZE];
-    Mantid::Nexus::DimVector dims{NX_UNLIMITED, DATA_SIZE};
+    Mantid::Nexus::DimVector dims{NX_UNLIMITED, DATA_SIZE}, chunk{DATA_SIZE, DATA_SIZE};
 
     FileResource resource("test_nxunlimited.nx5");
     std::string filename = resource.fullPath();
     File fileid = do_prep_files(filename);
 
     // make and open compressed data
-    TS_ASSERT_THROWS_NOTHING(fileid.makeCompData("data", NXnumtype::FLOAT64, dims, NXcompression::NONE, dims, true));
+    TS_ASSERT_THROWS_NOTHING(fileid.makeCompData("data", NXnumtype::FLOAT64, dims, NXcompression::NONE, chunk, true));
 
     Mantid::Nexus::DimVector slab_start{0, 0}, slab_size{1, DATA_SIZE};
     for (Mantid::Nexus::dimsize_t i = 0; i < 2; i++) {

--- a/docs/source/release/v6.14.0/Framework/Algorithms/Bugfixes/39954.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/Bugfixes/39954.rst
@@ -1,0 +1,1 @@
+- fixed a performance regression in :ref:`SaveMD <algm-SaveMD>` that led to dramatically increased save times

--- a/docs/source/release/v6.14.0/Framework/Algorithms/Bugfixes/39954.rst
+++ b/docs/source/release/v6.14.0/Framework/Algorithms/Bugfixes/39954.rst
@@ -1,1 +1,1 @@
-- fixed a performance regression in :ref:`SaveMD <algm-SaveMD>` that led to dramatically increased save times
+- fixed a performance regression in :ref:`SaveMD <algm-SaveMD>` that led to dramatically increased save times in release 6.13.1.1.


### PR DESCRIPTION
### Description of work

Fixes a performance regression in `SaveMD` that led to a many-fold increase in RAM usage, 3x increase in saved WS memory footprint, and a 30x increase in save and load times.

Closes #39954 

### To test:

Please run the test script in the original issue, and report save/load times.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
