### PR TITLE
Added UI elements for reduction part of HFIRPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -57,13 +57,16 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         self.declareProperty("Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels")
 
         # Reduction UI properties
-        self.declareProperty("Instrument", "", StringListValidator(["MIDAS", "WAND^2"]), "HB2 Instrument")
+        # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
+        self.declareProperty("Instrument", "", StringListValidator(["", "MIDAS", "WAND^2"]), "HB2 Instrument")
+        # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
             "Wavelength",
             0.0,  # A
             FloatBoundedValidator(lower=0.0),  # must be positive
             doc="Incident wavelength (A)",
         )
+        # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
             "Vandaium Diameter",
             0.0,  # cm
@@ -76,6 +79,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             StringListValidator(["2Theta", "d-spacing", "Q"]),
             doc="The unit to which spectrum axis is converted to",
         )
+        # TODO: These 2 fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.copyProperties("ResampleX", ["XMin", "XMax"])
         self.declareProperty(
             "XBinWidth",
@@ -89,6 +93,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             validator=FloatBoundedValidator(0.0),
             doc="The background will be scaled by this number before being subtracted.",
         )
+        # TODO: This field below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
             "NormaliseBy",
             "Monitor",
@@ -153,6 +158,10 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
                     issues[f"{field}RunNumbers"] = f"{field}RunNumbers must be provided if {field}IPTS is provided"
                 if runNumbersBool:
                     issues[f"{field}IPTS"] = f"{field}IPTS must be provided if {field}RunNumbers is provided"
+
+        instrument = self.getProperty("Instrument").value
+        if instrument == "":
+            issues["Instrument"] = "Instrument must be provided"
 
         xMinBool = len(self.getProperty("XMin").value)
         if xMinBool == 0:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -148,7 +148,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
                     issues[f"{field}RunNumbers"] = (
                         f"Too many fields filled: Must specify either {field}Filename or {field}IPTS AND {field}RunNumbers"
                     )
-            elif not (IPTSBool == Property.EMPTY_INT and runNumbersBool == 0):
+            elif (IPTSBool == Property.EMPTY_INT) ^ (runNumbersBool == 0):
                 if IPTSBool != Property.EMPTY_INT:
                     issues[f"{field}RunNumbers"] = f"{field}RunNumbers must be provided if {field}IPTS is provided"
                 if runNumbersBool:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -62,14 +62,14 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
             "Wavelength",
-            0.0,  # A
+            Property.EMPTY_DBL,  # A
             FloatBoundedValidator(lower=0.0),  # must be positive
             doc="Incident wavelength (A)",
         )
         # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
-            "Vandaium Diameter",
-            0.0,  # cm
+            "VanadiumDiameter",
+            Property.EMPTY_DBL,  # cm
             FloatBoundedValidator(lower=0.0),  # must be positive
             doc="Vanadium rod diamter (cm)",
         )
@@ -169,6 +169,12 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         xMaxBool = len(self.getProperty("XMax").value)
         if xMaxBool == 0:
             issues["XMax"] = "XMax must be provided"
+        wavelength = self.getProperty("Wavelength").value
+        if wavelength == Property.EMPTY_DBL:
+            issues["Wavelength"] = "Wavelength must be provided"
+        vanadiumDiameter = self.getProperty("VanadiumDiameter").value
+        if vanadiumDiameter == Property.EMPTY_DBL:
+            issues["VanadiumDiameter"] = "VanadiumDiameter must be provided"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -169,6 +169,21 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         xMaxBool = len(self.getProperty("XMax").value)
         if xMaxBool == 0:
             issues["XMax"] = "XMax must be provided"
+
+        size = xMinBool
+        xmins = self.getProperty("XMin").value
+        xmaxs = self.getProperty("XMax").value
+        if (xMinBool != xMaxBool) and (xMinBool and xMaxBool):
+            msg = f"XMin and XMax do not define same number of spectra ({xMinBool} != {xMaxBool})"
+            issues["XMin"] = msg
+            issues["XMax"] = msg
+        elif xMinBool and xMaxBool:
+            for i in range(size):
+                if xmins[i] >= xmaxs[i]:
+                    msg = f"XMin ({xmins[i]}) cannot be greater than or equal to XMax ({xmaxs[i]})"
+                    issues["XMin"] = msg
+                    issues["XMax"] = msg
+
         wavelength = self.getProperty("Wavelength").value
         if wavelength == Property.EMPTY_DBL:
             issues["Wavelength"] = "Wavelength must be provided"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -13,7 +13,7 @@ class LoadInputErrorMessages(unittest.TestCase):
     def test_validate_sample_inputs_too_many_fields(self):
         # Test that providing both filename and IPTS/RunNumbers raises a RuntimeError
         with self.assertRaises(RuntimeError) as cm:
-            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", SampleIPTS=123, SampleRunNumbers=[456])
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", SampleIPTS=123, SampleRunNumbers=[456], Instrument="WAND^2")
 
         # Check the error message
         error_msg = str(cm.exception)
@@ -23,7 +23,7 @@ class LoadInputErrorMessages(unittest.TestCase):
     def test_validate_sample_inputs_missing_fields(self):
         # Test that not providing any sample inputs raises a RuntimeError
         with self.assertRaises(RuntimeError) as cm:
-            HFIRPowderReduction()
+            HFIRPowderReduction(Instrument="WAND^2")
 
         # Check the error message
         error_msg = str(cm.exception)
@@ -41,6 +41,7 @@ class LoadInputErrorMessages(unittest.TestCase):
                 f"{field}Filename": "HB2C_7000.nxs.h5",
                 f"{field}IPTS": 123,
                 f"{field}RunNumbers": [456],
+                "Instrument": "WAND^2",
             }
 
             with self.assertRaises(RuntimeError) as cm:
@@ -57,7 +58,7 @@ class LoadInputErrorMessages(unittest.TestCase):
 
         for field in all_fields:
             # Test that missing IPTS or RunNumbers when the other is filled out for optional fields raises a RuntimeError
-            kwargs = {f"{field}IPTS": 123}
+            kwargs = {f"{field}IPTS": 123, "Instrument": "WAND^2"}
 
             with self.assertRaises(RuntimeError) as cm:
                 HFIRPowderReduction(**kwargs)
@@ -67,7 +68,7 @@ class LoadInputErrorMessages(unittest.TestCase):
             self.assertIn(f"{field}RunNumbers", error_msg)
             self.assertIn(f"{field}RunNumbers must be provided if {field}IPTS is provided", error_msg)
 
-            kwargs = {f"{field}RunNumbers": [456]}
+            kwargs = {f"{field}RunNumbers": [456], "Instrument": "WAND^2"}
 
             with self.assertRaises(RuntimeError) as cm:
                 HFIRPowderReduction(**kwargs)
@@ -80,17 +81,34 @@ class LoadInputErrorMessages(unittest.TestCase):
     def test_valid_sample_input_combinations(self):
         # Test filename only - should not raise
         try:
-            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5")
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", Instrument="WAND^2")
         except RuntimeError as e:
             if "Must specify either SampleFilename or SampleIPTS AND SampleRunNumbers" in str(e):
                 self.fail("Valid input combination with SampleFilename failed validation")
 
         # Test IPTS and RunNumbers - should not raise
         try:
-            HFIRPowderReduction(SampleIPTS=123, SampleRunNumbers=[456])
+            HFIRPowderReduction(SampleIPTS=123, SampleRunNumbers=[456], Instrument="WAND^2")
         except RuntimeError as e:
             if "Must specify either SampleFilename or SampleIPTS AND SampleRunNumbers" in str(e):
                 self.fail("Valid input combination with IPTS and RunNumbers failed validation")
+
+    def test_validate_xmin_xmax(self):
+        # Test that missing XMin raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMax=10.0, Instrument="WAND^2")
+
+        error_msg = str(cm.exception)
+        self.assertIn("XMin", error_msg)
+        self.assertIn("XMin must be provided", error_msg)
+
+        # Test that missing XMax raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=1.0, Instrument="WAND^2")
+
+        error_msg = str(cm.exception)
+        self.assertIn("XMax", error_msg)
+        self.assertIn("XMax must be provided", error_msg)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -110,6 +110,23 @@ class LoadInputErrorMessages(unittest.TestCase):
         self.assertIn("XMax", error_msg)
         self.assertIn("XMax must be provided", error_msg)
 
+        # Test that XMin >= XMax raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=10.0, XMax=5.0, Instrument="WAND^2")
+
+        error_msg = str(cm.exception)
+        self.assertIn("XMin", error_msg)
+        self.assertIn("XMax", error_msg)
+        self.assertIn("XMin (10.0) cannot be greater than or equal to XMax (5.0)", error_msg)
+
+        # Test that XMin and XMax of different lengths raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=[1.0, 2.0], XMax=[5.0], Instrument="WAND^2")
+        error_msg = str(cm.exception)
+        self.assertIn("XMin", error_msg)
+        self.assertIn("XMax", error_msg)
+        self.assertIn("XMin and XMax do not define same number of spectra (2 != 1)", error_msg)
+
     def test_validate_instrument(self):
         # Test that missing Instrument raises a RuntimeError
         with self.assertRaises(RuntimeError) as cm:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -119,6 +119,24 @@ class LoadInputErrorMessages(unittest.TestCase):
         self.assertIn("Instrument", error_msg)
         self.assertIn("Instrument must be provided", error_msg)
 
+    def test_validate_wavelength(self):
+        # Test that missing Wavelength raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=1.0, XMax=10.0, Instrument="WAND^2", VanadiumDiameter=0.5)
+
+        error_msg = str(cm.exception)
+        self.assertIn("Wavelength", error_msg)
+        self.assertIn("Wavelength must be provided", error_msg)
+
+    def test_vanadium_diameter(self):
+        # Test that missing Vandaium Diameter raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=1.0, XMax=10.0, Instrument="WAND^2", Wavelength=2.5)
+
+        error_msg = str(cm.exception)
+        self.assertIn("VanadiumDiameter", error_msg)
+        self.assertIn("VanadiumDiameter must be provided", error_msg)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -110,6 +110,15 @@ class LoadInputErrorMessages(unittest.TestCase):
         self.assertIn("XMax", error_msg)
         self.assertIn("XMax must be provided", error_msg)
 
+    def test_validate_instrument(self):
+        # Test that missing Instrument raises a RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            HFIRPowderReduction(SampleFilename="HB2C_7000.nxs.h5", XMin=1.0, XMax=10.0)
+
+        error_msg = str(cm.exception)
+        self.assertIn("Instrument", error_msg)
+        self.assertIn("Instrument must be provided", error_msg)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40213.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40213.rst
@@ -1,0 +1,1 @@
+- Added UI elements for the reduction part of :ref:`HFIRPowderReduction <algm-HFIRPowderReduction>`


### PR DESCRIPTION
### Description of work

This work just adds the fields required to perform reduction in HFIRPowderReduction. Checking was also added to verify XMin and XMax fields are filled out. There are other required fields, but those are the only two that will contain nothing if the user does not fill those out and tries to execute. Other required fields will have default values.

Work to help complete #40188 
EWM Item [13207](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13207)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Be sure to try and run HFIRPowderReduction without filling out XMin and XMax fields, and make sure that the related errors make sense.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
