### PR TITLE
Modify axes scale selection menu to make more user friendly

### DIFF
--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -123,10 +123,9 @@ class FigureInteractionTest(unittest.TestCase):
         mocked_figure_type.return_value = FigureType.Image
 
         # Expect the following calls to QMenu():
-        # - outer menu
-        # - 3x calls for the Axes, Normalization and Colorbar menus
-        # - 3x calls for the lin x, log x, symlog x menus.
-        mock_list = [MagicMock() for x in range(7)]
+        # - 1x call for the outer menu
+        # - 4x calls for the X-Axis, Y-Axis, Normalization and Colorbar menus
+        mock_list = [MagicMock() for x in range(5)]
         mocked_qmenu.side_effect = mock_list
 
         with patch("workbench.plotting.figureinteraction.QActionGroup", autospec=True):
@@ -135,26 +134,20 @@ class FigureInteractionTest(unittest.TestCase):
                 self.assertEqual(0, mock_list[0].addAction.call_count)
                 expected_qmenu_calls = [
                     call(),
-                    call("Axes", mock_list[0]),
-                    call("linear x", mock_list[1]),
-                    call("log x", mock_list[1]),
-                    call("symlog x", mock_list[1]),
+                    call("X-Axis Scale", mock_list[0]),
+                    call("Y-Axis Scale", mock_list[0]),
                     call("Normalization", mock_list[0]),
                     call("Color bar", mock_list[0]),
                 ]
                 self.assertEqual(expected_qmenu_calls, mocked_qmenu.call_args_list)
-                # 0 actions in Axes submenu
-                self.assertEqual(0, mock_list[1].addAction.call_count)
-                # 3 actions in linear x submenu
+                # 3 actions in X-Axis submenu
+                self.assertEqual(3, mock_list[1].addAction.call_count)
+                # 3 actions in Y-Axis submenu
                 self.assertEqual(3, mock_list[2].addAction.call_count)
-                # 3 actions in log x submenu
-                self.assertEqual(3, mock_list[3].addAction.call_count)
-                # 3 actions in log y submenu
-                self.assertEqual(3, mock_list[4].addAction.call_count)
                 # 2 actions in Normalization submenu
-                self.assertEqual(2, mock_list[5].addAction.call_count)
+                self.assertEqual(2, mock_list[3].addAction.call_count)
                 # 3 actions in Colorbar submenu
-                self.assertEqual(3, mock_list[6].addAction.call_count)
+                self.assertEqual(3, mock_list[4].addAction.call_count)
 
     @patch("workbench.plotting.figureinteraction.QMenu", autospec=True)
     @patch("workbench.plotting.figureinteraction.figure_type", autospec=True)
@@ -169,10 +162,9 @@ class FigureInteractionTest(unittest.TestCase):
         mocked_figure_type.return_value = FigureType.Line
 
         # Expect the following calls to QMenu():
-        # - outer menu
-        # - 3x calls for the Axes, Normalization and Markers menus
-        # - 3x calls for the lin x, log x, symlog x menus.
-        mock_list = [MagicMock() for x in range(7)]
+        # - 1x call for the outer menu
+        # - 4x calls for the X-Axis, Y-Axis, Normalization and Colorbar menus
+        mock_list = [MagicMock() for x in range(5)]
         mocked_qmenu.side_effect = mock_list
 
         with patch("workbench.plotting.figureinteraction.QActionGroup", autospec=True):
@@ -184,26 +176,20 @@ class FigureInteractionTest(unittest.TestCase):
                         self.assertEqual(1, mock_list[0].addAction.call_count)  # Show/hide legend action
                         expected_qmenu_calls = [
                             call(),
-                            call("Axes", mock_list[0]),
-                            call("linear x", mock_list[1]),
-                            call("log x", mock_list[1]),
-                            call("symlog x", mock_list[1]),
+                            call("X-Axis Scale", mock_list[0]),
+                            call("Y-Axis Scale", mock_list[0]),
                             call("Normalization", mock_list[0]),
                             call("Markers", mock_list[0]),
                         ]
                         self.assertEqual(expected_qmenu_calls, mocked_qmenu.call_args_list)
-                        # 0 actions in Axes submenu
-                        self.assertEqual(0, mock_list[1].addAction.call_count)
-                        # 3 actions in linear x submenu
+                        # 3 actions in X-Axis submenu
+                        self.assertEqual(3, mock_list[1].addAction.call_count)
+                        # 3 actions in Y-Axis submenu
                         self.assertEqual(3, mock_list[2].addAction.call_count)
-                        # 3 actions in log x submenu
-                        self.assertEqual(3, mock_list[3].addAction.call_count)
-                        # 3 actions in log y submenu
-                        self.assertEqual(3, mock_list[4].addAction.call_count)
                         # 2 actions in Normalization submenu
-                        self.assertEqual(2, mock_list[5].addAction.call_count)
+                        self.assertEqual(2, mock_list[3].addAction.call_count)
                         # 3 actions in Colorbar submenu
-                        self.assertEqual(3, mock_list[6].addAction.call_count)
+                        self.assertEqual(3, mock_list[4].addAction.call_count)
 
     def test_toggle_normalization_no_errorbars(self):
         self._test_toggle_normalization(errorbars_on=False, plot_kwargs={"distribution": True})
@@ -375,7 +361,6 @@ class FigureInteractionTest(unittest.TestCase):
         mock_canvas = MagicMock(figure=fig)
         fig_manager_mock = MagicMock(canvas=mock_canvas)
         fig_interactor = FigureInteraction(fig_manager_mock)
-        scale_types = ("log", "log")
 
         ax = fig.axes[0]
         ax1 = fig.axes[1]
@@ -383,7 +368,7 @@ class FigureInteractionTest(unittest.TestCase):
         current_scale_types1 = (ax1.get_xscale(), ax1.get_yscale())
         self.assertEqual(current_scale_types, current_scale_types1)
 
-        fig_interactor._quick_change_axes(scale_types, ax)
+        fig_interactor._quick_change_axes(ax, "log", "log")
         current_scale_types2 = (ax.get_xscale(), ax.get_yscale())
         self.assertNotEqual(current_scale_types2, current_scale_types1)
 

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -191,6 +191,60 @@ class FigureInteractionTest(unittest.TestCase):
                         # 3 actions in Colorbar submenu
                         self.assertEqual(3, mock_list[4].addAction.call_count)
 
+    def _quick_change_setup(self):
+        fig_manager = self._create_mock_fig_manager_to_accept_right_click()
+        interactor = FigureInteraction(fig_manager)
+        ax = MagicMock(
+            spec=["get_xscale", "get_yscale", "get_xlim", "get_ylim", "set_xscale", "set_yscale", "set_xlim", "set_ylim"],
+            **{
+                "get_xscale.return_value": "test_logx",
+                "get_yscale.return_value": "test_logy",
+                "get_xlim.return_value": "test_xlim",
+                "get_ylim.return_value": "test_ylim",
+            },
+        )
+        return interactor, ax
+
+    def test_quick_change_axes_x_scale(self):
+        interactor, ax = self._quick_change_setup()
+        x_scale_type = "test_linearx"
+        interactor._quick_change_axes(ax, x_scale_type=x_scale_type)
+        ax.get_xscale.assert_not_called()
+        ax.get_yscale.assert_called_once()
+        ax.get_xlim.assert_called_once()
+        ax.get_ylim.assert_called_once()
+        ax.set_xscale.assert_called_once_with(value=x_scale_type)
+        ax.set_yscale.assert_called_once_with(value="test_logy")
+        ax.set_xlim.assert_called_once_with("test_xlim")
+        ax.set_ylim.assert_called_once_with("test_ylim")
+
+    def test_quick_change_axes_y_scale(self):
+        interactor, ax = self._quick_change_setup()
+        y_scale_type = "test_lineary"
+        interactor._quick_change_axes(ax, y_scale_type=y_scale_type)
+        ax.get_xscale.assert_called_once()
+        ax.get_yscale.assert_not_called()
+        ax.get_xlim.assert_called_once()
+        ax.get_ylim.assert_called_once()
+        ax.set_xscale.assert_called_once_with(value="test_logx")
+        ax.set_yscale.assert_called_once_with(value=y_scale_type)
+        ax.set_xlim.assert_called_once_with("test_xlim")
+        ax.set_ylim.assert_called_once_with("test_ylim")
+
+    def test_quick_change_axes_both(self):
+        interactor, ax = self._quick_change_setup()
+        x_scale_type = "test_linearx"
+        y_scale_type = "test_logy"
+        interactor._quick_change_axes(ax, x_scale_type=x_scale_type, y_scale_type=y_scale_type)
+        ax.get_xscale.assert_not_called()
+        ax.get_yscale.assert_not_called()
+        ax.get_xlim.assert_called_once()
+        ax.get_ylim.assert_called_once()
+        ax.set_xscale.assert_called_once_with(value=x_scale_type)
+        ax.set_yscale.assert_called_once_with(value=y_scale_type)
+        ax.set_xlim.assert_called_once_with("test_xlim")
+        ax.set_ylim.assert_called_once_with("test_ylim")
+
     def test_toggle_normalization_no_errorbars(self):
         self._test_toggle_normalization(errorbars_on=False, plot_kwargs={"distribution": True})
 


### PR DESCRIPTION
### Description of work

The axes scale options on the figure interaction menu were changed earlier this release period to allow for the specification of a symlog scale.

To retain the ability to change both x and y scales with one click, a sub menu was added to each x axis scale option, that allows the specification of a y axis option.

This appears unintuitive to users, so each axis has been given its own independent menu.

Original Workflow:
`Axes` -> `Linx/Logy`

Modified workflow:
`Axes`  -> `Linx` -> `SymLogY`

Revised workflow:
`X-Axis Scale` -> `Lin`
`Y-Axis Scale` -> `Log`

### To test:

- Run below script
- Plot a spectra
- Right click, play around with options.
- Check different plot types
- Check operation of `k` and `l` keys.

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

nrows = 100
nbins = 100
output_ws = WorkspaceFactory.create("Workspace2D", NVectors=nrows,
                                    XLength=nbins, YLength=nbins)

create_histo_data = True
x_data = [x - 50 for x in range(nbins)]
xdata = np.array(x_data) # filled with 0->9
ydata = np.array([x*x*x for x in x_data])
edata = np.ndarray(shape=(nbins))
edata.fill(0)

for i in range(nrows):
    output_ws.setX(i, xdata)
    output_ws.setY(i, ydata)
    output_ws.setE(i, edata)
if create_histo_data:
    ConvertToHistogram(output_ws, OutputWorkspace="out_ws")
else:
    mtd.addOrReplace("out_ws", output_ws)
```



 *This does not require release notes* because it is not a regression.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
