### PR TITLE
Add more complete warning log when Mslice is not available on Mantid

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/MSlice.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/MSlice.py
@@ -8,12 +8,19 @@
 import sys
 from mantidqt.gui_helper import get_qapplication
 
+MSLICE_URL = "https://mantidproject.github.io/mslice/quickstart.html#starting-mslice"
+
 try:
     from mslice.app import show_gui
 except ImportError:
     from mantid.kernel import logger
 
-    logger.warning("MSlice is not available")
+    logger.warning(
+        f"MSlice is not available.\n"
+        f"If this is a conda installation of MantidWorkbench,\n"
+        f"Mslice must be installed as a separate package.\n"
+        f"Check <{MSLICE_URL}> for detailed installation instructions."
+    )
     show_gui = None
 
 if show_gui is not None:


### PR DESCRIPTION
### Description of work
Part of mantidproject/mslice#1134

As MSlice is an optional dependency of Mantid for conda installations since 6.14, it is possible that a user with a conda installation may want to launch mslice from mantid. As of now, the warning message is simply `Mslice is not available`, I have  added a small description and a link to the mslice installation instructions to provide more context to the user that is trying to launch `MSlice` from a conda install of Mantid and is not aware of this. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes mantidproject/mslice#1134. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Build this branch and try to launch mslice from mantid (you shouldn't have mslice installed in your conda environment), a more verbose warning message should appear in the Mantid messages logger.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
