### PR TITLE
Fix crash deleting peaks

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/peak_delete_crash.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/peak_delete_crash.rst
@@ -1,0 +1,1 @@
+- Fixed crash that could occur when erasing peaks in the Instrument View, especially when deleting lots of peaks in a short space of time.

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -195,19 +195,16 @@ PeakOverlay::PeakOverlay(UnwrappedSurface *surface, const std::shared_ptr<Mantid
  */
 void PeakOverlay::removeShapes(const QList<Shape2D *> &shapeList) {
   // vectors of rows to delete from the peaks workspace.
-  std::vector<size_t> rows;
+  std::vector<int> rows;
   for (auto shape : shapeList) {
     PeakMarker2D *marker = dynamic_cast<PeakMarker2D *>(shape);
     if (!marker)
       throw std::logic_error("Wrong shape type found.");
-    rows.emplace_back(static_cast<size_t>(marker->getRow()));
+    rows.emplace_back(marker->getRow());
   }
 
-  // Run the DeleteTableRows algorithm to delete the peak.
-  auto alg = Mantid::API::AlgorithmManager::Instance().create("DeleteTableRows", -1);
-  alg->setPropertyValue("TableWorkspace", m_peaksWorkspace->getName());
-  alg->setProperty("Rows", rows);
-  emit executeAlgorithm(alg);
+  m_peaksWorkspace->removePeaks(rows);
+  recreateMarkers(getCurrentStyle());
 }
 
 /**---------------------------------------------------------------------


### PR DESCRIPTION
Fixes a crash that can occur when deleting peaks in the old Instrument View.

By calling an algorithm we rely on the workspace getting updated, then the ADS callback coming back into the peak overlay and updating the workspace. If deleting lots of peaks in a short space of time it's luck whether or not the workspace has been updated. If out of date then the overlay will try and get an invalid index, interface will disappear.

Possibly related to numerous error reports.

### To test:

To reproduce original crash:
- Run script:
``` python
ws = Load('SXD23767')
FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace='peaks_conv')
```
- Overlay peaks in the Instrument View
- Select the erase peaks tool, drag it around over peaks with the mouse button down.

This should now work without crashing, and the corresponding peaks workspace should be updated with relevant peaks erased.

Check that the correct peaks have been erased.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
