### PR TITLE
Add prek GitHub Action

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: j178/prek-action@v1
+        with:
+          args: '--fix'

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -11,11 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Switch to PR branch
+        run: git switch ${{ github.head_ref }}
       - uses: j178/prek-action@v1
         with:
           install-only: true
       - name: Run prek
-        run: prek run --all-files --fix
+        run: prek run --all-files || true
       - name: Commit fixes
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,0 +1,12 @@
+name: Prek checks
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  prek:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: j178/prek-action@v1

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -12,19 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0
-      - name: Switch to PR branch
-        run: git switch ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: j178/prek-action@v1
         with:
           install-only: true
       - name: Run prek
         run: prek run --all-files || true
-      - name: Commit fixes
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git commit -am "prek fixes"
-            git push
-          fi
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: prek fixes
+          default_author: github_actions

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - '**'
+permissions:
+  contents: write
 
 jobs:
   prek:
@@ -11,4 +13,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: j178/prek-action@v1
         with:
-          args: '--fix'
+          install-only: true
+      - name: Run prek
+        run: prek run --all-files --fix
+      - name: Commit fixes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git commit -am "prek fixes"
+            git push
+          fi

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -20,7 +20,7 @@ class MockPosition:
         self.z = z
 
     def getSpherical(self):
-        return [self.x, self.y, self.z]
+        return [self.x,self.y,self.z]
 
     def __array__(self):
         return np.array([self.x, self.y, self.z])

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -20,7 +20,7 @@ class MockPosition:
         self.z = z
 
     def getSpherical(self):
-        return [self.x,self.y,self.z]
+        return [self.x, self.y, self.z]
 
     def __array__(self):
         return np.array([self.x, self.y, self.z])


### PR DESCRIPTION
This adds a workflow to run `prek` on a PR. `prek` is a Rust version of `pre-commit`, see [here](https://github.com/j178/prek).

It will run all the hooks in the existing `.pre-commit-config.yaml` file.

If it has produced fixes, then those are committed to the PR branch.

Once this is in we can delete the `pre-commit` job.

### To test:

This is a PR on my fork where you can see me making a formatting change and `prek` fixing it, https://github.com/jclarkeSTFC/mantid/pull/2

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
