### PR TITLE
Fix qt5 and qt6 warning and messaging crash on macOS ARM

### DIFF
--- a/qt/python/instrumentview/instrumentview/InteractorStyles.py
+++ b/qt/python/instrumentview/instrumentview/InteractorStyles.py
@@ -1,5 +1,5 @@
 from vtkmodules.vtkInteractionStyle import vtkInteractorStyleRubberBand3D, vtkInteractorStyleRubberBand2D, vtkInteractorStyleRubberBandZoom
-from vtk import vtkCommand
+from vtkmodules.vtkCommonCore import vtkCommand
 
 
 class CustomInteractorStyleRubberBand3D(vtkInteractorStyleRubberBand3D):

--- a/qt/widgets/common/src/NotificationService.cpp
+++ b/qt/widgets/common/src/NotificationService.cpp
@@ -71,11 +71,6 @@ bool NotificationService::isEnabled() {
   return retVal;
 }
 
-bool NotificationService::isSupportedByOS() {
-#if defined(__APPLE__) && defined(__arm64__)
-  return false;
-#endif
-  return QSystemTrayIcon::supportsMessages();
-}
+bool NotificationService::isSupportedByOS() { return QSystemTrayIcon::supportsMessages(); }
 
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
### Description of work
Fixes a bug which caused a crash when sending messages to the notification service due to the qt5 and qt6 cores being imported simultaneously. This has been fixed by replacing an import directly from `vtk` with one from `vtkmodules`. The crash occurred only on ARM versions of macOS. 

RE #40176
RE #40177
Closes #40191

### To test:
1. Launch on an ARM macOS machine.
2. Try to open the DNS Reduction gui or write anything in the script editor that would throw an error to the message log. 
3. Check there isn't a crash.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
