### PR TITLE
Create `TranslateSampleShape` algorithm

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -208,6 +208,7 @@ set(SRC_FILES
     src/SinglePeriodLoadMuonStrategy.cpp
     src/SortTableWorkspace.cpp
     src/StartAndEndTimeFromNexusFileExtractor.cpp
+    src/TranslateSampleShape.cpp
     src/UpdateInstrumentFromFile.cpp
     src/XmlHandler.cpp
     src/RotateSampleShape.cpp
@@ -427,6 +428,7 @@ set(INC_FILES
     inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
     inc/MantidDataHandling/SortTableWorkspace.h
     inc/MantidDataHandling/StartAndEndTimeFromNexusFileExtractor.h
+    inc/MantidDataHandling/TranslateSampleShape.h
     inc/MantidDataHandling/UpdateInstrumentFromFile.h
     inc/MantidDataHandling/XmlHandler.h
     src/LoadRaw/byte_rel_comp.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -637,6 +637,7 @@ set(TEST_FILES
     SetScalingPSDTest.h
     SortTableWorkspaceTest.h
     StartAndEndTimeFromNexusFileExtractorTest.h
+    TranslateSampleShapeTest.h
     UpdateInstrumentFromFileTest.h
     XMLInstrumentParameterTest.h
     RotateSampleShapeTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/TranslateSampleShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/TranslateSampleShape.h
@@ -10,8 +10,6 @@
 #include "MantidAPI/MultipleExperimentInfos.h"
 #include "MantidDataHandling/DllConfig.h"
 
-namespace Mantid {} // namespace Mantid
-
 namespace Mantid {
 namespace DataHandling {
 
@@ -20,7 +18,7 @@ public:
   /// Algorithm's name for identification
   const std::string name() const override { return "TranslateSampleShape"; };
   /// Summary of algorithms purpose
-  const std::string summary() const override { return "Redefine the initial position of the sample shape mesh"; }
+  const std::string summary() const override { return "Redefine the initial position of the sample shape"; }
 
   /// Algorithm's version for identification
   int version() const override { return 1; };
@@ -33,6 +31,7 @@ private:
   /// Run the algorithm
   void exec() override;
   bool checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML, bool &isMeshShape);
+  void setSampleShape(const API::Workspace_sptr &ws, std::string &translatedXML);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/TranslateSampleShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/TranslateSampleShape.h
@@ -1,0 +1,39 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MultipleExperimentInfos.h"
+#include "MantidDataHandling/DllConfig.h"
+
+namespace Mantid {} // namespace Mantid
+
+namespace Mantid {
+namespace DataHandling {
+
+class MANTID_DATAHANDLING_DLL TranslateSampleShape final : public API::Algorithm {
+public:
+  /// Algorithm's name for identification
+  const std::string name() const override { return "TranslateSampleShape"; };
+  /// Summary of algorithms purpose
+  const std::string summary() const override { return "Redefine the initial position of the sample shape mesh"; }
+
+  /// Algorithm's version for identification
+  int version() const override { return 1; };
+  /// Algorithm's category for identification
+  const std::string category() const override { return "DataHandling\\Instrument"; }
+
+private:
+  /// Initialise the properties
+  void init() override;
+  /// Run the algorithm
+  void exec() override;
+  bool checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML, bool &isMeshShape);
+};
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/TranslateSampleShape.cpp
+++ b/Framework/DataHandling/src/TranslateSampleShape.cpp
@@ -1,0 +1,273 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright © 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataHandling/TranslateSampleShape.h"
+
+#include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/MultipleExperimentInfos.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceProperty.h"
+
+#include "MantidDataHandling/CreateSampleShape.h"
+
+#include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/V3D.h"
+
+#include <Poco/AutoPtr.h>
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/DOM/DOMWriter.h>
+#include <Poco/DOM/Document.h>
+#include <Poco/DOM/Element.h>
+#include <Poco/DOM/Node.h>
+#include <Poco/DOM/NodeFilter.h>
+#include <Poco/DOM/NodeIterator.h>
+#include <Poco/DOM/NodeList.h>
+
+#include <sstream>
+
+namespace {
+
+// we need some xml parsing and altering functions, which we will just define here
+
+using namespace Poco::XML;
+
+// Decide if an element has attributes that should be shifted
+bool isPointLike(const std::string &tag) {
+  if (tag == "axis" || tag == "normal-to-plane")
+    // ignore vector like tags
+    return false;
+  if (tag == "centre" || tag == "centre-of-bottom-base" || tag == "tip" || tag == "point-in-plane")
+    return true;
+  // Cuboids/hexahedra can be defined by corners which end with the six characters: "-point"
+  if (tag.size() >= 6 && tag.rfind("-point") == tag.size() - 6)
+    return true;
+  // all other tags should also be ignored
+  return false;
+}
+
+void shiftAttribute(Element *e, const std::string attr, double d) {
+  if (!e)
+    return;
+  if (!e->hasAttribute(attr))
+    return;
+  const double v = std::stod(e->getAttribute(attr));
+  e->setAttribute(attr, std::to_string(v + d));
+};
+
+Element *firstElem(Element *parent, const std::string &tag) {
+  if (!parent)
+    return nullptr;
+  Poco::AutoPtr<NodeList> nl = parent->getElementsByTagName(tag);
+  if (nl && nl->length() > 0)
+    return static_cast<Poco::XML::Element *>(nl->item(0));
+  return nullptr;
+};
+
+// Shift x/y/z attributes if present
+void addXYZ(Element *el, double dx, double dy, double dz) {
+  if (el->hasAttribute("x") && el->hasAttribute("y") && el->hasAttribute("z")) {
+    shiftAttribute(el, "x", dx);
+    shiftAttribute(el, "y", dy);
+    shiftAttribute(el, "z", dz);
+  }
+}
+
+// If user has defined a bounding box, this needs to be shifted accordingly
+void shiftBoundingBox(Element *root, double dx, double dy, double dz) {
+
+  // find <bounding-box> anywhere under root
+  Element *bb = firstElem(root, "bounding-box");
+  if (!bb)
+    return;
+
+  shiftAttribute(firstElem(bb, "x-min"), "val", dx);
+  shiftAttribute(firstElem(bb, "x-max"), "val", dx);
+  shiftAttribute(firstElem(bb, "y-min"), "val", dy);
+  shiftAttribute(firstElem(bb, "y-max"), "val", dy);
+  shiftAttribute(firstElem(bb, "z-min"), "val", dz);
+  shiftAttribute(firstElem(bb, "z-max"), "val", dz);
+}
+
+// Go through all the children of the provided root node and write those corresponding to elements (the only ones we are
+// interested in)
+std::string writeOnlyElementChildNodes(Poco::XML::Element *root) {
+  if (!root)
+    return std::string();
+
+  std::ostringstream out;
+  DOMWriter writer;
+
+  // iterate over the child nodes in linked list style loop
+  for (Node *n = root->firstChild(); n; n = n->nextSibling()) {
+    if (n->nodeType() == Node::ELEMENT_NODE) {
+      writer.writeNode(out, n);
+    }
+  }
+  return out.str();
+}
+
+// If XML is user defined and created out the ShapeFactory, it will be wrapped in a <type> tag
+// this needs to be removed for the translated xml string to be re-parsed by the Factory
+std::string removeTypeTagWrapper(const std::string &xml) {
+  DOMParser parser;
+  Poco::AutoPtr<Document> doc;
+  try {
+    doc = parser.parseString(xml);
+  } catch (...) {
+    return xml; // If parsing fails, just return the original
+  }
+  Element *root = doc ? doc->documentElement() : nullptr;
+  if (!root)
+    return xml;
+
+  const std::string tag = root->tagName();
+  if (tag == "type") {
+    return writeOnlyElementChildNodes(root);
+  }
+
+  // No type tag, return original xml
+  return xml;
+}
+
+std::string translateCSG(const std::string &xml, double dx, double dy, double dz) {
+  DOMParser parser;
+  Poco::AutoPtr<Document> doc = parser.parseString(xml);
+
+  // Access root element
+  Element *root = doc ? doc->documentElement() : nullptr;
+  if (!root)
+    return xml; // fallback on malformed input
+
+  // Iterate over all nodes, selecting only elements, check if they should be translated, and if so update their
+  // definition
+  NodeIterator it(doc, NodeFilter::SHOW_ELEMENT);
+  for (Node *n = it.nextNode(); n; n = it.nextNode()) {
+    auto *el = dynamic_cast<Element *>(n);
+    if (!el)
+      continue;
+    const std::string tag = el->tagName();
+    // check if element tag is one that has x,y,z attributes that should be translated
+    if (isPointLike(tag)) {
+      addXYZ(el, dx, dy, dz);
+    }
+  }
+
+  // If there is a bounding-box, this should also be shifted
+  shiftBoundingBox(root, dx, dy, dz);
+
+  std::ostringstream out;
+  DOMWriter writer;
+  writer.writeNode(out, doc);
+  return out.str();
+}
+
+} // anonymous namespace
+
+namespace Mantid::DataHandling {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(TranslateSampleShape)
+
+using namespace Mantid::Geometry;
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+
+/** Initialize the algorithm's properties.
+ */
+void TranslateSampleShape::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InputWorkspace", "", Direction::InOut),
+                  "The workspace containing the sample whose shape is to be translated");
+
+  // Vector to translate shape
+  declareProperty(std::make_unique<ArrayProperty<double>>("TranslationVector", "0,0,0"),
+                  "Vector by which to translate the loaded sample shape (metres)");
+}
+
+/** Execute the algorithm.
+ */
+void TranslateSampleShape::exec() {
+  Workspace_sptr ws = getProperty("InputWorkspace");
+  auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+  const std::vector<double> translationVector = getProperty("TranslationVector");
+
+  if (!ei) {
+    // We're dealing with an MD workspace which has multiple experiment infos
+    auto infos = std::dynamic_pointer_cast<MultipleExperimentInfos>(ws);
+    if (!infos) {
+      throw std::invalid_argument("Input workspace does not support TranslateSampleShape");
+    }
+    if (infos->getNumExperimentInfo() < 1) {
+      ExperimentInfo_sptr info(new ExperimentInfo());
+      infos->addExperimentInfo(info);
+    }
+    ei = infos->getExperimentInfo(0);
+  }
+
+  std::string shapeXML;
+  bool isMeshShape = false;
+  if (!checkIsValidShape(ei, shapeXML, isMeshShape)) {
+    throw std::runtime_error("Input sample does not have a valid shape!");
+  }
+
+  const auto dx = translationVector[0];
+  const auto dy = translationVector[1];
+  const auto dz = translationVector[2];
+
+  if (isMeshShape) {
+    // Mesh shapes can be translated directly
+    auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+    meshShape->translate(V3D(dx, dy, dz));
+  } else {
+    // CSG shapes need to translate XML definition, then use this to set a new shape
+    auto csgShape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+
+    // get shape xml
+    const std::string &origXML = csgShape->getShapeXML();
+
+    // translate xml def
+    std::string translatedXML = translateCSG(origXML, dx, dy, dz);
+
+    // remove type tag, if there is one
+    translatedXML = removeTypeTagWrapper(translatedXML);
+
+    // use new csg xml string to replace the shape
+    Mantid::DataHandling::CreateSampleShape creator;
+    creator.initialize();
+    creator.setChild(true);
+    creator.setProperty("InputWorkspace", ws);
+    creator.setPropertyValue("ShapeXML", translatedXML);
+    creator.execute();
+  }
+}
+
+bool TranslateSampleShape::checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML,
+                                             bool &isMeshShape) {
+  if (ei->sample().hasShape()) {
+    const auto csgShape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+    if (csgShape && csgShape->hasValidShape()) {
+      shapeXML = csgShape->getShapeXML();
+      if (!shapeXML.empty()) {
+        return true;
+      }
+    } else {
+      const auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+      if (meshShape && meshShape->hasValidShape()) {
+        isMeshShape = true;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/TranslateSampleShape.cpp
+++ b/Framework/DataHandling/src/TranslateSampleShape.cpp
@@ -55,7 +55,7 @@ bool isPointLike(const std::string &tag) {
   return false;
 }
 
-void shiftAttribute(Element *e, const std::string attr, double d) {
+void shiftAttribute(Element *e, const std::string &attr, double d) {
   if (!e)
     return;
   if (!e->hasAttribute(attr))

--- a/Framework/DataHandling/test/TranslateSampleShapeTest.h
+++ b/Framework/DataHandling/test/TranslateSampleShapeTest.h
@@ -1,0 +1,471 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Sample.h"
+#include "MantidDataHandling/TranslateSampleShape.h"
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidKernel/V3D.h"
+
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/DOM/Document.h>
+#include <Poco/DOM/Element.h>
+#include <Poco/DOM/Node.h>
+#include <Poco/DOM/NodeList.h>
+
+#include <cxxtest/TestSuite.h>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+using Mantid::API::AnalysisDataService;
+using Mantid::API::ExperimentInfo;
+using Mantid::API::ExperimentInfo_sptr;
+using Mantid::API::MatrixWorkspace;
+using Mantid::API::Workspace_sptr;
+using Mantid::DataHandling::TranslateSampleShape;
+using Mantid::DataObjects::Workspace2D_sptr;
+using Mantid::Geometry::CSGObject;
+using Mantid::Geometry::MeshObject;
+using Mantid::Kernel::Material;
+using Mantid::Kernel::V3D;
+
+namespace {
+
+// ---- General helpers --------------------------------------------------------
+
+Workspace2D_sptr getWorkspaceWithCSGShape(const std::string &xmlContent) {
+  auto ws = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+  AnalysisDataService::Instance().addOrReplace("test_ws", ws);
+  Mantid::Geometry::ShapeFactory sf;
+  ws->mutableSample().setShape(sf.createShape(xmlContent));
+  return ws;
+}
+
+Workspace2D_sptr getWorkspaceWithMeshShape(std::unique_ptr<MeshObject> mesh) {
+  Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspace(3, 3);
+  AnalysisDataService::Instance().addOrReplace("test_ws", ws);
+  ws->mutableSample().setShape(std::move(mesh));
+  return ws;
+}
+
+std::unique_ptr<MeshObject> makeUnitCubeMesh(const V3D &centre) {
+  const double size = 2.0;
+  const double min = -0.5 * size;
+  const double max = 0.5 * size;
+
+  std::vector<V3D> vertices;
+  vertices.emplace_back(centre + V3D(max, max, max));
+  vertices.emplace_back(centre + V3D(min, max, max));
+  vertices.emplace_back(centre + V3D(max, min, max));
+  vertices.emplace_back(centre + V3D(min, min, max));
+  vertices.emplace_back(centre + V3D(max, max, min));
+  vertices.emplace_back(centre + V3D(min, max, min));
+  vertices.emplace_back(centre + V3D(max, min, min));
+  vertices.emplace_back(centre + V3D(min, min, min));
+
+  std::vector<uint32_t> triangles;
+  triangles.insert(triangles.end(), {0, 1, 2, 2, 1, 3});
+  triangles.insert(triangles.end(), {0, 2, 4, 4, 2, 6});
+  triangles.insert(triangles.end(), {0, 4, 1, 1, 4, 5});
+  triangles.insert(triangles.end(), {7, 5, 6, 6, 5, 4});
+  triangles.insert(triangles.end(), {7, 3, 5, 5, 3, 1});
+  triangles.insert(triangles.end(), {7, 6, 3, 3, 6, 2});
+
+  return std::make_unique<MeshObject>(std::move(triangles), std::move(vertices), Mantid::Kernel::Material());
+}
+
+void runTranslate(const Workspace2D_sptr &ws, const V3D &vec) {
+  std::ostringstream vecString;
+  vecString << std::setprecision(15) << vec.X() << "," << vec.Y() << "," << vec.Z();
+
+  TranslateSampleShape alg;
+  alg.initialize();
+  alg.setPropertyValue("InputWorkspace", ws->getName());
+  alg.setPropertyValue("TranslationVector", vecString.str());
+  alg.execute();
+  TS_ASSERT(alg.isExecuted());
+}
+
+std::string wsOutXml(const Workspace2D_sptr &ws) {
+  auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+  auto csg = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+  return csg ? csg->getShapeXML() : std::string();
+}
+
+// ---- XML parsing helpers ------------------------------------------------------------
+
+Poco::AutoPtr<Poco::XML::Document> parseXml(const std::string &xml) {
+  Poco::XML::DOMParser p;
+  return p.parseString(xml);
+}
+
+Poco::XML::Element *docRoot(Poco::AutoPtr<Poco::XML::Document> &doc) { return doc ? doc->documentElement() : nullptr; }
+
+Poco::XML::Element *first(Poco::XML::Element *root, const std::string &tag) {
+  if (!root)
+    return nullptr;
+  Poco::AutoPtr<Poco::XML::NodeList> nl = root->getElementsByTagName(tag);
+  if (nl && nl->length() > 0)
+    return dynamic_cast<Poco::XML::Element *>(nl->item(0));
+  return nullptr;
+}
+
+double attrD(Poco::XML::Element *el, const char *name) {
+  TS_ASSERT(el != nullptr);
+  TS_ASSERT(el->hasAttribute(name));
+  return std::stod(el->getAttribute(name));
+}
+
+} // namespace
+
+class TranslateSampleShapeTest : public CxxTest::TestSuite {
+public:
+  // define the setup and utility functions
+
+  void tearDown() override {
+    // Clean ADS between tests to avoid name clashes
+    auto &ads = AnalysisDataService::Instance();
+    for (auto const &name : ads.getObjectNames()) {
+      ads.remove(name);
+    }
+  }
+
+  void assertElementXYZTranslated(const Workspace2D_sptr &ws, std::string tag, V3D point, V3D translation) {
+    auto doc = parseXml(wsOutXml(ws));
+    auto root = docRoot(doc);
+    auto element = first(root, tag);
+    TS_ASSERT_DELTA(attrD(element, "x"), point.X() + translation.X(), 1e-12);
+    TS_ASSERT_DELTA(attrD(element, "y"), point.Y() + translation.Y(), 1e-12);
+    TS_ASSERT_DELTA(attrD(element, "z"), point.Z() + translation.Z(), 1e-12);
+  }
+
+  void assertElementValTranslated(const Workspace2D_sptr &ws, std::string tag, double point, double translation) {
+    auto doc = parseXml(wsOutXml(ws));
+    auto root = docRoot(doc);
+    auto element = first(root, tag);
+    TS_ASSERT_DELTA(attrD(element, "val"), point + translation, 1e-12);
+  }
+
+  // ##########   CSG Tests  ###############
+  // Here we will try and test the translation of all the shapes defined in
+  // https://docs.mantidproject.org/nightly/concepts/HowToDefineGeometricShape.html
+
+  // ---------- Sphere ----------
+  void test_sphere_centre_is_translated() {
+    const V3D centre(1, 2, 3);
+    const V3D d(0.1, -0.2, 0.3);
+
+    auto xml = ComponentCreationHelper::sphereXML(0.5, centre, "S");
+    auto ws = getWorkspaceWithCSGShape(xml);
+
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre", centre, d);
+  }
+
+  // ---------- Cylinder (finite) ----------
+  void test_cylinder_bottom_base_translated_axis_unchanged() {
+    const V3D base(-0.5, 0.0, 0.0), axis(1.0, 0.0, 0.0), d(0.1, -0.2, 0.3);
+    const double r = 0.05, h = 1.0;
+    std::ostringstream xml;
+    xml << "<cylinder id=\"C\">"
+        << "<centre-of-bottom-base x=\"" << base.X() << "\" y=\"" << base.Y() << "\" z=\"" << base.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "<radius val=\"" << r << "\"/><height val=\"" << h << "\"/></cylinder>"
+        << "<algebra val=\"C\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre-of-bottom-base", base, d);
+    // check axis hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ---------- Hollow Cylinder (finite) ----------
+  void test_hollow_cylinder_bottom_base_translated_axis_unchanged() {
+    const V3D base(0.0, 0.0, 0.0), axis(0.0, 1.0, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<hollow-cylinder id=\"HC\">"
+        << "<centre-of-bottom-base x=\"" << base.X() << "\" y=\"" << base.Y() << "\" z=\"" << base.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "<inner-radius val=\"0.007\"/><outer-radius val=\"0.01\"/><height val=\"0.05\"/></hollow-cylinder>"
+        << "<algebra val=\"HC\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre-of-bottom-base", base, d);
+    // check axis hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ---------- Infinite Cylinder ----------
+  void test_infinite_cylinder_centre_translated_axis_unchanged() {
+    const V3D centre(0.0, 0.2, 0.0), axis(0.0, 0.2, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<infinite-cylinder id=\"IC\">"
+        << "<centre x=\"" << centre.X() << "\" y=\"" << centre.Y() << "\" z=\"" << centre.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "<radius val=\"1\"/></infinite-cylinder>"
+        << "<algebra val=\"IC\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre", centre, d);
+    // check axis hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ---------- Slice of Cylinder Ring ----------
+  void test_slice_of_cylinder_ring_no_translatable_points() {
+
+    const double iR = 0.05, oR = 0.1, depth = 1.0, arc = 45.0;
+    const V3D d(0.1, -0.2, 0.3);
+
+    std::ostringstream xml;
+    xml << "<slice-of-cylinder-ring id=\"R\">"
+        << "<inner-radius val=\"" << iR << "\"/>"
+        << "<outer-radius val=\"" << oR << "\"/>"
+        << "<depth val=\"" << depth << "\"/>"
+        << "<arc val=\"" << arc << "\"/>"
+        << "</slice-of-cylinder-ring>"
+        << "<algebra val=\"R\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    // check none of these have changed
+    assertElementValTranslated(ws, "inner-radius", iR, 0.0);
+    assertElementValTranslated(ws, "outer-radius", oR, 0.0);
+    assertElementValTranslated(ws, "depth", depth, 0.0);
+    assertElementValTranslated(ws, "arc", arc, 0.0);
+  }
+
+  // ---------- Cone ----------
+  void test_cone_tip_translated_axis_unchanged() {
+    const V3D tip(0.0, 0.2, 0.0), axis(0.0, 0.2, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<cone id=\"CN\">"
+        << "<tip-point x=\"" << tip.X() << "\" y=\"" << tip.Y() << "\" z=\"" << tip.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "<angle val=\"30.1\"/><height val=\"10.2\"/></cone>"
+        << "<algebra val=\"CN\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "tip-point", tip, d);
+    // check axis hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ---------- Infinite Cone ----------
+  void test_infinite_cone_tip_translated_axis_unchanged() {
+    const V3D tip(0.0, 0.2, 0.0), axis(0.0, 0.2, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<infinite-cone id=\"ICN\">"
+        << "<tip-point x=\"" << tip.X() << "\" y=\"" << tip.Y() << "\" z=\"" << tip.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "<angle val=\"30.1\"/></infinite-cone>"
+        << "<algebra val=\"ICN\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "tip-point", tip, d);
+    // check axis hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ---------- Infinite Plane ----------
+  void test_infinite_plane_point_translated_normal_unchanged() {
+    const V3D pip(0.0, 0.2, 0.0), normal(0.0, 0.2, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<infinite-plane id=\"P\">"
+        << "<point-in-plane x=\"" << pip.X() << "\" y=\"" << pip.Y() << "\" z=\"" << pip.Z() << "\"/>"
+        << "<normal-to-plane x=\"" << normal.X() << "\" y=\"" << normal.Y() << "\" z=\"" << normal.Z() << "\"/>"
+        << "</infinite-plane><algebra val=\"P\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "point-in-plane", pip, d);
+    // check normal hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "normal-to-plane", normal, V3D(0, 0, 0));
+  }
+
+  // ---------- Cuboid (centre form) ----------
+  void test_cuboid_centre_form_translated() {
+    const V3D centre(10.0, 10.0, 10.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<cuboid id=\"CB\">"
+        << "<width val=\"2.0\"/><height val=\"4.0\"/><depth val=\"0.2\"/>"
+        << "<centre x=\"" << centre.X() << "\" y=\"" << centre.Y() << "\" z=\"" << centre.Z() << "\"/>"
+        << "</cuboid><algebra val=\"CB\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre", centre, d);
+  }
+
+  // ---------- Cuboid (four-point form) ----------
+  void test_cuboid_four_point_form_translated_all_points() {
+    const V3D p1(1, -0.4, -0.3), p2(1, -0.4, 0.3), p3(-1, -0.4, -0.3), p4(1, 0.4, -0.3);
+    const V3D d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<cuboid id=\"shape\">"
+        << "<left-front-bottom-point x=\"" << p1.X() << "\" y=\"" << p1.Y() << "\" z=\"" << p1.Z() << "\"/>"
+        << "<left-front-top-point x=\"" << p2.X() << "\" y=\"" << p2.Y() << "\" z=\"" << p2.Z() << "\"/>"
+        << "<left-back-bottom-point x=\"" << p3.X() << "\" y=\"" << p3.Y() << "\" z=\"" << p3.Z() << "\"/>"
+        << "<right-front-bottom-point x=\"" << p4.X() << "\" y=\"" << p4.Y() << "\" z=\"" << p4.Z() << "\"/>"
+        << "</cuboid><algebra val=\"shape\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "left-front-bottom-point", p1, d);
+    assertElementXYZTranslated(ws, "left-front-top-point", p2, d);
+    assertElementXYZTranslated(ws, "left-back-bottom-point", p3, d);
+    assertElementXYZTranslated(ws, "right-front-bottom-point", p4, d);
+  }
+
+  // ---------- Hexahedron ----------
+  void test_hexahedron_all_corners_translated() {
+
+    const V3D p1(0.0, 0.0, 0.0), p2(1.0, 0.0, 0.0), p3(1.0, 1.0, 0.0), p4(0.0, 1.0, 0.0), p5(0.0, 0.0, 2.0),
+        p6(0.5, 0.0, 2.0), p7(0.5, 0.5, 2.0), p8(0.0, 0.5, 2.0);
+    const V3D d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<hexahedron id=\"shape\">"
+        << "<left-back-bottom-point x=\"" << p1.X() << "\" y=\"" << p1.Y() << "\" z=\"" << p1.Z() << "\"/>"
+        << "<left-front-bottom-point x=\"" << p2.X() << "\" y=\"" << p2.Y() << "\" z=\"" << p2.Z() << "\"/>"
+        << "<right-front-bottom-point x=\"" << p3.X() << "\" y=\"" << p3.Y() << "\" z=\"" << p3.Z() << "\"/>"
+        << "<right-back-bottom-point x=\"" << p4.X() << "\" y=\"" << p4.Y() << "\" z=\"" << p4.Z() << "\"/>"
+        << "<left-back-top-point x=\"" << p5.X() << "\" y=\"" << p5.Y() << "\" z=\"" << p5.Z() << "\"/>"
+        << "<left-front-top-point x=\"" << p6.X() << "\" y=\"" << p6.Y() << "\" z=\"" << p6.Z() << "\"/>"
+        << "<right-front-top-point x=\"" << p7.X() << "\" y=\"" << p7.Y() << "\" z=\"" << p7.Z() << "\"/>"
+        << "<right-back-top-point x=\"" << p8.X() << "\" y=\"" << p8.Y() << "\" z=\"" << p8.Z() << "\"/>"
+        << "</hexahedron><algebra val=\"shape\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "left-back-bottom-point", p1, d);
+    assertElementXYZTranslated(ws, "left-front-bottom-point", p2, d);
+    assertElementXYZTranslated(ws, "right-front-bottom-point", p3, d);
+    assertElementXYZTranslated(ws, "right-back-bottom-point", p4, d);
+    assertElementXYZTranslated(ws, "left-back-top-point", p5, d);
+    assertElementXYZTranslated(ws, "left-front-top-point", p6, d);
+    assertElementXYZTranslated(ws, "right-front-top-point", p7, d);
+    assertElementXYZTranslated(ws, "right-back-top-point", p8, d);
+  }
+
+  // ---------- Tapered Guide ----------
+  void test_tapered_guide_centre_translated_axis_unchanged() {
+    const V3D centre(0.0, 5.0, 10.0), axis(0.5, 1.0, 0.0), d(0.1, -0.2, 0.3);
+    std::ostringstream xml;
+    xml << "<tapered-guide id=\"G\">"
+        << "<aperture-start height=\"2.0\" width=\"2.0\"/>"
+        << "<length val=\"3.0\"/>"
+        << "<aperture-end height=\"4.0\" width=\"4.0\"/>"
+        << "<centre x=\"" << centre.X() << "\" y=\"" << centre.Y() << "\" z=\"" << centre.Z() << "\"/>"
+        << "<axis x=\"" << axis.X() << "\" y=\"" << axis.Y() << "\" z=\"" << axis.Z() << "\"/>"
+        << "</tapered-guide><algebra val=\"G\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementXYZTranslated(ws, "centre", centre, d);
+    // check normal hasn't moved (i.e. translated by 0,0,0)
+    assertElementXYZTranslated(ws, "axis", axis, V3D(0, 0, 0));
+  }
+
+  // ####### General CSG tests ##############
+  // here we will test CSG shape functionality which is independent of the shape itself
+
+  // ---------- Bounding-Box ----------
+  void test_bounding_box_limits_are_translated() {
+    const V3D centre(0.0, 1.0, 2.0), d(0.1, -0.2, 0.3);
+    const double xMin = -1, xMax = 1, yMin = 0, yMax = 2, zMin = 1, zMax = 3;
+    std::ostringstream xml;
+    xml << "<sphere id=\"s\">"
+        << "<centre x=\"" << centre.X() << "\" y=\"" << centre.Y() << "\" z=\"" << centre.Z() << "\"/>"
+        << "<radius val=\"1.0\"/></sphere>"
+        << "<bounding-box><x-min val=\"" << xMin << "\"/><x-max val=\"" << xMax << "\"/>"
+        << "<y-min val=\"" << yMin << "\"/><y-max val=\"" << yMax << "\"/>"
+        << "<z-min val=\"" << zMin << "\"/><z-max val=\"" << zMax << "\"/></bounding-box>"
+        << "<algebra val=\"s\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml.str());
+    runTranslate(ws, d);
+
+    assertElementValTranslated(ws, "x-min", xMin, d.X());
+    assertElementValTranslated(ws, "x-max", xMax, d.X());
+    assertElementValTranslated(ws, "y-min", yMin, d.Y());
+    assertElementValTranslated(ws, "y-max", yMax, d.Y());
+    assertElementValTranslated(ws, "z-min", zMin, d.Z());
+    assertElementValTranslated(ws, "z-max", zMax, d.Z());
+  }
+
+  // ---------- Algebra preservation ----------
+  void test_algebra_string_is_preserved() {
+    const V3D d(0.1, -0.2, 0.3);
+    std::string xml;
+    xml += "<sphere id=\"a\"><centre x=\"0\" y=\"0\" z=\"0\"/><radius val=\"1\"/></sphere>";
+    xml += "<sphere id=\"b\"><centre x=\"2\" y=\"0\" z=\"0\"/><radius val=\"1\"/></sphere>";
+    xml += "<algebra val=\"a : b\"/>";
+
+    auto ws = getWorkspaceWithCSGShape(xml);
+    runTranslate(ws, d);
+
+    auto doc = parseXml(wsOutXml(ws));
+    auto root = docRoot(doc);
+    auto alg = first(root, "algebra");
+    TS_ASSERT(alg != nullptr);
+    TS_ASSERT_EQUALS(alg->getAttribute("val"), std::string("a : b"));
+  }
+
+  // ########### Mesh Test ############################
+  // Here we will test that the alg also works for a generic mesh
+  // (this is just calling the inbuilt translate method, which is already tested, so we will just check it doesn't
+  // crash)
+
+  // ---------- Mesh passthrough ----------
+  void test_mesh_shape_executes_and_remains_mesh() {
+    auto mesh = makeUnitCubeMesh(V3D(0, 0, 0));
+    const V3D d(0.1, -0.2, 0.3);
+
+    auto ws = getWorkspaceWithMeshShape(std::move(mesh));
+    runTranslate(ws, d);
+    auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+    auto meshOut = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+    TS_ASSERT(meshOut != nullptr);
+  }
+
+  // ---------- Error paths ----------
+  void test_throws_if_no_shape() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    AnalysisDataService::Instance().addOrReplace("test_ws", ws);
+
+    TranslateSampleShape alg;
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", ws->getName());
+    alg.setPropertyValue("TranslationVector", "0.1,0.2,0.3");
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
+  }
+};

--- a/docs/source/algorithms/TranslateSampleShape-v1.rst
+++ b/docs/source/algorithms/TranslateSampleShape-v1.rst
@@ -12,7 +12,7 @@ Description
 
 Use this algorithm to translate the geometry of the sample shape defined on a workspace. This algorithm will not change the defined location of the sample object, simply how the physical geometry is defined within the sample's coordinate system
 
-This algorithm work for both CSG shapes
+This algorithm works for both CSG shapes
 (e.g. cylinders, flat plates etc.) and Mesh files.
 
 
@@ -29,6 +29,7 @@ Usage
 
    ws1 = CreateSampleWorkspace()
    ws2 = CreateSampleWorkspace()
+   ws3 = CreateSampleWorkspace()
 
 
    shape_xml = """ <cylinder id="stick">
@@ -47,8 +48,12 @@ Usage
 
    SetSampleShape(InputWorkspace = "ws1", ShapeXML = shape_xml)
    SetSampleShape(InputWorkspace = "ws2", ShapeXML = shape_xml)
+   SetSampleShape(InputWorkspace = "ws3", ShapeXML = shape_xml)
 
+   # translate shape with comma separated string
    TranslateSampleShape("ws2", "0.0,0.2,0.0")
+   # or with sequence of floats
+   TranslateSampleShape("ws3", [0.0,0.0,0.3])
 
 .. categories::
 

--- a/docs/source/algorithms/TranslateSampleShape-v1.rst
+++ b/docs/source/algorithms/TranslateSampleShape-v1.rst
@@ -1,0 +1,55 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Use this algorithm to translate the geometry of the sample shape defined on a workspace. This algorithm will not change the defined location of the sample object, simply how the physical geometry is defined within the sample's coordinate system
+
+This algorithm work for both CSG shapes
+(e.g. cylinders, flat plates etc.) and Mesh files.
+
+
+Usage
+-----
+**Example - TranslateSampleShape for sample with a CSG shape**
+
+.. code-block:: python
+
+   # import mantid algorithms, numpy and matplotlib
+   from mantid.simpleapi import *
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   ws1 = CreateSampleWorkspace()
+   ws2 = CreateSampleWorkspace()
+
+
+   shape_xml = """ <cylinder id="stick">
+   <centre-of-bottom-base x="-0.5" y="0.0" z="0.0" />
+   <axis x="1.0" y="0.0" z="0.0" />
+   <radius val="0.05" />
+   <height val="1.0" />
+   </cylinder>
+
+   <sphere id="some-sphere">
+   <centre x="0.0"  y="0.0" z="0.0" />
+   <radius val="0.5" />
+   </sphere>
+
+   <algebra val="some-sphere (# stick)" />"""
+
+   SetSampleShape(InputWorkspace = "ws1", ShapeXML = shape_xml)
+   SetSampleShape(InputWorkspace = "ws2", ShapeXML = shape_xml)
+
+   TranslateSampleShape("ws2", "0.0,0.2,0.0")
+
+.. categories::
+
+.. sourcelink::


### PR DESCRIPTION
### Description of work

Currently we have a utility algorithm for rotating sample shapes from their initial definition `RotateSampleShape`, but no equivalent for translating.

This problem is fairly trivial for mesh shapes, which are just defined by vertex coordinates which can be translated with the built in `translate` method, but for CSG shapes it is less straight forward. The approach I have taken is to parse the `shapeXML`, edit relevant fields and reconstruct the shape from the new XML string.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

The unit tests try to cover all the shapes in https://docs.mantidproject.org/nightly/concepts/HowToDefineGeometricShape.html but attempting some translations in workbench would probably be useful.

The following scripts will let you check that a CSG shape defined as a sphere minus a cylinder is correctly translated:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws1 = CreateSimulationWorkspace(Instrument="ENGINX", BinParams="1,0.5,2.0", OutputWorkspace="ws1", UnitX="dSpacing")
ws2 = CreateSimulationWorkspace(Instrument="ENGINX", BinParams="1,0.5,2.0", OutputWorkspace="ws2", UnitX="dSpacing")


shape_xml = """ <cylinder id="stick">
  <centre-of-bottom-base x="-0.5" y="0.0" z="0.0" />
  <axis x="1.0" y="0.0" z="0.0" />
  <radius val="0.05" />
  <height val="1.0" />
</cylinder>

<sphere id="some-sphere">
  <centre x="0.0"  y="0.0" z="0.0" />
  <radius val="0.5" />
</sphere>

<algebra val="some-sphere (# stick)" />"""

SetSampleShape(InputWorkspace = "ws1", ShapeXML = shape_xml)
SetSampleShape(InputWorkspace = "ws2", ShapeXML = shape_xml)

TranslateSampleShape("ws2", "0.0,0.2,0.0")
``` 

Release notes to follow once it looks close to being approved

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
