### PR TITLE
Create FFT smoothing functions

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Smoothing.h
+++ b/Framework/Kernel/inc/MantidKernel/Smoothing.h
@@ -45,5 +45,27 @@ template <typename T> std::vector<T> boxcarErrorSmooth(std::vector<T> const &inp
  */
 template <typename T> std::vector<T> boxcarRMSESmooth(std::vector<T> const &input, unsigned int const numPoints);
 
+/** Performs FFT smoothing on the input data, with high frequencies set to zero
+ *  NOTE: the input data MUST be defined on a uniform grid
+ *
+ * @param input The input vector to be smoothed
+ * @param cutoff The cutoff frequency; all components from this number forward will be set to zero
+ * @return A new vector containing the smoothed data
+ * @tparam Y numeric type for y-values
+ */
+template <typename Y> std::vector<Y> fftSmooth(std::vector<Y> const &input, unsigned const cutoff);
+
+/** Performs FFT smoothing on the input data, using a Butterworth filter
+ *  NOTE: the input data MUST be defined on a uniform grid
+ *
+ * @param input The input vector to be smoothed
+ * @param cutoff Represents the cutoff frequency, where step function behavior begins descent
+ * @param order Represents the steepness of the frequency cutoff; as this approaches infinity, approaches step cutoff
+ * @return A new vector containing the smoothed data
+ * @tparam Y numeric type for y-values
+ */
+template <typename Y>
+std::vector<Y> fftButterworthSmooth(std::vector<Y> const &input, unsigned const cutoff, unsigned const order);
+
 } // namespace Smoothing
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/Smoothing.cpp
+++ b/Framework/Kernel/src/Smoothing.cpp
@@ -171,8 +171,8 @@ template <typename Y> struct ZeroFilter : public FFTFilter<Y> {
   // remove the higher frequencies by setting to zero
   // REF: see example code at
   // - https://www.gnu.org/software/gsl/doc/html/fft.html#overview-of-real-data-f
-  ZeroFilter(std::size_t n) : m_cutoff(n) {}
-  Y operator()(std::size_t index) const override { return (index >= m_cutoff ? 0 : 1); }
+  ZeroFilter(std::size_t const n) : m_cutoff(n) {}
+  Y operator()(std::size_t const index) const override { return (index >= m_cutoff ? 0 : 1); }
 
 private:
   std::size_t m_cutoff;
@@ -184,8 +184,9 @@ template <typename Y> struct ButterworthFilter : public FFTFilter<Y> {
   // - https://scikit-image.org/docs/0.25.x/api/skimage.filters.html#skimage.filters.butterworth
   // - https://isbweb.org/software/sigproc/bogert/filter.pdf
   // - https://users.cs.cf.ac.uk/dave/Vision_lecture/node22.html
-  ButterworthFilter(unsigned n, unsigned o) : m_two_order(2U * o), m_invcutoff(1.0 / static_cast<Y>(n)) {}
-  Y operator()(std::size_t index) const override {
+  ButterworthFilter(unsigned int const n, unsigned int const o)
+      : m_two_order(2U * o), m_invcutoff(1.0 / static_cast<Y>(n)) {}
+  Y operator()(std::size_t const index) const override {
     return 1.0 / (1.0 + std::pow(m_invcutoff * static_cast<Y>(index), m_two_order));
   }
 
@@ -195,7 +196,7 @@ private:
 };
 
 template <typename Y> std::vector<Y> fftSmoothWithFilter(std::vector<Y> const &input, FFTFilter<Y> const &filter) {
-  std::size_t dn = input.size();
+  std::size_t const dn = input.size();
   std::vector<Y> output(input.cbegin(), input.cend());
 
   // obtain the FFT
@@ -207,8 +208,8 @@ template <typename Y> std::vector<Y> fftSmoothWithFilter(std::vector<Y> const &i
   // NOTE: the halfcomplex storage requires special treatment of even/odd
   // NOTE: we cannot use GSL's unpack because these values would have to be altered and then re-packed
   // it is simpler to access them inplace.
-  bool even = (dn % 2 == 0);
-  std::size_t complex_size = (even ? dn / 2 : (dn - 1) / 2);
+  bool const even = (dn % 2 == 0);
+  std::size_t const complex_size = (even ? dn / 2 : (dn - 1) / 2);
   output[0] *= filter(0); // x[0] = z[0].real; z[0].imag = 0 and is not stored anywhere
   for (std::size_t fn = 1; fn < complex_size + (even ? 0UL : 1UL); fn++) {
     output[2 * fn - 1] *= filter(fn); // real parts

--- a/Framework/Kernel/src/Smoothing.cpp
+++ b/Framework/Kernel/src/Smoothing.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/Smoothing.h"
 #include "MantidKernel/DllConfig.h"
+#include "MantidKernel/GSL_FFT_Helpers.h"
 
 #include <algorithm>
 #include <cmath>
@@ -155,5 +156,107 @@ template <typename T> std::vector<T> boxcarRMSESmooth(std::vector<T> const &inpu
 template MANTID_KERNEL_DLL std::vector<double> boxcarSmooth(std::vector<double> const &, unsigned int const);
 template MANTID_KERNEL_DLL std::vector<double> boxcarRMSESmooth(std::vector<double> const &, unsigned int const);
 template MANTID_KERNEL_DLL std::vector<double> boxcarErrorSmooth(std::vector<double> const &, unsigned int const);
+
+// FFT SMOOTHING METHODS
+
+namespace fft {
+
+// filters
+template <typename Y> struct FFTFilter {
+  virtual Y operator()(std::size_t index) const = 0;
+  virtual ~FFTFilter() = default;
+};
+
+template <typename Y> struct ZeroFilter : public FFTFilter<Y> {
+  // remove the higher frequencies by setting to zero
+  // REF: see example code at
+  // - https://www.gnu.org/software/gsl/doc/html/fft.html#overview-of-real-data-f
+  ZeroFilter(std::size_t n) : cutoff(n) {}
+  Y operator()(std::size_t index) const override { return (index >= cutoff ? 0 : 1); }
+
+private:
+  std::size_t cutoff;
+};
+
+template <typename Y> struct ButterworthFilter : public FFTFilter<Y> {
+  // remove the higher frequencies by tapering with a Butterworth filter
+  // SOME REFS:
+  // - https://scikit-image.org/docs/0.25.x/api/skimage.filters.html#skimage.filters.butterworth
+  // - https://isbweb.org/software/sigproc/bogert/filter.pdf
+  // - https://users.cs.cf.ac.uk/dave/Vision_lecture/node22.html
+  ButterworthFilter(unsigned n, unsigned o) : two_order(2U * o), invcutoff(1.0 / static_cast<Y>(n)) {}
+  Y operator()(std::size_t index) const override {
+    return 1.0 / (1.0 + std::pow(invcutoff * static_cast<Y>(index), two_order));
+  }
+
+private:
+  unsigned two_order;
+  Y invcutoff;
+};
+
+template <typename Y> std::vector<Y> fftSmoothWithFilter(std::vector<Y> const &input, FFTFilter<Y> const &filter) {
+  std::size_t dn = input.size();
+  std::vector<Y> output(input.cbegin(), input.cend());
+
+  // obtain the FFT
+  Kernel::fft::real_ws_uptr real_ws = Kernel::fft::make_gsl_real_workspace(dn);
+  Kernel::fft::real_wt_uptr real_wt = Kernel::fft::make_gsl_real_wavetable(dn);
+  gsl_fft_real_transform(output.data(), 1, dn, real_wt.get(), real_ws.get());
+  real_wt.reset();
+
+  // NOTE: the halfcomplex storage requires special treatment of even/odd
+  // NOTE: we cannot use GSL's unpack because these values would have to be altered and then re-packed
+  // it is simpler to access them inplace.
+  bool even = (dn % 2 == 0);
+  std::size_t complex_size = (even ? dn / 2 : (dn - 1) / 2);
+  output[0] *= filter(0); // x[0] = z[0].real; z[0].imag = 0 and is not stored anywhere
+  for (std::size_t fn = 1; fn < complex_size + (even ? 0UL : 1UL); fn++) {
+    output[2 * fn - 1] *= filter(fn); // real parts
+    output[2 * fn] *= filter(fn);     // imaginary parts
+  }
+  // for even data, last point is an unmatched real value
+  if (even) {
+    output[dn - 1] *= filter(complex_size);
+  }
+
+  // transform back
+  Kernel::fft::hc_wt_uptr hc_wt = Kernel::fft::make_gsl_hc_wavetable(dn);
+  gsl_fft_halfcomplex_inverse(output.data(), 1, dn, hc_wt.get(), real_ws.get());
+  hc_wt.reset();
+  real_ws.reset();
+
+  // return the smoothed result
+  return output;
+}
+
+} // namespace fft
+
+template <typename Y> std::vector<Y> fftSmooth(std::vector<Y> const &input, unsigned const cutoff) {
+  if (cutoff == 0) {
+    throw std::invalid_argument("The cutoff frequency must be greater than zero");
+  } else if (cutoff > input.size()) {
+    throw std::invalid_argument("The cutoff frequency must be less than the array size");
+  }
+
+  fft::ZeroFilter<Y> filter(cutoff);
+  return fftSmoothWithFilter(input, filter);
+}
+
+template <typename Y>
+std::vector<Y> fftButterworthSmooth(std::vector<Y> const &input, unsigned const cutoff, unsigned const order) {
+  if (cutoff == 0) {
+    throw std::invalid_argument("The cutoff frequency must be greater than zero");
+  }
+  if (cutoff > input.size()) {
+    throw std::invalid_argument("The Butterworth cutoff frequency must be less than the array size");
+  }
+
+  fft::ButterworthFilter<Y> filter(cutoff, order);
+  return fft::fftSmoothWithFilter(input, filter);
+}
+
+template MANTID_KERNEL_DLL std::vector<double> fftSmooth(std::vector<double> const &, unsigned const);
+template MANTID_KERNEL_DLL std::vector<double> fftButterworthSmooth(std::vector<double> const &, unsigned const,
+                                                                    unsigned const);
 
 } // namespace Mantid::Kernel::Smoothing

--- a/Framework/Kernel/src/Smoothing.cpp
+++ b/Framework/Kernel/src/Smoothing.cpp
@@ -163,7 +163,7 @@ namespace fft {
 
 // filters
 template <typename Y> struct FFTFilter {
-  virtual Y operator()(std::size_t index) const = 0;
+  virtual Y operator()(std::size_t const index) const = 0;
   virtual ~FFTFilter() = default;
 };
 

--- a/Framework/Kernel/test/SmoothingTest.h
+++ b/Framework/Kernel/test/SmoothingTest.h
@@ -113,6 +113,16 @@ public:
 
   // FFT SMOOTHING
 
+  void test_fftSmooth_invalid() {
+    int N = 10;
+    int zero_cutoff = 0, large_cutoff = N + 1;
+    std::vector<double> input(N, 1);
+    TS_ASSERT_THROWS_ASSERT(fftSmooth(input, zero_cutoff), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "zero")));
+    TS_ASSERT_THROWS_ASSERT(fftSmooth(input, large_cutoff), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "array size")));
+  }
+
   void test_fftSmooth_flat() {
     // put flat signal in, get flat signal back out
     double const flatValue = 3.0;
@@ -194,6 +204,19 @@ public:
   }
 
   // butterworth
+
+  void test_fftButterworthSmooth_invalid() {
+    int N = 10;
+    int zero_cutoff = 0, large_cutoff = N + 1, good_cutoff = N / 2;
+    int zero_order = 0, good_order = 1;
+    std::vector<double> input(N, 1);
+    TS_ASSERT_THROWS_ASSERT(fftButterworthSmooth(input, zero_cutoff, good_order), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "zero")));
+    TS_ASSERT_THROWS_ASSERT(fftButterworthSmooth(input, large_cutoff, good_order), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "array size")));
+    TS_ASSERT_THROWS_ASSERT(fftButterworthSmooth(input, good_cutoff, zero_order), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "nonzero")));
+  }
 
   void test_fftButterworthSmooth_flat() {
     // put flat signal in, get flat signal back out

--- a/Framework/Kernel/test/SmoothingTest.h
+++ b/Framework/Kernel/test/SmoothingTest.h
@@ -110,4 +110,115 @@ public:
       TS_ASSERT_EQUALS(x, 2.0);
     }
   }
+
+  // FFT SMOOTHING
+
+  void test_fftSmooth_flat() {
+    // put flat signal in, get flat signal back out
+    double const flatValue = 3.0;
+    std::vector<double> input(20, flatValue);
+    std::vector<double> output = fftSmooth(input, 10);
+    TS_ASSERT_EQUALS(input, output);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (double const &x : output) {
+      TS_ASSERT_EQUALS(x, flatValue);
+    }
+  }
+
+  void test_fftSmooth_spikey() {
+    // put in flat signal with high-frequency noise, get flat out
+    double const flatValue = 3.0;
+    std::vector<double> input(20, flatValue);
+    // add high-frequency spikes
+    for (std::size_t i = 0; i < input.size(); i++) {
+      input[i] += (i % 2 == 0 ? +1 : -1);
+    }
+    std::vector<double> output = fftSmooth(input, 1);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (double const &x : output) {
+      TS_ASSERT_EQUALS(x, flatValue);
+    }
+  }
+
+  void test_fftSmooth_sines() {
+    // put in low-freq sine data with high-freq noise; get low-freq sine out
+    std::size_t const N{100};
+    std::vector<double> input(N);
+    // make periodic data
+    double const w0 = 6.28318530717958648 / double(N);
+    unsigned n1 = 3, n2 = 15;
+    double w1 = n1 * w0, w2 = n2 * w0;
+    auto sine = [](double w, std::size_t i) { return std::sin(w * double(i)); };
+    for (std::size_t i = 0; i < N; i++) {
+      input[i] = sine(w1, i) + sine(w2, i);
+    }
+    // cut off too low -- signal will be zero
+    std::vector<double> output = fftSmooth(input, n1 - 1);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (std::size_t i = 0; i < output.size(); i++) {
+      TS_ASSERT_DELTA(output[i], 0.0, 1.e-8);
+    }
+    // cutoff too high -- the higher frequency is still there
+    output = fftSmooth(input, n2 + 1);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (std::size_t i = 0; i < output.size(); i++) {
+      TS_ASSERT_DELTA(output[i], input[i], 1.e-8);
+    }
+    // cutoff just right -- the higher frequency part is removed
+    output = fftSmooth(input, n2 - 1);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (std::size_t i = 0; i < output.size(); i++) {
+      TS_ASSERT_DELTA(output[i], sine(w1, i), 1.e-8);
+    }
+  }
+
+  void test_fftSmooth_gauss() {
+    // put in gaussdata with high-freq noise; get gauss out
+    std::size_t const N{100};
+    std::vector<double> input(N);
+    // make gaussian data with noise
+    auto gauss = [](std::size_t i) { return std::exp(-std::pow(double(i) - 40.0, 2) / 15); };
+    for (std::size_t i = 0; i < N; i++) {
+      input[i] = gauss(i);
+    }
+    // add high-frequency noise
+    for (std::size_t i = 0; i < input.size(); i++) {
+      input[i] += (i % 2 == 0 ? +0.5 : -0.5);
+    }
+    // smooth and check
+    std::vector<double> output = fftSmooth(input, 50);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (std::size_t i = 0; i < output.size(); i++) {
+      TS_ASSERT_DELTA(output[i], gauss(i), 1.e-4);
+    }
+  }
+
+  // butterworth
+
+  void test_fftButterworthSmooth_flat() {
+    // put flat signal in, get flat signal back out
+    double const flatValue = 3.0;
+    std::vector<double> input(20, flatValue);
+    std::vector<double> output = fftButterworthSmooth(input, 1, 1);
+    TS_ASSERT_EQUALS(input, output);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (double const &x : output) {
+      TS_ASSERT_EQUALS(x, flatValue);
+    }
+  }
+
+  void test_fftButterworthSmooth_spikey() {
+    // put in flat signal with high-frequency noise, get flat out
+    double const flatValue = 3.0;
+    std::vector<double> input(20, flatValue);
+    // add high-frequency spikes
+    for (std::size_t i = 0; i < input.size(); i++) {
+      input[i] += (i % 2 == 0 ? +1 : -1);
+    }
+    std::vector<double> output = fftButterworthSmooth(input, 2, 10);
+    TS_ASSERT_EQUALS(input.size(), output.size());
+    for (double const &x : output) {
+      TS_ASSERT_DELTA(x, flatValue, 1.e-4);
+    }
+  }
 };


### PR DESCRIPTION
FFT smoothing applies a low-pass filter to the data to remove noise.  Given real data $\{x_i\}$, first a Fourier transform is applied (using [GSL's conventions](https://www.gnu.org/software/gsl/doc/html/fft.html#mathematical-definitions))
``` math
z_j = \sum x_k \cdot \exp(- 2\pi i j k / N)
```
where $\{z_j\}$ is a half-complex sequence, the discrete Fourier transform of $\{x_j\}$.  For memory purposes, the elements of $z_j$ are packed into a real array.  However, it is more conceptually helpful to think of the sequence $\{z_j\}$ as complex values in order, there $j$ labels the frequency states from lowest frequency to highest frequency, $f_j = 2\pi j / N$.

At the filter stage, we compute a new sequence $\{w_j\} = W(j, z_j)$, and then  perform the inverse-transform
``` math
\bar{x}_j = \frac{1}{N} \sum (z_j \cdot w_z) \cdot \exp(2\pi i j k)
``` 
The values $\{x_j\}$ will then be smoother.  Because of the actual ordering of elements by GSL inside a half-complex sequence, the logic is a bit more complicated than above.  But thinking of it in terms of the complex elements makes it more clear how the spectra are being altered.

There are several choices of $\{w_j\}$ which can produce a low-pass filter.  Here, we have chosen two:
- zero filtering: $w_j = 0$ for $j >= j_{cutoff}$.
- Butterworth filtering: $w_j = 1 / [ 1 + (j/j_{cutoff})^{2o}]$

There are other low-pass filtering methods we might try, such as [Wiener smoothing](https://docs.mantidproject.org/nightly/algorithms/WienerSmooth-v1.html).  The template functions in place should make that future implementation more easy.

I **wanted** to use these methods in the [FFTSmooth](https://docs.mantidproject.org/nightly/algorithms/FFTSmooth-v2.html) algorithm as it would greatly simplify the logic.  However, doing so gives slight numerical differences in results, which causes some system tests to fail and may represent an error.

Mantid Roadmap https://github.com/mantidproject/mantid/issues/40189
[EWM 13751](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13751)

Related to Issue #40284 

### To test:

This is a refactor. Ensure existing tests pass.

This does not require release notes because it is a pure refactor that will not impact users

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
