### PR TITLE
Pin vtk to fix instrument view crash

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -192,3 +192,8 @@ pin_run_as_build:
   numpy:
     min_pin: x
     max_pin: x.x
+
+# Pin to version 9.4.2 because previous versions were crashing new instrument view on Ubuntu
+# Newer version 9.5.0 does not yet work with pyvista
+vtk:
+  - '==9.4.2'

--- a/conda/recipes/mantid-developer/recipe.yaml
+++ b/conda/recipes/mantid-developer/recipe.yaml
@@ -89,6 +89,8 @@ requirements:
         - xorg-libxtst>=1.2.3
         # Development tooling:
         - gcovr>=4.2
+        # Required for new instrument view
+        - vtk ${{ vtk }}
     - if: win
       then:
         - conda-wrappers


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
The PR https://github.com/mantidproject/mantid/pull/40098 removed the pin on vtk.
This PR brings the pin back since on linux vtk needs to be at 9.4.2, otherwise get this crash: https://github.com/mantidproject/mantid/pull/39899


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Needs to be tested on Ubuntu:

- [ ] Follow the instructions at https://developer.mantidproject.org/Packaging.html for building a local developer environment
- [ ] Run cmake with fresh argument: `cmake --preset=linux --fresh`
- [ ] `cd build` and rebuild with `ninja`
- [ ] Once finished, open new instrument view with any workspace

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
