### PR TITLE
Fix for show invisible workspace checkbox unreliable behaviour

### DIFF
--- a/docs/source/release/v6.14.0/Workbench/Bugfixes/40028.rst
+++ b/docs/source/release/v6.14.0/Workbench/Bugfixes/40028.rst
@@ -1,0 +1,1 @@
+- ``Show Invisible Workspaces`` settings can now be updated from the settings menu.

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -171,7 +171,7 @@ class GeneralSettings(SettingsPresenterBase):
         use_notifications_setting = "on" == self._model.get_use_notifications().lower()
         crystallography_convention = "Crystallography" == self._model.get_crystallography_convention()
         use_open_gl = "on" == self._model.get_use_opengl().lower()
-        invisible_workspaces = "true" == self._model.get_show_invisible_workspaces().lower()
+        invisible_workspaces = "1" == self._model.get_show_invisible_workspaces().lower()
         completion_enabled = self._model.get_completion_enabled()
 
         self._view.project_recovery_enabled.setChecked(pr_enabled)

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings_model.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings_model.py
@@ -391,7 +391,7 @@ class GeneralSettingsModelTest(BaseSettingsModelTest):
     @patch(ADD_CHANGE_PATCH_PATH)
     def test_set_show_invisible_workspaces(self, add_change_mock: MagicMock):
         self._assert_setter_with_different_values(
-            add_change_mock, self.model.set_show_invisible_workspaces, ["Off", "On"], GeneralProperties.SHOW_INVISIBLE_WORKSPACES.value
+            add_change_mock, self.model.set_show_invisible_workspaces, ["0", "1"], GeneralProperties.SHOW_INVISIBLE_WORKSPACES.value
         )
 
     @patch(ADD_CHANGE_PATCH_PATH)

--- a/qt/python/mantidqtinterfaces/test/Muon/ADSHandler/workspace_naming_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/ADSHandler/workspace_naming_test.py
@@ -103,7 +103,7 @@ class WorkspaceNamingTest(unittest.TestCase):
 
     def test_get_pair_phasequad_name(self):
         AnalysisDataService.clear()
-        ConfigService["MantidOptions.InvisibleWorkspaces"] = "True"
+        ConfigService["MantidOptions.InvisibleWorkspaces"] = "1"
         filepath = FileFinder.findRuns("EMU00019489.nxs")[0]
 
         load_result, run_number, filename, psi_data = load_workspace_from_filename(filepath)

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -56,7 +56,7 @@ def divide_side_effect(LHS, RHS, name):
 class MuonContextTest(unittest.TestCase):
     def setUp(self):
         AnalysisDataService.clear()
-        ConfigService["MantidOptions.InvisibleWorkspaces"] = "True"
+        ConfigService["MantidOptions.InvisibleWorkspaces"] = "1"
         self.filepath = FileFinder.findRuns("EMU00019489.nxs")[0]
 
         self.load_result, self.run_number, self.filename, psi_data = load_workspace_from_filename(self.filepath)
@@ -81,7 +81,7 @@ class MuonContextTest(unittest.TestCase):
         self.pairs = [MuonPair("long", "bwd", "fwd")]
 
     def tearDown(self):
-        ConfigService["MantidOptions.InvisibleWorkspaces"] = "False"
+        ConfigService["MantidOptions.InvisibleWorkspaces"] = "0"
         self.context.ads_observer.unsubscribe()
 
     def add_group_diff(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_with_frequency_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_with_frequency_test.py
@@ -25,7 +25,7 @@ from mantidqtinterfaces.Muon.GUI.Common.test_helpers.context_setup import setup_
 class MuonContextWithFrequencyTest(unittest.TestCase):
     def setUp(self):
         AnalysisDataService.clear()
-        ConfigService["MantidOptions.InvisibleWorkspaces"] = "True"
+        ConfigService["MantidOptions.InvisibleWorkspaces"] = "1"
         self.filepath = FileFinder.findRuns("EMU00019489.nxs")[0]
 
         self.load_result, self.run_number, self.filename, psi_data = load_workspace_from_filename(self.filepath)
@@ -50,7 +50,7 @@ class MuonContextWithFrequencyTest(unittest.TestCase):
         self.pairs = [MuonPair("long", "bwd", "fwd")]
 
     def tearDown(self):
-        ConfigService["MantidOptions.InvisibleWorkspaces"] = "False"
+        ConfigService["MantidOptions.InvisibleWorkspaces"] = "0"
 
     def _calculate_all_data(self):
         self.context.calculate_all_counts()


### PR DESCRIPTION
### Description of work
This PR fixes a bug in setting the ``Show invisible Workspaces`` checkbox in the settings menu. The checkbox behaviour is unreliable, and under some conditions:   #40028 , it fails to properly update the setting. 
I think the problem was in the stage of loading the interface, as the initial value of the setting was compared against the string `true` while in most of the other parts of mantid (including the same presenter for the settings interface) the invisible workspace setting is compared against '1' or '0'. I have leave it as '1' or '0', although this could be converted to be 'true' or 'false', as it does not matter when setting the property from the config service. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40028. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- The bug reported in #40028 does not reproduce after this fix. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
