### PR TITLE
Fix memory leak in `Nexus::File::getSlab()`

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -64,7 +64,7 @@ public:
 
 using Deleter = int (*const)(hid_t);
 
-template <Deleter const deleter> class MANTID_NEXUS_DLL UniqueID {
+template <Deleter const deleter> class UniqueID {
 private:
   hid_t m_id;
   UniqueID &operator=(UniqueID<deleter> const &) = delete;
@@ -76,7 +76,7 @@ private:
   }
 
 public:
-  UniqueID(UniqueID<deleter> const &uid) = delete;
+  UniqueID(UniqueID<deleter> &uid) : m_id(uid.m_id) { uid.m_id = -1; };
   UniqueID(UniqueID<deleter> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = -1; };
   UniqueID &operator=(hid_t const id) {
     if (id != m_id) {

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -190,7 +190,7 @@ public:
    * \return A unix like address string pointing to the current
    *         position in the file
    */
-  std::string getAddress() const;
+  std::string const &getAddress() const { return m_address.string(); };
 
   // CHECK ADDRESS EXISTENCE
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -358,8 +358,6 @@ NexusAddress File::groupAddress(NexusAddress const &addr) const {
   }
 }
 
-std::string File::getAddress() const { return m_address; }
-
 bool File::hasAddress(std::string const &name) const {
   if (name == "/") { // NexusDescriptor does not keep the root, but it does exist
     return true;
@@ -1012,7 +1010,7 @@ template <typename NumT> void File::putSlab(NumT const *data, DimVector const &s
   stringstream msg;
   msg << "putSlab(data, " << toString(start) << ", " << toString(size) << ") failed: ";
 
-  /* check if there is an Dataset open */
+  /* check if there is a Dataset open */
   if (!isDataSetOpen()) {
     msg << "no dataset open";
     throw NXEXCEPTION(msg.str());

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -111,10 +111,10 @@ FileID::~FileID() {
   }
 }
 
-using GroupID = UniqueID<[](hid_t const id) { H5Gclose(id); }>;
-using DataSetID = UniqueID<[](hid_t const id) { H5Dclose(id); }>;
-using DataTypeID = UniqueID<[](hid_t const id) { H5Tclose(id); }>;
-using DataSpaceID = UniqueID<[](hid_t const id) { H5Sclose(id); }>;
+using GroupID = UniqueID<&H5Gclose>;
+using DataSetID = UniqueID<&H5Dclose>;
+using DataTypeID = UniqueID<&H5Tclose>;
+using DataSpaceID = UniqueID<&H5Sclose>;
 
 } // namespace Mantid::Nexus
 
@@ -569,28 +569,24 @@ void File::openData(std::string const &name) {
   NexusAddress absaddr(formAbsoluteAddress(name));
 
   /* find the ID number and open the dataset */
-  hid_t newData, newType, newSpace;
-  newData = H5Dopen(m_pfile->getId(), absaddr.c_str(), H5P_DEFAULT);
-  if (newData < 0) {
+  DataSetID newData = H5Dopen(m_pfile->getId(), absaddr.c_str(), H5P_DEFAULT);
+  if (newData.getId() < 0) {
     throw NXEXCEPTION("Dataset (" + absaddr + ") not found at this level");
   }
   /* find the ID number of datatype */
-  newType = H5Dget_type(newData);
-  if (newType < 0) {
-    H5Dclose(newData);
+  DataTypeID newType = H5Dget_type(newData.getId());
+  if (newType.getId() < 0) {
     throw NXEXCEPTION("Error opening dataset (" + absaddr + ")");
   }
   /* find the ID number of dataspace */
-  newSpace = H5Dget_space(newData);
-  if (newSpace < 0) {
-    H5Dclose(newData);
-    H5Tclose(newType);
+  DataSpaceID newSpace = H5Dget_space(newData.getId());
+  if (newSpace.getId() < 0) {
     throw NXEXCEPTION("Error opening dataset (" + absaddr + ")");
   }
   // now maintain stack
-  m_current_data_id = newData;
-  m_current_type_id = newType;
-  m_current_space_id = newSpace;
+  m_current_data_id = newData.releaseId();
+  m_current_type_id = newType.releaseId();
+  m_current_space_id = newSpace.releaseId();
   m_address = absaddr;
 }
 
@@ -787,14 +783,11 @@ template <typename NumT> void File::getData(NumT *data) {
   hsize_t ndims = H5Sget_simple_extent_ndims(m_current_space_id);
 
   if (ndims == 0) {
-    hid_t datatype = H5Dget_type(m_current_data_id);
-    hid_t filespace = H5Dget_space(m_current_data_id);
-    hid_t memtype_id = H5Screate(H5S_SCALAR);
-    H5Sselect_all(filespace);
-    ret = H5Dread(m_current_data_id, datatype, memtype_id, filespace, H5P_DEFAULT, data);
-    H5Sclose(memtype_id);
-    H5Sclose(filespace);
-    H5Tclose(datatype);
+    DataTypeID datatype = H5Dget_type(m_current_data_id);
+    DataSpaceID filespace = H5Dget_space(m_current_data_id);
+    DataSpaceID memspace_id = H5Screate(H5S_SCALAR);
+    H5Sselect_all(filespace.getId());
+    ret = H5Dread(m_current_data_id, datatype.getId(), memspace_id.getId(), filespace.getId(), H5P_DEFAULT, data);
   } else {
     if (H5Tget_class(m_current_type_id) == H5T_STRING) {
       this->getData<char>(reinterpret_cast<char *>(data));
@@ -881,10 +874,10 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
   }
 
   // create the correct datatype for this numeric type
-  hid_t datatype = H5Tcopy(nxToHDF5Type(type));
+  DataTypeID datatype = H5Tcopy(nxToHDF5Type(type));
 
   // create a dataspace
-  hid_t dataspace;
+  DataSpaceID dataspace;
   if (type == NXnumtype::CHAR) {
     std::size_t byte_zahl(mydim.back());
     DimVector mydim1(mydim.cbegin(), mydim.cend());
@@ -900,7 +893,7 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
       chunkdims.back() = 1;
     }
     dataspace = H5Screate_simple(rank, mydim1.data(), maxdims.data());
-    H5Tset_size(datatype, byte_zahl);
+    H5Tset_size(datatype.getId(), byte_zahl);
   } else {
     if (unlimited) {
       dataspace = H5Screate_simple(rank, mydim.data(), maxdims.data());
@@ -915,8 +908,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     herr_t ret = H5Pset_chunk(cparms, rank, chunkdims.data());
     if (ret < 0) {
       H5Pclose(cparms);
-      H5Tclose(datatype);
-      H5Sclose(dataspace);
       msg << "Size of chunks could not be set";
       throw NXEXCEPTION(msg.str());
     }
@@ -930,8 +921,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
       herr_t ret = H5Pset_chunk(cparms, rank, chunkdims.data());
       if (ret < 0) {
         H5Pclose(cparms);
-        H5Tclose(datatype);
-        H5Sclose(dataspace);
         msg << "Size of chunks could not be set";
         throw NXEXCEPTION(msg.str());
       }
@@ -943,8 +932,6 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
     herr_t ret = H5Pset_chunk(cparms, rank, chunkdims.data());
     if (ret < 0) {
       H5Pclose(cparms);
-      H5Tclose(datatype);
-      H5Sclose(dataspace);
       msg << "Size of chunks could not be set";
       throw NXEXCEPTION(msg.str());
     }
@@ -956,20 +943,16 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
 
   // create the dataset with the compression parameters
   NexusAddress absaddr(formAbsoluteAddress(name));
-  hid_t dataset = H5Dcreate(m_pfile->getId(), absaddr.c_str(), datatype, dataspace, H5P_DEFAULT, cparms, H5P_DEFAULT);
+  DataSetID dataset = H5Dcreate(m_pfile->getId(), absaddr.c_str(), datatype.getId(), dataspace.getId(), H5P_DEFAULT,
+                                cparms, H5P_DEFAULT);
   H5Pclose(cparms);
-  if (dataset < 0) {
-    H5Tclose(datatype);
-    H5Sclose(dataspace);
+  if (dataset.getId() < 0) {
     msg << "Creating chunked dataset failed";
     throw NXEXCEPTION(msg.str());
   }
   if (unlimited) {
-    herr_t ret = H5Dset_extent(dataset, mydim.data());
+    herr_t ret = H5Dset_extent(dataset.getId(), mydim.data());
     if (ret < 0) {
-      H5Tclose(datatype);
-      H5Sclose(dataspace);
-      H5Dclose(dataset);
       msg << "Cannot create dataset " << name;
       throw NXEXCEPTION(msg.str());
     }
@@ -977,23 +960,10 @@ void File::makeCompData(std::string const &name, NXnumtype const type, DimVector
   // cleanup
   registerEntry(absaddr, SCIENTIFIC_DATA_SET);
   if (open_data) {
-    m_current_type_id = datatype;
-    m_current_space_id = dataspace;
-    m_current_data_id = dataset;
+    m_current_type_id = datatype.releaseId();
+    m_current_space_id = dataspace.releaseId();
+    m_current_data_id = dataset.releaseId();
     m_address = absaddr;
-  } else {
-    if (H5Sclose(dataspace) < 0) {
-      msg << "HDF cannot close dataspace";
-      throw NXEXCEPTION(msg.str());
-    }
-    if (H5Tclose(datatype) < 0) {
-      msg << "HDF cannot close datatype";
-      throw NXEXCEPTION(msg.str());
-    }
-    if (H5Dclose(dataset) < 0) {
-      msg << "HDF cannot close dataset";
-      throw NXEXCEPTION(msg.str());
-    }
   }
 }
 
@@ -1060,30 +1030,26 @@ template <typename NumT> void File::putSlab(NumT const *data, DimVector const &s
     }
 
     // define slab
-    hid_t filespace = H5Dget_space(m_current_data_id);
-    iRet = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, myStart.data(), nullptr, mySize.data(), nullptr);
+    DataSpaceID filespace = H5Dget_space(m_current_data_id);
+    iRet = H5Sselect_hyperslab(filespace.getId(), H5S_SELECT_SET, myStart.data(), nullptr, mySize.data(), nullptr);
     if (iRet < 0) {
-      H5Sclose(filespace);
       msg << "selecting slab failed";
       throw NXEXCEPTION(msg.str());
     }
     // write slab
-    hid_t dataspace = H5Screate_simple(rank, mySize.data(), nullptr);
-    iRet = H5Dwrite(m_current_data_id, m_current_type_id, dataspace, filespace, H5P_DEFAULT, data);
-    H5Sclose(dataspace);
+    DataSpaceID dataspace = H5Screate_simple(rank, mySize.data(), nullptr);
+    iRet = H5Dwrite(m_current_data_id, m_current_type_id, dataspace.getId(), filespace.getId(), H5P_DEFAULT, data);
     if (iRet < 0) {
-      H5Sclose(filespace);
       msg << "writing slab failed";
       throw NXEXCEPTION(msg.str());
     }
     /* update with new size */
     iRet = H5Sclose(m_current_space_id);
     if (iRet < 0) {
-      H5Sclose(filespace);
       msg << "updating size failed";
       throw NXEXCEPTION(msg.str());
     }
-    m_current_space_id = filespace;
+    m_current_space_id = filespace.releaseId();
   } else { // no unlimited dimensions
     // define slab
     iRet = H5Sselect_hyperslab(m_current_space_id, H5S_SELECT_SET, myStart.data(), nullptr, mySize.data(), nullptr);
@@ -1093,9 +1059,8 @@ template <typename NumT> void File::putSlab(NumT const *data, DimVector const &s
       throw NXEXCEPTION(msg.str());
     }
     // write slab
-    hid_t dataspace = H5Screate_simple(rank, mySize.data(), nullptr);
-    iRet = H5Dwrite(m_current_data_id, m_current_type_id, dataspace, m_current_space_id, H5P_DEFAULT, data);
-    H5Sclose(dataspace);
+    DataSpaceID dataspace = H5Screate_simple(rank, mySize.data(), nullptr);
+    iRet = H5Dwrite(m_current_data_id, m_current_type_id, dataspace.getId(), m_current_space_id, H5P_DEFAULT, data);
     if (iRet < 0) {
       msg << "writing slab failed";
       throw NXEXCEPTION(msg.str());

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -258,6 +258,75 @@ public:
   // #################################################################################################################
   // TEST MAKE / OPEN / PUT / CLOSE DATASET
   // #################################################################################################################
+  void test_uniqueID() {
+    static int call_count = 0;
+    auto blank_deleter = [](hid_t) -> int { return ++call_count; };
+
+    // construct empty
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid;
+      TS_ASSERT_EQUALS(uid.getId(), -1);
+    }
+    TS_ASSERT_EQUALS(call_count, 0);
+
+    // construct
+    hid_t test = 101;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
+      TS_ASSERT_EQUALS(uid.getId(), test);
+    }
+    TS_ASSERT_EQUALS(call_count, 1);
+
+    // release
+    call_count = 0;
+    hid_t res;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
+      TS_ASSERT_THROWS_NOTHING(res = uid.releaseId());
+      TS_ASSERT_EQUALS(uid.getId(), -1);
+      TS_ASSERT_EQUALS(res, test);
+    }
+    TS_ASSERT_EQUALS(call_count, 0);
+    TS_ASSERT_EQUALS(res, test);
+
+    // copy construct
+    call_count = 0;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
+      {
+        Mantid::Nexus::UniqueID<blank_deleter> uid2(uid);
+        TS_ASSERT_EQUALS(uid.getId(), -1);
+        TS_ASSERT_EQUALS(uid2.getId(), test);
+      }
+      TS_ASSERT_EQUALS(uid.getId(), -1);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 1);
+
+    // assign from hid_t
+    call_count = 0;
+    hid_t val1 = 73, val2 = 17;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid(val1);
+      uid = val2;
+      TS_ASSERT_EQUALS(uid.getId(), val2);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 2);
+
+    // assign from uid
+    call_count = 0;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid1(val1), uid2(val2);
+      TS_ASSERT_EQUALS(uid1.getId(), val1);
+      TS_ASSERT_EQUALS(uid2.getId(), val2);
+      uid1 = uid2;
+      TS_ASSERT_EQUALS(uid1.getId(), val2);
+      TS_ASSERT_EQUALS(uid2.getId(), -1);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 2);
+  }
 
   void test_makeData() {
     cout << "\ntest make data\n";

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -33,6 +33,11 @@ using std::multimap;
 using std::string;
 using std::vector;
 
+namespace {
+static int call_count = 0;
+int blank_deleter(hid_t) { return ++call_count; }
+} // namespace
+
 class NexusFileTest : public CxxTest::TestSuite {
 
 public:
@@ -259,10 +264,9 @@ public:
   // TEST MAKE / OPEN / PUT / CLOSE DATASET
   // #################################################################################################################
   void test_uniqueID() {
-    static int call_count = 0;
-    static auto const blank_deleter = [](hid_t) -> int { return ++call_count; };
-
+    cout << "\ntest uniqueID\n";
     // construct empty
+    call_count = 0;
     {
       Mantid::Nexus::UniqueID<blank_deleter> uid;
       TS_ASSERT_EQUALS(uid.getId(), -1);
@@ -276,6 +280,7 @@ public:
       TS_ASSERT_EQUALS(uid.getId(), test);
     }
     TS_ASSERT_EQUALS(call_count, 1);
+    cout << "\ntest uniqueID\n";
 
     // release
     call_count = 0;

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -260,7 +260,7 @@ public:
   // #################################################################################################################
   void test_uniqueID() {
     static int call_count = 0;
-    auto blank_deleter = [](hid_t) -> int { return ++call_count; };
+    static auto const blank_deleter = [](hid_t) -> int { return ++call_count; };
 
     // construct empty
     {

--- a/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40368.rst
+++ b/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40368.rst
@@ -1,0 +1,1 @@
+- A memory leak in ``Nexus::File`` has been patched when loading slab data; this impacted memory erformance in several loading algorithms, including :ref:`LoadNexusProcessed <algm-LoadNexusProcessed>`.


### PR DESCRIPTION
### Description of work

During the Nexus refactor, we switched to using the HDF5 C-API inside `Nexus::File`.  While this has some benefits, it also runs the risk of memory leaks.

The method `Nexus::File::getSlab()` had a memory leak in it.  This was spotted when running integration tests for drtsans, and were found during the `LoadNexusProcessed` algorithm.

This fixes the memory leak by using unique resource handlers to provide RAII on the `hid_t` objects.

Future work should build on this solution and make it used generally throughout `Nexus::File`

[EWM 14083](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14083)

Future work described in [EWM 14139](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14139)

### To test:

Build and run this script:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import LoadNexusProcessed

dir = # path to biosans test data needs to go here
file1 = f'{dir}/CG3_127_5532_mBSub.h5'
file2 = f'{dir}/CG3_127_5562_mBSub.h5'
for i in range(3):
    ws1 = LoadNexusProcessed(Filename=file1, OutputWorkspace='sample', LoadHistory=False)
    ws2 = LoadNexusProcessed(Filename=file2, OutputWorkspace='Main_buffer', LoadHistory=False)
    ws1.delete()
    ws2.delete()
```
If this has failed, there will be about 1GB taken up.  Continuing to run will cause more and more memory to be used up.

If this has passed, memory will temporarily rise to around 0.8GB, then drop back down to 0.7GB.  It will stay there no matter how many times this is run.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
