### PR TITLE
Update release-next_nightly pipeline name in dev docs

### DIFF
--- a/dev-docs/source/CondaPackageManager.rst
+++ b/dev-docs/source/CondaPackageManager.rst
@@ -60,7 +60,7 @@ few examples on how to use it:
 
   python dependency_spotter.py -f 593 -s 598
   python dependency_spotter.py -f 593 -s 598 -os win-64
-  python dependency_spotter.py -f 593 -s 598 --pipeline main_nightly_deployment
+  python dependency_spotter.py -f 593 -s 598 --pipeline main_nightly
 
 Another useful command for investigating the dependencies of specific packages is `conda search <https://docs.conda.io/projects/conda/en/latest/commands/search.html>`_. To find the dependencies of a package:
 

--- a/dev-docs/source/PatchReleaseChecklist.rst
+++ b/dev-docs/source/PatchReleaseChecklist.rst
@@ -107,7 +107,7 @@ updated to the patch milestone.
 Nightly Builds
 ##############
 
-The `release-next nightly pipeline <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly_deployment>`__
+The `release-next nightly pipeline <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly>`__
 job checks for changes on the current release branch each night (00:00 GMT) and should
 be monitored during the patch release period to check for any failures.
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -418,8 +418,8 @@ Code Freeze
 
 **Create the Release Branch (once most PRs are merged)**
 
-* Ensure the latest `main nightly deployment pipeline
-  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment/>`__
+* Ensure the latest `main nightly pipeline
+  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/>`__
   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
   the next steps.
 * Ask a mantid gatekeeper or administrator to update the ``release-next`` branch so that it's up to

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -494,8 +494,8 @@ have been fixed. Then:
 
 We are now ready to create the release candidates for Smoke testing.
 
-* Build the `release-next_nightly_deployment Jenkins pipeline
-  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly_deployment/>`__
+* Build the `release-next_nightly Jenkins pipeline
+  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/>`__
   with the following parameters (most are already defaulted to the correct values):
 
   * set ``BUILD_DEVEL`` to ``all``
@@ -526,8 +526,8 @@ Check with the Quality Assurance Manager that the Smoke testing has been complet
 have been fixed. Additionally, ensure that the version of the ``mslice`` package in ``conda_build_config.yaml`` is correct.
 If there have been any updates to MSlice since the last release, it must be released first. The release candidates must
 now be recreated with their final version numbers. To do this, build the
-`release-next_nightly_deployment Jenkins pipeline
-<https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly_deployment/>`__
+`release-next_nightly Jenkins pipeline
+<https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/>`__
 with the following parameters (most are already defaulted to the correct values):
 
 * set ``BUILD_DEVEL`` to ``all``


### PR DESCRIPTION
### Description of work
release-next pipeline was renamed on Jenkins. This updates dev-docs accordingly.

### To test:
Check the links are OK.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
