### PR TITLE
Updated the range selector in the Inelastic Data Processing GUI (Moments tab) to place the vertical sliders at the integration limits

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/39444.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/39444.rst
@@ -1,1 +1,1 @@
-- The vertical sliders in the moments tab of the `Inelastic Data Processor` are moved to the edge to the integration limits when new data is loaded for visualization.
+- The vertical sliders in the ``Moments`` tab of the :ref:`interface-inelastic-data-processor` are moved to the edge to the integration limits when new data is loaded for visualization.

--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/39444.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/39444.rst
@@ -1,0 +1,1 @@
+- The vertical sliders in the moments tab of the `Inelastic Data Processor` are moved to the edge to the integration limits when new data is loaded for visualization.

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -157,20 +157,16 @@ void MomentsView::setPlotPropertyRange(const std::pair<double, double> &bounds) 
 void MomentsView::setRangeSelector(const std::pair<double, double> &bounds) {
   disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
-  double deltaX = abs(bounds.second - bounds.first);
-  double lowX = bounds.first + (0.1) * deltaX;
-  double highX = bounds.second - (0.1) * deltaX;
-
-  m_dblManager->setValue(m_properties["EMin"], lowX);
-  m_dblManager->setValue(m_properties["EMax"], highX);
+  m_dblManager->setValue(m_properties["EMin"], bounds.first);
+  m_dblManager->setValue(m_properties["EMax"], bounds.second);
 
   // connecting back so that the model is updated.
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
   auto xRangeSelector = getRangeSelector();
   xRangeSelector->setRange(bounds.first, bounds.second);
-  xRangeSelector->setMinimum(lowX);
-  xRangeSelector->setMaximum(highX);
+  xRangeSelector->setMinimum(bounds.first);
+  xRangeSelector->setMaximum(bounds.second);
 }
 
 /**


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39444 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
