### PR TITLE
Add links to git tags and the wiki-hosted release notes

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -14,66 +14,66 @@ Release Notes
 .. plot:: release/versions.py
 
 * v6.15.0 - in progress - :doc:`release notes <v6.15.0/index>`
-* v6.14.0 - 2025-10-23 - :doc:`release notes <v6.14.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.14.0>`_
-* v6.14.0 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`_
-* v6.13.0 - 2025-07-07 - :doc:`release notes <v6.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.0>`_
-* v6.12.0 - 2025-02-26 - :doc:`release notes <v6.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.12.0>`_
-* v6.11.0 - 2024-10-24 - :doc:`release notes <v6.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.11.0>`_
-* v6.10.0 - 2024-06-27 - :doc:`release notes <v6.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.10.0>`_
-* v6.9.1 - 2024-03-26 - :doc:`release notes <v6.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.1>`_
-* v6.9.0 - 2024-03-23 - :doc:`release notes <v6.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.0>`_
-* v6.8.0 - 2023-10-12 - :doc:`release notes <v6.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.8.0>`_
-* v6.7.0 - 2023-06-27 - :doc:`release notes <v6.7.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.7.0>`_
-* v6.6.0 - 2023-02-21 - :doc:`release notes <v6.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.6.0>`_
-* v6.5.0 - 2022-10-19 - :doc:`release notes <v6.5.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.5.0>`_
-* v6.4.0 - 2022-06-21 - :doc:`release notes <v6.4.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.4.0>`_
-* v6.3.0 - 2022-02-08 - :doc:`release notes <v6.3.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.3.0>`_
-* v6.2.0 - 2021-09-29 - :doc:`release notes <v6.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.2.0>`_
-* v6.1.0 - 2021-06-03 - :doc:`release notes <v6.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.1.0>`_
-* v6.0.0 - 2021-02-11 - :doc:`release notes <v6.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.0.0>`_ - remove mantidplot
-* v5.1.1 - 2020-10-23 - :doc:`release notes <v5.1.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.1>`_
-* v5.1.0 - 2020-09-29 - :doc:`release notes <v5.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.0>`_
-* v5.0.0 - 2020-03-16 - :doc:`release notes <v5.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.0.0>`_ - python 3
-* v4.2.0 - 2019-11-20 - :doc:`release notes <v4.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.2.0>`_
-* v4.1.0 - 2019-07-30 - :doc:`release notes <v4.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.1.0>`_
-* v4.0.0 - 2019-03-25 - :doc:`release notes <v4.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.0.0>`_ - introduce mantidworkbench
-* v3.13.0 - 2018-07-25 - :doc:`release notes <v3.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.13.0>`_
-* v3.12.1 - 2018-04-23 - :doc:`release notes <v3.12.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.1>`_
-* v3.12.0 - 2018-03-20 - :doc:`release notes <v3.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.0>`_
-* v3.11.0 - 2017-10-11 - :doc:`release notes <v3.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.11.0>`_
-* v3.10.1 - 2017-07-24 - :doc:`release notes <v3.10.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.1>`_
-* v3.10.0 - 2017-06-09 - :doc:`release notes <v3.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.0>`_
-* v3.9.2 - 2017-03-28 - :doc:`release notes <v3.9.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.2>`_
-* v3.9.1 - 2017-03-01 - :doc:`release notes <v3.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.1>`_
-* v3.9.0 - 2017-02-13 - :doc:`release notes <v3.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.0>`_
-* v3.8.0 - 2016-10-11 - :doc:`release notes <v3.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.8.0>`_
-* v3.7.1 - 2016-06-06 - :doc:`release notes <v3.7.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.7.1>`_
-* v3.6.1 - 2016-03-31 - :doc:`release notes <v3.6.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.1>`_
-* v3.6.0 - 2016-02-15 - :doc:`release notes <v3.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.0>`_
-* v3.5.2 - 2016-03-31 :doc:`release notes <v3.5.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.2>`_
-* v3.5.1 - 2015-11-23 -`release notes <https://archive.mantidproject.org/Release_Notes_3.5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.1>`_
-* v3.5.0 - 2015-10-05 - `release notes <https://archive.mantidproject.org/Release_Notes_3-6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.0>`_
-* v3.4.1 - 2015-08-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.4.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.1>`_
-* v3.4.0 - 2015-05-18 - `release notes <https://archive.mantidproject.org/Release_Notes_3-5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.0>`_
-* v3.3.0 - 2015-01-19 - `release notes <https://archive.mantidproject.org/Release_Notes_3-4.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.3.0>`_
-* v3.2.1 - 2014-08-22 - `release notes <https://archive.mantidproject.org/Release_Notes_3.2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.1>`_
-* v3.2.0 - 2014-07-14 - `release notes <https://archive.mantidproject.org/Release_Notes_3-3.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.0>`_
-* v3.1.1 - 2014-02-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.1.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.1>`_
-* v3.1.0 - 2014-02-06 - `release notes <https://archive.mantidproject.org/Release_Notes_3-2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.0>`_
-* v3.0.0 - 2013-11-04 - `release notes <https://archive.mantidproject.org/Release_Notes_3.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.0.0>`_ - mantid python API v2
-* v2.6.1 - 2013-08-20 - `release notes <https://archive.mantidproject.org/Release_Notes_2.6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6.1>`_
-* v2.6.0 - 2013-08-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-7.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6>`_
-* v2.5.3 - 2013-07-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2.5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.3>`_
-* v2.5.0 - 2013-05-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2-6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.0>`_
-* v2.4.0 - 2013-02-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2-5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.4>`_
-* v2.3.2 - 2012-12-14 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3-2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.3.2>`_
-* v2.3.1 - 2012-11-21 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3.html>`_
-* v2.3.0 - 2012-11-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-4.html>`_
-* v2.2.0 - 2012-08-13 - `release notes <https://archive.mantidproject.org/Release_Notes_2-3.html>`_
-* v2.1.1 - 2012-06-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2.1.html>`_
-* v2.1.0 - 2012-05-04 - `release notes <https://archive.mantidproject.org/Release_Notes_2-2.html>`_
-* v2.0.2 - 2012-02-16 - `release notes <https://archive.mantidproject.org/Release_Notes_2.0.html>`_
-* v2.0.0 - 2012-02-03 - `release notes <https://archive.mantidproject.org/Release_Notes_2.html>`_ - first full release
+* v6.14.0 - 2025-10-23 - :doc:`release notes <v6.14.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.14.0>`__
+* v6.14.0 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`__
+* v6.13.0 - 2025-07-07 - :doc:`release notes <v6.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.0>`__
+* v6.12.0 - 2025-02-26 - :doc:`release notes <v6.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.12.0>`__
+* v6.11.0 - 2024-10-24 - :doc:`release notes <v6.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.11.0>`__
+* v6.10.0 - 2024-06-27 - :doc:`release notes <v6.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.10.0>`__
+* v6.9.1 - 2024-03-26 - :doc:`release notes <v6.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.1>`__
+* v6.9.0 - 2024-03-23 - :doc:`release notes <v6.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.0>`__
+* v6.8.0 - 2023-10-12 - :doc:`release notes <v6.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.8.0>`__
+* v6.7.0 - 2023-06-27 - :doc:`release notes <v6.7.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.7.0>`__
+* v6.6.0 - 2023-02-21 - :doc:`release notes <v6.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.6.0>`__
+* v6.5.0 - 2022-10-19 - :doc:`release notes <v6.5.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.5.0>`__
+* v6.4.0 - 2022-06-21 - :doc:`release notes <v6.4.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.4.0>`__
+* v6.3.0 - 2022-02-08 - :doc:`release notes <v6.3.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.3.0>`__
+* v6.2.0 - 2021-09-29 - :doc:`release notes <v6.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.2.0>`__
+* v6.1.0 - 2021-06-03 - :doc:`release notes <v6.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.1.0>`__
+* v6.0.0 - 2021-02-11 - :doc:`release notes <v6.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.0.0>`__ - remove mantidplot
+* v5.1.1 - 2020-10-23 - :doc:`release notes <v5.1.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.1>`__
+* v5.1.0 - 2020-09-29 - :doc:`release notes <v5.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.0>`__
+* v5.0.0 - 2020-03-16 - :doc:`release notes <v5.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.0.0>`__ - python 3
+* v4.2.0 - 2019-11-20 - :doc:`release notes <v4.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.2.0>`__
+* v4.1.0 - 2019-07-30 - :doc:`release notes <v4.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.1.0>`__
+* v4.0.0 - 2019-03-25 - :doc:`release notes <v4.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.0.0>`__ - introduce mantidworkbench
+* v3.13.0 - 2018-07-25 - :doc:`release notes <v3.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.13.0>`__
+* v3.12.1 - 2018-04-23 - :doc:`release notes <v3.12.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.1>`__
+* v3.12.0 - 2018-03-20 - :doc:`release notes <v3.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.0>`__
+* v3.11.0 - 2017-10-11 - :doc:`release notes <v3.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.11.0>`__
+* v3.10.1 - 2017-07-24 - :doc:`release notes <v3.10.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.1>`__
+* v3.10.0 - 2017-06-09 - :doc:`release notes <v3.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.0>`__
+* v3.9.2 - 2017-03-28 - :doc:`release notes <v3.9.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.2>`__
+* v3.9.1 - 2017-03-01 - :doc:`release notes <v3.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.1>`__
+* v3.9.0 - 2017-02-13 - :doc:`release notes <v3.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.0>`__
+* v3.8.0 - 2016-10-11 - :doc:`release notes <v3.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.8.0>`__
+* v3.7.1 - 2016-06-06 - :doc:`release notes <v3.7.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.7.1>`__
+* v3.6.1 - 2016-03-31 - :doc:`release notes <v3.6.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.1>`__
+* v3.6.0 - 2016-02-15 - :doc:`release notes <v3.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.0>`__
+* v3.5.2 - 2016-03-31 :doc:`release notes <v3.5.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.2>`__
+* v3.5.1 - 2015-11-23 -`release notes <https://archive.mantidproject.org/Release_Notes_3.5.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.1>`__
+* v3.5.0 - 2015-10-05 - `release notes <https://archive.mantidproject.org/Release_Notes_3-6.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.0>`__
+* v3.4.1 - 2015-08-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.4.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.1>`__
+* v3.4.0 - 2015-05-18 - `release notes <https://archive.mantidproject.org/Release_Notes_3-5.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.0>`__
+* v3.3.0 - 2015-01-19 - `release notes <https://archive.mantidproject.org/Release_Notes_3-4.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.3.0>`__
+* v3.2.1 - 2014-08-22 - `release notes <https://archive.mantidproject.org/Release_Notes_3.2.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.1>`__
+* v3.2.0 - 2014-07-14 - `release notes <https://archive.mantidproject.org/Release_Notes_3-3.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.0>`__
+* v3.1.1 - 2014-02-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.1.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.1>`__
+* v3.1.0 - 2014-02-06 - `release notes <https://archive.mantidproject.org/Release_Notes_3-2.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.0>`__
+* v3.0.0 - 2013-11-04 - `release notes <https://archive.mantidproject.org/Release_Notes_3.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.0.0>`__ - mantid python API v2
+* v2.6.1 - 2013-08-20 - `release notes <https://archive.mantidproject.org/Release_Notes_2.6.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6.1>`__
+* v2.6.0 - 2013-08-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-7.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6>`__
+* v2.5.3 - 2013-07-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2.5.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.3>`__
+* v2.5.0 - 2013-05-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2-6.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.0>`__
+* v2.4.0 - 2013-02-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2-5.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.4>`__
+* v2.3.2 - 2012-12-14 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3-2.html>`__ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.3.2>`__
+* v2.3.1 - 2012-11-21 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3.html>`__
+* v2.3.0 - 2012-11-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-4.html>`__
+* v2.2.0 - 2012-08-13 - `release notes <https://archive.mantidproject.org/Release_Notes_2-3.html>`__
+* v2.1.1 - 2012-06-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2.1.html>`__
+* v2.1.0 - 2012-05-04 - `release notes <https://archive.mantidproject.org/Release_Notes_2-2.html>`__
+* v2.0.2 - 2012-02-16 - `release notes <https://archive.mantidproject.org/Release_Notes_2.0.html>`__
+* v2.0.0 - 2012-02-03 - `release notes <https://archive.mantidproject.org/Release_Notes_2.html>`__ - first full release
 
 .. click on the links rather than think that they are wrong
 .. v2.5.4 - https://archive.mantidproject.org/Release_Notes_2-7.html - never released

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -11,45 +11,70 @@ Release Notes
 
    */index
 
-* :doc:`v6.15.0 <v6.15.0/index>`
-* :doc:`v6.14.0 <v6.14.0/index>`
-* :doc:`v6.13.1 <v6.13.1/index>`
-* :doc:`v6.13.0 <v6.13.0/index>`
-* :doc:`v6.12.0 <v6.12.0/index>`
-* :doc:`v6.11.0 <v6.11.0/index>`
-* :doc:`v6.10.0 <v6.10.0/index>`
-* :doc:`v6.9.1 <v6.9.1/index>`
-* :doc:`v6.9.0 <v6.9.0/index>`
-* :doc:`v6.8.0 <v6.8.0/index>`
-* :doc:`v6.7.0 <v6.7.0/index>`
-* :doc:`v6.6.0 <v6.6.0/index>`
-* :doc:`v6.5.0 <v6.5.0/index>`
-* :doc:`v6.4.0 <v6.4.0/index>`
-* :doc:`v6.3.0 <v6.3.0/index>`
-* :doc:`v6.2.0 <v6.2.0/index>`
-* :doc:`v6.1.0 <v6.1.0/index>`
-* :doc:`v6.0.0 <v6.0.0/index>`
-* :doc:`v5.1.1 <v5.1.1/index>`
-* :doc:`v5.1.0 <v5.1.0/index>`
-* :doc:`v5.0.0 <v5.0.0/index>`
-* :doc:`v4.2.0 <v4.2.0/index>`
-* :doc:`v4.1.0 <v4.1.0/index>`
-* :doc:`v4.0.0 <v4.0.0/index>`
-* :doc:`v3.13.0 <v3.13.0/index>`
-* :doc:`v3.12.1 <v3.12.1/index>`
-* :doc:`v3.12.0 <v3.12.0/index>`
-* :doc:`v3.11.0 <v3.11.0/index>`
-* :doc:`v3.10.1 <v3.10.1/index>`
-* :doc:`v3.10.0 <v3.10.0/index>`
-* :doc:`v3.9.2 <v3.9.2/index>`
-* :doc:`v3.9.1 <v3.9.1/index>`
-* :doc:`v3.9.0 <v3.9.0/index>`
-* :doc:`v3.8.0 <v3.8.0/index>`
-* :doc:`v3.7.1 <v3.7.1/index>`
-* :doc:`v3.6.1 <v3.6.1/index>`
-* :doc:`v3.6.0 <v3.6.0/index>`
-* :doc:`v3.5.2 <v3.5.2/index>`
+.. plot:: release/versions.py
 
+* v6.15.0 - in progress - :doc:`release notes <v6.15.0/index>`
+* v6.14.0 - 2025-10-23 - :doc:`release notes <v6.14.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.14.0>`_
+* v6.14.0 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`_
+* v6.13.0 - 2025-07-07 - :doc:`release notes <v6.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.0>`_
+* v6.12.0 - 2025-02-26 - :doc:`release notes <v6.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.12.0>`_
+* v6.11.0 - 2024-10-24 - :doc:`release notes <v6.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.11.0>`_
+* v6.10.0 - 2024-06-27 - :doc:`release notes <v6.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.10.0>`_
+* v6.9.1 - 2024-03-26 - :doc:`release notes <v6.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.1>`_
+* v6.9.0 - 2024-03-23 - :doc:`release notes <v6.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.9.0>`_
+* v6.8.0 - 2023-10-12 - :doc:`release notes <v6.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.8.0>`_
+* v6.7.0 - 2023-06-27 - :doc:`release notes <v6.7.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.7.0>`_
+* v6.6.0 - 2023-02-21 - :doc:`release notes <v6.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.6.0>`_
+* v6.5.0 - 2022-10-19 - :doc:`release notes <v6.5.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.5.0>`_
+* v6.4.0 - 2022-06-21 - :doc:`release notes <v6.4.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.4.0>`_
+* v6.3.0 - 2022-02-08 - :doc:`release notes <v6.3.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.3.0>`_
+* v6.2.0 - 2021-09-29 - :doc:`release notes <v6.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.2.0>`_
+* v6.1.0 - 2021-06-03 - :doc:`release notes <v6.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.1.0>`_
+* v6.0.0 - 2021-02-11 - :doc:`release notes <v6.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.0.0>`_ - remove mantidplot
+* v5.1.1 - 2020-10-23 - :doc:`release notes <v5.1.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.1>`_
+* v5.1.0 - 2020-09-29 - :doc:`release notes <v5.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.1.0>`_
+* v5.0.0 - 2020-03-16 - :doc:`release notes <v5.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v5.0.0>`_ - python 3
+* v4.2.0 - 2019-11-20 - :doc:`release notes <v4.2.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.2.0>`_
+* v4.1.0 - 2019-07-30 - :doc:`release notes <v4.1.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.1.0>`_
+* v4.0.0 - 2019-03-25 - :doc:`release notes <v4.0.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v4.0.0>`_ - introduce mantidworkbench
+* v3.13.0 - 2018-07-25 - :doc:`release notes <v3.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.13.0>`_
+* v3.12.1 - 2018-04-23 - :doc:`release notes <v3.12.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.1>`_
+* v3.12.0 - 2018-03-20 - :doc:`release notes <v3.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.12.0>`_
+* v3.11.0 - 2017-10-11 - :doc:`release notes <v3.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.11.0>`_
+* v3.10.1 - 2017-07-24 - :doc:`release notes <v3.10.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.1>`_
+* v3.10.0 - 2017-06-09 - :doc:`release notes <v3.10.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.10.0>`_
+* v3.9.2 - 2017-03-28 - :doc:`release notes <v3.9.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.2>`_
+* v3.9.1 - 2017-03-01 - :doc:`release notes <v3.9.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.1>`_
+* v3.9.0 - 2017-02-13 - :doc:`release notes <v3.9.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.9.0>`_
+* v3.8.0 - 2016-10-11 - :doc:`release notes <v3.8.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.8.0>`_
+* v3.7.1 - 2016-06-06 - :doc:`release notes <v3.7.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.7.1>`_
+* v3.6.1 - 2016-03-31 - :doc:`release notes <v3.6.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.1>`_
+* v3.6.0 - 2016-02-15 - :doc:`release notes <v3.6.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.6.0>`_
+* v3.5.2 - 2016-03-31 :doc:`release notes <v3.5.2/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.2>`_
+* v3.5.1 - 2015-11-23 -`release notes <https://archive.mantidproject.org/Release_Notes_3.5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.1>`_
+* v3.5.0 - 2015-10-05 - `release notes <https://archive.mantidproject.org/Release_Notes_3-6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.5.0>`_
+* v3.4.1 - 2015-08-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.4.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.1>`_
+* v3.4.0 - 2015-05-18 - `release notes <https://archive.mantidproject.org/Release_Notes_3-5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.4.0>`_
+* v3.3.0 - 2015-01-19 - `release notes <https://archive.mantidproject.org/Release_Notes_3-4.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.3.0>`_
+* v3.2.1 - 2014-08-22 - `release notes <https://archive.mantidproject.org/Release_Notes_3.2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.1>`_
+* v3.2.0 - 2014-07-14 - `release notes <https://archive.mantidproject.org/Release_Notes_3-3.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.2.0>`_
+* v3.1.1 - 2014-02-28 - `release notes <https://archive.mantidproject.org/Release_Notes_3.1.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.1>`_
+* v3.1.0 - 2014-02-06 - `release notes <https://archive.mantidproject.org/Release_Notes_3-2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.1.0>`_
+* v3.0.0 - 2013-11-04 - `release notes <https://archive.mantidproject.org/Release_Notes_3.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v3.0.0>`_ - mantid python API v2
+* v2.6.1 - 2013-08-20 - `release notes <https://archive.mantidproject.org/Release_Notes_2.6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6.1>`_
+* v2.6.0 - 2013-08-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-7.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.6>`_
+* v2.5.3 - 2013-07-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2.5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.3>`_
+* v2.5.0 - 2013-05-10 - `release notes <https://archive.mantidproject.org/Release_Notes_2-6.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.5.0>`_
+* v2.4.0 - 2013-02-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2-5.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.4>`_
+* v2.3.2 - 2012-12-14 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3-2.html>`_ - `github tag <https://github.com/mantidproject/mantid/releases/tag/v2.3.2>`_
+* v2.3.1 - 2012-11-21 - `release notes <https://archive.mantidproject.org/Release_Notes_2.3.html>`_
+* v2.3.0 - 2012-11-02 - `release notes <https://archive.mantidproject.org/Release_Notes_2-4.html>`_
+* v2.2.0 - 2012-08-13 - `release notes <https://archive.mantidproject.org/Release_Notes_2-3.html>`_
+* v2.1.1 - 2012-06-01 - `release notes <https://archive.mantidproject.org/Release_Notes_2.1.html>`_
+* v2.1.0 - 2012-05-04 - `release notes <https://archive.mantidproject.org/Release_Notes_2-2.html>`_
+* v2.0.2 - 2012-02-16 - `release notes <https://archive.mantidproject.org/Release_Notes_2.0.html>`_
+* v2.0.0 - 2012-02-03 - `release notes <https://archive.mantidproject.org/Release_Notes_2.html>`_ - first full release
 
-For release notes prior to version 3.5.2 please see the
-`wiki archive <http://archive.mantidproject.org/Category:Release_Notes>`_.
+.. click on the links rather than think that they are wrong
+.. v2.5.4 - https://archive.mantidproject.org/Release_Notes_2-7.html - never released
+.. historical index of release notes in wiki archive http://archive.mantidproject.org/Category:Release_Notes

--- a/docs/source/release/versions.py
+++ b/docs/source/release/versions.py
@@ -1,0 +1,40 @@
+from datetime import date
+import matplotlib.pyplot as plt
+import re
+
+# data index is next to this file and contains all releases
+release_index = "index.rst"
+
+version_date_regexp = re.compile(r".+v(\d+\.\d+\.\d+).+(\d\d\d\d-\d\d-\d\d).+")
+
+# read all of the releases from index.rst
+versions = []
+dates = []
+with open(release_index, mode="r") as handle:
+    for line in handle:
+        line = line.strip()
+        if line:
+            match = version_date_regexp.match(line)
+            if match:
+                version, datestamp = match.groups()
+                dates.append(date.fromisoformat(datestamp))
+
+                major, minor = version.split(".")[:2]  # only major.minor
+
+                versions.append(float(f"{major}.{int(minor):02d}"))
+
+# set date-time for fist commit 44dd034194867159c37ee89c8d4087ed356361d8
+datestamp_first_commit = date.fromisoformat("2007-04-04")
+
+# plot in xkcd style - only this plot
+with plt.xkcd():
+    fig, ax = plt.subplots()
+    ax.scatter(dates, versions)
+    ax.plot((datestamp_first_commit, dates[-1]), (1, 1), linewidth=5)
+    ax.tick_params("x", rotation=90)
+    ax.set_xlabel("year")
+    ax.set_ylabel("mantid version")
+    ax.annotate("iterations", (datestamp_first_commit, 1.25))
+    print(dir(fig))
+    fig.tight_layout()
+    plt.show()


### PR DESCRIPTION
Add a bunch of links and dates to the index of release notes. This does include linking to the archive of the wiki site for releases back to v2.0.0.

There is no associated issue and doesn't get release notes because it is improving the release notes.

### To test:

1. `cmake -DDOCS_PLOTDIRECTIVE=on .` in your build tree
2. `ninja docs-html`
3. look at the locally built `docs/html/release/index.html` in your browser
4. (optional) be amazed

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
