### PR TITLE
Fix for flaky POLDI system test

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PoldiDataAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PoldiDataAnalysis.py
@@ -13,7 +13,6 @@ from mantid.kernel import (
 from mantid.simpleapi import (
     plotSpectrum,
     DeleteWorkspace,
-    Integration,
     GroupWorkspaces,
     Plus,
     PoldiAnalyseResiduals,
@@ -23,7 +22,6 @@ from mantid.simpleapi import (
     PoldiPeakSearch,
     PoldiAutoCorrelation,
     RenameWorkspace,
-    SumSpectra,
 )
 
 
@@ -219,15 +217,7 @@ class PoldiDataAnalysis(PythonAlgorithm):
         self.setProperty("OutputWorkspace", outputWs)
 
     def workspaceHasCounts(self, workspace):
-        integrated = Integration(workspace)
-        summed = SumSpectra(integrated)
-
-        counts = summed.readY(0)[0]
-
-        DeleteWorkspace(integrated)
-        DeleteWorkspace(summed)
-
-        return counts > 0
+        return workspace.extractY().sum() > 0
 
     def runCorrelation(self):
         correlationName = self.baseName + "_correlation"


### PR DESCRIPTION
### Description of work

Not related to recent POLDI work in v6.14, but good to get into release-next to make nightly more stable.

This change just simplifies method to check total counts in a workspace. We think this could have led to flaky behaviour on mac with possible reference to first y-value after workspace had been deleted.

The system test passes on windows (but it also passes on main).

No associated issue

No release note required as no user-facing change

### To test:

(1) On Mac check this system test fails on main (might need to run more than once - think that can be automated but don't know how sorry!)
`./systemtest.bat -C debugWithRelRuntime -R POLDIDataAnalysisTest.POLDIDataAnalysisTestSiIndividualDiscardUnindexed -j 2
`
(2) Checkout this PR and re-run the test - should hopefully pass.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
