### PR TITLE
Corrections to automerge CI skipping

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ jobs:
   merge-release-into-main:
     runs-on: ubuntu-latest
     # run on release-next branch and do not run in forks
-    if: ${{ github.ref_name == 'release-next' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.ref_name == 'release-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@master
 
@@ -26,7 +26,7 @@ jobs:
   merge-ornl-into-main:
     runs-on: ubuntu-latest
     # run on ornl-next branche and do not run in forks
-    if: ${{ github.ref_name == 'ornl-next' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.ref_name == 'ornl-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
In #40416 there was an attempt to skip automerging `ornl-next` and `release-next` into `main`. The selection was done in a way that they don't appear to run (see example on deeb84997194248e474796b3635e93407a1d38ef). This copies the selection mechanism used in `update-pixi-lockfile.yml` to bring it back.

There is no associated issue.

### To test:

The only real way to test this is to merge it and get it into `ornl-next`.

*This does not require release notes* because it is fixing a bug in automated code maintenance.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
