### PR TITLE
Resolve sans load dep warning

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/move_sans_instrument_component.py
+++ b/scripts/SANS/sans/algorithm_detail/move_sans_instrument_component.py
@@ -30,7 +30,7 @@ def move_component(component_name, state: AllStates, move_type, workspace, is_tr
     # Ensure we handle a None type
     parsed_component_name = _get_full_component_name(user_comp_name=component_name, inst_info=inst_info)
     # Get the selected component and the beam coordinates
-    if not beam_coordinates:
+    if beam_coordinates is None or not len(beam_coordinates):
         beam_coordinates = _get_coordinates(component_name=parsed_component_name, state=state)
 
     if move_type is MoveTypes.ELEMENTARY_DISPLACEMENT:


### PR DESCRIPTION
### Description of work

A user reported an error in the SANS workflow. It turns out their system was picking up a version of Numpy (>=2.2) that we don't support, so a certain depreciation message became instead an error.

We may as well resolve this depreciation warning proactively.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
