### PR TITLE
Instrument view mask

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ jobs:
   merge-release-into-main:
     runs-on: ubuntu-latest
     # run on release-next branch and do not run in forks
-    if: ${{ github.ref_name == 'release-next' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.ref_name == 'release-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -26,7 +26,7 @@ jobs:
   merge-ornl-into-main:
     runs-on: ubuntu-latest
     # run on ornl-next branche and do not run in forks
-    if: ${{ github.ref_name == 'ornl-next' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.ref_name == 'ornl-next' && github.repository_owner == 'mantidproject' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -218,6 +218,9 @@ Mantid Graphical User Interface Properties
 |                                                    |is only relevant if you using both Linux and a      |                 |
 |                                                    |broken version of Mesa.                             |                 |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``InstrumentView.MaintainAspectRatio``             |Value of the "Maintain Aspect Ratio" option in the  | ``Yes``, ``No`` |
+|                                                    |Instrument View                                     |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``MantidOptions.InvisibleWorkspaces``              |Do not show 'invisible' workspaces                  | ``0``, ``1``    |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``PeakColumn.hklPrec``                             |Precision of hkl values shown in tables             | ``2``           |

--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/39752.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/39752.rst
@@ -1,0 +1,1 @@
+- New option to either maintain (or not) the aspect ratio of a 2D projection of an instrument. This can result in a more efficient use of screen space, and clearer projections.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -5,40 +5,36 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from instrumentview.Detectors import DetectorInfo
+from instrumentview.Peaks.Peak import Peak
+from instrumentview.Peaks.DetectorPeaks import DetectorPeaks
 from instrumentview.Projections.SphericalProjection import SphericalProjection
 from instrumentview.Projections.CylindricalProjection import CylindricalProjection
 from instrumentview.Projections.SideBySide import SideBySide
-from instrumentview.Peaks.Peak import Peak
-from instrumentview.Peaks.DetectorPeaks import DetectorPeaks
+from instrumentview.Projections.ProjectionType import ProjectionType
 
 from mantid.dataobjects import Workspace2D, PeaksWorkspace
-from mantid.simpleapi import CreateDetectorTable, ExtractSpectra, ConvertUnits, AnalysisDataService, SumSpectra, Rebin
+from mantid.simpleapi import (
+    CreateDetectorTable,
+    ExtractSpectra,
+    ConvertUnits,
+    AnalysisDataService,
+    SumSpectra,
+    Rebin,
+    ExtractMask,
+    ExtractMaskToTable,
+    SaveMask,
+    MaskDetectors,
+    RenameWorkspace,
+    CloneWorkspace,
+)
+from mantid.api import MatrixWorkspace
 from itertools import groupby
+from pathlib import Path
 import numpy as np
-from typing import ClassVar
 
 
 class FullInstrumentViewModel:
     """Model for the Instrument View Window. Will calculate detector positions, indices, and integrated counts that give the colours"""
-
-    _FULL_3D: ClassVar[str] = "3D"
-    _SPHERICAL_X: ClassVar[str] = "Spherical X"
-    _SPHERICAL_Y: ClassVar[str] = "Spherical Y"
-    _SPHERICAL_Z: ClassVar[str] = "Spherical Z"
-    _CYLINDRICAL_X: ClassVar[str] = "Cylindrical X"
-    _CYLINDRICAL_Y: ClassVar[str] = "Cylindrical Y"
-    _CYLINDRICAL_Z: ClassVar[str] = "Cylindrical Z"
-    _SIDE_BY_SIDE: ClassVar[str] = "Side by Side"
-    _PROJECTION_OPTIONS: ClassVar[list[str]] = [
-        _FULL_3D,
-        _SPHERICAL_X,
-        _SPHERICAL_Y,
-        _SPHERICAL_Z,
-        _CYLINDRICAL_X,
-        _CYLINDRICAL_Y,
-        _CYLINDRICAL_Z,
-        _SIDE_BY_SIDE,
-    ]
 
     _sample_position = np.array([0, 0, 0])
     _source_position = np.array([0, 0, 0])
@@ -54,12 +50,13 @@ class FullInstrumentViewModel:
         """For the given workspace, calculate detector positions, the map from detector indices to workspace indices, and integrated
         counts. Optionally will draw detector geometry, e.g. rectangular bank or tube instead of points."""
         self._workspace = workspace
-        x_unit = workspace.getAxis(0).getUnit()
+
+    def setup(self):
+        x_unit = self._workspace.getAxis(0).getUnit()
         self._workspace_x_unit = x_unit.unitID()
         self._workspace_x_unit_display = f"{str(x_unit.caption())} ({str(x_unit.symbol())})"
         self._selected_peaks_workspaces = []
 
-    def setup(self):
         component_info = self._workspace.componentInfo()
         self._sample_position = np.array(component_info.samplePosition()) if component_info.hasSample() else np.zeros(3)
         has_source = self._workspace.getInstrument().getSource() is not None
@@ -76,18 +73,26 @@ class FullInstrumentViewModel:
         theta = detector_info_table.columnArray("Theta")
         phi = detector_info_table.columnArray("Phi")
         self._spherical_positions = np.transpose(np.vstack([r, theta, phi]))
-        self._detector_positions = detector_info_table.columnArray("Position")
+        self._detector_positions_3d = detector_info_table.columnArray("Position")
         self._workspace_indices = detector_info_table.columnArray("Index")
         # Array of strings 'yes', 'no' and 'n/a'
         self._is_monitor = detector_info_table.columnArray("Monitor")
         self._is_valid = self._is_monitor == "no"
-        self._monitor_positions = self._detector_positions[self._is_monitor == "yes"]
-        self._current_projected_positions = self.detector_positions
+        self._mask_ws, _ = ExtractMask(self._workspace, StoreInADS=False)
+        self._is_masked_in_ws = self._mask_ws.extractY().flatten().astype(bool)
+        # For computing current mask, detached from the permanent mask in ws
+        self._is_masked = self._is_masked_in_ws
+        self._monitor_positions = self._detector_positions_3d[self._is_monitor == "yes"]
 
         # Initialise with zeros
         self._counts = np.zeros_like(self._detector_ids)
         self._counts_limits = (0, 0)
-        self._detector_is_picked = np.full(len(self._detector_ids[self._is_valid]), False)
+        self._detector_is_picked = np.full(len(self._detector_ids), False)
+
+        self._projection_type = ProjectionType.THREE_D
+        self._cached_projections_map = {}
+
+        self._cached_masks_map = {}
 
         # Get min and max integration values
         if self._workspace.isRaggedWorkspace():
@@ -121,40 +126,36 @@ class FullInstrumentViewModel:
         return self._workspace_x_unit_display
 
     @property
-    def default_projection(self) -> str:
-        return self._workspace.getInstrument().getDefaultView()
-
-    @property
     def sample_position(self) -> np.ndarray:
         return self._sample_position
 
     @property
-    def detector_positions(self) -> np.ndarray:
-        return self._detector_positions[self._is_valid]
-
-    @property
     def detector_ids(self) -> np.ndarray:
-        return self._detector_ids[self._is_valid]
+        return self._detector_ids[self.is_pickable]
 
     @property
     def monitor_positions(self) -> np.ndarray:
         return self._monitor_positions
 
     @property
+    def is_pickable(self) -> np.ndarray:
+        return ~self._is_masked & self._is_valid
+
+    @property
     def picked_visibility(self) -> np.ndarray:
-        return self._detector_is_picked.astype(int)
+        return self._detector_is_picked.astype(int)[self.is_pickable]
 
     @property
     def picked_detector_ids(self) -> np.ndarray:
-        return self._detector_ids[self._is_valid][self._detector_is_picked]
+        return self._detector_ids[self._detector_is_picked]
 
     @property
     def picked_workspace_indices(self) -> np.ndarray:
-        return self._workspace_indices[self._is_valid][self._detector_is_picked]
+        return self._workspace_indices[self._detector_is_picked]
 
     @property
     def detector_counts(self) -> np.ndarray:
-        return self._counts[self._is_valid]
+        return self._counts[self.is_pickable]
 
     @property
     def counts_limits(self) -> tuple[int, int]:
@@ -170,8 +171,10 @@ class FullInstrumentViewModel:
         self._counts_limits = limits
 
     @property
-    def current_projected_positions(self) -> np.ndarray:
-        return self._current_projected_positions
+    def mask_ws(self) -> MatrixWorkspace:
+        for i, v in enumerate(self._is_masked):
+            self._mask_ws.dataY(i)[:] = v
+        return self._mask_ws
 
     @property
     def integration_limits(self) -> tuple[float, float]:
@@ -190,7 +193,7 @@ class FullInstrumentViewModel:
 
     def update_integration_range(self, integration_limits: tuple[float, float], entire_range: bool = False) -> None:
         integration_min, integration_max = integration_limits
-        workspace_indices = self._workspace_indices[self._is_valid]
+        workspace_indices = self._workspace_indices[self.is_pickable]
         new_detector_counts = np.array(
             self._workspace.getIntegratedCountsForWorkspaceIndices(
                 workspace_indices, len(workspace_indices), float(integration_min), float(integration_max), entire_range
@@ -198,10 +201,12 @@ class FullInstrumentViewModel:
             dtype=int,
         )
         self._counts_limits = (np.min(new_detector_counts), np.max(new_detector_counts))
-        self._counts[self._is_valid] = new_detector_counts
+        self._counts[self.is_pickable] = new_detector_counts
 
-    def negate_picked_visibility(self, indices: list[int] | np.ndarray) -> None:
-        self._detector_is_picked[indices] = ~self._detector_is_picked[indices]
+    def negate_picked_visibility(self, mask: np.ndarray) -> None:
+        # TODO: Check which selection is quicker, mask or indices
+        # NOTE: This is slightly awkard because cannot do chained mask selections
+        self._detector_is_picked[self.is_pickable] = mask ^ self._detector_is_picked[self.is_pickable]
 
     def clear_all_picked_detectors(self) -> None:
         self._detector_is_picked.fill(False)
@@ -209,11 +214,11 @@ class FullInstrumentViewModel:
     def picked_detectors_info_text(self) -> list[DetectorInfo]:
         """For the specified detector, extract info that can be displayed in the View, and wrap it all up in a DetectorInfo class"""
 
-        picked_ws_indices = self._workspace_indices[self._is_valid][self._detector_is_picked]
-        picked_ids = self._detector_ids[self._is_valid][self._detector_is_picked]
-        picked_xyz_positions = self._detector_positions[self._is_valid][self._detector_is_picked]
-        picked_spherical_positions = self._spherical_positions[self._is_valid][self._detector_is_picked]
-        picked_counts = self._counts[self._is_valid][self._detector_is_picked]
+        picked_ws_indices = self._workspace_indices[self._detector_is_picked]
+        picked_ids = self._detector_ids[self._detector_is_picked]
+        picked_xyz_positions = self._detector_positions_3d[self._detector_is_picked]
+        picked_spherical_positions = self._spherical_positions[self._detector_is_picked]
+        picked_counts = self._counts[self._detector_is_picked]
 
         picked_info = []
         for i, ws_index in enumerate(picked_ws_indices):
@@ -226,26 +231,72 @@ class FullInstrumentViewModel:
             picked_info.append(det_info)
         return picked_info
 
-    def reset_cached_projection_positions(self) -> None:
-        self._current_projected_positions = self.detector_positions
+    def get_default_projection_index_and_options(self) -> tuple[int, list[str]]:
+        possible_returns_map = {
+            "3D": ProjectionType.THREE_D,
+            "SPHERICAL_X": ProjectionType.SPHERICAL_X,
+            "SPHERICAL_Y": ProjectionType.SPHERICAL_Y,
+            "SPHERICAL_Z": ProjectionType.SPHERICAL_Z,
+            "CYLINDRICAL_X": ProjectionType.CYLINDRICAL_X,
+            "CYLINDRICAL_Y": ProjectionType.CYLINDRICAL_Y,
+            "CYLINDRICAL_Z": ProjectionType.CYLINDRICAL_Z,
+        }
+        default_projection_type = possible_returns_map[self._workspace.getInstrument().getDefaultView()]
+        projection_options = [p.value for p in ProjectionType]
+        return projection_options.index(default_projection_type.value), projection_options
 
-    def calculate_projection(self, projection_option: str, axis: list[int], positions: np.ndarray):
-        """Calculate the 2D projection with the specified axis. Can be cylindrical, spherical, or side-by-side."""
-        if projection_option == self._SIDE_BY_SIDE:
-            projection = SideBySide(
-                self._workspace, self.detector_ids, self.sample_position, self._root_position, positions, np.array(axis)
-            )
-        elif projection_option.startswith("Spherical"):
-            projection = SphericalProjection(self.sample_position, self._root_position, positions, np.array(axis))
-        elif projection_option.startswith("Cylindrical"):
-            projection = CylindricalProjection(self.sample_position, self._root_position, positions, np.array(axis))
+    @property
+    def projection_type(self):
+        return self._projection_type
+
+    @projection_type.setter
+    def projection_type(self, value: str):
+        self._projection_type = ProjectionType(value)
+
+    @property
+    def is_2d_projection(self) -> bool:
+        if self._projection_type == ProjectionType.THREE_D:
+            return False
+        return True
+
+    @property
+    def detector_positions(self) -> np.ndarray:
+        if self._projection_type == ProjectionType.THREE_D:
+            return self._detector_positions_3d[self.is_pickable]
+        return self._calculate_projection()[self.is_pickable]
+
+    @property
+    def masked_positions(self) -> np.ndarray:
+        if self._projection_type == ProjectionType.THREE_D:
+            return self._detector_positions_3d[self._is_masked & self._is_valid]
+        return self._calculate_projection()[self._is_masked & self._is_valid]
+
+    def _calculate_projection(self) -> np.ndarray:
+        """Calculate the 2D projection with the specified axis. Can be either cylindrical or spherical."""
+
+        if self._projection_type.name in self._cached_projections_map.keys():
+            return self._cached_projections_map[self._projection_type.name]
+
+        axis = [1, 0, 0]
+        if self._projection_type in (ProjectionType.SPHERICAL_Y, ProjectionType.CYLINDRICAL_Y):
+            axis = [0, 1, 0]
+        elif self._projection_type in (ProjectionType.SPHERICAL_Z, ProjectionType.CYLINDRICAL_Z):
+            axis = [0, 0, 1]
+
+        if self._projection_type in (ProjectionType.SPHERICAL_X, ProjectionType.SPHERICAL_Y, ProjectionType.SPHERICAL_Z):
+            projection = SphericalProjection(self._sample_position, self._root_position, self._detector_positions_3d, np.array(axis))
+        elif self._projection_type in (ProjectionType.CYLINDRICAL_X, ProjectionType.CYLINDRICAL_Y, ProjectionType.CYLINDRICAL_Z):
+            projection = CylindricalProjection(self._sample_position, self._root_position, self._detector_positions_3d, np.array(axis))
         else:
-            raise ValueError(f"Unknown projection type: {projection_option}")
+            projection = SideBySide(
+                self._workspace, self._detector_ids, self._sample_position, self._root_position, self._detector_positions_3d, np.array(axis)
+            )
 
-        projected_positions = np.zeros_like(positions)
+        projected_positions = np.zeros_like(self._detector_positions_3d)
         projected_positions[:, :2] = projection.positions()  # Assign only x and y coordinate
-        self._current_projected_positions = projected_positions
-        return self._current_projected_positions
+
+        self._cached_projections_map[self._projection_type.name] = projected_positions
+        return projected_positions
 
     def extract_spectra_for_line_plot(self, unit: str, sum_spectra: bool) -> None:
         workspace_indices = self.picked_workspace_indices
@@ -336,3 +387,43 @@ class FullInstrumentViewModel:
         phi = detector_info.azimuthal(detector_index)
         q_lab = np.array([-np.sin(two_theta) * np.cos(phi), -np.sin(two_theta) * np.sin(phi), 1 - np.cos(two_theta)])
         return q_lab / np.linalg.norm(q_lab)
+
+    def clear_stored_masks(self) -> None:
+        self._cached_masks_map.clear()
+
+    def add_new_detector_mask(self, new_mask: list[bool]) -> str:
+        new_key = f"Mask {len(self._cached_masks_map) + 1}"
+        mask_to_save = self._is_masked_in_ws.copy()
+        mask_to_save[self.is_pickable] = new_mask
+        self._cached_masks_map[new_key] = mask_to_save
+        return new_key
+
+    def apply_detector_masks(self, mask_keys: list[str]) -> None:
+        if not mask_keys:
+            mask_total = self._is_masked_in_ws
+        else:
+            mask_total = np.logical_or.reduce([self._cached_masks_map[key] for key in mask_keys])
+        self._is_masked = mask_total
+        self._detector_is_picked[~self.is_pickable] = False
+
+    def save_mask_workspace_to_ads(self) -> None:
+        name_exported_ws = f"instrument_view_mask_{self._workspace.name()}"
+        for i, v in enumerate(self._is_masked):
+            self._mask_ws.dataY(i)[:] = v
+
+        xmin, xmax = self._integration_limits
+        ExtractMaskToTable(self._mask_ws, Xmin=xmin, Xmax=xmax, OutputWorkspace=name_exported_ws)
+
+    def save_xml_mask(self, filename) -> None:
+        if not filename:
+            return
+        if Path(filename).suffix != ".xml":
+            filename += ".xml"
+        SaveMask(self.mask_ws, OutputFile=filename)
+
+    def overwrite_mask_to_current_workspace(self) -> None:
+        # TODO: Check if copies are expensive with big workspaces
+        temp_ws_name = f"__instrument_view_temp_{self._workspace.name()}"
+        CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name)
+        MaskDetectors(temp_ws_name, MaskedWorkspace=self.mask_ws)
+        RenameWorkspace(InputWorkspace=temp_ws_name, OutputWorkspace=self._workspace.name())

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -16,6 +16,8 @@ from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
 from instrumentview.InstrumentViewADSObserver import InstrumentViewADSObserver
 from instrumentview.Peaks.WorkspaceDetectorPeaks import WorkspaceDetectorPeaks
 
+from vtkmodules.vtkRenderingCore import vtkCoordinate
+
 
 class FullInstrumentViewPresenter:
     """Presenter for the Instrument View window"""
@@ -33,6 +35,7 @@ class FullInstrumentViewPresenter:
         any monitors."""
         self._view = view
         self._model = model
+        self._transform = np.eye(4)
         self._model.setup()
         self.setup()
 
@@ -116,13 +119,12 @@ class FullInstrumentViewPresenter:
         projection_type = self._model._PROJECTION_OPTIONS[selected_index]
 
         if projection_type.startswith("3D"):
-            # Plot orange sphere at the origin
-            # origin = pv.Sphere(radius=0.1, center=[0, 0, 0])
-            # self._view.add_simple_shape(origin, colour="orange", pickable=False)
             self._model.reset_cached_projection_positions()
             self._apply_projection_state(False, self._model.detector_positions)
+            self._view.set_aspect_ratio_box_visibility(False)
             return
 
+        self._view.set_aspect_ratio_box_visibility(True)
         projected_points = self._adjust_points_for_selected_projection(self._model.detector_positions, projection_type)
         self._apply_projection_state(True, projected_points)
 
@@ -154,15 +156,65 @@ class FullInstrumentViewPresenter:
         self._detector_mesh = self.create_poly_data_mesh(positions)
         self._detector_mesh[self._counts_label] = self._model.detector_counts
         self._view.add_main_mesh(self._detector_mesh, is_projection=is_projection, scalars=self._counts_label)
+        self._update_transform(is_projection, self._detector_mesh)
+        self._detector_mesh.transform(self._transform, inplace=True)
 
         self._pickable_main_mesh = self.create_poly_data_mesh(positions)
         self._pickable_main_mesh[self._visible_label] = self._model.picked_visibility
+        self._pickable_main_mesh.transform(self._transform, inplace=True)
         self._view.add_pickable_main_mesh(self._pickable_main_mesh, scalars=self._visible_label)
-
         self._view.enable_point_picking(self._is_projection_selected, callback=self.point_picked)
         self.set_view_contour_limits()
         self.set_view_integration_limits()
+
         self._view.reset_camera()
+
+    def _update_transform(self, is_projection: bool, mesh: pv.PolyData) -> None:
+        if not is_projection or self._view.is_maintain_aspect_ratio_checkbox_checked():
+            self._transform = np.eye(4)
+        else:
+            self._transform = self._transform_mesh_to_fill_window(mesh)
+
+    def _transform_mesh_to_fill_window(self, mesh: pv.PolyData) -> np.ndarray:
+        x_min, x_max, y_min, y_max, z_min, z_max = mesh.bounds
+        min_max_points = [
+            [x_min, y_min, z_min],
+            [x_max, y_max, z_max],
+        ]
+
+        # Convert to display coordinates (pixels)
+        plotter = self._view.main_plotter
+        coordinate = vtkCoordinate()
+        coordinate.SetCoordinateSystemToWorld()
+        display_coords = []
+        for p in min_max_points:
+            coordinate.SetValue(*p)
+            display_coords.append(coordinate.GetComputedDisplayValue(plotter.renderer))
+
+        window_width, window_height = plotter.window_size
+
+        mesh_width = display_coords[1][0] - display_coords[0][0]
+        mesh_height = display_coords[1][1] - display_coords[0][1]
+
+        return self._scale_matrix_relative_to_centre(mesh.center, window_width / mesh_width, window_height / mesh_height)
+
+    def _scale_matrix_relative_to_centre(self, centre, scale_x=1.0, scale_y=1.0) -> np.ndarray:
+        # Translate to centre, scale, translate back
+        # The matrix below is the product of those three transformations
+        c_x, c_y, _ = centre
+        return np.array([[scale_x, 0, 0, c_x * (1 - scale_x)], [0, scale_y, 0, c_y * (1 - scale_y)], [0, 0, 1, 0], [0, 0, 0, 1]])
+
+    def _transform_vectors_with_matrix(self, points: np.ndarray, transform: np.ndarray) -> np.ndarray:
+        # The transform is a 4x4 matrix, the points are 3D vectors, first we need an extra
+        # entry on the points
+        transformed_points = np.hstack([points, np.ones((points.shape[0], 1))])
+        transformed_points = transformed_points @ transform.T
+        # Now remove extra point
+        return transformed_points[:, :3]
+
+    def on_aspect_ratio_check_box_clicked(self) -> None:
+        self._view.store_maintain_aspect_ratio_option()
+        self.on_projection_option_selected(self._view._projection_combo_box.currentIndex())
 
     def on_multi_select_detectors_clicked(self) -> None:
         """Change between single and multi point picking"""
@@ -302,7 +354,8 @@ class FullInstrumentViewPresenter:
             projected_points = self._model.current_projected_positions[ordered_indices]
             # Plot the peaks and their labels on the projection
             if len(projected_points) > 0:
-                self._view.plot_overlay_mesh(projected_points, labels, ws_peaks.colour)
+                transformed_points = self._transform_vectors_with_matrix(projected_points, self._transform)
+                self._view.plot_overlay_mesh(transformed_points, labels, ws_peaks.colour)
 
     def refresh_lineplot_peaks(self) -> None:
         # Plot vertical lines on the lineplot if the peak detector is selected

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -200,8 +200,15 @@ class FullInstrumentViewPresenter:
         self._model.extract_spectra_for_line_plot(unit, self._view.sum_spectra_selected())
         self._view.show_plot_for_detectors(self._model.line_plot_workspace)
         self._view.set_selected_detector_info(self._model.picked_detectors_info_text())
+        self._update_relative_detector_angle()
         self._update_peaks_workspaces()
         self.refresh_lineplot_peaks()
+
+    def _update_relative_detector_angle(self) -> None:
+        if len(self._model.picked_detector_ids) != 2:
+            self._view.set_relative_detector_angle(None)
+        else:
+            self._view.set_relative_detector_angle(self._model.relative_detector_angle())
 
     def on_clear_selected_detectors_clicked(self) -> None:
         self.update_picked_detectors([])

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -33,6 +33,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from instrumentview.Detectors import DetectorInfo
 from instrumentview.InteractorStyles import CustomInteractorStyleZoomAndSelect, CustomInteractorStyleRubberBand3D
 from typing import Callable
+from instrumentview.Projections.ProjectionType import ProjectionType
 from mantid.dataobjects import Workspace2D
 from mantid import UsageService, ConfigService
 from mantid.kernel import FeatureType
@@ -42,6 +43,19 @@ import pyvista as pv
 from pyvista.plotting.picking import RectangleSelection
 from pyvista.plotting.opts import PickerType
 import os
+from vtkmodules.vtkInteractionWidgets import vtkImplicitCylinderWidget, vtkImplicitCylinderRepresentation
+from vtkmodules.vtkCommonCore import vtkCommand
+
+
+class CylinderWidgetNoRotation(vtkImplicitCylinderWidget):
+    def __init__(self):
+        super().__init__()
+        self.AddObserver(vtkCommand.StartInteractionEvent, lambda *_: self._on_interaction())
+
+    def _on_interaction(self):
+        if self.GetCylinderRepresentation().GetInteractionState() == 4:
+            self.GetCylinderRepresentation().SetInteractionState(3)
+            return
 
 
 class PeaksWorkspaceListWidget(QListWidget):
@@ -181,6 +195,35 @@ class FullInstrumentViewWindow(QMainWindow):
         self._peak_ws_list.setSizeAdjustPolicy(QListWidget.AdjustToContents)
         peak_v_layout.addWidget(self._peak_ws_list)
 
+        masking_group_box = QGroupBox("Masking")
+        masking_layout = QVBoxLayout(masking_group_box)
+        note = QLabel("Currently only a cylinder/circle shape is supported. A rectangular shape will be added in the next update.")
+        pre_list_layout = QHBoxLayout()
+        self._add_cylinder = QPushButton("Circle Shape")
+        self._cylinder_select = QPushButton("Apply Mask")
+        self._clear_masks = QPushButton("Clear Masks")
+        pre_list_layout.addWidget(self._add_cylinder)
+        pre_list_layout.addWidget(self._cylinder_select)
+        pre_list_layout.addWidget(self._clear_masks)
+        self._mask_list = QListWidget(self)
+        self._mask_list.setSizeAdjustPolicy(QListWidget.AdjustToContents)
+        self._mask_list.setSelectionMode(QAbstractItemView.NoSelection)
+        post_list_layout = QHBoxLayout()
+        self._save_mask_to_ws = QPushButton("Export to ADS")
+        self._save_mask_to_file = QPushButton("Save to XML")
+        self._overwrite_mask = QPushButton("Overwrite Permanently")
+        post_list_layout.addWidget(self._save_mask_to_ws)
+        post_list_layout.addWidget(self._save_mask_to_file)
+        post_list_layout.addWidget(self._overwrite_mask)
+        masking_layout.addWidget(note)
+        masking_layout.addLayout(pre_list_layout)
+        masking_layout.addWidget(self._mask_list)
+        masking_layout.addLayout(post_list_layout)
+
+        # TODO: Find a more apropriate solution than logic in view
+        self._add_cylinder.clicked.connect(lambda: self._add_cylinder.setDisabled(True))
+        self._cylinder_select.clicked.connect(lambda: self._add_cylinder.setDisabled(False))
+
         self.status_group_box = QGroupBox("Status")
         status_layout = QHBoxLayout(self.status_group_box)
         status_label = QLabel("Loading ...")
@@ -208,6 +251,7 @@ class FullInstrumentViewWindow(QMainWindow):
         units_group_box.setLayout(units_vbox)
         options_vertical_layout.addWidget(units_group_box)
         options_vertical_layout.addWidget(peak_ws_group_box)
+        options_vertical_layout.addWidget(masking_group_box)
         options_vertical_layout.addWidget(QSplitter(Qt.Horizontal))
 
         options_vertical_layout.addWidget(self.status_group_box)
@@ -225,6 +269,10 @@ class FullInstrumentViewWindow(QMainWindow):
         window_geometry.moveCenter(center_point)
         self.move(window_geometry.topLeft())
 
+        self._current_widget = CylinderWidgetNoRotation()
+        self._projection_camera_map = {}
+        self._parallel_scales = {}
+
         UsageService.registerFeatureUsage(FeatureType.Interface, "InstrumentView2025", False)
 
     def check_sum_spectra_checkbox(self) -> None:
@@ -241,8 +289,8 @@ class FullInstrumentViewWindow(QMainWindow):
         option = "Yes" if self.is_maintain_aspect_ratio_checkbox_checked() else "No"
         ConfigService.Instance()[self._ASPECT_RATIO_SETTING_STRING] = option
 
-    def set_aspect_ratio_box_visibility(self, is_visible: bool) -> None:
-        self._aspect_ratio_check_box.setVisible(is_visible)
+    def enable_or_disable_aspect_ratio_box(self) -> None:
+        self._aspect_ratio_check_box.setDisabled(self.current_selected_projection() == ProjectionType.THREE_D)
 
     def _on_splitter_moved(self, pos, index) -> None:
         self._detector_spectrum_fig.tight_layout()
@@ -252,7 +300,9 @@ class FullInstrumentViewWindow(QMainWindow):
 
     def reset_camera(self) -> None:
         if not self._off_screen:
-            self.main_plotter.reset_camera()
+            self.main_plotter.camera_position = self._projection_camera_map[self.current_selected_projection()]
+            self.main_plotter.camera.parallel_scale = self._parallel_scales[self.current_selected_projection()]
+        return
 
     def _add_min_max_group_box(self, parent_box: QGroupBox) -> tuple[QLineEdit, QLineEdit, QDoubleRangeSlider]:
         """Creates a minimum and a maximum box (with labels) inside the given group box. The callbacks will be attached to textEdited
@@ -340,8 +390,10 @@ class FullInstrumentViewWindow(QMainWindow):
         self.refresh_peaks_ws_list()
 
     def setup_connections_to_presenter(self) -> None:
-        self._projection_combo_box.currentIndexChanged.connect(self._presenter.on_projection_option_selected)
-        self._multi_select_check.stateChanged.connect(self._presenter.on_multi_select_detectors_clicked)
+        self._projection_combo_box.currentIndexChanged.connect(self._presenter.update_plotter)
+        self._multi_select_check.stateChanged.connect(self._presenter.update_detector_picker)
+        self._add_cylinder.clicked.connect(self._presenter.on_add_cylinder_clicked)
+        self._cylinder_select.clicked.connect(self._presenter.on_cylinder_select_clicked)
         self._clear_selection_button.clicked.connect(self._presenter.on_clear_selected_detectors_clicked)
         self._contour_range_slider.sliderReleased.connect(self._presenter.on_contour_limits_updated)
         self._integration_limit_slider.sliderReleased.connect(self._presenter.on_integration_limits_updated)
@@ -349,6 +401,11 @@ class FullInstrumentViewWindow(QMainWindow):
         self._export_workspace_button.clicked.connect(self._presenter.on_export_workspace_clicked)
         self._sum_spectra_checkbox.clicked.connect(self._presenter.on_sum_spectra_checkbox_clicked)
         self._peak_ws_list.itemChanged.connect(self._presenter.on_peaks_workspace_selected)
+        self._mask_list.itemChanged.connect(self._presenter.on_mask_item_selected)
+        self._save_mask_to_ws.clicked.connect(self._presenter.on_save_mask_to_workspace_clicked)
+        self._save_mask_to_file.clicked.connect(self._presenter.on_save_xml_mask_clicked)
+        self._overwrite_mask.clicked.connect(self._presenter.on_overwrite_mask_clicked)
+        self._clear_masks.clicked.connect(self._presenter.on_clear_masks_clicked)
         self._aspect_ratio_check_box.clicked.connect(self._presenter.on_aspect_ratio_check_box_clicked)
 
         self._add_connections_to_edits_and_slider(
@@ -471,7 +528,7 @@ class FullInstrumentViewWindow(QMainWindow):
         """Draw the given mesh in the main plotter window"""
         self.main_plotter.add_mesh(mesh, color=colour, pickable=pickable)
 
-    def add_main_mesh(self, mesh: PolyData, is_projection: bool, scalars=None) -> None:
+    def add_detector_mesh(self, mesh: PolyData, is_projection: bool, scalars=None) -> None:
         """Draw the given mesh in the main plotter window"""
         self.main_plotter.clear()
         scalar_bar_args = dict(interactive=True, vertical=False, title_font_size=15, label_font_size=12) if scalars is not None else None
@@ -484,10 +541,18 @@ class FullInstrumentViewWindow(QMainWindow):
 
         if is_projection:
             self.main_plotter.view_xy()
+            self.main_plotter.enable_parallel_projection()
             if not self.main_plotter.off_screen:
                 self.main_plotter.enable_zoom_style()
 
-    def add_pickable_main_mesh(self, point_cloud: PolyData, scalars: np.ndarray | str) -> None:
+        if self.current_selected_projection() not in self._projection_camera_map.keys():
+            self.main_plotter.reset_camera()
+            self._projection_camera_map[self.current_selected_projection()] = self.main_plotter.camera_position
+            self._parallel_scales[self.current_selected_projection()] = self.main_plotter.camera.parallel_scale
+
+        self.reset_camera()
+
+    def add_pickable_mesh(self, point_cloud: PolyData, scalars: np.ndarray | str) -> None:
         self.main_plotter.add_mesh(
             point_cloud,
             scalars=scalars,
@@ -498,6 +563,42 @@ class FullInstrumentViewWindow(QMainWindow):
             point_size=30,
             render_points_as_spheres=True,
         )
+
+    def add_masked_mesh(self, mesh: PolyData) -> None:
+        if mesh.number_of_points == 0:
+            return
+        # RGB for dark grey is (64, 64, 64), normalised is (0.25, 0.25, 0.25)
+        self.main_plotter.add_mesh(mesh, color=(0.25, 0.25, 0.25), pickable=False, render_points_as_spheres=True, point_size=15)
+
+    def add_cylinder_widget(self, bounds) -> None:
+        cylinder_repr = vtkImplicitCylinderRepresentation()
+        cylinder_repr.SetOutlineTranslation(False)
+        cylinder_repr.GetOutlineProperty().SetOpacity(0)
+        cylinder_repr.SetMinRadius(0.001)
+
+        xmin, xmax, ymin, ymax, _zmin, _zmax = bounds
+        cylinder_repr.SetCenter((xmin + xmax) / 2, (ymin + ymax) / 2, 0.5)
+        cylinder_repr.SetRadius(np.sqrt((xmax - xmin) ** 2 + (ymax - ymin) ** 2) / 8)
+
+        # For 2D projections, camera view is always perpendicular to Z axis
+        cylinder_repr.SetAxis([0, 0, 1])
+        # TODO: Find a better way than using fixed bounds
+        cylinder_repr.SetWidgetBounds([-10, 10, -10, 10, 0, 1])
+        cylinder_widget = CylinderWidgetNoRotation()
+        cylinder_widget.SetRepresentation(cylinder_repr)
+        cylinder_widget.SetCurrentRenderer(self.main_plotter.renderer)
+        cylinder_widget.SetInteractor(self.main_plotter.iren.interactor)
+        cylinder_widget.On()
+        self._current_widget = cylinder_widget
+        # The command below is a hacky way of making the widget appear on top of detectors
+        # No idea why it works
+        self.main_plotter.camera_position = self.main_plotter.camera_position
+
+    def get_current_widget(self):
+        return self._current_widget
+
+    def enable_or_disable_mask_widgets(self):
+        self._add_cylinder.setDisabled(self.current_selected_projection() == ProjectionType.THREE_D)
 
     def add_rgba_mesh(self, mesh: PolyData, scalars: np.ndarray | str):
         """Draw the given mesh in the main plotter window, and set the colours manually with RGBA numbers"""
@@ -648,3 +749,17 @@ class FullInstrumentViewWindow(QMainWindow):
     def redraw_lineplot(self) -> None:
         self._detector_spectrum_fig.tight_layout()
         self._detector_figure_canvas.draw()
+
+    def selected_masks(self) -> list[str]:
+        return [
+            self._mask_list.item(row_index).text()
+            for row_index in range(self._mask_list.count())
+            if self._mask_list.item(row_index).checkState() > 0
+        ]
+
+    def set_new_mask_key(self, new_key: str) -> None:
+        list_item = QListWidgetItem(new_key, self._mask_list)
+        list_item.setCheckState(Qt.Checked)
+
+    def clear_mask_list(self) -> None:
+        self._mask_list.clear()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -130,6 +130,8 @@ class FullInstrumentViewWindow(QMainWindow):
         self._detector_xyz_edit = self._add_detector_info_boxes(detector_info_layout, "XYZ Position")
         self._detector_spherical_position_edit = self._add_detector_info_boxes(detector_info_layout, "Spherical Position")
         self._detector_pixel_counts_edit = self._add_detector_info_boxes(detector_info_layout, "Pixel Counts")
+        self._detector_relative_angle_edit = self._add_detector_info_boxes(detector_info_layout, "Relative Angle (degrees)")
+        self.set_relative_detector_angle(None)
 
         self._integration_limit_group_box = QGroupBox("Time of Flight")
         self._integration_limit_min_edit, self._integration_limit_max_edit, self._integration_limit_slider = self._add_min_max_group_box(
@@ -549,6 +551,10 @@ class FullInstrumentViewWindow(QMainWindow):
             lambda d: f"r: {d.spherical_position[0]:.3f}, 2\u03b8: {d.spherical_position[1]:.1f}, \u03c6: {d.spherical_position[2]:.1f}",
         )
         self._set_detector_edit_text(self._detector_pixel_counts_edit, detector_infos, lambda d: str(d.pixel_counts))
+
+    def set_relative_detector_angle(self, angle: float | None) -> None:
+        angle_text = "Select exactly two detectors to show angle" if angle is None else f"{angle:.4f}"
+        self._detector_relative_angle_edit.setPlainText(angle_text)
 
     def _set_detector_edit_text(
         self, edit_box: QTextEdit, detector_infos: list[DetectorInfo], property_lambda: Callable[[DetectorInfo], str]

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QAbstractItemView,
+    QScrollArea,
 )
 from qtpy.QtGui import QDoubleValidator, QMovie, QDragEnterEvent, QDropEvent, QDragMoveEvent, QColor, QPalette
 from qtpy.QtCore import Qt, QEvent, QSize
@@ -80,7 +81,6 @@ class FullInstrumentViewWindow(QMainWindow):
 
         super(FullInstrumentViewWindow, self).__init__(parent)
         self.setWindowTitle("Instrument View")
-        self.resize(1500, 1500)
 
         self._off_screen = off_screen
 
@@ -93,10 +93,14 @@ class FullInstrumentViewWindow(QMainWindow):
         pyvista_vertical_layout = QVBoxLayout(pyvista_vertical_widget)
         left_column_layout = QVBoxLayout(left_column_widget)
 
+        left_column_scroll = QScrollArea()
+        left_column_scroll.setWidgetResizable(True)
+        left_column_scroll.setWidget(left_column_widget)
+
         hsplitter = QSplitter(Qt.Horizontal)
-        hsplitter.addWidget(left_column_widget)
+        hsplitter.addWidget(left_column_scroll)
         hsplitter.addWidget(pyvista_vertical_widget)
-        hsplitter.setSizes([100, 200])
+        hsplitter.setSizes([150, 200])
         hsplitter.splitterMoved.connect(self._on_splitter_moved)
         parent_horizontal_layout.addWidget(hsplitter)
 
@@ -115,8 +119,8 @@ class FullInstrumentViewWindow(QMainWindow):
         vsplitter = QSplitter(Qt.Vertical)
         vsplitter.addWidget(self.main_plotter.app_window)
         vsplitter.addWidget(plot_widget)
-        vsplitter.setStretchFactor(0, 0)
-        vsplitter.setStretchFactor(1, 1)
+        vsplitter.setStretchFactor(0, 5)
+        vsplitter.setStretchFactor(1, 4)
         vsplitter.splitterMoved.connect(self._on_splitter_moved)
 
         pyvista_vertical_layout.addWidget(vsplitter)
@@ -203,6 +207,13 @@ class FullInstrumentViewWindow(QMainWindow):
         self.interactor_style = CustomInteractorStyleZoomAndSelect()
         self._overlay_meshes = []
         self._lineplot_overlays = []
+
+        screen_geometry = self.screen().geometry()
+        self.resize(int(screen_geometry.width() * 0.8), int(screen_geometry.height() * 0.8))
+        window_geometry = self.frameGeometry()
+        center_point = screen_geometry.center()
+        window_geometry.moveCenter(center_point)
+        self.move(window_geometry.topLeft())
 
         UsageService.registerFeatureUsage(FeatureType.Interface, "InstrumentView2025", False)
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -453,7 +453,7 @@ class FullInstrumentViewWindow(QMainWindow):
     def add_main_mesh(self, mesh: PolyData, is_projection: bool, scalars=None) -> None:
         """Draw the given mesh in the main plotter window"""
         self.main_plotter.clear()
-        scalar_bar_args = dict(interactive=True, vertical=True, title_font_size=15, label_font_size=12) if scalars is not None else None
+        scalar_bar_args = dict(interactive=True, vertical=False, title_font_size=15, label_font_size=12) if scalars is not None else None
         self.main_plotter.add_mesh(
             mesh, pickable=False, scalars=scalars, render_points_as_spheres=True, point_size=15, scalar_bar_args=scalar_bar_args
         )
@@ -470,7 +470,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self.main_plotter.add_mesh(
             point_cloud,
             scalars=scalars,
-            opacity=[0.0, 0.5],
+            opacity=[0.0, 0.3],
             show_scalar_bar=False,
             pickable=True,
             cmap="Oranges",

--- a/qt/python/instrumentview/instrumentview/InstrumentView.py
+++ b/qt/python/instrumentview/instrumentview/InstrumentView.py
@@ -25,7 +25,7 @@ class InstrumentView:
     def start_app_open_window(file_path: Path) -> None:
         """Load the given file, then open the Instrument View in a separate window with that workspace displayed"""
         app = QApplication(sys.argv)
-        ws = Load(str(file_path), StoreInADS=False)
+        ws = Load(str(file_path))
 
         if (
             not ws.getInstrument()

--- a/qt/python/instrumentview/instrumentview/Projections/ProjectionType.py
+++ b/qt/python/instrumentview/instrumentview/Projections/ProjectionType.py
@@ -1,0 +1,18 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from enum import Enum
+
+
+class ProjectionType(str, Enum):
+    THREE_D = "3D"
+    SPHERICAL_X = "Spherical X"
+    SPHERICAL_Y = "Spherical Y"
+    SPHERICAL_Z = "Spherical Z"
+    CYLINDRICAL_X = "Cylindrical X"
+    CYLINDRICAL_Y = "Cylindrical Y"
+    CYLINDRICAL_Z = "Cylindrical Z"
+    SIDE_BY_SIDE = "Side by Side"

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -4,6 +4,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.simpleapi import CreateSampleWorkspace, CreatePeaksWorkspace, AddPeak
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
+from instrumentview.Projections.ProjectionType import ProjectionType
 import unittest
 from unittest import mock
 import numpy as np
@@ -32,18 +33,32 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         cls._ws = CreateSampleWorkspace(OutputWorkspace="TestFullInstrumentViewModel", XUnit="TOF")
 
     def setUp(self) -> None:
-        patcher = mock.patch("instrumentview.FullInstrumentViewModel.CreateDetectorTable")
-        self.addCleanup(patcher.stop)
-        mock_create_det_table = patcher.start()
+        table_patcher = mock.patch("instrumentview.FullInstrumentViewModel.CreateDetectorTable")
+        self.addCleanup(table_patcher.stop)
         self._mock_table = mock.MagicMock()
-        mock_create_det_table.return_value = self._mock_table
+        mock_table = table_patcher.start()
+        mock_table.return_value = self._mock_table
 
-    def _mock_detector_table(self, detector_ids: list[int], spectrum_no: np.ndarray = np.array([]), monitors: np.ndarray = np.array([])):
+        mask_patcher = mock.patch("instrumentview.FullInstrumentViewModel.ExtractMask")
+        self.addCleanup(mask_patcher.stop)
+        self._mock_extract_mask = mock.MagicMock()
+        self._mock_extract_mask = mask_patcher.start()
+
+    def _setup_mocks(
+        self,
+        detector_ids: list[int],
+        spectrum_no: np.ndarray = np.array([]),
+        monitors: np.ndarray = np.array([]),
+        det_mask: np.ndarray = np.array([]),
+    ):
         if monitors.size == 0:
             monitors = np.array(["no" for _ in detector_ids])
 
         if spectrum_no.size == 0:
             spectrum_no = np.array([i for i in range(len(detector_ids))])
+
+        if det_mask.size == 0:
+            det_mask = np.zeros(len(detector_ids))
 
         table_columns = {
             "Detector ID(s)": np.array([int(id) for id in detector_ids]),
@@ -56,6 +71,9 @@ class TestFullInstrumentViewModel(unittest.TestCase):
             "Spectrum No": spectrum_no,
         }
         self._mock_table.columnArray.side_effect = lambda x: table_columns[x]
+
+        mock_mask_ws = mock.MagicMock(extractY=mock.MagicMock(return_value=det_mask))
+        self._mock_extract_mask.return_value = mock_mask_ws, []
         return
 
     def _create_mock_workspace(self, detector_ids: list[int]):
@@ -70,30 +88,36 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = [100 * i for i in detector_ids]
         return mock_workspace
 
-    def test_update_integration_range(self):
-        self._mock_detector_table(list(range(self._ws.getNumberHistograms())))
-        model = FullInstrumentViewModel(self._ws)
+    def _setup_model(
+        self,
+        detector_ids: list[int],
+        spectrum_no: np.ndarray = np.array([]),
+        monitors: np.ndarray = np.array([]),
+        det_mask: np.ndarray = np.array([]),
+    ):
+        mock_ws = self._create_mock_workspace(detector_ids)
+        self._setup_mocks(detector_ids, spectrum_no, monitors, det_mask)
+        model = FullInstrumentViewModel(mock_ws)
         model.setup()
-        integrated_spectra = list(range((self._ws.getNumberHistograms())))
-        mock_workspace = mock.MagicMock()
+        return model, mock_ws
+
+    def test_update_integration_range(self):
+        model, mock_workspace = self._setup_model([1, 2, 3])
+        integrated_spectra = [1, 20, 100]
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = integrated_spectra
-        model._workspace = mock_workspace
         model.update_integration_range((200, 10000), False)
-        model._workspace.getIntegratedCountsForWorkspaceIndices.assert_called_once()
+        model._workspace.getIntegratedCountsForWorkspaceIndices.assert_called()
         self.assertEqual(min(integrated_spectra), model._counts_limits[0])
         self.assertEqual(max(integrated_spectra), model._counts_limits[1])
 
     @mock.patch("instrumentview.FullInstrumentViewModel.DetectorInfo")
     def test_picked_detectors_info_text(self, det_info_mock):
-        self._mock_detector_table([1, 20, 300])
-        mock_workspace = self._create_mock_workspace([1, 20, 300])
+        model, mock_workspace = self._setup_model([1, 20, 300])
         mock_workspace.getDetector.side_effect = lambda i: mock.MagicMock(
             getName=mock.Mock(return_value=str(i)), getFullName=mock.Mock(return_value=f"Full_{i}")
         )
-        model = FullInstrumentViewModel(mock_workspace)
-        model.setup()
         model._is_valid = np.array([False, True, True])
-        model._detector_is_picked = np.array([False, True])
+        model._detector_is_picked = np.array([False, False, True])
         model.picked_detectors_info_text()
         # Test each argument one by one because of array equality
         mock_args, mock_kwargs = det_info_mock.call_args
@@ -106,23 +130,19 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         self.assertEqual(mock_args[6], 30000)
 
     def test_negate_picked_visibility(self):
-        self._mock_detector_table(list(range(self._ws.getNumberHistograms())))
-        model = FullInstrumentViewModel(self._ws)
-        model.setup()
+        model, _ = self._setup_model([1, 2, 3])
         model._detector_is_picked = np.array([False, False, False])
-        model.negate_picked_visibility([1, 2])
+        model.negate_picked_visibility(np.array([False, True, True]))
         np.testing.assert_equal(model._detector_is_picked, [False, True, True])
 
     def test_clear_all_picked_detectors(self):
-        self._mock_detector_table(list(range(self._ws.getNumberHistograms())))
-        model = FullInstrumentViewModel(self._ws)
-        model.setup()
+        model, _ = self._setup_model([1, 2, 3])
         model._detector_is_picked = np.array([False, True, True])
         model.clear_all_picked_detectors()
         np.testing.assert_equal(model._detector_is_picked, [False, False, False])
 
     def test_detectors_with_no_spectra(self):
-        self._mock_detector_table([1, 20, 300, 400], monitors=np.array(["no", "no", "n/a", "yes"]))
+        self._setup_mocks([1, 20, 300, 400], monitors=np.array(["no", "no", "n/a", "yes"]))
         mock_workspace = self._create_mock_workspace([1, 20, 300, 400])
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = [100, 200]
         model = FullInstrumentViewModel(mock_workspace)
@@ -133,128 +153,100 @@ class TestFullInstrumentViewModel(unittest.TestCase):
 
     @mock.patch("instrumentview.FullInstrumentViewModel.SphericalProjection")
     def test_calculate_spherical_projection(self, mock_spherical_projection):
-        self._run_projection_test(mock_spherical_projection, FullInstrumentViewModel._SPHERICAL_Y)
+        self._run_projection_test(mock_spherical_projection, ProjectionType.SPHERICAL_Y)
 
     @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
     def test_calculate_cylindrical_projection(self, mock_cylindrical_projection):
-        self._run_projection_test(mock_cylindrical_projection, FullInstrumentViewModel._CYLINDRICAL_Y)
+        self._run_projection_test(mock_cylindrical_projection, ProjectionType.CYLINDRICAL_Y)
 
     @mock.patch("instrumentview.FullInstrumentViewModel.SideBySide")
     def test_calculate_side_by_side_projection(self, mock_side_by_side):
-        self._run_projection_test(mock_side_by_side, FullInstrumentViewModel._SIDE_BY_SIDE)
+        self._run_projection_test(mock_side_by_side, ProjectionType.SIDE_BY_SIDE)
 
     def _run_projection_test(self, mock_projection_constructor, projection_option):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
-        model = FullInstrumentViewModel(mock_workspace)
-        model.setup()
+        model, _ = self._setup_model([1, 2, 3])
         mock_projection = mock.MagicMock()
         mock_projection.positions.return_value = [[1, 2], [1, 2], [1, 2]]
         mock_projection_constructor.return_value = mock_projection
-        points = model.calculate_projection(projection_option, axis=[0, 1, 0], positions=model.detector_positions)
+        model._projection_type = projection_option
+        points = model._calculate_projection()
         mock_projection_constructor.assert_called_once()
         self.assertTrue(all(all(point == [1, 2, 0]) for point in points))
 
     def test_sample_position(self):
         expected_position = np.array([1.0, 2.0, 1.0])
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.componentInfo().samplePosition.return_value = expected_position
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         np.testing.assert_array_equal(model.sample_position, expected_position)
 
     def test_detector_positions(self):
-        self._mock_detector_table([1, 2, 3])
+        self._setup_mocks([1, 2, 3])
         mock_workspace = self._create_mock_workspace([1, 2, 3])
         model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         np.testing.assert_array_equal(model.detector_positions, [[0, 0, 0], [1, 1, 1], [2, 2, 2]])
 
     def test_picked_detector_ids(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
-        model = FullInstrumentViewModel(mock_workspace)
-        model.setup()
-        model._is_valid = np.array([False, True, True])
-        model._detector_is_picked = np.array([False, True])
+        model, _ = self._setup_model([1, 2, 3])
+        model._detector_is_picked = np.array([False, False, True])
         self.assertEqual(model.picked_detector_ids, [3])
 
     def test_picked_workspace_indices(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
-        model = FullInstrumentViewModel(mock_workspace)
-        model.setup()
-        model._is_valid = np.array([False, True, True])
-        model._detector_is_picked = np.array([False, True])
-        self.assertEqual(model.picked_workspace_indices, [2])
+        model, _ = self._setup_model([1, 2, 3])
+        model._detector_is_picked = np.array([False, False, True])
+        self.assertEqual(model.picked_workspace_indices, [2])  # Indices in mock start at 0
 
     def test_source_position(self):
+        model, mock_workspace = self._setup_model([1, 2, 3])
         expected_position = np.array([0.5, 1.0, 0.2])
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
         mock_workspace.componentInfo().sourcePosition.return_value = expected_position
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         np.testing.assert_array_equal(model._source_position, expected_position)
 
     def test_detector_counts(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         expected_counts = np.array([100, 200, 300])
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = expected_counts
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
-        expected_counts = np.array([100, 200, 300])
         np.testing.assert_array_equal(model.detector_counts, expected_counts)
 
     def test_detector_ids(self):
         expected_ids = [1, 2, 3]
-        self._mock_detector_table(expected_ids)
-        mock_workspace = self._create_mock_workspace(expected_ids)
-        model = FullInstrumentViewModel(mock_workspace)
-        model.setup()
+        model, _ = self._setup_model(expected_ids)
         np.testing.assert_array_equal(model.detector_ids, expected_ids)
 
     def test_counts_limits(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = [100, 200, 300]
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         self.assertEqual(model.counts_limits[0], 100)
         self.assertEqual(model.counts_limits[1], 300)
 
     def test_integration_limits_ws_with_common_bins(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.isCommonBins.return_value = True
         mock_workspace.dataX.return_value = np.array([1, 2, 3])
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         self.assertEqual(model.integration_limits, (1, 3))
 
     def test_integration_limits_on_ragged_workspace(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.isRaggedWorkspace.return_value = True
         data_x = {0: np.array([1, 2, 3]), 1: np.array([10, 20, 30, 40]), 2: np.array([10, 20, 30, 40, 50])}
         mock_workspace.readX.side_effect = lambda i: data_x[i]
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         self.assertEqual(model.integration_limits, (1, 50))
 
     def test_integration_limits_on_non_ragged_workspace(self):
-        self._mock_detector_table([1, 2, 3])
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.isRaggedWorkspace.return_value = False
         mock_workspace.extractX.return_value = np.array([[1, 2, 3], [10, 20, 30], [10, 20, 50]])
-        model = FullInstrumentViewModel(mock_workspace)
         model.setup()
         self.assertEqual(model.integration_limits, (1, 50))
 
     def test_monitor_positions(self):
-        self._mock_detector_table([1, 2, 3], monitors=np.array(["yes", "no", "yes"]))
+        self._setup_mocks([1, 2, 3], monitors=np.array(["yes", "no", "yes"]))
         mock_workspace = self._create_mock_workspace([1, 2, 3])
         mock_workspace.getIntegratedCountsForWorkspaceIndices.return_value = [100]
         model = FullInstrumentViewModel(mock_workspace)
@@ -266,9 +258,8 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewModel.ConvertUnits")
     @mock.patch.object(FullInstrumentViewModel, "picked_workspace_indices", new_callable=mock.PropertyMock)
     def test_extract_spectra_for_picked_detectors(self, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_picked_workspace_indices.return_value = [1, 2]
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("TOF", False)
         mock_extract_spectra.assert_called_once_with(
             InputWorkspace=mock_workspace, WorkspaceIndexList=[1, 2], EnableLogging=False, StoreInADS=False
@@ -282,9 +273,8 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewModel.ConvertUnits")
     @mock.patch.object(FullInstrumentViewModel, "picked_workspace_indices", new_callable=mock.PropertyMock)
     def test_extract_spectra_no_picked_detectors(self, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, _ = self._setup_model([1, 2, 3])
         mock_picked_workspace_indices.return_value = []
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("Wavelength", True)
         self.assertIsNone(model.line_plot_workspace)
         mock_extract_spectra.assert_not_called()
@@ -298,14 +288,13 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     def test_extract_spectra_sum(
         self, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra, mock_sum_spectra, mock_rebin
     ):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.isCommonBins.return_value = False
         mock_picked_workspace_indices.return_value = [1, 2]
         mock_extract_spectra.return_value = mock_workspace
         mock_convert_units.return_value = mock_workspace
         mock_sum_spectra.return_value = mock_workspace
         mock_rebin.return_value = mock_workspace
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("TOF", True)
         mock_extract_spectra.assert_called_once_with(
             InputWorkspace=mock_workspace, WorkspaceIndexList=[1, 2], EnableLogging=False, StoreInADS=False
@@ -324,14 +313,13 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     def test_extract_spectra_sum_common_bins(
         self, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra, mock_sum_spectra, mock_rebin
     ):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.isCommonBins.return_value = True
         mock_picked_workspace_indices.return_value = [1, 2]
         mock_extract_spectra.return_value = mock_workspace
         mock_convert_units.return_value = mock_workspace
         mock_sum_spectra.return_value = mock_workspace
         mock_rebin.return_value = mock_workspace
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("TOF", True)
         mock_extract_spectra.assert_called_once_with(
             InputWorkspace=mock_workspace, WorkspaceIndexList=[1, 2], EnableLogging=False, StoreInADS=False
@@ -349,12 +337,11 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     def test_extract_spectra_sum_one_spectra(
         self, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra, mock_sum_spectra
     ):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_picked_workspace_indices.return_value = [2]
         mock_extract_spectra.return_value = mock_workspace
         mock_convert_units.return_value = mock_workspace
         mock_sum_spectra.return_value = mock_workspace
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("Wavelength", True)
         mock_extract_spectra.assert_called_once_with(
             InputWorkspace=mock_workspace, WorkspaceIndexList=[2], EnableLogging=False, StoreInADS=False
@@ -370,9 +357,8 @@ class TestFullInstrumentViewModel(unittest.TestCase):
     @mock.patch.object(FullInstrumentViewModel, "picked_workspace_indices", new_callable=mock.PropertyMock)
     @mock.patch("instrumentview.FullInstrumentViewModel.AnalysisDataService")
     def test_save_line_plot_workspace_to_ads(self, mock_ads, mock_picked_workspace_indices, mock_convert_units, mock_extract_spectra):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, _ = self._setup_model([1, 2, 3])
         mock_picked_workspace_indices.return_value = [1, 2]
-        model = FullInstrumentViewModel(mock_workspace)
         model.extract_spectra_for_line_plot("TOF", False)
         mock_convert_units.assert_called_once()
         mock_extract_spectra.assert_called_once()
@@ -380,19 +366,19 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_ads.addOrReplace.assert_called_once()
 
     def test_has_no_unit(self):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.getAxis.return_value = mock.MagicMock()
         mock_workspace.getAxis(0).getUnit.return_value = mock.MagicMock()
         mock_workspace.getAxis(0).getUnit().unitID.return_value = "Empty"
-        model = FullInstrumentViewModel(mock_workspace)
+        model.setup()
         self.assertEqual(False, model.has_unit)
 
     def test_has_unit(self):
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.getAxis.return_value = mock.MagicMock()
         mock_workspace.getAxis(0).getUnit.return_value = mock.MagicMock()
         mock_workspace.getAxis(0).getUnit().unitID.return_value = "Wavelength"
-        model = FullInstrumentViewModel(mock_workspace)
+        model.setup()
         self.assertEqual(True, model.has_unit)
 
     @mock.patch("instrumentview.FullInstrumentViewModel.AnalysisDataService")
@@ -400,11 +386,10 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_ads_instance = mock_ads.Instance()
         mock_peaks_workspace = PeaksWorkspaceMock()
         instrument = "MyFirstInstrument"
-        mock_workspace = self._create_mock_workspace([1, 2, 3])
+        model, mock_workspace = self._setup_model([1, 2, 3])
         mock_workspace.getInstrument().getFullName.return_value = instrument
         mock_peaks_workspace.getInstrument().getFullName.return_value = instrument
         mock_ads_instance.retrieveWorkspaces.return_value = [mock_peaks_workspace, mock_workspace]
-        model = FullInstrumentViewModel(mock_workspace)
         peaks_workspaces = model.peaks_workspaces_in_ads()
         self.assertEqual(1, len(peaks_workspaces))
         self.assertEqual(mock_peaks_workspace, peaks_workspaces[0])
@@ -426,6 +411,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         model._selected_peaks_workspaces = [peaks_ws]
         model._detector_ids = np.array([100])
         model._is_valid = np.array([True])
+        model._is_masked = np.array([False])
         peaks = model.peak_overlay_points()
         self.assertEqual(1, len(peaks))
         detector_peak = peaks[0][0]
@@ -435,18 +421,17 @@ class TestFullInstrumentViewModel(unittest.TestCase):
 
     @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
     def test_relative_detector_angle_no_picked(self, mock_picked_detector_ids):
-        mock_ws = self._create_mock_workspace([10, 11, 12])
-        mock_detector_info = mock_ws.detectorInfo()
+        model, mock_workspace = self._setup_model([10, 11, 12])
+        mock_detector_info = mock_workspace.detectorInfo()
         mock_detector_info.azimuthal.return_value = 0.1
-        model = FullInstrumentViewModel(mock_ws)
         with self.assertRaisesRegex(RuntimeError, ".*two detectors are selected"):
             model.relative_detector_angle()
         mock_picked_detector_ids.assert_called_once()
 
     @mock.patch.object(FullInstrumentViewModel, "picked_detector_ids", new_callable=mock.PropertyMock)
     def test_relative_detector_angle_two_picked(self, mock_picked_detector_ids):
-        mock_ws = self._create_mock_workspace([10, 11, 12])
-        mock_detector_info = mock_ws.detectorInfo()
+        model, mock_workspace = self._setup_model([10, 11, 12])
+        mock_detector_info = mock_workspace.detectorInfo()
         mock_detector_info.azimuthal.return_value = 0.1
 
         def mock_index_of(idx):
@@ -459,18 +444,16 @@ class TestFullInstrumentViewModel(unittest.TestCase):
 
         mock_detector_info.twoTheta = mock_two_theta
         mock_picked_detector_ids.return_value = [10, 11]
-        model = FullInstrumentViewModel(mock_ws)
         angle = model.relative_detector_angle()
         np.testing.assert_allclose(14.324, angle, rtol=0.001)
         mock_picked_detector_ids.assert_called_once()
-        self.assertEquals(2, mock_detector_info.azimuthal.call_count)
+        self.assertEqual(2, mock_detector_info.azimuthal.call_count)
 
     def test_calculate_q_lab_direction(self):
-        mock_ws = self._create_mock_workspace([10])
+        model, mock_ws = self._setup_model([10])
         mock_detector_info = mock_ws.detectorInfo()
         mock_detector_info.azimuthal.return_value = 0.1
         mock_detector_info.twoTheta.return_value = 0.8
-        model = FullInstrumentViewModel(mock_ws)
         q_lab = model._calculate_q_lab_direction(10)
         np.testing.assert_allclose([-0.91646, -0.091953, 0.389418], q_lab, rtol=1e-5)
 
@@ -485,6 +468,114 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         model = FullInstrumentViewModel(self._ws)
         iv_qlab = model._calculate_q_lab_direction(detector_id)
         np.testing.assert_allclose(q_lab_direction, iv_qlab, rtol=1e-5)
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
+    def test_cached_projections_map_empty(self, mock_projection_constructor):
+        model, _ = self._setup_model([1, 2, 3])
+        model.projection_type = ProjectionType.CYLINDRICAL_X
+        mock_projection = mock.MagicMock(positions=mock.MagicMock(return_value=np.array([[1, 2], [1, 2], [1, 2]])))
+        mock_projection_constructor.return_value = mock_projection
+        model._cached_projections_map = {}
+        positions = model._calculate_projection()
+        np.testing.assert_almost_equal(positions, np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]]))
+        np.testing.assert_almost_equal(
+            model._cached_projections_map[ProjectionType.CYLINDRICAL_X.name], np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        )
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
+    def test_cached_projections_map_already_cached(self, mock_projection_constructor):
+        model, _ = self._setup_model([1, 2, 3])
+        model.projection_type = ProjectionType.CYLINDRICAL_X
+        model._cached_projections_map = {ProjectionType.CYLINDRICAL_X.name: np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]])}
+        positions = model._calculate_projection()
+        np.testing.assert_almost_equal(positions, np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]]))
+        mock_projection_constructor.assert_not_called()
+
+    def test_is_pickable(self):
+        model, _ = self._setup_model([1, 2, 3])
+        model._is_valid = np.array([False, True, True])
+        model._is_masked = np.array([False, False, True])
+        np.testing.assert_array_equal(model.is_pickable, np.array([False, True, False]))
+
+    def test_get_default_projection_index_and_options_3D(self):
+        model, mock_workspace = self._setup_model([1, 2, 3])
+        mock_workspace.getInstrument = mock.MagicMock(return_value=mock.MagicMock(getDefaultView=mock.MagicMock(return_value="3D")))
+        index, projection_options = model.get_default_projection_index_and_options()
+        self.assertEqual(projection_options[index], ProjectionType.THREE_D)
+
+    def test_get_default_projection_index_and_options_non_3D(self):
+        model, mock_workspace = self._setup_model([1, 2, 3])
+        mock_workspace.getInstrument = mock.MagicMock(
+            return_value=mock.MagicMock(getDefaultView=mock.MagicMock(return_value="SPHERICAL_X"))
+        )
+        index, projection_options = model.get_default_projection_index_and_options()
+        self.assertEqual(projection_options[index], ProjectionType.SPHERICAL_X)
+
+    def test_is_2d_projection_false(self):
+        model, _ = self._setup_model([1, 2, 3])
+        model._projection_type = ProjectionType.THREE_D
+        self.assertEqual(model.is_2d_projection, False)
+
+    def test_is_2d_projection_true(self):
+        model, _ = self._setup_model([1, 2, 3])
+        model._projection_type = ProjectionType.SPHERICAL_X
+        self.assertEqual(model.is_2d_projection, True)
+
+    def test_detector_positions_3D(self):
+        model, _ = self._setup_model([1, 2, 3])
+        expected_positions = np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        model._detector_positions_3d = expected_positions
+        model._projection_type = ProjectionType.THREE_D
+        model._is_valid = np.array([True, True, True])
+        model._is_masked = np.array([True, False, False])
+        np.testing.assert_array_equal(model.detector_positions, expected_positions[1:])
+
+    @mock.patch.object(FullInstrumentViewModel, "_calculate_projection")
+    def test_detector_positions_non_3D(self, mock_calc_projection):
+        model, _ = self._setup_model([1, 2, 3])
+        expected_positions = np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]])
+        mock_calc_projection.return_value = expected_positions
+        model._projection_type = ProjectionType.SPHERICAL_X
+        model._is_valid = np.array([True, True, True])
+        model._is_masked = np.array([True, False, False])
+        np.testing.assert_array_equal(model.detector_positions, expected_positions[1:])
+
+    def test_add_mask(self):
+        model, _ = self._setup_model([1, 2, 3])
+        model._cached_masks_map = {}
+        model._is_masked_in_ws = np.array([True, True, False])
+        model._is_valid = np.array([True, True, True])
+        model._is_masked = np.array([True, False, False])
+        model.add_new_detector_mask([True, True])
+        np.testing.assert_array_equal(model._cached_masks_map["Mask 1"], np.array([True, True, True]))
+
+    def test_apply_detector_mask(self):
+        model, _ = self._setup_model([1, 2, 3])
+        # All detectors picked, mask should unpick them
+        model._detector_is_picked = np.array([True, True, True])
+        model._cached_masks_map = {"Mask 1": np.array([True, False, False]), "Mask 2": np.array([False, True, False])}
+        model.apply_detector_masks(["Mask 1", "Mask 2"])
+        np.testing.assert_array_equal(model._is_masked, np.array([True, True, False]))
+        np.testing.assert_array_equal(model._detector_is_picked, np.array([False, False, True]))
+
+    def test_apply_detector_mask_empty(self):
+        model, _ = self._setup_model([1, 2, 3])
+        model._is_masked_in_ws = np.array([True, False, False])
+        model.apply_detector_masks([])
+        np.testing.assert_array_equal(model._is_masked, np.array([True, False, False]))
+        np.testing.assert_array_equal(model._detector_is_picked, np.array([False, False, False]))
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.ExtractMaskToTable")
+    def test_save_mask_workspace_to_ads(self, mock_extract_to_table):
+        model, _ = self._setup_model([1, 2, 3])
+        model.save_mask_workspace_to_ads()
+        mock_extract_to_table.assert_called_once()
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.SaveMask")
+    def test_save_xml_mask(self, mock_save_mask):
+        model, _ = self._setup_model([1, 2, 3])
+        model.save_xml_mask("file")
+        mock_save_mask.assert_called_with(model._mask_ws, OutputFile="file.xml")
 
 
 if __name__ == "__main__":

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -8,6 +8,7 @@ from instrumentview.FullInstrumentViewPresenter import FullInstrumentViewPresent
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 from instrumentview.Peaks.DetectorPeaks import DetectorPeaks
 from instrumentview.Peaks.Peak import Peak
+from instrumentview.Projections.ProjectionType import ProjectionType
 
 import numpy as np
 from mantid.simpleapi import CreateSampleWorkspace
@@ -20,6 +21,7 @@ from unittest.mock import MagicMock
 class TestFullInstrumentViewPresenter(unittest.TestCase):
     def setUp(self):
         self._mock_view = MagicMock()
+        self._mock_view.current_selected_projection.return_value = ProjectionType.CYLINDRICAL_Y
         self._ws = CreateSampleWorkspace(OutputWorkspace="TestFullInstrumentViewPresenter", EnableLogging=False)
         self._model = FullInstrumentViewModel(self._ws)
         with mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces"):
@@ -33,43 +35,15 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     def _create_detector_peaks(self, det_id: int, location: np.ndarray) -> DetectorPeaks:
         return DetectorPeaks([Peak(det_id, location, (1, 1, 1), 100, 1000, 100, 100)])
 
-    def test_projection_combo_options(self):
-        _, projections = self._presenter.projection_combo_options()
-        self.assertGreater(len(projections), 0)
-        self.assertTrue("Spherical X" in projections)
-
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
-    def test_projection_option_selected(self, mock_set_peaks_ws):
-        self._presenter.on_projection_option_selected(1)
-        self._mock_view.add_main_mesh.assert_called()
+    def test_update_plotter(self, mock_set_peaks_ws):
+        self._mock_view.current_selected_projection.return_value = ProjectionType.CYLINDRICAL_X
+        self._presenter.update_plotter()
+        self.assertEqual(self._model.projection_type, ProjectionType.CYLINDRICAL_X)
+        self._mock_view.add_detector_mesh.assert_called()
+        self._mock_view.add_pickable_mesh.assert_called()
+        self._mock_view.add_masked_mesh.assert_called()
         mock_set_peaks_ws.assert_called_once()
-
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.reset_cached_projection_positions")
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
-    def test_3d_projection_resets_cache(self, mock_set_peaks_ws, mock_reset_cache):
-        self.assertEquals("3D", self._model._PROJECTION_OPTIONS[0])
-        self._presenter.on_projection_option_selected(0)
-        mock_reset_cache.assert_called_once()
-        self._mock_view.add_main_mesh.assert_called()
-
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.create_poly_data_mesh")
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.calculate_projection")
-    def test_projection_option_axis(self, mock_calculate_projection, mock_create_poly_data_mesh):
-        _, options = self._presenter.projection_combo_options()
-        for option in options:
-            if option.endswith("X"):
-                axis = [1, 0, 0]
-            elif option.endswith("Y"):
-                axis = [0, 1, 0]
-            elif option.endswith("Z"):
-                axis = [0, 0, 1]
-            else:
-                return
-            self._presenter.on_projection_option_selected(options.index(option))
-            mock_calculate_projection.assert_called_once_with(option.startswith("Spherical"), axis)
-            mock_create_poly_data_mesh.assert_called()
-            mock_calculate_projection.reset_mock()
-            mock_create_poly_data_mesh.reset_mock()
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.update_integration_range")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.set_view_integration_limits")
@@ -97,30 +71,20 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.set_view_integration_limits()
         np.testing.assert_allclose(self._presenter._detector_mesh[self._presenter._counts_label], self._model.detector_counts)
 
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_picked_detectors")
-    def test_point_picked(self, mock_update_picked_detectors):
-        mock_picker = MagicMock()
-
-        def get_point_id():
-            return 1
-
-        mock_picker.GetPointId = get_point_id
-        self._presenter.point_picked(MagicMock(), mock_picker)
-        mock_update_picked_detectors.assert_called_with([1])
-
     def test_update_picked_detectors(self):
         self._model._workspace_indices = np.array([0, 1, 2])
         self._model._is_valid = np.array([True, True, True])
+        self._model._is_masked = np.array([False, False, False])
         self._model._detector_is_picked = np.array([True, True, False])
         self._model._detector_ids = np.array([1, 2, 3])
         self._model.picked_detectors_info_text = MagicMock(return_value=["a", "a"])
         self._model.extract_spectra_for_line_plot = MagicMock()
-        self._presenter._pickable_main_mesh = {}
+        self._presenter._pickable_mesh = {}
         self._presenter._pickable_projection_mesh = {}
         self._mock_view.current_selected_unit.return_value = "TOF"
         self._mock_view.sum_spectra_selected.return_value = True
         self._presenter.update_picked_detectors([])
-        np.testing.assert_allclose(self._presenter._pickable_main_mesh[self._presenter._visible_label], self._model._detector_is_picked)
+        np.testing.assert_allclose(self._presenter._pickable_mesh[self._presenter._visible_label], self._model._detector_is_picked)
         self._mock_view.show_plot_for_detectors.assert_called_once_with(self._model.line_plot_workspace)
         self._mock_view.set_selected_detector_info.assert_called_once_with(["a", "a"])
         self._model.extract_spectra_for_line_plot.assert_called_once_with("TOF", True)
@@ -132,13 +96,13 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
 
     def test_set_multi_select_enabled(self):
         self._mock_view.is_multi_picking_checkbox_checked.return_value = True
-        self._presenter.on_multi_select_detectors_clicked()
+        self._presenter.update_detector_picker()
         self._mock_view.enable_rectangle_picking.assert_called_once()
         self._mock_view.enable_point_picking.assert_not_called()
 
     def test_set_multi_select_disabled(self):
         self._mock_view.is_multi_picking_checkbox_checked.return_value = False
-        self._presenter.on_multi_select_detectors_clicked()
+        self._presenter.update_detector_picker()
         self._mock_view.enable_rectangle_picking.assert_not_called()
         self._mock_view.enable_point_picking.assert_called_once()
 
@@ -166,22 +130,23 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_has_unit.return_value = False
         units = self._presenter.available_unit_options()
         mock_has_unit.assert_called_once()
-        self.assertEquals(["No units"], units)
+        self.assertEqual(["No units"], units)
 
     @mock.patch.object(FullInstrumentViewModel, "has_unit", new_callable=mock.PropertyMock)
     def test_available_units_has_units(self, mock_has_unit):
         mock_has_unit.return_value = True
         units = self._presenter.available_unit_options()
         mock_has_unit.assert_called_once()
-        self.assertEquals(self._presenter._UNIT_OPTIONS, units)
+        self.assertEqual(self._presenter._UNIT_OPTIONS, units)
 
-    def test_only_close_on_correct_ws_replace(self):
+    def test_model_refresh_on_correct_ws_replace(self):
+        self._model.setup = MagicMock()
         ws_name = self._model.workspace.name()
         self._presenter.replace_workspace_callback(ws_name, None)
-        self._mock_view.close.assert_called_once()
-        self._mock_view.close.reset_mock()
+        self._model.setup.assert_called_once()
+        self._mock_view.setup.reset_mock()
         self._presenter.replace_workspace_callback("not_my_workspace", None)
-        self._mock_view.close.assert_not_called()
+        self._mock_view.setup.assert_not_called()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.on_peaks_workspace_selected")
     def test_reload_peaks_workspaces(self, mock_on_peaks_workspace_selected):
@@ -199,21 +164,19 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._transform_vectors_with_matrix")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.refresh_lineplot_peaks")
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._adjust_points_for_selected_projection")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.peak_overlay_points")
     def test_on_peaks_workspace_selected(
         self,
         mock_peak_overlay_points,
-        mock_adjust_points_projection,
         mock_refresh_lineplot_peaks,
         mock_set_peaks_workspaces,
         mock_transform,
     ):
         mock_peak_overlay_points.return_value = [[self._create_detector_peaks(50, np.zeros(3))]]
-        mock_adjust_points_projection.return_value = [mock_peak_overlay_points()[0][0].location]
-        self._model._current_projected_positions = np.array([np.zeros(3)])
+        self._model._calculate_projection = MagicMock(return_value=np.array([np.zeros(3), np.zeros(3)]))
         self._model._detector_ids = np.array([50, 52])
         self._model._is_valid = np.array([True, True])
+        self._model._is_masked = np.array([False, False])
         self._presenter.on_peaks_workspace_selected()
         mock_refresh_lineplot_peaks.assert_called_once()
         self._mock_view.clear_overlay_meshes.assert_called_once()
@@ -294,50 +257,45 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_relative_detector_angle.assert_called_once()
         self._mock_view.set_relative_detector_angle.assert_called_once()
 
-    @mock.patch.object(FullInstrumentViewModel, "default_projection", new_callable=mock.PropertyMock)
-    def test_default_projection(self, mock_default_projection):
-        mock_default_projection.return_value = "SPHERICAL_Z"
-        default_index, _ = self._presenter.projection_combo_options()
-        self.assertEqual(3, default_index)
-
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.reset_cached_projection_positions")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
-    def test_aspect_ratio_box_visibility_set(self, mock_set_peaks, mock_reset_cache):
-        self.assertEquals("3D", self._model._PROJECTION_OPTIONS[0])
-        self._presenter.on_projection_option_selected(0)
-        self._mock_view.set_aspect_ratio_box_visibility.assert_called_once_with(False)
-        self._mock_view.set_aspect_ratio_box_visibility.reset_mock()
-        self._presenter.on_projection_option_selected(1)
-        self._mock_view.set_aspect_ratio_box_visibility.assert_called_once_with(True)
+    def test_aspect_ratio_box_visibility_set(self, mock_set_peaks):
+        self._model.projection_type = ProjectionType.THREE_D
+        self._presenter.update_plotter()
+        self._mock_view.enable_or_disable_aspect_ratio_box.assert_called_once()
+        self._mock_view.enable_or_disable_aspect_ratio_box.reset_mock()
+        self._model.projection_type = ProjectionType.SPHERICAL_X
+        self._presenter.update_plotter()
+        self._mock_view.enable_or_disable_aspect_ratio_box.assert_called_once()
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.reset_cached_projection_positions")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._update_transform")
-    def test_transform_updated_on_redraw(self, mock_update_transform, mock_set_peaks, mock_reset_cache):
-        self.assertEquals("3D", self._model._PROJECTION_OPTIONS[0])
+    def test_transform_updated_on_redraw(self, mock_update_transform, mock_set_peaks):
         # Anything apart from 3D
-        self._presenter.on_projection_option_selected(2)
+        self._model.projection_type = ProjectionType.SPHERICAL_X
+        self._presenter.update_plotter()
         mock_update_transform.assert_called_once()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._transform_mesh_to_fill_window")
     def test_update_transform(self, mock_transform_mesh):
-        self._presenter._update_transform(False, MagicMock())
+        self._presenter._update_transform(MagicMock(), MagicMock())
         np.testing.assert_allclose(np.eye(4), self._presenter._transform, atol=1e-10)
         mock_transform_mesh.assert_not_called()
         self._mock_view.is_maintain_aspect_ratio_checkbox_checked.return_value = True
-        self._presenter._update_transform(False, MagicMock())
+        self._presenter._update_transform(MagicMock(), MagicMock())
         np.testing.assert_allclose(np.eye(4), self._presenter._transform, atol=1e-10)
         mock_transform_mesh.assert_not_called()
-        mock_mesh = MagicMock()
+        mock_det_mesh = MagicMock()
+        mock_mask_mesh = MagicMock()
         self._mock_view.is_maintain_aspect_ratio_checkbox_checked.return_value = False
-        self._presenter._update_transform(True, mock_mesh)
-        mock_transform_mesh.assert_called_once_with(mock_mesh)
+        self._presenter._update_transform(mock_det_mesh, mock_mask_mesh)
+        mock_transform_mesh.assert_called_once_with(mock_det_mesh, mock_mask_mesh)
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._scale_matrix_relative_to_centre")
     def test_transform_mesh_to_fill_window(self, mock_scale_matrix):
-        mock_mesh = MagicMock()
-        mock_mesh.bounds = [-1, 1, -1, 1, -1, 1]
-        mock_mesh.center = np.zeros(3)
+        mock_det_mesh = MagicMock(bounds=[-1, 1, -1, 0, -1, 1])
+        # mock_det_mesh.bounds = [-1, 1, -1, 1, -1, 1]
+        mock_mask_mesh = MagicMock(bounds=[0, 1, -1, 1, -1, 1])
+
         self._mock_view.main_plotter.window_size = (10, 10)
 
         class mock_vtkCoordinate(MagicMock):
@@ -354,13 +312,16 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         with mock.patch("instrumentview.FullInstrumentViewPresenter.vtkCoordinate") as mock_vtk:
             mock_vtk_instance = mock_vtkCoordinate()
             mock_vtk.return_value = mock_vtk_instance
-            self._presenter._transform_mesh_to_fill_window(mock_mesh)
+            self._presenter._transform_mesh_to_fill_window(mock_det_mesh, mock_mask_mesh)
             mock_vtk.assert_called_once()
             self.assertEquals(2, mock_vtk_instance.GetComputedDisplayValueCount)
 
         # The mesh width and height in pixels are 8 each, the window is width 10,
         # hence the scale factor should be 10 / 8 = 1.25
-        mock_scale_matrix.assert_called_once_with(mock_mesh.center, 1.25, 1.25)
+        args, _ = mock_scale_matrix.call_args_list[0]
+        np.testing.assert_array_equal(args[0], np.zeros(3))
+        self.assertEqual(args[1], 1.25)
+        self.assertEqual(args[2], 1.25)
 
     def test_scale_matrix_relative_to_origin(self):
         centre = np.zeros(3)

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -57,11 +57,11 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         self._view.add_simple_shape(mock_mesh, mock_colour, False)
         self._view.main_plotter.add_mesh.assert_called_once_with(mock_mesh, color=mock_colour, pickable=False)
 
-    def test_add_main_mesh(self):
+    def test_add_detector_mesh(self):
         self._view.main_plotter.reset_mock()
         mock_mesh = MagicMock()
         mock_scalars = MagicMock()
-        self._view.add_main_mesh(mock_mesh, False, mock_scalars)
+        self._view.add_detector_mesh(mock_mesh, False, mock_scalars)
         self._view.main_plotter.add_mesh.assert_called_once_with(
             mock_mesh,
             pickable=False,
@@ -71,11 +71,11 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
             scalar_bar_args={"interactive": True, "vertical": False, "title_font_size": 15, "label_font_size": 12},
         )
 
-    def test_add_pickable_main_mesh(self):
+    def test_add_pickable_mesh(self):
         self._view.main_plotter.reset_mock()
         mock_mesh = MagicMock()
         mock_scalars = MagicMock()
-        self._view.add_pickable_main_mesh(mock_mesh, mock_scalars)
+        self._view.add_pickable_mesh(mock_mesh, mock_scalars)
         self._view.main_plotter.add_mesh.assert_called_once_with(
             mock_mesh,
             scalars=mock_scalars,

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -68,7 +68,7 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
             scalars=mock_scalars,
             render_points_as_spheres=True,
             point_size=15,
-            scalar_bar_args={"interactive": True, "vertical": True, "title_font_size": 15, "label_font_size": 12},
+            scalar_bar_args={"interactive": True, "vertical": False, "title_font_size": 15, "label_font_size": 12},
         )
 
     def test_add_pickable_main_mesh(self):
@@ -79,7 +79,7 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         self._view.main_plotter.add_mesh.assert_called_once_with(
             mock_mesh,
             scalars=mock_scalars,
-            opacity=[0.0, 0.5],
+            opacity=[0.0, 0.3],
             show_scalar_bar=False,
             pickable=True,
             cmap="Oranges",


### PR DESCRIPTION
This pulls the following (mostly instrument view) changes into `ornl-next`:
* #40300 
* #40394 
* #40385 
* #40410 
* #40397 
* #40434