### PR TITLE
Add option to to maintain aspect ratio of pixels

### DIFF
--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -218,6 +218,9 @@ Mantid Graphical User Interface Properties
 |                                                    |is only relevant if you using both Linux and a      |                 |
 |                                                    |broken version of Mesa.                             |                 |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``InstrumentView.MaintainAspectRatio``             |Value of the "Maintain Aspect Ratio" option in the  | ``Yes``, ``No`` |
+|                                                    |Instrument View                                     |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``MantidOptions.InvisibleWorkspaces``              |Do not show 'invisible' workspaces                  | ``0``, ``1``    |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``PeakColumn.hklPrec``                             |Precision of hkl values shown in tables             | ``2``           |

--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/39752.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/39752.rst
@@ -1,0 +1,1 @@
+- New option to either maintain (or not) the aspect ratio of a 2D projection of an instrument. This can result in a more efficient use of screen space, and clearer projections.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -213,6 +213,7 @@ class FullInstrumentViewPresenter:
         return transformed_points[:, :3]
 
     def on_aspect_ratio_check_box_clicked(self) -> None:
+        self._view.store_maintain_aspect_ratio_option()
         self.on_projection_option_selected(self._view._projection_combo_box.currentIndex())
 
     def on_multi_select_detectors_clicked(self) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -158,8 +158,15 @@ class FullInstrumentViewWindow(QMainWindow):
         self._reset_projection = QPushButton("Reset Projection")
         self._reset_projection.setToolTip("Resets the projection to default.")
         self._reset_projection.clicked.connect(self.reset_camera)
+        self._aspect_ratio_check_box = QCheckBox()
+        self._aspect_ratio_check_box.setText("Maintain Aspect Ratio")
+        self._aspect_ratio_check_box.setToolTip(
+            "If checked, the detectors will be drawn in 2D projections in their original aspect ratio, "
+            "otherwise they will fill the available area."
+        )
         projection_layout.addWidget(self._projection_combo_box)
         projection_layout.addWidget(self._reset_projection)
+        projection_layout.addWidget(self._aspect_ratio_check_box)
 
         peak_ws_group_box = QGroupBox("Peaks Workspaces")
         peak_v_layout = QVBoxLayout(peak_ws_group_box)
@@ -212,6 +219,12 @@ class FullInstrumentViewWindow(QMainWindow):
 
     def is_multi_picking_checkbox_checked(self) -> bool:
         return self._multi_select_check.isChecked()
+
+    def is_maintain_aspect_ratio_checkbox_checked(self) -> bool:
+        return self._aspect_ratio_check_box.isChecked()
+
+    def set_aspect_ratio_box_visibility(self, is_visible: bool) -> None:
+        self._aspect_ratio_check_box.setVisible(is_visible)
 
     def _on_splitter_moved(self, pos, index) -> None:
         self._detector_spectrum_fig.tight_layout()
@@ -318,6 +331,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self._export_workspace_button.clicked.connect(self._presenter.on_export_workspace_clicked)
         self._sum_spectra_checkbox.clicked.connect(self._presenter.on_sum_spectra_checkbox_clicked)
         self._peak_ws_list.itemChanged.connect(self._presenter.on_peaks_workspace_selected)
+        self._aspect_ratio_check_box.clicked.connect(self._presenter.on_aspect_ratio_check_box_clicked)
 
         self._add_connections_to_edits_and_slider(
             self._contour_range_min_edit,

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -33,7 +33,7 @@ from instrumentview.Detectors import DetectorInfo
 from instrumentview.InteractorStyles import CustomInteractorStyleZoomAndSelect, CustomInteractorStyleRubberBand3D
 from typing import Callable
 from mantid.dataobjects import Workspace2D
-from mantid import UsageService
+from mantid import UsageService, ConfigService
 from mantid.kernel import FeatureType
 from mantidqt.plotting.mantid_navigation_toolbar import MantidNavigationToolbar
 import numpy as np
@@ -70,6 +70,7 @@ class FullInstrumentViewWindow(QMainWindow):
     detector, and a line plot of selected detector(s)"""
 
     _detector_spectrum_fig = None
+    _ASPECT_RATIO_SETTING_STRING = "InstrumentView.MaintainAspectRato"
 
     def __init__(self, parent=None, off_screen=False):
         """The instrument in the given workspace will be displayed. The off_screen option is for testing or rendering an image
@@ -164,6 +165,8 @@ class FullInstrumentViewWindow(QMainWindow):
             "If checked, the detectors will be drawn in 2D projections in their original aspect ratio, "
             "otherwise they will fill the available area."
         )
+        aspect_ratio_option = ConfigService.Instance()[self._ASPECT_RATIO_SETTING_STRING]
+        self._aspect_ratio_check_box.setChecked(aspect_ratio_option.casefold() == "yes")
         projection_layout.addWidget(self._projection_combo_box)
         projection_layout.addWidget(self._reset_projection)
         projection_layout.addWidget(self._aspect_ratio_check_box)
@@ -222,6 +225,10 @@ class FullInstrumentViewWindow(QMainWindow):
 
     def is_maintain_aspect_ratio_checkbox_checked(self) -> bool:
         return self._aspect_ratio_check_box.isChecked()
+
+    def store_maintain_aspect_ratio_option(self) -> None:
+        option = "Yes" if self.is_maintain_aspect_ratio_checkbox_checked() else "No"
+        ConfigService.Instance()[self._ASPECT_RATIO_SETTING_STRING] = option
 
     def set_aspect_ratio_box_visibility(self, is_visible: bool) -> None:
         self._aspect_ratio_check_box.setVisible(is_visible)


### PR DESCRIPTION
New option in the new Instrument View to not maintain the aspect ratio in 2D projections. By scaling the detector mesh to fit the plot window for 2D projections, it will be easier to use for some instruments with larger aspect ratios, e.g. WISH

The selected option is stored in the user settings, since probably a user will always use the same option.

New option (default):

<img width="922" height="717" alt="image" src="https://github.com/user-attachments/assets/6c17ce6e-06df-4fb6-a3b0-6a82edad2b84" />

Maintain aspect ratio:

<img width="938" height="698" alt="image" src="https://github.com/user-attachments/assets/d3198eab-0bba-4e4a-8c13-e9b926f3d851" />

This is achieved by scaling the pyvista meshes to match the aspect ratio of the pyvista window in which the mesh is being drawn. We do this through a 4x4 transformation matrix calculated using the main detector mesh. We need to use this transformation for all the other meshes in order for them to be drawn in the correct place. It's important that the transformation is calculated after the first mesh is drawn, otherwise when you convert the mesh coordinates to screen coordinates you will get nonsense numbers.

Fixes #39752 

### To test:

Try out the new checkbox, with/without peak overlays, try picking detectors.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
