### PR TITLE
Correct Abins Lagrange resolution model

### DIFF
--- a/docs/source/release/v6.15.0/Indirect/Algorithms/Bugfixes/40229.rst
+++ b/docs/source/release/v6.15.0/Indirect/Algorithms/Bugfixes/40229.rst
@@ -1,0 +1,6 @@
+- Improved Abins/Abins2D resolution function for ILL-LAGRANGE
+  instrument. A minimum resolution of 0.4 meV is applied at low energy
+  transfer for the Cu(220) monochromator: the switch between this
+  constant resolution and the energy-dependent resolution was
+  previously implemented too low in energy transfer, giving
+  unreasonably sharp peaks below 30meV.

--- a/scripts/abins/instruments/lagrangeinstrument.py
+++ b/scripts/abins/instruments/lagrangeinstrument.py
@@ -33,9 +33,7 @@ class LagrangeInstrument(IndirectInstrument):
 
         abs_resolution_cm = abs_resolution_meV * MILLI_EV_TO_WAVENUMBER
         width = frequencies * ei_resolution + abs_resolution_cm
-
-        low_energy_indices = frequencies / MILLI_EV_TO_WAVENUMBER < (self.get_parameter("low_energy_cutoff_meV", default=float("-Inf")))
-        width[low_energy_indices] = self.get_parameter("low_energy_resolution_meV", default=0.0) * MILLI_EV_TO_WAVENUMBER
+        width = np.maximum(width, self.get_parameter("minimum_resolution_meV", default=0.0) * MILLI_EV_TO_WAVENUMBER)
         return width / 2  # Lagrange reported resolution seems to equal 2*sigma
 
     def get_angles(self):

--- a/scripts/abins/instruments/lagrangeinstrument.py
+++ b/scripts/abins/instruments/lagrangeinstrument.py
@@ -34,7 +34,7 @@ class LagrangeInstrument(IndirectInstrument):
         abs_resolution_cm = abs_resolution_meV * MILLI_EV_TO_WAVENUMBER
         width = frequencies * ei_resolution + abs_resolution_cm
 
-        low_energy_indices = frequencies < (self.get_parameter("low_energy_cutoff_meV", default=float("-Inf")))
+        low_energy_indices = frequencies / MILLI_EV_TO_WAVENUMBER < (self.get_parameter("low_energy_cutoff_meV", default=float("-Inf")))
         width[low_energy_indices] = self.get_parameter("low_energy_resolution_meV", default=0.0) * MILLI_EV_TO_WAVENUMBER
         return width / 2  # Lagrange reported resolution seems to equal 2*sigma
 

--- a/scripts/abins/parameters.py
+++ b/scripts/abins/parameters.py
@@ -121,8 +121,7 @@ instruments = {
             "Cu(220) (Lagrange)": {
                 "Ei_range_meV": [26, 500],
                 "abs_resolution_meV": [7.6987e-5, 2.156e-2, -3.5961e-2],
-                "low_energy_cutoff_meV": 25,
-                "low_energy_resolution_meV": 0.8,
+                "minimum_resolution_meV": 0.8,
             },
             "Cu(331) (Lagrange)": {
                 "Ei_range_meV": [67, 500],

--- a/scripts/test/Abins/AbinsInstrumentTest.py
+++ b/scripts/test/Abins/AbinsInstrumentTest.py
@@ -58,8 +58,8 @@ class LagrangeResolutionTest(unittest.TestCase):
         """
         lagrange = get_instrument("Lagrange", setting="Cu(220) (Lagrange)")
 
-        # Cutoff should be at 25 meV
-        frequencies = ([24.5, 25.5] * ureg("meV")).to("1/cm", context="spectroscopy").magnitude
+        # Cutoff is around 35 meV
+        frequencies = ([30, 40] * ureg("meV")).to("1/cm", context="spectroscopy").magnitude
         sigma_below, sigma_above = lagrange.get_sigma(frequencies)
         self.assertAlmostEqual((sigma_below * ureg("1/cm")).to("meV").magnitude, 0.4, 6)
 

--- a/scripts/test/Abins/AbinsInstrumentTest.py
+++ b/scripts/test/Abins/AbinsInstrumentTest.py
@@ -6,7 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from euphonic import ureg
+
 from abins.constants import ALL_INSTRUMENTS
+from abins.instruments import get_instrument
 from abins.instruments.instrument import Instrument
 
 
@@ -29,12 +32,38 @@ class GetInstrumentTest(unittest.TestCase):
         ALL_INSTRUMENTS.pop()
 
     def test_instrument_notfound(self):
-        from abins.instruments import get_instrument
-
         with self.assertRaises(ValueError):
             get_instrument("Unheardof")
         with self.assertRaises(NotImplementedError):
             get_instrument("Unimplemented")
+
+
+class LagrangeResolutionTest(unittest.TestCase):
+    def test_lagrange_resolution_limits(self):
+        """Test Lagrange Cu(220) resolution function segments
+
+        This resolution function consists of a flat segment and polynomial;
+        make sure they are switching at the right place.
+
+        The parameters
+        # "low_energy_cutoff_meV": 25,
+        # "low_energy_resolution_meV": 0.8,
+
+        Mean that below an energy transfer of 25 meV the resolution
+        (expressed as 2 sigma) equals 0.8 meV. (I.e. sigma = 0.4 meV)
+
+        Abins internal units are wavenumber, not meV, so we use Euphonic's
+        Pint unit registry to convert to wavenumber. (Rather than rely on the
+        values in abins.constants, which are used in the implementation.)
+        """
+        lagrange = get_instrument("Lagrange", setting="Cu(220) (Lagrange)")
+
+        # Cutoff should be at 25 meV
+        frequencies = ([24.5, 25.5] * ureg("meV")).to("1/cm", context="spectroscopy").magnitude
+        sigma_below, sigma_above = lagrange.get_sigma(frequencies)
+        self.assertAlmostEqual((sigma_below * ureg("1/cm")).to("meV").magnitude, 0.4, 6)
+
+        self.assertGreater(sigma_above, sigma_below)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Abins applies instrumental broadening to its simulated spectra. For the Lagrange instrument and Cu(220) monochromator, this is modelled as a Gaussian with width depending on a polynomial and a flat low-energy limit.

A unit conversion was missing between the frequencies (in wavenumber) and lower-bound of polynomial fit (in meV), causing the low-energy limit to be engaged at the wrong energy.

### Description of work

The discrepancy between the model as fitted/described and implementated was discovered by Rastislav Turanyi while working on ResINS. The origin is a missing unit conversion.

As discovered in the thread below, the "corrected" function still has a concerning discontinuity in it; to get a simple and reasonable behaviour, we instead implement a basic floor function.

The LAGRANGE models could use a closer look in general, but for now this is clearly an improvement.

### To test:

A new unit test is included


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
