### PR TITLE
Accumulated copilot changes

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,9 +27,10 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
 
-    # this will install pre-commit into a python environment
+    # The following steps use pixi to set up the development environment as specified in pixi.toml,
+    # which includes pre-commit and other dependencies.
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v3
-      - run: python -m pip install pre-commit
-        shell: bash
+      - uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          manifest-path: pixi.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.5
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,50 @@
-# Agent Configuration
+Mantid is a C++ and Python repository that has a qt gui frontend.
+It is configured using cmake and uses conda for dependencies.
+The Mantid project provides tools to support the processing of materials-science data.
+This data can be gathered from Neutron scattering or Muon spectroscopy experiments or as the result of simulation.
 
-This file configures automated tasks and agents for the Mantid project.
+# Dev environment setup
 
-## Pre-commit Hook
+- Install pixi and activate the environment specified in `pixi.toml`:
+   - `pixi shell` (or `eval $(pixi shell-hook)` for non-interactive use)
+- Dependencies are tracked from a conda metapackage in `conda/recipes/mantid-developer`
 
-### Task: Run Pre-commit Checks
+# Dev workflow
 
-**Description**: Runs all pre-commit hooks across all files before committing code.
+- Configure:
+  - **Linux:** `cmake --preset=linux . && cd build/`
+  - **Windows:** `cmake --preset=win64 . && cd build/`
+  - **macOS (Apple Silicon):** `cmake --preset=osx-arm64 . && cd build/`
+  > _Choose the preset that matches your platform. If you are unsure, check the available presets in `CMakePresets.json` or ask for guidance._
+- Build:
+  - framework `ninja Framework`
+  - gui `ninja workbench`
+  - tests `ninja AllTests`
+- Run tests
+  - unit tests `ctest`
+  - system tests `./systemtest`
 
-**Command**:
-```bash
-pre-commit run --all-files
-```
+# PR checklist
 
-**When to Run**: Before committing code changes
+- Format using `pre-commit run --all-files`
+- Follow PR template in `.github/PULL_REQUEST_TEMPLATE.md`
 
-**Purpose**:
-- Ensures code quality and consistency
-- Catches formatting issues early
-- Validates file structure and content
-- Runs security checks with gitleaks
-- Enforces project coding standards
+# Project structure
 
-**Prerequisites**:
-- pre-commit must be installed (`pip install pre-commit`)
-- Pre-commit hooks must be installed (`pre-commit install`)
+- `.github/workflows` build configuration for github-actions
+- `buildconfig/Jenkins` build configuration for jenkins CI
+- `buildconfig/CMake` custom cmake modules
+- `conda/recipes` recipes for conda packages
+- `dev-docs` developer documentation
+- `docs` user documentation
+- `Framework` non-gui code
+- `instrument` xml files describing facilities, instruments, and sample environments
+- `qt` gui code
+- `scripts` python code
+- `Testing` test data and system test framework
+- `tools` small tools for maintaining code and report generation
 
-**Configuration**: See `.pre-commit-config.yaml` for the list of hooks that will be executed.
+# When stuck
 
-## Usage
-
-To run the pre-commit checks manually:
-
-```bash
-pre-commit run --all-files
-```
-
-To run pre-commit on staged files only:
-
-```bash
-pre-commit run
-```
-
-To skip pre-commit hooks temporarily (not recommended):
-
-```bash
-git commit --no-verify
-```
+- Ask a clarifying question, propose a short plan, or open a draft PR with notes
+- Look for PRs with similar changes

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -22,7 +22,6 @@
 #include "MantidKernel/StringTokenizer.h"
 #include <Poco/Exception.h>
 #include <Poco/File.h>
-#include <Poco/Glob.h>
 #include <Poco/Path.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
@@ -73,7 +72,7 @@ FileFinderImpl::FileFinderImpl() {
 
 // determine from Mantid property how sensitive Mantid should be
 #ifdef _WIN32
-  m_globOption = Poco::Glob::GLOB_DEFAULT;
+  m_globOption = Kernel::Glob::GLOB_DEFAULT;
 #else
   setCaseSensitive(Kernel::ConfigService::Instance().getValue<bool>("filefinder.casesensitive").value_or(false));
 #endif
@@ -85,9 +84,9 @@ FileFinderImpl::FileFinderImpl() {
  */
 void FileFinderImpl::setCaseSensitive(const bool cs) {
   if (cs)
-    m_globOption = Poco::Glob::GLOB_DEFAULT;
+    m_globOption = Kernel::Glob::GLOB_DEFAULT;
   else
-    m_globOption = Poco::Glob::GLOB_CASELESS;
+    m_globOption = Kernel::Glob::GLOB_CASELESS;
 }
 
 /**
@@ -95,7 +94,7 @@ void FileFinderImpl::setCaseSensitive(const bool cs) {
  * @return cs :: If case sensitive return true, if not case sensitive return
  * false
  */
-bool FileFinderImpl::getCaseSensitive() const { return (m_globOption == Poco::Glob::GLOB_DEFAULT); }
+bool FileFinderImpl::getCaseSensitive() const { return (m_globOption == Kernel::Glob::GLOB_DEFAULT); }
 
 /**
  * Return the full path to the file given its name

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -25,7 +25,6 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/UnitFactory.h"
 
-#include <Poco/File.h>
 #include <cmath>
 #include <fstream>
 #include <numeric>

--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -9,8 +9,8 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
-
-#include "Poco/Glob.h"
+#include "MantidKernel/Glob.h"
+#include <regex>
 
 namespace Mantid::Algorithms {
 
@@ -95,13 +95,14 @@ std::map<std::string, std::string> GroupWorkspaces::validateInputs() {
  * @param globExpression glob pattern for selecting names from the ADS
  */
 void GroupWorkspaces::addToGroup(const std::string &globExpression) {
-
-  Poco::Glob glob(globExpression);
+  const std::string globRegexp = Kernel::Glob::globToRegex(globExpression);
+  g_log.debug() << "convert \"" << globExpression << "\" to \"" << globRegexp << "\"\n";
+  std::regex pattern(globRegexp);
 
   const AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
   const auto wsNames = ads.topLevelItems();
   for (const auto &wsName : wsNames) {
-    if (glob.match(wsName.first)) {
+    if (std::regex_match(wsName.first, pattern)) {
       addToGroup(wsName.second);
     }
   }

--- a/Framework/Algorithms/test/ClearCacheTest.h
+++ b/Framework/Algorithms/test/ClearCacheTest.h
@@ -13,8 +13,8 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/ClearCache.h"
-#include <Poco/File.h>
-#include <Poco/Path.h>
+#include <filesystem>
+#include <fstream>
 
 using Mantid::Algorithms::ClearCache;
 using namespace Mantid::API;
@@ -33,35 +33,32 @@ public:
 
     // change the local download directory by adding a unittest subdirectory
     auto testDirectories = m_originalInstDir;
-    // std::filesystem doesn't append the '/' to denote directory
-    Poco::Path localDownloadPath(m_originalInstDir[0] + "/");
-    localDownloadPath.pushDirectory(TEST_SUFFIX);
-    m_localInstDir = localDownloadPath.toString();
+    std::filesystem::path localDownloadPath(m_originalInstDir[0]);
+    localDownloadPath /= TEST_SUFFIX;
+    m_localInstDir = localDownloadPath.string();
     createDirectory(localDownloadPath);
     testDirectories[0] = m_localInstDir;
 
     Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(testDirectories);
 
     // create a geometryCache subdirectory
-    Poco::Path GeomPath = localDownloadPath;
-    GeomPath.pushDirectory("geometryCache");
+    std::filesystem::path GeomPath = localDownloadPath / "geometryCache";
     createDirectory(GeomPath);
   }
 
-  void createDirectory(const Poco::Path &path) {
-    Poco::File file(path);
-    if (file.createDirectory()) {
-      m_directoriesToRemove.emplace_back(file);
+  void createDirectory(const std::filesystem::path &path) {
+    if (std::filesystem::create_directories(path)) {
+      m_directoriesToRemove.emplace_back(path);
     }
   }
 
   void removeDirectories() {
     for (auto directory : m_directoriesToRemove) {
       try {
-        if (directory.exists()) {
-          directory.remove(true);
+        if (std::filesystem::exists(directory)) {
+          std::filesystem::remove_all(directory);
         }
-      } catch (Poco::FileException &fe) {
+      } catch (std::filesystem::filesystem_error &fe) {
         std::cout << fe.what() << std::endl;
       }
     }
@@ -111,11 +108,11 @@ public:
     ClearCache alg;
 
     auto instrumentDirs = ConfigService::Instance().getInstrumentDirectories();
-    Poco::Path localPath(instrumentDirs[0]);
-    localPath.makeDirectory();
+    std::filesystem::path localPath(instrumentDirs[0]);
     // create a file in the directory
-    Poco::File testFile(localPath.append("test_exec_DownloadInstrument_Cache.xml"));
-    testFile.createFile();
+    std::filesystem::path testFilePath = localPath / "test_exec_DownloadInstrument_Cache.xml";
+    std::ofstream testFile(testFilePath);
+    testFile.close();
 
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
@@ -123,7 +120,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
-    TSM_ASSERT("The test file has not been deleted", !testFile.exists());
+    TSM_ASSERT("The test file has not been deleted", !std::filesystem::exists(testFilePath));
     int filesRemoved = alg.getProperty("FilesRemoved");
     TS_ASSERT_LESS_THAN_EQUALS(1, filesRemoved);
   }
@@ -132,13 +129,12 @@ public:
     ClearCache alg;
 
     auto instrumentDirs = ConfigService::Instance().getInstrumentDirectories();
-    Poco::Path localPath(instrumentDirs[0]);
-    localPath.makeDirectory();
-    Poco::Path GeomPath(localPath);
-    GeomPath.append("geometryCache").makeDirectory();
+    std::filesystem::path localPath(instrumentDirs[0]);
+    std::filesystem::path GeomPath = localPath / "geometryCache";
     // create a file in the directory
-    Poco::File testFile(GeomPath.append("test_exec_Geometry_Cache.vtp"));
-    testFile.createFile();
+    std::filesystem::path testFilePath = GeomPath / "test_exec_Geometry_Cache.vtp";
+    std::ofstream testFile(testFilePath);
+    testFile.close();
 
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
@@ -146,7 +142,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
-    TSM_ASSERT("The test file has not been deleted", !testFile.exists());
+    TSM_ASSERT("The test file has not been deleted", !std::filesystem::exists(testFilePath));
     int filesRemoved = alg.getProperty("FilesRemoved");
     TS_ASSERT_LESS_THAN_EQUALS(1, filesRemoved);
   }
@@ -166,5 +162,5 @@ public:
 
   std::string m_localInstDir;
   std::vector<std::string> m_originalInstDir;
-  std::vector<Poco::File> m_directoriesToRemove;
+  std::vector<std::filesystem::path> m_directoriesToRemove;
 };

--- a/Framework/Algorithms/test/CorrectToFileTest.h
+++ b/Framework/Algorithms/test/CorrectToFileTest.h
@@ -15,7 +15,6 @@
 #include "MantidDataHandling/LoadRKH.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/UnitFactory.h"
-#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using Mantid::API::AnalysisDataService;

--- a/Framework/Algorithms/test/CreateCalFileByNamesTest.h
+++ b/Framework/Algorithms/test/CreateCalFileByNamesTest.h
@@ -20,8 +20,8 @@
 #include "MantidGeometry/Instrument/FitParameter.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
-#include <Poco/File.h>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
@@ -66,7 +66,7 @@ public:
 
     // has the algorithm written a file to disk?
     bool fileExists = false;
-    TS_ASSERT(fileExists = Poco::File(outputFile).exists());
+    TS_ASSERT(fileExists = std::filesystem::exists(outputFile));
 
     if (fileExists) {
       // Do a few tests to see if the content of outputFile is what you
@@ -113,7 +113,7 @@ public:
       in.close();
 
       // remove file created by this algorithm
-      Poco::File(outputFile).remove();
+      std::filesystem::remove(outputFile);
     }
   }
 };

--- a/Framework/Algorithms/test/CreateDummyCalFileTest.h
+++ b/Framework/Algorithms/test/CreateDummyCalFileTest.h
@@ -21,8 +21,8 @@
 #include "MantidGeometry/Instrument/FitParameter.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
-#include <Poco/File.h>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
@@ -62,7 +62,7 @@ public:
 
     // has the algorithm written a file to disk?
     bool fileExists = false;
-    TS_ASSERT(fileExists = Poco::File(outputFile).exists());
+    TS_ASSERT(fileExists = std::filesystem::exists(outputFile));
 
     if (fileExists) {
       // Do a few tests to see if the content of outputFile is what you
@@ -109,7 +109,7 @@ public:
       in.close();
 
       // remove file created by this algorithm
-      Poco::File(outputFile).remove();
+      std::filesystem::remove(outputFile);
       // Remove workspace
       AnalysisDataService::Instance().remove(wsName);
     }

--- a/Framework/Algorithms/test/CreateLogTimeCorrectionTest.h
+++ b/Framework/Algorithms/test/CreateLogTimeCorrectionTest.h
@@ -16,7 +16,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/OptionalBool.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 
@@ -134,8 +134,7 @@ public:
     // clean workspaces and file written
     AnalysisDataService::Instance().remove("CorrectionTable");
 
-    Poco::File file("VucanCorrection.dat");
-    file.remove(false);
+    std::filesystem::remove("VucanCorrection.dat");
 
     return;
   }

--- a/Framework/Algorithms/test/DetectorEfficiencyVariationTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyVariationTest.h
@@ -18,7 +18,6 @@
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/UnitFactory.h"
-#include <Poco/Path.h>
 #include <cmath>
 #include <fstream>
 #include <ios>

--- a/Framework/Algorithms/test/DiffractionEventCalibrateDetectorsTest.h
+++ b/Framework/Algorithms/test/DiffractionEventCalibrateDetectorsTest.h
@@ -9,8 +9,8 @@
 #include "MantidAlgorithms/DiffractionEventCalibrateDetectors.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/Timer.h"
-#include <Poco/File.h>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace Mantid::Algorithms;
@@ -65,7 +65,7 @@ public:
     TS_ASSERT_DELTA(upy, 0.894435, 0.0001)
     TS_ASSERT_DELTA(upz, 0.447104, 0.0001)
     outFile.close();
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
 
     AnalysisDataService::Instance().remove("temp_event_ws");
   }

--- a/Framework/Algorithms/test/ExportTimeSeriesLogTest.h
+++ b/Framework/Algorithms/test/ExportTimeSeriesLogTest.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "MantidKernel/Timer.h"
-#include <Poco/File.h>
 #include <cmath>
 #include <cxxtest/TestSuite.h>
 #include <fstream>

--- a/Framework/Algorithms/test/FindDeadDetectorsTest.h
+++ b/Framework/Algorithms/test/FindDeadDetectorsTest.h
@@ -14,7 +14,7 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 
 #include <fstream>
 
@@ -120,7 +120,7 @@ public:
     std::fstream outFile(filename.c_str());
     TS_ASSERT(outFile)
     outFile.close();
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
 
     // Set Range_lower to later in the histogram when the yTooDead detectors
     // stop working

--- a/Framework/Algorithms/test/FixGSASInstrumentFileTest.h
+++ b/Framework/Algorithms/test/FixGSASInstrumentFileTest.h
@@ -10,9 +10,8 @@
 
 #include "MantidAlgorithms/FixGSASInstrumentFile.h"
 
+#include <filesystem>
 #include <fstream>
-
-#include "Poco/File.h"
 
 using namespace std;
 
@@ -43,9 +42,8 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // File existence
-    Poco::File file(prmfilename);
-    TS_ASSERT(file.exists());
-    if (!file.exists())
+    TS_ASSERT(std::filesystem::exists(prmfilename));
+    if (!std::filesystem::exists(prmfilename))
       return;
 
     // Check each line
@@ -62,7 +60,7 @@ public:
     chkfile.close();
 
     // Clean
-    file.remove();
+    std::filesystem::remove(prmfilename);
   }
 
   void createFaultFile(const std::string &prmfilename) {

--- a/Framework/Algorithms/test/GenerateEventsFilterTest.h
+++ b/Framework/Algorithms/test/GenerateEventsFilterTest.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <Poco/File.h>
 #include <cmath>
 #include <cxxtest/TestSuite.h>
 

--- a/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
+++ b/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
@@ -12,7 +12,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAlgorithms/GenerateGoniometerIndependentBackground.h"
 #include "MantidDataObjects/EventWorkspace.h"
-#include <Poco/File.h>
+#include <filesystem>
 
 using Mantid::Algorithms::GenerateGoniometerIndependentBackground;
 
@@ -52,8 +52,8 @@ public:
 
   void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().clear();
-    if (Poco::File("groups.xml").exists())
-      Poco::File("groups.xml").remove();
+    if (std::filesystem::exists("groups.xml"))
+      std::filesystem::remove("groups.xml");
   }
 
   void test_exec() {

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -19,7 +19,7 @@
 #include "MantidAlgorithms/GenerateIPythonNotebook.h"
 #include "MantidAlgorithms/Power.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 
 using namespace Mantid;
 using namespace Mantid::Algorithms;
@@ -109,8 +109,8 @@ public:
     TS_ASSERT_EQUALS(alg.getPropertyValue("NotebookText"), " \"nbformat_minor\" : 0,");
 
     file.close();
-    if (Poco::File(filename).exists())
-      Poco::File(filename).remove();
+    if (std::filesystem::exists(filename))
+      std::filesystem::remove(filename);
   }
 
   void create_test_workspace(const std::string &wsName) {

--- a/Framework/Algorithms/test/GeneratePythonFitScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonFitScriptTest.h
@@ -18,7 +18,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-#include <Poco/File.h>
+#include <filesystem>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -150,7 +150,7 @@ public:
 
 private:
   void assertExpectedScriptExists(std::vector<std::string> const &expectedLines) {
-    TS_ASSERT(Poco::File(m_filepath).exists());
+    TS_ASSERT(std::filesystem::exists(m_filepath));
 
     std::ifstream file(m_filepath.c_str(), std::ifstream::in);
 
@@ -162,7 +162,7 @@ private:
     }
 
     file.close();
-    Poco::File(m_filepath).remove();
+    std::filesystem::remove(m_filepath);
   }
 
   Mantid::API::IAlgorithm_sptr m_algorithm;

--- a/Framework/Algorithms/test/GeneratePythonScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonScriptTest.h
@@ -23,7 +23,7 @@
 #include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/MantidVersion.h"
 #include "MantidKernel/Timer.h"
-#include <Poco/File.h>
+#include <filesystem>
 
 #include <fstream>
 
@@ -119,8 +119,8 @@ public:
                                                          "OutputWorkspace='testGeneratePython', Exponent=1.5)");
 
     file.close();
-    if (Poco::File(filename).exists())
-      Poco::File(filename).remove();
+    if (std::filesystem::exists(filename))
+      std::filesystem::remove(filename);
 
     // Clean the ADS
     Mantid::API::AnalysisDataService::Instance().clear();

--- a/Framework/Algorithms/test/MaskDetectorsIfTest.h
+++ b/Framework/Algorithms/test/MaskDetectorsIfTest.h
@@ -14,7 +14,7 @@
 #include "MantidFrameworkTestHelpers/ScopedFileHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
-#include <Poco/File.h>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 
@@ -301,7 +301,7 @@ private:
     // check that the algorithm has written a file to disk
     std::string outputFile = alg.getProperty("OutputCalFile");
     bool fileExists = false;
-    TS_ASSERT(fileExists = Poco::File(outputFile).exists());
+    TS_ASSERT(fileExists = std::filesystem::exists(outputFile));
 
     // check that we can open the file
     if (fileExists) {

--- a/Framework/Algorithms/test/ReadGroupsFromFileTest.h
+++ b/Framework/Algorithms/test/ReadGroupsFromFileTest.h
@@ -21,9 +21,9 @@
 #include "MantidGeometry/Instrument/FitParameter.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
-#include <Poco/File.h>
 #include <cstring>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
@@ -75,7 +75,7 @@ public:
     outputFile = alg.getPropertyValue("Filename");
 
     bool fileExists = false;
-    TS_ASSERT(fileExists = Poco::File(outputFile).exists());
+    TS_ASSERT(fileExists = std::filesystem::exists(outputFile));
 
     if (fileExists) {
 
@@ -100,7 +100,7 @@ public:
       TS_ASSERT_DELTA(ws->y(45)[0], 3.0, 1e-6);
 
       // remove file created by this algorithm
-      Poco::File(outputFile).remove();
+      std::filesystem::remove(outputFile);
     }
 
     // Remove workspace

--- a/Framework/Algorithms/test/SpatialGroupingTest.h
+++ b/Framework/Algorithms/test/SpatialGroupingTest.h
@@ -14,8 +14,7 @@
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidIndexing/IndexInfo.h"
 
-#include <Poco/File.h>
-#include <Poco/Path.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace Mantid;
@@ -51,10 +50,9 @@ public:
 
     std::string file = alg.getProperty("Filename");
 
-    Poco::File fileobj(file);
-    const bool fileExists = fileobj.exists();
+    const bool fileExists = std::filesystem::exists(file);
 
-    TSM_ASSERT(fileobj.path(), fileExists);
+    TSM_ASSERT(file, fileExists);
 
     std::ifstream input;
     input.open(file.c_str());

--- a/Framework/Algorithms/test/WorkspaceGroupTest.h
+++ b/Framework/Algorithms/test/WorkspaceGroupTest.h
@@ -17,7 +17,7 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 #include <fstream>
 #include <utility>
 
@@ -243,7 +243,7 @@ public:
     std::fstream outFile(filename.c_str());
     TS_ASSERT(outFile)
     outFile.close();
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
 
     work_out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("testdead_out");
     work_out->removeAll();

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -444,6 +444,7 @@ set(INC_FILES
 set(TEST_FILES
     AlignAndFocusPowderSlimTest.h
     ApplyDiffCalTest.h
+    BankCalibrationTest.h
     BankPulseTimesTest.h
     CheckMantidVersionTest.h
     CompressEventAccumulatorTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -40,6 +40,7 @@ private:
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                    const std::vector<double> &difc_focus);
+  void initScaleAtSample(const API::MatrixWorkspace_sptr &wksp);
   std::vector<std::pair<size_t, size_t>> determinePulseIndices(const API::MatrixWorkspace_sptr &wksp,
                                                                const Kernel::TimeROI &filterROI);
   static std::vector<std::pair<int, std::pair<size_t, size_t>>>
@@ -48,7 +49,12 @@ private:
   Kernel::TimeROI getFilterROI(const API::MatrixWorkspace_sptr &wksp);
   DataObjects::TimeSplitter timeSplitterFromSplitterWorkspace(const Types::Core::DateAndTime &);
 
-  std::map<detid_t, double> m_calibration; // detid: 1/difc
+  std::map<detid_t, double> m_calibration; ///< detid: 1/difc
+  /**
+   * Multiplicative 0<value<1 to move neutron TOF at sample.
+   * It will only be filled if time at sample is requested.
+   */
+  std::map<detid_t, double> m_scale_at_sample;
   std::set<detid_t> m_masked;
   bool is_time_filtered{false};
   /// Index to load start at in the file
@@ -65,6 +71,7 @@ const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
 const std::string SPLITTER_WS("SplitterWorkspace");
 const std::string SPLITTER_RELATIVE("RelativeTime");
+const std::string CORRECTION_TO_SAMPLE("CorrectionToSample");
 const std::string PROCESS_BANK_SPLIT_TASK("ProcessBankSplitTask");
 const std::string FILTER_BAD_PULSES("FilterBadPulses");
 const std::string FILTER_BAD_PULSES_LOWER_CUTOFF("BadPulsesLowerCutoff");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
@@ -17,16 +17,27 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 constexpr double IGNORE_PIXEL{1.e6};
 
+/**
+ * Class that handles all the calibration constants for a bank of detectors. Accessing values DOES NO RANGE CHECKING so
+ * only request values within the range of detector IDs supplied to the constructor.
+ */
 class MANTID_DATAHANDLING_DLL BankCalibration {
 public:
   BankCalibration(const detid_t idmin, const detid_t idmax, const double time_conversion,
-                  const std::map<detid_t, double> &calibration_map, const std::set<detid_t> &mask);
-  const double &value(const detid_t detid) const;
+                  const std::map<detid_t, double> &calibration_map, const std::map<detid_t, double> &scale_at_sample,
+                  const std::set<detid_t> &mask);
+  const double &value_calibration(const detid_t detid) const;
+  /**
+   * This returns a value with no bounds checking. If scale_at_sample is not provided, this will have undefined
+   * behavior.
+   */
+  double value_scale_at_sample(const detid_t detid) const;
   const detid_t &idmin() const;
   detid_t idmax() const;
 
 private:
   std::vector<double> m_calibration;
+  std::vector<double> m_scale_at_sample;
   const detid_t m_detid_offset;
 };
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -21,8 +21,8 @@ class ProcessBankSplitTask {
 public:
   ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
                        std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
-                       const std::map<detid_t, double> &calibration, const std::set<detid_t> &masked,
-                       const size_t events_per_chunk, const size_t grainsize_event,
+                       const std::map<detid_t, double> &calibration, const std::map<detid_t, double> &scale_at_sample,
+                       const std::set<detid_t> &masked, const size_t events_per_chunk, const size_t grainsize_event,
                        std::vector<std::pair<int, PulseROI>> target_to_pulse_indices,
                        std::shared_ptr<API::Progress> &progress);
 
@@ -34,7 +34,8 @@ private:
   mutable NexusLoader m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
-  const std::map<detid_t, double> m_calibration; // detid: 1/difc
+  const std::map<detid_t, double> m_calibration; ///< detid: 1/difc
+  std::map<detid_t, double> m_scale_at_sample;   ///< multiplicative 0<value<1 to move neutron TOF at sample
   const std::set<detid_t> m_masked;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -21,8 +21,9 @@ class ProcessBankTask {
 public:
   ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
                   API::MatrixWorkspace_sptr &wksp, const std::map<detid_t, double> &calibration,
-                  const std::set<detid_t> &masked, const size_t events_per_chunk, const size_t grainsize_event,
-                  std::vector<PulseROI> pulse_indices, std::shared_ptr<API::Progress> &progress);
+                  const std::map<detid_t, double> &scale_at_sample, const std::set<detid_t> &masked,
+                  const size_t events_per_chunk, const size_t grainsize_event, std::vector<PulseROI> pulse_indices,
+                  std::shared_ptr<API::Progress> &progress);
 
   void operator()(const tbb::blocked_range<size_t> &range) const;
 
@@ -31,7 +32,8 @@ private:
   const std::vector<std::string> m_bankEntries;
   mutable NexusLoader m_loader;
   API::MatrixWorkspace_sptr m_wksp;
-  const std::map<detid_t, double> m_calibration; // detid: 1/difc
+  const std::map<detid_t, double> m_calibration; ///< detid: 1/difc
+  std::map<detid_t, double> m_scale_at_sample;   ///< multiplicative 0<value<1 to move neutron TOF at sample
   const std::set<detid_t> m_masked;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h
@@ -38,7 +38,7 @@ public:
     auto tof_iter = std::ranges::next(m_tofs->begin(), range.begin());
     for (size_t i = range.begin(); i < range_end; ++i) {
       const auto &detid = *detid_iter;
-      const auto &calib_factor = m_calibration->value(detid);
+      const auto &calib_factor = m_calibration->value_calibration(detid);
       if (calib_factor < IGNORE_PIXEL) {
         // Apply calibration
         const double &tof = static_cast<double>(*tof_iter) * calib_factor;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -12,6 +12,8 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/TimeAtSampleStrategyElastic.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h"
 #include "MantidDataHandling/LoadEventNexus.h"
@@ -23,6 +25,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidKernel/ArrayBoundedValidator.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -31,6 +34,7 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
+#include "MantidKernel/V3D.h"
 #include "MantidKernel/VectorHelper.h"
 #include "MantidNexus/H5Util.h"
 
@@ -44,6 +48,7 @@ using Mantid::API::AnalysisDataService;
 using Mantid::API::FileProperty;
 using Mantid::API::ITableWorkspace_sptr;
 using Mantid::API::MatrixWorkspace_sptr;
+using Mantid::API::TimeAtSampleStrategyElastic;
 using Mantid::API::WorkspaceProperty;
 using Mantid::DataObjects::MaskWorkspace_sptr;
 using Mantid::DataObjects::TimeSplitter;
@@ -159,6 +164,9 @@ void AlignAndFocusPowderSlim::init() {
       PropertyNames::PROCESS_BANK_SPLIT_TASK, false,
       "For development testing. Changes how the splitters are processed. If true then use ProcessBankSplitTask "
       "otherwise loop over ProcessBankTask.");
+  declareProperty(PropertyNames::CORRECTION_TO_SAMPLE, false,
+                  "Find time-of-flight when neutron was at the sample position. This is only necessary for fast logs "
+                  "(i.e. more frequent than proton on target pulse).");
   auto mustBePositive = std::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(0);
   declareProperty(PropertyNames::FILTER_BAD_PULSES, false,
@@ -296,6 +304,11 @@ void AlignAndFocusPowderSlim::exec() {
     this->initCalibrationConstants(wksp, difc_focused);
   }
 
+  // calculate correction for tof of the neutron at the sample position
+  if (this->getProperty(PropertyNames::CORRECTION_TO_SAMPLE)) {
+    this->initScaleAtSample(wksp);
+  }
+
   // set the instrument
   this->progress(.07, "Set instrument geometry");
   wksp = this->editInstrumentGeometry(wksp, l1, polars, specids, l2s, azimuthals);
@@ -377,7 +390,7 @@ void AlignAndFocusPowderSlim::exec() {
     const auto pulse_indices = this->determinePulseIndices(wksp, filterROI);
 
     auto progress = std::make_shared<API::Progress>(this, .17, .9, num_banks_to_read);
-    ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, wksp, m_calibration, m_masked,
+    ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, wksp, m_calibration, m_scale_at_sample, m_masked,
                          static_cast<size_t>(DISK_CHUNK), static_cast<size_t>(GRAINSIZE_EVENTS), pulse_indices,
                          progress);
     // generate threads only if appropriate
@@ -416,9 +429,9 @@ void AlignAndFocusPowderSlim::exec() {
       // determine the pulse indices from the time and splitter workspace
       const auto target_to_pulse_indices = this->determinePulseIndicesTargets(wksp, filterROI, timeSplitter);
 
-      ProcessBankSplitTask task(bankEntryNames, h5file, true, workspaceIndices, workspaces, m_calibration, m_masked,
-                                static_cast<size_t>(DISK_CHUNK), static_cast<size_t>(GRAINSIZE_EVENTS),
-                                target_to_pulse_indices, progress);
+      ProcessBankSplitTask task(bankEntryNames, h5file, true, workspaceIndices, workspaces, m_calibration,
+                                m_scale_at_sample, m_masked, static_cast<size_t>(DISK_CHUNK),
+                                static_cast<size_t>(GRAINSIZE_EVENTS), target_to_pulse_indices, progress);
       // generate threads only if appropriate
       if (num_banks_to_read > 1) {
         tbb::parallel_for(tbb::blocked_range<size_t>(0, num_banks_to_read), task);
@@ -449,7 +462,7 @@ void AlignAndFocusPowderSlim::exec() {
                             const auto pulse_indices = this->determinePulseIndices(target_wksp, target_roi);
 
                             ProcessBankTask task(bankEntryNames, h5file, is_time_filtered, target_wksp, m_calibration,
-                                                 m_masked, static_cast<size_t>(DISK_CHUNK),
+                                                 m_scale_at_sample, m_masked, static_cast<size_t>(DISK_CHUNK),
                                                  static_cast<size_t>(GRAINSIZE_EVENTS), pulse_indices, progress);
                             // generate threads only if appropriate
                             if (num_banks_to_read > 1) {
@@ -590,6 +603,25 @@ void AlignAndFocusPowderSlim::loadCalFile(const Mantid::API::Workspace_sptr &inp
   const MaskWorkspace_sptr maskWS = alg->getProperty("OutputMaskWorkspace");
   m_masked = maskWS->getMaskedDetectors();
   g_log.debug() << "Masked detectors: " << m_masked.size() << '\n';
+}
+
+/**
+ * For fast logs, calculate the sample position correction. This is a separate implementation of
+ * Mantid::API::TimeAtSampleElastic that uses DetectorInfo.
+ */
+void AlignAndFocusPowderSlim::initScaleAtSample(const API::MatrixWorkspace_sptr &wksp) {
+  // detector information for all of the L2
+  const auto detInfo = wksp->detectorInfo();
+  // cache a single L1 value
+  const double L1 = detInfo.l1();
+
+  // calculate scale factors for each detector
+  for (auto iter = detInfo.cbegin(); iter != detInfo.cend(); ++iter) {
+    if (!iter->isMonitor()) {
+      const double path_correction = (L1 + iter->l2()) / L1;
+      m_scale_at_sample.emplace(static_cast<detid_t>(iter->detid()), path_correction);
+    }
+  }
 }
 
 API::MatrixWorkspace_sptr AlignAndFocusPowderSlim::editInstrumentGeometry(

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -11,6 +11,28 @@
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
+namespace {
+void copy_values_from_map_to_offset_vector(const std::map<detid_t, double> &map_values, const detid_t idmin,
+                                           const detid_t idmax, std::vector<double> &vector_values) {
+  // allocate memory and set the default value to 1
+  vector_values.assign(static_cast<size_t>(idmax - idmin + 1), 1.);
+
+  // set up iterators for copying data - assumes ordered map
+  auto iter = map_values.find(idmin);
+  if (iter == map_values.end())
+    throw std::runtime_error("Failed to find idmin=" + std::to_string(idmin) + " in map");
+  auto iter_end = map_values.find(idmax);
+  if (iter_end != map_values.end())
+    ++iter_end;
+
+  // copy over values that matter
+  for (; iter != iter_end; ++iter) {
+    const auto index = static_cast<size_t>(iter->first - idmin);
+    vector_values[index] = iter->second;
+  }
+}
+} // namespace
+
 // ------------------------ BankCalibration object
 /**
  * Calibration of a subset of pixels as requested in the constructor. This is used because a vector is faster lookup
@@ -21,37 +43,33 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
  * @param time_conversion Value to bundle into the calibration constant to account for converting the time-of-flight
  * into microseconds. Applying it here is effectively the same as applying it to each event time-of-flight.
  * @param calibration_map Calibration for the entire instrument.
+ * @param scale_at_sample Scalar factor to multiply the time-of-flight by to get the time-of-flight of the neutron back
+ * at the sample position.
  * @param mask detector ids that exist in the map should not be included.
  */
 BankCalibration::BankCalibration(const detid_t idmin, const detid_t idmax, const double time_conversion,
-                                 const std::map<detid_t, double> &calibration_map, const std::set<detid_t> &mask)
+                                 const std::map<detid_t, double> &calibration_map,
+                                 const std::map<detid_t, double> &scale_at_sample, const std::set<detid_t> &mask)
     : m_detid_offset(idmin) {
   // error check the id-range
-  if (idmax < idmin)
-    throw std::runtime_error("BAD!"); // TODO better message
-
-  // allocate memory and set the default value to 1
-  m_calibration.assign(static_cast<size_t>(idmax - idmin + 1), 1.);
-
-  // set up iterators for copying data
-  auto iter = calibration_map.find(idmin);
-  if (iter == calibration_map.end())
-    throw std::runtime_error("ALSO BAD!");
-  auto iter_end = calibration_map.find(idmax);
-  if (iter_end != calibration_map.end())
-    ++iter_end;
-
-  // copy over values that matter
-  for (; iter != iter_end; ++iter) {
-    const auto index = static_cast<size_t>(iter->first - m_detid_offset);
-    m_calibration[index] = iter->second;
+  if (idmax < idmin) {
+    // std::string msg =
+    // std::string("encountered invalid detector ID range ") + std::to_string(idmin) + " > " + std::to_string(idmax);
+    throw std::runtime_error("encountered invalid detector ID range " + std::to_string(idmin) + " > " +
+                             std::to_string(idmax));
   }
 
+  // get the values copied over for calibration
+  copy_values_from_map_to_offset_vector(calibration_map, idmin, idmax, m_calibration);
   // apply time conversion here so it is effectively applied for each detector once rather than on each event
   if (time_conversion != 1.) {
     std::transform(m_calibration.begin(), m_calibration.end(), m_calibration.begin(),
                    [time_conversion](const auto &value) { return std::move(time_conversion * value); });
   }
+
+  // get the values copied over for scale_at_sample
+  if (!scale_at_sample.empty())
+    copy_values_from_map_to_offset_vector(scale_at_sample, idmin, idmax, m_scale_at_sample);
 
   // setup the detector mask - this assumes there are not many pixels in the overall mask
   // TODO could benefit from using lower_bound/upper_bound on the input mask rather than all
@@ -65,7 +83,13 @@ BankCalibration::BankCalibration(const detid_t idmin, const detid_t idmax, const
 /**
  * This assumes that everything is in range. Values that weren't in the calibration map get set to 1.
  */
-const double &BankCalibration::value(const detid_t detid) const { return m_calibration[detid - m_detid_offset]; }
+const double &BankCalibration::value_calibration(const detid_t detid) const {
+  return m_calibration[detid - m_detid_offset];
+}
+
+double BankCalibration::value_scale_at_sample(const detid_t detid) const {
+  return m_scale_at_sample[detid - m_detid_offset];
+}
 
 const detid_t &BankCalibration::idmin() const { return m_detid_offset; }
 detid_t BankCalibration::idmax() const { return m_detid_offset + static_cast<detid_t>(m_calibration.size()) - 1; }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -27,17 +27,16 @@ const std::string MICROSEC("microseconds");
 auto g_log = Kernel::Logger("ProcessBankSplitTask");
 
 } // namespace
-ProcessBankSplitTask::ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
-                                           const bool is_time_filtered, std::vector<int> &workspaceIndices,
-                                           std::vector<API::MatrixWorkspace_sptr> &wksps,
-                                           const std::map<detid_t, double> &calibration,
-                                           const std::set<detid_t> &masked, const size_t events_per_chunk,
-                                           const size_t grainsize_event,
-                                           std::vector<std::pair<int, PulseROI>> target_to_pulse_indices,
-                                           std::shared_ptr<API::Progress> &progress)
+ProcessBankSplitTask::ProcessBankSplitTask(
+    std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
+    std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
+    const std::map<detid_t, double> &calibration, const std::map<detid_t, double> &scale_at_sample,
+    const std::set<detid_t> &masked, const size_t events_per_chunk, const size_t grainsize_event,
+    std::vector<std::pair<int, PulseROI>> target_to_pulse_indices, std::shared_ptr<API::Progress> &progress)
     : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(is_time_filtered, {}, target_to_pulse_indices),
-      m_workspaceIndices(workspaceIndices), m_wksps(wksps), m_calibration(calibration), m_masked(masked),
-      m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
+      m_workspaceIndices(workspaceIndices), m_wksps(wksps), m_calibration(calibration),
+      m_scale_at_sample(scale_at_sample), m_masked(masked), m_events_per_chunk(events_per_chunk),
+      m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
@@ -146,8 +145,9 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
             // only recreate calibration if it doesn't already have the useful information
             if ((!calibration) || (calibration->idmin() > static_cast<detid_t>(minval)) ||
                 (calibration->idmax() < static_cast<detid_t>(maxval))) {
-              calibration = std::make_unique<BankCalibration>(
-                  static_cast<detid_t>(minval), static_cast<detid_t>(maxval), time_conversion, m_calibration, m_masked);
+              calibration =
+                  std::make_unique<BankCalibration>(static_cast<detid_t>(minval), static_cast<detid_t>(maxval),
+                                                    time_conversion, m_calibration, m_scale_at_sample, m_masked);
             }
           },
           [&] { // load time-of-flight

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -27,12 +27,13 @@ auto g_log = Kernel::Logger("ProcessBankTask");
 } // namespace
 ProcessBankTask::ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
                                  const bool is_time_filtered, API::MatrixWorkspace_sptr &wksp,
-                                 const std::map<detid_t, double> &calibration, const std::set<detid_t> &masked,
+                                 const std::map<detid_t, double> &calibration,
+                                 const std::map<detid_t, double> &scale_at_sample, const std::set<detid_t> &masked,
                                  const size_t events_per_chunk, const size_t grainsize_event,
                                  std::vector<PulseROI> pulse_indices, std::shared_ptr<API::Progress> &progress)
     : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(is_time_filtered, pulse_indices), m_wksp(wksp),
-      m_calibration(calibration), m_masked(masked), m_events_per_chunk(events_per_chunk),
-      m_grainsize_event(grainsize_event), m_progress(progress) {}
+      m_calibration(calibration), m_scale_at_sample(scale_at_sample), m_masked(masked),
+      m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
@@ -135,8 +136,9 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
             // only recreate calibration if it doesn't already have the useful information
             if ((!calibration) || (calibration->idmin() > static_cast<detid_t>(minval)) ||
                 (calibration->idmax() < static_cast<detid_t>(maxval))) {
-              calibration = std::make_unique<BankCalibration>(
-                  static_cast<detid_t>(minval), static_cast<detid_t>(maxval), time_conversion, m_calibration, m_masked);
+              calibration =
+                  std::make_unique<BankCalibration>(static_cast<detid_t>(minval), static_cast<detid_t>(maxval),
+                                                    time_conversion, m_calibration, m_scale_at_sample, m_masked);
             }
           },
           [&] { // load time-of-flight

--- a/Framework/DataHandling/test/BankCalibrationTest.h
+++ b/Framework/DataHandling/test/BankCalibrationTest.h
@@ -1,0 +1,55 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
+#include <cxxtest/TestSuite.h>
+#include <ranges>
+
+using Mantid::detid_t;
+using Mantid::DataHandling::AlignAndFocusPowderSlim::BankCalibration;
+
+class BankCalibrationTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static BankCalibrationTest *createSuite() { return new BankCalibrationTest(); }
+  static void destroySuite(BankCalibrationTest *suite) { delete suite; }
+
+  void test_ProcessEventsTask() {
+    constexpr double TIME_CONVERSION{10};
+
+    // simple calibration: tof' = tof * detID for testing
+    std::map<detid_t, double> calibration_map;
+    for (const auto &detid : std::views::iota(1, 5))
+      calibration_map[detid] = detid;
+
+    // simple scale at sample: scale = 2. * detid for testing
+    std::map<detid_t, double> scale_map;
+    for (const auto &detid : std::views::iota(1, 5))
+      scale_map[detid] = 2. * detid;
+
+    // mask detID 4
+    std::set<detid_t> mask{4};
+
+    // id range to use
+    detid_t DETID_MIN(2);
+    detid_t DETID_MAX(3);
+
+    // only get a subset of pixels
+    BankCalibration bankCalib(DETID_MIN, DETID_MAX, TIME_CONVERSION, calibration_map, scale_map, mask);
+
+    // check class constants
+    TS_ASSERT_EQUALS(bankCalib.idmin(), DETID_MIN);
+    TS_ASSERT_EQUALS(bankCalib.idmax(), DETID_MAX);
+    // only check values in range
+    TS_ASSERT_EQUALS(bankCalib.value_calibration(2), calibration_map[2] * TIME_CONVERSION);
+    TS_ASSERT_EQUALS(bankCalib.value_calibration(3), calibration_map[3] * TIME_CONVERSION);
+    TS_ASSERT_EQUALS(bankCalib.value_scale_at_sample(2), scale_map[2]);
+    TS_ASSERT_EQUALS(bankCalib.value_scale_at_sample(3), scale_map[3]);
+  }
+};

--- a/Framework/DataHandling/test/ProcessEventsTaskTest.h
+++ b/Framework/DataHandling/test/ProcessEventsTaskTest.h
@@ -33,7 +33,7 @@ public:
 
     std::set<detid_t> mask{4}; // mask detID 4
 
-    BankCalibration bankCal(1, 4, 1., calibration_map, mask);
+    BankCalibration bankCal(1, 4, 1., calibration_map, std::map<detid_t, double>(), mask);
 
     ProcessEventsTask task(&detIDs, &tofs, &bankCal, &binEdges);
     task(tbb::blocked_range<size_t>(0, tofs.size()));

--- a/Framework/DataHandling/test/SaveGSSTest.h
+++ b/Framework/DataHandling/test/SaveGSSTest.h
@@ -15,10 +15,10 @@
 #include "MantidFrameworkTestHelpers/FileComparisonHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
+#include "MantidKernel/Glob.h"
 #include "cxxtest/TestSuite.h"
 
 #include <Poco/File.h>
-#include <Poco/Glob.h>
 #include <Poco/TemporaryFile.h>
 #include <fstream>
 
@@ -270,7 +270,7 @@ public:
 
     // Use glob to find any files that match the output pattern
     std::set<std::string> returnedFiles;
-    Poco::Glob::glob(outFilePath, returnedFiles);
+    Kernel::Glob::glob(outFilePath, returnedFiles);
     for (const auto &filename : returnedFiles) {
       Poco::File pocoFile{filename};
       pocoFile.remove();
@@ -323,7 +323,7 @@ public:
 
     // Use glob to find any files that match the output pattern
     std::set<std::string> returnedFiles;
-    Poco::Glob::glob(globPattern, returnedFiles);
+    Kernel::Glob::glob(globPattern, returnedFiles);
     for (const auto &filename : returnedFiles) {
       Poco::File pocoFile{filename};
       pocoFile.remove();

--- a/Framework/Kernel/inc/MantidKernel/Glob.h
+++ b/Framework/Kernel/inc/MantidKernel/Glob.h
@@ -25,8 +25,18 @@ namespace Kernel {
 
 class MANTID_KERNEL_DLL Glob {
 public:
+  /// Glob option constants (compatible with Poco::Glob)
+  static constexpr int GLOB_DEFAULT = 0;
+  static constexpr int GLOB_CASELESS = 4;
+
   /// Creates a set of files that match the given pathPattern.
   static void glob(const std::string &pathPattern, std::set<std::string> &files, int options = 0);
+
+  /**
+   * Convert a glob pattern to an equivalent regular expression. This essentially converts non-escaped "*" to ".+" and
+   * non-escaped "?" to ".". This is how Poco's Glob module acts.
+   */
+  static std::string globToRegex(const std::string &globPattern);
 };
 
 } // namespace Kernel

--- a/Framework/Kernel/src/Glob.cpp
+++ b/Framework/Kernel/src/Glob.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/Glob.h"
+#include "MantidKernel/Strings.h"
 #include <Poco/Glob.h>
 
 namespace Mantid::Kernel {
@@ -45,6 +46,61 @@ void Glob::glob(const std::string &pathPattern, std::set<std::string> &files, in
 #else
   Poco::Glob::glob(pathPattern, files, options);
 #endif
+}
+
+std::string Glob::globToRegex(const std::string &globPattern) {
+  const std::string STAR("*");
+  const std::string STAR_ESCAPED("\\*");
+  const std::string QUESTION("?");
+  const std::string QUESTION_ESCAPED("\\?");
+
+  const std::string REGEX_MATCH_GLOB(".+");
+  const std::string REGEX_MATCH_CHAR(".");
+  const std::string REGEX_START_STR("^");
+  const std::string REGEX_END_STR("$");
+
+  // this is a variant of Strings::replace and Strings::replaceAll
+  std::string output = globPattern;
+
+  // replace stars
+  std::string::size_type pos = 0;
+  while ((pos = output.find(STAR, pos)) != std::string::npos) {
+    if ((pos > 0) && (pos + 1 != std::string::npos)) {
+      if (output.substr(pos - 1, STAR_ESCAPED.length()) == STAR_ESCAPED) {
+        pos += 1;
+        continue;
+      }
+    }
+    output.erase(pos, STAR.length());
+    output.insert(pos, REGEX_MATCH_GLOB);
+    pos += REGEX_MATCH_GLOB.length();
+  }
+
+  // now with question marks
+  pos = 0;
+  while ((pos = output.find(QUESTION, pos)) != std::string::npos) {
+    if ((pos > 0) && (pos + 1 != std::string::npos)) {
+      if (output.substr(pos - 1, QUESTION_ESCAPED.length()) == QUESTION_ESCAPED) {
+        pos += 1;
+        continue;
+      }
+    }
+    output.erase(pos, QUESTION.length());
+    output.insert(pos, REGEX_MATCH_CHAR);
+    pos += REGEX_MATCH_CHAR.length();
+  }
+
+  // now [! and don't worry about escaping
+  pos = 0;
+  while ((pos = output.find("[!", pos)) != std::string::npos) {
+    output.erase(pos, std::string("[!").length());
+    output.insert(pos, "![");
+    pos += std::string("![").length();
+  }
+
+  // replaced string with anchors
+  return REGEX_START_STR + output + REGEX_END_STR;
+  // return output;
 }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/test/GlobTest.h
+++ b/Framework/Kernel/test/GlobTest.h
@@ -11,7 +11,6 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Glob.h"
 
-#include <Poco/Glob.h>
 #include <filesystem>
 #include <fstream>
 
@@ -136,7 +135,29 @@ public:
     std::filesystem::path pattern = base / "instrument" / "unit_TESTING/dum_Definition.xml";
 
     std::set<std::string> files;
-    Glob::glob(pattern.string(), files, Poco::Glob::GLOB_CASELESS);
+    Glob::glob(pattern.string(), files, Glob::GLOB_CASELESS);
     TS_ASSERT(!files.empty());
+  }
+
+  void test_glob_to_regex() {
+    // no globbing specified
+    TS_ASSERT_EQUALS(Glob::globToRegex("abcd"), "^abcd$");
+
+    // globbing *
+    TS_ASSERT_EQUALS(Glob::globToRegex("a*bc*d"), "^a.+bc.+d$");
+    TS_ASSERT_EQUALS(Glob::globToRegex("*a*bc*d*"), "^.+a.+bc.+d.+$");
+
+    // globbing * with escapes
+    TS_ASSERT_EQUALS(Glob::globToRegex("a*bc\\*d"), "^a.+bc\\*d$");
+    TS_ASSERT_EQUALS(Glob::globToRegex("\\*a*bc\\*d"), "^\\*a.+bc\\*d$");
+
+    // globbing ?
+    TS_ASSERT_EQUALS(Glob::globToRegex("a?bc*d"), "^a.bc.+d$");
+
+    // globbing ? with escapes
+    TS_ASSERT_EQUALS(Glob::globToRegex("a?bc\\?d"), "^a.bc\\?d$");
+
+    // globbing both
+    TS_ASSERT_EQUALS(Glob::globToRegex("a?bc*d"), "^a.bc.+d$");
   }
 };

--- a/Framework/NexusGeometry/test/JSONGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/JSONGeometryParserTest.h
@@ -8,9 +8,9 @@
 
 #include "MantidFrameworkTestHelpers/JSONGeometryParserTestHelper.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/Glob.h"
 #include "MantidKernel/Strings.h"
 #include "MantidNexusGeometry/JSONGeometryParser.h"
-#include <Poco/Glob.h>
 #include <cxxtest/TestSuite.h>
 #include <exception>
 #include <json/json.h>
@@ -420,7 +420,7 @@ public:
 
   void setUp() override {
     std::string filename = "V20_file_write_start_20190524.json";
-    std::string fullPath = ConfigService::Instance().getFullPath(filename, true, Poco::Glob::GLOB_DEFAULT);
+    std::string fullPath = ConfigService::Instance().getFullPath(filename, true, Glob::GLOB_DEFAULT);
 
     instrument = Strings::loadFile(fullPath);
   }

--- a/Framework/NexusGeometry/test/NexusGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometryParserTest.h
@@ -18,13 +18,13 @@
 #include "MantidGeometry/Surfaces/Cylinder.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/EigenConversionHelpers.h"
+#include "MantidKernel/Glob.h"
 #include "MantidNexus/H5Util.h"
 #include "MantidNexusGeometry/NexusGeometryDefinitions.h"
 #include "MantidNexusGeometry/NexusGeometryParser.h"
 
 #include "mockobjects.h"
 #include <H5Cpp.h>
-#include <Poco/Glob.h>
 #include <chrono>
 #include <gmock/gmock.h>
 #include <string>
@@ -47,7 +47,7 @@ extractBeamline(const Mantid::Geometry::Instrument &instrument) {
 }
 
 std::string instrument_path(const std::string &local_name) {
-  return Kernel::ConfigService::Instance().getFullPath(local_name, true, Poco::Glob::GLOB_DEFAULT);
+  return Kernel::ConfigService::Instance().getFullPath(local_name, true, Kernel::Glob::GLOB_DEFAULT);
 }
 
 } // namespace


### PR DESCRIPTION
This pulls the following (mostly copilot associated) changed into `ornl-next`:
* #40341
* #40321
* #40351
* #40348