### PR TITLE
Leverage gitmailmap for fixing authors' names

### DIFF
--- a/tools/DOI/authors.py
+++ b/tools/DOI/authors.py
@@ -17,13 +17,7 @@ RELEASE_TAG_RE = re.compile(r"^v?\d+.\d+(.\d)?$")
 # to be used in the case where a Git user has multiple accounts; a translation
 # entry would suffice in such an instance.
 _blocklist = [
-    # bots
     "unknown",
-    "copilot",
-    "dependabot",
-    "mantid-builder",
-    "mantidbuilder",
-    "pre-commit-ci",
     # people
     "Utkarsh Ayachit",
     "Thomas Brooks",
@@ -89,8 +83,8 @@ def _clean_up_author_list(author_list):
     """Apply translations and blocklist, and get rid of duplicates."""
     # Get rid of count by splitting on tab - remove whitespace
     result = [author.split("\t")[-1].strip() for author in author_list]
-    # Get rid of email adddress
-    result = [author.split("<")[0].strip() for author in result]
+    # Get rid of email adddress - bot addresses are <bot> in gitmailmap
+    result = [author.split("<")[0].strip() for author in result if "<bot>" not in author]
     # Remove empty authors
     result = [author for author in result if bool(author)]
 

--- a/tools/DOI/doi.py
+++ b/tools/DOI/doi.py
@@ -485,7 +485,10 @@ def run(args):
 if __name__ == "__main__":
     check_for_curl()
 
-    parser = argparse.ArgumentParser(description="Script to generate the DOI needed for a Mantid release.")
+    parser = argparse.ArgumentParser(
+        description="Script to generate the DOI needed for a Mantid release",
+        epilog="This requires having a .gitmailmap file from a TWG member",
+    )
 
     # REQUIRED
     parser.add_argument("version", type=str, help='Version of Mantid whose DOI is to be created/updated in the form "major.minor.patch"')


### PR DESCRIPTION
This PR gets rid of the custom work for fixing committer/author information to use functionality git already has.

[gitmailmap](https://git-scm.com/docs/gitmailmap) is a built in git functionality for converting the random names/emails that people supply into something more meaningful. This includes correcting the names and email addresses.

There is no associated issue.

### To test:

This added the ability to get the authors directly from `tools/DOI/authors.py` and can be run without accidentally creating a DOI. Use `tools/DOI/authors.py --help` to find out how to use it and try the two modes. As it says, you need to contact a TWG member (i.e. me) to get the `.gitmailmap` file.

This does not require release notes* because it modifies how authors are generated for the DOI tool.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
