### PR TITLE
Prevent dot-pattern artifact when log scale rendering

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/SliceViewer/Bugfixes/40477.rst
+++ b/docs/source/release/v6.15.0/Workbench/SliceViewer/Bugfixes/40477.rst
@@ -1,0 +1,1 @@
+- correct for dot-pattern artifact when rendering sparse data in log scale.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -391,7 +391,7 @@ class SliceviewerDataViewTest(unittest.TestCase):
         view = SliceViewerDataView(presenter=self.presenter, dims_info=mock.MagicMock(), can_normalise=mock.Mock(), add_extents=False)
         self.assertIsNone(view.extents)
 
-    def test_scale_norm_changed_(self):
+    def test_scale_norm_changed(self):
         self.view.conf = mock.Mock()
         self.view.image = mock.Mock()
         cmap_mock = mock.Mock()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -9,9 +9,12 @@ from typing import Dict
 from unittest import mock
 import numpy as np
 
+from matplotlib.colors import LogNorm
+
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.views.view import SliceViewerDataView
+from mantidqt.widgets.sliceviewer.views.dataview import SCALENORM
 from mantidqt.widgets.sliceviewer.models.transform import NonOrthogonalTransform
 
 
@@ -387,6 +390,28 @@ class SliceviewerDataViewTest(unittest.TestCase):
     def test_extents_not_created_if_not_requested(self):
         view = SliceViewerDataView(presenter=self.presenter, dims_info=mock.MagicMock(), can_normalise=mock.Mock(), add_extents=False)
         self.assertIsNone(view.extents)
+
+    def test_scale_norm_changed_(self):
+        self.view.conf = mock.Mock()
+        self.view.image = mock.Mock()
+        cmap_mock = mock.Mock()
+        self.view.image.get_cmap.return_value = cmap_mock
+        self.view.colorbar = mock.Mock()
+
+        # user selects "Log" from the scale/norm dropdown
+        self.view.image.norm = LogNorm()
+        self.view.colorbar.norm.currentText.return_value = "Log"
+        self.view.scale_norm_changed()
+        cmap_mock.set_under.assert_called_with((1, 1, 1, 0))
+        self.view.conf.set.assert_called_with(SCALENORM, "Log")
+
+        # user selects "Linear" from the scale/norm dropdown
+        self.view.image.norm = mock.Mock(spec=["vmin", "vmax"])  # Not LogNorm
+        cmap_mock.return_value = (0.1, 0.2, 0.3, 1.0)  # mock cmap(0)
+        self.view.colorbar.norm.currentText.return_value = "Linear"
+        self.view.scale_norm_changed()
+        cmap_mock.set_under.assert_called_with((0.1, 0.2, 0.3, 1.0))
+        self.view.conf.set.assert_called_with(SCALENORM, "Linear")
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -783,7 +783,7 @@ class SliceViewerDataView(QWidget):
             if isinstance(self.image.norm, LogNorm):
                 cmap.set_under((1, 1, 1, 0))  # transparent for log scale
             else:
-                cmap.set_under(cmap(0))  # use first color in colormap (defult behavior)
+                cmap.set_under(cmap(0))  # use first color in colormap (default behavior)
 
         scale = self.colorbar.norm.currentText()
         self.conf.set(SCALENORM, scale)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (
     QDoubleSpinBox,
     QMessageBox,
 )
+from matplotlib.colors import LogNorm
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot, GridHelperCurveLinear
 from mpl_toolkits.axisartist.grid_finder import ExtremeFinderSimple, MaxNLocator
@@ -775,6 +776,14 @@ class SliceViewerDataView(QWidget):
     def scale_norm_changed(self):
         if self.conf is None:
             return
+
+        # Set transparent under color for log scale. Prevents a dotted-pattern artifact when rendering sparse data
+        if self.image:
+            cmap = self.image.get_cmap()
+            if isinstance(self.image.norm, LogNorm):
+                cmap.set_under((1, 1, 1, 0))  # transparent for log scale
+            else:
+                cmap.set_under(cmap(0))  # use first color in colormap (defult behavior)
 
         scale = self.colorbar.norm.currentText()
         self.conf.set(SCALENORM, scale)


### PR DESCRIPTION
(companion to PR #40480)

### Description of work

This PR fixes a visual artifact issue where dot patterns appear when rendering sparse data with logarithmic scale in the slice viewer. The solution sets the colormap's "under" color to transparent for log scale rendering while maintaining the default behavior for other scales.

The current dot-pattern artifact:

<img width="500" alt="screenshot" src="https://github.com/user-attachments/assets/25a44a55-0b34-4453-8bec-5ce502be1c7b" />

### To test:

Run the following script in the workbench:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm
import numpy as np

### experiment data info ###
IPTS = 31189
run = 46917
### -------------------- ###

### sample info ###
a = 11.93
b = 11.93
c = 11.93
alpha = 90
beta = 90
gamma = 90
centering = "I"
### ----------- ###

### incident wavelength ###
wavelength_band = [0.3, 3.5]
d_min = 0.7
### ------------------- ###

filename = "/SNS/TOPAZ/IPTS-{}/nexus/TOPAZ_{}.nxs.h5".format(IPTS, run)
print(filename)
LoadEventNexus(Filename=filename, OutputWorkspace="data")

SetGoniometer(
    Workspace="data",
    Axis0="BL12:Mot:omega,0,1,0,1",
    Axis1="BL12:Mot:chi,0,0,1,1",
    Axis2="BL12:Mot:phi,0,1,0,1",
    Average=True,
)

PreprocessDetectorsToMD(InputWorkspace="data", OutputWorkspace="detectors")

Q_max = 2 * np.pi / d_min

ConvertToMD(
    InputWorkspace="data",
    QDimensions="Q3D",
    dEAnalysisMode="Elastic",
    Q3DFrames="Q_sample",
    LorentzCorrection=True,
    MinValues=[-Q_max, -Q_max, -Q_max],
    MaxValues=[+Q_max, +Q_max, +Q_max],
    PreprocDetectorsWS="detectors",
    OutputWorkspace="md",
)
```
Then, select workspace `md` with a right-click and open it in the slice viewer. Select 200 bins for `Q_sample_x` and select scale `Log`, like in the picture:

<img width="500" alt="screenshot" src="https://github.com/user-attachments/assets/a5bdb0c6-a1e3-476a-8a9c-7587b8b29141" />

Confirm that the dot-pattern is gone. After this, change the scale to `SymmetricLog10`. The background should now match the color at the bottom of the colorbar, as shown in the image:

<img width="500" alt="screenshot" src="https://github.com/user-attachments/assets/afd1d83a-6254-4bc4-9585-9a4cd2c3cf00" />

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
