### PR TITLE
Move to cmake v4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake version check.
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 4.2)
 
 # Define the project name.
 project(Mantid)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 21,
+    "major": 4,
+    "minor": 2,
     "patch": 0
   },
   "configurePresets": [

--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -103,8 +103,10 @@ if(TARGET Boost::python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 else()
   set(PUBLIC_TARGETS Python::NumPy ${BoostPython_LIBRARIES})
 endif()
-if(USE_PYTHON_DYNAMIC_LIB OR APPLE)
+if(USE_PYTHON_DYNAMIC_LIB)
   list(APPEND PUBLIC_TARGETS Python::Python)
+elseif(TARGET Python::Module)
+  list(APPEND PUBLIC_TARGETS Python::Module)
 endif()
 # Dependencies
 target_link_libraries(

--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -90,6 +90,7 @@ target_precompile_headers(
 target_include_directories(
   ${_target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/Mantid>
 )
+target_include_directories(${_target_name} SYSTEM PUBLIC $<BUILD_INTERFACE:${Python_INCLUDE_DIRS}>)
 
 # Set the name of the generated library
 set_target_properties(

--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -103,7 +103,7 @@ if(TARGET Boost::python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 else()
   set(PUBLIC_TARGETS Python::NumPy ${BoostPython_LIBRARIES})
 endif()
-if(USE_PYTHON_DYNAMIC_LIB)
+if(USE_PYTHON_DYNAMIC_LIB OR APPLE)
   list(APPEND PUBLIC_TARGETS Python::Python)
 endif()
 # Dependencies

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -28,7 +28,7 @@ libboost:
   - '1.86.*'  # [osx]
 
 cmake:
-  - '>=3.21.0'
+  - '>=4.2,<5'
 
 # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
 doxygen:

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,7 +87,7 @@ rattler-index = "*"
 # per-platform [target.*.dependencies] tables below: linux-64 pulls the Qt6 stack,
 # win-64 and osx-arm64 keep the Qt5 stack.
 [dependencies]
-cmake = ">=3.21.0"
+cmake = ">=4.2,<5"
 ccache = ">=4.11.3,<5"
 cppcheck = "==2.18.1"
 euphonic = ">=1.6.0,<2.0"

--- a/qt/widgets/regionselector/CMakeLists.txt
+++ b/qt/widgets/regionselector/CMakeLists.txt
@@ -13,7 +13,7 @@ mtd_add_qt_library(
   NOMOC ${NOMOC_HEADERS}
   DEFS IN_MANTIDQT_REGIONSELECTOR
   INCLUDE_DIRS inc ${Boost_INCLUDE_DIRS}
-  LINK_LIBS Mantid::PythonInterfaceCore Mantid::API
+  LINK_LIBS Mantid::PythonInterfaceCore Mantid::API Python::Python
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
   INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../MacOS @loader_path/../Frameworks

--- a/qt/widgets/regionselector/CMakeLists.txt
+++ b/qt/widgets/regionselector/CMakeLists.txt
@@ -13,7 +13,7 @@ mtd_add_qt_library(
   NOMOC ${NOMOC_HEADERS}
   DEFS IN_MANTIDQT_REGIONSELECTOR
   INCLUDE_DIRS inc ${Boost_INCLUDE_DIRS}
-  LINK_LIBS Mantid::PythonInterfaceCore Mantid::API Python::Python
+  LINK_LIBS Mantid::PythonInterfaceCore Mantid::API
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
   INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../MacOS @loader_path/../Frameworks


### PR DESCRIPTION
Cmake v4.2 came out ([release notes](https://cmake.org/cmake/help/latest/release/4.2.html)). This updates the pin to the newer version (we're already using 4.2 on osx/windows and 4.4 on linux) and updates the minimum in cmake itself. There were a couple of small changes in linking behavior to fix.

There is no associated issue.

### To test:

Build on your local machine. 

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
