### PR TITLE
Adding missing neutrons conda channel to nightly docs publishing script

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -12,7 +12,7 @@ GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
 
 # Install conda and environment
 setup_mamba $WORKSPACE/miniforge "docs-build" true ""
-mamba install -c ${CONDA_LABEL} --yes mantid-developer mantidqt rsync
+mamba install -c ${CONDA_LABEL} -c neutrons --yes mantid-developer mantidqt rsync
 
 # Configure a clean build directory
 rm -rf build


### PR DESCRIPTION
### Description of work
The script installs mantid-developer into a conda environment, so now requires the neutrons channel.

### To test:
Read the code changes. This does not need any CI to pass since the script is outside of our PR checks.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
