### PR TITLE
AlignAndFocusPowderSlim output multiple workspaces when using splitter

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -62,7 +62,6 @@ const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
 const std::string SPLITTER_WS("SplitterWorkspace");
 const std::string SPLITTER_RELATIVE("RelativeTime");
-const std::string SPLITTER_TARGET("SplitterTarget");
 const std::string FILTER_BAD_PULSES("FilterBadPulses");
 const std::string FILTER_BAD_PULSES_LOWER_CUTOFF("BadPulsesLowerCutoff");
 const std::string X_MIN("XMin");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidDataObjects/TimeSplitter.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/TimeROI.h"
 
@@ -39,8 +40,10 @@ private:
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                    const std::vector<double> &difc_focus);
-  void determinePulseIndices(const API::MatrixWorkspace_sptr &wksp);
-  Kernel::TimeROI timeROIFromSplitterWorkspace(const Types::Core::DateAndTime &);
+  std::vector<std::pair<size_t, size_t>> determinePulseIndices(const API::MatrixWorkspace_sptr &wksp,
+                                                               const Kernel::TimeROI &roi);
+  Kernel::TimeROI getStartingTimeROI(const API::MatrixWorkspace_sptr &wksp);
+  DataObjects::TimeSplitter timeSplitterFromSplitterWorkspace(const Types::Core::DateAndTime &);
 
   std::map<detid_t, double> m_calibration; // detid: 1/difc
   std::set<detid_t> m_masked;
@@ -49,7 +52,6 @@ private:
   std::vector<int64_t> loadStart;
   /// How much to load in the file
   std::vector<int64_t> loadSize;
-  std::vector<std::pair<size_t, size_t>> pulse_indices;
 };
 
 // these properties are public to simplify testing and calling from other code

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -388,12 +388,12 @@ void AlignAndFocusPowderSlim::exec() {
   // threaded processing of the banks
   const int DISK_CHUNK = getProperty(PropertyNames::READ_SIZE_FROM_DISK);
   const int GRAINSIZE_EVENTS = getProperty(PropertyNames::EVENTS_PER_THREAD);
-  auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
   g_log.debug() << (DISK_CHUNK / GRAINSIZE_EVENTS) << " threads per chunk\n";
 
   if (timeSplitter.empty()) {
     const auto pulse_indices = this->determinePulseIndices(wksp, roi);
 
+    auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
     ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, wksp, m_calibration, m_masked,
                          static_cast<size_t>(DISK_CHUNK), static_cast<size_t>(GRAINSIZE_EVENTS), pulse_indices,
                          progress);
@@ -413,6 +413,10 @@ void AlignAndFocusPowderSlim::exec() {
   } else {
     std::string ws_basename = this->getPropertyValue(PropertyNames::OUTPUT_WKSP);
     std::vector<std::string> wsNames;
+
+    auto progress = std::make_shared<API::Progress>(this, .17, .9,
+                                                    num_banks_to_read * timeSplitter.outputWorkspaceIndices().size());
+
     for (const int &splitter_target : timeSplitter.outputWorkspaceIndices()) {
 
       auto splitter_roi = timeSplitter.getTimeROI(splitter_target);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
@@ -67,7 +67,8 @@ std::stack<EventROI> NexusLoader::getEventIndexRanges(H5::Group &event_group, co
       uint64_t start_event = event_index->at(pair.first);
       uint64_t stop_event =
           (pair.second == std::numeric_limits<size_t>::max()) ? number_events : event_index->at(pair.second);
-      ranges.emplace(start_event, stop_event);
+      if (start_event < stop_event)
+        ranges.emplace(start_event, stop_event);
     }
   } else {
     constexpr uint64_t START_DEFAULT = 0;

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -739,7 +739,7 @@ public:
     constexpr int NUM_HIST{6};
     for (int i = 1; i <= NUM_HIST; i++) {
       configuration.outputSpecNum = i;
-      MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+      auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
       // verify the output -- all spectra exist
       TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), NUM_HIST);

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/TimeROI.h"
@@ -20,7 +21,12 @@
 #include <gtest/gtest.h>
 #include <numbers>
 
+using Mantid::API::MatrixWorkspace;
 using Mantid::API::MatrixWorkspace_sptr;
+using Mantid::API::Workspace;
+using Mantid::API::Workspace_sptr;
+using Mantid::API::WorkspaceGroup;
+using Mantid::API::WorkspaceGroup_sptr;
 using Mantid::DataHandling::AlignAndFocusPowderSlim::AlignAndFocusPowderSlim;
 using Mantid::DataObjects::TableWorkspace_sptr;
 
@@ -43,7 +49,6 @@ struct TestConfig {
   double timeMax = -1.;
   TableWorkspace_sptr tablesplitter = nullptr;
   bool relativeTime = false;
-  int splitterTarget = -1;
   bool filterBadPulses = false;
   std::string logListBlock = "";
   std::string logListAllow = "";
@@ -65,8 +70,8 @@ public:
   }
 
   // run the algorithm do some common checks and return output workspace name
-  MatrixWorkspace_sptr run_algorithm(const std::string &filename, const TestConfig &configuration,
-                                     const bool should_throw = false) {
+  Workspace_sptr run_algorithm(const std::string &filename, const TestConfig &configuration,
+                               const bool should_throw = false) {
     // simplify setting property names
     using namespace Mantid::DataHandling::AlignAndFocusPowderSlim::PropertyNames;
 
@@ -101,8 +106,6 @@ public:
       TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_WS, configuration.tablesplitter));
       TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_RELATIVE, configuration.relativeTime));
     }
-    if (configuration.splitterTarget >= 0)
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty(SPLITTER_TARGET, configuration.splitterTarget));
     if (configuration.filterBadPulses) {
       TS_ASSERT_THROWS_NOTHING(alg.setProperty(FILTER_BAD_PULSES, configuration.filterBadPulses));
     }
@@ -112,20 +115,20 @@ public:
 
     if (should_throw) {
       TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
-      return MatrixWorkspace_sptr();
+      return Workspace_sptr();
     }
 
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
     std::cout << "==================> " << timer << '\n';
 
-    MatrixWorkspace_sptr outputWS = alg.getProperty(OUTPUT_WKSP);
+    Workspace_sptr outputWS = alg.getProperty(OUTPUT_WKSP);
     TS_ASSERT(outputWS);
     return outputWS;
   }
 
   void test_defaults() {
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, TestConfig());
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, TestConfig()));
 
     constexpr size_t NUM_Y{1874}; // observed value
 
@@ -156,7 +159,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("ReadSizeFromDisk", 1000000));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
 
-    MatrixWorkspace_sptr outputWS2 = alg.getProperty("OutputWorkspace");
+    Workspace_sptr outputWS2 = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS2);
 
     // Run CompareWorkspaces algorithm to verify the output
@@ -170,7 +173,7 @@ public:
 
   void test_common_x() {
     TestConfig configuration({13000.}, {36000.}, {}, "Logarithmic", "TOF");
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     constexpr size_t NUM_Y{637}; // observed value
 
@@ -195,7 +198,7 @@ public:
   void test_ragged_bins_x_min_max() {
     TestConfig configuration({13000., 14000., 15000., 16000., 17000., 18000.},
                              {36000., 37000., 38000., 39000., 40000., 41000.}, {}, "Logarithmic", "TOF");
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -212,7 +215,7 @@ public:
 
   void test_ragged_bins_x_delta() {
     TestConfig configuration({13000.}, {36000.}, {1000., 2000., 3000., 4000., 5000., 6000.}, "Linear", "TOF");
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -271,7 +274,7 @@ public:
   void run_test_with_different_units(std::vector<double> xmin, std::vector<double> xmax, std::vector<double> xdelta,
                                      std::string units) {
     TestConfig configuration(xmin, xmax, xdelta, "Linear", units);
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -289,7 +292,7 @@ public:
     configuration.timeMin = 0.;
     configuration.timeMax = 300.;
     configuration.logListBlock = "skf*";
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
@@ -310,7 +313,7 @@ public:
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.timeMin = 200.;
     configuration.timeMax = 300.;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -343,7 +346,7 @@ public:
   void test_start_time_filtering() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.timeMin = 200.;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -364,7 +367,7 @@ public:
   void test_stop_time_filtering() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.timeMax = 300.;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -386,7 +389,7 @@ public:
     // run is only ~600 seconds long so this include all events
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.timeMax = 3000.;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -421,8 +424,7 @@ public:
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.relativeTime = true;
     configuration.tablesplitter = create_splitter_table(configuration.relativeTime);
-    configuration.relativeTime = true;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<WorkspaceGroup>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -443,36 +445,38 @@ public:
 
     print(mtd["filtered_0"].extractY())
     */
-    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 807206);
-    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 805367);
-    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 920983);
-    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 909955);
-    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 310676);
-    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 590230);
+
+    auto outputWS0 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(0));
+    TS_ASSERT_EQUALS(outputWS0->readY(0).front(), 807206);
+    TS_ASSERT_EQUALS(outputWS0->readY(1).front(), 805367);
+    TS_ASSERT_EQUALS(outputWS0->readY(2).front(), 920983);
+    TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 909955);
+    TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 310676);
+    TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 590230);
   }
 
   void test_splitter_table_absolute_time() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.relativeTime = false;
     configuration.tablesplitter = create_splitter_table(configuration.relativeTime);
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<WorkspaceGroup>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results should be the same as test_splitter_table but produced with absolute time */
 
-    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 807206);
-    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 805367);
-    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 920983);
-    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 909955);
-    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 310676);
-    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 590230);
+    auto outputWS0 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(0));
+    TS_ASSERT_EQUALS(outputWS0->readY(0).front(), 807206);
+    TS_ASSERT_EQUALS(outputWS0->readY(1).front(), 805367);
+    TS_ASSERT_EQUALS(outputWS0->readY(2).front(), 920983);
+    TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 909955);
+    TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 310676);
+    TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 590230);
   }
 
   void test_splitter_table_multiple_targets() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.relativeTime = true;
     configuration.tablesplitter = create_splitter_table(configuration.relativeTime, false);
-    configuration.splitterTarget = 0;
-    MatrixWorkspace_sptr outputWS0 = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<WorkspaceGroup>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -482,15 +486,14 @@ public:
     print(ws.extractY())
     */
 
+    auto outputWS0 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(0));
+
     TS_ASSERT_EQUALS(outputWS0->readY(0).front(), 59561);
     TS_ASSERT_EQUALS(outputWS0->readY(1).front(), 59358);
     TS_ASSERT_EQUALS(outputWS0->readY(2).front(), 63952);
     TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 63299);
     TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 22917);
     TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 43843);
-
-    configuration.splitterTarget = 1; // next index
-    MatrixWorkspace_sptr outputWS1 = run_algorithm(VULCAN_218062, configuration);
 
     /* expected results came from running
 
@@ -500,15 +503,14 @@ public:
     print(ws.extractY())
     */
 
+    auto outputWS1 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(1));
+
     TS_ASSERT_EQUALS(outputWS1->readY(0).front(), 373262);
     TS_ASSERT_EQUALS(outputWS1->readY(1).front(), 372186);
     TS_ASSERT_EQUALS(outputWS1->readY(2).front(), 428220);
     TS_ASSERT_EQUALS(outputWS1->readY(3).front(), 423472);
     TS_ASSERT_EQUALS(outputWS1->readY(4).front(), 143703);
     TS_ASSERT_EQUALS(outputWS1->readY(5).front(), 273072);
-
-    configuration.splitterTarget = 2; // next index
-    MatrixWorkspace_sptr outputWS2 = run_algorithm(VULCAN_218062, configuration);
 
     /* expected results came from running
 
@@ -518,16 +520,13 @@ public:
     print(ws.extractY())
     */
 
+    auto outputWS2 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(2));
     TS_ASSERT_EQUALS(outputWS2->readY(0).front(), 374383);
     TS_ASSERT_EQUALS(outputWS2->readY(1).front(), 373823);
     TS_ASSERT_EQUALS(outputWS2->readY(2).front(), 428811);
     TS_ASSERT_EQUALS(outputWS2->readY(3).front(), 423184);
     TS_ASSERT_EQUALS(outputWS2->readY(4).front(), 144056);
     TS_ASSERT_EQUALS(outputWS2->readY(5).front(), 273315);
-
-    // target out of range, should throw
-    configuration.splitterTarget = 3;
-    run_algorithm(VULCAN_218062, configuration, true);
   }
 
   void test_splitter_table_and_time_start_stop() {
@@ -536,7 +535,7 @@ public:
     configuration.timeMax = 300;
     configuration.relativeTime = true;
     configuration.tablesplitter = create_splitter_table(configuration.relativeTime);
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<WorkspaceGroup>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -556,12 +555,14 @@ public:
 
     print(mtd["filtered_0"].extractY())
     */
-    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 415525);
-    TS_ASSERT_EQUALS(outputWS->readY(1).front(), 414435);
-    TS_ASSERT_EQUALS(outputWS->readY(2).front(), 476903);
-    TS_ASSERT_EQUALS(outputWS->readY(3).front(), 471846);
-    TS_ASSERT_EQUALS(outputWS->readY(4).front(), 160000);
-    TS_ASSERT_EQUALS(outputWS->readY(5).front(), 304167);
+
+    auto outputWS0 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(0));
+    TS_ASSERT_EQUALS(outputWS0->readY(0).front(), 415525);
+    TS_ASSERT_EQUALS(outputWS0->readY(1).front(), 414435);
+    TS_ASSERT_EQUALS(outputWS0->readY(2).front(), 476903);
+    TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 471846);
+    TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 160000);
+    TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 304167);
   }
 
   TableWorkspace_sptr create_splitter_table(const bool relativeTime = true, const bool sameTarget = true) {
@@ -594,7 +595,7 @@ public:
   void test_filter_bad_pulses() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
     configuration.filterBadPulses = true;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -618,7 +619,7 @@ public:
     configuration.filterBadPulses = true;
     configuration.timeMin = 200.;
     configuration.timeMax = 300.;
-    MatrixWorkspace_sptr outputWS = run_algorithm(VULCAN_218062, configuration);
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     /* expected results came from running
 
@@ -685,14 +686,15 @@ public:
   // ==================================
 
   void run_test(const std::string &filename) {
-    MatrixWorkspace_sptr outputWS = run_algorithm(filename, TestConfig());
+    Workspace_sptr outputWS = run_algorithm(filename, TestConfig());
+    auto WS = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
 
     // LoadEventNexus 4 seconds
     // tof 6463->39950
 
     // verify the output
-    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 6);
-    TS_ASSERT_EQUALS(outputWS->blocksize(), 3349); // observed value
+    TS_ASSERT_EQUALS(WS->getNumberHistograms(), 6);
+    TS_ASSERT_EQUALS(WS->blocksize(), 3349); // observed value
 
     // do not need to cleanup because workspace did not go into the ADS
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/TimeSplitter.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TimeSplitter.h
@@ -40,7 +40,7 @@ public:
   TimeSplitter(const SplittersWorkspace_sptr &sws);
 
   const std::map<DateAndTime, int> &getSplittersMap() const;
-  std::string getWorkspaceIndexName(const int workspaceIndex, const int numericalShift = 0);
+  std::string getWorkspaceIndexName(const int workspaceIndex, const int numericalShift = 0) const;
   /// Find the destination index for an event with a given time
   int valueAtTime(const DateAndTime &time) const;
   void addROI(const DateAndTime &start, const DateAndTime &stop, const int value);

--- a/Framework/DataObjects/src/TimeSplitter.cpp
+++ b/Framework/DataObjects/src/TimeSplitter.cpp
@@ -195,14 +195,14 @@ std::string TimeSplitter::debugPrint() const {
 const std::map<DateAndTime, int> &TimeSplitter::getSplittersMap() const { return m_roi_map; }
 
 // Get the target name from the target index.
-std::string TimeSplitter::getWorkspaceIndexName(const int workspaceIndex, const int numericalShift) {
+std::string TimeSplitter::getWorkspaceIndexName(const int workspaceIndex, const int numericalShift) const {
   if (m_index_name_map.count(workspaceIndex) == 0) {
     std::stringstream msg;
     msg << "Invalid target index " << workspaceIndex << " when calling TimeSplitter::getWorkspaceIndexName";
     throw std::runtime_error(msg.str());
   }
 
-  std::string target_name = m_index_name_map[workspaceIndex];
+  std::string target_name = m_index_name_map.at(workspaceIndex);
 
   // If numericalShift is not zero, the "_index" suffix of the name will be shifted.
   // This is needed to support FilterEvents property OutputWorkspaceIndexedFrom1.
@@ -218,7 +218,7 @@ std::string TimeSplitter::getWorkspaceIndexName(const int workspaceIndex, const 
           "FilterEvents property \"OutputWorkspaceIndexedFrom1\" is not compatible with non-numeric targets.");
     }
 
-    assert(target_index == m_name_index_map[target_name]);
+    assert(target_index == m_name_index_map.at(target_name));
     std::stringstream s;
     s << target_index + numericalShift;
     return s.str();

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -69,7 +69,8 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
     FilterEvents(ws2,
                  SplitterWorkspace=splitter, RelativeTime=True,
                  FilterByPulseTime=True,
-                 OutputWorkspaceBaseName="filtered")
+                 OutputWorkspaceBaseName="filtered",
+                 GroupWorkspaces=True)
     out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)
 
     CompareWorkspaces(ws, out, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
@@ -89,10 +90,12 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                          InformationWorkspace='info',
                          LogName='CaveTemperature',
                          MinimumLogValue=70.10,
-                         MaximumLogValue=70.15)
+                         MaximumLogValue=70.15,
+                         LogValueInterval=0.01)
 
-    # Use the splitter table to filter the events during loading
+    # Use the splitter table to filter the events during loading and output to workspace group
     ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter')
+    print(ws.getNumberOfEntries())  # should be 6 workspaces in the group
 
 
 **Example - filter bad pulses**
@@ -117,7 +120,7 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
 
 .. note::
 
-    While we currently only support a single output workspace when filtering events from a splitter table but the output target can be selected with the ``SplitterTarget`` property and you can run the algorithm multiple times with different targets. We also can currently only filter based on the pulse time, not the event time-of-flight.
+    We also can currently only filter based on the pulse time, not the event time-of-flight.
 
 .. categories::
 

--- a/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40035.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40035.rst
@@ -1,0 +1,1 @@
+- Now when using the spliiter workspace with :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` it will output multiple workspaces, one for each target. The ``SplitterTarget`` property has been removed.


### PR DESCRIPTION
### Description of work

When using `AlignAndFocusPowderSlim` with a splitter workspace input, instead of processing a single output target it will process them all. For this initial implementation it simply repeats the loading with `ProcessBankTask` for each output target.

It names the output workspace the same as `FilterEvents` and groups the output workspaces.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Ref [13335: Initial implementation. Simple approach, repeat ProcessBank for every output workspace.](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13335)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

You can create a complex splitter workspace based on a sample log

```python
cave_temperature = LoadEventNexus("VULCAN_218062.nxs.h5",
                                  MetaDataOnly=True,
                                  AllowList="CaveTemperature")

# Use GenerateEventsFilter to create a splitter table based on the log values
GenerateEventsFilter(cave_temperature,
                     OutputWorkspace='splitter',
                     InformationWorkspace='info',
                     LogName='CaveTemperature',
                     LogValueInterval=0.01)

result = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter', XMin=0, XMax=50000, XDelta=50000, BinningUnits="TOF", BinningMode="Linear")
```

We can then compare to using `FilterEvents` with the same splitter workspace

```python
ws = LoadEventNexus("VULCAN_218062.nxs.h5")
grp = CreateGroupingWorkspace(ws, GroupDetectorsBy='bank')
ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grp")
FilterEvents(ws, SplitterWorkspace='splitter', InformationWorkspace='info', OutputWorkspaceBaseName="eventFiltered", FilterByPulseTime=True, GroupWorkspaces=True)
Rebin("eventFiltered", "0,50000,50000", PreserveEvents=False, OutputWorkspace="eventFiltered")

CompareWorkspaces("eventFiltered", "result", CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
