### PR TITLE
Extend pawley fitting class for TOF data

### DIFF
--- a/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40095.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40095.rst
@@ -1,0 +1,2 @@
+- Support Pawley refinement of TOF workspaces in ``PawleyPattern1D`` class and added TOF peak profile ``BackToBackGauss`` for back-to-back exponential convoluted with a Gaussian.
+- Support zero shift and scale factor for reflection d-spacings in ``PawleyPattern1D`` class (equivalent to modifying TZERO and DIFC).

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -98,6 +98,26 @@ class GaussianProfile(PeakProfile):
         return {"Sigma": np.sqrt((self.p[0] ** 2) + (self.p[1] ** 2) * dpk**2 + (self.p[2] ** 2) * dpk**4)}  # Panel 6 in [1] with zeta=0
 
 
+class BackToBackGauss(PeakProfile):
+    def __init__(self):
+        self.func_name = "BackToBackExponential"
+        self.labels = ("sig0", "sig1", "sig2", "alpha_0", "alpha_1", "beta_0", "beta_1")
+        self.p: np.ndarray = np.array([0, 9.06, 6.52, 0, 0.0968, 0.0216, 0.0123])  # for ENGIN-X North Bank
+        self.default_isfree: np.ndarray = np.zeros_like(self.p, dtype=bool)
+
+    def get_mantid_peak_params(self, dpk: float) -> dict:
+        return {"S": self._calc_sigma(dpk), "A": self._calc_alpha(dpk), "B": self._calc_beta(dpk)}
+
+    def _calc_sigma(self, dpk: float) -> float:
+        return np.sqrt((self.p[0] ** 2) + (self.p[1] * dpk) ** 2 + (self.p[2] ** 2) * dpk**4)
+
+    def _calc_alpha(self, dpk: float) -> float:
+        return self.p[3] + self.p[4] / dpk
+
+    def _calc_beta(self, dpk: float) -> float:
+        return self.p[5] + self.p[6] / (dpk**4)
+
+
 class Phase:
     def __init__(self, crystal_structure: CrystalStructure, hkls: Optional[np.ndarray] = None):
         self.unit_cell = crystal_structure.getUnitCell()

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -12,7 +12,6 @@ from mantid.api import FunctionFactory
 from mantid.geometry import CrystalStructure, ReflectionGenerator, PointGroupFactory, PointGroup
 from mantid.kernel import V3D, logger, UnitConversion, DeltaEModeType
 from typing import Optional, Tuple, TYPE_CHECKING, Sequence
-from itertools import chain
 from scipy.optimize import least_squares
 from plugins.algorithms.poldi_utils import simulate_2d_data, get_dspac_array_from_ws
 from abc import ABC, abstractmethod
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
 class InstrumentParams:
     def __init__(self):
         self.p: np.ndarray = np.array([1.0, 0.0])
+        self.labels = ("scale", "shift")
         self.default_isfree: np.ndarray = np.zeros_like(self.p, dtype=bool)
 
     def get_peak_centre(self, dpk: float) -> float:
@@ -272,14 +272,14 @@ class PawleyPattern1D:
             [self.comp_func[len(self.comp_func) - 1].function.setParameter(ipar, par) for ipar, par in enumerate(self.bg_params)]
 
     def get_params(self) -> np.ndarray[float]:
-        return np.array(list(chain(*self.alatt_params, *self.intens, *self.profile_params, self.inst_params, self.bg_params)))
+        return np.concatenate((*self.alatt_params, *self.intens, *self.profile_params, self.inst_params, self.bg_params))
 
     def get_free_params(self) -> np.ndarray[float]:
         return self.get_params()[self.get_isfree()]
 
     def get_isfree(self) -> np.ndarray[bool]:
-        return np.array(
-            list(chain(*self.alatt_isfree, *self.intens_isfree, *self.profile_isfree, self.inst_isfree, self.bg_isfree)), dtype=bool
+        return np.concatenate((*self.alatt_isfree, *self.intens_isfree, *self.profile_isfree, self.inst_isfree, self.bg_isfree)).astype(
+            bool
         )
 
     def set_params(self, params: np.ndarray[float]):

--- a/scripts/test/Engineering/test_pawley_utils.py
+++ b/scripts/test/Engineering/test_pawley_utils.py
@@ -110,7 +110,7 @@ class PawleyPattern1DTest(unittest.TestCase):
 
     def test_get_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
-        self.assertEqual(len(pawley.get_params()), 5)
+        self.assertEqual(len(pawley.get_params()), 7)
 
     def test_get_free_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
@@ -118,7 +118,7 @@ class PawleyPattern1DTest(unittest.TestCase):
 
     def test_get_isfree(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
-        assert_array_equal(pawley.get_isfree(), array([True, True, True, True, False]))
+        assert_array_equal(pawley.get_isfree(), array([True, True, True, True, False, False, False]))
 
     def test_set_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
@@ -129,7 +129,7 @@ class PawleyPattern1DTest(unittest.TestCase):
     def test_set_free_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
         pawley.set_free_params(ones(4))
-        assert_array_equal(pawley.get_params().astype(int), array([1, 1, 1, 1, 0]))
+        assert_array_equal(pawley.get_params().astype(int), array([1, 1, 1, 1, 0, 1, 0]))
 
     def test_estimate_initial_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())

--- a/scripts/test/Engineering/test_pawley_utils.py
+++ b/scripts/test/Engineering/test_pawley_utils.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from mantid.api import AnalysisDataService, FileFinder
 from mantid.simpleapi import CreateWorkspace, FlatBackground, EditInstrumentGeometry, ConvertUnits
 from mantid.geometry import CrystalStructure
-from Engineering.pawley_utils import Phase, GaussianProfile, PVProfile, PawleyPattern1D, PawleyPattern2D
+from Engineering.pawley_utils import Phase, GaussianProfile, PVProfile, PawleyPattern1D, PawleyPattern2D, BackToBackGauss
 from plugins.algorithms.poldi_utils import load_poldi
 
 
@@ -81,6 +81,14 @@ class ProfileTest(unittest.TestCase):
         self.assertAlmostEqual(param_dict["FWHM"], 2 * sqrt(2 * log(2)) * self.GAUSS_SIGMA, delta=1e-5)
         self.assertAlmostEqual(param_dict["Mixing"], 0, delta=1e-8)
         self.assertEqual(profile.func_name, "PseudoVoigt")
+
+    def test_back_to_back_gauss(self):
+        profile = BackToBackGauss()
+        param_dict = profile.get_mantid_peak_params(self.DSPAC)
+        self.assertAlmostEqual(param_dict["A"], 0.0645, delta=1e-4)
+        self.assertAlmostEqual(param_dict["B"], 0.0240, delta=1e-4)
+        self.assertAlmostEqual(param_dict["S"], 20.0, delta=1e-1)
+        self.assertEqual(profile.func_name, "BackToBackExponential")
 
 
 class PawleyPattern1DTest(unittest.TestCase):


### PR DESCRIPTION
### Description of work

Add TOF peak profile parameterisation and support TOF data in `PawleyPattern1D` class

### To test:

(1) Run this script with this .nxs file which is a cropped section of ENGIN-X ceria data from the North Bank 
(note might need to change path to cif file distributed with Mantid)
[NorthBank_foc_cropped.nxs.txt](https://github.com/user-attachments/files/22799842/NorthBank_foc_cropped.nxs.txt)

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from Engineering.pawley_utils import BackToBackGauss, PawleyPattern1D, Phase
from time import time

# load data
ws_foc = LoadNexus(Filename=r"C:\Users\xhg73778\Documents\ENGINX\NorthBank_foc_cropped.nxs", OutputWorkspace='NorthBank')
ws_foc = ConvertToPointData(InputWorkspace=ws_foc, OutputWorkspace=ws_foc.name())

# define phase and set hkls
phase = Phase.from_cif(r"C:\mantid-conda\mantid\scripts\Engineering\ENGINX\phase_info\CEO2.cif")
dmin, dmax = 0.71, 2.75
phase.set_hkls_from_dspac_limits(dmin, dmax)
phase.merge_reflections()
# print(np.c_[phase.hkls, phase.calc_dspacings()])

# estimate background
bg_func = Chebyshev(n=8)
mtd_fit_kwargs = {"StepSizeMethod": "Sqrt epsilon", "CreateOutput": True, "IgnoreInvalidData": True}
bg_fit_res = Fit(bg_func, InputWorkspace=ws_foc, Output=f"InitialBackground", **mtd_fit_kwargs)
# mask peaks
mask = bg_fit_res.OutputWorkspace.readY(2) > 5
y = bg_fit_res.OutputWorkspace.dataY(0)
y[mask] = np.nan
# fit again
bg_fit_res = Fit(bg_fit_res.Function, InputWorkspace=bg_fit_res.OutputWorkspace, Output=f"InitialBackground", **mtd_fit_kwargs)

# estimate average intensity from area of residuals
ws_resid_integrated = Integration(InputWorkspace=bg_fit_res.OutputWorkspace, 
                                  StartWorkspaceIndex=2, EndWorkspaceIndex=3)
avg_intens = ws_resid_integrated.readY(0)[0]/phase.nhkls()

# do refinement  
pawley = PawleyPattern1D(ws_foc, [phase], profile=BackToBackGauss(), bg_func=bg_fit_res.Function)
pawley.intens[0][:] = avg_intens
pawley.update_profile_function()
EvaluateFunction(pawley.comp_func, InputWorkspace=ws_foc, OutputWorkspace="InitialProfile")

# fit peak intensities only
pawley.bg_isfree[:] = False
pawley.profile_isfree[0][:] = False
pawley.alatt_isfree[0][:] = False
start = time()
res = pawley.fit()
print("Elapsed = ", time() - start)

# optimise alatt and profile
pawley.alatt_isfree[0][:] = True
pawley.profile_isfree[0][:] = True
start = time()
res = pawley.fit()
print("Elapsed = ", time() - start)

# evaluate result
pawley.set_free_params(res.x)
pawley.update_profile_function()
ws_foc_fit = EvaluateFunction(pawley.comp_func, InputWorkspace=ws_foc, OutputWorkspace="FittedProfile")

fig, axes = plt.subplots(figsize=[10.0, 4.7564], subplot_kw={'projection': 'mantid'})
axes.plot(ws_foc_fit, color='tab:blue', marker='o', markersize=3, ls='', label='Data', wkspIndex=0)
axes.plot(ws_foc_fit, color='tab:orange', ls='-', label='Calc', wkspIndex=1)
axes.plot(ws_foc_fit, color='tab:green', label='Diff', wkspIndex=2)
axes.set_xlim([12976.0, 50887.0])
axes.set_ylim([-0.715, 41.808])
legend = axes.legend(fontsize=8.0).set_draggable(True).legend
fig.show()

```

(2) Check plot should look like this (note you wouldn't normally refine all the profile parameters)
<img width="1560" height="735" alt="image" src="https://github.com/user-attachments/assets/30327891-eaf0-411b-aab9-57bb8eab9068" />

(3) Follow instructions in #39912 to check nothing has broken!

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?

- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
