### PR TITLE
Updated smoke testing instructions to add correct label for MSlice release candidate

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -509,6 +509,7 @@ We are now ready to create the release candidates for Smoke testing.
   * set ``GITHUB_RELEASES_REPO`` to ``mantidproject/mantid``
   * set ``GITHUB_RELEASES_TAG`` to ``vX.Y.ZrcN``, where ``X.Y.Z`` is the release number,
     and ``N`` is an incremental build number for release candidates, starting at ``1``.
+  * On Anaconda, add the ``vX.Y.ZrcN`` label to the release candidate Conda package for MSlice
 
 * Once the packages have been published to GitHub and Anaconda, ask someone in the ISIS core or DevOps
   team to manually sign the Windows binary and re-upload it to the GitHub


### PR DESCRIPTION
### Description of work

When we were smoke testing the last time, it was difficult to get the correct release candidate version for MSlice for the Mantid release candidate. This PR adds a step in the instructions to take care of this.

Please note that it is sufficient if the change is merged into main and does not necessarily have to be merged into release-next.

### To test:

Check spelling and grammar and if the new instruction is easy to understand.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
