### PR TITLE
Add argument for direnv

### DIFF
--- a/dev-docs/source/GettingStarted/MantidDeveloperPixiSetup.rst
+++ b/dev-docs/source/GettingStarted/MantidDeveloperPixiSetup.rst
@@ -30,14 +30,14 @@ Once `direnv` is properly installed and in your path, create a file ``.envrc`` i
 .. code-block:: sh
 
   watch_file pixi.lock
-  eval "$(pixi shell-hook --change-ps1 false)"
+  eval "$(pixi shell-hook --frozen --change-ps1 false)"
 
 For out of source builds, the build directory should have a ``.envrc`` with the contents
 
 .. code-block:: sh
 
   watch_file /path/to/source/mantid/pixi.lock
-  eval "$(pixi shell-hook --manifest-path=/path/to/source/mantid/ --change-ps1 false)"
+  eval "$(pixi shell-hook --manifest-path=/path/to/source/mantid/ --frozen --change-ps1 false)"
   export PYTHONPATH=/path/to/build/bin/:$PYTHONPATH
 
 The last line is necessary to get the build results into the python path.


### PR DESCRIPTION
The `--frozen` argument stops the `pixi.lock` file from being updated during branch switching or other git operations.

There is no associated issue.

### To test:

Use direnv and follow the instructions.

*This does not require release notes* because it is additional instructions for developer setup.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
