### PR TITLE
Add new colorbar norm option to sliceviewer

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/SliceViewer/New_features/40055.rst
+++ b/docs/source/release/v6.15.0/Workbench/SliceViewer/New_features/40055.rst
@@ -1,0 +1,1 @@
+- SliceViewer now supports "Asinh" colormap, similar to log but valid for zero values.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QComboB
 from qtpy.QtCore import Signal
 from qtpy.QtGui import QDoubleValidator
 
-NORM_OPTS = ["Linear", "Log", "SymmetricLog10", "Power"]
+NORM_OPTS = ["Linear", "Log", "SymmetricLog10", "Power", "Asinh"]
 AUTO_SCALE_OPTS = ["Min/Max", "3-Sigma", "1.5-Interquartile Range", "1.5-Median Absolute Deviation"]
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -15,7 +15,7 @@ from mantid.plots.utility import get_current_cmap
 from mantidqt.MPLwidgets import FigureCanvas
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
-from matplotlib.colors import ListedColormap, Normalize, SymLogNorm, PowerNorm, LogNorm
+from matplotlib.colors import ListedColormap, Normalize, SymLogNorm, PowerNorm, LogNorm, AsinhNorm
 from matplotlib import colormaps
 import numpy as np
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QCheckBox, QLabel
@@ -280,6 +280,8 @@ class ColorbarWidget(QWidget):
             return SymLogNorm(1e-8 if cmin is None else max(1e-8, abs(cmin) * 1e-3), vmin=cmin, vmax=cmax)
         elif NORM_OPTS[idx] == "Log":
             return LogNorm(vmin=cmin, vmax=cmax)
+        elif NORM_OPTS[idx] == "Asinh":
+            return AsinhNorm(vmin=cmin, vmax=cmax)
         else:
             return Normalize(vmin=cmin, vmax=cmax)
 
@@ -291,6 +293,8 @@ class ColorbarWidget(QWidget):
             scale = "symlog"
         elif isinstance(norm, LogNorm):
             scale = "log"
+        elif isinstance(norm, AsinhNorm):
+            scale = "asinh"
         elif isinstance(norm, PowerNorm):
             scale = "function"
             kwargs = {"functions": (lambda x: np.power(x, norm.gamma), lambda x: np.power(x, 1 / norm.gamma))}

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -13,7 +13,7 @@ from unittest import TestCase, mock
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget, NORM_OPTS
-from matplotlib.colors import LogNorm, Normalize, SymLogNorm, ListedColormap
+from matplotlib.colors import LogNorm, Normalize, SymLogNorm, AsinhNorm, ListedColormap
 
 
 @start_qapplication
@@ -181,6 +181,19 @@ class ColorbarWidgetTest(TestCase):
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(0)
         self.widget.norm.setCurrentIndex(3)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_asinh(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=AsinhNorm(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+        self.widget.norm.setCurrentIndex(4)
 
         vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
 


### PR DESCRIPTION
### Description of work

Added Asinh colorbar (like Log, but valid for zero and negative 

<img width="567" height="547" alt="image" src="https://github.com/user-attachments/assets/b4eae12d-51cd-4c5d-a319-71f03253cb8f" />


### To test:

1. Open mantid workbench.
2. Open sliceviewer
3. Switch to Asinh

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
