### PR TITLE
Stop messages from crashing mantid on macOS ARM

### DIFF
--- a/qt/widgets/common/src/NotificationService.cpp
+++ b/qt/widgets/common/src/NotificationService.cpp
@@ -71,6 +71,11 @@ bool NotificationService::isEnabled() {
   return retVal;
 }
 
-bool NotificationService::isSupportedByOS() { return QSystemTrayIcon::supportsMessages(); }
+bool NotificationService::isSupportedByOS() {
+#if defined(__APPLE__) && defined(__arm64__)
+  return false;
+#endif
+  return QSystemTrayIcon::supportsMessages();
+}
 
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
### Description of work

`#if`s out the check to see if the OS is supported (as it seems to be lying) on Apple ARM machines since it causes a crash whenever anything would try to post messages to the SystemTray. 

I'm reasonably sure these have never worked on macOS anyway, so just stopping them from running isn't a great loss.
I've made attempts to see if there was a quick fix to actually make them work, but didn't find one - and any changes would be too big to take place this close to release anyway. 

Closes #40176 
Closes #40177 


### To test:
1. Open Workbench
2. Attempt to Open the `ILL -> DrILL` interface (with the facility set to ISIS).
3. Throw a syntax error from the script editor.
4. Attempt to open the `Direct -> DNS Reduction` interface.

  *This does not require release notes* because nothing should change from the user's perspective. 

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
