### PR TITLE
Fix the nightly docs publishing script

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -18,6 +18,8 @@ mamba install -c ${CONDA_LABEL} -c neutrons --yes mantid-developer mantidqt rsyn
 rm -rf build
 mkdir build && cd build
 
+# unset LD_PRELOAD as this causes cmake to segfault
+LD_PRELOAD="" \
 # Generate build files
 cmake -G Ninja \
   -DMANTID_FRAMEWORK_LIB=SYSTEM \


### PR DESCRIPTION
### Description of work
I copied this line from the mantiddocs recipe and it seems to fix the segfault.

### To test:
I ran this branch here and it succeeded:
https://builds.mantidproject.org/job/build_and_publish_docs/378/


*This does not require release notes* because it is a build script


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
