### PR TITLE
Update Abins2D energy limits

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-import numbers
 from typing import Dict
 
 import numpy as np
@@ -17,7 +16,7 @@ from mantid.kernel import logger
 # noinspection PyProtectedMember
 from mantid.simpleapi import GroupWorkspaces
 import abins
-from abins.abinsalgorithm import AbinsAlgorithm, AtomInfo
+from abins.abinsalgorithm import AbinsAlgorithm, AtomInfo, validate_e_init
 
 
 # noinspection PyPep8Naming,PyMethodMayBeStatic
@@ -66,7 +65,7 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
         """
         Performs input validation. Use to ensure the user has defined a consistent set of parameters.
         """
-        from abins.constants import MILLI_EV_TO_WAVENUMBER, TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS
+        from abins.constants import TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS
 
         issues = dict()
         issues = self.validate_common_inputs(issues)
@@ -87,23 +86,13 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
                     "Valid frequencies: " + ", ".join([str(freq) for freq in allowed_frequencies])
                 )
 
-        if not isinstance(float(self.getProperty("IncidentEnergy").value), numbers.Real):
-            issues["IncidentEnergy"] = "Incident energy must be a real number"
-
-        if "max_wavenumber" in abins.parameters.instruments[instrument_name]:
-            max_energy = abins.parameters.instruments[instrument_name]["max_wavenumber"]
-        else:
-            max_energy = abins.parameters.sampling["max_wavenumber"]
-
-        energy_units = self.getProperty("EnergyUnits").value
-
-        if energy_units == "meV":
-            max_energy = max_energy / MILLI_EV_TO_WAVENUMBER
-        else:
-            max_energy = max_energy
-
-        if float(self.getProperty("IncidentEnergy").value) > max_energy:
-            issues["IncidentEnergy"] = f"Incident energy cannot be greater than {max_energy:.3f} {energy_units} for this instrument."
+        issues.update(
+            validate_e_init(
+                e_init=self.getProperty("IncidentEnergy").value,
+                energy_units=self.getProperty("EnergyUnits").value,
+                instrument_name=instrument_name,
+            )
+        )
 
         return issues
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2DBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2DBasicTest.py
@@ -1,0 +1,61 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from tempfile import TemporaryDirectory
+import unittest
+
+from mantid.simpleapi import mtd, Abins2D
+
+
+class Abins2DBasicTest(unittest.TestCase):
+    base_kwargs = {
+        "VibrationalOrPhononFile": "squaricn_sum_Abins.phonon",
+        "AbInitioProgram": "CASTEP",
+        "OutputWorkspace": "output_workspace",
+        "TemperatureInKelvin": 10.0,
+        "Atoms": "",
+        "SumContributions": False,
+        "SaveAscii": False,
+        "ScaleByCrossSection": "Incoherent",
+        "QuantumOrderEventsNumber": "1",
+        "Autoconvolution": False,
+        "EnergyUnits": "meV",
+        "Instrument": "Ideal2D",
+        "Chopper": "",
+        "IncidentEnergy": "500",
+        "ChopperFrequency": "300",
+    }
+
+    _tolerance = 0.0001
+
+    def setUp(self):
+        self.tempdir = TemporaryDirectory()
+        self._cache_directory = self.tempdir.name
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+        mtd.clear()
+
+    def test_basic(self):
+        """Check that Abins2D algorithm runs without error using basic parameters"""
+
+        Abins2D(**(self.base_kwargs | {"CacheDirectory": self._cache_directory}))
+
+    def test_wrong_input(self):
+        """Check that out-of-range incident energy creates error running algorithm
+
+        A more detailed set of cases is considered in unit-tests of the
+        abinsalgorithm.validate_e_init function"""
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Incident energy cannot be greater than 1000.000 meV for this instrument.",
+        ):
+            Abins2D(**(self.base_kwargs | {"CacheDirectory": self._cache_directory, "Instrument": "MARI", "IncidentEnergy": "1001"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(WorkflowAlgorithms)
 set(TEST_PY_FILES
     AbinsBasicTest.py
     Abins2BasicTest.py
+    Abins2DBasicTest.py
     AbinsAdvancedParametersTest.py
     AlignComponentsTest.py
     AngularAutoCorrelationsSingleAxisTest.py

--- a/docs/source/release/v6.15.0/Indirect/Algorithms/Bugfixes/40240.rst
+++ b/docs/source/release/v6.15.0/Indirect/Algorithms/Bugfixes/40240.rst
@@ -1,0 +1,2 @@
+- Fixed incident energy limits of Abins2D instruments: MARI 1000 meV,
+  PANTHER 181 meV, Ideal2D infinite

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -1074,6 +1074,16 @@ def validate_e_init(*, e_init: str, energy_units: str, instrument_name: str) -> 
 
     Check that algorithm inputs specify a valid energy for the given instrument
     and return appropriate issues dict for .validateInputs() method.
+
+    Note that parameters are strings; this is the form they are received from
+    algorithm parameters.
+
+    Args:
+        e_init: IncidentEnergy for Abins2D
+        energy_units: 'meV' or 'cm-1'
+        instrument_name:
+            A valid Abins2D instrument. This must be validated elsewhere,
+            with a corresponding entry in abins.parameters.instruments.
     """
 
     issues = {}

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -1069,7 +1069,7 @@ class AbinsAlgorithm:
             raise RuntimeError("Invalid number of threads for parallelisation over atoms" + message_end)
 
 
-def validate_e_init(e_init: str, energy_units: str, instrument_name: str) -> dict[str, str]:
+def validate_e_init(*, e_init: str, energy_units: str, instrument_name: str) -> dict[str, str]:
     """Validator for direct-geometry incident energy parameters
 
     Check that algorithm inputs specify a valid energy for the given instrument
@@ -1087,10 +1087,13 @@ def validate_e_init(e_init: str, energy_units: str, instrument_name: str) -> dic
     else:
         max_energy = abins.parameters.sampling["max_wavenumber"]
 
-    if energy_units == "meV":
-        max_energy = max_energy / MILLI_EV_TO_WAVENUMBER
-    else:
-        max_energy = max_energy
+    match energy_units:
+        case "meV":
+            max_energy = max_energy / MILLI_EV_TO_WAVENUMBER
+        case "cm-1":
+            max_energy = max_energy
+        case _:
+            raise ValueError(f"Invalid energy unit: {energy_units}")
 
     if float(e_init) > max_energy:
         issues["IncidentEnergy"] = f"Incident energy cannot be greater than {max_energy:.3f} {energy_units} for this instrument."

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -10,6 +10,7 @@
 from collections import defaultdict
 from math import isnan
 import multiprocessing
+import numbers
 import os
 from pathlib import Path
 import re
@@ -38,6 +39,7 @@ from abins.constants import (
     ATOM_PREFIX,
     FLOAT_TYPE,
     MASS_EPS,
+    MILLI_EV_TO_WAVENUMBER,
     ONE_DIMENSIONAL_INSTRUMENTS,
     TWO_DIMENSIONAL_INSTRUMENTS,
 )
@@ -1065,3 +1067,32 @@ class AbinsAlgorithm:
             return  # Pool() will set a sensible default
         if not (1 <= threads <= multiprocessing.cpu_count()):
             raise RuntimeError("Invalid number of threads for parallelisation over atoms" + message_end)
+
+
+def validate_e_init(e_init: str, energy_units: str, instrument_name: str) -> dict[str, str]:
+    """Validator for direct-geometry incident energy parameters
+
+    Check that algorithm inputs specify a valid energy for the given instrument
+    and return appropriate issues dict for .validateInputs() method.
+    """
+
+    issues = {}
+
+    if not isinstance(float(e_init), numbers.Real):
+        issues["IncidentEnergy"] = "Incident energy must be a real number"
+        return issues
+
+    if "max_wavenumber" in abins.parameters.instruments[instrument_name]:
+        max_energy = abins.parameters.instruments[instrument_name]["max_wavenumber"]
+    else:
+        max_energy = abins.parameters.sampling["max_wavenumber"]
+
+    if energy_units == "meV":
+        max_energy = max_energy / MILLI_EV_TO_WAVENUMBER
+    else:
+        max_energy = max_energy
+
+    if float(e_init) > max_energy:
+        issues["IncidentEnergy"] = f"Incident energy cannot be greater than {max_energy:.3f} {energy_units} for this instrument."
+
+    return issues

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -1103,7 +1103,8 @@ def validate_e_init(*, e_init: str, energy_units: str, instrument_name: str) -> 
         case "cm-1":
             max_energy = max_energy
         case _:
-            raise ValueError(f"Invalid energy unit: {energy_units}")
+            issues["EnergyUnits"] = f"Invalid energy unit: {energy_units}"
+            return issues
 
     if float(e_init) > max_energy:
         issues["IncidentEnergy"] = f"Incident energy cannot be greater than {max_energy:.3f} {energy_units} for this instrument."

--- a/scripts/abins/parameters.py
+++ b/scripts/abins/parameters.py
@@ -31,7 +31,7 @@ instruments = {
         "settings_default": "",
         "settings": {"": {"chopper": ""}},
         "min_wavenumber": 0.0,
-        "max_wavenumber": 4100.0,
+        "max_wavenumber": float("Inf"),
     },
     "PANTHER": {
         "q_size": 100,
@@ -69,6 +69,7 @@ instruments = {
         "resolution": "pychop",
         "q_size": 100,
         "e_init": 400 * MILLI_EV_TO_WAVENUMBER,
+        "max_wavenumber": 1000 * MILLI_EV_TO_WAVENUMBER,
         "settings_default": "A",
         "settings": {
             "A": {"chopper": "A"},
@@ -83,6 +84,7 @@ instruments = {
         "resolution": "pychop",
         "q_size": 100,
         "e_init": 400 * MILLI_EV_TO_WAVENUMBER,
+        "max_wavenumber": 181 * MILLI_EV_TO_WAVENUMBER,
         "settings_default": "G",
         "settings": {
             "G": {"chopper": "G"},

--- a/scripts/test/Abins/AbinsAlgorithmTest.py
+++ b/scripts/test/Abins/AbinsAlgorithmTest.py
@@ -65,6 +65,10 @@ class AbinsAlgorithmValidatorsTest(unittest.TestCase):
         issues = AbinsAlgorithm._validate_euphonic_input_file(wrong_yaml)
         self.assertEqual(issues, {"Invalid": True, "Comment": f"No 'phonopy' section found in {wrong_yaml}"})
 
+    def test_validate_e_init(self):
+        """Check incident energy / instrument combinations"""
+        raise NotImplementedError()
+
 
 class AbinsAlgorithmMethodsTest(unittest.TestCase):
     """Test static methods on AbinsAlgorithm"""

--- a/scripts/test/Abins/AbinsAlgorithmTest.py
+++ b/scripts/test/Abins/AbinsAlgorithmTest.py
@@ -68,8 +68,9 @@ class AbinsAlgorithmValidatorsTest(unittest.TestCase):
     def test_validate_e_init(self):
         """Check incident energy / instrument combinations"""
 
-        with self.assertRaisesRegex(ValueError, "Invalid energy unit"):
-            validate_e_init(e_init="100", energy_units="invalid", instrument_name="MARI")
+        issues = validate_e_init(e_init="100", energy_units="invalid", instrument_name="MARI")
+        self.assertIn("EnergyUnits", issues)
+        self.assertEqual(issues["EnergyUnits"], "Invalid energy unit: invalid")
 
         for instrument_name, valid_energy, invalid_energy, energy_units in [
             ("Ideal2D", "1e12", None, "cm-1"),

--- a/scripts/test/Abins/AbinsAlgorithmTest.py
+++ b/scripts/test/Abins/AbinsAlgorithmTest.py
@@ -12,7 +12,7 @@ import numpy as np
 # Import mantid.simpleapi first, otherwise we get circular import
 import mantid.simpleapi  # noqa: F401
 
-from abins.abinsalgorithm import AbinsAlgorithm, AtomInfo
+from abins.abinsalgorithm import AbinsAlgorithm, AtomInfo, validate_e_init
 from abins.atomsdata import AtomsData
 
 
@@ -67,7 +67,31 @@ class AbinsAlgorithmValidatorsTest(unittest.TestCase):
 
     def test_validate_e_init(self):
         """Check incident energy / instrument combinations"""
-        raise NotImplementedError()
+
+        with self.assertRaisesRegex(ValueError, "Invalid energy unit"):
+            validate_e_init(e_init="100", energy_units="invalid", instrument_name="MARI")
+
+        for instrument_name, valid_energy, invalid_energy, energy_units in [
+            ("Ideal2D", "1e12", None, "cm-1"),
+            ("PANTHER", "149", "151", "meV"),
+            ("MAPS", "1999", "2001", "meV"),
+            ("MARI", "999", "1001", "meV"),
+            ("MERLIN", "180", "182", "meV"),
+        ]:
+            self.assertFalse(  # i.e. empty dict of validation errors
+                validate_e_init(e_init=valid_energy, energy_units=energy_units, instrument_name=instrument_name)
+            )
+
+            if invalid_energy is None:
+                continue
+
+            issues = validate_e_init(e_init=invalid_energy, energy_units=energy_units, instrument_name=instrument_name)
+
+            self.assertIn("IncidentEnergy", issues)
+            self.assertRegex(
+                issues["IncidentEnergy"],
+                r"Incident energy cannot be greater than \d+\.\d+ meV for this instrument.",
+            )
 
 
 class AbinsAlgorithmMethodsTest(unittest.TestCase):


### PR DESCRIPTION
Users have complained that Abins2D doesn't let them simulate MARI at 500eV when this is within the instrument capability.

To test the validator thoroughly I have factored it out of the Algorithm.

### Description of work

- MARI and PANTHER energy limits updated for consistency with PyChop
- Ideal2D  limit increased to infinity; any choice would be arbitrary as this instrument is for "ideal simulations"
- Added unit tests

**Report to:** Hamish Cavaye


### To test:

New unit tests were added for execution of the Abins2D algorithm (alongside existing systemtest) and a more thorough test of the validation function.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
