### PR TITLE
Add option for flipper analyzer calculation in FlipperEfficiency and SANSISISPolarizationCorrections algorithms

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -40,6 +40,7 @@ private:
   void saveToFile(API::MatrixWorkspace_sptr const &workspace, std::string const &filePathStr);
 
   /// Perform the main calculation for determining the efficiency on the given group.
-  API::MatrixWorkspace_sptr calculateEfficiency(API::WorkspaceGroup_sptr const &groupWs);
+  API::MatrixWorkspace_sptr calculateEfficiency(API::WorkspaceGroup_sptr const &groupWs,
+                                                bool const isFlipperAnalyser = false);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -18,7 +18,7 @@
 
 namespace Mantid::Algorithms {
 namespace PolarizationCorrectionsHelpers {
-MANTID_ALGORITHMS_DLL API::MatrixWorkspace_sptr workspaceForSpinState(API::WorkspaceGroup_sptr group,
+MANTID_ALGORITHMS_DLL API::MatrixWorkspace_sptr workspaceForSpinState(const API::WorkspaceGroup_sptr &group,
                                                                       const std::string &spinStateOrder,
                                                                       const std::string &targetSpinState);
 } // namespace PolarizationCorrectionsHelpers

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -13,6 +13,7 @@
 #include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
 #include "MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h"
 #include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/ListValidator.h"
 #include "MantidKernel/SpinStateValidator.h"
 #include "MantidKernel/Unit.h"
 
@@ -23,6 +24,8 @@ auto constexpr INPUT_WS{"InputWorkspace"};
 auto constexpr OUTPUT_WS{"OutputWorkspace"};
 auto constexpr OUTPUT_FILE{"OutputFilePath"};
 auto constexpr SPIN_STATES{"SpinStates"};
+auto constexpr FLIPPER_LOC{"Flipper"};
+auto constexpr POS_OPTIONS = {"Polarizer", "Analyzer"};
 } // namespace PropNames
 
 auto constexpr FILE_EXTENSION{".nxs"};
@@ -38,7 +41,9 @@ using PolarizationCorrectionsHelpers::workspaceForSpinState;
 // Register the algorithm in the AlgorithmFactory
 DECLARE_ALGORITHM(FlipperEfficiency)
 
-std::string const FlipperEfficiency::summary() const { return "Calculate the efficiency of the polarization flipper."; }
+std::string const FlipperEfficiency::summary() const {
+  return "Calculate the efficiency of the polarization or analyzer flipper.";
+}
 
 void FlipperEfficiency::init() {
   declareProperty(
@@ -46,8 +51,10 @@ void FlipperEfficiency::init() {
                                                           std::make_shared<Mantid::API::PolSANSWorkspaceValidator>()),
       "Group workspace containing flipper transmissions for all 4 polarization states.");
   auto const spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
-  declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
-                  "Order of individual flipper configurations in the input group workspace, e.g. \"01,11,00,10\"");
+  declareProperty(PropNames::FLIPPER_LOC, *PropNames::POS_OPTIONS.begin(),
+                  std::make_shared<StringListValidator>(PropNames::POS_OPTIONS)),
+      declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
+                      "Order of individual flipper configurations in the input group workspace, e.g. \"01,11,00,10\"");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output,
                                                                        PropertyMode::Optional),
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
@@ -56,19 +63,17 @@ void FlipperEfficiency::init() {
 }
 
 namespace {
+double calculateErrorValue(const std::vector<double> &TijY, const std::vector<double> &TijE) {
+  double const denom_1 = std::pow(TijY[0] + TijY[1], 2) * (TijY[3] - TijY[2]);
+  double const denom_0 = (TijY[0] + TijY[1]) * std::pow(TijY[3] - TijY[2], 2);
 
-double calculateErrorValue(double const t11Y, double const t11E, double const t10Y, double const t10E,
-                           double const t01Y, double const t01E, double const t00Y, double const t00E) {
-  double const denom_1 = std::pow((t11Y + t10Y), 2) * (t00Y - t01Y);
-  double const denom_0 = (t11Y + t10Y) * std::pow((t00Y - t01Y), 2);
+  double const deff_dt11 = (TijY[1] * (TijY[3] + TijY[2])) / denom_1;
+  double const deff_dt10 = (-TijY[0] * (TijY[3] + TijY[2])) / denom_1;
+  double const deff_dt00 = (TijY[2] * (TijY[1] - TijY[0])) / denom_0;
+  double const deff_dt01 = (TijY[3] * (TijY[0] - TijY[1])) / denom_0;
 
-  double const deff_dt11 = (t10Y * (t00Y + t01Y)) / denom_1;
-  double const deff_dt10 = (-t11Y * (t00Y + t01Y)) / denom_1;
-  double const deff_dt00 = (t01Y * (t10Y - t11Y)) / denom_0;
-  double const deff_dt01 = (t00Y * (t11Y - t10Y)) / denom_0;
-
-  double const sigma_squared = std::pow(deff_dt11, 2) * std::pow(t11E, 2) + std::pow(deff_dt00, 2) * std::pow(t00E, 2) +
-                               std::pow(deff_dt10, 2) * std::pow(t10E, 2) + std::pow(deff_dt01, 2) * std::pow(t01E, 2);
+  double const sigma_squared = std::pow(deff_dt11 * TijE[0], 2) + std::pow(deff_dt00 * TijE[3], 2) +
+                               std::pow(deff_dt10 * TijE[1], 2) + std::pow(deff_dt01 * TijE[2], 2);
 
   return std::sqrt(sigma_squared);
 }
@@ -89,7 +94,7 @@ std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
 
 void FlipperEfficiency::exec() {
   WorkspaceGroup_sptr const &groupWs = getProperty(PropNames::INPUT_WS);
-  auto const &efficiency = calculateEfficiency(groupWs);
+  auto const &efficiency = calculateEfficiency(groupWs, !isDefault(PropNames::FLIPPER_LOC));
 
   auto const &filename = getPropertyValue(PropNames::OUTPUT_FILE);
   if (!filename.empty()) {
@@ -102,30 +107,34 @@ void FlipperEfficiency::exec() {
   }
 }
 
-MatrixWorkspace_sptr FlipperEfficiency::calculateEfficiency(WorkspaceGroup_sptr const &groupWs) {
+MatrixWorkspace_sptr FlipperEfficiency::calculateEfficiency(WorkspaceGroup_sptr const &groupWs,
+                                                            bool const isFlipperAnalyser) {
+  using namespace FlipperConfigurations;
   auto const &spinConfig = getPropertyValue(PropNames::SPIN_STATES);
-  auto const &t11Ws = workspaceForSpinState(groupWs, spinConfig, FlipperConfigurations::ON_ON);
-  auto const &t10Ws = workspaceForSpinState(groupWs, spinConfig, FlipperConfigurations::ON_OFF);
-  auto const &t01Ws = workspaceForSpinState(groupWs, spinConfig, FlipperConfigurations::OFF_ON);
-  auto const &t00Ws = workspaceForSpinState(groupWs, spinConfig, FlipperConfigurations::OFF_OFF);
+  std::vector<MatrixWorkspace_sptr> Tij;
+  for (auto const &flipperConf : {ON_ON, ON_OFF, OFF_ON, OFF_OFF}) {
+    Tij.push_back(workspaceForSpinState(groupWs, spinConfig, flipperConf));
+  }
 
-  auto const &numerator = (t11Ws * t00Ws) - (t10Ws * t01Ws);
-  auto const &denominator = (t11Ws + t10Ws) * (t00Ws - t01Ws);
+  auto const &numerator = (Tij[0] * Tij[3]) - (Tij[2] * Tij[1]);
+  auto const &denominator =
+      isFlipperAnalyser ? (Tij[0] + Tij[1]) * (Tij[3] - Tij[2]) : (Tij[0] + Tij[2]) * (Tij[3] - Tij[1]);
   auto const &efficiency = numerator / denominator;
 
   // Calculate the errors
-  auto const &t11Y = t11Ws->y(0);
-  auto const &t11E = t11Ws->e(0);
-  auto const &t10Y = t10Ws->y(0);
-  auto const &t10E = t10Ws->e(0);
-  auto const &t01Y = t01Ws->y(0);
-  auto const &t01E = t01Ws->e(0);
-  auto const &t00Y = t00Ws->y(0);
-  auto const &t00E = t00Ws->e(0);
   auto &efficiencyE = efficiency->mutableE(0);
   auto const numBins = efficiencyE.size();
   for (size_t i = 0; i < numBins; ++i) {
-    efficiencyE[i] = calculateErrorValue(t11Y[i], t11E[i], t10Y[i], t10E[i], t01Y[i], t01E[i], t00Y[i], t00E[i]);
+    std::vector<double> tVec, tVecE;
+    for (auto const &wk : Tij) {
+      tVec.push_back(wk->y(0)[i]);
+      tVecE.push_back(wk->e(0)[i]);
+    }
+    if (isFlipperAnalyser) {
+      std::swap(tVec[1], tVec[2]);
+      std::swap(tVecE[1], tVecE[2]);
+    }
+    efficiencyE[i] = calculateErrorValue(tVec, tVecE);
   }
   return efficiency;
 }

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -118,7 +118,7 @@ MatrixWorkspace_sptr FlipperEfficiency::calculateEfficiency(WorkspaceGroup_sptr 
 
   auto const &numerator = (Tij[0] * Tij[3]) - (Tij[2] * Tij[1]);
   auto const &denominator =
-      isFlipperAnalyser ? (Tij[0] + Tij[1]) * (Tij[3] - Tij[2]) : (Tij[0] + Tij[2]) * (Tij[3] - Tij[1]);
+      isFlipperAnalyser ? (Tij[0] + Tij[2]) * (Tij[3] - Tij[1]) : (Tij[0] + Tij[1]) * (Tij[3] - Tij[2]);
   auto const &efficiency = numerator / denominator;
 
   // Calculate the errors

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
@@ -27,8 +27,8 @@ namespace PolarizationCorrectionsHelpers {
  * @param targetSpinState The spin state workspace to extract from the group.
  * @return The MatrixWorkspace containing the target spin state. nullptr if not present.
  */
-API::MatrixWorkspace_sptr workspaceForSpinState(API::WorkspaceGroup_sptr group, const std::string &spinStateOrder,
-                                                const std::string &targetSpinState) {
+API::MatrixWorkspace_sptr workspaceForSpinState(const API::WorkspaceGroup_sptr &group,
+                                                const std::string &spinStateOrder, const std::string &targetSpinState) {
   const auto &spinStateOrderVec = Mantid::Kernel::SpinStateHelpers::splitSpinStateString(spinStateOrder);
   const auto &wsIndex =
       Mantid::Kernel::SpinStateHelpers::indexOfWorkspaceForSpinState(spinStateOrderVec, targetSpinState);

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -132,6 +132,40 @@ public:
     }
   }
 
+  void test_normal_perfect_calculation_flipper_analyser() {
+    auto const &group = createPolarizedTestGroup("testWs", m_parameters, FLIPPER_AMPS);
+    auto alg = initialize_alg(group);
+    alg->setProperty("Flipper", "Analyzer");
+    alg->execute();
+
+    MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
+                     std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
+    auto const &outY = outWs->dataY(0);
+    auto const &outE = outWs->dataE(0);
+    auto const numBins = outY.size();
+    for (size_t i = 0; i < numBins; ++i) {
+      TS_ASSERT_EQUALS(1.0, outY[i])
+      TS_ASSERT_DELTA(0.4216370213557839, outE[i], 1e-8);
+    }
+  }
+
+  void test_flipper_polariser_and_analyser_eff_have_same_values_for_equal_amplitudes() {
+    auto const &group = createPolarizedTestGroup("testWs", m_parameters, FLIPPER_AMPS);
+    auto alg = initialize_alg(group);
+    alg->setProperty("Flipper", "Analyzer");
+    alg->execute();
+    MatrixWorkspace_sptr const outWsA = alg->getProperty("OutputWorkspace");
+
+    alg->setProperty("Flipper", "Polarizer");
+    alg->execute();
+    MatrixWorkspace_sptr const outWsP = alg->getProperty("OutputWorkspace");
+
+    auto const &outYA = outWsA->dataY(0);
+    auto const &outYP = outWsP->dataY(0);
+    TS_ASSERT_DELTA(outYA, outYP, 1e-8);
+  }
+
   void test_normal_typical_calculation_occurs() {
     auto flipAmps{FLIPPER_AMPS};
     flipAmps[0] *= 0.9;

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrections.py
@@ -17,6 +17,7 @@ from mantid.api import (
 from mantid.kernel import (
     ConfigService,
     Direction,
+    LogicOperator,
     FloatBoundedValidator,
     StringArrayProperty,
     StringListValidator,
@@ -512,6 +513,17 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
             self.setPropertyGroup(prop_name, FIT_PROPERTIES_GROUP_NAME)
 
         self.setPropertySettings(MAIN_PROPERTIES.ads, EnabledWhenProperty(MAIN_PROPERTIES.path, PropertyCriterion.IsNotDefault))
+        calibration = EnabledWhenProperty(MAIN_PROPERTIES.reduction, PropertyCriterion.IsEqualTo, REDUCTION.calibration)
+        calibration_or_both = EnabledWhenProperty(
+            calibration, EnabledWhenProperty(MAIN_PROPERTIES.reduction, PropertyCriterion.IsEqualTo, REDUCTION.both), LogicOperator.Or
+        )
+        self.setPropertySettings(
+            MAIN_PROPERTIES.scattering,
+            EnabledWhenProperty(MAIN_PROPERTIES.reduction, PropertyCriterion.IsNotEqualTo, REDUCTION.calibration),
+        )
+
+        for prop_name in [MAIN_PROPERTIES.cell, MAIN_PROPERTIES.direct, MAIN_PROPERTIES.transmission]:
+            self.setPropertySettings(prop_name, calibration_or_both)
 
     def validateInputs(self):
         issues = dict()

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrections.py
@@ -98,6 +98,7 @@ _prop_nt = namedtuple(
         "suffix",
         "ads",
         "sp_assert",
+        "second_flipper",
         "delete_partial",
         *FIT_PROPERTIES,
     ],
@@ -112,6 +113,7 @@ _prop_nt = namedtuple(
         "OutputSuffix",
         "KeepWsOnADS",
         "AssertSpinState",
+        "SecondFlipperEfficiency",
         "DeletePartialWsOnFail",
         "PxDInitialValue",
         "LifetimeInitialValue",
@@ -201,6 +203,7 @@ ALGS = _algs_nt()
 EFF_KEYS_USER = dict(
     analyzer_eff=["polarization", "analyzer", "efficiency"],
     flipper_eff=["polarization", "flipper", "polarizing", "efficiency"],
+    flipper_a_eff=["polarization", "flipper", "flipping", "efficiency"],
     pol_fit_table=["polarization", "analyzer", "initial_polarization"],
     polarizer_eff=["polarization", "polarizer", "efficiency"],
     empty_cell=["polarization", "analyzer", "empty_cell"],
@@ -314,7 +317,8 @@ def _user_file_reader(file_path: str, names_dict: dict[str, WsInfo]) -> Instrume
         instrument.spin_state_str = _get_value_from_dict(user_file, ["polarization", "flipper_configuration"], instrument.spin_state_str)
         # Efficiency files paths
         for name, key_list in EFF_KEYS_USER.items():
-            names_dict[name].path = _get_value_from_dict(user_file, key_list, "", False)
+            if name in names_dict:
+                names_dict[name].path = _get_value_from_dict(user_file, key_list, "", False)
 
         return instrument
 
@@ -387,9 +391,11 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
     delete_ads_ws: bool = False
     delete_partial: bool = True
     assert_spin: bool = True
+    has_2nd_flipper: bool = False
     reduction_type: str = None
     suffix: str = None
     progress: Progress = None
+    eff_basenames: list[str] = None
     scattering_runs: list[str] = None
     transmission_runs: list[str] = None
 
@@ -483,6 +489,15 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
             ),
         )
 
+        self.declareProperty(
+            name=MAIN_PROPERTIES.second_flipper,
+            defaultValue=False,
+            doc=(
+                "Whether to perform calculation for second flipper efficiency in calibration, as well as use second flipper efficiency "
+                "on correction if a path for the second flipper is found on the UserFile"
+            ),
+        )
+
         always_positive = FloatBoundedValidator(lower=0)
 
         self.declareProperty(
@@ -565,10 +580,13 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
         self.delete_ads_ws = not self.getProperty(MAIN_PROPERTIES.ads).value
         self.delete_partial = self.getProperty(MAIN_PROPERTIES.delete_partial).value
         self.assert_spin = self.getProperty(MAIN_PROPERTIES.sp_assert).value
+        self.has_2nd_flipper = self.getProperty(MAIN_PROPERTIES.second_flipper).value
 
         # We add efficiency auxiliary names here. We'll only delete those in the ADS at the end in case of error.
+        excluded = ["flipper_a_eff"] if not self.has_2nd_flipper else []
+        self.eff_basenames = [key for key in [*EFF_KEYS_USER.keys()] if key not in excluded]
         self.aux_ws = {
-            name: WsInfo(ads_name=_add_suffix(name, self.suffix)) for name in [*EFF_KEYS_USER.keys(), *AUX_WS_BASENAMES_CALIBRATION]
+            name: WsInfo(ads_name=_add_suffix(name, self.suffix)) for name in [*self.eff_basenames, *AUX_WS_BASENAMES_CALIBRATION]
         }
 
         self.parameters = {
@@ -630,7 +648,7 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
 
         if self.getProperty(MAIN_PROPERTIES.reduction).value == REDUCTION.correction:
             # We already have the efficiencies in the ADS and the parameters from the calibration
-            self._load_workspace_from_path([key for key in EFF_KEYS_USER.keys() if key not in ["empty_cell"]])
+            self._load_workspace_from_path([key for key in self.eff_basenames if key not in ["empty_cell"]])
             self.parameters = _build_parameters_from_table(self.aux_ws["pol_fit_table"].ads_name)
 
         scattering_runs_list = self._load_and_process_runs(
@@ -737,20 +755,23 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
 
     def _join_efficiencies(self, eff_list: list[str] = None) -> "MatrixWorkspace":
         """
-        Join efficiencies algorithm. We do not have a second flipper in this setup for LARMOR or ZOOM at the moment,
-        therefore we create a flat workspace for F2 based off the first flipper efficiency
+        Join efficiencies algorithm. If there is not a second flipper for LARMOR or ZOOM,
+        we create a flat workspace for F2 based off the first flipper efficiency
         """
-        pol_name, flip_name, analyzer_name = eff_list
-        fp = ADS.retrieve(flip_name)
+        pol_name, flip_p_name, analyzer_name = eff_list
 
-        """ Unlike simpleapi, running algorithm with `createChildAlgorithm` doesn't properly convert types like numpy arrays
-        to what's expected on the algorithm(dbl list in this case), so we need to be specific."""
-        x = fp.readX(0).tolist()
-        ones = np.ones_like(fp.readY(0)).tolist()
-        f2 = self._load_child_algorithm(ALGS.create, OUT_WS, DataX=x, DataY=ones, DataE=ones, UnitX=self.instrument.units)
-        efficiencies = self._load_child_algorithm(ALGS.join_eff, OUT_WS, P1=pol_name, F1=flip_name, P2=analyzer_name, F2=f2)
+        if not self.has_2nd_flipper:
+            flip_a_name = f"{TMP_NAME}_flipper_a_eff"
+            fp = ADS.retrieve(flip_p_name)
+            x = fp.readX(0).tolist()
+            ones = np.ones_like(fp.readY(0)).tolist()
+            self._load_child_algorithm(
+                ALGS.create, OutputWorkspace=flip_a_name, DataX=x, DataY=ones, DataE=ones, UnitX=self.instrument.units
+            )
+        else:
+            flip_a_name = self.aux_ws["flipper_a_eff"].ads_name
 
-        return efficiencies
+        return self._load_child_algorithm(ALGS.join_eff, OUT_WS, P1=pol_name, F1=flip_p_name, P2=analyzer_name, F2=flip_a_name)
 
     def _helium_analyzer_efficiency_at_scattering_run_time(self, ws_name: str):
         """
@@ -877,20 +898,27 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
         """
         self.progress.report("Calculating Flipper, Polarizer and Analyzer efficiencies")
 
-        pol_eff_names, flipper_eff_names = [self._create_run_list(transmission_run_list, prefix) for prefix in ["pol", "flipper"]]
+        pol_names = self._create_run_list(transmission_run_list, "pol")
+        flipper_p_names = self._create_run_list(transmission_run_list, "flipper_p")
+        flipper_a_names = self._create_run_list(transmission_run_list, "flipper_a") if self.has_2nd_flipper else None
+
         analyzer_eff_group = self._calculate_helium_analyzer_efficiency_and_parameters(transmission_run_list)
 
         for index, run in enumerate(transmission_run_list):
-            params = {"InputWorkspace": run, "SpinStates": self.instrument.spin_state_str, "OutputWorkspace": flipper_eff_names[index]}
+            params = {"InputWorkspace": run, "SpinStates": self.instrument.spin_state_str, "OutputWorkspace": flipper_p_names[index]}
             self._load_child_algorithm(ALGS.flipper, **params)
             self._load_child_algorithm(
-                ALGS.polarizer, **dict(params, OutputWorkspace=pol_eff_names[index]), AnalyserEfficiency=analyzer_eff_group.getItem(index)
+                ALGS.polarizer, **dict(params, OutputWorkspace=pol_names[index]), AnalyserEfficiency=analyzer_eff_group.getItem(index)
             )
+            if flipper_a_names:
+                self._load_child_algorithm(ALGS.flipper, **dict(params, Flipper="Analyzer", OutputWorkspace=flipper_a_names[index]))
 
         # Average out the efficiencies before storing, the partial workspaces are deleted
-        self._average_workspaces(flipper_eff_names, self.aux_ws["flipper_eff"].ads_name)
-        self._average_workspaces(pol_eff_names, self.aux_ws["polarizer_eff"].ads_name)
+        self._average_workspaces(flipper_p_names, self.aux_ws["flipper_eff"].ads_name)
+        self._average_workspaces(pol_names, self.aux_ws["polarizer_eff"].ads_name)
         self._average_workspaces([self.aux_ws["analyzer_eff"].ads_name], self.aux_ws["analyzer_eff"].ads_name, ungroup=True)
+        if flipper_a_names:
+            self._average_workspaces(flipper_a_names, self.aux_ws["flipper_a_eff"].ads_name)
 
     def _save_results(self, ws_names_list: Union[set[str], list[str]] = None, is_scattering_data: bool = False):
         """
@@ -1025,7 +1053,8 @@ class SANSISISPolarizationCorrections(DataProcessorAlgorithm):
         Additionally, we delete result workspaces if that is chosen in the properties.
         """
         scat_out_names = []
-        prefixes = ["transmission", *EFF_KEYS_USER.keys(), *AUX_WS_BASENAMES_CALIBRATION]
+        prefixes = ["transmission", *self.eff_basenames, *AUX_WS_BASENAMES_CALIBRATION]
+
         if scattering_list:
             prefixes.extend(["scattering", *AUX_WS_BASENAMES_CORRECTION])
             scat_out_names = self._prepare_corrected_data_for_save(scattering_list)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSISISPolarizationCorrectionsTest.py
@@ -28,9 +28,10 @@ from unittest.mock import patch, MagicMock, call
 
 
 class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
+    _ALG_PATCH_PATH = "plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections"
     _GROUP_NAME = "group"
     _WS_NAME = "test"
-    _EFF_NAMES = ["analyzer_eff", "flipper_eff", "pol_fit_table", "polarizer_eff"]
+    _EFF_NAMES = ["analyzer_eff", "flipper_eff", "flipper_a_eff", "pol_fit_table", "polarizer_eff"]
     _RED_TYPE = "Calibration"
 
     @classmethod
@@ -144,7 +145,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         filtered_names = alg._filter_ads_names(["pre_1", "pre_2"])
         self.assertEqual(filtered_names, [*names[0:2], names[4]])
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_load_runs_raises_runtime_error_for_non_groups_if_not_direct_run(self, mock_alg_child):
         self._create_test_workspace(out_name=self._WS_NAME)
         alg = self._setup_algorithm()
@@ -154,7 +155,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         )
         mock_alg_child.assert_called_once()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_load_runs_accepts_a_non_group_for_direct_runs(self, mock_alg_child):
         self._create_test_workspace(out_name="direct")
         alg = self._setup_algorithm()
@@ -162,7 +163,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         assertRaisesNothing(self, alg._load_run, "run_number", "direct")
         mock_alg_child.assert_called_once()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_ungroup_on_average_workspace_method(self, mock_alg_child):
         group_names = self._create_test_group(return_member_names=True)
         alg = self._setup_algorithm()
@@ -177,7 +178,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
 
         mock_alg_child.assert_has_calls(calls)
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_move_instrument_not_called_if_parameters_are_zero(self, mock_child_alg):
         alg = self._setup_algorithm()
         alg.instrument = self.inst
@@ -206,7 +207,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
             assertRaisesNothing(self, alg._load_workspace_from_path, self._EFF_NAMES)
             self.assertTrue(all([ads.doesExist(f"{key}_file_test") for key in self._EFF_NAMES]))
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections.load")
+    @patch(f"{_ALG_PATCH_PATH}.load")
     def test_load_ws_from_paths_doesnt_try_to_load_if_ws_on_ads(self, mock_data_processor_load):
         alg = self._setup_algorithm()
         alg.aux_ws = dict()
@@ -218,8 +219,8 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         assertRaisesNothing(self, alg._load_workspace_from_path, self._EFF_NAMES)
         mock_data_processor_load.assert_not_called()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_run")
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._prepare_workspace")
+    @patch(f"{_ALG_PATCH_PATH}._load_run")
+    @patch(f"{_ALG_PATCH_PATH}._prepare_workspace")
     def test_load_and_process_runs_doesnt_do_anything_if_ws_on_ads(self, mock_prepare, mock_load):
         alg = self._setup_algorithm()
         alg.aux_ws = dict()
@@ -232,7 +233,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         mock_load.assert_not_called()
         mock_prepare.assert_not_called()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_assert_spin_alg_not_called_if_assert_spin_states_property_false(self, mock_load_child_alg):
         self._create_test_group()
         alg = self._setup_algorithm()
@@ -243,7 +244,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         assertRaisesNothing(self, alg._check_spin_states, self._GROUP_NAME)
         mock_load_child_alg.assert_not_called()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_check_spin_state_raises_error_if_not_assert_spin_and_group_size_different_than_spin_states(self, mock_load_child_alg):
         self._create_test_group()
         alg = self._setup_algorithm()
@@ -259,7 +260,28 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         )
         mock_load_child_alg.assert_not_called()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._load_child_algorithm")
+    @patch(f"{_ALG_PATCH_PATH}._average_workspaces")
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
+    def test_process_efficiencies_calls_correctly_for_every_flipper_configuration(self, mock_child, mock_average):
+        alg = self._setup_algorithm()
+        alg.aux_ws = {key: WsInfo(key, "") for key in self._EFF_NAMES}
+        alg.instrument = self.inst
+        alg.instrument.spin_state_str = "00,01,10,11"
+
+        alg.progress = MagicMock()
+        alg._calculate_helium_analyzer_efficiency_and_parameters = MagicMock()
+        alg._create_run_list = MagicMock(return_value=["test_1"])
+
+        for has_2nd_flipper, no_calls in zip([False, True], [2, 3]):
+            with self.subTest(has_2nd_flipper=has_2nd_flipper, no_calls=no_calls):
+                alg.has_2nd_flipper = has_2nd_flipper
+                alg._process_efficiencies(["1"])
+                self.assertEqual(mock_child.call_count, no_calls)
+                self.assertEqual(mock_average.call_count, no_calls + 1)
+                mock_child.reset_mock()
+                mock_average.reset_mock()
+
+    @patch(f"{_ALG_PATCH_PATH}._load_child_algorithm")
     def test_check_spin_state_raises_error_for_wrong_spin_assertion(self, mock_load_child_alg):
         alg = self._setup_algorithm()
         alg.instrument = self.inst
@@ -275,7 +297,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         )
         mock_load_child_alg.assert_called_once()
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections.createChildAlgorithm")
+    @patch(f"{_ALG_PATCH_PATH}.createChildAlgorithm")
     def test_load_child_algorithm_when_output_param_is_not_set(self, mock_create_child_alg):
         alg_name = "TestAlg"
         alg = self._setup_algorithm()
@@ -290,7 +312,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         child_alg.setAlwaysStoreInADS.assert_called_once_with(True)
         self.assertEqual(result, None)
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections.createChildAlgorithm")
+    @patch(f"{_ALG_PATCH_PATH}.createChildAlgorithm")
     def test_load_child_algorithm_when_output_param_set(self, mock_create_child_alg):
         alg_name = "TestAlg"
         alg = self._setup_algorithm()
@@ -307,7 +329,7 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         child_alg.setAlwaysStoreInADS.assert_called_once_with(False)
         self.assertEqual(result_alg, "OutputWS")
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections.createChildAlgorithm")
+    @patch(f"{_ALG_PATCH_PATH}.createChildAlgorithm")
     def test_load_child_algorithm_error(self, mock_create_child_alg):
         alg_name = "TestAlg"
         error_msg = "error message"
@@ -320,10 +342,8 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, f"Error in execution of child algorithm {alg_name} : {error_msg}"):
             alg._load_child_algorithm(alg_name)
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._init_reduction_settings")
-    @patch(
-        "plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._polarization_calibration"
-    )
+    @patch(f"{_ALG_PATCH_PATH}._init_reduction_settings")
+    @patch(f"{_ALG_PATCH_PATH}._polarization_calibration")
     def test_context_manager_deletes_partial_ads_names_on_error(self, mock_calibration, mock_init):
         alg = self._setup_algorithm()
         # add test workspaces to ads
@@ -345,10 +365,8 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         mock_calibration.assert_called_once()
         self.assertEqual(0, len(ads.getObjectNames()))
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._init_reduction_settings")
-    @patch(
-        "plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._polarization_calibration"
-    )
+    @patch(f"{_ALG_PATCH_PATH}._init_reduction_settings")
+    @patch(f"{_ALG_PATCH_PATH}._polarization_calibration")
     def test_context_manager_does_not_deletes_partial_ads_names_on_error_if_delete_partial_property_set_to_false(
         self, mock_calibration, mock_init
     ):
@@ -374,10 +392,8 @@ class SANSISISPolarizationCorrectionsTest(unittest.TestCase):
         mock_calibration.assert_called_once()
         self.assertEqual(len(names), len(ads.getObjectNames()))
 
-    @patch("plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._init_reduction_settings")
-    @patch(
-        "plugins.algorithms.WorkflowAlgorithms.SANSISISPolarizationCorrections.SANSISISPolarizationCorrections._polarization_calibration"
-    )
+    @patch(f"{_ALG_PATCH_PATH}._init_reduction_settings")
+    @patch(f"{_ALG_PATCH_PATH}._polarization_calibration")
     def test_context_manager_restores_config(self, mock_calibration, mock_init):
         def set_config(input_dict):
             for k, v in input_dict.items():

--- a/Testing/SystemTests/tests/framework/PolarizationCorrections/FlipperEfficiencyTest.py
+++ b/Testing/SystemTests/tests/framework/PolarizationCorrections/FlipperEfficiencyTest.py
@@ -25,7 +25,7 @@ class FlipperEfficiencyTestBase(SANSPolarizationCorrectionsBase, metaclass=ABCMe
 
     def _run_test(self):
         pre_processed = self._prepare_workspace(self.input_filename)
-        FlipperEfficiency(pre_processed, "00,10,11,01", OutputWorkspace="result")
+        FlipperEfficiency(pre_processed, SpinStates="00,10,11,01", OutputWorkspace="result")
 
     def _validate(self):
         result = "result"

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -14,42 +14,33 @@ The input workspace must be a group of four single spectrum workspaces,
 each representing the transmission of a known spin state as specified by the ``SpinStates`` parameter. These four spin
 state transmissions are used to calculate the proportion of neutrons lost to the flipper as a function of wavelength.
 
-The polarization of the flipper :math:`P_{F}` is given by:
+With the ``Flipper`` property, the efficiency of the analyzer or polarizer flipper is calculated by choosing, respectively,
+`Analyzer` or `Polarizer`.
+
+The polarization of the polarizer flipper, :math:`P_{F_{P}}`, is given by:
 
 .. math::
 
-   P_F = \frac{(\frac{T_{11} - T_{10}}{T_{11} + T_{10}})}{(\frac{T_{00} - T_{01}}{T_{00} + T_{01}})}
+   P_{F_{P}} = \frac{(\frac{T_{11} - T_{10}}{T_{11} + T_{10}})}{(\frac{T_{00} - T_{01}}{T_{00} + T_{01}})}
 
-Since the efficiency :math:`\epsilon_{F}` is equal to :math:`\frac{1 + P_{F}}{2}`, we can calculate the efficiency of
-the flipper directly using:
-
-.. math::
-
-   \epsilon_{F} = \frac{T_{11}T_{00} - T_{10}T_{01}}{(T_{11} + T_{10})(T_{00} - T_{01})}
-
-The errors are calculated as follows:
+While the polarization of the analyzer flipper, :math:`P_{F_{A}}` is:
 
 .. math::
 
-   \sigma_{\epsilon_{F}} = \sqrt{| \frac{\partial \epsilon_{F}}{\partial T_{11}}|^2 * \sigma^2_{T_{11}} + | \frac{\partial \epsilon_{F}}{\partial T_{00}}|^2 * \sigma^2_{T_{00}} + | \frac{\partial \epsilon_{F}}{\partial T_{10}}|^2 * \sigma^2_{T_{10}} + | \frac{\partial \epsilon_{F}}{\partial T_{01}}|^2 * \sigma^2_{T_{01}}}
+   P_{F_{A}} = \frac{(\frac{T_{11} - T_{01}}{T_{11} + T_{01}})}{(\frac{T_{00} - T_{10}}{T_{00} + T_{10}})}
 
-Where:
-
-.. math::
-
-   \frac{\partial \epsilon_{F}}{\partial T_{11}} = \frac{T_{10} * (T_{00} + T_{01})}{(T_{11} + T_{10})^2 * (T_{00} - T_{01})}
+And the efficiency is calculated from the polarization as :
 
 .. math::
 
-   \frac{\partial \epsilon_{F}}{\partial T_{00}} = \frac{T_{01} * (T_{10} - T_{11})}{(T_{11} + T_{10}) * (T_{00} - T_{01})^2}
+   \epsilon_{F} = \frac{1 + P_{F}}{2}
+
+The errors are calculated with error propagation from the partial derivatives with respect ot the transmission amplitudes:
 
 .. math::
 
-   \frac{\partial \epsilon_{F}}{\partial T_{10}} = \frac{-T_{11} * (T_{00} + T_{01})}{(T_{11} + T_{10})^2 * (T_{00} - T_{01})}
+       \sigma_{\epsilon_{F}} = \sqrt{\sum_{i,j=0,1} \left( \frac{\partial{\epsilon_{F}}}{\partial{T_{ij}}} \right)^{2} \,  \sigma_{i,j}^2 }
 
-.. math::
-
-   \frac{\partial \epsilon_{F}}{\partial T_{01}} = \frac{T_{00} * (T_{11} - T_{10})}{(T_{11} + T_{10}) * (T_{00} - T_{01})^2}
 
 Outputs
 =======

--- a/docs/source/release/v6.14.0/SANS/New_features/37293.rst
+++ b/docs/source/release/v6.14.0/SANS/New_features/37293.rst
@@ -1,0 +1,1 @@
+- Add the option to calculate the efficiency for an analyzer flipper in :ref:`algm-FlipperEfficiency`.

--- a/docs/source/release/v6.14.0/SANS/New_features/37293.rst
+++ b/docs/source/release/v6.14.0/SANS/New_features/37293.rst
@@ -1,1 +1,0 @@
-- Add the option to calculate the efficiency for an analyzer flipper in :ref:`algm-FlipperEfficiency`.

--- a/docs/source/release/v6.15.0/SANS/New_features/37293.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/37293.rst
@@ -1,0 +1,1 @@
+- Add the option to calculate the efficiency for an analyzer flipper in :ref:`algm-FlipperEfficiency` and in :ref:`algm-SANSISISPolarizationCorrections`.

--- a/docs/source/release/v6.15.0/SANS/New_features/40208.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/40208.rst
@@ -1,0 +1,1 @@
+- Disable line edits for not needed runs on either calibration or correction for the algorithm dialog of :ref:`algm-SANSISISPolarizationCorrections`.


### PR DESCRIPTION
### Description of work
Ditto. 
The equation for the flipper analyzer is very similar to the flipper polarizer, just changing the cross terms (01->10, 10->01), I have refactor a bit the `FlipperEfficiency` algorithm to accomodate this and the choice for which flipper to use in the algorithm is accessed through a `StringListValidator` with the choices `[Polarizer, Analyzer]`. 
For completion, it is possible to calculate the efficiency of the second flipper in the SANSISISPolarizationCorrections algorithm if the `SecondFlipperEfficiency` checkbox is ticked on.
I have absorbed #40208 into this one, as it is a very minimal change. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #37293 
Closes #40208

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Build docs, and check new algorithm description is clear and release notes are well formatted. 
- Build this branch
- Try test example in the docs, changing to `Analyzer`
- To test #40208, open `SANSISISPolarizationCorrections` in the algorithm dialog from mantid workbench. When correction mode `Calibration` is selected, the property `ScatteringRuns` should be greyed out, when `Correction` mode is selected, the properties `Transmissionruns`, `DirectBeamRun` and `DepolarizedCellRun` should be greyed out. NOTHING should be greyed out when selecting `CalibrationAndCorrection` mode.
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
