### PR TITLE
Improve `UniqueID` RAII handling of HDF5 C-API and proliferate

### DIFF
--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     src/NexusException.cpp
     src/NexusFile.cpp
     src/NexusAddress.cpp
+    src/UniqueID.cpp
 )
 
 set(INC_FILES
@@ -20,6 +21,7 @@ set(INC_FILES
     inc/MantidNexus/NexusException.h
     inc/MantidNexus/NexusFile.h
     inc/MantidNexus/NexusAddress.h
+    inc/MantidNexus/UniqueID.h
 )
 
 set(TEST_FILES
@@ -33,6 +35,7 @@ set(TEST_FILES
     NexusFileReadWriteTest.h
     NexusAddressTest.h
     NapiUnitTest.h
+    UniqueIDTest.h
 )
 
 if(COVERAGE)

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -25,6 +25,18 @@ namespace H5 {
 class H5Object;
 } // namespace H5
 
+// forward declare
+// NOTE declare extern "C" to prevent conflict with actual declaration
+extern "C" herr_t H5Gclose(hid_t);
+extern "C" herr_t H5Dclose(hid_t);
+extern "C" herr_t H5Tclose(hid_t);
+extern "C" herr_t H5Sclose(hid_t);
+
+using GroupID = Mantid::Nexus::UniqueID<&H5Gclose>;
+using DataSetID = Mantid::Nexus::UniqueID<&H5Dclose>;
+using DataTypeID = Mantid::Nexus::UniqueID<&H5Tclose>;
+using DataSpaceID = Mantid::Nexus::UniqueID<&H5Sclose>;
+
 /**
  * \file NexusFile.h Definition of the Nexus C++ API.
  * \defgroup cpp_types C++ Types

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -27,12 +27,12 @@ class H5Object;
 
 // forward declare
 // NOTE declare extern "C" to prevent conflict with actual declaration
-extern "C" herr_t H5Gclose(hid_t);
-extern "C" herr_t H5Dclose(hid_t);
-extern "C" herr_t H5Tclose(hid_t);
-extern "C" herr_t H5Sclose(hid_t);
-extern "C" herr_t H5Aclose(hid_t);
-extern "C" herr_t H5Pclose(hid_t);
+extern "C" MYH5DLL herr_t H5Gclose(hid_t);
+extern "C" MYH5DLL herr_t H5Dclose(hid_t);
+extern "C" MYH5DLL herr_t H5Tclose(hid_t);
+extern "C" MYH5DLL herr_t H5Sclose(hid_t);
+extern "C" MYH5DLL herr_t H5Aclose(hid_t);
+extern "C" MYH5DLL herr_t H5Pclose(hid_t);
 
 /**
  * \file NexusFile.h Definition of the Nexus C++ API.

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -64,10 +64,10 @@ private:
   hid_t m_fid;
   // There is no reason to copy or assign a file ID
   FileID(FileID const &f) = delete;
-  FileID(FileID const &&f) = delete;
+  FileID(FileID &&f) = delete;
   FileID &operator=(hid_t const) = delete;
   FileID &operator=(FileID const &) = delete;
-  FileID &operator=(FileID const &&) = delete;
+  FileID &operator=(FileID &&) = delete;
 
 public:
   bool operator==(int const v) const { return static_cast<int>(m_fid) == v; }

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -4,6 +4,7 @@
 #include "MantidNexus/NexusAddress.h"
 #include "MantidNexus/NexusDescriptor.h"
 #include "MantidNexus/NexusFile_fwd.h"
+#include "MantidNexus/UniqueID.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -60,65 +61,6 @@ public:
   FileID() : m_fid(-1) {}
   FileID(hid_t const v) : m_fid(v) {}
   ~FileID();
-};
-
-using Deleter = int (*const)(hid_t);
-
-/**
- * \class UniqueID
- * \brief A wrapper class for managing HDF5 object handles (hid_t).
- *
- * The UniqueID class is designed to manage the lifecycle of HDF5 object handles (hid_t),
- * ensuring that the handle is properly closed when the UniqueID object is destroyed.
- * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
- */
-template <Deleter const deleter> class UniqueID {
-private:
-  hid_t m_id;
-  UniqueID &operator=(UniqueID<deleter> const &) = delete;
-  UniqueID &operator=(UniqueID<deleter> const &&) = delete;
-  void closeId() const {
-    if (m_id >= 0) {
-      deleter(m_id);
-    }
-  }
-
-public:
-  UniqueID(UniqueID<deleter> &uid) : m_id(uid.m_id) { uid.m_id = -1; };
-  UniqueID(UniqueID<deleter> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = -1; };
-  /// @brief Assign a HDF5 object ID to be managed
-  /// @param id : the ID to be managed
-  UniqueID &operator=(hid_t const id) {
-    if (id != m_id) {
-      closeId();
-      m_id = id;
-    }
-    return *this;
-  };
-  /// @brief Pass the HDF5 object ID from an existing UniqueID to another UniqueID
-  /// @param uid : the UniqueID previously managing the ID; it will lose ownership of the ID.
-  UniqueID &operator=(UniqueID<deleter> &uid) {
-    if (this != &uid) {
-      closeId();
-      m_id = uid.m_id;
-      uid.m_id = -1;
-    }
-    return *this;
-  }
-  bool operator==(int const v) const { return static_cast<int>(m_id) == v; }
-  bool operator<=(int const v) const { return static_cast<int>(m_id) <= v; }
-  operator hid_t const &() const { return m_id; };
-  hid_t getId() const { return m_id; }
-  /// @brief  Release hold on the managed ID; it will not be closed by this UniqueID
-  /// @return the managed ID
-  hid_t releaseId() {
-    hid_t tmp = m_id;
-    m_id = -1;
-    return tmp;
-  }
-  UniqueID() : m_id(-1) {}
-  UniqueID(hid_t const id) : m_id(id) {}
-  ~UniqueID() { closeId(); }
 };
 
 /**

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -31,11 +31,15 @@ extern "C" herr_t H5Gclose(hid_t);
 extern "C" herr_t H5Dclose(hid_t);
 extern "C" herr_t H5Tclose(hid_t);
 extern "C" herr_t H5Sclose(hid_t);
+extern "C" herr_t H5Aclose(hid_t);
+extern "C" herr_t H5Pclose(hid_t);
 
 using GroupID = Mantid::Nexus::UniqueID<&H5Gclose>;
 using DataSetID = Mantid::Nexus::UniqueID<&H5Dclose>;
 using DataTypeID = Mantid::Nexus::UniqueID<&H5Tclose>;
 using DataSpaceID = Mantid::Nexus::UniqueID<&H5Sclose>;
+using AttributeID = Mantid::Nexus::UniqueID<&H5Aclose>;
+using ParameterID = Mantid::Nexus::UniqueID<&H5Pclose>;
 
 /**
  * \file NexusFile.h Definition of the Nexus C++ API.

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -34,13 +34,6 @@ extern "C" herr_t H5Sclose(hid_t);
 extern "C" herr_t H5Aclose(hid_t);
 extern "C" herr_t H5Pclose(hid_t);
 
-using GroupID = Mantid::Nexus::UniqueID<&H5Gclose>;
-using DataSetID = Mantid::Nexus::UniqueID<&H5Dclose>;
-using DataTypeID = Mantid::Nexus::UniqueID<&H5Tclose>;
-using DataSpaceID = Mantid::Nexus::UniqueID<&H5Sclose>;
-using AttributeID = Mantid::Nexus::UniqueID<&H5Aclose>;
-using ParameterID = Mantid::Nexus::UniqueID<&H5Pclose>;
-
 /**
  * \file NexusFile.h Definition of the Nexus C++ API.
  * \defgroup cpp_types C++ Types
@@ -50,6 +43,13 @@ using ParameterID = Mantid::Nexus::UniqueID<&H5Pclose>;
 
 namespace Mantid {
 namespace Nexus {
+
+using GroupID = UniqueID<&H5Gclose>;
+using DataSetID = UniqueID<&H5Dclose>;
+using DataTypeID = UniqueID<&H5Tclose>;
+using DataSpaceID = UniqueID<&H5Sclose>;
+using AttributeID = UniqueID<&H5Aclose>;
+using ParameterID = UniqueID<&H5Pclose>;
 
 /**
  * \class FileID

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -15,6 +15,7 @@
 // forward declare typedefs from hdf5
 typedef int64_t hid_t;
 typedef uint64_t hsize_t;
+typedef int herr_t;
 
 /** \enum NXaccess
  * Nexus file access codes.

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -1,0 +1,83 @@
+#include "MantidNexus/NexusFile_fwd.h"
+#include <memory>
+
+// external forward declare
+extern "C" herr_t H5Iis_valid(hid_t);
+
+namespace Mantid::Nexus {
+
+/**
+ * \class UniqueID
+ * \brief A wrapper class for managing HDF5 object handles (hid_t).
+ *
+ * The UniqueID class is designed to manage the lifecycle of HDF5 object handles (hid_t),
+ * ensuring that the handle is properly closed when the UniqueID object is destroyed.
+ * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
+ */
+template <herr_t (*const deleter)(hid_t)> class UniqueID {
+private:
+  hid_t m_id;
+  UniqueID &operator=(UniqueID<deleter> const &) = delete;
+  UniqueID &operator=(UniqueID<deleter> const &&) = delete;
+  virtual void closeId();
+
+public:
+  UniqueID(UniqueID<deleter> &uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; };
+  UniqueID(UniqueID<deleter> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; };
+  virtual UniqueID &operator=(hid_t const id);
+  virtual UniqueID &operator=(UniqueID<deleter> &uid);
+  virtual bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
+  virtual bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
+  virtual bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
+  virtual operator hid_t const &() const { return m_id; };
+  virtual hid_t getId() const { return m_id; }
+  virtual hid_t releaseId();
+  virtual void resetId(hid_t const id = INVALID_ID);
+  virtual bool isValid() const;
+  UniqueID() : m_id(INVALID_ID) {}
+  UniqueID(hid_t const id) : m_id(id) {}
+  virtual ~UniqueID() { closeId(); }
+
+  static hid_t constexpr INVALID_ID{-1};
+};
+
+template <herr_t (*const D)(hid_t)> bool UniqueID<D>::isValid() const { return H5Iis_valid(m_id); }
+
+template <herr_t (*const deleter)(hid_t)> void UniqueID<deleter>::closeId() {
+  if (isValid()) {
+    deleter(this->m_id);
+    this->m_id = INVALID_ID;
+  }
+}
+
+/// @brief  Release hold on the managed ID; it will not be closed by this UniqueID
+/// @return the managed ID
+template <herr_t (*const D)(hid_t)> hid_t UniqueID<D>::releaseId() {
+  hid_t tmp = m_id;
+  m_id = INVALID_ID;
+  return tmp;
+}
+
+template <herr_t (*const D)(hid_t)> void UniqueID<D>::resetId(hid_t const id) {
+  if (m_id != id) {
+    closeId();
+    m_id = id;
+  }
+}
+
+/// @brief Assign a HDF5 object ID to be managed
+/// @param id : the ID to be managed
+template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(hid_t const id) {
+  resetId(id);
+  return *this;
+}
+
+/// @brief Pass the HDF5 object ID from an existing UniqueID to another UniqueID
+/// @param uid : the UniqueID previously managing the ID; it will lose ownership of the ID.
+template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(UniqueID<D> &uid) {
+  resetId(uid.m_id);
+  uid.m_id = INVALID_ID;
+  return *this;
+}
+
+} // namespace Mantid::Nexus

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -3,7 +3,12 @@
 #include "MantidNexus/NexusFile_fwd.h"
 
 // external forward declare
-extern "C" herr_t H5Iis_valid(hid_t);
+#if defined(_MSC_VER) // on Windows builds
+#define MYH5DLL __declspec(dllimport)
+#else
+#define MYH5DLL
+#endif
+extern "C" MYH5DLL herr_t H5Iis_valid(hid_t);
 
 namespace Mantid::Nexus {
 
@@ -23,20 +28,20 @@ private:
   void close();
 
 public:
-  UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; };
+  UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; }
   UniqueID<D> &operator=(hid_t const id);
   UniqueID<D> &operator=(UniqueID<D> &&uid);
   bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
   bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
   bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
-  operator hid_t const &() const { return m_id; };
+  operator hid_t() const { return m_id; }
   hid_t get() const { return m_id; }
   hid_t release();
   void reset(hid_t const id = INVALID_ID);
   bool isValid() const;
   UniqueID() : m_id(INVALID_ID) {}
   UniqueID(hid_t const id) : m_id(id) {}
-  virtual ~UniqueID() { close(); }
+  ~UniqueID() { close(); }
 
   static hid_t constexpr INVALID_ID{-1};
 };

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1,8 +1,6 @@
-#include <cstring>
-// REMOVE
+#include "MantidNexus/NexusFile.h"
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NexusException.h"
-#include "MantidNexus/NexusFile.h"
 #include "MantidNexus/hdf5_type_helper.h"
 #include "MantidNexus/inverted_napi.h"
 #include "MantidTypes/Core/DateAndTime.h"
@@ -11,6 +9,7 @@
 #include <algorithm>
 #include <array>
 #include <assert.h>
+#include <cstring>
 #include <filesystem>
 #include <hdf5.h>
 #include <iostream>

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -9,5 +9,7 @@ template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Sclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Aclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Pclose>;
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -1,0 +1,13 @@
+#include "MantidNexus/UniqueID.h"
+#include "MantidNexus/DllConfig.h"
+#include <hdf5.h>
+
+namespace Mantid::Nexus {
+
+template class MANTID_NEXUS_DLL UniqueID<&H5Fclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;
+template class MANTID_NEXUS_DLL UniqueID<&H5Sclose>;
+
+} // namespace Mantid::Nexus

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -713,30 +713,25 @@ public:
     FileResource resource("test_ess_instrument.nxs");
     std::string filename = resource.fullPath();
     // file permissions
-    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
     hid_t fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
-    H5Pclose(fapl);
 
     // put an initial entry
-    hid_t groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     // add a NX_class attribute
-    hid_t attrtype = H5Tcopy(H5T_C_S1);
+    DataTypeID attrtype = H5Tcopy(H5T_C_S1);
     H5Tset_size(attrtype, 7);
-    hid_t attrspce = H5Screate(H5S_SCALAR);
-    hid_t attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
+    DataSpaceID attrspce = H5Screate(H5S_SCALAR);
+    AttributeID attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
     H5Awrite(attrid, attrtype, "NXpants");
-    // cleanup attribute
-    H5Sclose(attrspce);
-    H5Tclose(attrtype);
-    H5Aclose(attrid);
 
     // make and put the data
-    hid_t datatype = H5Tcopy(H5T_C_S1);
+    DataTypeID datatype = H5Tcopy(H5T_C_S1);
     H5Tset_size(datatype, data.size());
     // hsize_t dims[] = {0, data.size()}; // dims are zero
-    hid_t dataspace = H5Screate(H5S_SCALAR); // H5Screate_simple(2, dims, NULL);
-    hid_t dataid = H5Dcreate(groupid, "data", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    DataSpaceID dataspace = H5Screate(H5S_SCALAR); // H5Screate_simple(2, dims, NULL);
+    DataSetID dataid = H5Dcreate(groupid, "data", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dataid, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.c_str());
 
     // verify the file was setup correctly
@@ -749,10 +744,6 @@ public:
     TS_ASSERT_EQUALS(len, data.size());
 
     // cleanup and close file
-    H5Tclose(datatype);
-    H5Sclose(dataspace);
-    H5Dclose(dataid);
-    H5Gclose(groupid);
     H5Fclose(fid);
 
     // now open the file and read

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -713,25 +713,26 @@ public:
     FileResource resource("test_ess_instrument.nxs");
     std::string filename = resource.fullPath();
     // file permissions
-    ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+    Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
     hid_t fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     // put an initial entry
-    GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    Mantid::Nexus::GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     // add a NX_class attribute
-    DataTypeID attrtype = H5Tcopy(H5T_C_S1);
+    Mantid::Nexus::DataTypeID attrtype = H5Tcopy(H5T_C_S1);
     H5Tset_size(attrtype, 7);
-    DataSpaceID attrspce = H5Screate(H5S_SCALAR);
-    AttributeID attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
+    Mantid::Nexus::DataSpaceID attrspce = H5Screate(H5S_SCALAR);
+    Mantid::Nexus::AttributeID attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
     H5Awrite(attrid, attrtype, "NXpants");
 
     // make and put the data
-    DataTypeID datatype = H5Tcopy(H5T_C_S1);
+    Mantid::Nexus::DataTypeID datatype = H5Tcopy(H5T_C_S1);
     H5Tset_size(datatype, data.size());
     // hsize_t dims[] = {0, data.size()}; // dims are zero
-    DataSpaceID dataspace = H5Screate(H5S_SCALAR); // H5Screate_simple(2, dims, NULL);
-    DataSetID dataid = H5Dcreate(groupid, "data", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    Mantid::Nexus::DataSpaceID dataspace = H5Screate(H5S_SCALAR); // H5Screate_simple(2, dims, NULL);
+    Mantid::Nexus::DataSetID dataid =
+        H5Dcreate(groupid, "data", datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dataid, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.c_str());
 
     // verify the file was setup correctly

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -33,11 +33,6 @@ using std::multimap;
 using std::string;
 using std::vector;
 
-namespace {
-static int call_count = 0;
-int blank_deleter(hid_t) { return ++call_count; }
-} // namespace
-
 class NexusFileTest : public CxxTest::TestSuite {
 
 public:
@@ -263,75 +258,6 @@ public:
   // #################################################################################################################
   // TEST MAKE / OPEN / PUT / CLOSE DATASET
   // #################################################################################################################
-  void test_uniqueID() {
-    cout << "\ntest uniqueID\n";
-    // construct empty
-    call_count = 0;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid;
-      TS_ASSERT_EQUALS(uid.getId(), -1);
-    }
-    TS_ASSERT_EQUALS(call_count, 0);
-
-    // construct
-    hid_t test = 101;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
-      TS_ASSERT_EQUALS(uid.getId(), test);
-    }
-    TS_ASSERT_EQUALS(call_count, 1);
-    cout << "\ntest uniqueID\n";
-
-    // release
-    call_count = 0;
-    hid_t res;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
-      TS_ASSERT_THROWS_NOTHING(res = uid.releaseId());
-      TS_ASSERT_EQUALS(uid.getId(), -1);
-      TS_ASSERT_EQUALS(res, test);
-    }
-    TS_ASSERT_EQUALS(call_count, 0);
-    TS_ASSERT_EQUALS(res, test);
-
-    // copy construct
-    call_count = 0;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid(test);
-      {
-        Mantid::Nexus::UniqueID<blank_deleter> uid2(uid);
-        TS_ASSERT_EQUALS(uid.getId(), -1);
-        TS_ASSERT_EQUALS(uid2.getId(), test);
-      }
-      TS_ASSERT_EQUALS(uid.getId(), -1);
-      TS_ASSERT_EQUALS(call_count, 1);
-    }
-    TS_ASSERT_EQUALS(call_count, 1);
-
-    // assign from hid_t
-    call_count = 0;
-    hid_t val1 = 73, val2 = 17;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid(val1);
-      uid = val2;
-      TS_ASSERT_EQUALS(uid.getId(), val2);
-      TS_ASSERT_EQUALS(call_count, 1);
-    }
-    TS_ASSERT_EQUALS(call_count, 2);
-
-    // assign from uid
-    call_count = 0;
-    {
-      Mantid::Nexus::UniqueID<blank_deleter> uid1(val1), uid2(val2);
-      TS_ASSERT_EQUALS(uid1.getId(), val1);
-      TS_ASSERT_EQUALS(uid2.getId(), val2);
-      uid1 = uid2;
-      TS_ASSERT_EQUALS(uid1.getId(), val2);
-      TS_ASSERT_EQUALS(uid2.getId(), -1);
-      TS_ASSERT_EQUALS(call_count, 1);
-    }
-    TS_ASSERT_EQUALS(call_count, 2);
-  }
 
   void test_makeData() {
     cout << "\ntest make data\n";

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -467,7 +467,7 @@ public:
   }
 
   void test_data_putget_string() {
-    cout << "\ntest dataset read/write -- string\n" << std::flush;
+    cout << "\ntest dataset read/write -- string" << std::endl;
 
     // open a file
     FileResource resource("test_nexus_file_stringrw.h5");
@@ -476,7 +476,7 @@ public:
     file.makeGroup("entry", "NXentry", true);
 
     // put/get a string
-    cout << "\nread/write string...\n";
+    cout << "\nread/write string..." << std::endl;
     string in("this is a string"), out;
     file.makeData("string_data", NXnumtype::CHAR, in.size(), true);
     file.putData(&in);
@@ -505,6 +505,7 @@ public:
   }
 
   void test_check_str_length() {
+    cout << "\ntest dataset read/write -- string length" << std::endl;
     FileResource resource("test_nexus_str_len.h5");
     std::string filename = resource.fullPath();
     Mantid::Nexus::File file(filename, NXaccess::CREATE5);

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -112,16 +112,16 @@ public:
     cout << "\ntest uniqueID\n";
   }
 
-  void test_uniqueID_copy_construct() {
-    cout << "\ntest uniqueID copy construct\n";
-    // copy construct
+  void test_uniqueID_move_construct() {
+    cout << "\ntest uniqueID move construct\n";
+    // move construct
     call_count = 0;
     hid_t test = GOOD_ID;
     {
       TestUniqueID uid(test);
       {
-        TestUniqueID uid2(uid);
-        // copy constructor invalidates uid, sets uid2 to value
+        TestUniqueID uid2(std::move(uid));
+        // move constructor invalidates uid, sets uid2 to value
         TS_ASSERT(!uid.isValid());
         TS_ASSERT_EQUALS(uid2.get(), test);
       }
@@ -159,7 +159,7 @@ public:
       Mantid::Nexus::UniqueID<blank_deleter> uid1(val1), uid2(val2);
       TS_ASSERT_EQUALS(uid1.get(), val1);
       TS_ASSERT_EQUALS(uid2.get(), val2);
-      uid1 = uid2;
+      uid1 = std::move(uid2);
       TS_ASSERT_EQUALS(uid1.get(), val2);
       TS_ASSERT_EQUALS(uid2.get(), TestUniqueID::INVALID_ID);
       TS_ASSERT_EQUALS(call_count, 1);
@@ -197,6 +197,8 @@ public:
       TS_ASSERT_EQUALS(uid.get(), test);
       TS_ASSERT_EQUALS(call_count, 0);
     }
+    // deleter called once when uid goes out of scope
+    TS_ASSERT_EQUALS(call_count, 1);
   }
 
   void test_uniqueID_reset_other() {
@@ -212,6 +214,8 @@ public:
       TS_ASSERT_EQUALS(uid.get(), other);
       TS_ASSERT_EQUALS(call_count, 1);
     }
+    // deleter not called when invalid ID (101) exits scope
+    TS_ASSERT_EQUALS(call_count, 1);
   }
 
   void test_uniqueID_reset_none() {

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -236,9 +236,10 @@ public:
   void test_uniqueID_groups_close() {
     cout << "\ntest uniqueID groups close" << endl;
 
+    std::string filename{"test_uniqueid.h5"};
     {
       // create a file held by a unique ID
-      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate("test_uniqueid.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
       {
         // create a group within that file
@@ -251,7 +252,7 @@ public:
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
     }
     // cleanup
-    H5Fdelete("test_uniqueid.h5", H5P_DEFAULT);
+    std::filesystem::remove(filename);
   }
 
   void test_uniqueID_no_double_close() {
@@ -264,10 +265,10 @@ public:
       return 0;
     };
     H5Eset_auto2(H5E_DEFAULT, err, &err_count);
-
+    std::string filename{"test_uniqueid.h5"};
     {
       // create a file to hold a group
-      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate("test_uniqueid.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
       // now create a group in the file with a group ID
       hid_t gid = H5Gcreate1(fid.get(), "a_group", 1);
@@ -298,7 +299,7 @@ public:
     // after exit, the deleter was not called because fid is no longer valid
     TS_ASSERT_EQUALS(err_count, 1); // no further errors registered
     // cleanup
-    H5Fdelete("test_uniqueid.h5", H5P_DEFAULT);
+    std::filesystem::remove(filename);
   }
 
   void test_uniqueID_zero() {

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -1,0 +1,254 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidNexus/NexusException.h"
+#include "MantidNexus/NexusFile.h"
+#include "MantidTypes/Core/DateAndTime.h"
+#include "test_helper.h"
+#include <H5Cpp.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace NexusTest;
+using std::cout;
+using std::endl;
+using std::map;
+using std::multimap;
+using std::string;
+using std::vector;
+
+namespace {
+// an ID which will always return as valid
+const hid_t GOOD_ID = H5T_NATIVE_INT;
+static int call_count = 0;
+int blank_deleter(hid_t) { return ++call_count; }
+} // namespace
+
+using TestUniqueID = Mantid::Nexus::UniqueID<blank_deleter>;
+
+class UniqueIDTest : public CxxTest::TestSuite {
+
+public:
+  // // This pair of boilerplate methods prevent the suite being created statically
+  // // This means the constructor isn't called when running other tests
+  static UniqueIDTest *createSuite() { return new UniqueIDTest(); }
+  static void destroySuite(UniqueIDTest *suite) { delete suite; }
+
+  void test_uniqueId_isValid() {
+    cout << "\ntest uniqueID isValid" << endl;
+    call_count = 0;
+
+    // if set with the invalid ID, will be invalid
+    {
+      TestUniqueID uid(TestUniqueID::INVALID_ID);
+      TS_ASSERT(!uid.isValid());
+    }
+    // the deleter was not called on exit
+    TS_ASSERT_EQUALS(call_count, 0);
+
+    // if set with a positive integer that is not actually an hdf5 object, will be invalid
+    hid_t test = 101;
+    TS_ASSERT(!H5Iis_valid(test));
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT(!uid.isValid());
+    }
+    // the deleter was not called on exit
+    TS_ASSERT_EQUALS(call_count, 0);
+
+    // if set with a valid identifier, returns valid
+    hid_t good = GOOD_ID;
+    TS_ASSERT(H5Iis_valid(good));
+    {
+      TestUniqueID uid(good);
+      TS_ASSERT(uid.isValid());
+    }
+    // the deleter was called on exit
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_uniqueID_construct_empty() {
+    cout << "\ntest uniqueID constructor empty" << endl;
+    // construct empty
+    call_count = 0;
+    {
+      TestUniqueID uid;
+      TS_ASSERT_EQUALS(uid.getId(), TestUniqueID::INVALID_ID);
+      TS_ASSERT(!uid.isValid());
+    }
+    // no deleter called on invalid ID
+    TS_ASSERT_EQUALS(call_count, 0);
+  }
+
+  void test_uniqueID_construct() {
+    cout << "\ntest uniqueID construct" << endl;
+    // construct
+    call_count = 0;
+    hid_t test = GOOD_ID;
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT_EQUALS(uid.getId(), test);
+      TS_ASSERT_DIFFERS(uid.getId(), TestUniqueID::INVALID_ID);
+      TS_ASSERT(uid.isValid());
+    }
+    // deleter called on valid ID
+    TS_ASSERT_EQUALS(call_count, 1);
+    cout << "\ntest uniqueID\n";
+  }
+
+  void test_uniqueID_copy_construct() {
+    cout << "\ntest uniqueID copy construct\n";
+    // copy construct
+    call_count = 0;
+    hid_t test = GOOD_ID;
+    {
+      TestUniqueID uid(test);
+      {
+        TestUniqueID uid2(uid);
+        // copy constructor invalidates uid, sets uid2 to value
+        TS_ASSERT(!uid.isValid());
+        TS_ASSERT_EQUALS(uid2.getId(), test);
+      }
+      // uid2 out of scope, deleter called once, uid still invalid
+      TS_ASSERT_EQUALS(uid.getId(), TestUniqueID::INVALID_ID);
+      TS_ASSERT(!uid.isValid());
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    // ensure no double-delete
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_uniqueID_assign_hid() {
+    // assign from hid_t
+    call_count = 0;
+    hid_t val1 = GOOD_ID, val2 = H5T_NATIVE_CHAR;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid(val1);
+      TS_ASSERT_EQUALS(uid.getId(), val1);
+      TS_ASSERT(uid.isValid());
+      uid = val2;
+      TS_ASSERT_EQUALS(uid.getId(), val2);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 2);
+  }
+
+  void test_uniqueID_assign_uniqueID() {
+    cout << "\ntest uniqueID assign" << endl;
+    // assign from uid
+    call_count = 0;
+    hid_t val1 = GOOD_ID, val2 = H5T_NATIVE_CHAR;
+    {
+      Mantid::Nexus::UniqueID<blank_deleter> uid1(val1), uid2(val2);
+      TS_ASSERT_EQUALS(uid1.getId(), val1);
+      TS_ASSERT_EQUALS(uid2.getId(), val2);
+      uid1 = uid2;
+      TS_ASSERT_EQUALS(uid1.getId(), val2);
+      TS_ASSERT_EQUALS(uid2.getId(), -1);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 2);
+  }
+
+  void test_uniqueID_release() {
+    cout << "\ntest uniqueID release" << endl;
+    // release
+    call_count = 0;
+    hid_t test = GOOD_ID;
+    hid_t res;
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT_THROWS_NOTHING(res = uid.releaseId());
+      TS_ASSERT_EQUALS(uid.getId(), TestUniqueID::INVALID_ID);
+      TS_ASSERT(!uid.isValid());
+      TS_ASSERT_EQUALS(res, test);
+    }
+    TS_ASSERT_EQUALS(call_count, 0);
+    TS_ASSERT_EQUALS(res, test);
+  }
+
+  void test_uniqueID_reset_same() {
+    cout << "\ntest uniqueID same" << endl;
+    // reset
+    call_count = 0;
+    hid_t test = GOOD_ID;
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(uid.getId(), test);
+      TS_ASSERT_THROWS_NOTHING(uid.resetId(test))
+      TS_ASSERT_EQUALS(uid.getId(), test);
+      TS_ASSERT_EQUALS(call_count, 0);
+    }
+  }
+
+  void test_uniqueID_reset_other() {
+    cout << "\ntest uniqueID reset" << endl;
+    // reset
+    call_count = 0;
+    hid_t test = GOOD_ID, other = 101;
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(uid.getId(), test);
+      TS_ASSERT_THROWS_NOTHING(uid.resetId(other))
+      TS_ASSERT_EQUALS(uid.getId(), other);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+  }
+
+  void test_uniqueID_reset_none() {
+    cout << "\ntest uniqueID  none" << endl;
+    // reset
+    call_count = 0;
+    hid_t test = GOOD_ID;
+    {
+      TestUniqueID uid(test);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(uid.getId(), test);
+      TS_ASSERT_THROWS_NOTHING(uid.resetId())
+      TS_ASSERT_EQUALS(uid.getId(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+  }
+
+  void test_uniqueID_no_double_close() {
+    cout << "\ntest uniqueID no double close" << endl;
+    call_count = 0;
+    // create some object, make a unique id, then close the file's ID separately
+    // ensure there is no double-close
+    hid_t fid = H5Fcreate("test_uniqueid.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    {
+      TestUniqueID uid(fid);
+      // this is a valid id
+      TS_ASSERT(H5Iis_valid(fid));
+      TS_ASSERT(uid.isValid());
+      // now close it by some other process
+      H5Fclose(fid);
+      // once fid closed, the unique id is no longer valid
+      TS_ASSERT(!H5Iis_valid(fid));
+      TS_ASSERT(!uid.isValid());
+      // note, double-closing would cause an error if improperly handled
+      TS_ASSERT(H5Fclose(fid) < 0);
+    }
+    // after exit, the deleter was not called because fid is no longer valid
+    TS_ASSERT_EQUALS(call_count, 0);
+  }
+};


### PR DESCRIPTION
### Description of work

During the Nexus refactor, we switched to using the HDF5 C-API inside Nexus::File. While this has some benefits, it also runs the risk of memory leaks.

A memory leak was discovered and reported in [EWM 14083](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14083), which was causing large memory overheads in `drtsans`.

The leak was fixed in PR #40368 using `UniqueID` structures, to hold the `hid_t` resources from the HDF5 C-API and automatically call the appropriate close operation when they go out of scope.

This work part of [EWM 14139](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14139)

Incidentally fixes [EWM 14098](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14098)

Future work will replace all of the member variables of `Nexus::File` with `UniqueID` objects.

### To test:

This is a refactor.  Ensure all tests pass, especially those in `NexusTest` and `DataHandlingTest`.

Build and run this script:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import LoadNexusProcessed

dir = # path to biosans test data needs to go here
file1 = f'{dir}/CG3_127_5532_mBSub.h5'
file2 = f'{dir}/CG3_127_5562_mBSub.h5'
for i in range(3):
    ws1 = LoadNexusProcessed(Filename=file1, OutputWorkspace='sample', LoadHistory=False)
    ws2 = LoadNexusProcessed(Filename=file2, OutputWorkspace='Main_buffer', LoadHistory=False)
    ws1.delete()
    ws2.delete()
```
Try selecting the for loop and running it many times, and make sure memory use stays approx constant.

This does not need release notes because user behavior is not impacts.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
