### PR TITLE
Uncapture `data_order` for reasons

### DIFF
--- a/Framework/Kernel/test/SplineTest.h
+++ b/Framework/Kernel/test/SplineTest.h
@@ -42,7 +42,7 @@ public:
     for (std::size_t i = 0; i < data_order; i++) {
       A[i] = coefficient_maker(this->generator);
     }
-    std::function<double(double)> polynomial = [A, data_order](double x) -> double {
+    std::function<double(double)> polynomial = [A](double x) -> double {
       double y = A[0];
       for (std::size_t i = 1; i < data_order; i++) {
         y += A[i] * pow(x, i);
@@ -92,7 +92,7 @@ public:
     for (std::size_t i = 0; i < data_order; i++) {
       A[i] = coefficient_maker(this->generator);
     }
-    std::function<double(double)> polynomial = [A, data_order](double x) -> double {
+    std::function<double(double)> polynomial = [A](double x) -> double {
       double y = A[0];
       for (std::size_t i = 1; i < data_order; i++) {
         y += A[i] * pow(x, i);


### PR DESCRIPTION
### Description of work

Shortly after merging central spline methods, `clang` decided that actually it doesn't like one of the lambdas in a test and we need to go back and change it.

The lambda had captured a variable that was used inside the lambda, but `clang` didn't want us to capture it.

This should make `clang` happy.

### To test:

Make sure the OSX build passes without `clang` warnings.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
