### PR TITLE
Pin pyvista to avoid vtk incompitibility that will crash mantidworkbench on launch

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -119,6 +119,10 @@ pyqt5_sip:
 python_dateutil:
   - '>=2.8.1'
 
+# v0.45 and above addresses vtk compatibility issues by pinning in the pyvista feedstock.
+pyvista:
+  - '>=0.45'
+
 pyyaml:
   - '>=5.4.1'
 
@@ -174,11 +178,6 @@ librdkafka:
 
 versioningit:
   - '>=2.1'
-
-# Pin to version 9.4.2 because previous versions were crashing new instrument view on Ubuntu
-# Newer version 9.5.0 does not yet work with pyvista
-vtk:
-  - '9.4.2'
 
 pin_run_as_build:
   boost:

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - python-dateutil {{ python_dateutil }}
     - python {{ python }}
     - python.app # [osx]
-    - pyvista
+    - pyvista {{ pyvista }}
     - pyvistaqt
     - superqt
     - pyyaml {{ pyyaml }}
@@ -67,7 +67,6 @@ requirements:
     - texlive-core {{ texlive_core }} # [osx and not arm64]
     - toml {{ toml }}
     - versioningit {{ versioningit }}
-    - vtk {{ vtk }} # [linux]
     - zlib
     - joblib
     - orsopy {{ orsopy }}

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -49,7 +49,6 @@ requirements:
     - tbb-devel {{ tbb }}
     - versioningit {{ versioningit }}
     - numpy {{ numpy }}                      # [build_platform != target_platform]
-    - vtk {{ vtk }} # [linux]
     - libgl-devel  # [linux]
     - xorg-libxxf86vm  # [linux]
     - xorg-libx11  # [linux]

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - python.app  # [osx]
     - pystack  # [linux]
     - gdk-pixbuf {{ gdk_pixbuf }} # [win]
-    - pyvista
+    - pyvista {{ pyvista }}
     - pyvistaqt
     - superqt
     - qtconsole {{ qtconsole }}


### PR DESCRIPTION
### Description of work
Today I updated my mantid-developer environment, and mamba decided to do this:
```
  - vtk-base                                    9.2.6  qt_py311h1234567_223     conda-forge              Cached
  + vtk-base                                    9.5.1  py311h8cd0633_2          conda-forge                44MB

  - pyvista                                    0.46.3  pyhd8ed1ab_0             conda-forge              Cached
  + pyvista                                    0.44.1  pyhd8ed1ab_0             conda-forge                 2MB
```

Sadly this results in a crash due to pyvista importing `vtkCapsuleSource` that was removed in vtk version 9.4 (I think):

```
FrameworkManager-[Notice] Welcome to Mantid 6.13.20251007.1511
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
DownloadInstrument-[Notice] All instrument definitions up to date
Traceback (most recent call last):
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\workbench\app\workbench_process.py", line 144, in create_and_launch_workbench
    main_window.setup()
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\workbench\app\mainwindow.py", line 181, in setup
    from workbench.plugins.workspacewidget import WorkspaceWidget
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\workbench\plugins\workspacewidget.py", line 12, in <module>
    from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\instrumentview\FullInstrumentViewWindow.py", line 7, in <module>
    from pyvista import PolyData
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\pyvista\__init__.py", line 14, in <module>
    from pyvista.core import *
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\pyvista\core\__init__.py", line 6, in <module>
    from . import _vtk_core
  File "C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\pyvista\core\_vtk_core.py", line 311, in <module>
    from vtkmodules.vtkFiltersSources import vtkCapsuleSource
ImportError: cannot import name 'vtkCapsuleSource' from 'vtkmodules.vtkFiltersSources' (C:\Users\dsc49661\.local\share\mamba\envs\pyvista-test\Lib\site-packages\vtkmodules\vtkFiltersSources.cp311-win_amd64.pyd)
```

It seems that pyvista have resolved this in more recent versions by putting various pins on vtk. Therefore we make the most progressive pin that solves our problem and trust that pyvista will not make the same mistake again.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
You can reproduce the error by doing:
`mamba install -c mantid/label/nightly mantidworkbench pyvista=0.44 vtk-base=9.5`
The addition in this PR prevents that broken combination. You can verfiy that by trying this in a conda env:
`mamba install vtk-base=9.5 pyvista=0.45`
and observe:
`error    libmamba Could not solve for environment specs`


*This does not require release notes* because it is intended to maintain current behaviour.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
