### PR TITLE
Peak overlays now fully working with multi-detector IDs per spectrum

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40415.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40415.rst
@@ -1,0 +1,1 @@
+- Peak overlays in the new Instrument View now work when an instrument has multiple detector IDs per spectrum.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -364,7 +364,7 @@ class FullInstrumentViewModel:
             detector_ids = peaks_dict["DetID"]
             workspace_indices = self.workspace.getIndicesFromDetectorIDs(detector_ids)
             spectrum_nos = self._spectrum_nos[workspace_indices]
-            hkls = zip(peaks_dict["h"], peaks_dict["k"], peaks_dict["l"])
+            hkls = zip(peaks_dict["h"], peaks_dict["k"], peaks_dict["l"], strict=True)
             positions = [np.array(detector_info.position(detector_info.indexOf(id))) for id in detector_ids]
             tofs = peaks_dict["TOF"]
             dspacings = peaks_dict["DSpacing"]
@@ -372,16 +372,16 @@ class FullInstrumentViewModel:
             peaks += [
                 Peak(det_id, spec_no, v, hkl, tof, dspacing, wavelength, 2 * np.pi / dspacing)
                 for (det_id, spec_no, v, hkl, tof, dspacing, wavelength) in zip(
-                    detector_ids, spectrum_nos, positions, hkls, tofs, dspacings, wavelengths
+                    detector_ids, spectrum_nos, positions, hkls, tofs, dspacings, wavelengths, strict=True
                 )
             ]
             # Combine peaks on the same detector
             detector_peaks = []
             # groupby groups consecutive matches, so must be sorted
-            peaks.sort(key=lambda x: x.detector_id)
-            for spec_no, peaks_for_id in groupby(peaks, lambda x: x.spectrum_no):
+            peaks.sort(key=lambda x: x.spectrum_no)
+            for spec_no, peaks_for_spec in groupby(peaks, lambda x: x.spectrum_no):
                 if spec_no in self._spectrum_nos:
-                    detector_peaks.append(DetectorPeaks(list(peaks_for_id)))
+                    detector_peaks.append(DetectorPeaks(list(peaks_for_spec)))
 
             peaks_grouped_by_ws.append(detector_peaks)
         return peaks_grouped_by_ws

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -75,6 +75,7 @@ class FullInstrumentViewModel:
         self._spherical_positions = np.transpose(np.vstack([r, theta, phi]))
         self._detector_positions_3d = detector_info_table.columnArray("Position")
         self._workspace_indices = detector_info_table.columnArray("Index")
+        self._spectrum_nos = detector_info_table.columnArray("Spectrum No")
         # Array of strings 'yes', 'no' and 'n/a'
         self._is_monitor = detector_info_table.columnArray("Monitor")
         self._is_valid = self._is_monitor == "no"
@@ -134,6 +135,10 @@ class FullInstrumentViewModel:
         return self._detector_ids[self.is_pickable]
 
     @property
+    def spectrum_nos(self) -> np.ndarray:
+        return self._spectrum_nos[self._is_valid]
+
+    @property
     def monitor_positions(self) -> np.ndarray:
         return self._monitor_positions
 
@@ -148,6 +153,10 @@ class FullInstrumentViewModel:
     @property
     def picked_detector_ids(self) -> np.ndarray:
         return self._detector_ids[self._detector_is_picked]
+
+    @property
+    def picked_spectrum_nos(self) -> np.ndarray:
+        return self._spectrum_nos[self._is_valid][self._detector_is_picked]
 
     @property
     def picked_workspace_indices(self) -> np.ndarray:
@@ -353,22 +362,27 @@ class FullInstrumentViewModel:
             peaks = []
             peaks_dict = pws.toDict()
             detector_ids = peaks_dict["DetID"]
+            workspace_indices = self.workspace.getIndicesFromDetectorIDs(detector_ids)
+            spectrum_nos = self._spectrum_nos[workspace_indices]
             hkls = zip(peaks_dict["h"], peaks_dict["k"], peaks_dict["l"])
             positions = [np.array(detector_info.position(detector_info.indexOf(id))) for id in detector_ids]
             tofs = peaks_dict["TOF"]
             dspacings = peaks_dict["DSpacing"]
             wavelengths = peaks_dict["Wavelength"]
             peaks += [
-                Peak(det_id, v, hkl, tof, dspacing, wavelength, 2 * np.pi / dspacing)
-                for (det_id, v, hkl, tof, dspacing, wavelength) in zip(detector_ids, positions, hkls, tofs, dspacings, wavelengths)
+                Peak(det_id, spec_no, v, hkl, tof, dspacing, wavelength, 2 * np.pi / dspacing)
+                for (det_id, spec_no, v, hkl, tof, dspacing, wavelength) in zip(
+                    detector_ids, spectrum_nos, positions, hkls, tofs, dspacings, wavelengths
+                )
             ]
             # Combine peaks on the same detector
             detector_peaks = []
             # groupby groups consecutive matches, so must be sorted
             peaks.sort(key=lambda x: x.detector_id)
-            for det_id, peaks_for_id in groupby(peaks, lambda x: x.detector_id):
-                if det_id in self.detector_ids:
+            for spec_no, peaks_for_id in groupby(peaks, lambda x: x.spectrum_no):
+                if spec_no in self._spectrum_nos:
                     detector_peaks.append(DetectorPeaks(list(peaks_for_id)))
+
             peaks_grouped_by_ws.append(detector_peaks)
         return peaks_grouped_by_ws
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -156,7 +156,7 @@ class FullInstrumentViewModel:
 
     @property
     def picked_spectrum_nos(self) -> np.ndarray:
-        return self._spectrum_nos[self._is_valid][self._detector_is_picked]
+        return self._spectrum_nos[self._is_valid & self._detector_is_picked]
 
     @property
     def picked_workspace_indices(self) -> np.ndarray:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -355,17 +355,17 @@ class FullInstrumentViewPresenter:
             return
         # Keeping the points from each workspace separate so we can colour them differently
         for ws_peaks in self._peaks_grouped_by_ws:
-            peaks_detector_ids = np.array([p.detector_id for p in ws_peaks.detector_peaks])
-            detector_ids = self._model.detector_ids
+            peaks_spectrum_nos = np.array([p.spectrum_no for p in ws_peaks.detector_peaks])
+            spectrum_nos = self._model.spectrum_nos
             # Use argsort + searchsorted for fast lookup. Using np.where(np.isin) does not
             # maintain the original order. It is faster to sort then search the sorted
-            # array for matching detector IDs
-            sorted_idx = np.argsort(detector_ids)
-            sorted_detector_ids = detector_ids[sorted_idx]
-            positions = np.searchsorted(sorted_detector_ids, peaks_detector_ids)
+            # array for matching spectrum numbers
+            sorted_idx = np.argsort(spectrum_nos)
+            sorted_spectrum_nos = spectrum_nos[sorted_idx]
+            positions = np.searchsorted(sorted_spectrum_nos, peaks_spectrum_nos)
             # Map back to original indices
             ordered_indices = sorted_idx[positions]
-            valid = sorted_detector_ids[positions] == peaks_detector_ids
+            valid = sorted_spectrum_nos[positions] == peaks_spectrum_nos
             ordered_indices = ordered_indices[valid]
             labels = [p.label for i, p in enumerate(ws_peaks.detector_peaks) if valid[i]]
             projected_points = self._model.detector_positions[ordered_indices]
@@ -382,7 +382,7 @@ class FullInstrumentViewPresenter:
             x_values = []
             labels = []
             for peak in ws_peaks.detector_peaks:
-                if peak.detector_id in self._model.picked_detector_ids:
+                if peak.spectrum_no in self._model.picked_spectrum_nos:
                     match self._view.current_selected_unit():
                         case self._TIME_OF_FLIGHT:
                             x_values += [p.tof for p in peak.peaks]

--- a/qt/python/instrumentview/instrumentview/Peaks/DetectorPeaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/DetectorPeaks.py
@@ -13,6 +13,7 @@ class DetectorPeaks:
             raise ValueError("peaks list cannot be empty")
         self.peaks = peaks
         self.detector_id = peaks[0].detector_id
+        self.spectrum_no = peaks[0].spectrum_no
         self.location = peaks[0].location
         if len(self.peaks) > 1:
             # Find peak with highest d-spacing for label

--- a/qt/python/instrumentview/instrumentview/Peaks/Peak.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/Peak.py
@@ -15,6 +15,7 @@ def _format_hkl(value):
 @dataclass(frozen=True)
 class Peak:
     detector_id: int
+    spectrum_no: int
     location: np.ndarray
     hkl: tuple[float, float, float]
     tof: float

--- a/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
@@ -13,8 +13,8 @@ import unittest
 class TestDetectorPeaks(unittest.TestCase):
     def test_detector_peaks(self):
         location = np.array([1, 2, 3.0])
-        peak1 = Peak(1, location, (4, 4, 4), 100, 10, 10, 10)
-        peak2 = Peak(1, location, (20, 4, 4), 1000, 5, 5, 5)
+        peak1 = Peak(1, 5, location, (4, 4, 4), 100, 10, 10, 10)
+        peak2 = Peak(1, 5, location, (20, 4, 4), 1000, 5, 5, 5)
         detector_peaks = DetectorPeaks([peak1, peak2])
         self.assertEqual(1, detector_peaks.detector_id)
         np.testing.assert_almost_equal(location, detector_peaks.location)
@@ -22,8 +22,8 @@ class TestDetectorPeaks(unittest.TestCase):
 
     def test_highest_d_spacing_used_for_label(self):
         location = np.array([1, 2, 3.0])
-        peak1 = Peak(1, location, (4, 4, 4), 100, 10, 5, 5)
-        peak2 = Peak(1, location, (20, 4, 4), 1000, 50, 5, 5)
+        peak1 = Peak(1, 5, location, (4, 4, 4), 100, 10, 5, 5)
+        peak2 = Peak(1, 5, location, (20, 4, 4), 1000, 50, 5, 5)
         detector_peaks = DetectorPeaks([peak1, peak2])
         self.assertEqual(1, detector_peaks.detector_id)
         np.testing.assert_almost_equal(location, detector_peaks.location)

--- a/qt/python/instrumentview/instrumentview/Peaks/test/test_peak.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/test/test_peak.py
@@ -10,7 +10,7 @@ import unittest
 
 class TestPeak(unittest.TestCase):
     def test_label(self):
-        peak = Peak(0, None, (1.233333, 4.0, 36), 0, 0, 0, 0)
+        peak = Peak(0, 0, None, (1.233333, 4.0, 36), 0, 0, 0, 0)
         self.assertEqual("(1.23, 4, 36)", peak.label)
 
 

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -455,12 +455,12 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         peaks = model.peak_overlay_points()
         # Should get one peak with detector ID 4 and spectrum
         # number 1
-        self.assertEquals(1, len(peaks))
+        self.assertEqual(1, len(peaks))
         detector_peak = peaks[0][0]
-        self.assertEquals(1, len(detector_peak.peaks))
-        self.assertEquals(test_detector_id, detector_peak.detector_id)
-        self.assertEquals("(2, 2, 2)", detector_peak.label)
-        self.assertEquals(test_spectrum_no, detector_peak.spectrum_no)
+        self.assertEqual(1, len(detector_peak.peaks))
+        self.assertEqual(test_detector_id, detector_peak.detector_id)
+        self.assertEqual("(2, 2, 2)", detector_peak.label)
+        self.assertEqual(test_spectrum_no, detector_peak.spectrum_no)
         single_peak = detector_peak.peaks[0]
         self.assertEqual(test_detector_id, single_peak.detector_id)
         self.assertEqual(test_spectrum_no, single_peak.spectrum_no)

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -410,6 +410,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         peaks_ws = CreatePeaksWorkspace(self._ws, 2)
         model._selected_peaks_workspaces = [peaks_ws]
         model._detector_ids = np.array([100])
+        model._spectrum_nos = np.array([2])
         model._is_valid = np.array([True])
         model._is_masked = np.array([False])
         peaks = model.peak_overlay_points()
@@ -418,6 +419,51 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         self.assertEqual(100, detector_peak.detector_id)
         self.assertEqual("[0, 0, 0] x 2", detector_peak.label)
         np.testing.assert_almost_equal(np.array([0, 0, 5.0]), detector_peak.location)
+
+    def test_peaks_with_spectrum_multiple_detectors(self):
+        # We want to test the case where a peaks workspace has a
+        # detector ID that is not in the model. This can happen when
+        # an instrument has multiple detector IDs per spectrum. The
+        # spectrum number should be used instead
+        mock_ws = self._create_mock_workspace([1, 2, 3, 4])
+        test_detector_id = 4
+        test_spectrum_no = 1
+
+        # Detector ID 4 is workspace index 2
+        def mock_getIndicesFromDetectorIDs(ids):
+            return [2]
+
+        mock_ws.getIndicesFromDetectorIDs = mock_getIndicesFromDetectorIDs
+        model = FullInstrumentViewModel(mock_ws)
+        mock_peaks_ws = mock.MagicMock()
+        mock_peaks_ws.toDict.return_value = {
+            "DetID": [test_detector_id],
+            "h": [2],
+            "k": [2],
+            "l": [2],
+            "DSpacing": [10],
+            "Wavelength": [10],
+            "TOF": [10],
+        }
+
+        model._selected_peaks_workspaces = [mock_peaks_ws]
+        # Only read three detectors, not ID 4
+        model._detector_ids = np.array([1, 2, 3])
+        # Everything on spectrum number 1
+        model._spectrum_nos = np.array([test_spectrum_no, test_spectrum_no, test_spectrum_no])
+        model._is_valid = np.array([True, True, True])
+        peaks = model.peak_overlay_points()
+        # Should get one peak with detector ID 4 and spectrum
+        # number 1
+        self.assertEquals(1, len(peaks))
+        detector_peak = peaks[0][0]
+        self.assertEquals(1, len(detector_peak.peaks))
+        self.assertEquals(test_detector_id, detector_peak.detector_id)
+        self.assertEquals("(2, 2, 2)", detector_peak.label)
+        self.assertEquals(test_spectrum_no, detector_peak.spectrum_no)
+        single_peak = detector_peak.peaks[0]
+        self.assertEqual(test_detector_id, single_peak.detector_id)
+        self.assertEqual(test_spectrum_no, single_peak.spectrum_no)
 
     @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
     def test_relative_detector_angle_no_picked(self, mock_picked_detector_ids):

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -32,13 +32,8 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.handle_close()
         self._ws.delete()
 
-    def _create_detector_peaks(self, det_id: int, location: np.ndarray) -> DetectorPeaks:
-        return DetectorPeaks([Peak(det_id, location, (1, 1, 1), 100, 1000, 100, 100)])
-
-    def test_projection_combo_options(self):
-        _, projections = self._presenter.projection_combo_options()
-        self.assertGreater(len(projections), 0)
-        self.assertTrue("Spherical X" in projections)
+    def _create_detector_peaks(self, det_id: int, spec_no: int, location: np.ndarray) -> DetectorPeaks:
+        return DetectorPeaks([Peak(det_id, spec_no, location, (1, 1, 1), 100, 1000, 100, 100)])
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
     def test_update_plotter(self, mock_set_peaks_ws):
@@ -49,33 +44,6 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._mock_view.add_pickable_mesh.assert_called()
         self._mock_view.add_masked_mesh.assert_called()
         mock_set_peaks_ws.assert_called_once()
-
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.reset_cached_projection_positions")
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
-    def test_3d_projection_resets_cache(self, mock_set_peaks_ws, mock_reset_cache):
-        self.assertEqual("3D", self._model._PROJECTION_OPTIONS[0])
-        self._presenter.on_projection_option_selected(0)
-        mock_reset_cache.assert_called_once()
-        self._mock_view.add_main_mesh.assert_called()
-
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.create_poly_data_mesh")
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.calculate_projection")
-    def test_projection_option_axis(self, mock_calculate_projection, mock_create_poly_data_mesh):
-        _, options = self._presenter.projection_combo_options()
-        for option in options:
-            if option.endswith("X"):
-                axis = [1, 0, 0]
-            elif option.endswith("Y"):
-                axis = [0, 1, 0]
-            elif option.endswith("Z"):
-                axis = [0, 0, 1]
-            else:
-                return
-            self._presenter.on_projection_option_selected(options.index(option))
-            mock_calculate_projection.assert_called_once_with(option.startswith("Spherical"), axis)
-            mock_create_poly_data_mesh.assert_called()
-            mock_calculate_projection.reset_mock()
-            mock_create_poly_data_mesh.reset_mock()
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.update_integration_range")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.set_view_integration_limits")
@@ -205,7 +173,6 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_transform,
     ):
         mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
-        mock_adjust_points_projection.return_value = [mock_peak_overlay_points()[0][0].location]
         self._model._calculate_projection = MagicMock(return_value=np.array([np.zeros(3), np.zeros(3)]))
         self._model._detector_ids = np.array([50, 52])
         self._model._spectrum_nos = np.array([50, 52])

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -35,6 +35,11 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     def _create_detector_peaks(self, det_id: int, location: np.ndarray) -> DetectorPeaks:
         return DetectorPeaks([Peak(det_id, location, (1, 1, 1), 100, 1000, 100, 100)])
 
+    def test_projection_combo_options(self):
+        _, projections = self._presenter.projection_combo_options()
+        self.assertGreater(len(projections), 0)
+        self.assertTrue("Spherical X" in projections)
+
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
     def test_update_plotter(self, mock_set_peaks_ws):
         self._mock_view.current_selected_projection.return_value = ProjectionType.CYLINDRICAL_X
@@ -172,9 +177,11 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_set_peaks_workspaces,
         mock_transform,
     ):
-        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
+        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
+        mock_adjust_points_projection.return_value = [mock_peak_overlay_points()[0][0].location]
         self._model._calculate_projection = MagicMock(return_value=np.array([np.zeros(3), np.zeros(3)]))
         self._model._detector_ids = np.array([50, 52])
+        self._model._spectrum_nos = np.array([50, 52])
         self._model._is_valid = np.array([True, True])
         self._model._is_masked = np.array([False, False])
         self._presenter.on_peaks_workspace_selected()
@@ -185,10 +192,10 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_transform.assert_called_once()
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.peak_overlay_points")
-    @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
-    def test_refresh_lineplot_peaks(self, mock_picked_detector_ids, mock_peak_overlay_points):
-        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
-        mock_picked_detector_ids.return_value = [50]
+    @mock.patch.object(FullInstrumentViewModel, "picked_spectrum_nos", new_callable=mock.PropertyMock)
+    def test_refresh_lineplot_peaks(self, mock_picked_spectrum_nos, mock_peak_overlay_points):
+        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
+        mock_picked_spectrum_nos.return_value = [50]
         self._mock_view.current_selected_unit.return_value = self._presenter._TIME_OF_FLIGHT
         self._presenter._update_peaks_workspaces()
         self._presenter.refresh_lineplot_peaks()
@@ -201,10 +208,10 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self.assertEqual(["(1, 1, 1)"], overlay_call_args[1])
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.peak_overlay_points")
-    @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
-    def test_refresh_lineplot_peaks_q(self, mock_picked_detector_ids, mock_peak_overlay_points):
-        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
-        mock_picked_detector_ids.return_value = [50]
+    @mock.patch.object(FullInstrumentViewModel, "picked_spectrum_nos", new_callable=mock.PropertyMock)
+    def test_refresh_lineplot_peaks_q(self, mock_picked_spectrum_nos, mock_peak_overlay_points):
+        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
+        mock_picked_spectrum_nos.return_value = [50]
         self._mock_view.current_selected_unit.return_value = self._presenter._MOMENTUM_TRANSFER
         self._presenter._update_peaks_workspaces()
         self._presenter.refresh_lineplot_peaks()
@@ -219,7 +226,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.peak_overlay_points")
     @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
     def test_refresh_lineplot_peaks_no_detector(self, mock_picked_detector_ids, mock_peak_overlay_points):
-        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
+        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
         mock_picked_detector_ids.return_value = []
         self._mock_view.current_selected_unit.return_value = self._presenter._TIME_OF_FLIGHT
         self._presenter._update_peaks_workspaces()
@@ -232,7 +239,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.peak_overlay_points")
     @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
     def test_refresh_lineplot_peaks_wrong_unit(self, mock_picked_detector_ids, mock_peak_overlay_points):
-        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
+        mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, 50, np.zeros(3))]]
         mock_picked_detector_ids.return_value = [50]
         self._mock_view.current_selected_unit.return_value = "Light Years"
         self._presenter.refresh_lineplot_peaks()


### PR DESCRIPTION
This fixes a bug with the peak overlay in the new Instrument View, where the overlay would not display the peaks if the detector ID in the peaks workspace is not the one used by the Instrument View. This can happen if an instrument has multiple detectors in a single spectra, e.g. WISH.

### To test:

Pick some peaks on WISH using the old Instrument View, and view them in the new Instrument View.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
