### PR TITLE
Add argument to ignore existing CMakeCache.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ endif()
 if(POLICY CMP0177)
   cmake_policy(SET CMP0177 NEW)
 endif()
+# invalidate timestamps on dependencies https://cmake.org/cmake/help/latest/policy/CMP0168.html
+if(POLICY CMP0168)
+  cmake_policy(SET CMP0168 NEW)
+endif()
 
 # Add the path to our custom 'find' modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/buildconfig/CMake")

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -36,7 +36,8 @@ if [[ $OSTYPE == "msys"* ]]; then
 fi
 
 # Run CMake using preset and variables
-cmake --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $WORKSPACE
+# --fresh ignores previous cmake configuration - build results may still be reused if they match
+cmake --fresh --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $WORKSPACE
 
 # Run the actual builds for the code, unit tests, and system tests.
 cd $WORKSPACE/build


### PR DESCRIPTION
The extra argument ignores the cmake cach during configuration. When the configuration overlaps with previous runs, the build results (e.g. object files, shared libraries, data files) will still be reused.

Unfortunately, this does re-link all of the test data and forces downloading external projects again. It also required setting [CMP0168](https://cmake.org/cmake/help/latest/policy/CMP0168.html) to "NEW" to get the correct generator for google-test.

[Reference in cmake docs](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-fresh)

This was motivated by changing from ninja to msvc during the rattler-build work #39687.

### To test:

Look at the build logs and see that not much is recompiled which demonstrates that this does not invalidate the builds. This table lists information about the builds. "all" is the number of targets in `cmake --build .` (all target). "tests" is number of targets for `cmake --build . --target StandardTestData AllTests` (linux also gets `SystemTestData`) "time" is the total job time.

| OS      | all | tests | time  |
|---------|-----|-------|-------|
| linux   | 105 | 4893  |       |
| docs    | 105 | 1360  | 6m53s |
| osx     | 101 | 1433  |       |
| windows |     |       |       |

**linux showed that it cmake policy CMP0168 invalidates everything that is fetched in the external project.**

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
