### PR TITLE
Tell agents what version of c++ and python are supported

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,6 +5,7 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
   push:
+    branches: [main, release-next]
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-Mantid is a C++ and Python repository that has a qt gui frontend.
+Mantid is a c++20 and python 3.11 repository that has a qt gui frontend.
 It is configured using cmake and uses conda for dependencies.
 The Mantid project provides tools to support the processing of materials-science data.
 This data can be gathered from Neutron scattering or Muon spectroscopy experiments or as the result of simulation.
@@ -26,6 +26,7 @@ This data can be gathered from Neutron scattering or Muon spectroscopy experimen
 
 # PR checklist
 
+- Run `clang-tidy` using the configuration in `.clang-tidy`
 - Format using `pre-commit run --all-files`
 - Follow PR template in `.github/PULL_REQUEST_TEMPLATE.md`
 


### PR DESCRIPTION
To aid AI development, inform the agents what version of C++ and Python we are using so they can make more informed decisions. 

There is also a small change to the rules for running the github action for setting up an environment for copilot. This removes duplicate runs in PRs that modify the job.

There is no associated issue and this doesn't need release notes because it is a change to the instructions for AI agents.

### To test:

Review the change in text and see that the `copilot-setup-steps` job is only run once.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
