### PR TITLE
Explicit versions in automerge github CI

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,10 +13,10 @@ jobs:
     # run on release-next branch and do not run in forks
     if: ${{ github.ref_name == 'release-next' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
 
       - name: Merge release-next into main
-        uses: devmasx/merge-branch@master
+        uses: devmasx/merge-branch@v1.4.0
         with:
           type: now
           target_branch: main
@@ -28,10 +28,10 @@ jobs:
     # run on ornl-next branche and do not run in forks
     if: ${{ github.ref_name == 'ornl-next' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
 
       - name: Merge ornl-next into main
-        uses: devmasx/merge-branch@master
+        uses: devmasx/merge-branch@v1.4.0
         with:
           type: now
           target_branch: main


### PR DESCRIPTION
The actions in `automerge.yml` are using the tip of the `master` branches for those actions. This explicitly uses the latest version and allows for depdenabot to propose updating the versions. This allows us to be more deliberate in using new versions.

There is no associated issue.

### To test:

Since the job only runs when we push to `ornl-next` or `release-next`, a code review is more appropriate. To confirm that the tags exist:
* [actions/checkout@v6](https://github.com/actions/checkout/releases/tag/v6) is already used in all the other workflows
* [devmasx/merge-branch@v1.4.0](https://github.com/devmasx/merge-branch/releases/tag/v1.4.0)

This does not require release notes because it is a change to CI and does not affect users.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
