### PR TITLE
Add Doxygen GitHub actions workflow

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,14 +1,21 @@
-name: doxygen documentation build test
+name: doxygen documentation build
 on:
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - 'Framework/Doxygen/**'
+      - 'conda/recipes/mantid-developer/**'
+      - 'conda/recipes/conda_build_config.yaml'
+      - 'buildconfig/Jenkins/Conda/doxygen.sh'
 
 jobs:
   doxygen:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,6 +12,7 @@ on:
       - 'conda/recipes/mantid-developer/**'
       - 'conda/recipes/conda_build_config.yaml'
       - 'buildconfig/Jenkins/Conda/doxygen.sh'
+      - '.github/workflows/doxygen.yml'
 
 jobs:
   doxygen:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,23 @@
+name: doxygen documentation build test
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  doxygen:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: build doxygen
+        run: |
+          $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE


### PR DESCRIPTION
### Description of work

A minimal addition of our Doxygen build test to GitHub actions.

As the logic is encapsulated within `Doxygen.sh`, any change to the script (i.e using pixie > mamba) will be picked up automatically.

The workflow is likely to developed further as the migration to GHA progresses, and as pixi is implemented.

Closes #40286

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Check the relevant workflow has run on this PR.
Confirm workflow has run on this PR and failed, the change made is bad: https://github.com/MialLewis/mantid/pull/7

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
