### PR TITLE
Abins2D: validate chopper parameters

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -75,17 +75,6 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
         self._check_advanced_parameter()
 
         instrument_name = self.getProperty("Instrument").value
-        if instrument_name in TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS:
-            allowed_frequencies = abins.parameters.instruments[instrument_name]["chopper_allowed_frequencies"]
-            default_frequency = abins.parameters.instruments[instrument_name].get("chopper_frequency_default", None)
-
-            if (self.getProperty("ChopperFrequency").value) == "" and (default_frequency is None):
-                issues["ChopperFrequency"] = "This instrument does not have a default chopper frequency"
-            elif self.getProperty("ChopperFrequency").value and int(self.getProperty("ChopperFrequency").value) not in allowed_frequencies:
-                issues["ChopperFrequency"] = (
-                    f"This chopper frequency is not valid for the instrument {instrument_name}. "
-                    "Valid frequencies: " + ", ".join([str(freq) for freq in allowed_frequencies])
-                )
 
         issues.update(
             validate_e_init(
@@ -95,9 +84,7 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
             )
         )
 
-        if instrument_name in TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS and not set(issues) & (
-            {"Chopper", "ChopperFrequency", "IncidentEnergy", "EnergyUnits"}
-        ):
+        if instrument_name in TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS and not set(issues) & ({"Chopper", "IncidentEnergy", "EnergyUnits"}):
             issues.update(
                 validate_pychop_params(
                     instrument_name,

--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -17,6 +17,7 @@ from mantid.kernel import logger
 from mantid.simpleapi import GroupWorkspaces
 import abins
 from abins.abinsalgorithm import AbinsAlgorithm, AtomInfo, validate_e_init
+from abins.instruments.pychop import validate_pychop_params
 
 
 # noinspection PyPep8Naming,PyMethodMayBeStatic
@@ -93,6 +94,19 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
                 instrument_name=instrument_name,
             )
         )
+
+        if instrument_name in TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS and not set(issues) & (
+            {"Chopper", "ChopperFrequency", "IncidentEnergy", "EnergyUnits"}
+        ):
+            issues.update(
+                validate_pychop_params(
+                    instrument_name,
+                    self.getProperty("Chopper").value,
+                    self.getProperty("ChopperFrequency").value,
+                    self.getProperty("IncidentEnergy").value,
+                    self.getProperty("EnergyUnits").value,
+                )
+            )
 
         return issues
 

--- a/docs/source/release/v6.15.0/Indirect/Algorithms/New_features/40399.rst
+++ b/docs/source/release/v6.15.0/Indirect/Algorithms/New_features/40399.rst
@@ -1,0 +1,4 @@
+- Abins2D algorithm will now validate combined chopper settings
+  (Chopper, IncidentEnergy, ChopperFrequency) for pychop-based
+  instruments (MAPS, MARI, MERLIN) and prevent algorithm running if
+  there would be no neutron transmission.

--- a/scripts/abins/instruments/__init__.py
+++ b/scripts/abins/instruments/__init__.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # flake8: noqa
-from abins.constants import ALL_INSTRUMENTS
+from abins.constants import ALL_INSTRUMENTS, TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS
 from .instrument import Instrument
 from .lagrangeinstrument import LagrangeInstrument
 from .panther import PantherInstrument
@@ -18,11 +18,11 @@ instruments = {
     "lagrange": LagrangeInstrument,
     "tosca": ToscaInstrument,
     "ideal2d": Ideal2D,
-    "maps": (PyChopInstrument, {"name": "MAPS"}),
-    "mari": (PyChopInstrument, {"name": "MARI"}),
-    "merlin": (PyChopInstrument, {"name": "MERLIN"}),
     "panther": PantherInstrument,
 }
+
+for name in TWO_DIMENSIONAL_CHOPPER_INSTRUMENTS:
+    instruments[name.lower()] = (PyChopInstrument, {"name": name})
 
 
 def get_instrument(name: str, **kwargs) -> Instrument:

--- a/scripts/abins/instruments/pychop.py
+++ b/scripts/abins/instruments/pychop.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 from pychop import Instruments as pychop_instruments
@@ -72,16 +72,29 @@ class PyChopInstrument(DirectInstrument):
 
 
 @validate_call
-def validate_pychop_params(name: str, chopper: str, chopper_frequency: str, e_i: str, energy_units: str) -> dict[str, str]:
+def validate_pychop_params(
+    name: str, chopper: str, chopper_frequency: str, e_i: str, energy_units: Literal["meV", "cm-1"]
+) -> dict[str, str]:
     """Check chopper parameters are in valid range
 
     If the chopper speed is too high relative to incident this can lead to zero transmission
+
+    Input parameters are in string form, corresponding to Abins2D algorithm inputs
+
+    :param name: Instrument name e.g. "MARI"
+    :param name: Chopper setting e.g. "A"
+    :param name: Chopper frequency e.g. "350"
+    :param e_i: Incident energy in energy_units
+    :param energy_units: "meV" or "cm-1"
+
+    :return: issues dict for Algorithm validation, of form {"ParamName": "Error message"}
+
     """
 
     EPSILON = 1e-8  # Calculation range is slightly reduced to avoid considering stationary neutrons
 
     energy = float(e_i)
-    if energy_units != "meV":
+    if energy_units == "cm-1":
         energy = energy / MILLI_EV_TO_WAVENUMBER
     pychop_instrument = pychop_instruments.Instrument(name, chopper=chopper, freq=int(chopper_frequency))
 

--- a/scripts/test/Abins/AbinsInstrumentTest.py
+++ b/scripts/test/Abins/AbinsInstrumentTest.py
@@ -76,6 +76,7 @@ class DirectValidationTest(unittest.TestCase):
         catch this before performing intensity calculations.
         """
 
+        # All good, empty dict is False-y
         self.assertFalse(
             validate_pychop_params(
                 name="MARI",
@@ -86,15 +87,38 @@ class DirectValidationTest(unittest.TestCase):
             )
         )
 
-        self.assertTrue(
-            validate_pychop_params(
-                name="MARI",
-                chopper="A",
-                chopper_frequency="400",
-                e_i="10",
-                energy_units="meV",
-            )
+        # Frequency outside limits
+        issues = validate_pychop_params(
+            name="MARI",
+            chopper="A",
+            chopper_frequency="100000",
+            e_i="4000",
+            energy_units="meV",
         )
+        self.assertIn("ChopperFrequency", issues)
+        self.assertIn("Valid frequencies: ", issues["ChopperFrequency"])
+
+        # Non-int-able frequency
+        issues = validate_pychop_params(
+            name="MARI",
+            chopper="A",
+            chopper_frequency="not_castable_to_int",
+            e_i="4000",
+            energy_units="meV",
+        )
+        self.assertIn("ChopperFrequency", issues)
+        self.assertIn("could not cast to integer", issues["ChopperFrequency"])
+
+        # Bad freq / e_i combination, no transmission
+        issues = validate_pychop_params(
+            name="MARI",
+            chopper="A",
+            chopper_frequency="400",
+            e_i="10",
+            energy_units="meV",
+        )
+        self.assertIn("ChopperFrequency", issues)
+        self.assertIn("Use PyChop to identify a valid setting.", issues["ChopperFrequency"])
 
 
 if __name__ == "__main__":

--- a/scripts/test/Abins/AbinsInstrumentTest.py
+++ b/scripts/test/Abins/AbinsInstrumentTest.py
@@ -11,6 +11,7 @@ from euphonic import ureg
 from abins.constants import ALL_INSTRUMENTS
 from abins.instruments import get_instrument
 from abins.instruments.instrument import Instrument
+from abins.instruments.pychop import validate_pychop_params
 
 
 class InstrumentTest(unittest.TestCase):
@@ -64,6 +65,36 @@ class LagrangeResolutionTest(unittest.TestCase):
         self.assertAlmostEqual((sigma_below * ureg("1/cm")).to("meV").magnitude, 0.4, 6)
 
         self.assertGreater(sigma_above, sigma_below)
+
+
+class DirectValidationTest(unittest.TestCase):
+    def test_pychop_validation(self):
+        """Test validation function used by Abins with pychop instruments
+
+        If the wrong incident energy / chopper setting are used together, there
+        is no transmission ans pychop will raise errors. The validator should
+        catch this before performing intensity calculations.
+        """
+
+        self.assertFalse(
+            validate_pychop_params(
+                name="MARI",
+                chopper="A",
+                chopper_frequency="400",
+                e_i="4000",
+                energy_units="cm-1",
+            )
+        )
+
+        self.assertTrue(
+            validate_pychop_params(
+                name="MARI",
+                chopper="A",
+                chopper_frequency="400",
+                e_i="10",
+                energy_units="meV",
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

Improve Abins2D validator; for chopper instruments, attempt to get a Pychop resolution value and ensure there is neutron transmission. If not, better to raise a validation error now than  _after_ calculating intensities.

Closes #38085

**Report to:** Hamish Cavaye

### To test:

A unit test is included.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
