### PR TITLE
Create a github actions workflow to publish doxygen artifacts to doxygen repo

### DIFF
--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -43,8 +43,8 @@ jobs:
         -   name: Commit and push
             working-directory: doxygen_repo
             run: |
-                git config user.name "mantid-tech"
-                git config user.email "mantid-tech@stfc.ac.uk"
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
                 git add .
                 git commit -m "Update Doxygen docs"
                 git push origin main

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -4,6 +4,14 @@ on:
     push:
         branches:
             - main
+        paths:
+        - '**.cpp'
+        - '**.h'
+        - 'Framework/Doxygen/**'
+        - 'conda/recipes/mantid-developer/**'
+        - 'conda/recipes/conda_build_config.yaml'
+        - 'buildconfig/Jenkins/Conda/doxygen.sh'
+        - '.github/workflows/doxygen.yml'
 
 jobs:
     build_and_publish_doxygen:
@@ -19,7 +27,7 @@ jobs:
 
         -   name: Build Doxygen
             run:
-                $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE false
+                $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE
 
         -   name: Checkout Doxygen repository
             env:

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -1,0 +1,42 @@
+name: Publish Doxygen artifacts to website
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    build_and_publish_doxygen:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                shell: bash -l {0}
+
+        steps:
+        -   uses: actions/checkout@v6
+            with:
+                fetch-depth: 0
+
+        -   name: Build Doxygen
+            run:
+                $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE false
+
+        -   name: Checkout Doxygen repository
+            env:
+                DOXYGEN_REPO_TOKEN: ${{ secrets.DOXYGEN_REPO_TOKEN }}
+            run: |
+                git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
+                rm -rf doxygen_repo/*
+
+        -   name: Copy Doxygen artifacts
+            run: |
+                cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
+
+        -   name: Commit and push
+            working-directory: doxygen_repo
+            run: |
+                git config user.name "mantid-tech"
+                git config user.email "mantid-tech@stfc.ac.uk"
+                git add .
+                git commit -m "Update Doxygen docs"
+                git push origin main

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -7,12 +7,10 @@
 #
 # Example command to run a PR build on ubuntu:
 # doxygen.sh $WORKSPACE
-# Example command to run doxygen build without checking for changes
-# doxygen.sh $WORKSPACE false
+#
 # Expected args:
 #   1. WORKSPACE: path to the root of the source code. On Windows, only use / for
 #                 this argument do not use \\ or \ in the path.
-#   2. Bool(optional): whether to check for changes, default is true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
 
@@ -25,14 +23,9 @@ fi
 WORKSPACE=$1
 shift 1
 
-CHECK_FOR_CHANGES=${1-true}
-if [ $# -ne 0 ]; then
-        shift 1
-fi
-
 cd $WORKSPACE
 
-if [ "$CHECK_FOR_CHANGES" = true ] && $SCRIPT_DIR/../check_for_changes doxygen; then
+if $SCRIPT_DIR/../check_for_changes doxygen; then
     echo "No C++ files or doxygen configuration have changed. Skipping check."
     exit 0
 fi

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -26,7 +26,9 @@ WORKSPACE=$1
 shift 1
 
 CHECK_FOR_CHANGES=${1-true}
-shift 1
+if [ $# -ne 0 ]; then
+        shift 1
+fi
 
 cd $WORKSPACE
 

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -7,10 +7,12 @@
 #
 # Example command to run a PR build on ubuntu:
 # doxygen.sh $WORKSPACE
-#
+# Example command to run doxygen build without checking for changes
+# doxygen.sh $WORKSPACE false
 # Expected args:
 #   1. WORKSPACE: path to the root of the source code. On Windows, only use / for
 #                 this argument do not use \\ or \ in the path.
+#   2. Bool(optional): whether to check for changes, default is true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
 
@@ -23,9 +25,12 @@ fi
 WORKSPACE=$1
 shift 1
 
+CHECK_FOR_CHANGES=${1-true}
+shift 1
+
 cd $WORKSPACE
 
-if $SCRIPT_DIR/../check_for_changes doxygen; then
+if [ "$CHECK_FOR_CHANGES" = true ] && $SCRIPT_DIR/../check_for_changes doxygen; then
     echo "No C++ files or doxygen configuration have changed. Skipping check."
     exit 0
 fi

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -25,11 +25,6 @@ shift 1
 
 cd $WORKSPACE
 
-if $SCRIPT_DIR/../check_for_changes doxygen; then
-    echo "No C++ files or doxygen configuration have changed. Skipping check."
-    exit 0
-fi
-
 # Setup Mamba. Create and activate environment
 setup_mamba $WORKSPACE/miniforge "" true ""
 create_and_activate_mantid_developer_env $WORKSPACE

--- a/buildconfig/Jenkins/check_for_changes
+++ b/buildconfig/Jenkins/check_for_changes
@@ -17,10 +17,6 @@ case "$TYPE" in
     py)
         exit $(git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.py)
     ;;
-    doxygen)
-        git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- Framework/Doxygen/ || exit $FOUND
-        # fall through into cpp case
-    ;&
     cpp)
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.h || exit $FOUND
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.cpp || exit $FOUND


### PR DESCRIPTION
### Description of work
This PR introduces a new Github actions workflow that is only run when PRs are merged onto the `main` branch. 

The workflow builds `Doxygen` for the mantid repository on github runners and publishes the artifacts into the [doxygen](https://github.com/mantidproject/doxygen) repository by replacing its existing files. 

These static files are served from https://doxygen.mantidproject.org/ via an active pages deployment published at  https://mantidproject.github.io/doxygen/ that is routed by [Traefik ](https://github.com/mantidproject/ansible-linode/blob/8000beec1703ae57148a93489fed46a7ce1d01e2/roles/traefik/templates/dynamic/rules.yml.j2#L65) 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40372. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->


### To test:
As the same workflow files have been added to [mantid-staging](https://github.com/mantidproject/mantid-staging) this can be tested there
1. Create a test PR at [mantid-staging](https://github.com/mantidproject/mantid-staging) updating a doxygen comment
2. The workflow for [Publish Doxygen artifacts to website](https://github.com/mantidproject/mantid-staging/actions/workflows/publish_doxygen.yml) should NOT be triggered 
3. Merge the test PR at matid-staging
4. The workflow for [Publish Doxygen artifacts to website](https://github.com/mantidproject/mantid-staging/actions/workflows/publish_doxygen.yml) should be triggered and completes successfully
5. The files at [doxygen](https://github.com/mantidproject/doxygen) repo should have been updated
6. https://doxygen.mantidproject.org/ (or https://doxygen.a.staging-mantidproject.stfc.ac.uk/ ) should now serve the updated files

### NOTE! Before merging this PR
- Define a fine grained access token with `repo` permissions to [doxygen](https://github.com/mantidproject/doxygen) with `mantidproject` as the owner
- Store the token in Keeper
- Store the token as a `GitHub Actions Repository Secret` in mantid repository with `DOXYGEN_REPO_TOKEN` as the key

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
