### PR TITLE
Refactor PeakShapeEllipsoid from std::vector to std::array

### DIFF
--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -117,6 +117,7 @@ set(INC_FILES
     inc/MantidDataObjects/PeakNoShapeFactory.h
     inc/MantidDataObjects/PeakShapeBase.h
     inc/MantidDataObjects/PeakShapeEllipsoid.h
+    inc/MantidDataObjects/PeakShapeEllipsoid_fwd.h
     inc/MantidDataObjects/PeakShapeEllipsoidFactory.h
     inc/MantidDataObjects/PeakShapeFactory.h
     inc/MantidDataObjects/PeakShapeSpherical.h

--- a/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/CoordTransformDistance.h
@@ -42,6 +42,9 @@ public:
                          const std::vector<Kernel::V3D> &eigenvects = std::vector<Kernel::V3D>(0),
                          const std::vector<double> &eigenvals = std::vector<double>(0, 0.0));
 
+  CoordTransformDistance(const size_t inD, const coord_t *center, const bool *dimensionsUsed, const size_t outD,
+                         const std::array<Kernel::V3D, 3> &eigenvects, const std::array<double, 3> &eigenvals);
+
   CoordTransform *clone() const override;
   std::string toXMLString() const override;
   std::string id() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -13,24 +13,26 @@
 namespace Mantid {
 namespace DataObjects {
 
+typedef std::array<double, 3> PeakEllipsoidExtent;
+
 /** PeakShapeEllipsoid : PeakShape representing a 3D ellipsoid
  */
 class MANTID_DATAOBJECTS_DLL PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
-  PeakShapeEllipsoid(const std::array<Mantid::Kernel::V3D, 3> &directions, const std::array<double, 3> &abcRadii,
-                     const std::array<double, 3> &abcRadiiBackgroundInner,
-                     const std::array<double, 3> &abcRadiiBackgroundOuter, Kernel::SpecialCoordinateSystem frame,
+  PeakShapeEllipsoid(const std::array<Mantid::Kernel::V3D, 3> &directions, const PeakEllipsoidExtent &abcRadii,
+                     const PeakEllipsoidExtent &abcRadiiBackgroundInner,
+                     const PeakEllipsoidExtent &abcRadiiBackgroundOuter, Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(), int algorithmVersion = -1,
                      const Mantid::Kernel::V3D &translation = {0.0, 0.0, 0.0});
   /// Equals operator
   bool operator==(const PeakShapeEllipsoid &other) const;
   /// Get radii
-  const std::array<double, 3> &abcRadii() const;
+  const PeakEllipsoidExtent &abcRadii() const;
   /// Get background inner radii
-  const std::array<double, 3> &abcRadiiBackgroundInner() const;
+  const PeakEllipsoidExtent &abcRadiiBackgroundInner() const;
   /// Get background outer radii
-  const std::array<double, 3> &abcRadiiBackgroundOuter() const;
+  const PeakEllipsoidExtent &abcRadiiBackgroundOuter() const;
   /// Get ellipsoid directions
   const std::array<Mantid::Kernel::V3D, 3> &directions() const;
   /// Get translation of center
@@ -53,11 +55,11 @@ private:
   /// principle axis
   std::array<Mantid::Kernel::V3D, 3> m_directions;
   /// radii
-  std::array<double, 3> m_abc_radii;
+  PeakEllipsoidExtent m_abc_radii;
   /// inner radii
-  std::array<double, 3> m_abc_radiiBackgroundInner;
+  PeakEllipsoidExtent m_abc_radiiBackgroundInner;
   /// outer radii
-  std::array<double, 3> m_abc_radiiBackgroundOuter;
+  PeakEllipsoidExtent m_abc_radiiBackgroundOuter;
   /// translation of center
   Mantid::Kernel::V3D m_translation;
 };

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -7,20 +7,19 @@
 #pragma once
 
 #include "MantidDataObjects/PeakShapeBase.h"
+#include "MantidDataObjects/PeakShapeEllipsoid_fwd.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/V3D.h"
 
 namespace Mantid {
 namespace DataObjects {
 
-typedef std::array<double, 3> PeakEllipsoidExtent;
-
 /** PeakShapeEllipsoid : PeakShape representing a 3D ellipsoid
  */
 class MANTID_DATAOBJECTS_DLL PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
-  PeakShapeEllipsoid(const std::array<Mantid::Kernel::V3D, 3> &directions, const PeakEllipsoidExtent &abcRadii,
+  PeakShapeEllipsoid(const PeakEllipsoidFrame &directions, const PeakEllipsoidExtent &abcRadii,
                      const PeakEllipsoidExtent &abcRadiiBackgroundInner,
                      const PeakEllipsoidExtent &abcRadiiBackgroundOuter, Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(), int algorithmVersion = -1,
@@ -34,11 +33,11 @@ public:
   /// Get background outer radii
   const PeakEllipsoidExtent &abcRadiiBackgroundOuter() const;
   /// Get ellipsoid directions
-  const std::array<Mantid::Kernel::V3D, 3> &directions() const;
+  const PeakEllipsoidFrame &directions() const;
   /// Get translation of center
   const Kernel::V3D &translation() const;
   /// Get ellipsoid directions in a specified frame
-  std::array<Kernel::V3D, 3> getDirectionInSpecificFrame(Kernel::Matrix<double> &invertedGoniometerMatrix) const;
+  PeakEllipsoidFrame getDirectionInSpecificFrame(Kernel::Matrix<double> &invertedGoniometerMatrix) const;
 
   /// PeakShape interface
   std::string toJSON() const override;
@@ -53,7 +52,7 @@ public:
 
 private:
   /// principle axis
-  std::array<Mantid::Kernel::V3D, 3> m_directions;
+  PeakEllipsoidFrame m_directions;
   /// radii
   PeakEllipsoidExtent m_abc_radii;
   /// inner radii

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -18,25 +18,25 @@ namespace DataObjects {
 class MANTID_DATAOBJECTS_DLL PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
-  PeakShapeEllipsoid(const std::vector<Mantid::Kernel::V3D> &directions, const std::vector<double> &abcRadii,
-                     const std::vector<double> &abcRadiiBackgroundInner,
-                     const std::vector<double> &abcRadiiBackgroundOuter, Kernel::SpecialCoordinateSystem frame,
+  PeakShapeEllipsoid(const std::array<Mantid::Kernel::V3D, 3> &directions, const std::array<double, 3> &abcRadii,
+                     const std::array<double, 3> &abcRadiiBackgroundInner,
+                     const std::array<double, 3> &abcRadiiBackgroundOuter, Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(), int algorithmVersion = -1,
                      const Mantid::Kernel::V3D &translation = {0.0, 0.0, 0.0});
   /// Equals operator
   bool operator==(const PeakShapeEllipsoid &other) const;
   /// Get radii
-  const std::vector<double> &abcRadii() const;
+  const std::array<double, 3> &abcRadii() const;
   /// Get background inner radii
-  const std::vector<double> &abcRadiiBackgroundInner() const;
+  const std::array<double, 3> &abcRadiiBackgroundInner() const;
   /// Get background outer radii
-  const std::vector<double> &abcRadiiBackgroundOuter() const;
+  const std::array<double, 3> &abcRadiiBackgroundOuter() const;
   /// Get ellipsoid directions
-  const std::vector<Mantid::Kernel::V3D> &directions() const;
+  const std::array<Mantid::Kernel::V3D, 3> &directions() const;
   /// Get translation of center
   const Kernel::V3D &translation() const;
   /// Get ellipsoid directions in a specified frame
-  std::vector<Kernel::V3D> getDirectionInSpecificFrame(Kernel::Matrix<double> &invertedGoniometerMatrix) const;
+  std::array<Kernel::V3D, 3> getDirectionInSpecificFrame(Kernel::Matrix<double> &invertedGoniometerMatrix) const;
 
   /// PeakShape interface
   std::string toJSON() const override;
@@ -51,13 +51,13 @@ public:
 
 private:
   /// principle axis
-  std::vector<Mantid::Kernel::V3D> m_directions;
+  std::array<Mantid::Kernel::V3D, 3> m_directions;
   /// radii
-  std::vector<double> m_abc_radii;
+  std::array<double, 3> m_abc_radii;
   /// inner radii
-  std::vector<double> m_abc_radiiBackgroundInner;
+  std::array<double, 3> m_abc_radiiBackgroundInner;
   /// outer radii
-  std::vector<double> m_abc_radiiBackgroundOuter;
+  std::array<double, 3> m_abc_radiiBackgroundOuter;
   /// translation of center
   Mantid::Kernel::V3D m_translation;
 };

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid_fwd.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid_fwd.h
@@ -1,0 +1,23 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/V3D.h"
+
+namespace Mantid {
+namespace DataObjects {
+
+constexpr size_t PEAK_ELLIPSOID_DIMS{3};
+typedef std::array<double, PEAK_ELLIPSOID_DIMS> PeakEllipsoidExtent;
+typedef std::array<Kernel::V3D, PEAK_ELLIPSOID_DIMS> PeakEllipsoidFrame;
+class PeakShapeEllipsoid;
+
+using PeakShapeEllipsoid_sptr = std::shared_ptr<PeakShapeEllipsoid>;
+using PeakShapeEllipsoid_const_sptr = std::shared_ptr<const PeakShapeEllipsoid>;
+
+} // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/src/CoordTransformDistance.cpp
+++ b/Framework/DataObjects/src/CoordTransformDistance.cpp
@@ -50,6 +50,25 @@ CoordTransformDistance::CoordTransformDistance(const size_t inD, const coord_t *
   }
 }
 
+CoordTransformDistance::CoordTransformDistance(const size_t inD, const coord_t *center, const bool *dimensionsUsed,
+                                               const size_t outD, const std::array<Kernel::V3D, 3> &eigenvects,
+                                               const std::array<double, 3> &eigenvals)
+    : CoordTransform(inD, outD) {
+
+  m_center.reserve(inD);
+  m_dimensionsUsed.reserve(inD);
+  m_eigenvals.reserve(inD);
+  m_maxEigenval = 0.0;
+  for (size_t d = 0; d < inD; d++) {
+    m_center.push_back(center[d]);
+    m_dimensionsUsed.push_back(dimensionsUsed[d]);
+    // coord transform for n-ellipsoid specified
+    m_eigenvals.push_back(eigenvals[d]);
+    m_eigenvects.push_back(eigenvects[d]);
+    m_maxEigenval = std::max(m_maxEigenval, eigenvals[d]);
+  }
+}
+
 //----------------------------------------------------------------------------------------------
 /** Virtual cloner
  * @return a copy of this object  */

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -13,8 +13,7 @@
 
 namespace Mantid::DataObjects {
 
-PeakShapeEllipsoid::PeakShapeEllipsoid(const std::array<Kernel::V3D, 3> &directions,
-                                       const PeakEllipsoidExtent &abcRadii,
+PeakShapeEllipsoid::PeakShapeEllipsoid(const PeakEllipsoidFrame &directions, const PeakEllipsoidExtent &abcRadii,
                                        const PeakEllipsoidExtent &abcRadiiBackgroundInner,
                                        const PeakEllipsoidExtent &abcRadiiBackgroundOuter,
                                        Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
@@ -36,11 +35,11 @@ const PeakEllipsoidExtent &PeakShapeEllipsoid::abcRadiiBackgroundInner() const {
 
 const PeakEllipsoidExtent &PeakShapeEllipsoid::abcRadiiBackgroundOuter() const { return m_abc_radiiBackgroundOuter; }
 
-const std::array<Kernel::V3D, 3> &PeakShapeEllipsoid::directions() const { return m_directions; }
+const PeakEllipsoidFrame &PeakShapeEllipsoid::directions() const { return m_directions; }
 
 const Kernel::V3D &PeakShapeEllipsoid::translation() const { return m_translation; }
 
-std::array<Kernel::V3D, 3>
+PeakEllipsoidFrame
 PeakShapeEllipsoid::getDirectionInSpecificFrame(Kernel::Matrix<double> &invertedGoniometerMatrix) const {
 
   if ((invertedGoniometerMatrix.numCols() != m_directions.size()) ||
@@ -49,7 +48,7 @@ PeakShapeEllipsoid::getDirectionInSpecificFrame(Kernel::Matrix<double> &inverted
                                 "compatible with the direction vector");
   }
 
-  std::array<Kernel::V3D, 3> directionsInFrame;
+  PeakEllipsoidFrame directionsInFrame;
   std::transform(m_directions.cbegin(), m_directions.cend(), directionsInFrame.begin(),
                  [&invertedGoniometerMatrix](const auto &direction) { return invertedGoniometerMatrix * direction; });
   return directionsInFrame;

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -14,9 +14,9 @@
 namespace Mantid::DataObjects {
 
 PeakShapeEllipsoid::PeakShapeEllipsoid(const std::array<Kernel::V3D, 3> &directions,
-                                       const std::array<double, 3> &abcRadii,
-                                       const std::array<double, 3> &abcRadiiBackgroundInner,
-                                       const std::array<double, 3> &abcRadiiBackgroundOuter,
+                                       const PeakEllipsoidExtent &abcRadii,
+                                       const PeakEllipsoidExtent &abcRadiiBackgroundInner,
+                                       const PeakEllipsoidExtent &abcRadiiBackgroundOuter,
                                        Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
                                        int algorithmVersion, const Kernel::V3D &translation)
     : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion), m_directions(directions), m_abc_radii(abcRadii),
@@ -30,11 +30,11 @@ bool PeakShapeEllipsoid::operator==(const PeakShapeEllipsoid &other) const {
          other.translation() == this->translation();
 }
 
-const std::array<double, 3> &PeakShapeEllipsoid::abcRadii() const { return m_abc_radii; }
+const PeakEllipsoidExtent &PeakShapeEllipsoid::abcRadii() const { return m_abc_radii; }
 
-const std::array<double, 3> &PeakShapeEllipsoid::abcRadiiBackgroundInner() const { return m_abc_radiiBackgroundInner; }
+const PeakEllipsoidExtent &PeakShapeEllipsoid::abcRadiiBackgroundInner() const { return m_abc_radiiBackgroundInner; }
 
-const std::array<double, 3> &PeakShapeEllipsoid::abcRadiiBackgroundOuter() const { return m_abc_radiiBackgroundOuter; }
+const PeakEllipsoidExtent &PeakShapeEllipsoid::abcRadiiBackgroundOuter() const { return m_abc_radiiBackgroundOuter; }
 
 const std::array<Kernel::V3D, 3> &PeakShapeEllipsoid::directions() const { return m_directions; }
 

--- a/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
@@ -31,24 +31,14 @@ Mantid::Geometry::PeakShape *PeakShapeEllipsoidFactory::create(const std::string
       const std::string algorithmName(root["algorithm_name"].asString());
       const int algorithmVersion(root["algorithm_version"].asInt());
       const auto frame(static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
-      std::array<double, 3> abcRadii{root["radius0"].asDouble(), root["radius1"].asDouble(),
-                                     root["radius2"].asDouble()};
-      std::array<double, 3> abcRadiiBackgroundInner{root["background_inner_radius0"].asDouble(),
-                                                    root["background_inner_radius1"].asDouble(),
-                                                    root["background_inner_radius2"].asDouble()};
-      std::array<double, 3> abcRadiiBackgroundOuter{root["background_outer_radius0"].asDouble(),
-                                                    root["background_outer_radius1"].asDouble(),
-                                                    root["background_outer_radius2"].asDouble()};
-      /*
-      std::vector<double> abcRadii, abcRadiiBackgroundInner, abcRadiiBackgroundOuter;
-      abcRadiiBackgroundInner.emplace_back(root["background_inner_radius0"].asDouble());
-      abcRadiiBackgroundInner.emplace_back(root["background_inner_radius1"].asDouble());
-      abcRadiiBackgroundInner.emplace_back(root["background_inner_radius2"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius0"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius1"].asDouble());
-      abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius2"].asDouble());
-      */
-      std::array<V3D, 3> directions;
+      PeakEllipsoidExtent abcRadii{root["radius0"].asDouble(), root["radius1"].asDouble(), root["radius2"].asDouble()};
+      PeakEllipsoidExtent abcRadiiBackgroundInner{root["background_inner_radius0"].asDouble(),
+                                                  root["background_inner_radius1"].asDouble(),
+                                                  root["background_inner_radius2"].asDouble()};
+      PeakEllipsoidExtent abcRadiiBackgroundOuter{root["background_outer_radius0"].asDouble(),
+                                                  root["background_outer_radius1"].asDouble(),
+                                                  root["background_outer_radius2"].asDouble()};
+      PeakEllipsoidFrame directions;
       directions[0].fromString(root["direction0"].asString());
       directions[1].fromString(root["direction1"].asString());
       directions[2].fromString(root["direction2"].asString());

--- a/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
@@ -31,18 +31,24 @@ Mantid::Geometry::PeakShape *PeakShapeEllipsoidFactory::create(const std::string
       const std::string algorithmName(root["algorithm_name"].asString());
       const int algorithmVersion(root["algorithm_version"].asInt());
       const auto frame(static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
+      std::array<double, 3> abcRadii{root["radius0"].asDouble(), root["radius1"].asDouble(),
+                                     root["radius2"].asDouble()};
+      std::array<double, 3> abcRadiiBackgroundInner{root["background_inner_radius0"].asDouble(),
+                                                    root["background_inner_radius1"].asDouble(),
+                                                    root["background_inner_radius2"].asDouble()};
+      std::array<double, 3> abcRadiiBackgroundOuter{root["background_outer_radius0"].asDouble(),
+                                                    root["background_outer_radius1"].asDouble(),
+                                                    root["background_outer_radius2"].asDouble()};
+      /*
       std::vector<double> abcRadii, abcRadiiBackgroundInner, abcRadiiBackgroundOuter;
-      abcRadii.emplace_back(root["radius0"].asDouble());
-      abcRadii.emplace_back(root["radius1"].asDouble());
-      abcRadii.emplace_back(root["radius2"].asDouble());
       abcRadiiBackgroundInner.emplace_back(root["background_inner_radius0"].asDouble());
       abcRadiiBackgroundInner.emplace_back(root["background_inner_radius1"].asDouble());
       abcRadiiBackgroundInner.emplace_back(root["background_inner_radius2"].asDouble());
       abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius0"].asDouble());
       abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius1"].asDouble());
       abcRadiiBackgroundOuter.emplace_back(root["background_outer_radius2"].asDouble());
-
-      std::vector<V3D> directions(3);
+      */
+      std::array<V3D, 3> directions;
       directions[0].fromString(root["direction0"].asString());
       directions[1].fromString(root["direction1"].asString());
       directions[2].fromString(root["direction2"].asString());

--- a/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
@@ -69,10 +69,10 @@ public:
 
   void test_create() {
 
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<Mantid::Kernel::V3D, 3> directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const std::array<double, 3> abcRadii{2, 3, 4};
+    const std::array<double, 3> abcInnerRadii{5, 6, 7};
+    const std::array<double, 3> abcOuterRadii{8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;

--- a/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
@@ -69,10 +69,10 @@ public:
 
   void test_create() {
 
-    std::array<Mantid::Kernel::V3D, 3> directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const std::array<double, 3> abcRadii{2, 3, 4};
-    const std::array<double, 3> abcInnerRadii{5, 6, 7};
-    const std::array<double, 3> abcOuterRadii{8, 9, 10};
+    PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent abcRadii{2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii{5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii{8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;

--- a/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
@@ -29,10 +29,10 @@ public:
   static void destroySuite(PeakShapeEllipsoidTest *suite) { delete suite; }
 
   void test_constructor() {
-    auto directions = {(V3D(1, 0, 0)), (V3D(0, 1, 0)), (V3D(0, 0, 1))};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<V3D, 3> directions = {(V3D(1, 0, 0)), (V3D(0, 1, 0)), (V3D(0, 0, 1))};
+    const std::array<double, 3> abcRadii = {2, 3, 4};
+    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
+    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -50,36 +50,11 @@ public:
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
   }
 
-  void test_constructor_throws() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    auto bad_directions = {V3D(1, 0, 0)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec bad_abcRadii = {2, 3, 4, 5};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec bad_abcInnerRadii = {5, 6};
-    const MantidVec abcOuterRadii = {8, 9, 10};
-    const MantidVec bad_abcOuterRadii = {8, 9, 10, 11};
-    const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
-
-    TSM_ASSERT_THROWS("Should throw, bad directions",
-                      PeakShapeEllipsoid(bad_directions, abcRadii, abcInnerRadii, abcOuterRadii, frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad radii",
-                      PeakShapeEllipsoid(directions, bad_abcRadii, abcInnerRadii, abcOuterRadii, frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad inner radii",
-                      PeakShapeEllipsoid(directions, abcRadii, bad_abcInnerRadii, abcOuterRadii, frame),
-                      std::invalid_argument &);
-    TSM_ASSERT_THROWS("Should throw, bad outer radii",
-                      PeakShapeEllipsoid(directions, abcRadii, abcInnerRadii, bad_abcOuterRadii, frame),
-                      std::invalid_argument &);
-  }
-
   void test_copy_constructor() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const std::array<double, 3> abcRadii = {2, 3, 4};
+    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
+    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -116,7 +91,7 @@ public:
 
   void test_radius() {
 
-    std::vector<double> radius = {1, 2, 3};
+    std::array<double, 3> radius = {1, 2, 3};
 
     PeakShapeEllipsoid shape({V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}, radius, radius, radius, Mantid::Kernel::HKL);
 
@@ -140,10 +115,10 @@ public:
 
   void test_toJSON() {
 
-    std::vector<V3D> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const std::array<double, 3> abcRadii = {2, 3, 4};
+    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
+    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -172,10 +147,10 @@ public:
   }
 
   void test_directionsInSpecificFrameThrowsForMatrixWithInvalidDimensions() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const std::array<double, 3> abcRadii = {2, 3, 4};
+    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
+    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -200,10 +175,10 @@ public:
   }
 
   void test_directionsInSepcificFrame() {
-    auto directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const MantidVec abcRadii = {2, 3, 4};
-    const MantidVec abcInnerRadii = {5, 6, 7};
-    const MantidVec abcOuterRadii = {8, 9, 10};
+    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const std::array<double, 3> abcRadii = {2, 3, 4};
+    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
+    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -231,7 +206,7 @@ public:
     matrix.setColumn(1, column2);
     matrix.setColumn(2, column3);
 
-    std::vector<Mantid::Kernel::V3D> directionInNewFrame(3);
+    std::array<Mantid::Kernel::V3D, 3> directionInNewFrame;
     TSM_ASSERT_THROWS_NOTHING("Should throw nothing, valid goniometer matrix",
                               directionInNewFrame = a.getDirectionInSpecificFrame(matrix));
 

--- a/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
@@ -16,6 +16,8 @@
 #include <json/json.h>
 #include <vector>
 
+using Mantid::DataObjects::PeakEllipsoidExtent;
+using Mantid::DataObjects::PeakEllipsoidFrame;
 using Mantid::DataObjects::PeakShapeEllipsoid;
 using Mantid::Kernel::SpecialCoordinateSystem;
 using namespace Mantid;
@@ -29,10 +31,10 @@ public:
   static void destroySuite(PeakShapeEllipsoidTest *suite) { delete suite; }
 
   void test_constructor() {
-    std::array<V3D, 3> directions = {(V3D(1, 0, 0)), (V3D(0, 1, 0)), (V3D(0, 0, 1))};
-    const std::array<double, 3> abcRadii = {2, 3, 4};
-    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
-    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
+    PeakEllipsoidFrame directions = {(V3D(1, 0, 0)), (V3D(0, 1, 0)), (V3D(0, 0, 1))};
+    const PeakEllipsoidExtent abcRadii = {2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii = {5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -51,10 +53,10 @@ public:
   }
 
   void test_copy_constructor() {
-    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const std::array<double, 3> abcRadii = {2, 3, 4};
-    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
-    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
+    PeakEllipsoidFrame directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent abcRadii = {2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii = {5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -91,7 +93,7 @@ public:
 
   void test_radius() {
 
-    std::array<double, 3> radius = {1, 2, 3};
+    PeakEllipsoidExtent radius = {1, 2, 3};
 
     PeakShapeEllipsoid shape({V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)}, radius, radius, radius, Mantid::Kernel::HKL);
 
@@ -115,10 +117,10 @@ public:
 
   void test_toJSON() {
 
-    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const std::array<double, 3> abcRadii = {2, 3, 4};
-    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
-    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
+    PeakEllipsoidFrame directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent abcRadii = {2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii = {5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::HKL;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -147,10 +149,10 @@ public:
   }
 
   void test_directionsInSpecificFrameThrowsForMatrixWithInvalidDimensions() {
-    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const std::array<double, 3> abcRadii = {2, 3, 4};
-    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
-    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
+    PeakEllipsoidFrame directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent abcRadii = {2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii = {5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;
@@ -175,10 +177,10 @@ public:
   }
 
   void test_directionsInSepcificFrame() {
-    std::array<V3D, 3> directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
-    const std::array<double, 3> abcRadii = {2, 3, 4};
-    const std::array<double, 3> abcInnerRadii = {5, 6, 7};
-    const std::array<double, 3> abcOuterRadii = {8, 9, 10};
+    PeakEllipsoidFrame directions = {V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent abcRadii = {2, 3, 4};
+    const PeakEllipsoidExtent abcInnerRadii = {5, 6, 7};
+    const PeakEllipsoidExtent abcOuterRadii = {8, 9, 10};
     const SpecialCoordinateSystem frame = Mantid::Kernel::QLab;
     const std::string algorithmName = "foo";
     const int algorithmVersion = 3;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "MantidDataObjects/Peak.h"
-#include "MantidDataObjects/PeakShapeEllipsoid.h"
+#include "MantidDataObjects/PeakShapeEllipsoid_fwd.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/V3D.h"
 #include "MantidMDAlgorithms/DllConfig.h"
@@ -21,9 +21,6 @@
 namespace Mantid {
 namespace Geometry {
 class PeakShape;
-}
-namespace DataObjects {
-class PeakShapeEllipsoid;
 }
 namespace MDAlgorithms {
 
@@ -74,7 +71,7 @@ public:
   std::shared_ptr<const Mantid::Geometry::PeakShape>
   ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q, bool specify_size,
                          double peak_radius, double back_inner_radius, double back_outer_radius,
-                         std::array<double, 3> &axes_radii, double &inti, double &sigi);
+                         DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi);
 
   /// Find the net integrated intensity of a modulated peak, using ellipsoidal
   /// volumes
@@ -82,7 +79,7 @@ public:
   ellipseIntegrateModEvents(const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q,
                             Mantid::Kernel::V3D const &hkl, Mantid::Kernel::V3D const &mnp, bool specify_size,
                             double peak_radius, double back_inner_radius, double back_outer_radius,
-                            std::array<double, 3> &axes_radii, double &inti, double &sigi);
+                            DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi);
 
   /// Find the net integrated intensity of a peak, using ellipsoidal volumes
   std::pair<std::shared_ptr<const Mantid::Geometry::PeakShape>, std::tuple<double, double, double>>
@@ -104,19 +101,20 @@ private:
 
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,
                                const std::vector<Mantid::Kernel::V3D> &E1Vecs, const Mantid::Kernel::V3D &peak_q,
-                               const std::array<double, 3> &axesRadii, const std::array<double, 3> &bkgInnerRadii,
-                               const std::array<double, 3> &bkgOuterRadii);
+                               const DataObjects::PeakEllipsoidExtent &axesRadii,
+                               const DataObjects::PeakEllipsoidExtent &bkgInnerRadii,
+                               const DataObjects::PeakEllipsoidExtent &bkgOuterRadii);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoid(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
-                 std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sizes);
+                 DataObjects::PeakEllipsoidFrame const &directions, DataObjects::PeakEllipsoidExtent const &sizes);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoidBkg(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
-                    std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sizes,
-                    std::array<double, 3> const &sizesIn, const bool useOnePercentBackgroundCorrection);
+                    DataObjects::PeakEllipsoidFrame const &directions, DataObjects::PeakEllipsoidExtent const &sizes,
+                    DataObjects::PeakEllipsoidExtent const &sizesIn, const bool useOnePercentBackgroundCorrection);
 
   /// Calculate the 3x3 covariance matrix of a list of Q-vectors at 0,0,0
   static void makeCovarianceMatrix(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
@@ -124,7 +122,7 @@ private:
 
   /// Calculate the eigen vectors of a 3x3 real symmetric matrix
   static void getEigenVectors(Kernel::DblMatrix const &cov_matrix, std::array<Mantid::Kernel::V3D, 3> &eigen_vectors,
-                              std::array<double, 3> &eigen_values);
+                              DataObjects::PeakEllipsoidExtent &eigen_values);
 
   /// Form a map key as 10^12*h + 10^6*k + l from the integers h, k, l
   static int64_t getHklKey(int h, int k, int l);
@@ -145,13 +143,14 @@ private:
   std::shared_ptr<const Mantid::DataObjects::PeakShapeEllipsoid>
   ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Kernel::V3D const &peak_q,
                          std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &ev_list,
-                         std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sigmas,
-                         bool specify_size, double peak_radius, double back_inner_radius, double back_outer_radius,
-                         std::array<double, 3> &axes_radii, double &inti, double &sigi);
+                         DataObjects::PeakEllipsoidFrame const &directions,
+                         DataObjects::PeakEllipsoidExtent const &sigmas, bool specify_size, double peak_radius,
+                         double back_inner_radius, double back_outer_radius,
+                         DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi);
 
   /// Compute if a particular Q falls on the edge of a detector
   double detectorQ(const std::vector<Kernel::V3D> &E1Vec, const Mantid::Kernel::V3D &QLabFrame,
-                   const std::array<double, 3> &r);
+                   const DataObjects::PeakEllipsoidExtent &r);
 
   std::tuple<double, double, double> calculateRadiusFactors(const IntegrationParameters &params,
                                                             double max_sigma) const;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -74,7 +74,7 @@ public:
   std::shared_ptr<const Mantid::Geometry::PeakShape>
   ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q, bool specify_size,
                          double peak_radius, double back_inner_radius, double back_outer_radius,
-                         std::vector<double> &axes_radii, double &inti, double &sigi);
+                         std::array<double, 3> &axes_radii, double &inti, double &sigi);
 
   /// Find the net integrated intensity of a modulated peak, using ellipsoidal
   /// volumes
@@ -82,7 +82,7 @@ public:
   ellipseIntegrateModEvents(const std::vector<Kernel::V3D> &E1Vec, Mantid::Kernel::V3D const &peak_q,
                             Mantid::Kernel::V3D const &hkl, Mantid::Kernel::V3D const &mnp, bool specify_size,
                             double peak_radius, double back_inner_radius, double back_outer_radius,
-                            std::vector<double> &axes_radii, double &inti, double &sigi);
+                            std::array<double, 3> &axes_radii, double &inti, double &sigi);
 
   /// Find the net integrated intensity of a peak, using ellipsoidal volumes
   std::pair<std::shared_ptr<const Mantid::Geometry::PeakShape>, std::tuple<double, double, double>>
@@ -104,27 +104,27 @@ private:
 
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,
                                const std::vector<Mantid::Kernel::V3D> &E1Vecs, const Mantid::Kernel::V3D &peak_q,
-                               const std::vector<double> &axesRadii, const std::vector<double> &bkgInnerRadii,
-                               const std::vector<double> &bkgOuterRadii);
+                               const std::array<double, 3> &axesRadii, const std::array<double, 3> &bkgInnerRadii,
+                               const std::array<double, 3> &bkgOuterRadii);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoid(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
-                 std::vector<Mantid::Kernel::V3D> const &directions, std::vector<double> const &sizes);
+                 std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sizes);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
   static std::pair<double, double>
   numInEllipsoidBkg(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
-                    std::vector<Mantid::Kernel::V3D> const &directions, std::vector<double> const &sizes,
-                    std::vector<double> const &sizesIn, const bool useOnePercentBackgroundCorrection);
+                    std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sizes,
+                    std::array<double, 3> const &sizesIn, const bool useOnePercentBackgroundCorrection);
 
   /// Calculate the 3x3 covariance matrix of a list of Q-vectors at 0,0,0
   static void makeCovarianceMatrix(std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &events,
                                    Kernel::DblMatrix &matrix, double radius);
 
   /// Calculate the eigen vectors of a 3x3 real symmetric matrix
-  static void getEigenVectors(Kernel::DblMatrix const &cov_matrix, std::vector<Mantid::Kernel::V3D> &eigen_vectors,
-                              std::vector<double> &eigen_values);
+  static void getEigenVectors(Kernel::DblMatrix const &cov_matrix, std::array<Mantid::Kernel::V3D, 3> &eigen_vectors,
+                              std::array<double, 3> &eigen_values);
 
   /// Form a map key as 10^12*h + 10^6*k + l from the integers h, k, l
   static int64_t getHklKey(int h, int k, int l);
@@ -145,13 +145,13 @@ private:
   std::shared_ptr<const Mantid::DataObjects::PeakShapeEllipsoid>
   ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Kernel::V3D const &peak_q,
                          std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &ev_list,
-                         std::vector<Mantid::Kernel::V3D> const &directions, std::vector<double> const &sigmas,
+                         std::array<Mantid::Kernel::V3D, 3> const &directions, std::array<double, 3> const &sigmas,
                          bool specify_size, double peak_radius, double back_inner_radius, double back_outer_radius,
-                         std::vector<double> &axes_radii, double &inti, double &sigi);
+                         std::array<double, 3> &axes_radii, double &inti, double &sigi);
 
   /// Compute if a particular Q falls on the edge of a detector
   double detectorQ(const std::vector<Kernel::V3D> &E1Vec, const Mantid::Kernel::V3D &QLabFrame,
-                   const std::vector<double> &r);
+                   const std::array<double, 3> &r);
 
   std::tuple<double, double, double> calculateRadiusFactors(const IntegrationParameters &params,
                                                             double max_sigma) const;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -140,12 +140,11 @@ private:
   void addModEvent(std::pair<std::pair<double, double>, Mantid::Kernel::V3D> event_Q, bool hkl_integ);
 
   /// Find the net integrated intensity of a list of Q's using ellipsoids
-  std::shared_ptr<const Mantid::DataObjects::PeakShapeEllipsoid>
+  DataObjects::PeakShapeEllipsoid_const_sptr
   ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Kernel::V3D const &peak_q,
-                         std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &ev_list,
-                         DataObjects::PeakEllipsoidFrame const &directions,
-                         DataObjects::PeakEllipsoidExtent const &sigmas, bool specify_size, double peak_radius,
-                         double back_inner_radius, double back_outer_radius,
+                         std::vector<std::pair<std::pair<double, double>, Kernel::V3D>> const &ev_list,
+                         DataObjects::PeakEllipsoidFrame const &directions, std::array<double, 3> const &sigmas,
+                         bool specify_size, double peak_radius, double back_inner_radius, double back_outer_radius,
                          DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi);
 
   /// Compute if a particular Q falls on the edge of a detector

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoidsV1.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoidsV1.h
@@ -37,7 +37,7 @@ public:
   const std::string category() const override;
 
 private:
-  using PrincipleAxes = std::array<std::vector<double>, 3>;
+  using PrincipleAxes = DataObjects::PeakEllipsoidExtent;
 
   void init() override;
   void exec() override;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
@@ -66,12 +66,12 @@ private:
   void findEllipsoid(const typename DataObjects::MDEventWorkspace<MDE, nd>::sptr ws,
                      const Mantid::API::CoordTransform &getRadiusSq, const Mantid::Kernel::V3D &pos,
                      const coord_t &radiusSquared, const bool &qAxisBool, const bool &useCentroid,
-                     const double &bgDensity, std::vector<Mantid::Kernel::V3D> &eigenvects,
-                     std::vector<double> &eigenvals, Mantid::Kernel::V3D &mean, const int maxIter = 1);
+                     const double &bgDensity, std::array<Mantid::Kernel::V3D, 3> &eigenvects,
+                     std::array<double, 3> &eigenvals, Mantid::Kernel::V3D &mean, const int maxIter = 1);
 
   void calcCovar(const std::vector<std::pair<Mantid::Kernel::V3D, double>> &peak_events, const Mantid::Kernel::V3D &pos,
                  const coord_t &radiusSquared, const bool &qAxisIsFixed, const bool &useCentroid,
-                 std::vector<Mantid::Kernel::V3D> &eigenvects, std::vector<double> &eigenvals,
+                 std::array<Mantid::Kernel::V3D, 3> &eigenvects, std::array<double, 3> &eigenvals,
                  Mantid::Kernel::V3D &mean, const int maxIter);
 
   // get matrix to transform from Qlab to plane perp to Q

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateQLabEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateQLabEvents.h
@@ -146,7 +146,7 @@ public:
    * @param backi : (output) collects background intensity subtracted from inti and sigi */
   PeakShape_const_sptr ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
                                               double peak_radius, double back_inner_radius, double back_outer_radius,
-                                              std::array<double, 3> &axes_radii, double &inti, double &sigi,
+                                              DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi,
                                               std::pair<double, double> &backi);
 
   /**
@@ -169,8 +169,9 @@ private:
    * @param sizes : List of three values a,b,c giving half the length
    * of the three axes of the ellisoid.
    * @return number of events and estimated error */
-  static std::pair<double, double> numInEllipsoid(SlimEvents const &events, std::array<V3D, 3> const &directions,
-                                                  std::array<double, 3> const &sizes);
+  static std::pair<double, double> numInEllipsoid(SlimEvents const &events,
+                                                  DataObjects::PeakEllipsoidFrame const &directions,
+                                                  DataObjects::PeakEllipsoidExtent const &sizes);
 
   /**
    * @brief Number of events in an ellipsoid with background correction.
@@ -187,9 +188,10 @@ private:
    * @param useOnePercentBackgroundCorrection : flag if one percent background
    * correction should be used.
    * @return number of events and estimated error */
-  static std::pair<double, double> numInEllipsoidBkg(SlimEvents const &events, std::array<V3D, 3> const &directions,
-                                                     std::array<double, 3> const &sizes,
-                                                     std::array<double, 3> const &sizesIn,
+  static std::pair<double, double> numInEllipsoidBkg(SlimEvents const &events,
+                                                     DataObjects::PeakEllipsoidFrame const &directions,
+                                                     DataObjects::PeakEllipsoidExtent const &sizes,
+                                                     DataObjects::PeakEllipsoidExtent const &sizesIn,
                                                      const bool useOnePercentBackgroundCorrection);
 
   /**
@@ -257,12 +259,12 @@ private:
    * @param inti : (output) net integrated intensity
    * @param sigi : (output) estimate of the standard deviation the intensity
    * @param backi : (output) background intensity subtracted from inti and sigi */
-  PeakShapeEllipsoid_const_sptr ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q,
-                                                       SlimEvents const &ev_list, std::array<V3D, 3> const &directions,
-                                                       std::array<double, 3> const &sigmas, bool specify_size,
-                                                       double peak_radius, double back_inner_radius,
-                                                       double back_outer_radius, std::array<double, 3> &axes_radii,
-                                                       double &inti, double &sigi, std::pair<double, double> &backi);
+  PeakShapeEllipsoid_const_sptr
+  ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, SlimEvents const &ev_list,
+                         DataObjects::PeakEllipsoidFrame const &directions, std::array<double, 3> const &sigmas,
+                         bool specify_size, double peak_radius, double back_inner_radius, double back_outer_radius,
+                         DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi,
+                         std::pair<double, double> &backi);
 
   /**
    * @brief Calculate if this Q is on a detector
@@ -275,7 +277,7 @@ private:
    * @param QLabFrame: The Peak center.
    * @param r: Peak radius.
    */
-  double detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame, const std::array<double, 3> &r);
+  double detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame, const DataObjects::PeakEllipsoidExtent &r);
 
   // Private data members
   double m_radius; // size of sphere to use for events around a peak

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateQLabEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateQLabEvents.h
@@ -146,7 +146,7 @@ public:
    * @param backi : (output) collects background intensity subtracted from inti and sigi */
   PeakShape_const_sptr ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
                                               double peak_radius, double back_inner_radius, double back_outer_radius,
-                                              std::vector<double> &axes_radii, double &inti, double &sigi,
+                                              std::array<double, 3> &axes_radii, double &inti, double &sigi,
                                               std::pair<double, double> &backi);
 
   /**
@@ -169,8 +169,8 @@ private:
    * @param sizes : List of three values a,b,c giving half the length
    * of the three axes of the ellisoid.
    * @return number of events and estimated error */
-  static std::pair<double, double> numInEllipsoid(SlimEvents const &events, std::vector<V3D> const &directions,
-                                                  std::vector<double> const &sizes);
+  static std::pair<double, double> numInEllipsoid(SlimEvents const &events, std::array<V3D, 3> const &directions,
+                                                  std::array<double, 3> const &sizes);
 
   /**
    * @brief Number of events in an ellipsoid with background correction.
@@ -187,9 +187,9 @@ private:
    * @param useOnePercentBackgroundCorrection : flag if one percent background
    * correction should be used.
    * @return number of events and estimated error */
-  static std::pair<double, double> numInEllipsoidBkg(SlimEvents const &events, std::vector<V3D> const &directions,
-                                                     std::vector<double> const &sizes,
-                                                     std::vector<double> const &sizesIn,
+  static std::pair<double, double> numInEllipsoidBkg(SlimEvents const &events, std::array<V3D, 3> const &directions,
+                                                     std::array<double, 3> const &sizes,
+                                                     std::array<double, 3> const &sizesIn,
                                                      const bool useOnePercentBackgroundCorrection);
 
   /**
@@ -219,8 +219,8 @@ private:
    * @param eigen_vectors : (output) returned eigen vectors
    * @param eigen_values : (output) three eigenvalues
    */
-  static void getEigenVectors(Kernel::DblMatrix const &cov_matrix, std::vector<V3D> &eigen_vectors,
-                              std::vector<double> &eigen_values);
+  static void getEigenVectors(Kernel::DblMatrix const &cov_matrix, std::array<V3D, 3> &eigen_vectors,
+                              std::array<double, 3> &eigen_values);
 
   /**
    * @brief assign an event to one cell of the partitioned QLab space.
@@ -258,10 +258,10 @@ private:
    * @param sigi : (output) estimate of the standard deviation the intensity
    * @param backi : (output) background intensity subtracted from inti and sigi */
   PeakShapeEllipsoid_const_sptr ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q,
-                                                       SlimEvents const &ev_list, std::vector<V3D> const &directions,
-                                                       std::vector<double> const &sigmas, bool specify_size,
+                                                       SlimEvents const &ev_list, std::array<V3D, 3> const &directions,
+                                                       std::array<double, 3> const &sigmas, bool specify_size,
                                                        double peak_radius, double back_inner_radius,
-                                                       double back_outer_radius, std::vector<double> &axes_radii,
+                                                       double back_outer_radius, std::array<double, 3> &axes_radii,
                                                        double &inti, double &sigi, std::pair<double, double> &backi);
 
   /**
@@ -275,7 +275,7 @@ private:
    * @param QLabFrame: The Peak center.
    * @param r: Peak radius.
    */
-  double detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame, const std::vector<double> &r);
+  double detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame, const std::array<double, 3> &r);
 
   // Private data members
   double m_radius; // size of sphere to use for events around a peak

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -140,11 +140,11 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params, cons
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(events, cov_matrix, params.regionRadius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -162,12 +162,12 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params, cons
   auto rValues = calculateRadiusFactors(params, max_sigma);
   auto &r1 = std::get<0>(rValues), r2 = std::get<1>(rValues), r3 = std::get<2>(rValues);
 
-  std::vector<double> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
-  std::vector<double> peakRadii;
+  std::array<double, 3> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
+  std::array<double, 3> peakRadii;
   for (int i = 0; i < 3; i++) {
-    abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-    abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-    peakRadii.emplace_back(r1 * sigmas[i]);
+    abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+    abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+    peakRadii[i] = r1 * sigmas[i];
   }
 
   const auto isPeakOnDetector = correctForDetectorEdges(rValues, params.E1Vectors, peak_q, peakRadii,
@@ -275,11 +275,11 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(events, cov_matrix, params.regionRadius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -291,22 +291,22 @@ double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters
 
   auto rValues = calculateRadiusFactors(params, max_sigma);
   auto &r1 = std::get<0>(rValues), r2 = std::get<1>(rValues), r3 = std::get<2>(rValues);
-  std::vector<double> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
-  std::vector<double> peakRadii;
+  std::array<double, 3> abcBackgroundOuterRadii, abcBackgroundInnerRadii;
+  std::array<double, 3> peakRadii;
   if (forceSpherical) {
     // test for spherically symmeteric peak (within tolerance)
     if ((max_sigma - min_sigma) / max_sigma > sphericityTol)
       return .0;
     for (int i = 0; i < 3; i++) {
-      abcBackgroundOuterRadii.emplace_back(r3 * max_sigma);
-      abcBackgroundInnerRadii.emplace_back(r2 * max_sigma);
-      peakRadii.emplace_back(r1 * max_sigma);
+      abcBackgroundOuterRadii[i] = r3 * max_sigma;
+      abcBackgroundInnerRadii[i] = r2 * max_sigma;
+      peakRadii[i] = r1 * max_sigma;
     }
   } else {
     for (int i = 0; i < 3; i++) {
-      abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-      abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-      peakRadii.emplace_back(r1 * sigmas[i]);
+      abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+      abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+      peakRadii[i] = r1 * sigmas[i];
     }
   }
 
@@ -344,9 +344,9 @@ const std::vector<std::pair<std::pair<double, double>, V3D>> *Integrate3DEvents:
 
 bool Integrate3DEvents::correctForDetectorEdges(std::tuple<double, double, double> &radii,
                                                 const std::vector<V3D> &E1Vecs, const V3D &peak_q,
-                                                const std::vector<double> &axesRadii,
-                                                const std::vector<double> &bkgInnerRadii,
-                                                const std::vector<double> &bkgOuterRadii) {
+                                                const std::array<double, 3> &axesRadii,
+                                                const std::array<double, 3> &bkgInnerRadii,
+                                                const std::array<double, 3> &bkgOuterRadii) {
 
   if (E1Vecs.empty())
     return true;
@@ -412,7 +412,7 @@ bool Integrate3DEvents::correctForDetectorEdges(std::tuple<double, double, doubl
 Mantid::Geometry::PeakShape_const_sptr
 Integrate3DEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
                                           double peak_radius, double back_inner_radius, double back_outer_radius,
-                                          std::vector<double> &axes_radii, double &inti, double &sigi) {
+                                          std::array<double, 3> &axes_radii, double &inti, double &sigi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
@@ -437,11 +437,11 @@ Integrate3DEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D con
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(some_events, cov_matrix, m_radius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++) {
     sigmas[i] = sqrt(eigen_values[i]);
   }
@@ -462,7 +462,7 @@ Mantid::Geometry::PeakShape_const_sptr
 Integrate3DEvents::ellipseIntegrateModEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, V3D const &hkl,
                                              V3D const &mnp, bool specify_size, double peak_radius,
                                              double back_inner_radius, double back_outer_radius,
-                                             std::vector<double> &axes_radii, double &inti, double &sigi) {
+                                             std::array<double, 3> &axes_radii, double &inti, double &sigi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
@@ -492,11 +492,11 @@ Integrate3DEvents::ellipseIntegrateModEvents(const std::vector<V3D> &E1Vec, V3D 
   else
     makeCovarianceMatrix(some_events, cov_matrix, s_radius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++)
     sigmas[i] = sqrt(eigen_values[i]);
 
@@ -526,7 +526,7 @@ Integrate3DEvents::ellipseIntegrateModEvents(const std::vector<V3D> &E1Vec, V3D 
  */
 std::pair<double, double>
 Integrate3DEvents::numInEllipsoid(std::vector<std::pair<std::pair<double, double>, V3D>> const &events,
-                                  std::vector<V3D> const &directions, std::vector<double> const &sizes) {
+                                  std::array<V3D, 3> const &directions, std::array<double, 3> const &sizes) {
 
   std::pair<double, double> count(0, 0);
   for (const auto &event : events) {
@@ -562,8 +562,9 @@ Integrate3DEvents::numInEllipsoid(std::vector<std::pair<std::pair<double, double
  */
 std::pair<double, double>
 Integrate3DEvents::numInEllipsoidBkg(std::vector<std::pair<std::pair<double, double>, V3D>> const &events,
-                                     std::vector<V3D> const &directions, std::vector<double> const &sizes,
-                                     std::vector<double> const &sizesIn, const bool useOnePercentBackgroundCorrection) {
+                                     std::array<V3D, 3> const &directions, std::array<double, 3> const &sizes,
+                                     std::array<double, 3> const &sizesIn,
+                                     const bool useOnePercentBackgroundCorrection) {
   std::pair<double, double> count(0, 0);
   std::vector<std::pair<double, double>> eventVec;
   for (const auto &event : events) {
@@ -651,9 +652,9 @@ void Integrate3DEvents::makeCovarianceMatrix(std::vector<std::pair<std::pair<dou
  *                        in this list.
  *  @param eigen_values   3 eigenvalues of matrix
  */
-void Integrate3DEvents::getEigenVectors(DblMatrix const &cov_matrix, std::vector<V3D> &eigen_vectors,
-                                        std::vector<double> &eigen_values) {
-  unsigned int size = 3;
+void Integrate3DEvents::getEigenVectors(DblMatrix const &cov_matrix, std::array<V3D, 3> &eigen_vectors,
+                                        std::array<double, 3> &eigen_values) {
+  constexpr unsigned int size = 3;
 
   gsl_matrix *matrix = gsl_matrix_alloc(size, size);
   gsl_vector *eigen_val = gsl_vector_alloc(size);
@@ -670,9 +671,9 @@ void Integrate3DEvents::getEigenVectors(DblMatrix const &cov_matrix, std::vector
 
   // copy the resulting eigen vectors to output vector
   for (size_t col = 0; col < size; col++) {
-    eigen_vectors.emplace_back(gsl_matrix_get(eigen_vec, 0, col), gsl_matrix_get(eigen_vec, 1, col),
-                               gsl_matrix_get(eigen_vec, 2, col));
-    eigen_values.emplace_back(gsl_vector_get(eigen_val, col));
+    eigen_vectors[col] =
+        V3D(gsl_matrix_get(eigen_vec, 0, col), gsl_matrix_get(eigen_vec, 1, col), gsl_matrix_get(eigen_vec, 2, col));
+    eigen_values[col] = gsl_vector_get(eigen_val, col);
   }
 
   gsl_matrix_free(matrix);
@@ -1051,8 +1052,8 @@ void Integrate3DEvents::addModEvent(std::pair<std::pair<double, double>, V3D> ev
 PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     const std::vector<V3D> &E1Vec, V3D const &peak_q,
     std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &ev_list,
-    std::vector<V3D> const &directions, std::vector<double> const &sigmas, bool specify_size, double peak_radius,
-    double back_inner_radius, double back_outer_radius, std::vector<double> &axes_radii, double &inti, double &sigi) {
+    std::array<V3D, 3> const &directions, std::array<double, 3> const &sigmas, bool specify_size, double peak_radius,
+    double back_inner_radius, double back_outer_radius, std::array<double, 3> &axes_radii, double &inti, double &sigi) {
   // r1, r2 and r3 will give the sizes of the major axis of
   // the peak ellipsoid, and of the inner and outer surface
   // of the background ellipsoidal shell, respectively.
@@ -1088,15 +1089,14 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     }
   }
 
-  axes_radii.clear();
-  std::vector<double> abcBackgroundOuterRadii;
-  std::vector<double> abcBackgroundInnerRadii;
-  std::vector<double> abcRadii;
+  std::array<double, 3> abcBackgroundOuterRadii;
+  std::array<double, 3> abcBackgroundInnerRadii;
+  std::array<double, 3> abcRadii;
   for (int i = 0; i < 3; i++) {
-    abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-    abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-    abcRadii.emplace_back(r1 * sigmas[i]);
-    axes_radii.emplace_back(r1 * sigmas[i]);
+    abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+    abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+    abcRadii[i] = r1 * sigmas[i];
+    axes_radii[i] = r1 * sigmas[i];
   }
 
   if (!E1Vec.empty()) {
@@ -1144,7 +1144,8 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
  * @param QLabFrame: The Peak center.
  * @param r: Peak radius.
  */
-double Integrate3DEvents::detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame, const std::vector<double> &r) {
+double Integrate3DEvents::detectorQ(const std::vector<V3D> &E1Vec, const V3D &QLabFrame,
+                                    const std::array<double, 3> &r) {
   double quot = 1.0;
   for (const auto &E1 : E1Vec) {
     V3D distv = QLabFrame - E1 * (QLabFrame.scalar_prod(E1)); // distance to the trajectory as a vector

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -1049,12 +1049,13 @@ void Integrate3DEvents::addModEvent(std::pair<std::pair<double, double>, V3D> ev
  *                            of the net integrated intensity
  *
  */
-PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
-    const std::vector<V3D> &E1Vec, V3D const &peak_q,
-    std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const &ev_list,
-    DataObjects::PeakEllipsoidFrame const &directions, std::array<double, 3> const &sigmas, bool specify_size,
-    double peak_radius, double back_inner_radius, double back_outer_radius,
-    DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi) {
+PeakShapeEllipsoid_const_sptr
+Integrate3DEvents::ellipseIntegrateEvents(const std::vector<Kernel::V3D> &E1Vec, Kernel::V3D const &peak_q,
+                                          std::vector<std::pair<std::pair<double, double>, Kernel::V3D>> const &ev_list,
+                                          DataObjects::PeakEllipsoidFrame const &directions,
+                                          std::array<double, 3> const &sigmas, bool specify_size, double peak_radius,
+                                          double back_inner_radius, double back_outer_radius,
+                                          DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi) {
   // r1, r2 and r3 will give the sizes of the major axis of
   // the peak ellipsoid, and of the inner and outer surface
   // of the background ellipsoidal shell, respectively.

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV1.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV1.cpp
@@ -512,7 +512,7 @@ void IntegrateEllipsoidsV1::exec() {
       BackgroundInnerRadiusVector[i] = adaptiveBack_inner_radius;
       BackgroundOuterRadiusVector[i] = adaptiveBack_outer_radius;
 
-      std::vector<double> axes_radii;
+      std::array<double, 3> axes_radii;
       Mantid::Geometry::PeakShape_const_sptr shape = integrator.ellipseIntegrateModEvents(
           E1Vec, peak_q, hkl, mnp, specify_size, adaptiveRadius, adaptiveBack_inner_radius, adaptiveBack_outer_radius,
           axes_radii, inti, sigi);
@@ -601,7 +601,7 @@ void IntegrateEllipsoidsV1::exec() {
         V3D mnp(peaks[i].getIntMNP());
         if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0) || Geometry::IndexingUtils::ValidIndex(mnp, 1.0)) {
           const V3D peak_q = peaks[i].getQLabFrame();
-          std::vector<double> axes_radii;
+          std::array<double, 3> axes_radii;
           integrator.ellipseIntegrateModEvents(E1Vec, peak_q, hkl, mnp, specify_size, peak_radius, back_inner_radius,
                                                back_outer_radius, axes_radii, inti, sigi);
           peaks[i].setIntensity(inti);

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV1.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV1.cpp
@@ -512,7 +512,7 @@ void IntegrateEllipsoidsV1::exec() {
       BackgroundInnerRadiusVector[i] = adaptiveBack_inner_radius;
       BackgroundOuterRadiusVector[i] = adaptiveBack_outer_radius;
 
-      std::array<double, 3> axes_radii;
+      DataObjects::PeakEllipsoidExtent axes_radii;
       Mantid::Geometry::PeakShape_const_sptr shape = integrator.ellipseIntegrateModEvents(
           E1Vec, peak_q, hkl, mnp, specify_size, adaptiveRadius, adaptiveBack_inner_radius, adaptiveBack_outer_radius,
           axes_radii, inti, sigi);
@@ -601,7 +601,7 @@ void IntegrateEllipsoidsV1::exec() {
         V3D mnp(peaks[i].getIntMNP());
         if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0) || Geometry::IndexingUtils::ValidIndex(mnp, 1.0)) {
           const V3D peak_q = peaks[i].getQLabFrame();
-          std::array<double, 3> axes_radii;
+          DataObjects::PeakEllipsoidExtent axes_radii;
           integrator.ellipseIntegrateModEvents(E1Vec, peak_q, hkl, mnp, specify_size, peak_radius, back_inner_radius,
                                                back_outer_radius, axes_radii, inti, sigi);
           peaks[i].setIntensity(inti);

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
@@ -424,7 +424,7 @@ void IntegrateEllipsoidsV2::exec() {
       // Integrate peak properly
       double inti;
       double sigi;
-      std::array<double, 3> axes_radii;
+      DataObjects::PeakEllipsoidExtent axes_radii;
 
       // calculate adaptive background inner and outer radius
       // compute adaptive background radius
@@ -716,7 +716,7 @@ void IntegrateEllipsoidsV2::integratePeaksCutoffISigI(const double &meanMax, con
     const bool isSatellitePeak = (peaks[i].getIntMNP().norm2() > 0);
     //
     const V3D peak_q = peaks[i].getQLabFrame();
-    std::array<double, 3> axes_radii;
+    DataObjects::PeakEllipsoidExtent axes_radii;
 
     double inti{0.}, sigi{0.};
     std::pair<double, double> backi;

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
@@ -424,7 +424,7 @@ void IntegrateEllipsoidsV2::exec() {
       // Integrate peak properly
       double inti;
       double sigi;
-      std::vector<double> axes_radii;
+      std::array<double, 3> axes_radii;
 
       // calculate adaptive background inner and outer radius
       // compute adaptive background radius
@@ -716,7 +716,7 @@ void IntegrateEllipsoidsV2::integratePeaksCutoffISigI(const double &meanMax, con
     const bool isSatellitePeak = (peaks[i].getIntMNP().norm2() > 0);
     //
     const V3D peak_q = peaks[i].getQLabFrame();
-    std::vector<double> axes_radii;
+    std::array<double, 3> axes_radii;
 
     double inti{0.}, sigi{0.};
     std::pair<double, double> backi;

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -608,9 +608,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
           // set peak shape
           // get radii in same proprtion as eigenvalues
           auto max_stdev = pow(*std::max_element(eigenvals.begin(), eigenvals.end()), 0.5);
-          std::array<double, 3> peakRadii{0., 0., 0.};
-          std::array<double, 3> backgroundInnerRadii{0., 0., 0.};
-          std::array<double, 3> backgroundOuterRadii{0., 0., 0.};
+          PeakEllipsoidExtent peakRadii{0., 0., 0.};
+          PeakEllipsoidExtent backgroundInnerRadii{0., 0., 0.};
+          PeakEllipsoidExtent backgroundOuterRadii{0., 0., 0.};
           for (size_t irad = 0; irad < peakRadii.size(); irad++) {
             auto scale = pow(eigenvals[irad], 0.5) / max_stdev;
             peakRadii[irad] = PeakRadiusVector[i] * scale;
@@ -668,9 +668,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
               pow(*std::max_element(eigenvals_background_inner.begin(), eigenvals_background_inner.end()), 0.5);
           auto max_stdev_outer =
               pow(*std::max_element(eigenvals_background_outer.begin(), eigenvals_background_outer.end()), 0.5);
-          std::array<double, 3> peakRadii{0., 0., 0.};
-          std::array<double, 3> backgroundInnerRadii{0., 0., 0.};
-          std::array<double, 3> backgroundOuterRadii{0., 0., 0.};
+          PeakEllipsoidExtent peakRadii{0., 0., 0.};
+          PeakEllipsoidExtent backgroundInnerRadii{0., 0., 0.};
+          PeakEllipsoidExtent backgroundOuterRadii{0., 0., 0.};
           for (size_t irad = 0; irad < peakRadii.size(); irad++) {
             peakRadii[irad] = PeakRadiusVector[i] * pow(eigenvals[irad], 0.5) / max_stdev;
             backgroundInnerRadii[irad] =

--- a/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
@@ -81,7 +81,7 @@ void IntegrateQLabEvents::addEvents(SlimEvents const &event_qs) {
 Mantid::Geometry::PeakShape_const_sptr
 IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
                                             double peak_radius, double back_inner_radius, double back_outer_radius,
-                                            std::vector<double> &axes_radii, double &inti, double &sigi,
+                                            std::array<double, 3> &axes_radii, double &inti, double &sigi,
                                             std::pair<double, double> &backi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
@@ -99,11 +99,11 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
   DblMatrix cov_matrix(3, 3);
   makeCovarianceMatrix(some_events, cov_matrix, m_radius);
 
-  std::vector<V3D> eigen_vectors;
-  std::vector<double> eigen_values;
+  std::array<V3D, 3> eigen_vectors;
+  std::array<double, 3> eigen_values;
   getEigenVectors(cov_matrix, eigen_vectors, eigen_values);
 
-  std::vector<double> sigmas(3);
+  std::array<double, 3> sigmas;
   for (int i = 0; i < 3; i++)
     sigmas[i] = sqrt(eigen_values[i]);
 
@@ -119,8 +119,8 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
 }
 
 std::pair<double, double> IntegrateQLabEvents::numInEllipsoid(SlimEvents const &events,
-                                                              std::vector<V3D> const &directions,
-                                                              std::vector<double> const &sizes) {
+                                                              std::array<V3D, 3> const &directions,
+                                                              std::array<double, 3> const &sizes) {
   std::pair<double, double> count(0, 0);
   for (const auto &event : events) {
     double sum = 0;
@@ -137,9 +137,9 @@ std::pair<double, double> IntegrateQLabEvents::numInEllipsoid(SlimEvents const &
 }
 
 std::pair<double, double> IntegrateQLabEvents::numInEllipsoidBkg(SlimEvents const &events,
-                                                                 std::vector<V3D> const &directions,
-                                                                 std::vector<double> const &sizes,
-                                                                 std::vector<double> const &sizesIn,
+                                                                 std::array<V3D, 3> const &directions,
+                                                                 std::array<double, 3> const &sizes,
+                                                                 std::array<double, 3> const &sizesIn,
                                                                  const bool useOnePercentBackgroundCorrection) {
   std::pair<double, double> count(0, 0);
   std::vector<std::pair<double, double>> eventVec;
@@ -199,9 +199,9 @@ void IntegrateQLabEvents::makeCovarianceMatrix(SlimEvents const &events, DblMatr
   }
 }
 
-void IntegrateQLabEvents::getEigenVectors(DblMatrix const &cov_matrix, std::vector<V3D> &eigen_vectors,
-                                          std::vector<double> &eigen_values) {
-  unsigned int size = 3;
+void IntegrateQLabEvents::getEigenVectors(DblMatrix const &cov_matrix, std::array<V3D, 3> &eigen_vectors,
+                                          std::array<double, 3> &eigen_values) {
+  constexpr unsigned int size = 3;
 
   gsl_matrix *matrix = gsl_matrix_alloc(size, size);
   gsl_vector *eigen_val = gsl_vector_alloc(size);
@@ -218,9 +218,9 @@ void IntegrateQLabEvents::getEigenVectors(DblMatrix const &cov_matrix, std::vect
 
   // copy the resulting eigen vectors to output vector
   for (size_t col = 0; col < size; col++) {
-    eigen_vectors.emplace_back(gsl_matrix_get(eigen_vec, 0, col), gsl_matrix_get(eigen_vec, 1, col),
-                               gsl_matrix_get(eigen_vec, 2, col));
-    eigen_values.emplace_back(gsl_vector_get(eigen_val, col));
+    eigen_vectors[col] =
+        V3D(gsl_matrix_get(eigen_vec, 0, col), gsl_matrix_get(eigen_vec, 1, col), gsl_matrix_get(eigen_vec, 2, col));
+    eigen_values[col] = gsl_vector_get(eigen_val, col);
   }
 
   gsl_matrix_free(matrix);
@@ -246,9 +246,9 @@ void IntegrateQLabEvents::addEvent(const SlimEvent event) {
 
 PeakShapeEllipsoid_const_sptr
 IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, SlimEvents const &ev_list,
-                                            std::vector<V3D> const &directions, std::vector<double> const &sigmas,
+                                            std::array<V3D, 3> const &directions, std::array<double, 3> const &sigmas,
                                             bool specify_size, double peak_radius, double back_inner_radius,
-                                            double back_outer_radius, std::vector<double> &axes_radii, double &inti,
+                                            double back_outer_radius, std::array<double, 3> &axes_radii, double &inti,
                                             double &sigi, std::pair<double, double> &backi) {
   /* r1, r2 and r3 will give the sizes of the major axis of the peak
    * ellipsoid, and of the inner and outer surface of the background
@@ -286,15 +286,14 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
     }
   }
 
-  axes_radii.clear();
-  std::vector<double> abcBackgroundOuterRadii;
-  std::vector<double> abcBackgroundInnerRadii;
-  std::vector<double> abcRadii;
+  std::array<double, 3> abcBackgroundOuterRadii;
+  std::array<double, 3> abcBackgroundInnerRadii;
+  std::array<double, 3> abcRadii;
   for (int i = 0; i < 3; i++) {
-    abcBackgroundOuterRadii.emplace_back(r3 * sigmas[i]);
-    abcBackgroundInnerRadii.emplace_back(r2 * sigmas[i]);
-    abcRadii.emplace_back(r1 * sigmas[i]);
-    axes_radii.emplace_back(r1 * sigmas[i]);
+    abcBackgroundOuterRadii[i] = r3 * sigmas[i];
+    abcBackgroundInnerRadii[i] = r2 * sigmas[i];
+    abcRadii[i] = r1 * sigmas[i];
+    axes_radii[i] = r1 * sigmas[i];
   }
 
   if (!E1Vec.empty()) {
@@ -359,8 +358,8 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
                                                     abcBackgroundOuterRadii, Mantid::Kernel::QLab,
                                                     "IntegrateEllipsoids");
 }
-double IntegrateQLabEvents::detectorQ(const std::vector<V3D> &E1Vec, const Kernel::V3D &QLabFrame,
-                                      const std::vector<double> &r) {
+double IntegrateQLabEvents::detectorQ(const std::vector<Mantid::Kernel::V3D> &E1Vec,
+                                      const Mantid::Kernel::V3D &QLabFrame, const std::array<double, 3> &r) {
   double quot = 1.0;
   for (const auto &E1 : E1Vec) {
     V3D distv = QLabFrame - E1 * (QLabFrame.scalar_prod(E1)); // distance to the trajectory as a vector

--- a/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateQLabEvents.cpp
@@ -81,7 +81,7 @@ void IntegrateQLabEvents::addEvents(SlimEvents const &event_qs) {
 Mantid::Geometry::PeakShape_const_sptr
 IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, bool specify_size,
                                             double peak_radius, double back_inner_radius, double back_outer_radius,
-                                            std::array<double, 3> &axes_radii, double &inti, double &sigi,
+                                            PeakEllipsoidExtent &axes_radii, double &inti, double &sigi,
                                             std::pair<double, double> &backi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
@@ -119,8 +119,8 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
 }
 
 std::pair<double, double> IntegrateQLabEvents::numInEllipsoid(SlimEvents const &events,
-                                                              std::array<V3D, 3> const &directions,
-                                                              std::array<double, 3> const &sizes) {
+                                                              PeakEllipsoidFrame const &directions,
+                                                              PeakEllipsoidExtent const &sizes) {
   std::pair<double, double> count(0, 0);
   for (const auto &event : events) {
     double sum = 0;
@@ -137,9 +137,9 @@ std::pair<double, double> IntegrateQLabEvents::numInEllipsoid(SlimEvents const &
 }
 
 std::pair<double, double> IntegrateQLabEvents::numInEllipsoidBkg(SlimEvents const &events,
-                                                                 std::array<V3D, 3> const &directions,
-                                                                 std::array<double, 3> const &sizes,
-                                                                 std::array<double, 3> const &sizesIn,
+                                                                 PeakEllipsoidFrame const &directions,
+                                                                 PeakEllipsoidExtent const &sizes,
+                                                                 PeakEllipsoidExtent const &sizesIn,
                                                                  const bool useOnePercentBackgroundCorrection) {
   std::pair<double, double> count(0, 0);
   std::vector<std::pair<double, double>> eventVec;
@@ -246,9 +246,9 @@ void IntegrateQLabEvents::addEvent(const SlimEvent event) {
 
 PeakShapeEllipsoid_const_sptr
 IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D const &peak_q, SlimEvents const &ev_list,
-                                            std::array<V3D, 3> const &directions, std::array<double, 3> const &sigmas,
+                                            PeakEllipsoidFrame const &directions, std::array<double, 3> const &sigmas,
                                             bool specify_size, double peak_radius, double back_inner_radius,
-                                            double back_outer_radius, std::array<double, 3> &axes_radii, double &inti,
+                                            double back_outer_radius, PeakEllipsoidExtent &axes_radii, double &inti,
                                             double &sigi, std::pair<double, double> &backi) {
   /* r1, r2 and r3 will give the sizes of the major axis of the peak
    * ellipsoid, and of the inner and outer surface of the background
@@ -286,9 +286,9 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
     }
   }
 
-  std::array<double, 3> abcBackgroundOuterRadii;
-  std::array<double, 3> abcBackgroundInnerRadii;
-  std::array<double, 3> abcRadii;
+  PeakEllipsoidExtent abcBackgroundOuterRadii;
+  PeakEllipsoidExtent abcBackgroundInnerRadii;
+  PeakEllipsoidExtent abcRadii;
   for (int i = 0; i < 3; i++) {
     abcBackgroundOuterRadii[i] = r3 * sigmas[i];
     abcBackgroundInnerRadii[i] = r2 * sigmas[i];
@@ -359,7 +359,7 @@ IntegrateQLabEvents::ellipseIntegrateEvents(const std::vector<V3D> &E1Vec, V3D c
                                                     "IntegrateEllipsoids");
 }
 double IntegrateQLabEvents::detectorQ(const std::vector<Mantid::Kernel::V3D> &E1Vec,
-                                      const Mantid::Kernel::V3D &QLabFrame, const std::array<double, 3> &r) {
+                                      const Mantid::Kernel::V3D &QLabFrame, const PeakEllipsoidExtent &r) {
   double quot = 1.0;
   for (const auto &E1 : E1Vec) {
     V3D distv = QLabFrame - E1 * (QLabFrame.scalar_prod(E1)); // distance to the trajectory as a vector

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -88,7 +88,7 @@ public:
     double peak_radius = 1.2;
     double back_inner_radius = 1.2;
     double back_outer_radius = 1.3;
-    std::vector<double> new_sigma;
+    std::array<double, 3> new_sigma;
     std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;
@@ -189,7 +189,7 @@ public:
     double peak_radius = 0.3;
     double back_inner_radius = 0.3;
     double back_outer_radius = 0.35;
-    std::vector<double> new_sigma;
+    std::array<double, 3> new_sigma;
     std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -43,7 +43,7 @@ using Mantid::Kernel::Logger;
 using Mantid::Kernel::V3D;
 
 namespace {
-void assert_radii_delta(const std::array<double, 3> &observed, const std::vector<double> &expected,
+void assert_radii_delta(const PeakEllipsoidExtent &observed, const std::vector<double> &expected,
                         const double tolerance) {
   TS_ASSERT_EQUALS(expected.size(), 3);
   for (size_t i = 0; i < 3; ++i) {

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -42,6 +42,16 @@ using namespace Mantid::MDAlgorithms;
 using Mantid::Kernel::Logger;
 using Mantid::Kernel::V3D;
 
+namespace {
+void assert_radii_delta(const std::array<double, 3> &observed, const std::vector<double> &expected,
+                        const double tolerance) {
+  TS_ASSERT_EQUALS(expected.size(), 3);
+  for (size_t i = 0; i < 3; ++i) {
+    TS_ASSERT_DELTA(observed[i], expected[i], tolerance);
+  }
+}
+} // namespace
+
 class IntegratePeaksMD2Test : public CxxTest::TestSuite {
 public:
   IntegratePeaksMD2Test() { Mantid::API::FrameworkManager::Instance(); }
@@ -134,8 +144,8 @@ public:
 
   //-------------------------------------------------------------------------------
   /** Add a fake ellipsoid peak */
-  static void addEllipsoid(size_t num, double x, double y, double z, std::vector<std::vector<double>> eigvects,
-                           std::vector<double> eigvals, double doCounts) {
+  static void addEllipsoid(size_t num, double x, double y, double z, std::array<std::vector<double>, 3> eigvects,
+                           std::array<double, 3> eigvals, double doCounts) {
 
     std::ostringstream mess;
     mess << num << ", " << x << ", " << y << ", " << z << ", ";
@@ -539,43 +549,43 @@ public:
   void test_exec_EllipsoidWithBackground_SingleCount() { EllipsoidTestHelper(-1.0, false, true); }
 
   void test_exec_EllipsoidRadii_NoBackground_SingleCount() {
-    std::vector<double> radii = {0.05, 0.03, 0.02};
+    std::vector<double> radii{0.05, 0.03, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(-1.0, false, false, {0.05, 0.03, 0.02}, radii);
   }
 
   void test_exec_EllipsoidRadii_NoBackground_SingleCount_FixQAxis() {
-    std::vector<double> radii = {0.05, 0.03, 0.02};
+    std::vector<double> radii{0.05, 0.03, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(-1.0, true, false, {0.05, 0.03, 0.02}, radii);
   }
 
   void test_exec_EllipsoidRadii_NoBackground_SingleCount_Qy() {
-    std::vector<double> radii = {0.03, 0.05, 0.02};
+    std::vector<double> radii{0.03, 0.05, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(-1.0, false, false, {0.03, 0.05, 0.02}, radii);
   }
 
   void test_exec_EllipsoidRadii_NoBackground_SingleCount_Qz() {
-    std::vector<double> radii = {0.03, 0.02, 0.05};
+    std::vector<double> radii{0.03, 0.02, 0.05};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(-1.0, false, false, {0.03, 0.02, 0.05}, radii);
   }
 
   void test_exec_EllipsoidRadii_NoBackground_NonSingleCount() {
-    std::vector<double> radii = {0.05, 0.03, 0.02};
+    std::vector<double> radii{0.05, 0.03, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(1.0, false, false, {0.05, 0.03, 0.02}, radii);
   }
 
   void test_exec_EllipsoidRadii_NoBackground_NonSingleCount_FixQAxis() {
-    std::vector<double> radii = {0.05, 0.03, 0.02};
+    std::vector<double> radii{0.05, 0.03, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     EllipsoidTestHelper(1.0, true, false, {0.05, 0.03, 0.02}, radii);
   }
 
   void test_exec_EllipsoidRadii_WithBackground_SingleCount() {
-    std::vector<double> radii = {0.05, 0.03, 0.02};
+    std::vector<double> radii{0.05, 0.03, 0.02};
     std::for_each(radii.begin(), radii.end(), [](double &r) { r = 4.0 * sqrt(r); });
     std::vector<double> outer;
     std::transform(radii.begin(), radii.end(), std::back_inserter(outer),
@@ -678,7 +688,7 @@ public:
     AnalysisDataService::Instance().addOrReplace("IntegratePeaksMD2Test_peaks", peakWS);
 
     // Major axis along z
-    std::vector<double> radii = {0.03, 0.04, 0.05};
+    std::vector<double> radii{0.03, 0.04, 0.05};
     doRun(radii, {0.0}, "IntegratePeaksMD2Test_peaks_out", {0.0}, false, false, "NoFit", 0.0, true, false);
 
     PeaksWorkspace_sptr peakResult = std::dynamic_pointer_cast<PeaksWorkspace>(
@@ -752,9 +762,9 @@ public:
     // Check the shape is what we expect
     TSM_ASSERT("Wrong sort of peak", ellipsoidShape);
 
-    TS_ASSERT_DELTA(ellipsoidShape->abcRadii(), radii, 1e-9);
-    TS_ASSERT_DELTA(ellipsoidShape->abcRadiiBackgroundInner(), radii, 1e-9);
-    TS_ASSERT_DELTA(ellipsoidShape->abcRadiiBackgroundOuter(), background, 1e-9);
+    assert_radii_delta(ellipsoidShape->abcRadii(), radii, 1e-9);
+    assert_radii_delta(ellipsoidShape->abcRadiiBackgroundInner(), radii, 1e-9);
+    assert_radii_delta(ellipsoidShape->abcRadiiBackgroundOuter(), background, 1e-9);
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[0], V3D(1, 0, 0));
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[1], V3D(0, 1, 0));
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[2], V3D(0, 0, 1));
@@ -766,11 +776,11 @@ public:
     // peak Q
     V3D Q(1.0, 0.0, 0.0);
     // set eigenvectors and eigenvalues
-    std::vector<double> eigenvals = {0.05, 0.03, 0.02};
-    std::vector<std::vector<double>> eigenvects;
-    eigenvects.push_back(std::vector<double>{Q[0], Q[1], Q[2]}); // para Q
-    eigenvects.push_back(std::vector<double>{0.0, 1.0, 0.0});
-    eigenvects.push_back(std::vector<double>{0.0, 0.0, 1.0});
+    std::array<double, 3> eigenvals{0.05, 0.03, 0.02};
+    std::array<std::vector<double>, 3> eigenvects;
+    eigenvects[0] = std::vector<double>{Q[0], Q[1], Q[2]}; // para Q
+    eigenvects[1] = std::vector<double>{0.0, 1.0, 0.0};
+    eigenvects[2] = std::vector<double>{0.0, 0.0, 1.0};
 
     size_t numEvents = 20000;
     V3D offset(0.05, 0.0, 0.0); // generate peak away from nominal position
@@ -824,11 +834,11 @@ public:
     // peak Q
     V3D Q(1.0, 0.0, 0.0);
     // set eigenvectors and eigenvalues
-    std::vector<double> eigenvals = {0.05, 0.03, 0.02};
-    std::vector<std::vector<double>> eigenvects;
-    eigenvects.push_back(std::vector<double>{Q[0], Q[1], Q[2]}); // para Q
-    eigenvects.push_back(std::vector<double>{0.0, 1.0, 0.0});
-    eigenvects.push_back(std::vector<double>{0.0, 0.0, 1.0});
+    std::array<double, 3> eigenvals{0.05, 0.03, 0.02};
+    std::array<std::vector<double>, 3> eigenvects;
+    eigenvects[0] = std::vector<double>{Q[0], Q[1], Q[2]}; // para Q
+    eigenvects[1] = std::vector<double>{0.0, 1.0, 0.0};
+    eigenvects[2] = std::vector<double>{0.0, 0.0, 1.0};
 
     size_t numEvents = 20000;
     addEllipsoid(numEvents, Q[0], Q[1], Q[2], eigenvects, eigenvals, true);
@@ -888,11 +898,11 @@ public:
     // peak Q
     V3D Q(1.0, 0.0, 0.0);
     // set eigenvectors and eigenvalues
-    std::vector<double> eigenvals = {0.05, 0.03, 0.02};
-    std::vector<std::vector<double>> eigenvects;
-    eigenvects.push_back(std::vector<double>{Q[0], Q[1], Q[2]}); // para Q
-    eigenvects.push_back(std::vector<double>{0.0, 1.0, 0.0});
-    eigenvects.push_back(std::vector<double>{0.0, 0.0, 1.0});
+    std::array<double, 3> eigenvals{0.05, 0.03, 0.02};
+    std::array<std::vector<double>, 3> eigenvects;
+    eigenvects[0] = std::vector<double>{Q[0], Q[1], Q[2]}; // para Q
+    eigenvects[1] = std::vector<double>{0.0, 1.0, 0.0};
+    eigenvects[2] = std::vector<double>{0.0, 0.0, 1.0};
 
     size_t numEvents = 2000;
     addEllipsoid(numEvents, Q[0], Q[1], Q[2], eigenvects, eigenvals, true);
@@ -962,20 +972,18 @@ public:
     // peak Q
     V3D Q(1.0, 0.0, 0.0);
     // set eigenvectors and eigenvalues
-    std::vector<std::vector<double>> eigenvects;
-    std::vector<double> eigenvals;
-    eigenvects.push_back(std::vector<double>{Q[0], Q[1], Q[2]}); // para Q
+    std::array<std::vector<double>, 3> eigenvects;
+    std::array<double, 3> eigenvals;
+    eigenvects[0] = std::vector<double>{Q[0], Q[1], Q[2]}; // para Q
     // other orthogonal axes
-    eigenvects.push_back(std::vector<double>{0.0, 1.0, 0.0});
-    eigenvects.push_back(std::vector<double>{0.0, 0.0, 1.0});
+    eigenvects[1] = std::vector<double>{0.0, 1.0, 0.0};
+    eigenvects[2] = std::vector<double>{0.0, 0.0, 1.0};
 
     if (ellipsoidRadii.empty()) {
       // Use default eigenvals for ellipsoid peaks
-      eigenvals.push_back(0.05);
-      eigenvals.push_back(0.03);
-      eigenvals.push_back(0.02);
+      eigenvals = {0.05, 0.03, 0.02};
     } else {
-      eigenvals = peakEigenvals;
+      eigenvals = {peakEigenvals[0], peakEigenvals[1], peakEigenvals[2]};
     }
 
     size_t numEvents = 20000;
@@ -983,8 +991,8 @@ public:
 
     // radius for integration (4 stdevs of principal axis)
     auto peakRadius = 4 * sqrt(eigenvals[0]);
-    std::vector<double> bgInnerRadius = {};
-    std::vector<double> bgOuterRadius = {};
+    std::vector<double> bgInnerRadius;
+    std::vector<double> bgOuterRadius;
 
     // background w
     if (doBkgrd == true) {
@@ -1165,7 +1173,7 @@ public:
 
   void test_exec_EllipsoidRadii_with_LeanElasticPeaks() {
     // Test an ellipsoid against theoretical vol
-    const std::vector<double> radii = {0.4, 0.3, 0.2};
+    const std::vector<double> radii{0.4, 0.3, 0.2};
     const V3D pos(0.0, 0.0, 0.0); // peak position
     const int numEvents = 1000000;
 
@@ -1195,7 +1203,7 @@ public:
     // Check the shape is what we expect
     TSM_ASSERT("Wrong sort of peak", ellipsoidShape);
 
-    TS_ASSERT_DELTA(ellipsoidShape->abcRadii(), radii, 1e-9);
+    assert_radii_delta(ellipsoidShape->abcRadii(), radii, 1e-9);
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[0], V3D(1, 0, 0));
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[1], V3D(0, 1, 0));
     TS_ASSERT_EQUALS(ellipsoidShape->directions()[2], V3D(0, 0, 1));

--- a/Framework/MDAlgorithms/test/IntegrateQLabEventsTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateQLabEventsTest.h
@@ -81,7 +81,7 @@ public:
     double peak_radius = 1.2;
     double back_inner_radius = 1.2;
     double back_outer_radius = 1.3;
-    std::vector<double> new_sigma;
+    std::array<double, 3> new_sigma;
     std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
@@ -22,35 +22,33 @@ PeakShapeEllipsoid *initPeakShapeEllipsoid(const boost::python::list &directions
                                            const boost::python::list &abcRadiiBackgroundInner,
                                            const boost::python::list abcRadiiBackgroundOuter,
                                            SpecialCoordinateSystem frame) {
-  constexpr size_t ARRAY_SIZE{3}; // PeakShapeEllipsoid only takes array<double,3>
-
   auto directionsVec = PySequenceToVector<V3D>(directions)();
-  if (directionsVec.size() != ARRAY_SIZE) {
+  if (directionsVec.size() != PEAK_ELLIPSOID_DIMS) {
     throw std::runtime_error("directions must be size=3. Found size=" + std::to_string(directionsVec.size()));
   }
-  std::array<V3D, ARRAY_SIZE> directionsArray = {directionsVec[0], directionsVec[1], directionsVec[2]};
+  PeakEllipsoidFrame directionsArray = {directionsVec[0], directionsVec[1], directionsVec[2]};
 
   auto abcRadiiVec = PySequenceToVector<double>(abcRadii)();
-  if (abcRadiiVec.size() != ARRAY_SIZE) {
+  if (abcRadiiVec.size() != PEAK_ELLIPSOID_DIMS) {
     throw std::runtime_error("abcRadii must be size=3. Found size=" + std::to_string(abcRadiiVec.size()));
   }
-  std::array<double, ARRAY_SIZE> abcRadiiArray = {abcRadiiVec[0], abcRadiiVec[1], abcRadiiVec[2]};
+  PeakEllipsoidExtent abcRadiiArray = {abcRadiiVec[0], abcRadiiVec[1], abcRadiiVec[2]};
 
   auto abcRadiiBackgroundInnerVec = PySequenceToVector<double>(abcRadiiBackgroundInner)();
-  if (abcRadiiBackgroundInnerVec.size() != ARRAY_SIZE) {
+  if (abcRadiiBackgroundInnerVec.size() != PEAK_ELLIPSOID_DIMS) {
     throw std::runtime_error("abcRadiiBackgroundInner must be size=3. Found size=" +
                              std::to_string(abcRadiiBackgroundInnerVec.size()));
   }
-  std::array<double, ARRAY_SIZE> abcRadiiBackgroundInnerArray = {
-      abcRadiiBackgroundInnerVec[0], abcRadiiBackgroundInnerVec[1], abcRadiiBackgroundInnerVec[2]};
+  PeakEllipsoidExtent abcRadiiBackgroundInnerArray = {abcRadiiBackgroundInnerVec[0], abcRadiiBackgroundInnerVec[1],
+                                                      abcRadiiBackgroundInnerVec[2]};
 
   auto abcRadiiBackgroundOuterVec = PySequenceToVector<double>(abcRadiiBackgroundOuter)();
-  if (abcRadiiBackgroundOuterVec.size() != ARRAY_SIZE) {
+  if (abcRadiiBackgroundOuterVec.size() != PEAK_ELLIPSOID_DIMS) {
     throw std::runtime_error("abcRadiiBackgroundOuter must be size=3. Found size=" +
                              std::to_string(abcRadiiBackgroundOuterVec.size()));
   }
-  std::array<double, ARRAY_SIZE> abcRadiiBackgroundOuterArray = {
-      abcRadiiBackgroundOuterVec[0], abcRadiiBackgroundOuterVec[1], abcRadiiBackgroundOuterVec[2]};
+  PeakEllipsoidExtent abcRadiiBackgroundOuterArray = {abcRadiiBackgroundOuterVec[0], abcRadiiBackgroundOuterVec[1],
+                                                      abcRadiiBackgroundOuterVec[2]};
 
   // create the object
   return new PeakShapeEllipsoid(directionsArray, abcRadiiArray, abcRadiiBackgroundInnerArray,

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
@@ -10,6 +10,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/make_constructor.hpp>
+#include <stdexcept>
 
 using namespace boost::python;
 using namespace Mantid::DataObjects;
@@ -21,9 +22,39 @@ PeakShapeEllipsoid *initPeakShapeEllipsoid(const boost::python::list &directions
                                            const boost::python::list &abcRadiiBackgroundInner,
                                            const boost::python::list abcRadiiBackgroundOuter,
                                            SpecialCoordinateSystem frame) {
-  return new PeakShapeEllipsoid(PySequenceToVector<V3D>(directions)(), PySequenceToVector<double>(abcRadii)(),
-                                PySequenceToVector<double>(abcRadiiBackgroundInner)(),
-                                PySequenceToVector<double>(abcRadiiBackgroundOuter)(), frame);
+  constexpr size_t ARRAY_SIZE{3}; // PeakShapeEllipsoid only takes array<double,3>
+
+  auto directionsVec = PySequenceToVector<V3D>(directions)();
+  if (directionsVec.size() != ARRAY_SIZE) {
+    throw std::runtime_error("directions must be size=3. Found size=" + std::to_string(directionsVec.size()));
+  }
+  std::array<V3D, ARRAY_SIZE> directionsArray = {directionsVec[0], directionsVec[1], directionsVec[2]};
+
+  auto abcRadiiVec = PySequenceToVector<double>(abcRadii)();
+  if (abcRadiiVec.size() != ARRAY_SIZE) {
+    throw std::runtime_error("abcRadii must be size=3. Found size=" + std::to_string(abcRadiiVec.size()));
+  }
+  std::array<double, ARRAY_SIZE> abcRadiiArray = {abcRadiiVec[0], abcRadiiVec[1], abcRadiiVec[2]};
+
+  auto abcRadiiBackgroundInnerVec = PySequenceToVector<double>(abcRadiiBackgroundInner)();
+  if (abcRadiiBackgroundInnerVec.size() != ARRAY_SIZE) {
+    throw std::runtime_error("abcRadiiBackgroundInner must be size=3. Found size=" +
+                             std::to_string(abcRadiiBackgroundInnerVec.size()));
+  }
+  std::array<double, ARRAY_SIZE> abcRadiiBackgroundInnerArray = {
+      abcRadiiBackgroundInnerVec[0], abcRadiiBackgroundInnerVec[1], abcRadiiBackgroundInnerVec[2]};
+
+  auto abcRadiiBackgroundOuterVec = PySequenceToVector<double>(abcRadiiBackgroundOuter)();
+  if (abcRadiiBackgroundOuterVec.size() != ARRAY_SIZE) {
+    throw std::runtime_error("abcRadiiBackgroundOuter must be size=3. Found size=" +
+                             std::to_string(abcRadiiBackgroundOuterVec.size()));
+  }
+  std::array<double, ARRAY_SIZE> abcRadiiBackgroundOuterArray = {
+      abcRadiiBackgroundOuterVec[0], abcRadiiBackgroundOuterVec[1], abcRadiiBackgroundOuterVec[2]};
+
+  // create the object
+  return new PeakShapeEllipsoid(directionsArray, abcRadiiArray, abcRadiiBackgroundInnerArray,
+                                abcRadiiBackgroundOuterArray, frame);
 }
 
 void export_PeakShapeEllipsoid() {


### PR DESCRIPTION
Since the underlying objects for Ellipsoids are always length 3, change the code to use fixed-length arrays. There are various knock-on effects for other code that intersects this, but it should allow the compiler to deal with memory more efficiently which should have a positive effect on performance with a larger number of peaks (think protein crystallography).

There is a single unit test that is removed because the compiler no longer allows supplying more/less than 3 values for the radii and directions.

There is no associated issue, but this was originally attempted in #30389. 

### To test:

This is a refactor with no other intended effects. If the tests pass, it was done correctly.

*This does not require release notes* because it is a change to internal data structures.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
