### PR TITLE
Rebase `FileID` to inherit from `UniqueID`

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -27,12 +27,14 @@ class H5Object;
 
 // forward declare
 // NOTE declare extern "C" to prevent conflict with actual declaration
-extern "C" MYH5DLL herr_t H5Gclose(hid_t);
-extern "C" MYH5DLL herr_t H5Dclose(hid_t);
-extern "C" MYH5DLL herr_t H5Tclose(hid_t);
-extern "C" MYH5DLL herr_t H5Sclose(hid_t);
-extern "C" MYH5DLL herr_t H5Aclose(hid_t);
-extern "C" MYH5DLL herr_t H5Pclose(hid_t);
+extern "C" {
+MYH5DLL herr_t H5Gclose(hid_t);
+MYH5DLL herr_t H5Dclose(hid_t);
+MYH5DLL herr_t H5Tclose(hid_t);
+MYH5DLL herr_t H5Sclose(hid_t);
+MYH5DLL herr_t H5Aclose(hid_t);
+MYH5DLL herr_t H5Pclose(hid_t);
+}
 
 /**
  * \file NexusFile.h Definition of the Nexus C++ API.

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -29,7 +29,6 @@ class H5Object;
 // NOTE declare extern "C" to prevent conflict with actual declaration
 // NOTE use MYH5DLL, set to match HDF5's H5_DLL, to allow Windows build
 extern "C" {
-MYH5DLL herr_t H5Fclose(hid_t);
 MYH5DLL herr_t H5Gclose(hid_t);
 MYH5DLL herr_t H5Dclose(hid_t);
 MYH5DLL herr_t H5Tclose(hid_t);

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -25,7 +25,7 @@ namespace H5 {
 class H5Object;
 } // namespace H5
 
-// forward declare
+// Forward declarations for HDF5 close functions
 // NOTE declare extern "C" to prevent conflict with actual declaration
 extern "C" {
 MYH5DLL herr_t H5Gclose(hid_t);
@@ -46,7 +46,6 @@ MYH5DLL herr_t H5Pclose(hid_t);
 namespace Mantid {
 namespace Nexus {
 
-using FileID = UniqueID<&H5Fclose>;
 using GroupID = UniqueID<&H5Gclose>;
 using DataSetID = UniqueID<&H5Dclose>;
 using DataTypeID = UniqueID<&H5Tclose>;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -29,6 +29,7 @@ class H5Object;
 // NOTE declare extern "C" to prevent conflict with actual declaration
 // NOTE use MYH5DLL, set to match HDF5's H5_DLL, to allow Windows build
 extern "C" {
+MYH5DLL herr_t H5Fclose(hid_t);
 MYH5DLL herr_t H5Gclose(hid_t);
 MYH5DLL herr_t H5Dclose(hid_t);
 MYH5DLL herr_t H5Tclose(hid_t);
@@ -47,6 +48,7 @@ MYH5DLL herr_t H5Pclose(hid_t);
 namespace Mantid {
 namespace Nexus {
 
+using FileID = UniqueID<&H5Fclose>;
 using GroupID = UniqueID<&H5Gclose>;
 using DataSetID = UniqueID<&H5Dclose>;
 using DataTypeID = UniqueID<&H5Tclose>;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -27,6 +27,7 @@ class H5Object;
 
 // Forward declarations for HDF5 close functions
 // NOTE declare extern "C" to prevent conflict with actual declaration
+// NOTE use MYH5DLL, set to match HDF5's H5_DLL, to allow Windows build
 extern "C" {
 MYH5DLL herr_t H5Gclose(hid_t);
 MYH5DLL herr_t H5Dclose(hid_t);

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -46,40 +46,13 @@ MYH5DLL herr_t H5Pclose(hid_t);
 namespace Mantid {
 namespace Nexus {
 
+using FileID = UniqueID<&H5Fclose>;
 using GroupID = UniqueID<&H5Gclose>;
 using DataSetID = UniqueID<&H5Dclose>;
 using DataTypeID = UniqueID<&H5Tclose>;
 using DataSpaceID = UniqueID<&H5Sclose>;
 using AttributeID = UniqueID<&H5Aclose>;
 using ParameterID = UniqueID<&H5Pclose>;
-
-/**
- * \class FileID
- * \brief A wrapper class for managing HDF5 file handles (hid_t).
- *
- * The FileID class is designed to manage the lifecycle of HDF5 file handles (hid_t),
- * ensuring that the handle is properly closed when the FileID object is destroyed.
- * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
- */
-class MANTID_NEXUS_DLL FileID {
-private:
-  hid_t m_fid;
-  // There is no reason to copy or assign a file ID
-  FileID(FileID const &f) = delete;
-  FileID(FileID &&f) = delete;
-  FileID &operator=(hid_t const) = delete;
-  FileID &operator=(FileID const &) = delete;
-  FileID &operator=(FileID &&) = delete;
-
-public:
-  bool operator==(int const v) const { return static_cast<int>(m_fid) == v; }
-  bool operator<=(int const v) const { return static_cast<int>(m_fid) <= v; }
-  operator hid_t const &() const { return m_fid; }
-  hid_t getId() const { return m_fid; }
-  FileID() : m_fid(-1) {}
-  FileID(hid_t const v) : m_fid(v) {}
-  ~FileID();
-};
 
 /**
  * The Object that allows access to the information in the file.

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -1,60 +1,83 @@
 #pragma once
 
+#include "MantidNexus/DllConfig.h"
 #include "MantidNexus/NexusFile_fwd.h"
 
-// external forward declare
+// Forward declarations for needed HDF5 functions
+// NOTE declare extern "C" to prevent conflict with actual declaration
+// NOTE use MYH5DLL, set to match HDF5's H5_DLL, to allow Windows build
 #if defined(_MSC_VER) // on Windows builds
 #define MYH5DLL __declspec(dllimport)
 #else
-#define MYH5DLL
+#define MYH5DLL // gcc and clang do not need a DLL specifier
 #endif
-extern "C" MYH5DLL herr_t H5Iis_valid(hid_t);
+extern "C" MYH5DLL {
+  herr_t H5Iis_valid(hid_t);
+  herr_t H5Fclose(hid_t);
+}
 
 namespace Mantid::Nexus {
 
 /**
- * \class UniqueID
- * \brief A wrapper class for managing HDF5 object handles (hid_t).
- *
- * The UniqueID class is designed to manage the lifecycle of HDF5 object handles (hid_t),
+ * @class UniqueID
+ * @brief A wrapper class for managing HDF5 object handles (hid_t).
+ * @details The UniqueID class is designed to manage the lifecycle of HDF5 object handles (hid_t),
  * ensuring that the handle is properly closed when the UniqueID object is destroyed.
  * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
  */
 template <herr_t (*const D)(hid_t)> class UniqueID {
-private:
+protected:
   hid_t m_id;
+
+private:
   UniqueID(UniqueID<D> const &uid) = delete;
   UniqueID &operator=(UniqueID<D> const &) = delete;
   void close();
 
 public:
-  UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; }
-  UniqueID<D> &operator=(hid_t const id);
-  UniqueID<D> &operator=(UniqueID<D> &&uid);
-  bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
-  bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
-  bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
-  operator hid_t() const { return m_id; }
-  hid_t get() const { return m_id; }
-  hid_t release();
-  void reset(hid_t const id = INVALID_ID);
-  bool isValid() const;
+// constructors / destructor 
   UniqueID() : m_id(INVALID_ID) {}
   UniqueID(hid_t const id) : m_id(id) {}
   ~UniqueID() { close(); }
+  UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; }
+  
+  // assignment
+  UniqueID<D> &operator=(hid_t const id);
+  UniqueID<D> &operator=(UniqueID<D> &&uid);
+  
+  // comparators
+  bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
+  bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
+  bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
+  
+  // using the id
+  operator hid_t() const { return m_id; }
 
+  /// @brief Return the managed HDF5 handle
+  /// @return the managed HDF5 handle
+  hid_t get() const { return m_id; }
+  
+  hid_t release();
+  void reset(hid_t const id = INVALID_ID);
+  bool isValid() const;
+
+  /// @brief represents an invalid ID value
   static hid_t constexpr INVALID_ID{-1};
 };
 
+/// @brief Return whether the UniqueId corresponds to a valid HDF5 object 
+/// @return true if it is valid; otherwise false; on error, false
 template <herr_t (*const D)(hid_t)> bool UniqueID<D>::isValid() const {
   // fail early condition
   if (m_id < 0) {
     return false;
   } else {
-    return H5Iis_valid(m_id);
+    return H5Iis_valid(m_id) > 0;
   }
 }
 
+/// @brief Close the held ID by calling its deleter function
+/// @tparam deleter 
 template <herr_t (*const deleter)(hid_t)> void UniqueID<deleter>::close() {
   if (isValid()) {
     deleter(this->m_id);
@@ -70,6 +93,8 @@ template <herr_t (*const D)(hid_t)> hid_t UniqueID<D>::release() {
   return tmp;
 }
 
+/// @brief  Close the existing ID and replace with the new ID; or, set to invalid
+/// @param id The new ID to be held; defaults to invalid
 template <herr_t (*const D)(hid_t)> void UniqueID<D>::reset(hid_t const id) {
   if (m_id != id) {
     close();
@@ -93,5 +118,26 @@ template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(UniqueID
   }
   return *this;
 }
+
+/***
+ * @class FileID
+ * @brief A special wrapper class for managing HDF5 file handles.
+ *  Inherits from UniqueID<&H5Fclose>
+ * @details Designed to manage the lifecycle of HDF5 file handles (hid_t),
+ * ensuring that the handle is properly closed when the FileID object is destroyed.
+ * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
+ * On close, calls garbage collection.
+ * @see UniqueID
+ */
+class MANTID_NEXUS_DLL FileID : public UniqueID<&H5Fclose> {
+public:
+  FileID() : UniqueID<&H5Fclose>() {}
+  FileID(hid_t const id) : UniqueID<&H5Fclose>(id) {}
+  ~FileID();
+  FileID &operator=(hid_t const id);
+  // disable move semantics
+  FileID(FileID &&) = delete;
+  FileID &operator=(FileID &&) = delete;
+};
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -11,9 +11,9 @@
 #else
 #define MYH5DLL // gcc and clang do not need a DLL specifier
 #endif
-extern "C" MYH5DLL {
-  herr_t H5Iis_valid(hid_t);
-  herr_t H5Fclose(hid_t);
+extern "C" {
+MYH5DLL herr_t H5Iis_valid(hid_t);
+MYH5DLL herr_t H5Fclose(hid_t);
 }
 
 namespace Mantid::Nexus {

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -35,28 +35,28 @@ private:
   void close();
 
 public:
-// constructors / destructor 
+  // constructors / destructor
   UniqueID() : m_id(INVALID_ID) {}
   UniqueID(hid_t const id) : m_id(id) {}
   ~UniqueID() { close(); }
   UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; }
-  
+
   // assignment
   UniqueID<D> &operator=(hid_t const id);
   UniqueID<D> &operator=(UniqueID<D> &&uid);
-  
+
   // comparators
   bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
   bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
   bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
-  
+
   // using the id
   operator hid_t() const { return m_id; }
 
   /// @brief Return the managed HDF5 handle
   /// @return the managed HDF5 handle
   hid_t get() const { return m_id; }
-  
+
   hid_t release();
   void reset(hid_t const id = INVALID_ID);
   bool isValid() const;
@@ -65,7 +65,7 @@ public:
   static hid_t constexpr INVALID_ID{-1};
 };
 
-/// @brief Return whether the UniqueId corresponds to a valid HDF5 object 
+/// @brief Return whether the UniqueId corresponds to a valid HDF5 object
 /// @return true if it is valid; otherwise false; on error, false
 template <herr_t (*const D)(hid_t)> bool UniqueID<D>::isValid() const {
   // fail early condition
@@ -77,7 +77,7 @@ template <herr_t (*const D)(hid_t)> bool UniqueID<D>::isValid() const {
 }
 
 /// @brief Close the held ID by calling its deleter function
-/// @tparam deleter 
+/// @tparam deleter
 template <herr_t (*const deleter)(hid_t)> void UniqueID<deleter>::close() {
   if (isValid()) {
     deleter(this->m_id);

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -11,10 +11,7 @@
 #else
 #define MYH5DLL // gcc and clang do not need a DLL specifier
 #endif
-extern "C" {
-MYH5DLL herr_t H5Iis_valid(hid_t);
-MYH5DLL herr_t H5Fclose(hid_t);
-}
+extern "C" MYH5DLL herr_t H5Iis_valid(hid_t);
 
 namespace Mantid::Nexus {
 
@@ -118,26 +115,5 @@ template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(UniqueID
   }
   return *this;
 }
-
-/***
- * @class FileID
- * @brief A special wrapper class for managing HDF5 file handles.
- *  Inherits from UniqueID<&H5Fclose>
- * @details Designed to manage the lifecycle of HDF5 file handles (hid_t),
- * ensuring that the handle is properly closed when the FileID object is destroyed.
- * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
- * On close, calls garbage collection.
- * @see UniqueID
- */
-class MANTID_NEXUS_DLL FileID : public UniqueID<&H5Fclose> {
-public:
-  FileID() : UniqueID<&H5Fclose>() {}
-  FileID(hid_t const id) : UniqueID<&H5Fclose>(id) {}
-  ~FileID();
-  FileID &operator=(hid_t const id);
-  // disable move semantics
-  FileID(FileID &&) = delete;
-  FileID &operator=(FileID &&) = delete;
-};
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -88,8 +88,7 @@ template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(hid_t co
 /// @param uid : the UniqueID previously managing the ID; it will lose ownership of the ID.
 template <herr_t (*const D)(hid_t)> UniqueID<D> &UniqueID<D>::operator=(UniqueID<D> &&uid) {
   if (this != &uid) {
-    close();
-    m_id = uid.m_id;
+    reset(uid.m_id);
     uid.m_id = INVALID_ID;
   }
   return *this;

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -4,15 +4,6 @@
 
 namespace Mantid::Nexus {
 
-template <> void UniqueID<&H5Fclose>::close() {
-  if (isValid()) {
-    H5Fclose(this->m_id);
-    this->m_id = INVALID_ID;
-    // call garbage collection to close any and all open objects on this file
-    H5garbage_collect();
-  }
-}
-
 template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -4,7 +4,15 @@
 
 namespace Mantid::Nexus {
 
-template class MANTID_NEXUS_DLL UniqueID<&H5Fclose>;
+template <> void UniqueID<&H5Fclose>::close() {
+  if (isValid()) {
+    H5Fclose(this->m_id);
+    this->m_id = INVALID_ID;
+    // call garbage collection to close any and all open objects on this file
+    H5garbage_collect();
+  }
+}
+
 template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -4,7 +4,19 @@
 
 namespace Mantid::Nexus {
 
-template class MANTID_NEXUS_DLL UniqueID<&H5Fclose>;
+FileID::~FileID() {
+  if (this->isValid()) {
+    H5Fclose(this->m_id);
+    // H5garbage_collect();
+    this->m_id = INVALID_ID;
+  }
+}
+
+FileID &FileID::operator=(hid_t const id) {
+  this->reset(id);
+  return *this;
+}
+
 template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -4,19 +4,7 @@
 
 namespace Mantid::Nexus {
 
-FileID::~FileID() {
-  if (this->isValid()) {
-    H5Fclose(this->m_id);
-    // H5garbage_collect();
-    this->m_id = INVALID_ID;
-  }
-}
-
-FileID &FileID::operator=(hid_t const id) {
-  this->reset(id);
-  return *this;
-}
-
+template class MANTID_NEXUS_DLL UniqueID<&H5Fclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -1537,7 +1537,7 @@ public:
     cout << "\ntest the file id\n" << std::flush;
 
     Mantid::Nexus::FileID fid;
-    TS_ASSERT_EQUALS(fid.getId(), -1);
+    TS_ASSERT(!fid.isValid());
 
     // create a file
     FileResource resource("test_nexus_fid.nxs");
@@ -1548,11 +1548,11 @@ public:
     TS_ASSERT(file_is_closed(filename));
 
     { // scoped fid
-      hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+      Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
       H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
       Mantid::Nexus::FileID fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
       TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(fid.getId(), -1);
+      TS_ASSERT(fid.isValid());
     } // fid goes out of scope and deconstructor is called
     // the file is now closed
     TS_ASSERT(file_is_closed(filename));
@@ -1570,24 +1570,24 @@ public:
     TS_ASSERT(file_is_closed(filename));
 
     { // scoped fid
-      hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+      Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
       H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
       auto pfid1 = std::make_shared<Mantid::Nexus::FileID>(H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl));
       auto pfid2(pfid1);
       auto pfid3(pfid2);
       TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid1->getId(), -1);
-      TS_ASSERT_DIFFERS(pfid2->getId(), -1);
-      TS_ASSERT_DIFFERS(pfid3->getId(), -1);
+      TS_ASSERT_DIFFERS(pfid1->get(), Mantid::Nexus::FileID::INVALID_ID);
+      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
+      TS_ASSERT_DIFFERS(pfid3->get(), Mantid::Nexus::FileID::INVALID_ID);
       // close pfid1
       pfid1.reset();
       TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid2->getId(), -1);
-      TS_ASSERT_DIFFERS(pfid3->getId(), -1);
+      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
+      TS_ASSERT_DIFFERS(pfid3->get(), Mantid::Nexus::FileID::INVALID_ID);
       // close pfid3
       pfid3.reset();
       TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid2->getId(), -1);
+      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
     } // last pfid goes out of scope and deconstructor is called
     // the file is now closed
     TS_ASSERT(file_is_closed(filename));

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -715,7 +715,7 @@ public:
     // file permissions
     Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-    hid_t fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    Mantid::Nexus::FileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     // put an initial entry
     Mantid::Nexus::GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -745,7 +745,7 @@ public:
     TS_ASSERT_EQUALS(len, data.size());
 
     // cleanup and close file
-    H5Fclose(fid);
+    H5Fclose(fid.release());
 
     // now open the file and read
     Mantid::Nexus::File file(filename, NXaccess::READ);
@@ -1421,17 +1421,17 @@ public:
     std::cout << "\ntest getEntries with missing NX_class and soft link\n";
 
     std::string filename = "test_missing_nxclass.h5";
-    hid_t file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    TS_ASSERT(file_id >= 0);
+    Mantid::Nexus::FileID file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    TS_ASSERT(file_id.isValid());
 
-    hid_t group_id = H5Gcreate(file_id, "/nogroupclass", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    TS_ASSERT(group_id >= 0);
-    H5Gclose(group_id);
+    Mantid::Nexus::GroupID group_id = H5Gcreate(file_id, "/nogroupclass", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    TS_ASSERT(group_id.isValid());
+    H5Gclose(group_id.release());
 
     herr_t status = H5Lcreate_soft("/nogroupclass", file_id, "/soft_link", H5P_DEFAULT, H5P_DEFAULT);
     TS_ASSERT(status >= 0);
 
-    H5Fclose(file_id);
+    H5Fclose(file_id.release());
 
     Mantid::Nexus::File file(filename, NXaccess::READ);
 
@@ -1508,12 +1508,10 @@ public:
     // if this operation FAILS (fid <= 0), then the file is STILL OPENED
     // if this operation SUCCEEDS (fid > 0), then the file was CLOSED
     // NOTE this is ONLY meaningful AFTER a file with the name has been definitely opened
-    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fclose_degree(fapl, H5F_CLOSE_WEAK);
-    hid_t fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
-    bool ret = (fid > 0);
-    H5Fclose(fid);
-    return ret;
+    Mantid::Nexus::FileID fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+    return fid.isValid();
   }
 
   void test_file_is_closed() {

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -109,7 +109,6 @@ public:
     }
     // deleter called on valid ID
     TS_ASSERT_EQUALS(call_count, 1);
-    cout << "\ntest uniqueID\n";
   }
 
   void test_uniqueID_move_construct() {
@@ -193,7 +192,7 @@ public:
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
       TS_ASSERT_EQUALS(uid.get(), test);
-      TS_ASSERT_THROWS_NOTHING(uid.reset(test))
+      TS_ASSERT_THROWS_NOTHING(uid.reset(test));
       TS_ASSERT_EQUALS(uid.get(), test);
       TS_ASSERT_EQUALS(call_count, 0);
     }
@@ -210,7 +209,7 @@ public:
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
       TS_ASSERT_EQUALS(uid.get(), test);
-      TS_ASSERT_THROWS_NOTHING(uid.reset(other))
+      TS_ASSERT_THROWS_NOTHING(uid.reset(other));
       TS_ASSERT_EQUALS(uid.get(), other);
       TS_ASSERT_EQUALS(call_count, 1);
     }
@@ -219,7 +218,7 @@ public:
   }
 
   void test_uniqueID_reset_none() {
-    cout << "\ntest uniqueID  none" << endl;
+    cout << "\ntest uniqueID none" << endl;
     // reset
     call_count = 0;
     hid_t test = GOOD_ID;
@@ -227,7 +226,7 @@ public:
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
       TS_ASSERT_EQUALS(uid.get(), test);
-      TS_ASSERT_THROWS_NOTHING(uid.reset())
+      TS_ASSERT_THROWS_NOTHING(uid.reset());
       TS_ASSERT_EQUALS(uid.get(), TestUniqueID::INVALID_ID);
       TS_ASSERT_EQUALS(call_count, 1);
     }


### PR DESCRIPTION
### Description of work

The Nexus refactor work left `Nexus::File` using the HDF5 C-API, which handles objects through identifying integers.  Close operations must be called on these IDs, or else memory leaks can occur.

At the end of the Nexus refactor, in PR #39732  created a special class `FileID`  to house the ID corresponding to the file, to ensure file closure on exit.

After a memory leak was discovered in `Nexus::File::getSlab()`, a similar class, `UniqueID` was created in PR #40368, to handle more general HDF5 handles.  Then in PR #40464, this class was made more official and used in more situations.

Since the APIs of `UniqueID` and `FileID` are similar, and they serve similar uses, it is reasonable to think `FileID` can be made a special type of `UniqueID`.  This PR simplifies things by making `FileID` the specialization of `UniqueID` with a `H5Fclose` deleter.

### To test:

This is a refactor.  Ensure all tests pass.  Note there are existing tests of `FileID` inside `NexusFileTest`.

Please run the system test VanadiumAndFocusWithSolidAngleTest,
```
ninja Framework && ./systemtest -R VanadiumAndFocusWithSolidAngleTest
```

This does not require release notes because it does not impact user experience.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
