### PR TITLE
Pin pillow to avoid allocator mismatch

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -102,6 +102,9 @@ sphinx_bootstrap_theme:
 scipy:
   - '>=1.10.0'
 
+pillow:
+  - '<12.0.0'
+
 pip:
   - '>=21.0.1'
 

--- a/conda/recipes/mantid-developer/recipe.yaml
+++ b/conda/recipes/mantid-developer/recipe.yaml
@@ -32,6 +32,7 @@ requirements:
     - ninja ${{ ninja }}
     - numpy ${{ numpy }}
     - occt ${{ occt }}
+    - pillow ${{ pillow }}
     - pip ${{ pip }}
     - poco ${{ poco }}
     - psutil ${{ psutil }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -97,6 +97,7 @@ requirements:
     - ${{ pin_subpackage('mantid', upper_bound='x.x.x') }}
   run_constraints:
     - matplotlib-base ${{ matplotlib }}
+    - pillow ${{ pillow }}
     - pystog ${{ pystog }}
 
 tests:


### PR DESCRIPTION
### Description of work
The newest version of `pillow` (>12.0.0) was built against `zlib-ng` (see [here](https://github.com/conda-forge/pillow-feedstock/pull/173)). For some reason this is causing a segfault in `jemalloc`. This is the cause of our recent CI failures. The long term solution is to move away from jemalloc, since it is no longer maintained. The short term solution is to pin pillow back.

Closes #40244

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
