### PR TITLE
Avoid duplicate modal window on sans gui when changing line edits

### DIFF
--- a/docs/source/release/v6.15.0/SANS/New_features/40411.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/40411.rst
@@ -1,0 +1,1 @@
+- Setting a wrong value on the line edits of the settings tab in the :ref:`SANS User Interface<ISIS_Sans_interface_contents>` no longer creates a duplicate warning box when pressing enter.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -546,11 +546,13 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
     def _on_field_edit(self):
         sender = self.sender()
-        if isinstance(sender, QLineEdit) and not sender.isModified():
+        if (is_line_edit := isinstance(sender, QLineEdit)) and not sender.isModified():
             # We only want editingFinished to fire if a user has modified. This
             # prevents a warning appearing after the first one - commonly when
             # clicking another line edit with invalid input or attempting to close the interface
             return
+        elif is_line_edit and sender.isModified():
+            sender.setModified(False)
 
         self._call_settings_listeners(lambda listener: listener.on_field_edit())
 


### PR DESCRIPTION
### Description of work
This was found whilst working on : #39596 
When entering a wrong setting on the settings tab of the sans gui, for example, setting 'a' on the Radius Limit line edit, which expects something that can be cast into float, sends a warning message to the user as a modal qmessagebox. 
If the wrong setting is typed on the line edit, and the line edit goes out of focus (clicking somewhere else or pressing tab), a single modal window appears. But if the return key is pressed on the line edit, the signal is sent twice, once when the return key is pressed, and  a second one when the modal window appears on top and takes the focus away from the line edit. 
This is not much of an issue on linux and windows (you can close the two modal windows and continue), but it on macosx the modal windows appear to work a bit differently, and it can cause the interface to be blocked when closing the warning boxes. 
I have added a simple fix in this PR. There may be a better way to fix this, I'm open for suggestions on this PR, but for the time being it serves to avoid a possible crash on macos. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

No associated issue. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Try setting wrong inputs on the mask line edits of the settings tab of the sansgui interface, expect to have only one warning box. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
