### PR TITLE
Add option to CreateDetectorTable to return column of Detector ID(s) as integers

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
@@ -54,7 +54,8 @@ private:
 /// Creates table workspace of detector information from a given workspace
 API::ITableWorkspace_sptr createDetectorTableWorkspace(const API::MatrixWorkspace_sptr &ws,
                                                        const std::vector<int> &indices, const bool includeData,
-                                                       const bool includeDetectorPosition, Kernel::Logger &logger);
+                                                       const bool includeDetectorPosition,
+                                                       const bool detectorIDAsIntegers, Kernel::Logger &logger);
 
 /// Converts a list to a string, shortened if necessary
 std::string createTruncatedList(const std::set<int> &elements);
@@ -64,10 +65,11 @@ void populateTable(Mantid::API::ITableWorkspace_sptr &t, const Mantid::API::Matr
                    bool signedThetaParamRetrieved, bool showSignedTwoTheta,
                    const Mantid::Geometry::PointingAlong &beamAxisIndex, const double sampleDist, const bool isScanning,
                    const bool include_data, const bool calcQ, const bool includeDiffConstants,
-                   const bool includeDetectorPosition, Kernel::Logger &logger);
+                   const bool includeDetectorPosition, const bool detectorIDAsIntegers, Kernel::Logger &logger);
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
                                                                const bool calcQ, const bool hasDiffConstants,
-                                                               const bool includeDetectorPosition);
+                                                               const bool includeDetectorPosition,
+                                                               const bool detectorIDAsIntegers);
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
@@ -54,8 +54,8 @@ private:
 /// Creates table workspace of detector information from a given workspace
 API::ITableWorkspace_sptr createDetectorTableWorkspace(const API::MatrixWorkspace_sptr &ws,
                                                        const std::vector<int> &indices, const bool includeData,
-                                                       const bool includeDetectorPosition,
-                                                       const bool detectorIDAsIntegers, Kernel::Logger &logger);
+                                                       const bool includeDetectorPosition, const bool pickOneDetectorID,
+                                                       Kernel::Logger &logger);
 
 /// Converts a list to a string, shortened if necessary
 std::string createTruncatedList(const std::set<int> &elements);
@@ -65,11 +65,11 @@ void populateTable(Mantid::API::ITableWorkspace_sptr &t, const Mantid::API::Matr
                    bool signedThetaParamRetrieved, bool showSignedTwoTheta,
                    const Mantid::Geometry::PointingAlong &beamAxisIndex, const double sampleDist, const bool isScanning,
                    const bool include_data, const bool calcQ, const bool includeDiffConstants,
-                   const bool includeDetectorPosition, const bool detectorIDAsIntegers, Kernel::Logger &logger);
+                   const bool includeDetectorPosition, const bool pickOneDetectorID, Kernel::Logger &logger);
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
                                                                const bool calcQ, const bool hasDiffConstants,
                                                                const bool includeDetectorPosition,
-                                                               const bool detectorIDAsIntegers);
+                                                               const bool pickOneDetectorID);
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -31,6 +31,10 @@ void CreateDetectorTable::init() {
                         "Include the absolute position of the detector group for each spectrum.", Direction::Input);
   setPropertySettings("IncludeDetectorPosition",
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
+  declareProperty<bool>("DetectorIDAsIntegers", false, "Return the column of detector IDs as integers type.",
+                        Direction::Input);
+  setPropertySettings("IncludeDetectorPosition",
+                      std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
   declareProperty(std::make_unique<WorkspaceProperty<TableWorkspace>>("DetectorTableWorkspace", "", Direction::Output,
                                                                       PropertyMode::Optional),
                   "The name of the outputted detector table workspace, if left empty then "
@@ -42,6 +46,7 @@ void CreateDetectorTable::exec() {
   bool includeData = getProperty("IncludeData");
   std::vector<int> indices = getProperty("WorkspaceIndices");
   bool includeDetectorPosition = getProperty("IncludeDetectorPosition");
+  bool detectorIDAsIntegers = getProperty("DetectorIDAsIntegers");
 
   ITableWorkspace_sptr detectorTable;
 
@@ -50,7 +55,8 @@ void CreateDetectorTable::exec() {
     if (sample == nullptr) {
       throw std::runtime_error("Matrix workspace has no instrument information");
     }
-    detectorTable = createDetectorTableWorkspace(matrix, indices, includeData, includeDetectorPosition, g_log);
+    detectorTable = createDetectorTableWorkspace(matrix, indices, includeData, includeDetectorPosition,
+                                                 detectorIDAsIntegers, g_log);
 
     if (detectorTable == nullptr) {
       throw std::runtime_error("Unknown error while creating detector table for matrix workspace");
@@ -110,7 +116,7 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
  */
 ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws, const std::vector<int> &indices,
                                                   const bool includeData, const bool includeDetectorPosition,
-                                                  Logger &logger) {
+                                                  const bool detectorIDAsIntegers, Logger &logger) {
   IComponent_const_sptr sample = ws->getInstrument()->getSample();
 
   // check if efixed value is available
@@ -141,7 +147,8 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
   }
 
   // Prepare column names
-  auto colNames = createColumns(isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition);
+  auto colNames =
+      createColumns(isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition, detectorIDAsIntegers);
 
   const int ncols = static_cast<int>(colNames.size());
   const int nrows = indices.empty() ? static_cast<int>(ws->getNumberHistograms()) : static_cast<int>(indices.size());
@@ -163,18 +170,24 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
                                                                     // value should be displayed
 
   populateTable(t, ws, nrows, indices, spectrumInfo, signedThetaParamRetrieved, showSignedTwoTheta, beamAxisIndex,
-                sampleDist, isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition, logger);
+                sampleDist, isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition,
+                detectorIDAsIntegers, logger);
 
   return t;
 }
 
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
                                                                const bool calcQ, const bool hasDiffConstants,
-                                                               const bool includeDetectorPosition) {
+                                                               const bool includeDetectorPosition,
+                                                               const bool detectorIDAsIntegers) {
   std::vector<std::pair<std::string, std::string>> colNames;
   colNames.emplace_back("double", "Index");
   colNames.emplace_back("int", "Spectrum No");
-  colNames.emplace_back("str", "Detector ID(s)");
+  if (detectorIDAsIntegers) {
+    colNames.emplace_back("int", "Detector ID(s)");
+  } else {
+    colNames.emplace_back("str", "Detector ID(s)");
+  }
   if (isScanning)
     colNames.emplace_back("str", "Time Indexes");
   if (includeData) {
@@ -205,7 +218,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
                    const std::vector<int> &indices, const SpectrumInfo &spectrumInfo, bool signedThetaParamRetrieved,
                    bool showSignedTwoTheta, const PointingAlong &beamAxisIndex, const double sampleDist,
                    const bool isScanning, const bool includeData, const bool calcQ, const bool includeDiffConstants,
-                   const bool includeDetectorPosition, Logger &logger) {
+                   const bool includeDetectorPosition, const bool detectorIDAsIntegers, Logger &logger) {
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(*ws))
   for (int row = 0; row < nrows; ++row) {
     TableRow colValues = t->getRow(row);
@@ -216,6 +229,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
       auto &spectrum = ws->getSpectrum(wsIndex);
       Mantid::specnum_t specNo = spectrum.getSpectrumNo();
       const auto &ids = dynamic_cast<const std::set<int> &>(spectrum.getDetectorIDs());
+      int detId = static_cast<int>(*ids.begin());
       std::string detIds = createTruncatedList(ids);
 
       // Geometry
@@ -254,7 +268,12 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
         theta = sampleDist > dist ? 180.0 : 0.0;
       }
       const std::string isMonitorDisplay = isMonitor ? "yes" : "no";
-      colValues << static_cast<int>(specNo) << detIds;
+      colValues << static_cast<int>(specNo);
+      if (detectorIDAsIntegers) {
+        colValues << detId;
+      } else {
+        colValues << detIds;
+      }
       if (isScanning) {
         std::set<int> timeIndexSet;
         for (const auto &def : spectrumInfo.spectrumDefinition(wsIndex)) {
@@ -318,7 +337,12 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
       colValues.row(row);
       colValues << static_cast<double>(wsIndex);
       // spectrumNo=-1, detID=0
-      colValues << -1 << "0";
+      colValues << -1;
+      if (detectorIDAsIntegers) {
+        colValues << 0;
+      } else {
+        colValues << "0";
+      }
       // Y/E
       if (includeData) {
         colValues << dataY0 << dataE0; // data

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -27,14 +27,17 @@ void CreateDetectorTable::init() {
   declareProperty("IncludeData", false, "Include the first value from each spectrum.");
   setPropertySettings("IncludeData",
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
+
   declareProperty<bool>("IncludeDetectorPosition", false,
                         "Include the absolute position of the detector group for each spectrum.", Direction::Input);
   setPropertySettings("IncludeDetectorPosition",
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
-  declareProperty<bool>("DetectorIDAsIntegers", false, "Return the column of detector IDs as integers type.",
+
+  declareProperty<bool>("PickOneDetectorID", false, "Populate the Detector ID column with only the first of the set.",
                         Direction::Input);
-  setPropertySettings("IncludeDetectorPosition",
+  setPropertySettings("PickOneDetectorID",
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
+
   declareProperty(std::make_unique<WorkspaceProperty<TableWorkspace>>("DetectorTableWorkspace", "", Direction::Output,
                                                                       PropertyMode::Optional),
                   "The name of the outputted detector table workspace, if left empty then "
@@ -46,7 +49,7 @@ void CreateDetectorTable::exec() {
   bool includeData = getProperty("IncludeData");
   std::vector<int> indices = getProperty("WorkspaceIndices");
   bool includeDetectorPosition = getProperty("IncludeDetectorPosition");
-  bool detectorIDAsIntegers = getProperty("DetectorIDAsIntegers");
+  bool pickOneDetectorID = getProperty("PickOneDetectorID");
 
   ITableWorkspace_sptr detectorTable;
 
@@ -55,8 +58,8 @@ void CreateDetectorTable::exec() {
     if (sample == nullptr) {
       throw std::runtime_error("Matrix workspace has no instrument information");
     }
-    detectorTable = createDetectorTableWorkspace(matrix, indices, includeData, includeDetectorPosition,
-                                                 detectorIDAsIntegers, g_log);
+    detectorTable =
+        createDetectorTableWorkspace(matrix, indices, includeData, includeDetectorPosition, pickOneDetectorID, g_log);
 
     if (detectorTable == nullptr) {
       throw std::runtime_error("Unknown error while creating detector table for matrix workspace");
@@ -110,13 +113,14 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
  * displayed
  * @param includeDetectorPosition :: If true then include the absolute position of
  * the detector group for each spectrum
+ * @param pickOneDetectorID :: If true then picks only the first detector ID per row
  * @param logger: The Mantid logger so errors can be written to it.
  *
  * @return A pointer to the table workspace of detector information
  */
 ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws, const std::vector<int> &indices,
                                                   const bool includeData, const bool includeDetectorPosition,
-                                                  const bool detectorIDAsIntegers, Logger &logger) {
+                                                  const bool pickOneDetectorID, Logger &logger) {
   IComponent_const_sptr sample = ws->getInstrument()->getSample();
 
   // check if efixed value is available
@@ -148,7 +152,7 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
 
   // Prepare column names
   auto colNames =
-      createColumns(isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition, detectorIDAsIntegers);
+      createColumns(isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition, pickOneDetectorID);
 
   const int ncols = static_cast<int>(colNames.size());
   const int nrows = indices.empty() ? static_cast<int>(ws->getNumberHistograms()) : static_cast<int>(indices.size());
@@ -171,7 +175,7 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
 
   populateTable(t, ws, nrows, indices, spectrumInfo, signedThetaParamRetrieved, showSignedTwoTheta, beamAxisIndex,
                 sampleDist, isScanning, includeData, calcQ, hasDiffConstants, includeDetectorPosition,
-                detectorIDAsIntegers, logger);
+                pickOneDetectorID, logger);
 
   return t;
 }
@@ -179,11 +183,11 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
                                                                const bool calcQ, const bool hasDiffConstants,
                                                                const bool includeDetectorPosition,
-                                                               const bool detectorIDAsIntegers) {
+                                                               const bool pickOneDetectorID) {
   std::vector<std::pair<std::string, std::string>> colNames;
   colNames.emplace_back("double", "Index");
   colNames.emplace_back("int", "Spectrum No");
-  if (detectorIDAsIntegers) {
+  if (pickOneDetectorID) {
     colNames.emplace_back("int", "Detector ID(s)");
   } else {
     colNames.emplace_back("str", "Detector ID(s)");
@@ -218,7 +222,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
                    const std::vector<int> &indices, const SpectrumInfo &spectrumInfo, bool signedThetaParamRetrieved,
                    bool showSignedTwoTheta, const PointingAlong &beamAxisIndex, const double sampleDist,
                    const bool isScanning, const bool includeData, const bool calcQ, const bool includeDiffConstants,
-                   const bool includeDetectorPosition, const bool detectorIDAsIntegers, Logger &logger) {
+                   const bool includeDetectorPosition, const bool pickOneDetectorID, Logger &logger) {
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(*ws))
   for (int row = 0; row < nrows; ++row) {
     TableRow colValues = t->getRow(row);
@@ -269,7 +273,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
       }
       const std::string isMonitorDisplay = isMonitor ? "yes" : "no";
       colValues << static_cast<int>(specNo);
-      if (detectorIDAsIntegers) {
+      if (pickOneDetectorID) {
         colValues << detId;
       } else {
         colValues << detIds;
@@ -338,7 +342,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
       colValues << static_cast<double>(wsIndex);
       // spectrumNo=-1, detID=0
       colValues << -1;
-      if (detectorIDAsIntegers) {
+      if (pickOneDetectorID) {
         colValues << 0;
       } else {
         colValues << "0";

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -55,7 +55,7 @@ public:
     TS_ASSERT_EQUALS(props[3]->name(), "IncludeDetectorPosition");
     TS_ASSERT(props[3]->isDefault());
 
-    TS_ASSERT_EQUALS(props[4]->name(), "DetectorIDAsIntegers");
+    TS_ASSERT_EQUALS(props[4]->name(), "PickOneDetectorID");
     TS_ASSERT(props[4]->isDefault());
 
     TS_ASSERT_EQUALS(props[5]->name(), "DetectorTableWorkspace");
@@ -282,7 +282,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorIDAsIntegers", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PickOneDetectorID", true));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorTableWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -41,7 +41,7 @@ public:
     TS_ASSERT(alg.isInitialized());
 
     const auto &props = alg.getProperties();
-    TS_ASSERT_EQUALS(props.size(), 5);
+    TS_ASSERT_EQUALS(props.size(), 6);
 
     TS_ASSERT_EQUALS(props[0]->name(), "InputWorkspace");
     TS_ASSERT(props[0]->isDefault());
@@ -55,9 +55,12 @@ public:
     TS_ASSERT_EQUALS(props[3]->name(), "IncludeDetectorPosition");
     TS_ASSERT(props[3]->isDefault());
 
-    TS_ASSERT_EQUALS(props[4]->name(), "DetectorTableWorkspace");
+    TS_ASSERT_EQUALS(props[4]->name(), "DetectorIDAsIntegers");
     TS_ASSERT(props[4]->isDefault());
-    TS_ASSERT(dynamic_cast<WorkspaceProperty<TableWorkspace> *>(props[4]));
+
+    TS_ASSERT_EQUALS(props[5]->name(), "DetectorTableWorkspace");
+    TS_ASSERT(props[5]->isDefault());
+    TS_ASSERT(dynamic_cast<WorkspaceProperty<TableWorkspace> *>(props[5]));
   }
 
   void test_Exec_Matrix_Workspace() {
@@ -266,6 +269,61 @@ public:
     TS_ASSERT_EQUALS(ws->cell<int>(0, 1), -1);                  // Spectrum No should be -1
     TS_ASSERT_EQUALS(ws->cell<V3D>(0, 11), V3D(0.0, 0.0, 0.0)); // Detector Position should be (0.0, 0.0, 0.0)
 
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(ws->getName());
+  }
+
+  void test_Exec_Matrix_Workspace_with_Detector_ID_as_integers() {
+
+    Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 10, true);
+    std::string outWSName = "out_int_detid";
+
+    CreateDetectorTable alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorIDAsIntegers", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorTableWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    TableWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outWSName));
+    TS_ASSERT(ws);
+
+    if (!ws) {
+      return;
+    }
+
+    // Check the results
+    TS_ASSERT_EQUALS(ws->cell<int>(0, 2), 1);
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(ws->getName());
+  }
+
+  void test_Exec_Matrix_Workspace_with_Detector_ID_as_strings() {
+
+    Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 10, true);
+    std::string outWSName = "out_int_detid";
+
+    CreateDetectorTable alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorTableWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    TableWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outWSName));
+    TS_ASSERT(ws);
+
+    if (!ws) {
+      return;
+    }
+
+    // Check the results
+    TS_ASSERT_EQUALS(ws->cell<std::string>(0, 2), "1");
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());
   }

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40128.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40128.rst
@@ -1,3 +1,3 @@
-- :ref:`CreateDetectorTable <algm-CreateDetectorTable>` now supports option ``detectorIDAsIntegers`` for returning column of detector IDs as a column of integers containing only one detector ID per row.
+- :ref:`CreateDetectorTable <algm-CreateDetectorTable>` now supports option ``PickOneDetectorID`` for returning column of detector IDs as a column of integers containing only one detector ID per row.
   By default this option is disabled, so by default the column of detector IDs will consist of strings of one or more detector ID per row.
   This new option was introduced to be used in the background of the new instrument view interface, but might also be useful if the user wants a single detector ID per row.

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40128.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40128.rst
@@ -1,0 +1,3 @@
+- :ref:`CreateDetectorTable <algm-CreateDetectorTable>` now supports option ``detectorIDAsIntegers`` for returning column of detector IDs as a column of integers containing only one detector ID per row.
+  By default this option is disabled, so by default the column of detector IDs will consist of strings of one or more detector ID per row.
+  This new option was introduced to be used in the background of the new instrument view interface, but might also be useful if the user wants a single detector ID per row.


### PR DESCRIPTION
### Description of work
This will allow for the column of Detector IDs to be integers instead of strings. Together with the method columnArray() in #40054 this will enable Detector IDs to be extracted as numpy array of integers rather than strings. The default behaviour is left unchanged, if not specified CreateDetectorTable will return a collumn of Detector IDs in strings, since some rows will have more than one detector id, eg. "1, 2, 3". But in situations where a single detector ID suffices, as is the case with the new instrument view, it's more convenient to have one detector per row and for that detector to be an integer type.

So for example, if the default behaviour is to place "1, 2, 3" in one row of the detector ids, this option will return only an integer 1 instead.

Closes #39867 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
Run the following script and check that the types printed are `<U5` (string type) and `int32` (integer type)
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

Load(Filename='/home/gui/Documents/SampleData-ISIS/SXD23767.raw', OutputWorkspace='SXD23767')
CreateDetectorTable(InputWorkspace='SXD23767', DetectorTableWorkspace='SXD23767-Detectors')
 
table = mtd['SXD23767-Detectors']
print(table.columnArray('Detector ID(s)').dtype)

CreateDetectorTable(InputWorkspace='SXD23767', DetectorTableWorkspace='SXD23767-Detectors', DetectorIDAsIntegers=True)
 
table = mtd['SXD23767-Detectors']
print(table.columnArray('Detector ID(s)').dtype)
``` 
Can also load a wish file, run `CreateDetectorTable` and check that if `DetectorIDAsIntegers` is ticked then only one ID per row is shown

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
