### PR TITLE
Improve GetIPTS error message

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/GetIPTS.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetIPTS.py
@@ -56,7 +56,7 @@ class GetIPTS(PythonAlgorithm):
                 pass  # just keep looking
 
         # failed to find any is an error
-        raise RuntimeError(f"Cannot find IPTS directory for RunNumber'{runnumber}' at Instrument='{instrument}'")
+        raise RuntimeError(f"Cannot find IPTS directory for RunNumber='{runnumber}' at Instrument='{instrument}'")
 
     def getIPTSLocal(self, instrument, runnumber):
         # prepend non-empty instrument name for FileFinder

--- a/Framework/PythonInterface/plugins/algorithms/GetIPTS.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetIPTS.py
@@ -56,7 +56,7 @@ class GetIPTS(PythonAlgorithm):
                 pass  # just keep looking
 
         # failed to find any is an error
-        raise RuntimeError("Cannot find IPTS directory for '%s'" % runnumber)
+        raise RuntimeError(f"Cannot find IPTS directory for RunNumber'{runnumber}' at Instrument='{instrument}'")
 
     def getIPTSLocal(self, instrument, runnumber):
         # prepend non-empty instrument name for FileFinder


### PR DESCRIPTION
When there are no runs found, give an error message that shows the the inputs for finding the run.

There are no associated issues.

### To test:

* `GetIPTS(0)` should still show the error that the run number is an invalid input.
* `GetIPTS(1)` should show an error about the run not being found


*This does not require release notes* because it is a minor change to an error string that hopefully people don't see too often.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
