### PR TITLE
Index column in `CreateDetectorTable` is now int

### DIFF
--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -156,7 +156,7 @@ void CreateDetectorTable::setup() {
 
 void CreateDetectorTable::createColumns() {
   std::vector<std::pair<std::string, std::string>> colNames;
-  colNames.emplace_back("double", "Index");
+  colNames.emplace_back("int", "Index");
   colNames.emplace_back("int", "Spectrum No");
   if (PickOneDetectorID) {
     colNames.emplace_back("int", "Detector ID(s)");
@@ -200,7 +200,7 @@ void CreateDetectorTable::populateTable() {
   for (int row = 0; row < nrows; ++row) {
     TableRow colValues = table->getRow(row);
     size_t wsIndex = workspaceIndices.empty() ? static_cast<size_t>(row) : workspaceIndices[row];
-    colValues << static_cast<double>(wsIndex);
+    colValues << static_cast<int>(wsIndex);
     const double dataY0{ws->y(wsIndex)[0]}, dataE0{ws->e(wsIndex)[0]};
     try {
       auto &spectrum = ws->getSpectrum(wsIndex);
@@ -314,7 +314,7 @@ void CreateDetectorTable::populateTable() {
       }
     } catch (const std::exception &) {
       colValues.row(row);
-      colValues << static_cast<double>(wsIndex);
+      colValues << static_cast<int>(wsIndex);
       // spectrumNo=-1, detID=0
       colValues << -1;
       if (PickOneDetectorID) {

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -327,6 +327,29 @@ public:
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());
   }
+
+  void test_index_column_is_int() {
+    Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 10, true);
+    std::string outWSName = "out_int_detid";
+    CreateDetectorTable alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DetectorTableWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    TableWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outWSName));
+    TS_ASSERT(ws);
+    if (!ws) {
+      return;
+    }
+    const auto indexCol = ws->getColumn(0);
+    TS_ASSERT_EQUALS("Index", indexCol->name());
+    TS_ASSERT(indexCol->isType<int>());
+    AnalysisDataService::Instance().remove(ws->getName());
+  }
 };
 
 class CreateDetectorTablePerformance : public CxxTest::TestSuite {

--- a/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/40336.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/Bugfixes/40336.rst
@@ -1,0 +1,1 @@
+- ``CreateDetectorTable`` will now return the workspace index as an integer, not a floating point number.


### PR DESCRIPTION
`Index` was a double, now it is an `int`. The workspace index is originally stored as an `int_32` so no need to cast it to a double.

I spotted this because the `columnArray` method on a table workspace was returning a `numpy` array of type `float` for `Index`, which resulted in workspace indices in the new Instrument View appearing as floating point numbers.

### To test:

```python
ws = LoadEmptyInstrument(InstrumentName='SXD')
d = CreateDetectorTable(ws)
ws_index = d.columnArray('Index')
print(type(ws_index[0]))
```
The `columnArray` method is not in 6.14 but it is in the nightly.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
