### PR TITLE
fix the issue with sample and container geometry definition

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -362,9 +362,10 @@ def calculate_absorption_correction(
 
     environment = {}
     find_env = True
-    if (can_geometry and can_material) or container_shape:
+    custom_can = can_geometry and can_material
+    if custom_can or container_shape:
         find_env = False
-        if not (can_geometry and can_material):
+        if not custom_can:
             environment["Name"] = "InAir"
             environment["Container"] = container_shape
 

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -362,10 +362,10 @@ def calculate_absorption_correction(
 
     environment = {}
     find_env = True
-    if container_shape or (can_geometry and can_material):
-        environment["Name"] = "InAir"
+    if (can_geometry and can_material) or container_shape:
         find_env = False
         if not (can_geometry and can_material):
+            environment["Name"] = "InAir"
             environment["Container"] = container_shape
 
     donorWS = create_absorption_input(

--- a/docs/source/release/v6.15.0/Diffraction/Powder/Bugfixes/40201.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/Bugfixes/40201.rst
@@ -1,0 +1,1 @@
+- Solve the crash issue in ref:`SNSPowderReduction <algm-SNSPowderReduction>` regarding the definition of non-standard sample and container geometries for the absorption correction purpose.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

This is to fix the issue with the sample and container geometry definition for the powder diffraction absorption correction. Usually, we use standard container for which the geometry is defined in Mantid. If we were to define a new geometry, the current code will run into a bug due to the container ID not present in `environment`. This PR is to fix this bug.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Use the following script for testing,

```python
from mantid.simpleapi import *

sam_geo = {
    'Shape': 'HollowCylinder',
    'Height': 4.0,
    'InnerRadius': 0.3,
    'OuterRadius': 0.32,
    'Center': [0.,0.,0.]
}

c_geo = {
    'Shape': 'HollowCylinderHolder',
    'Height': 4.0,
    'InnerRadius': 0.28,
    'InnerOuterRadius': 0.3,
    'OuterInnerRadius': 0.32,
    'OuterRadius': 0.34,
    'Center': [0.,0.,0.]
}

c_mat = {
    'ChemicalFormula': 'V',
    'NumberDensity': 0.072324
}

SNSPowderReduction(
    Filename='/SNS/PG3/IPTS-34523/nexus/PG3_58812.nxs.h5',
    CalibrationFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_OC_d58772_2025-02-12.h5',
    CharacterizationRunsFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2-HighRes_OC.txt,/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2_OC_limit.txt',
    RemovePromptPulseWidth=50,
    Binning='-0.0008',
    BackgroundSmoothParams='5, 2',
    FilterBadPulses=90,
    ScaleData=100,
    TypeOfCorrection='SampleAndContainer',
    SampleFormula='Ba-Nb-Cr-Ru',
    MeasuredMassDensity='6.0',
    SampleGeometry=sam_geo,
    SampleNumberDensity='0.088',
    ContainerGeometry=c_geo,
    ContainerMaterial=c_mat,
    SaveAs='gsas topas and fullprof',
    OutputDirectory='/path/to/output/directory',
    CacheDir='/path/to/cache/directory'
)
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
