### PR TITLE
BinaryFile accepts std::filesystem::path

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/BinaryFile.h
+++ b/Framework/Kernel/inc/MantidKernel/BinaryFile.h
@@ -18,13 +18,13 @@ namespace Mantid {
 namespace Kernel {
 
 /// Default number of items to read in from any of the files.
-static const size_t DEFAULT_BLOCK_SIZE = 100000; // 100,000
+constexpr size_t DEFAULT_BLOCK_SIZE{100000}; // 100,000
 
 /// Max size block to read from a file (memory limitations)
-static const size_t MAX_BLOCK_SIZE = 100000000; // 100 million
+constexpr size_t MAX_BLOCK_SIZE{100000000}; // 100 million
 
 /// Min size of a block (too small is inefficient)
-static const size_t MIN_BLOCK_SIZE = 1000;
+constexpr size_t MIN_BLOCK_SIZE{1000};
 
 /**
  * The BinaryFile template is a helper function for loading simple binary files.
@@ -48,27 +48,25 @@ public:
 
   //------------------------------------------------------------------------------------
   /// Constructor - open a file
-  BinaryFile(const std::string &filename) { this->open(filename); }
+  BinaryFile(std::filesystem::path const &filepath) { this->open(filepath); }
 
   /// Destructor, close the file if needed
   ~BinaryFile() { this->close(); }
 
   //------------------------------------------------------------------------------------
   /** Open a file and keep a handle to the file
-   * @param filename :: full path to open
+   * @param filepath :: full path to open
    * @throw runtime_error if the file size is not an even multiple of the type
    * size
    * @throw invalid_argument if the file does not exist
    * */
-  void open(const std::string &filename) {
+  void open(std::filesystem::path const &filepath) {
     this->handle.reset(nullptr);
-    if (!std::filesystem::exists(filename)) {
-      std::stringstream msg;
-      msg << "BinaryFile::open: File " << filename << " was not found.";
-      throw std::invalid_argument("File does not exist.");
+    if (!std::filesystem::exists(filepath)) {
+      throw std::invalid_argument(std::string("BinaryFile::open \"") + filepath.string() + "\" was not found.");
     }
     // Open the file
-    this->handle = std::make_unique<std::ifstream>(filename.c_str(), std::ios::binary);
+    this->handle = std::make_unique<std::ifstream>(filepath, std::ios::binary);
     // Count the # of elements.
     this->num_elements = this->getFileSize();
     // Make sure we are starting at 0

--- a/Framework/TestHelpers/src/FileComparisonHelper.cpp
+++ b/Framework/TestHelpers/src/FileComparisonHelper.cpp
@@ -140,11 +140,11 @@ bool areFilesEqual(const std::string &referenceFileFullPath, const std::string &
   std::ifstream outFileStream(outFileFullPath, std::ifstream::binary);
 
   if (refFileStream.fail()) {
-    throw std::runtime_error("Could not open reference file at specified path");
+    throw std::runtime_error("Could not open reference file at specified path \"" + referenceFileFullPath + "\"");
   }
 
   if (outFileStream.fail()) {
-    throw std::runtime_error("Could not open output file at specified path");
+    throw std::runtime_error("Could not open output file at specified path \"" + outFileFullPath + "\"");
   }
 
   return areFileStreamsEqual(refFileStream, outFileStream);


### PR DESCRIPTION
Change `BinaryFile` to accept a `std::filesystem::path const &` and add the file name to the exception produced in `FileComparisonHelper`.

Refs #37868.

### To test:

This is an internal refactor so if the builds pass it fine.

This does not require release notes for the same reason.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
