### PR TITLE
Use joblib in EnggEstimateFocussedBackground

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -106,12 +106,14 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
 
 def _get_nbins_in_xwindow(x, xwindow):
     binwidth = np.mean(np.diff(x))
-    nwindow = max(int(np.ceil(xwindow / binwidth)), 3)
+    nwindow = int(np.ceil(xwindow / binwidth))
     if not nwindow % 2:
         nwindow += 1
     if nwindow >= len(x):
         # not effective due to edge effects of the convolution
-        raise RuntimeError("Data has must have at least the number of points as the convolution window")
+        raise RuntimeError("Data must have at least as many points as the convolution window")
+    if nwindow < MIN_WINDOW_SIZE:
+        raise RuntimeError("Convolution window must have at least three points")
     return nwindow
 
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -14,9 +14,10 @@ from functools import lru_cache
 from multiprocessing import cpu_count
 
 
-class EnggEstimateFocussedBackground(PythonAlgorithm):
-    MIN_WINDOW_SIZE = 3
+MIN_WINDOW_SIZE = 3
 
+
+class EnggEstimateFocussedBackground(PythonAlgorithm):
     def category(self):
         return "Diffraction\\Engineering"
 
@@ -71,7 +72,7 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
         inws = self.getProperty("InputWorkspace").value
         if not isinstance(inws, MatrixWorkspace):
             issues["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace."
-        elif inws.blocksize() < self.MIN_WINDOW_SIZE:
+        elif inws.blocksize() < MIN_WINDOW_SIZE:
             issues["InputWorkspace"] = "At least three points needed in each spectra"
         return issues
 
@@ -108,6 +109,9 @@ def _get_nbins_in_xwindow(x, xwindow):
     nwindow = max(int(np.ceil(xwindow / binwidth)), 3)
     if not nwindow % 2:
         nwindow += 1
+    if nwindow >= len(x):
+        # not effective due to edge effects of the convolution
+        raise RuntimeError("Data has must have at least the number of points as the convolution window")
     return nwindow
 
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy.signal import savgol_filter
 from joblib import Parallel, delayed
 from functools import lru_cache
+from multiprocessing import cpu_count
 
 
 class EnggEstimateFocussedBackground(PythonAlgorithm):
@@ -84,7 +85,7 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
         # do smoothing in parallel loop over spectra
         nspec = inws.getNumberHistograms()
         prog = Progress(self, start=0.0, end=1.0, nreports=nspec)
-        out = Parallel(n_jobs=-2, prefer="threads", return_as="generator")(
+        out = Parallel(n_jobs=min(4, cpu_count()), prefer="threads", return_as="generator")(
             delayed(find_bg_of_spectrum)(inws.name(), ispec, xwindow, niter, do_sg_filter, prog) for ispec in range(nspec)
         )
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
@@ -55,9 +55,6 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
         self.assertAlmostEqual(np.median(ws_diff.readY(0)[self.mask]), 0, delta=0.01)
 
     def test_window_validation(self):
-        # test too small a window
-        with self.assertRaisesRegex(RuntimeError, "Convolution window must have at least three points"):
-            EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=0.1)
         # test too large a window
         with self.assertRaisesRegex(RuntimeError, "Data has must have at least the number of points as the convolution window"):
             EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=200)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
@@ -55,8 +55,11 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
         self.assertAlmostEqual(np.median(ws_diff.readY(0)[self.mask]), 0, delta=0.01)
 
     def test_window_validation(self):
+        # test too small a window
+        with self.assertRaisesRegex(RuntimeError, "Convolution window must have at least three points"):
+            EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=0.1)
         # test too large a window
-        with self.assertRaisesRegex(RuntimeError, "Data has must have at least the number of points as the convolution window"):
+        with self.assertRaisesRegex(RuntimeError, "Data must have at least as many points as the convolution window"):
             EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=200)
 
 

--- a/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40441.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40441.rst
@@ -1,0 +1,1 @@
+- Use multi-threading in :ref:`algm-EnggEstimateFocussedBackground` algorithm to speed up execution time by factor ~2-3


### PR DESCRIPTION
### Description of work

Use joblib in `EnggEstimateFocussedBackground` to speed up.

### To test:

(1) Run script

```
ws = Load(Filename=r'ENGINX00193749.nxs', OutputWorkspace='ENGINX00193749')
ws_bg = EnggEstimateFocussedBackground(InputWorkspace=ws, OutputWorkspace=f'{ws.name()}_bg', 
                                       XWindow=600)


ispec = 1600
fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
axes.plot(ws, color='#1f77b4', wkspIndex=ispec)
axes.plot(ws_bg, color='#ff7f0e', wkspIndex=ispec)
legend = axes.legend(fontsize=8.0).set_draggable(True).legend
fig.show()
```
 `EnggEstimateFocussedBackground` executes in ~18 s on this PR branch, compared to ~45 s on main

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
