### PR TITLE
Remove fields for intel osx because it is no longer supported

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,19 +47,12 @@
       }
     },
     {
-      "name": "osx-64-ci",
-      "description": "Build options for a CI build on macOS",
+      "name": "osx-arm64-ci",
+      "description": "Build options for a CI build on an Arm macOS machine",
       "inherits": [
         "osx-default",
         "ci-default",
         "conda"
-      ]
-    },
-    {
-      "name": "osx-arm64-ci",
-      "description": "Build options for a CI build on an Arm macOS machine",
-      "inherits": [
-        "osx-64-ci"
       ]
     },
     {

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -67,7 +67,7 @@ EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 # This removes '-ci' from the end of the cmake preset to get the target platform
 # We check that it's not e.g. cppcheck or doxygen
 PLATFORM="${CMAKE_PRESET%-ci}"
-allowed_platforms=("win-64" "linux-64" "osx-64" "osx-arm64")
+allowed_platforms=("win-64" "linux-64" "osx-arm64")
 is_allowed=false
 for item in "${allowed_platforms[@]}"; do
     if [ "$PLATFORM" == "$item" ]; then

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -127,8 +127,6 @@ EXTRA_BUILD_OPTIONS="--debug "
 if [[ $OSTYPE == "msys" ]]; then
     # Do not use build id as it makes the path too long (>260 chars) for CMake (Legacy Windows API issue)
     EXTRA_BUILD_OPTIONS+="--no-build-id"
-elif [[ $PLATFORM == "osx-64" ]]; then
-    EXTRA_BUILD_OPTIONS+="-m ./osx_64.yaml"
 fi
 
 export CONDA_SUBDIR=$PLATFORM

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -64,7 +64,6 @@ requirements:
     - sphinx_bootstrap_theme {{ sphinx_bootstrap_theme }}
     - tbb-devel {{ tbb }}
     - texlive-core {{ texlive_core }} # [linux]
-    - texlive-core {{ texlive_core }} # [osx and not arm64]
     - toml {{ toml }}
     - versioningit {{ versioningit }}
     - vtk {{ vtk }} # [linux]
@@ -95,10 +94,8 @@ requirements:
 
     # Use conda version of clang to get matching CXXFLAGS.
     # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
-    - clang_osx-64 {{ c_compiler_version }} # [osx and not arm64]
-    - clangxx_osx-64 {{ cxx_compiler_version }} # [osx and not arm64]
-    - clang_osx-arm64 {{ c_compiler_version }} # [osx and arm64]
-    - clangxx_osx-arm64 {{ cxx_compiler_version }} # [osx and arm64]
+    - clang_osx-arm64 {{ c_compiler_version }} # [osx]
+    - clangxx_osx-arm64 {{ cxx_compiler_version }} # [osx]
     - llvm-openmp {{ llvm_openmp }} # [osx]
 
 about:

--- a/conda/recipes/osx_64.yaml
+++ b/conda/recipes/osx_64.yaml
@@ -1,6 +1,0 @@
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.10
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk
-target_platform:
-  - osx-64

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -138,8 +138,8 @@ for a given branch of mantid. The branch can be from the main mantid repo or fro
 Options
 #######
 
-- ``BUILD_DEVEL`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-64``]: Run the system tests for this OS.
-- ``BUILD_PACKAGE`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-64``]: Build a package on this OS.
+- ``BUILD_DEVEL`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-arm64``]: Run the system tests for this OS.
+- ``BUILD_PACKAGE`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-arm64``]: Build a package on this OS.
 - ``PACKAGE_SUFFIX``: String to append onto the standalone package name, useful for distinguishing builds. By default this is ``Unstable``.
 - ``PUBLISH_TO_ANACONDA``: Set true to publish to the given Anaconda channel and label.
 - ``PUBLISH_TO_GITHUB``: Set true to publish to the Github repository using the specified tag.

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -136,7 +136,7 @@ function usage() {
   echo "Options:"
   echo "  -c Optional conda channel overriding the default mantid"
   echo "  -s Optional Add a suffix to the output mantid file, has to be Unstable, or Nightly or not used"
-  echo "  -p Target platform, e.g. osx-64 or osx-arm64"
+  echo "  -p Target platform, e.g. osx-arm64"
   exit $exitcode
 }
 


### PR DESCRIPTION
As a continuation of the other changes to drop intel osx, this removes values from the `mantid-developer-package`.

There is no associated issue.

### To test:

A code review is the best way to confirm that intel osx has be properly removed.


*This does not require release notes* because it is already covered in previous release notes.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
