### PR TITLE
Fix some cppcheck issues that start with "useless"

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h
@@ -60,8 +60,6 @@ public:
   UserFunction1D() : m_x(0.0), m_x_set(false), m_parameters(100), m_nPars(0) {};
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "UserFunction1D"; }
-  /// Algorithm's version for identification overriding a virtual method
-  int version() const override { return (1); }
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "Optimization\\FitAlgorithms"; }
   /// Summary of algorithms purpose

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -542,9 +542,8 @@ void LoadFITS::parseHeader(FITSInfo &headerInfo) {
 
         // Comments on header entries are added after the value separated by a /
         // symbol. Exclude those comments.
-        auto slashPos = value.find('/');
-        if (slashPos > 0)
-          value = value.substr(0, slashPos);
+        if (auto pos = value.find('/'); pos != std::string::npos && pos > 0)
+          value.erase(pos);
 
         boost::trim(key);
         boost::trim(value);

--- a/Framework/DataHandling/src/SaveFocusedXYE.cpp
+++ b/Framework/DataHandling/src/SaveFocusedXYE.cpp
@@ -70,7 +70,7 @@ void SaveFocusedXYE::exec() {
     if (pos != std::string::npos) // Remove the extension
     {
       ext = filename.substr(pos + 1, filename.npos);
-      filename = filename.substr(0, pos);
+      filename.erase(pos);
     }
 
     filepath = Poco::Path(directory, filename).toString();

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -213,9 +213,6 @@ public:
 
   bool isEmptyInstrument() const;
 
-  /// Add a component to the instrument
-  virtual int add(IComponent *component) override;
-
   void parseTreeAndCacheBeamline();
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
   makeBeamline(ParameterMap &pmap, const ParameterMap *source = nullptr) const;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -626,8 +626,8 @@ void Instrument::markAsDetector(const IDetector *det) {
   if ((it != m_detectorCache.end()) && (std::get<0>(*it) == det->getID())) {
     raiseDuplicateDetectorError(det->getID());
   }
-  bool isMonitor = false;
-  m_detectorCache.emplace(it, det->getID(), det_sptr, isMonitor);
+  bool isMonitorFlag = false;
+  m_detectorCache.emplace(it, det->getID(), det_sptr, isMonitorFlag);
 }
 
 /// As markAsDetector but without the required sorting. Must call
@@ -639,8 +639,8 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
 
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  bool isMonitor = false;
-  m_detectorCache.emplace_back(det->getID(), det_sptr, isMonitor);
+  bool isMonitorFlag = false;
+  m_detectorCache.emplace_back(det->getID(), det_sptr, isMonitorFlag);
 }
 
 /// Sorts the detector cache. Called after all detectors have been marked via

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1158,11 +1158,6 @@ bool Instrument::isMonitorViaIndex(const size_t index) const {
 
 bool Instrument::isEmptyInstrument() const { return this->nelements() == 0; }
 
-int Instrument::add(IComponent *component) {
-  // invalidate cache
-  return CompAssembly::add(component);
-}
-
 /// Returns the index for a detector ID. Used for accessing DetectorInfo.
 size_t Instrument::detectorIndex(const detid_t detID) const {
   const auto &baseInstr = m_map ? *m_instr : *this;

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -44,10 +44,8 @@ public:
   // Unhide the base class assignment operator
   using PropertyWithValue<std::vector<T>>::operator=;
 
-  // cppcheck-suppress uselessOverride
   std::string value() const override;
 
-  // cppcheck-suppress uselessOverride
   std::string setValue(const std::string &value) override;
   // May want to add specialisation to the class later, e.g. setting just one
   // element of the vector

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -44,9 +44,11 @@ public:
   // Unhide the base class assignment operator
   using PropertyWithValue<std::vector<T>>::operator=;
 
-  std::string value() const override; // cppcheck-suppress uselessOverride
+  // cppcheck-suppress uselessOverride
+  std::string value() const override;
 
-  std::string setValue(const std::string &value) override; // cppcheck-suppress uselessOverride
+  // cppcheck-suppress uselessOverride
+  std::string setValue(const std::string &value) override;
   // May want to add specialisation to the class later, e.g. setting just one
   // element of the vector
 

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -44,9 +44,9 @@ public:
   // Unhide the base class assignment operator
   using PropertyWithValue<std::vector<T>>::operator=;
 
-  std::string value() const override;
+  std::string value() const override; // cppcheck-suppress uselessOverride
 
-  std::string setValue(const std::string &value) override;
+  std::string setValue(const std::string &value) override; // cppcheck-suppress uselessOverride
   // May want to add specialisation to the class later, e.g. setting just one
   // element of the vector
 

--- a/Framework/MDAlgorithms/src/UnaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/UnaryOperationMD.cpp
@@ -56,7 +56,7 @@ void UnaryOperationMD::exec() {
   if (std::dynamic_pointer_cast<MatrixWorkspace>(m_in)) {
     // Pass-through to the same function without "MD"
     std::string matrixAlg = this->name();
-    matrixAlg = matrixAlg.substr(0, matrixAlg.size() - 2);
+    matrixAlg.erase(matrixAlg.size() - 2);
     auto alg = createChildAlgorithm(matrixAlg);
     // Copy all properties from THIS to the non-MD version
     std::vector<Property *> props = this->getProperties();

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -279,7 +279,6 @@ useInitializationList:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScattererInCrystalStructure.h:36
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/CrystalStructure.h:76
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/UnitCell.h:212
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Instrument.h:217
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:96
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:112
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:128

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -188,7 +188,6 @@ containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:607
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h:64
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/Fit1D.cpp:379
 derefInvalidIteratorRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/ExcludeRangeFinder.cpp:77
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp:377

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -222,7 +222,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/RalNlls/T
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DefaultEventLoader.cpp:112
 constVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadAscii2.cpp:787
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadCalFile.cpp:57
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFITS.cpp:547
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadHFIRSANS.cpp:433
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:567
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:593

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -297,6 +297,8 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/Rend
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp:64
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheWriter.cpp:83
 invalidFunctionArgBool:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Surfaces/General.cpp:53
+uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ArrayProperty.h:47
+uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ArrayProperty.h:49
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:148
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:156
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigPropertyObserver.h:20

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -299,8 +299,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/Rend
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp:64
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheWriter.cpp:83
 invalidFunctionArgBool:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Surfaces/General.cpp:53
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ArrayProperty.h:47
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ArrayProperty.h:49
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:148
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:156
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigPropertyObserver.h:20

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -249,7 +249,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpice
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D.cpp:32
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D.cpp:397
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D2.cpp:24
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFocusedXYE.cpp:73
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFullprofResolution.cpp:177
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSS.cpp:432
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSS.cpp:566

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -294,8 +294,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/Index
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/ProductOfCyclicGroups.cpp:49
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/ScalarUtils.cpp:389
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/StructureFactorCalculatorSummation.cpp:55
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument.cpp:629
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument.cpp:642
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/CompAssembly.cpp:376
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/CompAssembly.cpp:405
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/ComponentInfo.cpp:129

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -370,7 +370,6 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/Replicate
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/ReplicateMD.cpp:151
 templateRecursion:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SliceMD.cpp:300
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/TransposeMD.cpp:83
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/UnaryOperationMD.cpp:59
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Muon/src/ConvertFitFunctionForMuonTFAsymmetry.cpp:60
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFile.h:193
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/GlobalInterpreterLock.cpp:24

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -365,9 +365,6 @@ nullPointerOutOfMemory:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ISIS/DAE/isisd
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ISIS/FakeISISHistoDAE.cpp:27
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ISIS/FakeISISHistoDAE.cpp:268
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp:527
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp:125
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp:283
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp:452
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:49
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:58
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/PreprocessDetectorsToMD.h:27


### PR DESCRIPTION
### Description of work

Fix some cppcheck issues that start with the word "useless" and remove the suppressions of the fixed issues.

This is part of the Mantid developer meeting code camp.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
