### PR TITLE
Add diagnostic messages to cmake to help with SIP

### DIFF
--- a/buildconfig/CMake/FindSIP.cmake
+++ b/buildconfig/CMake/FindSIP.cmake
@@ -78,6 +78,8 @@ if(SIP_BUILD_EXECUTABLE)
 endif()
 
 if(NOT SIP_FOUND)
+  message(STATUS "looking for sip on older system")
+
   # Python development is required for the older system
   if(NOT Python_Development_FOUND)
     message(FATAL_ERROR "FindSIP requires find_package(Python) to be called first")
@@ -102,4 +104,8 @@ if(NOT SIP_FOUND)
     REQUIRED_VARS SIP_EXECUTABLE SIP_INCLUDE_DIR
     VERSION_VAR SIP_VERSION
   )
+endif()
+
+if(NOT SIP_VERSION)
+  message(WARNING "FindSIP failed to determine sip version")
 endif()


### PR DESCRIPTION
This is a version of #40072 into `ornl-next`