### PR TITLE
Create github action to automatically add the current milestone to new PRs

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   add-milestone:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ornl-next') }}
     runs-on: ubuntu-latest
     steps:
       - uses: benelan/milestone-action@v3

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,0 +1,13 @@
+name: Add milestone to new PRs 
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benelan/milestone-action@v3
+        with:
+          farthest: false      # false = use current milestone by due date
+          overwrite: false     # don't overwrite if milestone already exists

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,7 +1,8 @@
 name: Add milestone to new PRs
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
+    branches: [main, release-next]
 
 jobs:
   add-milestone:

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   add-milestone:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ornl-next') }}
     runs-on: ubuntu-latest
     steps:
       - uses: benelan/milestone-action@v3

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,4 +1,4 @@
-name: Add milestone to new PRs 
+name: Add milestone to new PRs
 on:
   pull_request:
     types: [opened]


### PR DESCRIPTION
### Description of work

See milestone here: https://github.com/benelan/milestone-action

### To test:

PR tests itself 😎 

<img width="874" height="112" alt="image" src="https://github.com/user-attachments/assets/9ca90d3a-cf1c-475c-a9f7-6d047a41e305" />

---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
