### PR TITLE
Updated dev docs to include neutrons channel in mamba create step

### DIFF
--- a/dev-docs/source/GettingStarted/MantidDeveloperSetup.rst
+++ b/dev-docs/source/GettingStarted/MantidDeveloperSetup.rst
@@ -3,11 +3,11 @@ Create ``mantid-developer`` conda environment by following the steps below:
 * First create a new conda environment and install the ``mantid-developer`` conda metapackage.
   You will normally want the nightly version, specified below by adding the label ``mantid/label/nightly``.
   Here we have named the conda environment ``mantid-developer`` for consistency with the rest of the documentation
-  but you are free to choose any name.
+  but you are free to choose any name. The ``neutrons`` channel is also required for PyStoG.
 
   .. code-block:: sh
 
-    mamba create -n mantid-developer mantid/label/nightly::mantid-developer
+    mamba create -n mantid-developer mantid/label/nightly::mantid-developer -c neutrons
 
 * Then activate the conda environment with
 
@@ -20,6 +20,6 @@ Create ``mantid-developer`` conda environment by following the steps below:
 
   .. code-block:: sh
 
-    mamba update -c mantid/label/nightly --all
+    mamba update -c mantid/label/nightly -c neutrons --all
 
 See :ref:`packaging <Packaging>` for more information on this topic.


### PR DESCRIPTION
### Description of work

This is just to update the dev docs so that the dev will include the neutrons channel to get PyStoG to work.
Original PR: #39936

### To test:
Make sure docs make sense
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
