### PR TITLE
Fixed issues with shortcut keys in colorfill plot when colorscale is log

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40136.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40136.rst
@@ -1,0 +1,4 @@
+- Fixed a bug in :ref:`colorfill plots <Colorfill_Plots>` with log colorscale where it was giving errors when the keys given below are pressed from the keyboard. The behaviour of the colorfill plot after the fix is given below.
+- `c`, `left`, `backspace`, `MouseButton.BACK`, The colorscale of the colorfill plot would change in backwards direction. ex: log to linear,
+- `v`, `right`, `MouseButton.FORWARD`, The colorscale of the colorfill plot would change in forward direction. ex: log to symlog
+- `r`, `h`, `home`, The plot would be reset to Home view, i.e similar to pressing Home button of the plot

--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40136.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40136.rst
@@ -1,4 +1,4 @@
-- Fixed a bug in :ref:`colorfill plots <Colorfill_Plots>` with log colorscale where it was giving errors when the keys given below are pressed from the keyboard. The behaviour of the colorfill plot after the fix is given below.
-- `c`, `left`, `backspace`, `MouseButton.BACK`, The colorscale of the colorfill plot would change in backwards direction. ex: log to linear,
-- `v`, `right`, `MouseButton.FORWARD`, The colorscale of the colorfill plot would change in forward direction. ex: log to symlog
-- `r`, `h`, `home`, The plot would be reset to Home view, i.e similar to pressing Home button of the plot
+- Fixed a bug in :ref:`colorfill plots <Colorfill_Plots>` with log colorscale where it was giving errors when the below keys are pressed. The behaviour of the colorfill plot after the fix is given below.
+- `c`, `left`, `backspace`, `MouseButton.BACK` - The behaviour is similar to pressing Back button on plot the toolbar
+- `v`, `right`, `MouseButton.FORWARD` - The behaviour is similar to pressing Forward button on plot the toolbar
+- `r`, `h`, `home` - The plot would be reset to Home view, i.e similar to pressing Home button of the plot

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -47,11 +47,11 @@ def initialize_matplotlib():
     def remove_keys(shortcut_keys, rc_param_key):
         [mpl.rcParams[rc_param_key].remove(k) for k in shortcut_keys if k in mpl.rcParams[rc_param_key]]
 
-    # Disabling default shortcuts for toggling colorbar normalization
+    # Disabling to override default shortcuts to navigate backward and forward
     remove_keys(["c", "left", "backspace", "MouseButton.BACK"], "keymap.back")
     remove_keys(["v", "right", "MouseButton.FORWARD"], "keymap.forward")
 
-    # Disabling default shortcuts for home
+    # Disabling to override default shortcuts for home
     remove_keys(["h", "r", "home"], "keymap.home")
 
 

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -44,6 +44,16 @@ def initialize_matplotlib():
     mpl.rcParams["keymap.xscale"].remove("L")
     mpl.rcParams["keymap.yscale"].remove("l")
 
+    def remove_keys(shortcut_keys, rc_param_key):
+        [mpl.rcParams[rc_param_key].remove(k) for k in shortcut_keys if k in mpl.rcParams[rc_param_key]]
+
+    # Disabling default shortcuts for toggling colorbar normalization
+    remove_keys(["c", "left", "backspace", "MouseButton.BACK"], "keymap.back")
+    remove_keys(["v", "right", "MouseButton.FORWARD"], "keymap.forward")
+
+    # Disabling default shortcuts for home
+    remove_keys(["h", "r", "home"], "keymap.home")
+
 
 def init_mpl_gcf():
     """

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -147,50 +147,25 @@ class FigureInteraction(object):
         if ax is None or isinstance(ax, Axes3D) or len(ax.get_images()) == 0 and len(ax.get_lines()) == 0:
             return
 
-        if event.key == "k":
-            current_xscale = ax.get_xscale()
-            next_xscale = self._get_next_axis_scale(current_xscale)
-            self._quick_change_axes(ax, next_xscale, ax.get_yscale())
-
-        if event.key == "l":
-            current_yscale = ax.get_yscale()
-            next_yscale = self._get_next_axis_scale(current_yscale)
-            self._quick_change_axes(ax, ax.get_xscale(), next_yscale)
-
-        if event.key in ["c", "left", "backspace", "MouseButton.BACK"]:
-            self._navigate_colorbar_normalization(ax, False)
-
-        if event.key in ["v", "right", "MouseButton.FORWARD"]:
-            self._navigate_colorbar_normalization(ax, True)
-
-        if event.key in ["h", "r", "home"]:
-            self.toolbar_manager.emit_sig_home_clicked()
+        match event.key:
+            case "k":
+                current_xscale = ax.get_xscale()
+                next_xscale = self._get_next_axis_scale(current_xscale)
+                self._quick_change_axes(ax, next_xscale, ax.get_yscale())
+            case "l":
+                current_yscale = ax.get_yscale()
+                next_yscale = self._get_next_axis_scale(current_yscale)
+                self._quick_change_axes(ax, ax.get_xscale(), next_yscale)
+            case "c" | "left" | "backspace" | "MouseButton.BACK":
+                self.toolbar_manager.update_navigate_mpl_stack(nav_forward=False)
+            case "v" | "right" | "MouseButton.FORWARD":
+                self.toolbar_manager.update_navigate_mpl_stack(nav_forward=True)
+            case "h" | "r" | "home":
+                self.toolbar_manager.emit_sig_home_clicked()
 
     def _get_next_axis_scale(self, current_scale):
         next_index = AXES_SCALE_MENU_OPTS.index(current_scale) + 1
         return AXES_SCALE_MENU_OPTS[next_index] if next_index < len(AXES_SCALE_MENU_OPTS) else AXES_SCALE_MENU_OPTS[0]
-
-    def _navigate_colorbar_normalization(self, ax, forward):
-        """Changes the colorbar normalization to the next or the previous option"""
-        if ax.images:
-            current_normalization = ax.images[-1].norm
-            current_norm_key = next((k for k, v in COLORBAR_SCALE_MENU_OPTS.items() if v == current_normalization.__class__), None)
-            if current_norm_key:
-                colorbar_scale_key_list = list(COLORBAR_SCALE_MENU_OPTS.keys())
-                current_colorbar_norm_key_index = colorbar_scale_key_list.index(current_norm_key)
-                if forward:
-                    next_colorbar_norm_key = (
-                        colorbar_scale_key_list[current_colorbar_norm_key_index + 1]
-                        if current_colorbar_norm_key_index + 1 < len(colorbar_scale_key_list)
-                        else colorbar_scale_key_list[0]
-                    )
-                else:
-                    next_colorbar_norm_key = (
-                        colorbar_scale_key_list[current_colorbar_norm_key_index - 1]
-                        if current_colorbar_norm_key_index > 0
-                        else colorbar_scale_key_list[-1]
-                    )
-                self._change_colorbar_axes(COLORBAR_SCALE_MENU_OPTS[next_colorbar_norm_key])
 
     def _correct_for_scroll_event_on_legend(self, event):
         # Corrects default behaviour in Matplotlib where legend is picked up by scroll event

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -856,7 +856,6 @@ class FigureInteraction(object):
                     if cb:
                         datafunctions.add_colorbar_label(cb, ax.get_figure().axes)
                 if colorbar_log:  # If it had a log scaled colorbar before, put it back.
-                    # self._change_colorbar_axes(colorbar_scale)
                     self._change_colorbar_axes(norm.__class__)
 
                 axesfunctions.update_colorplot_datalimits(ax, ax.images)

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -32,7 +32,6 @@ from mantidqt.plotting.figuretype import FigureType
 from mantidqt.plotting.functions import plot, pcolormesh_from_names, plot_contour, pcolormesh
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figureinteraction import FigureInteraction, LogNorm
-from matplotlib.colors import Normalize, SymLogNorm
 
 
 @start_qapplication
@@ -841,40 +840,31 @@ class FigureInteractionTest(unittest.TestCase):
         key_press_event.inaxes.set_xlim.assert_called_once_with((0, 100))
         key_press_event.inaxes.set_ylim.assert_called_once_with((5, 10))
 
-    def _util_check_colorbar_norm_navigation(self, test_cases):
-        for key, current_norm, expected_norm_class in test_cases:
-            with self.subTest(key=key, current_norm=current_norm, expected_class=expected_norm_class):
-                with mock.patch(
-                    "workbench.plotting.figureinteraction.FigureInteraction._change_colorbar_axes"
-                ) as mock_change_colorbar_axes:
-                    key_press_event = self._create_mock_key_press_event(key)
-                    mock_norm = MagicMock()
-                    mock_norm.__class__ = current_norm
-                    key_press_event.inaxes.images[-1].norm = mock_norm
-                    key_press_event.inaxes.get_lines.return_value = ["fake_line"]
-                    fig_manager = MagicMock()
-                    fig_manager.canvas = MagicMock()
-                    interactor = FigureInteraction(fig_manager)
-                    interactor.on_key_press(key_press_event)
+    def test_keyboard_shortcut_navigate_backward(self):
+        for key in ["c", "left", "backspace", "MouseButton.BACK"]:
+            with self.subTest(key=key):
+                key_press_event = self._create_mock_key_press_event(key)
+                key_press_event.inaxes = MagicMock()
+                key_press_event.inaxes.get_lines.return_value = ["fake_line"]
+                fig_manager = MagicMock()
+                fig_manager.canvas = MagicMock()
+                interactor = FigureInteraction(fig_manager)
+                interactor.toolbar_manager = MagicMock()
+                interactor.on_key_press(key_press_event)
+                interactor.toolbar_manager.update_navigate_mpl_stack.assert_called_with(nav_forward=False)
 
-                    mock_change_colorbar_axes.assert_called_once_with(expected_norm_class)
-
-    def test_keyboard_shortcut_navigate_colorbar_norm_backward(self):
-        test_cases = [
-            ("c", LogNorm, matplotlib.colors.Normalize),
-            ("left", Normalize, matplotlib.colors.SymLogNorm),
-            ("backspace", SymLogNorm, matplotlib.colors.LogNorm),
-            ("MouseButton.BACK", LogNorm, matplotlib.colors.Normalize),
-        ]
-        self._util_check_colorbar_norm_navigation(test_cases)
-
-    def test_keyboard_shortcut_navigate_colorbar_norm_forward(self):
-        test_cases = [
-            ("v", LogNorm, matplotlib.colors.SymLogNorm),
-            ("right", SymLogNorm, matplotlib.colors.Normalize),
-            ("MouseButton.FORWARD", Normalize, matplotlib.colors.LogNorm),
-        ]
-        self._util_check_colorbar_norm_navigation(test_cases)
+    def test_keyboard_shortcut_navigate_forward(self):
+        for key in ["v", "right", "MouseButton.FORWARD"]:
+            with self.subTest(key=key):
+                key_press_event = self._create_mock_key_press_event(key)
+                key_press_event.inaxes = MagicMock()
+                key_press_event.inaxes.get_lines.return_value = ["fake_line"]
+                fig_manager = MagicMock()
+                fig_manager.canvas = MagicMock()
+                interactor = FigureInteraction(fig_manager)
+                interactor.toolbar_manager = MagicMock()
+                interactor.on_key_press(key_press_event)
+                interactor.toolbar_manager.update_navigate_mpl_stack.assert_called_with(nav_forward=True)
 
     def test_keyboard_shortcut_home_keys(self):
         shortcut_keys = ["r", "home", "h"]

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -55,8 +55,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
 
     toolitems = (
         MantidNavigationTool("Home", "Reset axes limits", "mdi.home", "on_home_clicked", None),
-        MantidStandardNavigationTools.BACK,
-        MantidStandardNavigationTools.FORWARD,
+        MantidNavigationTool("Back", "Back to previous view", "mdi.arrow-left", "on_back_clicked", None),
+        MantidNavigationTool("Forward", "Forward to next view", "mdi.arrow-right", "on_forward_clicked", None),
         MantidStandardNavigationTools.SEPARATOR,
         MantidStandardNavigationTools.PAN,
         MantidStandardNavigationTools.ZOOM,
@@ -187,6 +187,58 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
             return replace if found else item
         return tuple(self._recursive_replace(sub_item, find, replace) for sub_item in item)
 
+    def set_history_buttons(self):
+        """
+        Overrides the parent class' method to correctly set the status of backward and forward buttons.
+        Returns:
+            None
+        """
+        can_backward = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
+        if "on_back_clicked" in self._actions:
+            self._actions["on_back_clicked"].setEnabled(can_backward)
+        if "on_forward_clicked" in self._actions:
+            self._actions["on_forward_clicked"].setEnabled(can_forward)
+
+    def on_back_clicked(self):
+        self.update_navigate_mpl_stack(nav_forward=False)
+
+    def on_forward_clicked(self):
+        self.update_navigate_mpl_stack(nav_forward=True)
+
+    def update_navigate_mpl_stack(self, nav_forward: bool):
+        """
+        This method navigates mpl stack either in backward or forward direction after updating it whenever the plot is
+        a colormap and the color bar is in Log scale.
+        Args:
+            nav_forward: True when navigating forward and False when navigating backward
+
+        Returns:
+            None
+        """
+        edit_stack = self.is_colormap(self.canvas.figure) and self._colorbar_is_log_scale(self.canvas.figure) and self._nav_stack._elements
+        if not edit_stack:
+            self._navigate_mpl_stack(nav_forward)
+        else:
+            if nav_forward:
+                next_pos = min(self._nav_stack._pos + 1, len(self._nav_stack._elements) - 1)
+            else:
+                next_pos = max(self._nav_stack._pos - 1, 0)
+            orig_next_entry = self._nav_stack._elements[next_pos].data
+            orig_limits = list(orig_next_entry.items())[1][1][0]
+            if orig_limits[0] == 0:
+                self._nav_stack._elements[next_pos].data = {
+                    k: self._recursive_replace(v, find=orig_limits, replace=(0.0001, orig_limits[1])) for k, v in orig_next_entry.items()
+                }
+            self._navigate_mpl_stack(nav_forward)
+            self._nav_stack._elements[next_pos].data = orig_next_entry
+
+    def _navigate_mpl_stack(self, nav_forward):
+        if nav_forward:
+            self.forward()
+        else:
+            self.back()
+
     def waterfall_conversion(self, is_waterfall):
         self.sig_waterfall_conversion.emit(is_waterfall)
 
@@ -233,12 +285,12 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     def adjust_for_3d_plots(self):
         self._actions["toggle_grid"].setChecked(True)
 
-        for action in ["back", "forward", "pan", "zoom"]:
+        for action in ["on_back_clicked", "on_forward_clicked", "pan", "zoom"]:
             toolbar_action = self._actions[action]
             toolbar_action.setEnabled(False)
             toolbar_action.setVisible(False)
 
-        action = self._actions["forward"]
+        action = self._actions["on_forward_clicked"]
         self.toggle_separator_visibility(action, False)
 
     def toggle_separator_visibility(self, action, enabled):
@@ -424,3 +476,6 @@ class ToolbarStateManager(object):
 
     def emit_sig_home_clicked(self):
         self._toolbar.sig_home_clicked.emit()
+
+    def update_navigate_mpl_stack(self, nav_forward: bool):
+        self._toolbar.update_navigate_mpl_stack(nav_forward)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -226,7 +226,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
                 next_pos = max(self._nav_stack._pos - 1, 0)
             orig_next_entry = self._nav_stack._elements[next_pos].data
             orig_limits = list(orig_next_entry.items())[1][1][0]
-            if orig_limits[0] == 0:
+            if orig_limits[0] <= 0:
                 self._nav_stack._elements[next_pos].data = {
                     k: self._recursive_replace(v, find=orig_limits, replace=(0.0001, orig_limits[1])) for k, v in orig_next_entry.items()
                 }


### PR DESCRIPTION
### Description of work
This PR fixes errors coming from `colorfill` plots when the colorscale is in `Log` and certains keys are pressed. In addition to the issues originated from pressing keyboard key `c` as reported in the original issue, there were errors coming from the below keys as well. The behaviour of the colorfill plot after the fix is also given inline

- `c, left, backsapce, MouseButton.BACK` - The colorscale of the colorfill plot should change in **backward** direction ex: `log` to `linear`,  `linear` to `symlog`, `symlog` to `log`
- `v, right, MouseButton.FORWARD` - The colorscale of the colorfill plot should change in **forward** direction ex: `linear` to `log`, `log` to `symlog`, `symlog` to `linear`
- `r, h, home` - The behaviour should be similar to pressing the <img width="25" height="25" alt="image" src="https://github.com/user-attachments/assets/3c11f5fe-d15d-48a1-8bde-f3c19d4bb208" /> button of the plot.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40136. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Run below script
```
ws=Load('SXD23767')
ExtractSpectra(InputWorkspace=ws, OutputWorkspace='SXD23767_spec', EndWorkspaceIndex=100)
```
2. click `Plot`->`Colorfill` on `SXD23767_spec`
3. Right click on the plot and change the colorbar scale to log by `Color bar`->`Log` 
4. Press above given keyboard keys and observe the behaviour is as given above.
5. Try pressing other keys of the keyboard and observe any problematic behaviours

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
