### PR TITLE
Deprecate GetTimeSeriesLogInformation algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/GetTimeSeriesLogInformation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetTimeSeriesLogInformation.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -21,7 +22,7 @@ namespace Algorithms {
 
   @date 2011-12-22
 */
-class MANTID_ALGORITHMS_DLL GetTimeSeriesLogInformation final : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL GetTimeSeriesLogInformation final : public API::Algorithm, public API::DeprecatedAlgorithm {
 public:
   GetTimeSeriesLogInformation();
 

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -42,6 +42,9 @@ GetTimeSeriesLogInformation::GetTimeSeriesLogInformation()
 /** Definition of all input arguments
  */
 void GetTimeSeriesLogInformation::init() {
+  g_log.warning("GetTimeSeriesLogInformation is deprecated. Use workspace.run().getStatistics(\"log_name\") instead "
+                "to access time series log statistics directly.");
+
   declareProperty(
       std::make_unique<API::WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "Anonymous", Direction::InOut),
       "Input EventWorkspace.  Each spectrum corresponds to 1 pixel");

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -42,9 +42,6 @@ GetTimeSeriesLogInformation::GetTimeSeriesLogInformation()
 /** Definition of all input arguments
  */
 void GetTimeSeriesLogInformation::init() {
-  g_log.warning("GetTimeSeriesLogInformation is deprecated. Use workspace.run().getStatistics(\"log_name\") instead "
-                "to access time series log statistics directly.");
-
   declareProperty(
       std::make_unique<API::WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "Anonymous", Direction::InOut),
       "Input EventWorkspace.  Each spectrum corresponds to 1 pixel");

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -33,8 +33,11 @@ DECLARE_ALGORITHM(GetTimeSeriesLogInformation)
 /** Constructor
  */
 GetTimeSeriesLogInformation::GetTimeSeriesLogInformation()
-    : API::Algorithm(), m_dataWS(), mRunStartTime(), mFilterT0(), mFilterTf(), m_intInfoMap(), m_dblInfoMap(),
-      m_log(nullptr), m_timeVec(), m_valueVec(), m_starttime(), m_endtime(), m_ignoreNegativeTime(false) {}
+    : API::Algorithm(), API::DeprecatedAlgorithm(), m_dataWS(), mRunStartTime(), mFilterT0(), mFilterTf(),
+      m_intInfoMap(), m_dblInfoMap(), m_log(nullptr), m_timeVec(), m_valueVec(), m_starttime(), m_endtime(),
+      m_ignoreNegativeTime(false) {
+  this->deprecatedDate("2025-11-21");
+}
 
 /** Definition of all input arguments
  */

--- a/docs/source/algorithms/GetTimeSeriesLogInformation-v1.rst
+++ b/docs/source/algorithms/GetTimeSeriesLogInformation-v1.rst
@@ -32,11 +32,11 @@ Output:
 
 .. testoutput:: exGetTimeSeriesLogInformationRunObject
 
-   duration 117.901
-   minimum 30.000
-   maximum 30.000
-   mean 30.000
-   time_mean 30.000
+   duration 171.702
+   minimum 299.800
+   maximum 300.000
+   mean 299.900
+   time_mean 299.888
 
 **Example - Get Information from One Log**
 

--- a/docs/source/algorithms/GetTimeSeriesLogInformation-v1.rst
+++ b/docs/source/algorithms/GetTimeSeriesLogInformation-v1.rst
@@ -15,6 +15,29 @@ Usage
 -----
 .. include:: ../usagedata-note.txt
 
+**Example - Get Information Using Run Object (Recommended)**
+
+.. testcode:: exGetTimeSeriesLogInformationRunObject
+
+   w=Load('CNCS_7860')
+
+   speed5_stats = w.run().getStatistics("Speed5")
+   print("duration {:.3f}".format(speed5_stats.duration))
+   print("minimum {:.3f}".format(speed5_stats.minimum))
+   print("maximum {:.3f}".format(speed5_stats.maximum))
+   print("mean {:.3f}".format(speed5_stats.mean))
+   print("time_mean {:.3f}".format(speed5_stats.time_mean))
+
+Output:
+
+.. testoutput:: exGetTimeSeriesLogInformationRunObject
+
+   duration 117.901
+   minimum 30.000
+   maximum 30.000
+   mean 30.000
+   time_mean 30.000
+
 **Example - Get Information from One Log**
 
 .. testcode:: exGetTimeSeriesLogInformationSimple

--- a/docs/source/release/v6.15.0/Framework/Algorithms/Deprecated/13756_deprecate_gettimeseriesloginformation.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/Deprecated/13756_deprecate_gettimeseriesloginformation.rst
@@ -1,0 +1,1 @@
+- :ref:`GetTimeSeriesLogInformation <algm-GetTimeSeriesLogInformation>` has been deprecated. Use ``workspace.run().getStatistics("log_name")`` instead to access time series log statistics directly.


### PR DESCRIPTION
# Deprecate GetTimeSeriesLogInformation algorithm

## Description of work

This PR deprecates the `GetTimeSeriesLogInformation` algorithm as it's no longer needed. Users can achieve the same functionality using the run object's `getStatistics()` method directly, which is simpler and more intuitive.

Changes made:
1. Modified the algorithm to inherit from `DeprecatedAlgorithm` with deprecation date of 2025-11-21
2. Added a new usage example in the documentation showing the recommended approach using `w.run().getStatistics("LogName")`
3. No replacement algorithm is specified since the functionality is available through the run object API

Closes [EWM # 13756](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13756).

## To test:

1. **Test deprecation warning:**
   - Load a workspace with time series logs (e.g., `w = Load('CNCS_7860')`)
   - Run `GetTimeSeriesLogInformation(InputWorkspace=w, LogName='Speed5', InformationWorkspace='info')`
   - Verify a deprecation warning is displayed

2. **Test the recommended approach:**
   - Load the same workspace
   - Run `stats = w.run().getStatistics("Speed5")`
   - Verify you can access `stats.duration`, `stats.minimum`, `stats.maximum`, `stats.mean`, and `stats.time_mean`
   - Confirm the values match what the deprecated algorithm would return

3. **Build documentation:**
   - Run the doc tests to ensure the new example passes

*This requires release notes* - added a note about the algorithm deprecation and the recommended alternative approach.

---

## Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn't in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

## Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
