### PR TITLE
Remove osx 64 from main nightly

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -15,7 +15,7 @@ def publishPackages = (gitBranch == "${BRANCH_TO_PUBLISH}")
 def defaults = [
   anacondaChannel : 'mantid',
   githubReleasesRepo: 'mantidproject/mantid',
-  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64', 'all_ARM'],
+  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64'],
   publishToAnaconda : publishPackages,
   publishToGithub   : publishPackages,
   packageSuffix     : 'Unstable',
@@ -39,7 +39,7 @@ switch(gitBranch) {
   case ['main']:
     defaults.packageSuffix = 'Nightly'
     defaults.anacondaLabel = 'nightly'
-    defaults.platformChoices = ['all_ARM']
+    defaults.platformChoices = ['linux-64', 'win-64', 'osx-arm64']
     break
   case ['ornl-next', 'ornl-qa', 'ornl']:
     defaults.packageSuffix = 'Nightly'
@@ -145,7 +145,6 @@ pipeline {
             beforeOptions true
               anyOf {
                 expression { params.BUILD_DEVEL == 'all' }
-				expression { params.BUILD_DEVEL == 'all_ARM' }
                 expression { params.BUILD_DEVEL == 'linux-64' }
             }
           }
@@ -168,7 +167,6 @@ pipeline {
             beforeOptions true
             anyOf {
               expression { params.BUILD_DEVEL == 'all' }
-			  expression { params.BUILD_DEVEL == 'all_ARM' }
               expression { params.BUILD_DEVEL == 'win-64' }
             }
           }
@@ -215,7 +213,6 @@ pipeline {
             beforeOptions true
               anyOf {
                 expression { params.BUILD_DEVEL == 'all' }
-				expression { params.BUILD_DEVEL == 'all_ARM' }
                 expression { params.BUILD_DEVEL == 'osx-arm64' }
             }
           }
@@ -271,7 +268,6 @@ pipeline {
             anyOf {
               expression { params.BUILD_PACKAGE == 'win-64' }
               expression { params.BUILD_PACKAGE == 'all' }
-			  expression { params.BUILD_PACKAGE == 'all_ARM' }
             }
           }
           agent { label 'win-64' }
@@ -336,7 +332,6 @@ pipeline {
             anyOf {
               expression { params.BUILD_PACKAGE == 'osx-arm64' }
               expression { params.BUILD_PACKAGE == 'all' }
-			  expression { params.BUILD_PACKAGE == 'all_ARM' }
             }
           }
           agent { label 'osx-arm64' }
@@ -379,7 +374,6 @@ pipeline {
               beforeOptions true
               anyOf {
                   expression { params.BUILD_PACKAGE == "${PLATFORM}" }
-				  expression { params.BUILD_PACKAGE == 'all_ARM' }
                   expression { params.BUILD_PACKAGE == 'all' }
               }
             }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -15,7 +15,7 @@ def publishPackages = (gitBranch == "${BRANCH_TO_PUBLISH}")
 def defaults = [
   anacondaChannel : 'mantid',
   githubReleasesRepo: 'mantidproject/mantid',
-  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-64', 'osx-arm64'],
+  platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-arm64'],
   publishToAnaconda : publishPackages,
   publishToGithub   : publishPackages,
   packageSuffix     : 'Unstable',
@@ -180,28 +180,6 @@ pipeline {
             }
           }
         }
-        stage('build and test: osx-64') {
-          when {
-            beforeAgent true
-            beforeOptions true
-              anyOf {
-                expression { params.BUILD_DEVEL == 'all' }
-                expression { params.BUILD_DEVEL == 'osx-64' }
-            }
-          }
-          agent { label 'osx-64' }
-          options { timestamps () }
-          steps {
-            checkoutSource("${GIT_SHA}")
-            build_and_test('osx-64')
-          }
-          post {
-            always {
-              archive_test_logs()
-              publish_test_reports()
-            }
-          }
-        }
         stage('build and test: osx-arm64') {
           when {
             beforeAgent true
@@ -288,38 +266,6 @@ pipeline {
             }
           }
         }
-        stage('package conda: osx-64') {
-          when {
-            beforeAgent true
-            beforeOptions true
-            anyOf {
-              expression { params.BUILD_PACKAGE == 'osx-64' }
-              expression { params.BUILD_PACKAGE == 'all' }
-            }
-          }
-          agent { label 'osx-64' }
-          options {
-              timestamps ()
-              retry(3)
-          }
-          steps {
-            // Clean up conda-bld before we start to avoid any
-            // confusion with old packages
-            dir('conda-bld') {
-              deleteDir()
-            }
-            checkoutSource("${GIT_SHA}")
-            // Build the base set of packages (ones not required for mantidworkbench)
-            // in parallel
-            package_conda('osx-64', 'base')
-            archive_conda_packages('osx-64')
-          }
-          post {
-            always {
-              archive_env_logs('osx-64')
-            }
-          }
-        }
         stage('package conda: osx-arm64') {
           when {
             beforeAgent true
@@ -359,7 +305,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'linux-64', 'win-64', 'osx-64', 'osx-arm64'
+            values 'linux-64', 'win-64', 'osx-arm64'
           }
         }
         stages {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -31,15 +31,10 @@ def defaults = [
 
 // Restrict the parameter choices for certain named branches.
 switch(gitBranch) {
-  case ['release-next']:
+  case ['main', 'release-next']:
     defaults.packageSuffix = 'Nightly'
     defaults.anacondaLabel = 'nightly'
     defaults.platformChoices = ['all']
-    break
-  case ['main']:
-    defaults.packageSuffix = 'Nightly'
-    defaults.anacondaLabel = 'nightly'
-    defaults.platformChoices = ['linux-64', 'win-64', 'osx-arm64']
     break
   case ['ornl-next', 'ornl-qa', 'ornl']:
     defaults.packageSuffix = 'Nightly'


### PR DESCRIPTION
### Description of work
An attempt was made to remove osx-64 from the main nightly but it was broken. I have reverted those changes and implemented the correct removal. Since this is going into `main` it will not impact the `release-next` builds until we enter code freze for v6.15.0.

### To test:
Review the changes. To make it less confusing, just look at the changes after the reverts:
https://github.com/mantidproject/mantid/pull/40077/commits/df7b4d10bbbdcb4139aa07763059dfe8f601e3b5
This commit simply removes all osx-64 stages.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
