### PR TITLE
VULCAN single bank loading

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -73,6 +73,7 @@ const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
 const std::string EVENTS_PER_THREAD("EventsPerThread");
 const std::string ALLOW_LOGS("LogAllowList");
 const std::string BLOCK_LOGS("LogBlockList");
+const std::string OUTPUT_SPEC_NUM("OutputSpectrumNumber");
 } // namespace PropertyNames
 
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -26,7 +26,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnumeratedString.h"
 #include "MantidKernel/EnumeratedStringProperty.h"
-#include "MantidKernel/ListValidator.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
@@ -199,11 +198,9 @@ void AlignAndFocusPowderSlim::init() {
   setPropertyGroup(PropertyNames::EVENTS_PER_THREAD, CHUNKING_PARAM_GROUP);
 
   // load single spectrum
-  std::array<int, 7> vulcan_banks = {{1, 2, 3, 4, 5, 6, EMPTY_INT()}};
-  auto bankValidator = std::make_shared<Mantid::Kernel::ListValidator<int>>(vulcan_banks);
-  declareProperty(
-      std::make_unique<Kernel::PropertyWithValue<int>>(PropertyNames::OUTPUT_SPEC_NUM, EMPTY_INT(), bankValidator),
-      "The bank for which to read data; if specified, others will be blank");
+  declareProperty(std::make_unique<Kernel::PropertyWithValue<int>>(PropertyNames::OUTPUT_SPEC_NUM, EMPTY_INT(),
+                                                                   positiveIntValidator),
+                  "The bank for which to read data; if specified, others will be blank");
 }
 
 std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -38,6 +38,10 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
   for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
     const auto &bankName = m_bankEntries[wksp_index];
+    // empty bank names indicate spectra to skip; control should never get here, but just in case
+    if (bankName.empty()) {
+      continue;
+    }
     Kernel::Timer timer;
     g_log.debug() << bankName << " start" << std::endl;
 

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -647,7 +647,6 @@ public:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS(alg.setProperty(OUTPUT_SPEC_NUM, -1), std::invalid_argument const &);
     TS_ASSERT_THROWS(alg.setProperty(OUTPUT_SPEC_NUM, 0), std::invalid_argument const &);
-    TS_ASSERT_THROWS(alg.setProperty(OUTPUT_SPEC_NUM, 7), std::invalid_argument const &);
     for (int i = 1; i <= 6; i++) {
       TS_ASSERT_THROWS_NOTHING(alg.setProperty(OUTPUT_SPEC_NUM, i));
     }

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -663,7 +663,7 @@ public:
       // verify the output -- all spectra exist
       TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), NUM_HIST);
       for (int j = 0; j < NUM_HIST; j++) {
-        // check all epectra have bins
+        // check all spectra have bins
         TS_ASSERT_EQUALS(outputWS->readX(j).front(), 0.);
         TS_ASSERT_EQUALS(outputWS->readX(j).back(), 50000.);
         if (j == i - 1) {

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40067.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40067.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` now has the parameter ``OutputSpectrumNumber`` for selecting to load only a single bank of data.


### PR DESCRIPTION
### Description of work

This modifies `AlignAndFocusPowderSlim` to load a single bank of data.  The created workspace has six spectra; all are empty (no events / zero in all histo bins) except the indicated spectrum.  This is specified by spectrum number, NOT workspace index.

Part of [EWM 10910](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10910) in the VNEXT project.

### To test:

Check new unit tests.

Build this branch and run this script:
``` python
from mantid.simpleapi import AlignAndFocusPowderSlim
ws = AlignAndFocusPowderSlim(
    "VULCAN_218062.nxs.h5",
     RelativeTime=False,
     OutputSpectrumNumber = 3,
     XMin=0, XMax=50000, XDelta=50000,
     BinningMode="Linear",
     BinningUnits="TOF",
)
```

Check the data for the created workspace, and ensure ONLY spectrum 3 has loaded values.  Others will have value 0.  Experiment with binning and spectrum numbers.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
