### PR TITLE
Specify full exception handling support on Windows with msbuild

### DIFF
--- a/buildconfig/CMake/WindowsSetup.cmake
+++ b/buildconfig/CMake/WindowsSetup.cmake
@@ -32,7 +32,7 @@ add_definitions(-D_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} \
   /MP /W3 /bigobj \
-  /wd4251 /wd4275 /wd4373 \
+  /wd4251 /wd4275 /wd4373 /EHsc \
   /experimental:external /external:W0 "
 )
 # the warnings suppressed are:
@@ -45,6 +45,9 @@ set(CMAKE_CXX_FLAGS
 #
 # 4373 previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers.
 # This is basically saying that it now follows the C++ standard and doesn't seem useful
+#
+# /EHsc Full compiler support for the Standard C++ exception handling model
+# https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason Any other
 # value lower or higher seems to work but not the default. It is fine without this when compiling in the GUI though...


### PR DESCRIPTION
The `/EHsc` option specifies full compiler support for the Standard C++ exception handling model

Since switching to pixi, not specifying this option generates lots of warnings about exception handling, e.g.:

`warning C4530: C++ exception handler used, but unwind semantics are not enabled.`

https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170

From that link:

`Full compiler support for the Standard C++ exception handling model that safely unwinds stack objects requires /EHsc (recommended), /EHs, or /EHa.`

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
