### PR TITLE
Only run jobs in mantidproject/mantid repository

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -12,3 +12,5 @@ jobs:
         with:
           farthest: false      # false = use current milestone by due date
           overwrite: false     # don't overwrite if milestone already exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   merge-release-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'release-next' && github.repository_owner == 'mantidproject' }}
+    # run on release-next branch and do not run in forks
+    if: ${{ github.ref_name == 'release-next' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@master
 
@@ -24,7 +25,8 @@ jobs:
 
   merge-ornl-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'ornl-next' && github.repository_owner == 'mantidproject' }}
+    # run on ornl-next branche and do not run in forks
+    if: ${{ github.ref_name == 'ornl-next' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   merge-release-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'release-next' }}
+    if: ${{ github.ref_name == 'release-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@master
 
@@ -24,7 +24,7 @@ jobs:
 
   merge-ornl-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'ornl-next' }}
+    if: ${{ github.ref_name == 'ornl-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/delete_old_nightly_releases.yml
+++ b/.github/workflows/delete_old_nightly_releases.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   delete-old-nightly-releases:
+    if: github.repository_owner == 'mantidproject'
     runs-on: ubuntu-latest
     steps:
       - uses: thomashampson/delete-older-releases@main

--- a/.github/workflows/delete_old_nightly_releases.yml
+++ b/.github/workflows/delete_old_nightly_releases.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   delete-old-nightly-releases:
-    if: github.repository_owner == 'mantidproject'
+    # do not run in forks
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: thomashampson/delete-older-releases@main

--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pixi-update-lockfile:
-    if: github.repository_owner == 'mantidproject'
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +32,8 @@ jobs:
           body-path: diff.md
           branch: update-pixi
           base: main  # change this to the default branch of your repository
-          labels: ['pixi', 'Maintenanance']
+          labels: |
+            pixi
+            Maintenanance
           delete-branch: true
           add-paths: pixi.lock

--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pixi-update-lockfile:
+    if: github.repository_owner == 'mantidproject'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,6 +32,6 @@ jobs:
           body-path: diff.md
           branch: update-pixi
           base: main  # change this to the default branch of your repository
-          labels: pixi
+          labels: ['pixi', 'Maintenanance']
           delete-branch: true
           add-paths: pixi.lock


### PR DESCRIPTION
Since forks likely won't need some of the maintenance running, modify the condition for running the jobs to only be in `mantidproject` owned repositories.

There is no associated issue.

### To test:

A code review is the appropriate way to see, but copying this PR into a fork repository would be a more complete test.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
