### PR TITLE
Pin pyvista to avoid vtk incompitibility that will crash mantidworkbench on launch

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -119,6 +119,10 @@ pyqt5_sip:
 python_dateutil:
   - '>=2.8.1'
 
+# v0.45 and above addresses vtk compatibility issues by pinning in the pyvista feedstock.
+pyvista:
+  - '>=0.45'
+
 pyyaml:
   - '>=5.4.1'
 
@@ -174,11 +178,6 @@ librdkafka:
 
 versioningit:
   - '>=2.1'
-
-# Pin to version 9.4.2 because previous versions were crashing new instrument view on Ubuntu
-# Newer version 9.5.0 does not yet work with pyvista
-vtk:
-  - '9.4.2'
 
 pin_run_as_build:
   boost:

--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - python-dateutil {{ python_dateutil }}
     - python {{ python }}
     - python.app # [osx]
-    - pyvista
+    - pyvista {{ pyvista }}
     - pyvistaqt
     - superqt
     - pyyaml {{ pyyaml }}
@@ -67,7 +67,6 @@ requirements:
     - texlive-core {{ texlive_core }} # [osx and not arm64]
     - toml {{ toml }}
     - versioningit {{ versioningit }}
-    - vtk {{ vtk }} # [linux]
     - zlib
     - joblib
     - orsopy {{ orsopy }}

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -49,7 +49,6 @@ requirements:
     - tbb-devel {{ tbb }}
     - versioningit {{ versioningit }}
     - numpy {{ numpy }}                      # [build_platform != target_platform]
-    - vtk {{ vtk }} # [linux]
     - libgl-devel  # [linux]
     - xorg-libxxf86vm  # [linux]
     - xorg-libx11  # [linux]

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - python.app  # [osx]
     - pystack  # [linux]
     - gdk-pixbuf {{ gdk_pixbuf }} # [win]
-    - pyvista
+    - pyvista {{ pyvista }}
     - pyvistaqt
     - superqt
     - qtconsole {{ qtconsole }}


### PR DESCRIPTION
This is a version of #40098 into `ornl-next`