### PR TITLE
Allow Linux to build with clang

### DIFF
--- a/Framework/API/src/AlgoTimeRegister.cpp
+++ b/Framework/API/src/AlgoTimeRegister.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/AlgoTimeRegister.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/MultiThreaded.h"
 #include <fstream>
 #include <time.h>

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -22,6 +22,7 @@
 #include "MantidGeometry/MDGeometry/MDFrame.h"
 #include "MantidIndexing/GlobalSpectrumIndex.h"
 #include "MantidIndexing/IndexInfo.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MDUnit.h"
 #include "MantidKernel/MultiThreaded.h"

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/cow_ptr.h"
 
 #include <iosfwd>
+#include <optional>
 #include <vector>
 
 namespace Mantid {

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectProperty.h
@@ -25,12 +25,13 @@ class Value;
 namespace Mantid::Kernel {
 using PythonObject = boost::python::object;
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !(defined(__linux__) && defined(__clang__))
 /** NOTE:
  *  For Linux builds (and maybe Windows), it is necessary that the below DLL export occur here.
  *  This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
  *  not linked in Kernel, this declaration can only occur inside the PythonInterface layer
  *  For Linux builds, this MUST be instantiated BEFORE the declaration of PythonObjectProperty
+ *  Exception: Linux with clang needs this in the source file instead
  */
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
 template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;

--- a/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
+++ b/Framework/PythonInterface/core/src/PythonObjectProperty.cpp
@@ -133,12 +133,13 @@ template <> Json::Value encodeAsJson(PythonObject const &) {
   throw Exception::NotImplementedError("encodeAsJson(const boost::python::object &)");
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || (defined(__linux__) && defined(__clang__))
 /** NOTE:
  *  For mac builds, it is necessary the DLL export occur here.
  *  This declaration normally lives in Framework/Kernel/PropertyWithValue.cpp.  However, because the boost library is
  *  not linked in Kernel, this declaration can only occur in a file inside the PythonInterface layer
  *  For mac builds, this MUST occur inside a source file, and not in the header
+ *  For Linux with clang, we also need it in the source file to avoid linking issues
  */
 // Instantiate a copy of the class with our template type so we generate the symbols for the methods in the hxx header.
 template class MANTID_PYTHONINTERFACE_CORE_DLL PropertyWithValue<PythonObject>;


### PR DESCRIPTION
### Description of work

While we don't support building with clang on Linux there is no reason it shouldn't work. This did compile previously. So this fixes a couple of missing headers and a template specialization for `PropertyWithValue` after which you should be able to use clang on Linux to compile and run mantid workbench again.

The unit tests do compile and run with clang but I found about 20 fail.  I haven't looked too closely as to why.

To build with clang on linux first install clang in your conda environment with whatever tool you are using, _e.g._

```
micromamba install clangxx==18.1.8
```

I installed version 18 as that is the version OSX [uses](https://github.com/mantidproject/mantid/blob/c1052ef805e0c48a4878f22cc3c07f0bd48501d9/conda/recipes/conda_build_config.yaml#L6).

Then run cmake specifying which compilers to use with a clean build directory

```
CC=clang CXX=clang++ cmake ...
```

and check that cmake found the expected compiler.

You should then be able to compile and run mantid workbench as normal.

My thought is this may help with fixing some issues in #39159 where we could get it working on Linux first.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Build and start mantid workbench as shown above.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

*This does not require release notes* because it's for developers only.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
