### PR TITLE
Turn on refurb rules in ruff-static

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.4
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff-check

--- a/Framework/DataObjects/src/generate_mdevent_declarations.py
+++ b/Framework/DataObjects/src/generate_mdevent_declarations.py
@@ -183,8 +183,7 @@ def generate():
     lines += footer_lines + lines_after
 
     f = open("../inc/MantidDataObjects/MDEventFactory.h", "w")
-    for line in lines:
-        f.write(line + "\n")
+    f.writelines(line + "\n" for line in lines)
     f.close()
 
     padding, lines, lines_after = parse_file("./MDEventFactory.cpp", "//### BEGIN AUTO-GENERATED CODE", "//### END AUTO-GENERATED CODE")
@@ -210,13 +209,12 @@ def generate():
 
     lines += footer_lines + lines_after
     f = open("./MDEventFactory.cpp", "w")
-    for line in lines:
-        f.write(line + "\n")
+    f.writelines(line + "\n" for line in lines)
     f.close()
 
     # Post message about updating the id strings in the python layer to
     # understand the new structure
-    print("")
+    print()
     print("The available IDs on the templated MDEventWorkspace classes may have changed.")
     print("Please update the casting IDs in PythonInterface/mantid/api/IMDEventWorkspace accordingly")
 

--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -72,8 +72,7 @@ def get_plugin_paths_as_set(key):
     @returns A set containing defined plugins paths
     """
     s = set(config[key].split(PATH_SEPARATOR))
-    if "" in s:
-        s.remove("")
+    s.discard("")
     return s
 
 

--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -197,7 +197,7 @@ class HB2AReduce(PythonAlgorithm):
                 _target = "# def_x = 2theta"
                 for fn in filenames:
                     with open(fn) as f:
-                        if not any([_target in line for line in f.readlines()]):
+                        if not any([_target in line for line in f]):
                             issues["OutputFormat"] = f"{fn} can't be saved to GSAS due to missing header:\n{_target}"
                             break
         return issues
@@ -229,7 +229,7 @@ class HB2AReduce(PythonAlgorithm):
             if metadata is None:
                 # Read in metadata from first file only file
                 metadata = dict(
-                    [np.char.strip(re.split("#(.*?)=(.*)", line, flags=re.U)[1:3]) for line in lines if re.match("^#.*=", line)]
+                    [np.char.strip(re.split("#(.*?)=(.*)", line, flags=re.UNICODE)[1:3]) for line in lines if re.match("^#.*=", line)]
                 )
                 # Get indir and exp from first file
                 indir, data_filename = os.path.split(filename)

--- a/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
@@ -408,8 +408,7 @@ class LRScalingFactors(PythonAlgorithm):
         fd.write("# y=a+bx\n#\n")
         fd.write("# LambdaRequested[Angstroms] S1H[mm] (S2/Si)H[mm] S1W[mm] (S2/Si)W[mm] a b error_a error_b\n#\n")
 
-        for k, v in scaling_file_meta.items():
-            fd.write("%s\n" % v)
+        fd.writelines("%s\n" % v for k, v in scaling_file_meta.items())
         for item in scaling_file_content:
             fd.write("IncidentMedium=%s " % item["IncidentMedium"])
             fd.write("LambdaRequested=%s " % item["LambdaRequested"])

--- a/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn3Ascii.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn3Ascii.py
@@ -401,8 +401,7 @@ class LoadNMoldyn3Ascii(PythonAlgorithm):
         handle = open(path, "w")
         head = "spectrum,theta"
         handle.write(f"{head} \n")
-        for n in range(0, len(theta)):
-            handle.write(f"{n + 1}   {str(theta[n])}\n")
+        handle.writelines(f"{n + 1}   {str(theta[n])}\n" for n in range(0, len(theta)))
         handle.close()
         UpdateInstrumentFromFile(Workspace=workspace_name, Filename=path, MoveMonitors=False, IgnorePhi=False, AsciiHeader=head)
 

--- a/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
@@ -95,8 +95,7 @@ class MaskWorkspaceToCalFile(PythonAlgorithm):
                     detIDs = det.getDetectorIDs()
                 except AttributeError:
                     detIDs = [det.getID()]
-                for did in detIDs:
-                    calFile.write(self.FormatLine(i, did, 0.0, group, group))
+                calFile.writelines(self.FormatLine(i, did, 0.0, group, group) for did in detIDs)
             except RuntimeError:
                 # no detector for this spectra
                 pass

--- a/Framework/PythonInterface/plugins/algorithms/SaveINS.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveINS.py
@@ -146,8 +146,7 @@ class SaveINS(PythonAlgorithm):
             f_handle.write(f"LATT {latt_type}\n")
 
             # print sym operations
-            for sym_str in self._get_shelx_symmetry_operators(spgr, latt_type):
-                f_handle.write(f"SYMM {sym_str}\n")
+            f_handle.writelines(f"SYMM {sym_str}\n" for sym_str in self._get_shelx_symmetry_operators(spgr, latt_type))
 
             # print atom info
             f_handle.write("NEUT\n")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
@@ -790,8 +790,7 @@ class CalculateMonteCarloAbsorption(DataProcessorAlgorithm):
         handle = open(path, "w")
         head = "spectrum,theta"
         handle.write(head + " \n")
-        for n in range(0, len(theta)):
-            handle.write(str(n + 1) + "   " + str(theta[n]) + "\n")
+        handle.writelines(str(n + 1) + "   " + str(theta[n]) + "\n" for n in range(0, len(theta)))
         handle.close()
 
         update_alg = self.createChildAlgorithm("UpdateInstrumentFromFile", enableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -803,7 +803,7 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
         for sample in sample_runs:
             match = re.search(r"OSIRIS(\d+).", sample)
             if match:
-                number = match.groups()[0][2:] if match.groups()[0].startswith("00") else match.groups()[0]
+                number = match.groups()[0].removeprefix("00")
                 run_numbers = run_numbers + "," + number
             else:
                 return ""

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -861,8 +861,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
         handle = open(path, "w")
         head = "spectrum,theta"
         handle.write(head + " \n")
-        for n in range(0, len(theta)):
-            handle.write(str(n + 1) + "   " + str(theta[n]) + "\n")
+        handle.writelines(str(n + 1) + "   " + str(theta[n]) + "\n" for n in range(0, len(theta)))
         handle.close()
 
         update_alg = self.createChildAlgorithm("UpdateInstrumentFromFile", enableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
@@ -495,7 +495,7 @@ class SANSILLIntegration(PythonAlgorithm):
         pixel_width = instrument.getNumberParameter("x-pixel-size")[0] / 1000
         pixel_height = instrument.getNumberParameter("y-pixel-size")[0] / 1000
 
-        pixel_size = pixel_height if pixel_height >= pixel_width else pixel_width
+        pixel_size = max(pixel_height, pixel_width)
         binning_factor = self.getProperty("BinningFactor").value
         wavelength = 0.0  # for TOF mode there is no wavelength
         if run.hasProperty("wavelength"):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D4ILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D4ILLReductionTest.py
@@ -82,8 +82,7 @@ class D4ILLReductionTest(unittest.TestCase):
         bank_positions = np.linspace(0, 9, 9)
         calibration_file = "calibration.dat"
         with open(calibration_file, "w") as f:
-            for bank_no, bank_pos in enumerate(bank_positions):
-                f.write("{}\t{}\n".format(bank_no, bank_pos))
+            f.writelines("{}\t{}\n".format(bank_no, bank_pos) for bank_no, bank_pos in enumerate(bank_positions))
         output_ws = "calibrate_positions"
         D4ILLReduction(Run="387230", OutputWorkspace=output_ws, BankPositionOffsetsFile=calibration_file, ExportAscii=True)
         remove(calibration_file)  # clean up the temporary file

--- a/Testing/SystemTests/tests/framework/LRScalingFactorsTest.py
+++ b/Testing/SystemTests/tests/framework/LRScalingFactorsTest.py
@@ -45,7 +45,7 @@ class LRPrimaryFractionTest(systemtesting.MantidSystemTest):
         tolerances = [[0.1, 5e-6, 0.1, 3e-6], [0.1, 1e-5, 0.2, 2e-5]]
         filed = open(self.cfg_file, "r")
         item_number = 0
-        for line in filed.readlines():
+        for line in filed:
             if line.startswith("#"):
                 continue
             toks = line.split()

--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -181,7 +181,7 @@ def useFile(direc, filename):
 
     # list of banned files by regexp
     for regexp in BANNED_REGEXP:
-        if re.match(regexp, filename, re.I) is not None:
+        if re.match(regexp, filename, re.IGNORECASE) is not None:
             return False, filename
 
     filename = os.path.join(direc, filename)

--- a/buildconfig/doxygen_to_sip.py
+++ b/buildconfig/doxygen_to_sip.py
@@ -85,12 +85,9 @@ def doxygen_to_docstring(doxygen, method):
 
     for line in doxygen:
         line = line.strip()
-        if line.startswith("/**"):
-            line = line[3:]
-        if line.endswith("*/"):
-            line = line[:-2]
-        if line.startswith("*"):
-            line = line[1:]
+        line = line.removeprefix("/**")
+        line = line.removesuffix("*/")
+        line = line.removeprefix("*")
 
         # Add the 'Args:' line.
         if not args_started:

--- a/buildconfig/python_export_maker.py
+++ b/buildconfig/python_export_maker.py
@@ -120,7 +120,7 @@ void export_%(class)s()
         cppfile.write(cppcode % {"header": include, "namespace": namespace, "class": classname})
 
     print('Generated export file "%s"' % os.path.basename(exportfile))
-    print("")
+    print()
     print(
         "  ** Add this to the EXPORT_FILES variable in '%s'"
         % os.path.join(get_modulepath(get_frameworkdir(headerfile), get_submodule(headerfile)), "CMakeLists.txt")
@@ -155,7 +155,7 @@ if __name__ == '__main__':
     unittest.close()
 
     print('Generated unit test file "%s"' % os.path.basename(filename))
-    print("")
+    print()
     print("  ** Add this to the TEST_PY_FILES variable in '%s'" % os.path.join("PythonInterface", "CMakeLists.txt"))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 140
 # https://beta.ruff.rs/docs/rules/
-lint.select = ["C90", "E", "F", "RUF100", "W", "NPY201", "S"]
+lint.select = ["C90", "E", "F", "FURB", "RUF100", "W", "NPY201", "S"]
 lint.ignore = ["E722", # bare except https://docs.astral.sh/ruff/rules/bare-except/
 "S101", # using assert https://docs.astral.sh/ruff/rules/assert/
 "S110", # try-except-pass https://docs.astral.sh/ruff/rules/try-except-pass/

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -224,14 +224,14 @@ class FullInstrumentViewWindow(QMainWindow):
         def set_slider(callled_from_min):
             def wrapped():
                 try:
-                    min, max = float(min_edit.text()), float(max_edit.text())
+                    min_val, max_val = float(min_edit.text()), float(max_edit.text())
                 except ValueError:
                     return
                 if callled_from_min:
-                    min = min(min, max)
+                    min_val = min(min_val, max_val)
                 else:
-                    max = max(min, max)
-                slider.setValue((min, max))
+                    max_val = max(min_val, max_val)
+                slider.setValue((min_val, max_val))
                 presenter_callback()
                 return
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -228,9 +228,9 @@ class FullInstrumentViewWindow(QMainWindow):
                 except ValueError:
                     return
                 if callled_from_min:
-                    min = max if min > max else min
+                    min = min(min, max)
                 else:
-                    max = min if max < min else max
+                    max = max(min, max)
                 slider.setValue((min, max))
                 presenter_callback()
                 return

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -185,8 +185,7 @@ class HelpWindowModel:
             # Set final base URL based on online path and version string
             if self._version_string:
                 base_online = self._raw_online_base
-                if base_online.endswith("/stable"):
-                    base_online = base_online[: -len("/stable")]
+                base_online = base_online.removesuffix("/stable")
                 # Avoid double versioning if base_online already has it
                 if self._version_string not in base_online:
                     self._base_url = f"{base_online.rstrip('/')}/{self._version_string}"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
@@ -17,7 +17,7 @@ def print_histogram_R_factors(project):
     print("*** Weighted profile R-factor: Rwp " + os.path.split(project.filename)[1])
     for loop_histogram in project.histograms():
         print("\t{:20s}: {:.2f}".format(loop_histogram.name, loop_histogram.get_wR()))
-    print("")
+    print()
 
 
 def add_phases(project, phase_files):
@@ -123,8 +123,7 @@ def export_reflections(temp_save_directory, name_of_project, project):
             with open(reflection_file_path, "wt", encoding="utf-8") as file:
                 file.write(f"{loop_histogram_name}\n")
                 file.write(f"{phase_name}\n")
-                for reflection in reflection_positions:
-                    file.write(f"{str(reflection)}\n")
+                file.writelines(f"{str(reflection)}\n" for reflection in reflection_positions)
 
 
 def export_refined_instrument_parameters(temp_save_directory, name_of_project, project):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -605,7 +605,7 @@ class GSAS2Model:
 
     def get_no_banks(self, prm_file):
         with open(prm_file) as f:
-            for line in f.readlines():
+            for line in f:
                 if "BANK" in line and len(line.split()) == 3:
                     return int(line.split()[-1])
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
@@ -22,8 +22,8 @@ def get_y_min_max_between_x_range(line, x_min, x_max, y_min, y_max):
         return y_min, y_max
     current_min = np.min(crop)
     current_max = np.max(crop)
-    y_min = current_min if current_min < y_min else y_min
-    y_max = current_max if current_max > y_max else y_max
+    y_min = min(y_min, current_min)
+    y_max = max(y_max, current_max)
     return y_min, y_max
 
 

--- a/scripts/DiamondAttenuationCorrection/FitTrans.py
+++ b/scripts/DiamondAttenuationCorrection/FitTrans.py
@@ -49,7 +49,7 @@ def dlmread(filename):
     """
     content = []
     with open(filename, "r") as f:
-        for line in f.readlines():
+        for line in f:
             content.append(float(line))
     return np.array(content)
 

--- a/scripts/DiamondAttenuationCorrection/FitTransReadUB.py
+++ b/scripts/DiamondAttenuationCorrection/FitTransReadUB.py
@@ -50,7 +50,7 @@ def dlmread(filename):
     """
     content = []
     with open(filename, "r") as f:
-        for line in f.readlines():
+        for line in f:
             content.append(float(line))
     return np.array(content)
 

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -430,7 +430,7 @@ def read_diff_constants_from_prm(file_path):
     """
     diff_consts = []  # one list per component (e.g. bank)
     with open(file_path) as f:
-        for line in f.readlines():
+        for line in f:
             if "ICONS" in line:
                 # If formatted correctly the line should be in the format INS bank ICONS difc difa tzero
                 elements = line.split()

--- a/scripts/Engineering/texture/correction/correction_model.py
+++ b/scripts/Engineering/texture/correction/correction_model.py
@@ -232,7 +232,7 @@ class TextureCorrectionModel:
     ) -> None:
         if self._validate_file(txt_file, ".txt"):
             with open(txt_file, "r") as f:
-                goniometer_strings = [line.strip().replace("\t", ",") for line in f.readlines()]
+                goniometer_strings = [line.strip().replace("\t", ",") for line in f]
                 goniometer_lists = [[float(x) for x in gs.split(",")] for gs in goniometer_strings]
             try:
                 n_ws, n_gonios = len(wss), len(goniometer_lists)

--- a/scripts/Inelastic/CrystalField/normalisation.py
+++ b/scripts/Inelastic/CrystalField/normalisation.py
@@ -187,7 +187,7 @@ def split2range(*args, **kwargs):
     argin["Output"] = "dictionary"
     argin["Parameters"] = []
     # Parses the non-keyword arguments
-    for ia in range(3 if len(args) > 3 else len(args)):
+    for ia in range(min(len(args), 3)):
         argin[argnames[ia]] = args[ia]
     # Further arguments beyond the first 3 are treated as crystal field parameter names
     for ia in range(3, len(args)):

--- a/scripts/Inelastic/CrystalField/pointcharge.py
+++ b/scripts/Inelastic/CrystalField/pointcharge.py
@@ -135,7 +135,7 @@ class PointCharge(object):
         # Parse args / kwargs
         argname = ["Structure", "IonLabel", "Charges", "Ion", "MaxDistance", "Neighbour"]
         argdict = {"MaxDistance": 5.0}
-        for ind in range(0, (len(argname) if len(args) > len(argname) else len(args))):
+        for ind in range(0, (min(len(args), len(argname)))):
             argdict[argname[ind]] = args[ind]
         for ind in kwargs.keys():
             if ind in argname:

--- a/scripts/Inelastic/Direct/diagnostics.py
+++ b/scripts/Inelastic/Direct/diagnostics.py
@@ -501,7 +501,7 @@ def print_test_summary(test_results, test_name=None):
         print(format_string.format(t_name, t_result[0], t_result[1]))
     # Append a new line
     print("================================================================")
-    print("")
+    print()
 
 
 # -------------------------------------------------------------------------------

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -1142,8 +1142,8 @@ def _get_x_range_when_bins_vary(workspace: MatrixWorkspace, grouping_workspace: 
         if detector_ids[0] in excluded_ids:
             continue
         x = workspace.extractX()[i]
-        min_value = x.min() if x.min() < min_value else min_value
-        max_value = x.max() if x.max() > max_value else max_value
+        min_value = min(min_value, x.min())
+        max_value = max(max_value, x.max())
 
     assert min_value > 0, "The minimum x value in a dSpacing workspace should be a positive number."
     assert max_value == float("-inf") or max_value > 0, "The maximum x value in a dSpacing workspace should be a positive number."

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -634,7 +634,7 @@ def get_bins_for_rebin_setting(min_value, max_value, step_value, step_type):
 
         # Check if the step will bring us out of bounds. If so, then set the new upper value to the max_value
         upper_bound = lower_bound + step
-        upper_bound = upper_bound if upper_bound < max_value else max_value
+        upper_bound = min(max_value, upper_bound)
 
         # Now we advance the lower bound
         lower_bound = upper_bound

--- a/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
+++ b/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
@@ -23,8 +23,7 @@ class RowOptionsModel(object):
         for k, v in self._developer_options.items():
             output += k + "=" + str(v) + ", "
 
-        if output.endswith(", "):
-            output = output[:-2]
+        output = output.removesuffix(", ")
         return output
 
     def get_options_dict(self):
@@ -88,8 +87,7 @@ class RowOptionsModel(object):
 
         # The findall option finds all instances of the pattern specified above in the options string.
         for key, value in option_pattern.findall(options_column_string_no_whitespace):
-            if value.endswith(","):
-                value = value[:-1]
+            value = value.removesuffix(",")
             parsed.update({key: value})
 
         return parsed

--- a/scripts/pychop/Instruments.py
+++ b/scripts/pychop/Instruments.py
@@ -887,7 +887,7 @@ class Instrument(object):
             frac_dist = 1 - (xm / x0)
             tsmeff = tsqmod * frac_dist**2  # Effective moderator time at first chopper
             x0 -= xm  # Propagate from first chopper, not from moderator (after rescaling tmod)
-            tsqmod = tsmeff if (tsqchp[1] > tsmeff) else tsqchp[1]
+            tsqmod = min(tsqchp[1], tsmeff)
         tsqchp = tsqchp[0]
         tsqmodchop = np.array([tsqmod, tsqchp, x0])
         # Propagate the time widths to the sample position

--- a/tools/Copyright/copyrightupdate.py
+++ b/tools/Copyright/copyrightupdate.py
@@ -271,8 +271,7 @@ if not args.noreport:
     # write out reporting files
     for reporting_filename, reporting_dict in reporting_dictionaries.items():
         with open(reporting_filename, "w") as reporting_file:
-            for key, value in reporting_dict.items():
-                reporting_file.write("{0}\t{1}{2}".format(key, value, os.linesep))
+            reporting_file.writelines("{0}\t{1}{2}".format(key, value, os.linesep) for key, value in reporting_dict.items())
 
 # Final comments
 print()

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -55,14 +55,14 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
             print(f"{i + 1}) {file}")
     else:
         print("None")
-    print("")
+    print()
     print("Files missing from second build:")
     if len(files_missing_from_second_build) > 0:
         for file in files_missing_from_second_build:
             print(file)
     else:
         print("None")
-    print("")
+    print()
 
     if len(files_in_both_builds) == 0:
         print("No matching pair of files was found in the two builds specified, so unable to go any further.")
@@ -78,13 +78,13 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
         file_indices = files_to_compare.split(",")
         file_indices = [int(x) - 1 for x in file_indices]
 
-    print("")
+    print()
     for file_id in file_indices:
         file = files_in_both_builds[file_id]
         print(f"{file}:")
-        print("")
+        print()
         compare_dependencies_for_file(os_name, first_build, second_build, pipeline, file)
-        print("")
+        print()
 
 
 def extract_available_log_files(os_name: str, build_number: int, pipeline: str) -> List[str]:
@@ -120,7 +120,7 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
     print(f"Path to first build: {first_build_output_path}")
     second_build_output_path = form_url_for_build_artifact(second_build, os_name, pipeline, log_file)
     print(f"Path to second build: {second_build_output_path}")
-    print("")
+    print()
 
     # Read in the packages used, with versions
     first_output_packages = extract_package_versions(first_build_output_path, os_name)
@@ -154,12 +154,12 @@ def output_package_changes_to_console(added: list, removed: list, changed: Dict[
         print("Packages added:")
         for p in added:
             print(p)
-        print("")
+        print()
     if len(removed) > 0:
         print("Packages removed:")
         for p in removed:
             print(p)
-        print("")
+        print()
     if len(changed) > 0:
         print("Packages changed:")
         for p in changed:

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -157,8 +157,7 @@ def getTemplateRoot() -> pathlib.Path:
 
 
 def fixReleaseName(name):
-    if name.startswith("v"):
-        name = name[1:]
+    name = name.removeprefix("v")
 
     # make sure that all of the parts can be converted to integers
     try:

--- a/tools/unit_test_speed.py
+++ b/tools/unit_test_speed.py
@@ -22,5 +22,4 @@ times = [line.split("Passed")[-1].split("sec")[0] for line in lines]
 
 with open(sys.argv[2], "w") as f:
     f.write("name, time\n")
-    for name, time in zip(names, times):
-        f.write(", ".join([name, time]) + "\n")
+    f.writelines(", ".join([name, time]) + "\n" for name, time in zip(names, times))


### PR DESCRIPTION
[refurb](https://docs.astral.sh/ruff/rules/#refurb-furb) does automatic modernization changes to exiting python code. This enables the check and moves to the latest version of the ruff pre-commit hooks from v0.14.3 to v0.14.4.

There is no associated issue. 

### To test:

This is a simple modernization and should have no user-facing effects.

*This does not require release notes*


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
