### PR TITLE
Add numpy dependency to mantid run requirements

### DIFF
--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -83,6 +83,7 @@ requirements:
     - quasielasticbayes ${{ quasielasticbayes }}
     - quickbayes ${{ quickbayes }}
     - zlib
+    - numpy ${{ numpy }}
     - if: linux
       then:
         - libglu ${{ libglu }}


### PR DESCRIPTION
### Description of work

In previous versions of mantid, numpy was pinned at runtime to `numpy ${{ numpy }}`.

In the nightly (perhaps since change to rattler-build) this pin no longer exists. Users (on IDAaaS specifically) are reporting errors as numpy version `2.3.5` is installed, which has incompatabilites with our code base due to deprecations.



### To test:

Test package build if you want, check correction version of numpy present at run time.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
