### PR TITLE
Pin sphinx<9 to avoid docs build failure

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -96,7 +96,7 @@ pydantic:
  - '>=2.11.4,<3'
 
 sphinx:
-  - '>=4.5'
+  - '>=4.5,<9'
 
 sphinx_bootstrap_theme:
   - '==0.8.1'


### PR DESCRIPTION
### Description of work
Documentation builds are failing with 33 warnings ([example](https://builds.mantidproject.org/view/Pull%20Requests/job/pull_requests-doc-tests/7345/console)) since sphinx went up to v9. Pin while we investigate.

### To test:
- Sphinx should be version 8.something in the `mantid-developer` env.
- CI builds should pass (particularly `Conda: linux package build` and `Conda: linux docs build`)

*This does not require release notes* because it's a dependency pin.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
