### PR TITLE
add numpy and boost as pins_compatible

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -32,13 +32,13 @@ cmake:
 
 # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
 doxygen:
-  - 1.9.*
+  - '1.9.*'
 
 eigen:
-  - 3.4.*
+  - '3.4.*'
 
 hdf4:
-  - 4.2.*
+  - '4.2.*'
 
 hdf5: # this is to move to libcurl>=8.4
   - '>1.14.0,<1.15'
@@ -65,11 +65,11 @@ muparser:
 
 # Aim to build using the latest minor version, and rely on numpy's generous backward compatibility.
 numpy:
-  - 2.1.*
+  - '2.1.*'
 
 # Mimumum Numpy version at runtime, propagated through pin_compatible
 numpy_min:
-  - 2.0.0
+  - '2.0'
 
 matplotlib:
   - '3.9.*'

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -67,10 +67,6 @@ muparser:
 numpy:
   - '2.1.*'
 
-# Mimumum Numpy version at runtime, propagated through pin_compatible
-numpy_min:
-  - '2.0'
-
 matplotlib:
   - '3.9.*'
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -67,6 +67,10 @@ muparser:
 numpy:
   - 2.1.*
 
+# Mimumum Numpy version at runtime, propagated through pin_compatible
+numpy_min:
+  - 2.0.0
+
 matplotlib:
   - '3.9.*'
 
@@ -185,10 +189,3 @@ librdkafka:
 
 versioningit:
   - '>=2.1'
-
-pin_run_as_build:
-  boost:
-    max_pin: x.x
-  numpy:
-    min_pin: x
-    max_pin: x.x

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -83,6 +83,9 @@ requirements:
     - quasielasticbayes ${{ quasielasticbayes }}
     - quickbayes ${{ quickbayes }}
     - zlib
+    - ${{ pin_compatible('numpy', lower_bound=numpy_min, upper_bound='x.x') }}
+    - ${{ pin_compatible('libboost-devel', upper_bound='x.x') }}
+    - ${{ pin_compatible('libboost-python-devel', upper_bound='x.x') }}
     - if: linux
       then:
         - libglu ${{ libglu }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -84,8 +84,8 @@ requirements:
     - quickbayes ${{ quickbayes }}
     - zlib
     - ${{ pin_compatible('numpy', lower_bound=numpy_min, upper_bound='x.x') }}
-    - ${{ pin_compatible('libboost-devel', upper_bound='x.x') }}
-    - ${{ pin_compatible('libboost-python-devel', upper_bound='x.x') }}
+    - ${{ pin_compatible('libboost', upper_bound='x.x') }}
+    - ${{ pin_compatible('libboost-python', upper_bound='x.x') }}
     - if: linux
       then:
         - libglu ${{ libglu }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -83,7 +83,7 @@ requirements:
     - quasielasticbayes ${{ quasielasticbayes }}
     - quickbayes ${{ quickbayes }}
     - zlib
-    - ${{ pin_compatible('numpy', lower_bound=numpy_min, upper_bound='x.x') }}
+    - ${{ pin_compatible('numpy', lower_bound='2.0', upper_bound='x.x') }}
     - ${{ pin_compatible('libboost', upper_bound='x.x') }}
     - ${{ pin_compatible('libboost-python', upper_bound='x.x') }}
     - if: linux


### PR DESCRIPTION
### Description of work

Users (on IDAaaS specifically) are reporting errors as `numpy` version `2.3.5` is installed, which has incompatabilites with our code base due to deprecations.

In previous versions of mantid, `numpy` was pinned at runtime through `pin_run_as_build`.

`ratter-build` does not consider this automatically. It looks like it requires a separate `variants.yaml` file: https://rattler-build.prefix.dev/v0.8.1/variants/

Given an additional file is now needed, I've added `numpy` and `boost` to as a `pin_compatible` of the `mantid` package. I think this should propagate to all other packages


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
