### PR TITLE
Update vscode debugging config in docs

### DIFF
--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -161,24 +161,22 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
 .. code-block:: javascript
 
     {
-      "name": "(gdb) Workbench C++ Only",
-      "type": "cppdbg",
-      "request": "launch",
-      "program": "/usr/bin/python3", // Path to your used Python interpreter, here and below
-      "args": ["Path/To/Build/Directory/bin/workbench", "--single-process", "&&","gdb","/usr/bin/python3","$!"], // $! gets the process ID
-      "stopAtEntry": false,
-      "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
-      "environment": [],
-      "externalConsole": true,
-      "MIMode": "gdb",
-      "preLaunchTask": "Build Mantid",
-      "setupCommands": [
-        {
-          "description": "Enable pretty-printing for gdb",
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        }
-      ]
+        "name": "(gdb) Workbench C++ Only",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "/Path/To/Mamba/Install/envs/mantid-developer/bin/python",   // Full path (do not use '~') to the python executable inside your build directory
+        "preLaunchTask": "Build Mantid",
+        "args": ["-m", "workbench", "--single-process"],
+        "MIMode": "gdb",
+        "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
+        "stopAtEntry": false,
+        "setupCommands": [
+            {
+            "description": "Enable pretty-printing for gdb",
+            "text": "-enable-pretty-printing",
+            "ignoreFailures": true
+            }
+        ]
     }
 
 The ``--single-process`` flag is necessary for debugging. See the :ref:`Running Workbench <RunningWorkbench>` documentation for more information.


### PR DESCRIPTION
### Description of work
In all honesty, this change is not required, since the previous vscode configuration was already working.
I've only simplified a little bit.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Copy and paste the configuration into your `launch.json` file in VS Code and check debugging in C++ is working.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
