### PR TITLE
Add diagnostic messages to cmake to help with SIP

### DIFF
--- a/buildconfig/CMake/FindSIP.cmake
+++ b/buildconfig/CMake/FindSIP.cmake
@@ -78,6 +78,8 @@ if(SIP_BUILD_EXECUTABLE)
 endif()
 
 if(NOT SIP_FOUND)
+  message(STATUS "looking for sip on older system")
+
   # Python development is required for the older system
   if(NOT Python_Development_FOUND)
     message(FATAL_ERROR "FindSIP requires find_package(Python) to be called first")
@@ -102,4 +104,8 @@ if(NOT SIP_FOUND)
     REQUIRED_VARS SIP_EXECUTABLE SIP_INCLUDE_DIR
     VERSION_VAR SIP_VERSION
   )
+endif()
+
+if(NOT SIP_VERSION)
+  message(WARNING "FindSIP failed to determine sip version")
 endif()


### PR DESCRIPTION
To add in diagnosing configure/build problems with SIP, add some diagnostic prints to make.

This was pulled out of #39687.

There is no associated issue, but vaguely related to [EWM12339](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12339).

### To test:

There are two additional print statements. Rerun `cmake .` in your build tree and you'll see at least one of them.

*This does not require release notes* because It does not affect users.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
