### PR TITLE
Introduce columnArray method for extracting columns as arrays from TableWorkspaces

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -32,10 +32,12 @@
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/overloads.hpp>
 
+#include <cstdint>
 #include <cstring>
 #include <numpy/ndarraytypes.h>
 #include <numpy/npy_common.h>
 #include <pytypedefs.h>
+#include <tuple>
 #include <typeinfo>
 #include <vector>
 
@@ -321,33 +323,33 @@ PyObject *column(const ITableWorkspace &self, const object &value) {
   return result;
 }
 
-PyArray_Descr *numpy_descr_from_typeid(const std::type_info &typeID) {
-  if (false) {
-  } else if (typeID.hash_code() == typeid(int).hash_code()) {
-    return PyArray_DescrFromType(NPY_INT);
-  } else if (typeID.hash_code() == typeid(int32_t).hash_code()) {
-    return PyArray_DescrFromType(NPY_INT32);
-  } else if (typeID.hash_code() == typeid(int64_t).hash_code()) {
-    return PyArray_DescrFromType(NPY_INT64);
-  } else if (typeID.hash_code() == typeid(uint32_t).hash_code()) {
-    return PyArray_DescrFromType(NPY_UINT32);
-  } else if (typeID.hash_code() == typeid(uint64_t).hash_code()) {
-    return PyArray_DescrFromType(NPY_UINT64);
-  } else if (typeID.hash_code() == typeid(double).hash_code()) {
-    return PyArray_DescrFromType(NPY_DOUBLE);
-  } else if (typeID.hash_code() == typeid(float).hash_code()) {
-    return PyArray_DescrFromType(NPY_FLOAT);
-  } else if (typeID.hash_code() == typeid(size_t).hash_code()) {
-    return PyArray_DescrFromType((sizeof(size_t) == 4) ? NPY_UINT : NPY_ULONGLONG);
-  } else if (typeID.hash_code() == typeid(std::vector<int>).hash_code()) {
-    return PyArray_DescrFromType(NPY_INT);
-  } else if (typeID.hash_code() == typeid(std::vector<double>).hash_code()) {
-    return PyArray_DescrFromType(NPY_DOUBLE);
-  } else if (typeID.hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
-    return PyArray_DescrFromType(NPY_DOUBLE);
-  }
-  throw std::invalid_argument("ColumnArray does not yet support strings.");
-}
+// PyArray_Descr *numpy_descr_from_typeid(const std::type_info &typeID) {
+//   if (false) {
+//   } else if (typeID.hash_code() == typeid(int).hash_code()) {
+//     return PyArray_DescrFromType(NPY_INT);
+//   } else if (typeID.hash_code() == typeid(int32_t).hash_code()) {
+//     return PyArray_DescrFromType(NPY_INT32);
+//   } else if (typeID.hash_code() == typeid(int64_t).hash_code()) {
+//     return PyArray_DescrFromType(NPY_INT64);
+//   } else if (typeID.hash_code() == typeid(uint32_t).hash_code()) {
+//     return PyArray_DescrFromType(NPY_UINT32);
+//   } else if (typeID.hash_code() == typeid(uint64_t).hash_code()) {
+//     return PyArray_DescrFromType(NPY_UINT64);
+//   } else if (typeID.hash_code() == typeid(double).hash_code()) {
+//     return PyArray_DescrFromType(NPY_DOUBLE);
+//   } else if (typeID.hash_code() == typeid(float).hash_code()) {
+//     return PyArray_DescrFromType(NPY_FLOAT);
+//   } else if (typeID.hash_code() == typeid(size_t).hash_code()) {
+//     return PyArray_DescrFromType((sizeof(size_t) == 4) ? NPY_UINT : NPY_ULONGLONG);
+//   } else if (typeID.hash_code() == typeid(std::vector<int>).hash_code()) {
+//     return PyArray_DescrFromType(NPY_INT);
+//   } else if (typeID.hash_code() == typeid(std::vector<double>).hash_code()) {
+//     return PyArray_DescrFromType(NPY_DOUBLE);
+//   } else if (typeID.hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
+//     return PyArray_DescrFromType(NPY_DOUBLE);
+//   }
+//   throw std::invalid_argument("ColumnArray does not yet support strings.");
+// }
 
 size_t getSecondDim(Mantid::API::Column_const_sptr column) {
   const std::type_info &typeID = column->get_type_info();
@@ -364,68 +366,112 @@ size_t getSecondDim(Mantid::API::Column_const_sptr column) {
   return 1;
 }
 
-template <typename T>
-void copyToArrayWithType(void *dest, Mantid::API::Column_const_sptr column, int numRows, npy_intp secondDim) {
-
-  if (typeid(T).hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
-    auto dest_p = static_cast<double *>(dest);
-    for (npy_intp i = 0; i < numRows; ++i) {
-      const std::vector<double> src = std::vector<double>(column->cell<Mantid::Kernel::V3D>(i));
-      std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
-    }
-    return;
-  }
-  if (typeid(T).hash_code() == typeid(std::vector<int>).hash_code()) {
-    auto dest_p = static_cast<int *>(dest);
-    for (npy_intp i = 0; i < numRows; ++i) {
-      const auto src = column->cell<std::vector<int>>(i);
-      std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
-    }
-  }
-
-  if (typeid(T).hash_code() == typeid(std::vector<double>).hash_code()) {
-    auto dest_p = static_cast<double *>(dest);
-    for (npy_intp i = 0; i < numRows; ++i) {
-      const auto src = column->cell<std::vector<double>>(i);
-      std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
-    }
-  }
-
+template <typename T> void copyTo1DArray(void *dest, const Mantid::API::Column_const_sptr &column) {
   auto dest_p = static_cast<T *>(dest);
-  for (npy_intp i = 0; i < numRows; ++i) {
+  for (size_t i = 0; i < column->size(); ++i) {
     dest_p[i] = column->cell<T>(i);
   }
 }
 
-void copyToArray(void *dest, Mantid::API::Column_const_sptr column, npy_intp secondDim) {
-  const std::type_info &typeID = column->get_type_info();
-  const int numRows = static_cast<npy_intp>(column->size());
-  if (false) {
-  } else if (typeID.hash_code() == typeid(int).hash_code()) {
-    return copyToArrayWithType<int>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(int32_t).hash_code()) {
-    return copyToArrayWithType<int32_t>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(int64_t).hash_code()) {
-    return copyToArrayWithType<int64_t>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(uint32_t).hash_code()) {
-    return copyToArrayWithType<uint32_t>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(uint64_t).hash_code()) {
-    return copyToArrayWithType<uint64_t>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(double).hash_code()) {
-    return copyToArrayWithType<double>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(float).hash_code()) {
-    return copyToArrayWithType<float>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(size_t).hash_code()) {
-    return copyToArrayWithType<size_t>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(std::vector<int>).hash_code()) {
-    return copyToArrayWithType<std::vector<int>>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(std::vector<double>).hash_code()) {
-    return copyToArrayWithType<std::vector<double>>(dest, column, numRows, secondDim);
-  } else if (typeID.hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
-    return copyToArrayWithType<Mantid::Kernel::V3D>(dest, column, numRows, secondDim);
+template <typename T> void copyTo2DArray(void *dest, const Mantid::API::Column_const_sptr &column) {
+  auto dest_p = static_cast<T *>(dest);
+  int stride = column->cell<std::vector<T>>(0).size();
+  for (size_t i = 0; i < column->size(); ++i) {
+    const std::vector<T> src = column->cell<std::vector<T>>(i);
+    std::copy(src.begin(), src.end(), std::next(dest_p, i * stride));
   }
   return;
 }
+
+const std::unordered_map<size_t,
+                         std::tuple<PyArray_Descr *, std::function<void(void *, Mantid::API::Column_const_sptr)>>>
+    handlers = {{typeid(int).hash_code(), {PyArray_DescrFromType(NPY_INT), copyTo1DArray<int>}},
+                {typeid(int32_t).hash_code(), {PyArray_DescrFromType(NPY_INT32), copyTo1DArray<int32_t>}},
+                {typeid(uint32_t).hash_code(), {PyArray_DescrFromType(NPY_UINT32), copyTo1DArray<uint32_t>}},
+                {typeid(int64_t).hash_code(), {PyArray_DescrFromType(NPY_INT64), copyTo1DArray<int64_t>}},
+                {typeid(uint64_t).hash_code(), {PyArray_DescrFromType(NPY_UINT64), copyTo1DArray<uint64_t>}},
+                {typeid(double).hash_code(), {PyArray_DescrFromType(NPY_DOUBLE), copyTo1DArray<double>}},
+                {typeid(float).hash_code(), {PyArray_DescrFromType(NPY_FLOAT), copyTo1DArray<float>}},
+                {typeid(size_t).hash_code(),
+                 {(sizeof(size_t) == 4) ? PyArray_DescrFromType(NPY_UINT32) : PyArray_DescrFromType(NPY_UINT64),
+                  (sizeof(size_t) == 4) ? copyTo1DArray<uint32_t> : copyTo1DArray<uint64_t>}},
+                {typeid(std::vector<int>).hash_code(), {PyArray_DescrFromType(NPY_INT), copyTo2DArray<int>}},
+                {typeid(std::vector<double>).hash_code(), {PyArray_DescrFromType(NPY_DOUBLE), copyTo2DArray<double>}},
+                {typeid(Mantid::Kernel::V3D).hash_code(), {PyArray_DescrFromType(NPY_DOUBLE), copyTo2DArray<double>}}};
+
+// void copyColumnArray(void* dest, const Mantid::API::Column_const_sptr &column, const std::type_info &typeID, int
+// numRows, npy_intp secondDim) {
+//
+//     if (auto it = handlers.find(typeID.hash_code()); it != handlers.end()) {
+//       it->second(dest, column);
+//     } else {
+//       throw std::invalid_argument("Column type not recognised.");
+//     }
+//   return;
+// }
+
+// template <typename T>
+// void copyToArrayWithType(void *dest, Mantid::API::Column_const_sptr column, int numRows, npy_intp secondDim) {
+//
+//   if (typeid(T).hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
+//     auto dest_p = static_cast<double *>(dest);
+//     for (npy_intp i = 0; i < numRows; ++i) {
+//       const std::vector<double> src = std::vector<double>(column->cell<Mantid::Kernel::V3D>(i));
+//       std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
+//     }
+//     return;
+//   }
+//   if (typeid(T).hash_code() == typeid(std::vector<int>).hash_code()) {
+//     auto dest_p = static_cast<int *>(dest);
+//     for (npy_intp i = 0; i < numRows; ++i) {
+//       const auto src = column->cell<std::vector<int>>(i);
+//       std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
+//     }
+//   }
+//
+//   if (typeid(T).hash_code() == typeid(std::vector<double>).hash_code()) {
+//     auto dest_p = static_cast<double *>(dest);
+//     for (npy_intp i = 0; i < numRows; ++i) {
+//       const auto src = column->cell<std::vector<double>>(i);
+//       std::copy(src.begin(), src.end(), std::next(dest_p, i * secondDim));
+//     }
+//   }
+//
+//   auto dest_p = static_cast<T *>(dest);
+//   for (npy_intp i = 0; i < numRows; ++i) {
+//     dest_p[i] = column->cell<T>(i);
+//   }
+// }
+
+// void copyToArray(void *dest, Mantid::API::Column_const_sptr column, npy_intp secondDim) {
+//   const std::type_info &typeID = column->get_type_info();
+//   const int numRows = static_cast<npy_intp>(column->size());
+//   if (false) {
+//   } else if (typeID.hash_code() == typeid(int).hash_code()) {
+//     return copyToArrayWithType<int>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(int32_t).hash_code()) {
+//     return copyToArrayWithType<int32_t>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(int64_t).hash_code()) {
+//     return copyToArrayWithType<int64_t>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(uint32_t).hash_code()) {
+//     return copyToArrayWithType<uint32_t>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(uint64_t).hash_code()) {
+//     return copyToArrayWithType<uint64_t>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(double).hash_code()) {
+//     return copyToArrayWithType<double>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(float).hash_code()) {
+//     return copyToArrayWithType<float>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(size_t).hash_code()) {
+//     return copyToArrayWithType<size_t>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(std::vector<int>).hash_code()) {
+//     return copyToArrayWithType<std::vector<int>>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(std::vector<double>).hash_code()) {
+//     return copyToArrayWithType<std::vector<double>>(dest, column, numRows, secondDim);
+//   } else if (typeID.hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
+//     return copyToArrayWithType<Mantid::Kernel::V3D>(dest, column, numRows, secondDim);
+//   }
+//   return;
+// }
 
 PyObject *columnArray(const ITableWorkspace &self, const object &value) {
   // Find the column and row
@@ -437,16 +483,19 @@ PyObject *columnArray(const ITableWorkspace &self, const object &value) {
   }
   const std::type_info &typeID = column->get_type_info();
 
-  PyArray_Descr *descr = numpy_descr_from_typeid(typeID);
   const npy_intp numRows = static_cast<npy_intp>(self.rowCount());
   npy_intp secondDim = getSecondDim(column);
   int nDims = (secondDim > 1) ? 2 : 1;
   npy_intp arrayDims[2] = {numRows, secondDim};
 
+  auto it = handlers.find(typeID.hash_code());
+  if (it == handlers.end()) {
+    throw std::invalid_argument("Column type not recognised.");
+  }
+  auto &[descr, copy_func] = it->second;
   auto *nparray = PyArray_NewFromDescr(&PyArray_Type, descr, nDims, arrayDims, nullptr, nullptr, 0, nullptr);
   void *dest = PyArray_DATA((PyArrayObject *)nparray); // HEAD of the contiguous numpy data array
-
-  copyToArray(dest, column, secondDim);
+  copy_func(dest, column);
   return nparray;
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -347,7 +347,7 @@ PyObject *stringNumpyArray(const Mantid::API::Column_const_sptr &column) {
 size_t getStride(const Mantid::API::Column_const_sptr &column) {
   const std::type_info &typeID = column->get_type_info();
   if (typeID.hash_code() == typeid(Mantid::Kernel::V3D).hash_code()) {
-    return static_cast<std::vector<double>>(column->cell<Mantid::Kernel::V3D>(0)).size();
+    return column->cell<Mantid::Kernel::V3D>(0).size();
   }
   if (typeID.hash_code() == typeid(std::vector<int>).hash_code()) {
     return column->cell<std::vector<int>>(0).size();
@@ -840,7 +840,7 @@ void export_ITableWorkspace() {
       .def("column", &column, (arg("self"), arg("column")), "Return all values of a specific column as a list.")
 
       .def("columnArray", &columnArray, (arg("self"), arg("column")),
-           "Return all values of a specific column as a numpy array.")
+           "Return all values of a specific column (either index or name) as a numpy array.")
 
       .def("row", &row, (arg("self"), arg("row")), "Return all values of a specific row as a dict.")
 

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -221,6 +221,112 @@ class ITableWorkspaceTest(unittest.TestCase):
         self.assertEqual(types[1], "str")
         self.assertEqual(types[2], "V3D")
 
+    def test_array_column_int(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="int", name="index")
+        table.addRow([1])
+        table.addRow([2])
+        table.addRow([3])
+
+        arr = table.columnArray("index")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([1, 2, 3])))
+        self.assertEqual(arr.dtype, numpy.dtype("int32"))
+
+    def test_array_column_float(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="float", name="value")
+        table.addRow([1.1])
+        table.addRow([2.2])
+        table.addRow([3.3])
+
+        arr = table.columnArray("value")
+        numpy.testing.assert_array_almost_equal(arr, numpy.array([1.1, 2.2, 3.3]))
+        self.assertEqual(arr.dtype, numpy.dtype("float32"))
+
+    def test_array_column_double(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="double", name="value")
+        table.addRow([1.1])
+        table.addRow([2.2])
+        table.addRow([3.3])
+
+        arr = table.columnArray("value")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([1.1, 2.2, 3.3])))
+        self.assertEqual(arr.dtype, numpy.dtype("double"))
+
+    def test_array_column_bool(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="bool", name="value")
+        table.addRow([False])
+        table.addRow([True])
+        table.addRow([True])
+
+        arr = table.columnArray("value")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([False, True, True])))
+        self.assertEqual(arr.dtype, numpy.dtype("bool"))
+
+    def test_array_column_string(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="str", name="values")
+
+        table.addRow(["1"])
+        table.addRow(["12"])
+        table.addRow(["123"])
+        table.addRow(["yes"])
+        table.addRow(["n/a"])
+
+        arr = table.columnArray("values")
+        numpy.testing.assert_array_equal(arr, numpy.array(["1", "12", "123", "yes", "n/a"], dtype=numpy.dtype("<U3")))
+        self.assertEqual(arr.dtype, numpy.dtype("<U3"))
+
+    def test_array_column_v3d(self):
+        from mantid.kernel import V3D
+
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="V3D", name="pos")
+        table.addRow([V3D(1, 1, 1)])
+        table.addRow([V3D(2, 2, 2)])
+
+        arr = table.columnArray("pos")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([[1, 1, 1], [2, 2, 2]])))
+
+    def test_array_column_long(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="long64", name="index")
+        table.addRow([1])
+        table.addRow([2])
+        table.addRow([3])
+
+        arr = table.columnArray("index")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([1, 2, 3])))
+        self.assertEqual(arr.dtype, numpy.dtype("long"))
+
+    def test_array_column_vector_ints(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="vector_int", name="values")
+
+        # Settings from general Python list
+        table.addRow([[1, 2, 3, 4, 5]])
+        # Setting from numpy array
+        table.addRow([numpy.array([6, 7, 8, 9, 10])])
+
+        arr = table.columnArray("values")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])))
+        self.assertEqual(arr.dtype, numpy.dtype("int32"))
+
+    def test_array_column_vector_doubles(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="vector_double", name="values")
+
+        # Settings from general Python list
+        table.addRow([[1.0, 2.0, 3.0]])
+        # Setting from numpy array
+        table.addRow([numpy.array([6.0, 7.0, 8.0])])
+
+        arr = table.columnArray("values")
+        self.assertTrue(numpy.array_equal(arr, numpy.array([[1.0, 2.0, 3.0], [6.0, 7.0, 8.0]])))
+        self.assertEqual(arr.dtype, numpy.dtype("double"))
+
     def test_convert_to_dict(self):
         from mantid.kernel import V3D
 

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -229,8 +229,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([3])
 
         arr = table.columnArray("index")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([1, 2, 3])))
-        self.assertEqual(arr.dtype, numpy.dtype("int32"))
+        numpy.testing.assert_array_equal(arr, numpy.array([1, 2, 3], dtype="int32"))
 
     def test_array_column_float(self):
         table = WorkspaceFactory.createTable()
@@ -251,8 +250,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([3.3])
 
         arr = table.columnArray("value")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([1.1, 2.2, 3.3])))
-        self.assertEqual(arr.dtype, numpy.dtype("double"))
+        numpy.testing.assert_array_equal(arr, numpy.array([1.1, 2.2, 3.3], dtype="double"))
 
     def test_array_column_bool(self):
         table = WorkspaceFactory.createTable()
@@ -262,8 +260,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([True])
 
         arr = table.columnArray("value")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([False, True, True])))
-        self.assertEqual(arr.dtype, numpy.dtype("bool"))
+        numpy.testing.assert_array_equal(arr, numpy.array([False, True, True], dtype="bool"))
 
     def test_array_column_string(self):
         table = WorkspaceFactory.createTable()
@@ -277,7 +274,6 @@ class ITableWorkspaceTest(unittest.TestCase):
 
         arr = table.columnArray("values")
         numpy.testing.assert_array_equal(arr, numpy.array(["1", "12", "123", "yes", "n/a"], dtype=numpy.dtype("<U3")))
-        self.assertEqual(arr.dtype, numpy.dtype("<U3"))
 
     def test_array_column_v3d(self):
         from mantid.kernel import V3D
@@ -288,7 +284,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([V3D(2, 2, 2)])
 
         arr = table.columnArray("pos")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([[1, 1, 1], [2, 2, 2]])))
+        numpy.testing.assert_array_equal(arr, numpy.array([[1, 1, 1], [2, 2, 2]], dtype="double"))
 
     def test_array_column_long(self):
         table = WorkspaceFactory.createTable()
@@ -298,8 +294,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([3])
 
         arr = table.columnArray("index")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([1, 2, 3])))
-        self.assertEqual(arr.dtype, numpy.dtype("long"))
+        numpy.testing.assert_array_equal(arr, numpy.array([1, 2, 3], dtype="int64"))
 
     def test_array_column_vector_ints(self):
         table = WorkspaceFactory.createTable()
@@ -311,8 +306,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([numpy.array([6, 7, 8, 9, 10])])
 
         arr = table.columnArray("values")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])))
-        self.assertEqual(arr.dtype, numpy.dtype("int32"))
+        numpy.testing.assert_array_equal(arr, numpy.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], dtype="int32"))
 
     def test_array_column_vector_doubles(self):
         table = WorkspaceFactory.createTable()
@@ -324,8 +318,44 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([numpy.array([6.0, 7.0, 8.0])])
 
         arr = table.columnArray("values")
-        self.assertTrue(numpy.array_equal(arr, numpy.array([[1.0, 2.0, 3.0], [6.0, 7.0, 8.0]])))
-        self.assertEqual(arr.dtype, numpy.dtype("double"))
+        numpy.testing.assert_array_equal(arr, numpy.array([[1.0, 2.0, 3.0], [6.0, 7.0, 8.0]], dtype="double"))
+
+    def test_array_column_vector_variable_len(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="vector_int", name="values")
+
+        table.addRow([[1, 2, 3, 4, 5]])
+        table.addRow([[1, 2, 3]])
+
+        self.assertRaises(RuntimeError, table.columnArray, "values")
+
+    def test_array_column_1d_empty(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="int", name="values")
+        arr = table.columnArray("values")
+        numpy.testing.assert_array_equal(arr, numpy.array([], dtype="int32"))
+
+    def test_array_column_2d_empty(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="vector_int", name="values")
+        table.addRow([[]])
+        table.addRow([[]])
+        arr = table.columnArray("values")
+        numpy.testing.assert_array_equal(arr, numpy.array([[], []], dtype="int32"))
+
+    def test_array_column_string_empty(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="str", name="values")
+        arr = table.columnArray("values")
+        numpy.testing.assert_array_equal(arr, numpy.array([], dtype="<U1"))
+
+    def test_array_column_empty_strings(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="str", name="values")
+        table.addRow([""])
+        table.addRow([""])
+        arr = table.columnArray("values")
+        numpy.testing.assert_array_equal(arr, numpy.array(["", ""], dtype="<U1"))
 
     def test_convert_to_dict(self):
         from mantid.kernel import V3D

--- a/docs/source/release/v6.15.0/Framework/Data_Objects/New_features/40054.rst
+++ b/docs/source/release/v6.15.0/Framework/Data_Objects/New_features/40054.rst
@@ -1,1 +1,2 @@
-- :py:obj:`Table Workspaces <mantid.api.ITableWorkspace>` now support new method `columnArray` for retrieving the column of a `TableWorkspace` as a numpy array. For example `table_ws.columnArray("Index")` will return `np.array([0, 1, 2, 3])`
+- :py:obj:`Table Workspaces <mantid.api.ITableWorkspace>` now support :py:meth:`mantid.api.ITableWorkspace.columnArray` for retrieving a column as a NumPy array.
+  For example, with ``import numpy as np``: ``table_ws.columnArray("Index")`` returns ``np.array([0, 1, 2, 3])``.

--- a/docs/source/release/v6.15.0/Framework/Data_Objects/New_features/40054.rst
+++ b/docs/source/release/v6.15.0/Framework/Data_Objects/New_features/40054.rst
@@ -1,0 +1,1 @@
+- :py:obj:`Table Workspaces <mantid.api.ITableWorkspace>` now support new method `columnArray` for retrieving the column of a `TableWorkspace` as a numpy array. For example `table_ws.columnArray("Index")` will return `np.array([0, 1, 2, 3])`


### PR DESCRIPTION
### Description of work
This method will be especially important for improving the performance of the new instrument view, since creating the arrays in C++ is about 100x faster than extracting columns as lists and having to create the numpy array from the Python side.
It's a good method to have in general regardless, since it's very common that users convert the lists from columns into arrays.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Closes https://github.com/mantidproject/mantid/issues/39867
<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Run the script, which covers columns of ints, doubles, strings and V3D:
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid.simpleapi import *

Load(Filename='/home/gui/Documents/SampleData-ISIS/MAR11060.raw', OutputWorkspace='MAR11060')
CreateDetectorTable(InputWorkspace='MAR11060', IncludeDetectorPosition=True, DetectorTableWorkspace='table')
for c in ["Index", "R", "Monitor", "Position"]:
    print(mtd['table'].columnArray(c))

empty_table = CreateEmptyTableWorkspace()
empty_table.addColumn('int', 'Index')
print(empty_table.columnArray('Index'))

variable_table = CreateEmptyTableWorkspace()
variable_table.addColumn('vector_int', 'Index')
variable_table.addRow([[1, 2, 3]])
variable_table.addRow([[1, 2, 3, 4]])
print(variable_table.columnArray('Index'))
``` 
and check that the correct columns are printed correctly and there is an error at the end for the case where vectors have variable lengths

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
