### PR TITLE
Add github token to milestone action

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,6 +1,6 @@
 name: Add milestone to new PRs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
     branches: [main, release-next]
 

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           farthest: false      # false = use current milestone by due date
           overwrite: false     # don't overwrite if milestone already exists
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action has been failing on some pull requests when the branch being merged is on a fork.

This should fix the permissions on those pull requests (I think).


### To test:

Hopefully this pr should test itself since it is from a fork.

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
