### PR TITLE
Fix linthreshz key error when changing 3D plot background color

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -44,6 +44,7 @@ from workbench.plotting.propertiesdialog import (
     ColorbarAxisEditor,
     ZAxisEditor,
     LegendEditor,
+    LINTHRESH_DEFAULT,
 )
 from workbench.plotting.style import VALID_LINE_STYLE, VALID_COLORS
 from workbench.plotting.toolbar import ToolbarStateManager
@@ -942,7 +943,8 @@ class FigureInteraction(object):
         # set_xscale/set_yscale only autoscale the view
 
         scale_args = [
-            {"value": scale_type, "linthresh": 2} if scale_type == "symlog" else {"value": scale_type} for scale_type in scale_types
+            {"value": scale_type, "linthresh": LINTHRESH_DEFAULT} if scale_type == "symlog" else {"value": scale_type}
+            for scale_type in scale_types
         ]
 
         xlim = copy(ax.get_xlim())
@@ -967,7 +969,7 @@ class FigureInteraction(object):
                         "vmax": image.norm.vmax,
                     }
                     if scale_type == SymLogNorm:
-                        update_args["linthresh"] = 2.0  # Set to default mpl linthresh
+                        update_args["linthresh"] = LINTHRESH_DEFAULT
                     datafunctions.update_colorbar_scale(**update_args)
         self.canvas.draw_idle()
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/colorfills.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/colorfills.py
@@ -12,6 +12,7 @@ from matplotlib.colors import LogNorm, SymLogNorm
 from matplotlib.collections import QuadMesh
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from workbench.plotting.plotscriptgenerator.utils import convert_args_to_string, clean_variable_name
+from workbench.plotting.propertiesdialog import LINTHRESH_DEFAULT
 
 BASE_IMSHOW_COMMAND = "imshow"
 BASE_PCOLORMESH_COMMAND = "pcolormesh"
@@ -52,7 +53,7 @@ def get_colorbar(artist, image_name, ax_object_var):
                 scale_str = "SymLogNorm"
                 linthresh_str = ", linthresh=2"
                 loglocator_import_str = "SymmetricalLogLocator"
-                loglocator_args_str = "subs=np.arange(1, 10), base=10, linthresh=2"
+                loglocator_args_str = f"subs=np.arange(1, 10), base=10, linthresh={LINTHRESH_DEFAULT}"
 
             headers.append("import numpy as np")
             headers.append(f"from matplotlib.colors import {scale_str}")

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -27,6 +27,7 @@ SCIENTIFIC_FORMAT = "Scientific Format"
 SCALE_MODES = ["linear", "log", "symlog"]
 STR_TO_COLOR_NORMALIZATION = {"linear": Normalize, "log": LogNorm, "symlog": SymLogNorm}
 COLOR_NORMALIZATION_TO_STR = {v: k for k, v in STR_TO_COLOR_NORMALIZATION.items()}
+LINTHRESH_DEFAULT = 2  # Set to default mpl linthresh
 
 
 class PropertiesEditorBase(QDialog):
@@ -281,7 +282,7 @@ class ColorbarAxisEditor(AxisEditor):
         scale = STR_TO_COLOR_NORMALIZATION[self.ui.scaleBox.currentText()]
         update_args = {"figure": self.canvas.figure, "scale": scale, "vmin": limit_min, "vmax": limit_max}
         if scale == SymLogNorm:
-            update_args["linthresh"] = 2.0  # Set to default mpl linthresh
+            update_args["linthresh"] = LINTHRESH_DEFAULT
 
         for img in self.images:
             update_colorbar_scale(image=img, **update_args)

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
@@ -44,6 +44,7 @@ class AxProperties(dict):
             props["zlabel"] = ax.get_zlabel()
             props["zscale"] = ax.get_zscale().title()
             props["zautoscale"] = ax.get_autoscalez_on()
+            props["linthreshz"] = ax.zaxis.get_transform().linthresh if props["zscale"] == "Symlog" else 2
         else:
             props["minor_ticks"] = not isinstance(ax.xaxis.minor.locator, NullLocator)
             props["minor_gridlines"] = ax.show_minor_gridlines if hasattr(ax, "show_minor_gridlines") else False

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/__init__.py
@@ -9,6 +9,8 @@
 from matplotlib.ticker import NullLocator
 from mpl_toolkits.mplot3d import Axes3D
 
+from workbench.plotting.propertiesdialog import LINTHRESH_DEFAULT
+
 
 class AxProperties(dict):
     """
@@ -36,15 +38,15 @@ class AxProperties(dict):
         props["yautoscale"] = ax.get_autoscaley_on()
         props["canvas_color"] = ax.get_facecolor()
 
-        props["linthreshx"] = ax.xaxis.get_transform().linthresh if props["xscale"] == "Symlog" else 2
-        props["linthreshy"] = ax.yaxis.get_transform().linthresh if props["yscale"] == "Symlog" else 2
+        props["linthreshx"] = ax.xaxis.get_transform().linthresh if props["xscale"] == "Symlog" else LINTHRESH_DEFAULT
+        props["linthreshy"] = ax.yaxis.get_transform().linthresh if props["yscale"] == "Symlog" else LINTHRESH_DEFAULT
 
         if isinstance(ax, Axes3D):
             props["zlim"] = ax.get_zlim()
             props["zlabel"] = ax.get_zlabel()
             props["zscale"] = ax.get_zscale().title()
             props["zautoscale"] = ax.get_autoscalez_on()
-            props["linthreshz"] = ax.zaxis.get_transform().linthresh if props["zscale"] == "Symlog" else 2
+            props["linthreshz"] = ax.zaxis.get_transform().linthresh if props["zscale"] == "Symlog" else LINTHRESH_DEFAULT
         else:
             props["minor_ticks"] = not isinstance(ax.xaxis.minor.locator, NullLocator)
             props["minor_gridlines"] = ax.show_minor_gridlines if hasattr(ax, "show_minor_gridlines") else False

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -22,7 +22,6 @@ from mantidqt.widgets.plotconfigdialog.axestabwidget.presenter import AxesTabWid
 class AxesTabWidgetPresenterTstBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ax.plot([0, 1], [10, 12], "rx")
         cls.title = "My Axes"
         cls.ax.set_title(cls.title)
         cls.x_label = "X"
@@ -48,6 +47,7 @@ class AxesTabWidgetPresenterTest(AxesTabWidgetPresenterTstBase):
     def setUpClass(cls):
         cls.fig = figure()
         cls.ax = cls.fig.add_subplot(211)
+        cls.ax.plot([0, 1], [10, 12], "rx")
         super().setUpClass()
 
     def test_generate_ax_name_returns_correct_name(self):

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -14,6 +14,8 @@ from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_images_from_
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
 from mantidqt.widgets.plotconfigdialog.imagestabwidget.view import ImagesTabWidgetView, SCALES
 
+from workbench.plotting.propertiesdialog import LINTHRESH_DEFAULT
+
 
 class ImagesTabWidgetPresenter:
     def __init__(self, fig, view=None, parent=None):
@@ -44,7 +46,7 @@ class ImagesTabWidgetPresenter:
             image.set_cmap(props.colormap)
             if props.interpolation and not (isinstance(image, QuadMesh) or isinstance(image, Poly3DCollection)):
                 image.set_interpolation(props.interpolation)
-            kwargs = {"linthresh": 2} if props.scale == "SymLog" else {}
+            kwargs = {"linthresh": LINTHRESH_DEFAULT} if props.scale == "SymLog" else {}
             update_colorbar_scale(self.fig, image, SCALES[props.scale], props.vmin, props.vmax, **kwargs)
 
         if props.vmin > props.vmax:


### PR DESCRIPTION
### Description of work

This PR:
- Fixes an error thrown when a change to the plot background color. "linthreshz" has been added to axes props. This whilst symlog is disabled for 3D plots and therefore not applicable to the Z axis, this is still used to set the value of the hidden `linthresh` field in the background.
- Moves the default value on linthresh to a variable

Closes #40041

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Follow the test instructions in the issue.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
