### PR TITLE
Remove intel osx builds from nightly

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -31,10 +31,15 @@ def defaults = [
 
 // Restrict the parameter choices for certain named branches.
 switch(gitBranch) {
-  case ['main', 'release-next']:
+  case ['release-next']:
     defaults.packageSuffix = 'Nightly'
     defaults.anacondaLabel = 'nightly'
     defaults.platformChoices = ['all']
+    break
+  case ['main']:
+    defaults.packageSuffix = 'Nightly'
+    defaults.anacondaLabel = 'nightly'
+    defaults.platformChoices = ['linux-64', 'win-64', 'osx-arm64']
     break
   case ['ornl-next', 'ornl-qa', 'ornl']:
     defaults.packageSuffix = 'Nightly'

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -15,7 +15,7 @@ def publishPackages = (gitBranch == "${BRANCH_TO_PUBLISH}")
 def defaults = [
   anacondaChannel : 'mantid',
   githubReleasesRepo: 'mantidproject/mantid',
-  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64'],
+  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64', 'all_ARM'],
   publishToAnaconda : publishPackages,
   publishToGithub   : publishPackages,
   packageSuffix     : 'Unstable',
@@ -39,7 +39,7 @@ switch(gitBranch) {
   case ['main']:
     defaults.packageSuffix = 'Nightly'
     defaults.anacondaLabel = 'nightly'
-    defaults.platformChoices = ['linux-64', 'win-64', 'osx-arm64']
+    defaults.platformChoices = ['all_ARM']
     break
   case ['ornl-next', 'ornl-qa', 'ornl']:
     defaults.packageSuffix = 'Nightly'
@@ -145,6 +145,7 @@ pipeline {
             beforeOptions true
               anyOf {
                 expression { params.BUILD_DEVEL == 'all' }
+				expression { params.BUILD_DEVEL == 'all_ARM' }
                 expression { params.BUILD_DEVEL == 'linux-64' }
             }
           }
@@ -167,6 +168,7 @@ pipeline {
             beforeOptions true
             anyOf {
               expression { params.BUILD_DEVEL == 'all' }
+			  expression { params.BUILD_DEVEL == 'all_ARM' }
               expression { params.BUILD_DEVEL == 'win-64' }
             }
           }
@@ -213,6 +215,7 @@ pipeline {
             beforeOptions true
               anyOf {
                 expression { params.BUILD_DEVEL == 'all' }
+				expression { params.BUILD_DEVEL == 'all_ARM' }
                 expression { params.BUILD_DEVEL == 'osx-arm64' }
             }
           }
@@ -268,6 +271,7 @@ pipeline {
             anyOf {
               expression { params.BUILD_PACKAGE == 'win-64' }
               expression { params.BUILD_PACKAGE == 'all' }
+			  expression { params.BUILD_PACKAGE == 'all_ARM' }
             }
           }
           agent { label 'win-64' }
@@ -332,6 +336,7 @@ pipeline {
             anyOf {
               expression { params.BUILD_PACKAGE == 'osx-arm64' }
               expression { params.BUILD_PACKAGE == 'all' }
+			  expression { params.BUILD_PACKAGE == 'all_ARM' }
             }
           }
           agent { label 'osx-arm64' }
@@ -374,6 +379,7 @@ pipeline {
               beforeOptions true
               anyOf {
                   expression { params.BUILD_PACKAGE == "${PLATFORM}" }
+				  expression { params.BUILD_PACKAGE == 'all_ARM' }
                   expression { params.BUILD_PACKAGE == 'all' }
               }
             }


### PR DESCRIPTION
This pulls #40060 and #40061 into `ornl-next`