### PR TITLE
Make use of a new mantid-test Anaconda channel

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
             }
           }
           agent { label 'linux-64' }
-          options { timestamps () }
+          options { timestamps() }
           steps {
             checkoutSource("${GIT_SHA}")
             build_and_test('linux-64')
@@ -185,7 +185,7 @@ pipeline {
             }
           }
           agent { label 'win-64' }
-          options { timestamps () }
+          options { timestamps() }
           steps {
             checkoutSource("${GIT_SHA}")
             build_and_test('win-64')
@@ -209,7 +209,7 @@ pipeline {
             }
           }
           agent { label 'osx-arm64' }
-          options { timestamps () }
+          options { timestamps() }
           steps {
             checkoutSource("${GIT_SHA}")
             build_and_test('osx-arm64')
@@ -231,7 +231,7 @@ pipeline {
           }
           agent { label 'linux-64' }
           options {
-              timestamps ()
+              timestamps()
               retry(3)
           }
           steps {
@@ -264,7 +264,7 @@ pipeline {
           }
           agent { label 'win-64' }
           options {
-              timestamps ()
+              timestamps()
               retry(3)
           }
           steps {
@@ -296,7 +296,7 @@ pipeline {
           }
           agent { label 'osx-arm64' }
           options {
-              timestamps ()
+              timestamps()
               retry(3)
           }
           steps {
@@ -380,7 +380,7 @@ pipeline {
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options {
-        timestamps ()
+        timestamps()
         retry(3)
       }
       steps {
@@ -418,7 +418,7 @@ pipeline {
         }
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
-      options { timestamps () }
+      options { timestamps() }
       steps {
         def channel = params.ANACONDA_CHANNEL.trim()
         def credId = anacondaChannelToCredId(channel)
@@ -442,7 +442,7 @@ pipeline {
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options {
-        timestamps ()
+        timestamps()
         retry(3)
       }
       environment {
@@ -476,7 +476,7 @@ pipeline {
     stage ('Keep latest successful build') {
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options {
-        timestamps ()
+        timestamps()
       }
       steps {
         script {
@@ -689,7 +689,7 @@ def archive_test_logs(){
 
 def archive_env_logs(platform) {
   def env_log_dir = "**/env_logs/${platform}"
-  archiveArtifacts artifacts: env_log_dir += "/**/*.txt",
+  archiveArtifacts artifacts: "${env_log_dir}/**/*.txt",
     allowEmptyArchive: false,
     fingerprint: true,
     onlyIfSuccessful: false

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -420,13 +420,15 @@ pipeline {
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options { timestamps() }
       steps {
-        def channel = params.ANACONDA_CHANNEL.trim()
-        def credId = anacondaChannelToCredId(channel)
+        script {
+          def channel = params.ANACONDA_CHANNEL.trim()
+          def credId = anacondaChannelToCredId(channel)
 
-        withCredentials([string(credentialsId: credId, variable: 'ANACONDA_TOKEN')]) {
-          checkoutSource("${GIT_SHA}")
-          sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
-            "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench mantid-developer"
+          withCredentials([string(credentialsId: credId, variable: 'ANACONDA_TOKEN')]) {
+            checkoutSource("${GIT_SHA}")
+            sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
+              "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench mantid-developer"
+          }
         }
       }
     }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -2,7 +2,6 @@
 // GITHUB_USER_NAME - The name of the user, being used with pushing/pulling from git
 // GITHUB_USER_EMAIL - The email of the user, being used with pushing/pulling from git
 // GITHUB_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for pushing to the mantid repo
-// ANACONDA_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for publishing conda packages
 
 import groovy.transform.Field
 
@@ -13,7 +12,7 @@ def publishPackages = (gitBranch == "${BRANCH_TO_PUBLISH}")
 
 // Determine default values of parameters. Some are based on the branch.
 def defaults = [
-  anacondaChannel : 'mantid',
+  anacondaChannelChoices : ['mantid-test'],
   githubReleasesRepo: 'mantidproject/mantid',
   platformChoices : ['none', 'all', 'linux-64', 'win-64', 'osx-arm64'],
   publishToAnaconda : publishPackages,
@@ -29,12 +28,29 @@ def defaults = [
 // pipeline parameters because it's only switched off for ornl-next anaconda publishing.
 @Field Boolean buildMantiddocs = true
 
+// Map Anaconda channel name to the Jenkins credential ID for the channel token.
+def anacondaChannelToCredId(channel) {
+    def map = [
+      'mantid'      : 'anaconda-cloud-token',
+      'mantid-ornl' : 'anaconda-token-ornl',
+      'mantid-test' : 'anaconda-token-mantid-test'
+    ]
+    def id = map[channel]
+    if (!id) {
+      error("No Jenkins credential configured for Anaconda channel '${channel}'. " +
+            "Please add it to the map in the Jenkinsfile and create the appropriate credential.")
+    }
+    return id
+}
+
 // Restrict the parameter choices for certain named branches.
 switch(gitBranch) {
   case ['main', 'release-next']:
     defaults.packageSuffix = 'Nightly'
     defaults.anacondaLabel = 'nightly'
     defaults.platformChoices = ['all']
+    // The mantid channel is reserved only for main and release-next branches.
+    defaults.anacondaChannelChoices = ['mantid', 'mantid-test']
     break
   case ['ornl-next', 'ornl-qa', 'ornl']:
     defaults.packageSuffix = 'Nightly'
@@ -42,7 +58,7 @@ switch(gitBranch) {
     defaults.platformChoices = ['linux-64']
     defaults.publishToGithub = false
     defaults.publishToAnaconda = true
-    defaults.anacondaChannel = 'mantid-ornl'
+    defaults.anacondaChannelChoices = ['mantid-ornl', 'mantid-test']
     buildMantiddocs = false
     break
 }
@@ -68,8 +84,8 @@ pipeline {
                  description: 'If true, publish the packages to the specified Anaconda channel')
     booleanParam(name: 'PUBLISH_TO_GITHUB', defaultValue: defaults.publishToGithub,
                  description: 'If true, publish the packages to GitHub')
-    string(name: 'ANACONDA_CHANNEL', defaultValue: defaults.anacondaChannel,
-           description: 'The Anaconda channel to accept the package')
+    choice(name: 'ANACONDA_CHANNEL', choices: defaults.anacondaChannelChoices,
+           description: 'The Anaconda channel where the packages will be published')
     string(name: 'ANACONDA_CHANNEL_LABEL', defaultValue: defaults.anacondaLabel,
            description: 'The label attached to package in the Anaconda channel')
     string(name: 'GITHUB_RELEASES_REPO', defaultValue: defaults.githubReleasesRepo,
@@ -99,6 +115,9 @@ pipeline {
             if(!params.ANACONDA_CHANNEL?.trim()) {
               error("You must specify an Anaconda channel to publish packages.")
             }
+            // Verify that the channel has an associated token.
+            // This will throw an error and exit the pipeline if no token exists in the map.
+            anacondaChannelToCredId(params.ANACONDA_CHANNEL.trim())
           }
         }
       }
@@ -364,22 +383,28 @@ pipeline {
         timestamps ()
         retry(3)
       }
-      environment {
-        ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
-      }
       steps {
-        checkoutSource("${GIT_SHA}")
-        // Conda first
-        sh 'rm -fr ${WORKSPACE}/conda-packages'
-        copyArtifacts filter: '**/conda-bld/**/*.conda',
-          fingerprintArtifacts: true,
-          projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}'),
-          target: 'conda-packages',
-          flatten: true
-        // Single quotes are required for token variables to avoid them leaking
-        sh "${CISCRIPT_DIR}/publish-to-anaconda ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
-          "${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.conda"
+        script {
+          def channel = params.ANACONDA_CHANNEL.trim()
+          def credId = anacondaChannelToCredId(channel)
+
+          withCredentials([string(credentialsId: credId, variable: 'ANACONDA_TOKEN')]) {
+            checkoutSource("${GIT_SHA}")
+
+            // Remove any old package left over from previous jobs.
+            sh 'rm -fr ${WORKSPACE}/conda-packages'
+            copyArtifacts filter: '**/conda-bld/**/*.conda',
+              fingerprintArtifacts: true,
+              projectName: '${JOB_NAME}',
+              selector: specific('${BUILD_NUMBER}'),
+              target: 'conda-packages',
+              flatten: true
+
+            // Single quotes are required for token variables to avoid them leaking
+            sh "${CISCRIPT_DIR}/publish-to-anaconda ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
+              "${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.conda"
+          }
+        }
       }
     }
 
@@ -394,11 +419,15 @@ pipeline {
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options { timestamps () }
-      environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
       steps {
-        checkoutSource("${GIT_SHA}")
-        sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
-          "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench mantid-developer"
+        def channel = params.ANACONDA_CHANNEL.trim()
+        def credId = anacondaChannelToCredId(channel)
+
+        withCredentials([string(credentialsId: credId, variable: 'ANACONDA_TOKEN')]) {
+          checkoutSource("${GIT_SHA}")
+          sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
+            "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench mantid-developer"
+        }
       }
     }
 

--- a/dev-docs/source/AutomatedBuildProcess.rst
+++ b/dev-docs/source/AutomatedBuildProcess.rst
@@ -55,7 +55,7 @@ The nightly pipelines are Jenkins jobs responsible for building Mantid packages
 and deploying them to the Mantid conda channel. They build both nightly and release versions.
 You can find them on `this page <https://builds.mantidproject.org/view/Nightly%20Pipelines/>`_.
 
-The `build_packages_from_branch <https://builds.mantidproject.org/view/Nightly%20Pipelines/>`_
+The `build_branch <https://builds.mantidproject.org/job/build_branch/>`_ pipeline
 is a Jenkins job based on these nightly jobs that allows you to manually build packages
 from an upstream branch in the Mantid repository. For the full guide on how to use the
 job, please follow `this link <https://developer.mantidproject.org/Packaging.html#build-packages-from-branch-using-jenkins>`_.

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -212,7 +212,7 @@ It is advised to take the target node offline.
     // Example: "isis-ndw1597"
     String agentName = <agent/node name>
 
-    // Example: "pull_requests-conda-windows" , "build_packages_from_branch"
+    // Example: "pull_requests-conda-windows" , "build_branch"
     jobs = [<job 1 string> , <job 2 string>, ...]
 
     nodes = Jenkins.instance.slaves

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -128,49 +128,49 @@ Build packages from branch using Jenkins
 
 Developers can build packages to test branches using the ``build_branch`` `Jenkins job <build_branch_job_>`_. This job provides the ability to,
 
-- Run system tests on Windows, Mac, Linux, or all three.
-- Build a packages on Windows, Mac, Linux, or all three.
-- Publish the package(s) to a given Anaconda channel and label.
-- Publish the package(s) to a given Github repository under a specified tag.
+- Run system tests on Windows, Mac, Linux, or all three
+- Build a packages on Windows, Mac, Linux, or all three
+- Publish the package(s) to the ``mantid-test`` Anaconda channel
+- Publish the package(s) to a given Github repository under a specified tag
 
 for a given branch of mantid. The branch can be from the main mantid repo or from a remote.
 
 Options
 #######
 
+- ``DESCRIPTION``: A description to help catalogue the build. Please make use of this!
 - ``BUILD_DEVEL`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-arm64``]: Run the system tests for this OS.
 - ``BUILD_PACKAGE`` [``none``, ``all``, ``linux-64``, ``win-64``, ``osx-arm64``]: Build a package on this OS.
 - ``PACKAGE_SUFFIX``: String to append onto the standalone package name, useful for distinguishing builds. By default this is ``Unstable``.
 - ``PUBLISH_TO_ANACONDA``: Set true to publish to the given Anaconda channel and label.
 - ``PUBLISH_TO_GITHUB``: Set true to publish to the Github repository using the specified tag.
-- ``ANACONDA_CHANNEL``: Anaconda channel to upload the package to. By default this is ``mantid``.
-- ``ANACONDA_CHANNEL_LABEL``: Label attached to the uploaded package. By default this is ``unstable``.
+- ``ANACONDA_CHANNEL``: Anaconda channel to upload the package to. For this job the only option is ``mantid-test``.
+- ``ANACONDA_CHANNEL_LABEL``: Label attached to the uploaded package. By default this is ``unstable``. Please give it a meaningful label.
 - ``GITHUB_RELEASES_REPO``: Repository to store the release. By Default this is ``mantidproject/mantid``.
 - ``GITHUB_RELEASES_TAG``: Name of the tag for the release; only to be used for release candidate builds.
-- ``ANACONDA_TOKEN_CREDENTIAL_ID`` [``anaconda-cloud-token``, ``anaconda-token-ornl``]: One of two credentials to use for publishing to Anaconda.
 - ``GH_ORGANIZATION_OR_USERNAME``: Name of the organisation or Github user name who owns the repository with the code to build. By default this is ``mantidproject``, if you are building from a fork this will need to change to your username.
 - ``BRANCH_NAME``: Name of the branch to build the packages from.
 
 Example
 #######
 
-Say I've implemented a new file searching method on a branch ``1234_new_file_search`` and I want to test this on IDAaaS, one of the easiest ways to do this would be to build the packages and upload them to Anaconda using the pipeline. These are the steps I'd take to do this.
+Say I've implemented a new file searching method on a branch ``1234_new_file_search`` and I want to test this on IDAaaS, one of the easiest ways to do this would be to build the packages and upload them to Anaconda using the pipeline. These are the steps I'd take to do this:
 
 1. Go to the ``build_branch`` `Jenkins job <build_branch_job_>`_.
 2. If needed click ``login`` in the top right of the window.
 3. Go to ``Build with parameters`` in the side bar.
 4. Fill out the following options:
 
+   - ``DESCRIPTION`` = ``Upload Linux test packages for new file searching method``
    - ``BUILD_DEVEL`` = ``none``
    - ``BUILD_PACKAGE`` = ``linux-64``
    - ``PUBLISH_TO_ANACONDA`` = true
-   - ``ANACONDA_CHANNEL_LABEL`` = ``new_file_system_test``
-   - ``ANACONDA_TOKEN_CREDENTIAL_ID`` = ``anaconda-cloud-token``
+   - ``ANACONDA_CHANNEL_LABEL`` = ``new_file_search_test``
    - ``BRANCH_NAME`` = ``1234_new_file_search``
 
 5. Click ``Build``. This will take you back to the main job page, the build just set off will be the most recent (highest number) build on the left hand side. It is a good idea to make note of the build number / copy the link somewhere safe. If the build is for testing a pr, make sure to add the link to the testing instructions.
 6. Once the job has successfully completed, check `the Mantid Anaconda page <mantid-conda-org_>`_ to make sure it has uploaded.
-7. Head to IDAaaS (or any linux system) and run ``mamba install -c mantid/label/new_file_system_test mantidworkbench`` in a new environment to install the test package.
+7. Head to IDAaaS (or any linux system) and run ``mamba install -c mantid-test/label/new_file_search_test mantidworkbench`` in a new environment to install the test package.
 
 Most often, you won't need to upload the packages to Anaconda, this is most useful in cases where installing standalone packages is inconvenient. Standalone package builds created by the jenkins job can be found under the jenkins job build artifacts, this is near the top of the page. Say you built a package for Windows using the jenkins job, you should find a ``mantidworkbench`` exe file in the build artifacts.
 

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -126,7 +126,7 @@ by the CI pipeline to indicate it has been built outside of the standard process
 Build packages from branch using Jenkins
 ----------------------------------------
 
-Developers can build packages to test branches using the ``build_packages_from_branch`` `Jenkins job <build_packages_from_branch_job_>`_. This job provides the ability to,
+Developers can build packages to test branches using the ``build_branch`` `Jenkins job <build_branch_job_>`_. This job provides the ability to,
 
 - Run system tests on Windows, Mac, Linux, or all three.
 - Build a packages on Windows, Mac, Linux, or all three.
@@ -156,7 +156,7 @@ Example
 
 Say I've implemented a new file searching method on a branch ``1234_new_file_search`` and I want to test this on IDAaaS, one of the easiest ways to do this would be to build the packages and upload them to Anaconda using the pipeline. These are the steps I'd take to do this.
 
-1. Go to the ``build_packages_from_branch`` `Jenkins job <build_packages_from_branch_job_>`_.
+1. Go to the ``build_branch`` `Jenkins job <build_branch_job_>`_.
 2. If needed click ``login`` in the top right of the window.
 3. Go to ``Build with parameters`` in the side bar.
 4. Fill out the following options:
@@ -252,4 +252,4 @@ Generally a listing of the contents is what is desired
 .. _download-page: https://download.mantidproject.org
 .. _nsis: https://sourceforge.net/projects/nsis/
 .. _dmg: https://en.wikipedia.org/wiki/Apple_Disk_Image
-.. _build_packages_from_branch_job: https://builds.mantidproject.org/job/build_packages_from_branch/
+.. _build_branch_job: https://builds.mantidproject.org/job/build_branch/

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -498,12 +498,13 @@ We are now ready to create the release candidates for Smoke testing.
   <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/>`__
   with the following parameters (most are already defaulted to the correct values):
 
+  * set ``DESCRIPTION`` to ``Smoke testing candidates vX.Y.ZrcN``
   * set ``BUILD_DEVEL`` to ``all``
   * set ``BUILD_PACKAGE`` to ``all``
   * set ``PACKAGE_SUFFIX`` to an **empty string**
   * tick the ``PUBLISH_TO_ANACONDA`` checkbox
   * tick the ``PUBLISH_TO_GITHUB`` checkbox
-  * set the ``ANACONDA_CHANNEL`` to ``mantid``
+  * set the ``ANACONDA_CHANNEL`` to ``mantid-test``
   * set the ``ANACONDA_CHANNEL_LABEL`` to ``vX.Y.ZrcN`` where ``X.Y.Z`` is the release number,
     and ``N`` is an incremental build number for release candidates, starting at ``1`` (e.g. ``v6.7.0rc1``)
   * set ``GITHUB_RELEASES_REPO`` to ``mantidproject/mantid``
@@ -530,6 +531,7 @@ now be recreated with their final version numbers. To do this, build the
 <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/>`__
 with the following parameters (most are already defaulted to the correct values):
 
+* set ``DESCRIPTION`` to ``Release build for vX.Y.Z``
 * set ``BUILD_DEVEL`` to ``all``
 * set ``BUILD_PACKAGE`` to ``all``
 * set ``PACKAGE_SUFFIX`` to an **empty string**


### PR DESCRIPTION
### Description of work
A new mantid-test channel has been created, which can be published to using the nightly deployment Jenkinsfile. It is intended to be used for two purposes:
1. For developers to publish to when using the [build_branch](https://builds.mantidproject.org/job/build_branch/) pipeline. This will avoid clogging up the `mantid` channel with test packages and help us stay under the allowed storage limit.
2. For uploading the smoke testing packages for release testing.
Both the above use cases will also avoid the need to manually delete packages from the main `mantid` channel, which is too prone to user error (e.g. one can easily delete production packages by mistake). Developer documentation has been updated accordingly.

Below is a summary of how the new mechanism works.
- The `ANACONDA_CHANNEL` Jenkins pipeline parameter is now a choice parameter. It used to be a string parameter. A choice parameter makes more sense since we only store a limited number of credentials in Jenkins, so anything outside of the available choices will not work.
- The `mantid` channel is only available as a choice if the branch name is `main` or `release-next`.
- The `mantid-test` channel is available for all branch names.
- The `mantid-ornl` channel is available for only `ornl` branches.
- Channel names and credential IDs are mapped within the jenkinsfile, so the correct credentials are used for each channel.


Closes #40017

### To test:
The following Jenkins job was set to publish to the new mantid-test channel (look a the parameter values set in the job):
https://builds.mantidproject.org/job/Core_Team_test_pipeline/416/
You can verify that it did upload to the correct label by visiting the channel:
https://anaconda.org/mantid-test/repo/files?label=tom-test-one


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
