### PR TITLE
Make `SharedID` for `Nexus::File`

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -29,6 +29,7 @@ class H5Object;
 // NOTE declare extern "C" to prevent conflict with actual declaration
 // NOTE use MYH5DLL, set to match HDF5's H5_DLL, to allow Windows build
 extern "C" {
+MYH5DLL herr_t H5Fclose(hid_t);
 MYH5DLL herr_t H5Gclose(hid_t);
 MYH5DLL herr_t H5Dclose(hid_t);
 MYH5DLL herr_t H5Tclose(hid_t);
@@ -47,7 +48,8 @@ MYH5DLL herr_t H5Pclose(hid_t);
 namespace Mantid {
 namespace Nexus {
 
-using FileID = UniqueID<&H5Fclose>;
+using UniqueFileID = UniqueID<&H5Fclose>;
+using SharedFileID = SharedID<&H5Fclose>;
 using GroupID = UniqueID<&H5Gclose>;
 using DataSetID = UniqueID<&H5Dclose>;
 using DataTypeID = UniqueID<&H5Tclose>;
@@ -70,14 +72,14 @@ private:
   /** The address of currently-opened element */
   NexusAddress m_address;
   /** Variables for use inside the C-API, formerly of NexusFile5
-   * \li m_pfile -- shared ptr to a H5File object
+   * \li m_fileID -- SharedID for an H5File object
    * \li m_current_group_id -- the ID for currently opened group (or 0 if none)
    * \li m_current_data_id -- the ID for currently opened dataset (or 0 if none)
    * \li m_current_type_id -- the ID of the type of the opened dataset
    * \li m_current_space_id -- the ID of the dataspace for the opened dataset
    * \li m_gid_stack -- a vector stack of opened group IDs
    */
-  std::shared_ptr<FileID> m_pfile;
+  SharedFileID m_fileID;
   hid_t m_current_group_id;
   hid_t m_current_data_id;
   hid_t m_current_type_id;

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -1,6 +1,4 @@
 /** This class defines data types which are used as part of the Nexus API.
- * They should more properly be moved into NexusFile, when the nexus layer has been cleaned up.
- * OR all type and enum definitions in NexusFile all moved here.
  */
 
 #pragma once

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -21,11 +21,11 @@ typedef int herr_t;
  * Nexus file access codes.
  * these codes are taken directly from values used in hdf5 package
  * https://github.com/HDFGroup/hdf5/blob/develop/src/H5Fpublic.h
- * \li READ read-only. Same as H5F_ACC_RDONLY
+ * \li READ read-only. Same as H5F_ACC_RDONLY | H5F_ACC_SWMR_READ
  * \li RDWR open an existing file for reading and writing. Same as H5F_ACC_RDWR.
  * \li CREATE5 create a Nexus HDF-5 file. Same as H5F_ACC_TRUNC.
  */
-enum class NXaccess : unsigned int { READ = 0x0000u, RDWR = 0x0001u, CREATE5 = 0x0002u };
+enum class NXaccess : unsigned int { READ = 0x0040u, RDWR = 0x0001u, CREATE5 = 0x0002u };
 
 MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXaccess &value);
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -19,11 +19,11 @@ typedef int herr_t;
  * Nexus file access codes.
  * these codes are taken directly from values used in hdf5 package
  * https://github.com/HDFGroup/hdf5/blob/develop/src/H5Fpublic.h
- * \li READ read-only. Same as H5F_ACC_RDONLY | H5F_ACC_SWMR_READ
+ * \li READ read-only. Same as H5F_ACC_RDONLY
  * \li RDWR open an existing file for reading and writing. Same as H5F_ACC_RDWR.
  * \li CREATE5 create a Nexus HDF-5 file. Same as H5F_ACC_TRUNC.
  */
-enum class NXaccess : unsigned int { READ = 0x0040u, RDWR = 0x0001u, CREATE5 = 0x0002u };
+enum class NXaccess : unsigned int { READ = 0x0000u, RDWR = 0x0001u, CREATE5 = 0x0002u };
 
 MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXaccess &value);
 

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -257,7 +257,7 @@ template <herr_t (*const D)(hid_t)> inline void SharedID<D>::decrement_leash_cou
     std::size_t counts = (*m_leash_counts).load();
     if (counts > 1) {
       (*m_leash_counts)--;
-    } else if (counts == 1) { // cppcheck-suppress knownConditionTrueFalse
+    } else if (counts == 1) {
       this->close();
       *m_leash_counts = 0;
       delete m_leash_counts;

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -2,6 +2,7 @@
 
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexus/NexusFile_fwd.h"
+#include <atomic>
 
 // Forward declarations for needed HDF5 functions
 // NOTE declare extern "C" to prevent conflict with actual declaration
@@ -19,6 +20,68 @@ MYH5DLL herr_t H5garbage_collect();
 
 namespace Mantid::Nexus {
 
+/// @brief an ID that HDF5 will always consider invalid
+constexpr hid_t INVALID_HID{-1};
+
+/**
+ * @class Hdf5ID
+ * @brief A very simple wrapper that holds an HDF5 object through its hid_t.
+ */
+template <herr_t (*const D)(hid_t)> class Hdf5ID {
+protected:
+  hid_t m_id;
+
+  void close();
+
+public:
+  // constructors
+  Hdf5ID() noexcept : m_id(INVALID_HID) {}
+  Hdf5ID(hid_t const id) noexcept : m_id(id) {}
+
+  // comparators
+  bool operator==(hid_t const id) const { return m_id == id; }
+  bool operator!=(hid_t const id) const { return m_id != id; }
+  bool operator<=(hid_t const id) const { return m_id <= id; }
+  bool operator<(hid_t const id) const { return m_id < id; }
+
+  /// @brief Return the managed HDF5 handle
+  /// @return the managed HDF5 handle
+  hid_t get() const { return m_id; }
+  operator hid_t() const { return m_id; }
+  /// @brief Return whether the UniqueId corresponds to a valid HDF5 object
+  /// @return true if it is valid; otherwise false; on error, false
+  bool isValid() const {
+    // fail early condition
+    if (m_id <= 0) {
+      return false;
+    } else {
+      return H5Iis_valid(m_id) > 0;
+    }
+  }
+};
+
+/// @brief Close the held object ID
+template <herr_t (*const closer)(hid_t)> inline void Hdf5ID<closer>::close() {
+  if (this->isValid()) {
+    closer(this->m_id);
+    this->m_id = INVALID_HID;
+  }
+}
+
+/// @brief Close a held file ID, and also call garbage collection
+template <> inline void Hdf5ID<&H5Fclose>::close() {
+  if (this->isValid()) {
+    H5Fclose(this->m_id);
+    this->m_id = INVALID_HID;
+    // call garbage collection to close any and all open objects on this file
+    H5garbage_collect();
+  }
+}
+
+// ******************************************************************
+// UNIQUE ID
+// ******************************************************************
+
 /**
  * @class UniqueID
  * @brief A wrapper class for managing HDF5 object handles (hid_t).
@@ -26,90 +89,53 @@ namespace Mantid::Nexus {
  * ensuring that the handle is properly closed when the UniqueID object is destroyed.
  * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
  */
-template <herr_t (*const D)(hid_t)> class UniqueID {
-protected:
-  hid_t m_id;
-
+template <herr_t (*const D)(hid_t)> class UniqueID : public Hdf5ID<D> {
 private:
-  UniqueID(UniqueID<D> const &uid) = delete;
+  // prohibit copying a unique ID
+  UniqueID(UniqueID<D> const &) = delete;
   UniqueID &operator=(UniqueID<D> const &) = delete;
-  void close();
 
 public:
   // constructors / destructor
-  UniqueID() : m_id(INVALID_ID) {}
-  UniqueID(hid_t const id) : m_id(id) {}
-  ~UniqueID() { close(); }
-  UniqueID(UniqueID<D> &&uid) noexcept : m_id(uid.m_id) { uid.m_id = INVALID_ID; }
+  UniqueID() : Hdf5ID<D>() {}
+  UniqueID(hid_t const id) : Hdf5ID<D>(id) {}
+  UniqueID(UniqueID<D> &&uid) noexcept : Hdf5ID<D>(uid.m_id) { uid.m_id = INVALID_HID; }
+  ~UniqueID() { this->close(); }
 
   // assignment
-  UniqueID<D> &operator=(hid_t const id);
-  UniqueID<D> &operator=(UniqueID<D> &&uid);
+  UniqueID<D> &operator=(hid_t const);
+  UniqueID<D> &operator=(UniqueID<D> &&);
 
-  // comparators
-  bool operator==(int const id) const { return static_cast<int>(m_id) == id; }
-  bool operator<=(int const id) const { return static_cast<int>(m_id) <= id; }
-  bool operator<(int const id) const { return static_cast<int>(m_id) < id; }
-
-  // using the id
-  operator hid_t() const { return m_id; }
-
-  /// @brief Return the managed HDF5 handle
-  /// @return the managed HDF5 handle
-  hid_t get() const { return m_id; }
-
+  void reset() { reset(INVALID_HID); };
+  void reset(hid_t const);
+  void reset(UniqueID<D> const &) = delete;
+  void reset(UniqueID<D> &&);
   hid_t release();
-  void reset(hid_t const id = INVALID_ID);
-  bool isValid() const;
-
-  /// @brief represents an invalid ID value
-  static hid_t constexpr INVALID_ID{-1};
 };
-
-/// @brief Return whether the UniqueId corresponds to a valid HDF5 object
-/// @return true if it is valid; otherwise false; on error, false
-template <herr_t (*const D)(hid_t)> inline bool UniqueID<D>::isValid() const {
-  // fail early condition
-  if (m_id < 0) {
-    return false;
-  } else {
-    return H5Iis_valid(m_id) > 0;
-  }
-}
-
-/// @brief Close the held ID by calling its deleter function
-/// @tparam deleter
-template <herr_t (*const deleter)(hid_t)> inline void UniqueID<deleter>::close() {
-  if (isValid()) {
-    deleter(this->m_id);
-    this->m_id = INVALID_ID;
-  }
-}
-
-/// @brief Close a ID corresponding to a file; and call garbage collection
-template <> inline void UniqueID<&H5Fclose>::close() {
-  if (isValid()) {
-    H5Fclose(this->m_id);
-    this->m_id = INVALID_ID;
-    // call garbage collection to close any and all open objects on this file
-    H5garbage_collect();
-  }
-}
 
 /// @brief  Release hold on the managed ID; it will not be closed by this UniqueID
 /// @return the managed ID
 template <herr_t (*const D)(hid_t)> inline hid_t UniqueID<D>::release() {
-  hid_t tmp = m_id;
-  m_id = INVALID_ID;
+  hid_t tmp = this->m_id;
+  this->m_id = INVALID_HID;
   return tmp;
 }
 
 /// @brief  Close the existing ID and replace with the new ID; or, set to invalid
 /// @param id The new ID to be held; defaults to invalid
 template <herr_t (*const D)(hid_t)> inline void UniqueID<D>::reset(hid_t const id) {
-  if (m_id != id) {
-    close();
-    m_id = id;
+  if (this->m_id != id) {
+    this->close();
+    this->m_id = id;
+  }
+}
+
+/// @brief  Close the existing ID and replace with the new ID; or, set to invalid
+/// @param uid a UniqueID being moved and releasing control to this UniqueID
+template <herr_t (*const D)(hid_t)> inline void UniqueID<D>::reset(UniqueID<D> &&uid) {
+  if (this != &uid) {
+    reset(uid.m_id);
+    uid.m_id = INVALID_HID;
   }
 }
 
@@ -123,10 +149,136 @@ template <herr_t (*const D)(hid_t)> inline UniqueID<D> &UniqueID<D>::operator=(h
 /// @brief Pass the HDF5 object ID from an existing UniqueID to another UniqueID
 /// @param uid : the UniqueID previously managing the ID; it will lose ownership of the ID.
 template <herr_t (*const D)(hid_t)> inline UniqueID<D> &UniqueID<D>::operator=(UniqueID<D> &&uid) {
-  if (this != &uid) {
-    reset(uid.m_id);
-    uid.m_id = INVALID_ID;
+  reset(std::move(uid));
+  return *this;
+}
+
+// ******************************************************************
+// SHARED ID
+// ******************************************************************
+
+/**
+ * @class SharedID
+ * @brief A wrapper class for managing HDF5 object handles (hid_t) that can be shared.
+ * @details The SharedID class is designed to manage the lifecycle of HDF5 object handles (hid_t),
+ * with multiple ownership, ensuring the handle is properly closed when all leashes to it are dropped.
+ * This helps prevent resource leaks and ensures proper cleanup of HDF5 resources.
+ */
+template <herr_t (*const D)(hid_t)> class SharedID : public Hdf5ID<D> {
+private:
+  std::atomic<std::size_t> *m_leash_counts;
+  void increment_leash_counts();
+  void decrement_leash_counts();
+
+public:
+  // constructors / destructor
+  SharedID() : Hdf5ID<D>(), m_leash_counts(nullptr) {}
+  SharedID(hid_t id) : Hdf5ID<D>(id), m_leash_counts(new std::atomic<std::size_t>(1)) {}
+  SharedID(SharedID<D> const &uid) : Hdf5ID<D>(uid.m_id), m_leash_counts(uid.m_leash_counts) {
+    increment_leash_counts();
   }
+  SharedID(SharedID<D> &&uid) : Hdf5ID<D>(uid.m_id), m_leash_counts(uid.m_leash_counts) {
+    uid.m_id = INVALID_HID;
+    uid.m_leash_counts = nullptr;
+  }
+  ~SharedID() { decrement_leash_counts(); }
+
+  SharedID<D> &operator=(hid_t const);
+  SharedID<D> &operator=(SharedID<D> const &);
+  SharedID<D> &operator=(SharedID<D> &&);
+
+  /// @brief ensure two SharedIDs are tracking the same object
+  bool operator==(SharedID<D> const &uid) const {
+    if (m_leash_counts == uid.m_leash_counts) {
+      return this->m_id == uid.m_id;
+    } else {
+      return false;
+    }
+  }
+
+  /// @brief Returns the number of SharedID objects holding the same ID
+  std::size_t use_count() const { return (m_leash_counts ? (*m_leash_counts).load() : 0); }
+
+  void reset() { reset(INVALID_HID); };
+  void reset(hid_t const);
+  void reset(SharedID<D> const &);
+  void reset(SharedID<D> &&);
+};
+
+/// @brief  Decrement the existing ID and replace with the new ID; or, set to invalid
+/// @param id The new ID to be held; defaults to invalid
+template <herr_t (*const D)(hid_t)> inline void SharedID<D>::reset(hid_t const id) {
+  if (this->m_id != id) {
+    decrement_leash_counts();
+    this->m_id = id;
+    m_leash_counts = nullptr;
+    increment_leash_counts();
+  }
+}
+
+/// @brief  Decrement the existing ID and replace with the new ID; or, set to invalid
+/// @param uid A SharedID whose ID will be shared
+template <herr_t (*const D)(hid_t)> inline void SharedID<D>::reset(SharedID<D> const &uid) {
+  if (&uid != this && uid.m_id != this->m_id) {
+    decrement_leash_counts();
+    this->m_id = uid.m_id;
+    m_leash_counts = uid.m_leash_counts;
+    increment_leash_counts();
+  }
+}
+
+/// @brief  Decrement the existing ID and replace with the new ID; or, set to invalid
+/// @param uid A SharedID whose ID will be moved to here
+template <herr_t (*const D)(hid_t)> inline void SharedID<D>::reset(SharedID<D> &&uid) {
+  if (&uid != this && uid.m_id != this->m_id) {
+    decrement_leash_counts();
+    this->m_id = uid.m_id;
+    m_leash_counts = uid.m_leash_counts;
+    // unset the moved id
+    uid.m_id = INVALID_HID;
+    uid.m_leash_counts = nullptr;
+    // no increment -- number of leashes is same
+  }
+}
+
+template <herr_t (*const D)(hid_t)> inline void SharedID<D>::increment_leash_counts() {
+  if (this->isValid()) {
+    if (!m_leash_counts) {
+      m_leash_counts = new std::atomic<std::size_t>(1);
+    } else {
+      (*m_leash_counts)++;
+    }
+  }
+}
+
+template <herr_t (*const D)(hid_t)> inline void SharedID<D>::decrement_leash_counts() {
+  if (m_leash_counts) {
+    if (*m_leash_counts > 1) {
+      (*m_leash_counts)--;
+    } else if (*m_leash_counts == 1) {
+      this->close();
+      *m_leash_counts = 0;
+      delete m_leash_counts;
+      m_leash_counts = nullptr;
+    } else if (*m_leash_counts == 0) {
+      delete m_leash_counts;
+      m_leash_counts = nullptr;
+    }
+  }
+}
+
+template <herr_t (*const D)(hid_t)> inline SharedID<D> &SharedID<D>::operator=(hid_t id) {
+  reset(id);
+  return *this;
+}
+
+template <herr_t (*const D)(hid_t)> inline SharedID<D> &SharedID<D>::operator=(SharedID<D> const &uid) {
+  reset(uid);
+  return *this;
+}
+
+template <herr_t (*const D)(hid_t)> inline SharedID<D> &SharedID<D>::operator=(SharedID<D> &&uid) {
+  reset(std::move(uid));
   return *this;
 }
 

--- a/Framework/Nexus/inc/MantidNexus/UniqueID.h
+++ b/Framework/Nexus/inc/MantidNexus/UniqueID.h
@@ -257,12 +257,12 @@ template <herr_t (*const D)(hid_t)> inline void SharedID<D>::decrement_leash_cou
     std::size_t counts = (*m_leash_counts).load();
     if (counts > 1) {
       (*m_leash_counts)--;
-    } else if (counts == 1) {
+    } else if (counts == 1) { // cppcheck-suppress knownConditionTrueFalse
       this->close();
       *m_leash_counts = 0;
       delete m_leash_counts;
       m_leash_counts = nullptr;
-    } else if (counts == 0) {
+    } else if (counts == 0) { // cppcheck-suppress knownConditionTrueFalse
       delete m_leash_counts;
       m_leash_counts = nullptr;
     }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -216,7 +216,7 @@ File::~File() {
     m_current_group_id = INVALID_HID;
   }
   for (hid_t &gid : m_gid_stack) {
-    if (H5Iis_valid(gid)) {
+    if (H5Iis_valid(gid) > 0) {
       H5Gclose(gid);
     }
     gid = INVALID_HID;
@@ -290,7 +290,7 @@ void File::openAddress(std::string const &address) {
   NexusAddress groupstack(absaddr.parent_path());
   NexusAddress fromroot;
   if (groupstack.isRoot()) {
-    m_current_group_id = INVALID_HID;
+    m_current_group_id = 0; // root!
   } else {
     m_current_group_id = m_fileID.get();
     for (auto const &name : groupstack.parts()) {

--- a/Framework/Nexus/src/UniqueID.cpp
+++ b/Framework/Nexus/src/UniqueID.cpp
@@ -4,11 +4,18 @@
 
 namespace Mantid::Nexus {
 
+// ******************************************************************
+// EXPORTS
+// ******************************************************************
+
+template class MANTID_NEXUS_DLL UniqueID<&H5Fclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Gclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Dclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Tclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Sclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Aclose>;
 template class MANTID_NEXUS_DLL UniqueID<&H5Pclose>;
+// this will be used in Nexus::File
+template class MANTID_NEXUS_DLL SharedID<&H5Fclose>;
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -46,7 +46,7 @@ public:
    */
 
   void test_leak1() {
-    int const nReOpen = 1000;
+    int constexpr nReOpen = 1000;
     cout << "\nRunning Leak Test 1: " << nReOpen << " iterations" << endl;
     FileResource fr("nexus_leak_test1.nxs");
     std::string const szFile(fr.fullPath());
@@ -125,7 +125,7 @@ public:
     FileResource fr("nexus_leak_test3.nxs");
     std::string const szFile(fr.fullPath());
 
-    int const iBinarySize = TEST_SIZE * TEST_SIZE;
+    int constexpr iBinarySize = TEST_SIZE * TEST_SIZE;
     cout << "Creating array of " << iBinarySize << " integers" << endl;
     int16_t aiBinaryData[iBinarySize];
 

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -47,7 +47,7 @@ public:
 
   void test_leak1() {
     int const nReOpen = 1000;
-    cout << "\nRunning Leak Test 1: " << nReOpen << " iterations\n";
+    cout << "\nRunning Leak Test 1: " << nReOpen << " iterations" << endl;
     FileResource fr("nexus_leak_test1.nxs");
     std::string const szFile(fr.fullPath());
 
@@ -55,13 +55,13 @@ public:
 
     for (int iReOpen = 0; iReOpen < nReOpen; iReOpen++) {
       if (0 == iReOpen % 100) {
-        cout << "loop count " << iReOpen << "\n";
+        cout << "loop count " << iReOpen << endl;
       }
 
       File other_file(file_obj);
     }
 
-    cout << "Leak Test 1 Success!\n";
+    cout << "Leak Test 1 Success!" << endl;
   }
 
   void test_leak2() {
@@ -70,7 +70,7 @@ public:
     int const nData = 10;
     vector<int16_t> const i2_array{1000, 2000, 3000, 4000};
 
-    cout << "Running Leak Test 2: " << nFiles << " iterations\n";
+    cout << "Running Leak Test 2: " << nFiles << " iterations" << endl;
 
     NXaccess access_mode = NXaccess::CREATE5;
     std::string strFile;
@@ -78,7 +78,7 @@ public:
     for (int iFile = 0; iFile < nFiles; iFile++) {
       FileResource fr(strmakef("nexus_leak_test2_%03d.nxs", iFile));
       strFile = fr.fullPath();
-      cout << "file " << strFile << "\n";
+      cout << "file " << strFile << endl;
 
       File fileid(strFile, access_mode);
 
@@ -105,11 +105,11 @@ public:
       fileid.close();
       removeFile(strFile);
     }
-    cout << "Leak Test 2 Success!\n";
+    cout << "Leak Test 2 Success!" << endl;
   }
 
   void test_leak3() {
-    cout << "Running Leak Test 3\n" << std::flush;
+    cout << "Running Leak Test 3" << endl;
     const int nFiles = 10;
     const int nEntry = 2;
     const int nData = 2;
@@ -126,16 +126,16 @@ public:
     std::string const szFile(fr.fullPath());
 
     int const iBinarySize = TEST_SIZE * TEST_SIZE;
-    cout << "Creating array of " << iBinarySize << " integers\n" << std::flush;
+    cout << "Creating array of " << iBinarySize << " integers" << endl;
     int16_t aiBinaryData[iBinarySize];
 
     for (int i = 0; i < iBinarySize; i++) {
       aiBinaryData[i] = static_cast<int16_t>(rand());
     }
-    cout << "Created " << iBinarySize << " random integers\n";
+    cout << "Created " << iBinarySize << " random integers" << endl;
 
     for (int iFile = 0; iFile < nFiles; iFile++) {
-      cout << "file " << iFile << "\n";
+      cout << "file " << iFile << endl;
 
       File fileid(szFile, NXaccess::CREATE5);
 
@@ -163,6 +163,6 @@ public:
 
       fileid.close();
     }
-    cout << "Leak Test 3 Success!\n";
+    cout << "Leak Test 3 Success!" << endl;
   }
 };

--- a/Framework/Nexus/test/NexusFileLeakTest.h
+++ b/Framework/Nexus/test/NexusFileLeakTest.h
@@ -117,9 +117,9 @@ public:
     // NOTE the Windows runners do not have enough stack space for the full test (max 1MB stack)
     // Rather than skip the entire test, we can use a smaller array size
     // It is no longer testing the same behavior on Windows with this choice.
-    std::size_t const TEST_SIZE(8);
+    std::size_t constexpr TEST_SIZE(8);
 #else
-    std::size_t const TEST_SIZE(512);
+    std::size_t constexpr TEST_SIZE(512);
 #endif // WIN32
     DimVector array_dims({TEST_SIZE, TEST_SIZE});
     FileResource fr("nexus_leak_test3.nxs");

--- a/Framework/Nexus/test/NexusFileReadWriteTest.h
+++ b/Framework/Nexus/test/NexusFileReadWriteTest.h
@@ -290,7 +290,7 @@ public:
   }
 
   void test_openPath() {
-    cout << "tests for openPath\n" << std::flush;
+    cout << "tests for openPath" << endl;
 
     // make file with path /entry
     FileResource resource("NexusFile_openpathtest.nxs");
@@ -337,18 +337,18 @@ public:
 
     // cleanup
     fileid.close();
-    cout << "NXopenaddress checks OK\n";
+    cout << "NXopenaddress checks OK" << endl;
   }
 
   void test_links() {
-    cout << "tests of linkature\n" << std::flush;
+    cout << "tests of linkature" << endl;
 
     FileResource resource("NexusFile_linktest.nxs");
     std::string const filename(resource.fullPath());
     File fileid = do_prep_files(filename);
 
     // Create some data with a link
-    cout << "create entry at /entry/some_data\n";
+    cout << "create entry at /entry/some_data" << endl;
     string const somedata("this is some data");
     fileid.makeData("some_data", NXnumtype::CHAR, DimVector({(dimsize_t)somedata.size()}));
     fileid.openData("some_data");
@@ -358,7 +358,7 @@ public:
     fileid.flush();
 
     // Create a group, and link it to that data
-    cout << "create group at /entry/data to link to the data\n";
+    cout << "create group at /entry/data to link to the data" << endl;
     fileid.makeGroup("data", "NXdata");
     fileid.openGroup("data", "NXdata");
     fileid.makeLink(datalink);
@@ -372,7 +372,7 @@ public:
     NXlink res1 = fileid.getDataID();
     TS_ASSERT_EQUALS(datalink.linkType, res1.linkType);
     TS_ASSERT_EQUALS(datalink.targetAddress, res1.targetAddress);
-    cout << "data link works\n";
+    cout << "data link works" << endl;
     fileid.closeData();
 
     fileid.openAddress("/entry");
@@ -380,7 +380,7 @@ public:
     // Create two groups, group1 and group2
     // Make a link inside group2 to group1
     // make group1
-    cout << "create group /entry/group1\n" << std::flush;
+    cout << "create group /entry/group1" << endl;
     std::string const strdata("NeXus sample data");
     fileid.makeGroup("group1", "NXentry");
     fileid.openGroup("group1", "NXentry");
@@ -388,7 +388,7 @@ public:
     fileid.closeGroup();
 
     // make group 2
-    cout << "create group /entry/group2/group1\n";
+    cout << "create group /entry/group2/group1" << endl;
     fileid.makeGroup("group2", "NXentry");
     fileid.openGroup("group2", "NXentry");
     fileid.makeLink(grouplink);
@@ -399,6 +399,6 @@ public:
     NXlink res2 = fileid.getGroupID();
     TS_ASSERT_EQUALS(grouplink.linkType, res2.linkType);
     TS_ASSERT_EQUALS(string(grouplink.targetAddress), string(res2.targetAddress));
-    cout << "group link works\n";
+    cout << "group link works" << endl;
   }
 };

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -715,7 +715,7 @@ public:
     // file permissions
     Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-    Mantid::Nexus::FileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    Mantid::Nexus::UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
     // put an initial entry
     Mantid::Nexus::GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -1421,7 +1421,7 @@ public:
     std::cout << "\ntest getEntries with missing NX_class and soft link\n";
 
     std::string filename = "test_missing_nxclass.h5";
-    Mantid::Nexus::FileID file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    Mantid::Nexus::UniqueFileID file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     TS_ASSERT(file_id.isValid());
 
     Mantid::Nexus::GroupID group_id = H5Gcreate(file_id, "/nogroupclass", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -1503,32 +1503,21 @@ public:
   // TEST RULE OF THREE
   // ################################################################################################################
 
-  bool file_is_closed(std::string const &filename) {
-    // this will check if a file is already opened, by trying to open it with incompatible (WEAK) access
-    // if this operation FAILS (fid <= 0), then the file is STILL OPENED
-    // if this operation SUCCEEDS (fid > 0), then the file was CLOSED
-    // NOTE this is ONLY meaningful AFTER a file with the name has been definitely opened
-    Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
-    H5Pset_fclose_degree(fapl, H5F_CLOSE_WEAK);
-    Mantid::Nexus::FileID fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
-    return fid.isValid();
-  }
-
   void test_file_is_closed() {
     cout << "\ntest closing files" << std::endl;
 
     FileResource resource("test_nexus_close.nxs");
     std::string filename(resource.fullPath());
     Mantid::Nexus::File file(filename, NXaccess::CREATE5);
-    TS_ASSERT(!file_is_closed(filename));
+    TS_ASSERT(!hdf_file_is_closed(filename));
     file.close();
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
 
     { // scope the file to check deconstructor
       Mantid::Nexus::File file2(filename, NXaccess::READ);
-      TS_ASSERT(!file_is_closed(filename));
+      TS_ASSERT(!hdf_file_is_closed(filename));
     }
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 
   void test_shared_file_id() {
@@ -1540,52 +1529,30 @@ public:
     { // scoped file creation
       Mantid::Nexus::File file(filename, NXaccess::CREATE5);
     }
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
 
     { // scoped fid
       Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
       H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-      Mantid::Nexus::FileID fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
-      TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT(fid.isValid());
-    } // fid goes out of scope and deconstructor is called
+      auto fid1 = Mantid::Nexus::SharedFileID(H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl));
+      auto fid2(fid1);
+      auto fid3(fid2);
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid1.isValid());
+      TS_ASSERT(fid2.isValid());
+      TS_ASSERT(fid3.isValid());
+      // close fid1
+      fid1.reset();
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid2.isValid());
+      TS_ASSERT(fid3.isValid());
+      // close fid3
+      fid3.reset();
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid2.isValid());
+    } // last fid goes out of scope and destructor is called
     // the file is now closed
-    TS_ASSERT(file_is_closed(filename));
-  }
-
-  void test_file_id_shared_ptr() {
-    cout << "\ntest the file id in shared ptr\n" << std::flush;
-
-    // create a file
-    FileResource resource("test_nexus_fid.nxs");
-    std::string filename(resource.fullPath());
-    { // scoped file creation
-      Mantid::Nexus::File file(filename, NXaccess::CREATE5);
-    }
-    TS_ASSERT(file_is_closed(filename));
-
-    { // scoped fid
-      Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
-      H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-      auto pfid1 = std::make_shared<Mantid::Nexus::FileID>(H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl));
-      auto pfid2(pfid1);
-      auto pfid3(pfid2);
-      TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid1->get(), Mantid::Nexus::FileID::INVALID_ID);
-      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
-      TS_ASSERT_DIFFERS(pfid3->get(), Mantid::Nexus::FileID::INVALID_ID);
-      // close pfid1
-      pfid1.reset();
-      TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
-      TS_ASSERT_DIFFERS(pfid3->get(), Mantid::Nexus::FileID::INVALID_ID);
-      // close pfid3
-      pfid3.reset();
-      TS_ASSERT(!file_is_closed(filename));
-      TS_ASSERT_DIFFERS(pfid2->get(), Mantid::Nexus::FileID::INVALID_ID);
-    } // last pfid goes out of scope and deconstructor is called
-    // the file is now closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 
   void test_open_concurrent() {
@@ -1601,7 +1568,7 @@ public:
       file.close();
     }
     // check the file is closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
 
     { // scope the files to verify close
       // open the file, twice
@@ -1613,10 +1580,10 @@ public:
       // confirm we are in different locations
       TS_ASSERT_EQUALS(file2.getAddress(), "/entry2");
       TS_ASSERT_EQUALS(file1.getAddress(), "/entry1");
-      TS_ASSERT(!file_is_closed(filename));
+      TS_ASSERT(!hdf_file_is_closed(filename));
     }
     // check the file is closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 
   void test_copy_creation() {
@@ -1657,7 +1624,7 @@ public:
       TS_ASSERT_EQUALS(file1.getAddress(), "/entry2");
     }
     // check the file is closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 
   void test_copy_from_pointers() {
@@ -1673,7 +1640,7 @@ public:
       file.putAttr("info", "some info");
       file.closeGroup();
     }
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
 
     // check with pointers
     { // scope file1
@@ -1686,12 +1653,12 @@ public:
         file2.openGroup("entry", "NXshorts");
         TS_ASSERT_EQUALS(file2.getStrAttr("info"), "some info");
       } // file2 goes out of scope
-      TS_ASSERT(!file_is_closed(filename));
+      TS_ASSERT(!hdf_file_is_closed(filename));
       pfile->openGroup("entry", "NXshorts");
       TS_ASSERT_EQUALS(pfile->getStrAttr("info"), "some info");
     }
     // check the file is closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
 
     // check with shared pointers
     { // scope file1
@@ -1703,11 +1670,11 @@ public:
         file2.openGroup("entry", "NXshorts");
         TS_ASSERT_EQUALS(file2.getStrAttr("info"), "some info");
       } // file2 goes out of scope
-      TS_ASSERT(!file_is_closed(filename));
+      TS_ASSERT(!hdf_file_is_closed(filename));
       pfile->openGroup("entry", "NXshorts");
       TS_ASSERT_EQUALS(pfile->getStrAttr("info"), "some info");
     }
     // check the file is closed
-    TS_ASSERT(file_is_closed(filename));
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 };

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -1515,7 +1515,7 @@ public:
   }
 
   void test_file_is_closed() {
-    cout << "\ntest closing files\n" << std::flush;
+    cout << "\ntest closing files" << std::endl;
 
     FileResource resource("test_nexus_close.nxs");
     std::string filename(resource.fullPath());
@@ -1531,11 +1531,8 @@ public:
     TS_ASSERT(file_is_closed(filename));
   }
 
-  void test_file_id() {
-    cout << "\ntest the file id\n" << std::flush;
-
-    Mantid::Nexus::FileID fid;
-    TS_ASSERT(!fid.isValid());
+  void test_shared_file_id() {
+    cout << "\ntest the shared file id" << std::endl;
 
     // create a file
     FileResource resource("test_nexus_fid.nxs");

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -772,5 +772,8 @@ public:
     }
     // now check
     TS_ASSERT_EQUALS(id.use_count(), 1);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   }
 };

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -731,7 +731,8 @@ public:
 // NOTE this warning causes build failures; suppress for now
 // the issue is caused by capturing variables of type TestSharedID,
 // which have a deleter method defined at global scope
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !(defined(__clang__))
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsubobject-linkage"
 #endif
     constexpr int N{10};
@@ -772,7 +773,7 @@ public:
     }
     // now check
     TS_ASSERT_EQUALS(id.use_count(), 1);
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !(defined(__clang__))
 #pragma GCC diagnostic pop
 #endif
   }

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -420,7 +420,7 @@ public:
     {
       TestSharedID uid(INVALID_HID);
       TS_ASSERT(!uid.isValid());
-      TS_ASSERT_EQUALS(uid.use_count(), 1);
+      TS_ASSERT_EQUALS(uid.use_count(), 0);
     }
     // the deleter was not called on exit
     TS_ASSERT_EQUALS(call_count, 0);

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -6,24 +6,17 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include <cxxtest/TestSuite.h>
-
 #include "MantidNexus/NexusException.h"
-#include "MantidNexus/NexusFile.h"
-#include "MantidTypes/Core/DateAndTime.h"
+#include "MantidNexus/UniqueID.h"
+
 #include "test_helper.h"
-#include <H5Cpp.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <map>
-#include <regex>
-#include <sstream>
-#include <string>
-#include <vector>
+#include <cxxtest/TestSuite.h>
+#include <hdf5.h>
+#include <thread>
 
 using namespace NexusTest;
 using std::cout;
@@ -33,14 +26,24 @@ using std::multimap;
 using std::string;
 using std::vector;
 
+using GroupID = Mantid::Nexus::UniqueID<&H5Gclose>;
+using ParameterID = Mantid::Nexus::UniqueID<&H5Pclose>;
+using UniqueFileID = Mantid::Nexus::UniqueID<&H5Fclose>;
+using SharedFileID = Mantid::Nexus::SharedID<&H5Fclose>;
+
 namespace {
 // an ID which will always return as valid
-const hid_t GOOD_ID = H5T_NATIVE_INT;
+const hid_t GOOD_ID1 = H5T_NATIVE_INT;
+const hid_t GOOD_ID2 = H5T_NATIVE_CHAR;
+const hid_t BAD_ID = 101;
 static int call_count = 0;
 int blank_deleter(hid_t) { return ++call_count; }
 } // namespace
 
+using TestHdf5ID = Mantid::Nexus::Hdf5ID<blank_deleter>;
 using TestUniqueID = Mantid::Nexus::UniqueID<blank_deleter>;
+using TestSharedID = Mantid::Nexus::SharedID<blank_deleter>;
+using Mantid::Nexus::INVALID_HID;
 
 class UniqueIDTest : public CxxTest::TestSuite {
 
@@ -50,30 +53,104 @@ public:
   static UniqueIDTest *createSuite() { return new UniqueIDTest(); }
   static void destroySuite(UniqueIDTest *suite) { delete suite; }
 
-  void test_uniqueId_isValid() {
-    cout << "\ntest uniqueID isValid" << endl;
-    call_count = 0;
+  void setUp() override { call_count = 0; }
+
+  // ******************************************************************
+  // HDF ID -- tests of basic functionality
+  // ******************************************************************
+
+  void test_hdf5ID_isValid() {
+    cout << "\ntest hdf5ID isValid" << endl;
+
+    // if set with default value, will be invalid
+    {
+      TestHdf5ID uid;
+      TS_ASSERT(!uid.isValid());
+    }
 
     // if set with the invalid ID, will be invalid
     {
-      TestUniqueID uid(TestUniqueID::INVALID_ID);
+      TestHdf5ID uid(INVALID_HID);
       TS_ASSERT(!uid.isValid());
     }
-    // the deleter was not called on exit
-    TS_ASSERT_EQUALS(call_count, 0);
 
     // if set with a positive integer that is not actually an hdf5 object, will be invalid
-    hid_t test = 101;
+    hid_t test = BAD_ID;
     TS_ASSERT(!H5Iis_valid(test));
     {
-      TestUniqueID uid(test);
+      TestHdf5ID uid(test);
+      TS_ASSERT(!uid.isValid());
+    }
+
+    // if set with a valid identifier, returns valid
+    hid_t good = GOOD_ID1;
+    TS_ASSERT(H5Iis_valid(good));
+    {
+      TestHdf5ID uid(good);
+      TS_ASSERT(uid.isValid());
+    }
+  }
+
+  void test_hdf5ID_construct_empty() {
+    cout << "\ntest hdf5ID constructor empty" << endl;
+    // construct empty
+    {
+      TestHdf5ID uid;
+      TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
+      TS_ASSERT(!uid.isValid());
+    }
+  }
+
+  void test_hdf5ID_construct() {
+    cout << "\ntest hdf5ID construct" << endl;
+    // construct
+    hid_t test = GOOD_ID1;
+    {
+      TestHdf5ID uid(test);
+      TS_ASSERT_EQUALS(uid.get(), test);
+      TS_ASSERT_DIFFERS(uid.get(), INVALID_HID);
+      TS_ASSERT(uid.isValid());
+    }
+    // deleter not called on exit
+    TS_ASSERT_EQUALS(call_count, 0);
+  }
+
+  void test_file_is_closed() {
+    cout << "\ntest closing files" << std::endl;
+    H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
+
+    FileResource resource("test_file_is_closed_fixture.nxs");
+    std::string filename{resource.fullPath()};
+    ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+    UniqueFileID file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    TS_ASSERT(!hdf_file_is_closed(filename));
+    file.reset();
+    TS_ASSERT(hdf_file_is_closed(filename));
+    { // scope the file to check deconstructor
+      UniqueFileID file2 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+      TS_ASSERT(!hdf_file_is_closed(filename));
+    }
+    TS_ASSERT(hdf_file_is_closed(filename));
+  }
+
+  // ******************************************************************
+  // UNIQUE ID
+  // ******************************************************************
+
+  void test_uniqueID_close_on_exit() {
+    cout << "\ntest uniqueID close on exit" << endl;
+
+    // if set with the invalid ID, no close on exit
+    {
+      TestUniqueID uid(INVALID_HID);
       TS_ASSERT(!uid.isValid());
     }
     // the deleter was not called on exit
     TS_ASSERT_EQUALS(call_count, 0);
 
-    // if set with a valid identifier, returns valid
-    hid_t good = GOOD_ID;
+    // if set with a valid ID, will close on exit
+    hid_t good = GOOD_ID1;
     TS_ASSERT(H5Iis_valid(good));
     {
       TestUniqueID uid(good);
@@ -86,10 +163,9 @@ public:
   void test_uniqueID_construct_empty() {
     cout << "\ntest uniqueID constructor empty" << endl;
     // construct empty
-    call_count = 0;
     {
       TestUniqueID uid;
-      TS_ASSERT_EQUALS(uid.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
       TS_ASSERT(!uid.isValid());
     }
     // no deleter called on invalid ID
@@ -99,12 +175,11 @@ public:
   void test_uniqueID_construct() {
     cout << "\ntest uniqueID construct" << endl;
     // construct
-    call_count = 0;
-    hid_t test = GOOD_ID;
+    hid_t test = GOOD_ID1;
     {
       TestUniqueID uid(test);
       TS_ASSERT_EQUALS(uid.get(), test);
-      TS_ASSERT_DIFFERS(uid.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_DIFFERS(uid.get(), INVALID_HID);
       TS_ASSERT(uid.isValid());
     }
     // deleter called on valid ID
@@ -114,8 +189,7 @@ public:
   void test_uniqueID_move_construct() {
     cout << "\ntest uniqueID move construct\n";
     // move construct
-    call_count = 0;
-    hid_t test = GOOD_ID;
+    hid_t test = GOOD_ID1;
     {
       TestUniqueID uid(test);
       {
@@ -125,7 +199,7 @@ public:
         TS_ASSERT_EQUALS(uid2.get(), test);
       }
       // uid2 out of scope, deleter called once, uid still invalid
-      TS_ASSERT_EQUALS(uid.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
       TS_ASSERT(!uid.isValid());
       TS_ASSERT_EQUALS(call_count, 1);
     }
@@ -135,12 +209,12 @@ public:
 
   void test_uniqueID_assign_hid() {
     // assign from hid_t
-    call_count = 0;
-    hid_t val1 = GOOD_ID, val2 = H5T_NATIVE_CHAR;
+    hid_t val1 = GOOD_ID1, val2 = GOOD_ID2;
     {
       TestUniqueID uid(val1);
       TS_ASSERT_EQUALS(uid.get(), val1);
       TS_ASSERT(uid.isValid());
+      // ASSIGN THE VALUE
       uid = val2;
       TS_ASSERT_EQUALS(uid.get(), val2);
       TS_ASSERT(uid.isValid());
@@ -152,15 +226,15 @@ public:
   void test_uniqueID_assign_uniqueID() {
     cout << "\ntest uniqueID assign" << endl;
     // assign from uid
-    call_count = 0;
-    hid_t val1 = GOOD_ID, val2 = H5T_NATIVE_CHAR;
+    hid_t val1 = GOOD_ID1, val2 = GOOD_ID2;
     {
-      Mantid::Nexus::UniqueID<blank_deleter> uid1(val1), uid2(val2);
+      TestUniqueID uid1(val1), uid2(val2);
       TS_ASSERT_EQUALS(uid1.get(), val1);
       TS_ASSERT_EQUALS(uid2.get(), val2);
+      // ASSIGN FROM MOVE
       uid1 = std::move(uid2);
       TS_ASSERT_EQUALS(uid1.get(), val2);
-      TS_ASSERT_EQUALS(uid2.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(uid2.get(), INVALID_HID);
       TS_ASSERT_EQUALS(call_count, 1);
     }
     TS_ASSERT_EQUALS(call_count, 2);
@@ -169,13 +243,12 @@ public:
   void test_uniqueID_release() {
     cout << "\ntest uniqueID release" << endl;
     // release
-    call_count = 0;
-    hid_t test = GOOD_ID;
+    hid_t test = GOOD_ID1;
     hid_t res;
     {
       TestUniqueID uid(test);
       TS_ASSERT_THROWS_NOTHING(res = uid.release());
-      TS_ASSERT_EQUALS(uid.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
       TS_ASSERT(!uid.isValid());
       TS_ASSERT_EQUALS(res, test);
     }
@@ -186,8 +259,7 @@ public:
   void test_uniqueID_reset_same() {
     cout << "\ntest uniqueID same" << endl;
     // reset
-    call_count = 0;
-    hid_t test = GOOD_ID;
+    hid_t test = GOOD_ID1;
     {
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
@@ -203,8 +275,7 @@ public:
   void test_uniqueID_reset_other() {
     cout << "\ntest uniqueID reset" << endl;
     // reset
-    call_count = 0;
-    hid_t test = GOOD_ID, other = 101;
+    hid_t test = GOOD_ID1, other = BAD_ID;
     {
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
@@ -213,21 +284,20 @@ public:
       TS_ASSERT_EQUALS(uid.get(), other);
       TS_ASSERT_EQUALS(call_count, 1);
     }
-    // deleter not called when invalid ID (101) exits scope
+    // deleter not called when invalid ID (BAD_ID) exits scope
     TS_ASSERT_EQUALS(call_count, 1);
   }
 
   void test_uniqueID_reset_none() {
     cout << "\ntest uniqueID none" << endl;
     // reset
-    call_count = 0;
-    hid_t test = GOOD_ID;
+    hid_t test = GOOD_ID1;
     {
       TestUniqueID uid(test);
       TS_ASSERT(uid.isValid());
       TS_ASSERT_EQUALS(uid.get(), test);
       TS_ASSERT_THROWS_NOTHING(uid.reset());
-      TS_ASSERT_EQUALS(uid.get(), TestUniqueID::INVALID_ID);
+      TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
       TS_ASSERT_EQUALS(call_count, 1);
     }
   }
@@ -235,23 +305,27 @@ public:
   void test_uniqueID_groups_close() {
     cout << "\ntest uniqueID groups close" << endl;
 
-    std::string filename{"test_uniqueid.h5"};
+    FileResource resource("test_uniqueid_close_groups.h5");
+    std::string filename(resource.fullPath());
     {
       // create a file held by a unique ID
-      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+      ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+      H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+      UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+      TS_ASSERT(!hdf_file_is_closed(filename));
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
       {
         // create a group within that file
-        Mantid::Nexus::UniqueID<&H5Gclose> gid = H5Gcreate1(fid.get(), "a_group", 1);
+        GroupID gid = H5Gcreate1(fid.get(), "a_group", 1);
         TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 1);
         TS_ASSERT(gid.isValid());
-        Mantid::Nexus::UniqueID<&H5Gclose> gid2 = H5Gopen1(fid.get(), "a_group");
+        GroupID gid2 = H5Gopen1(fid.get(), "a_group");
         TS_ASSERT(gid2.isValid());
       }
+      TS_ASSERT(!hdf_file_is_closed(filename));
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
     }
-    // cleanup
-    std::filesystem::remove(filename);
+    TS_ASSERT(hdf_file_is_closed(filename));
   }
 
   void test_uniqueID_no_double_close() {
@@ -264,17 +338,19 @@ public:
       return 0;
     };
     H5Eset_auto2(H5E_DEFAULT, err, &err_count);
-    std::string filename{"test_uniqueid.h5"};
+
+    FileResource resource("test_uniqueid_no_double.h5");
+    std::string filename(resource.fullPath());
     {
       // create a file to hold a group
-      Mantid::Nexus::UniqueID<&H5Fclose> fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+      UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 0);
       // now create a group in the file with a group ID
       hid_t gid = H5Gcreate1(fid.get(), "a_group", 1);
       TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 1);
       {
         // hold that group ID in a UniqueID
-        Mantid::Nexus::UniqueID<&H5Gclose> uid(gid);
+        GroupID uid(gid);
         // this is a valid id
         TS_ASSERT_EQUALS(H5Fget_obj_count(fid, H5F_OBJ_GROUP), 1);
         TS_ASSERT(H5Iis_valid(gid));
@@ -290,19 +366,393 @@ public:
         TS_ASSERT(H5Gclose(gid) < 0);
         TS_ASSERT_EQUALS(err_count, 1); // now there's one
       }
-      // after exit, the deleter was not called because fid is no longer valid
+      // after exit, the deleter was not called because gid is no longer valid
       TS_ASSERT_EQUALS(err_count, 1); // no further errors registered
       // close the file by some other process
       H5Fclose(fid.get());
     }
     // after exit, the deleter was not called because fid is no longer valid
     TS_ASSERT_EQUALS(err_count, 1); // no further errors registered
-    // cleanup
-    std::filesystem::remove(filename);
   }
 
   void test_uniqueID_zero() {
     TestUniqueID uid(0);
     TS_ASSERT(!uid.isValid());
+  }
+
+  void test_unique_file_id() {
+    cout << "\ntest the file id" << endl;
+
+    UniqueFileID fid;
+    TS_ASSERT(!fid.isValid());
+
+    // create a file
+    FileResource resource("test_nexus_unique_fid.nxs");
+    std::string filename(resource.fullPath());
+    ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+    { // scoped file creation
+      UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+      TS_ASSERT(fid.isValid());
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      H5Fclose(fid.release());
+      H5garbage_collect();
+    }
+    TS_ASSERT(hdf_file_is_closed(filename));
+
+    { // scoped fid
+      UniqueFileID fid = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid.isValid());
+    } // fid goes out of scope and deconstructor is called
+    // the file is now closed
+    TS_ASSERT(hdf_file_is_closed(filename));
+  }
+
+  // ******************************************************************
+  // SHARED ID
+  // ******************************************************************
+
+  void test_sharedID_close_on_exit() {
+    cout << "\ntest sharedID close on exit" << endl;
+
+    // if set with the invalid ID, no close on exit
+    {
+      TestSharedID uid(INVALID_HID);
+      TS_ASSERT(!uid.isValid());
+      TS_ASSERT_EQUALS(uid.use_count(), 1);
+    }
+    // the deleter was not called on exit
+    TS_ASSERT_EQUALS(call_count, 0);
+
+    // if set with a valid ID, will close on exit
+    hid_t good = GOOD_ID1;
+    TS_ASSERT(H5Iis_valid(good));
+    {
+      TestSharedID uid(good);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(uid.use_count(), 1);
+    }
+    // the deleter was called on exit
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_sharedID_no_close_when_shared() {
+    cout << "\ntest sharedID no close when shared" << endl;
+
+    // if set with the invalid ID, no close on exit
+    {
+      TestSharedID uid1;
+      TS_ASSERT_EQUALS(uid1.use_count(), 0);
+      {
+        TestSharedID uid2(GOOD_ID1);
+        TS_ASSERT(uid2.isValid());
+        TS_ASSERT_EQUALS(uid2.use_count(), 1);
+        uid1 = uid2;
+        TS_ASSERT(uid1.isValid());
+        TS_ASSERT_EQUALS(uid1.use_count(), 2);
+        TS_ASSERT_EQUALS(uid2.use_count(), 2);
+        TS_ASSERT_EQUALS(uid1.get(), GOOD_ID1);
+        TS_ASSERT_EQUALS(uid2.get(), GOOD_ID1);
+        // close uid2; uid2 is invaldiated, but uid1 is unchanged
+        uid2.reset();
+        TS_ASSERT_EQUALS(uid2.use_count(), 0);
+        TS_ASSERT_EQUALS(uid1.use_count(), 1);
+        TS_ASSERT(!uid2.isValid());
+        TS_ASSERT(uid1.isValid());
+        TS_ASSERT_EQUALS(uid1.get(), GOOD_ID1);
+        // deleter was not called on reset
+        TS_ASSERT_EQUALS(call_count, 0);
+      }
+      // the deleter was not called on exit
+      TS_ASSERT_EQUALS(call_count, 0);
+      // uid1 is still valid
+      TS_ASSERT_EQUALS(uid1.use_count(), 1);
+      TS_ASSERT(uid1.isValid());
+      TS_ASSERT_EQUALS(uid1.use_count(), 1);
+      TS_ASSERT_EQUALS(uid1.get(), GOOD_ID1);
+      {
+        // make another ID
+        TestSharedID uid3(uid1);
+        TS_ASSERT(uid3.isValid());
+        TS_ASSERT_EQUALS(uid1.use_count(), 2);
+        TS_ASSERT_EQUALS(uid3.use_count(), 2);
+        TS_ASSERT_EQUALS(uid1.get(), GOOD_ID1);
+        TS_ASSERT_EQUALS(uid3.get(), GOOD_ID1);
+        // close uid1
+        uid1.reset();
+        TS_ASSERT_EQUALS(uid1.use_count(), 0);
+        TS_ASSERT_EQUALS(uid3.use_count(), 1);
+        TS_ASSERT(!uid1.isValid());
+        TS_ASSERT(uid3.isValid());
+        TS_ASSERT_EQUALS(uid3.get(), GOOD_ID1);
+        // deleter was not called on reset
+        TS_ASSERT_EQUALS(call_count, 0);
+      }
+      // deleter called on exit (uid3)
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    // the deleter was not called on exit (uid1 already invalid)
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_sharedID_no_segfaults() {
+    cout << "\ntest sharedID no segfaults" << endl;
+    // Make sure calling the public API methods never generates a segfault.
+    // If handled improperly, there could be a nullptr dereference.
+    TestSharedID uid; // default init, leash counts is nullptr
+    // make sure none of these dereference the nullptr
+    TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
+    TS_ASSERT(!uid.isValid());
+    TS_ASSERT_EQUALS(uid.use_count(), 0);
+    TS_ASSERT_THROWS_NOTHING(uid.reset());
+    // set to a valid value, try again
+    uid = GOOD_ID1;
+    TS_ASSERT_EQUALS(uid.get(), GOOD_ID1);
+    TS_ASSERT(uid.isValid());
+    TS_ASSERT_EQUALS(uid.use_count(), 1);
+    // set to an invalid id, try again
+    TS_ASSERT_THROWS_NOTHING(uid.reset(BAD_ID));
+    TS_ASSERT_EQUALS(uid.get(), BAD_ID);
+    TS_ASSERT(!uid.isValid());
+    TS_ASSERT_EQUALS(uid.use_count(), 0);
+    // close the ID and then check
+    TS_ASSERT_THROWS_NOTHING(uid.reset());
+    TS_ASSERT_EQUALS(uid.get(), INVALID_HID);
+    TS_ASSERT(!uid.isValid());
+    TS_ASSERT_EQUALS(uid.use_count(), 0);
+  }
+
+  void test_sharedID_reset_close_no_segfault() {
+    cout << "\ntest sharedID no segfault when reset" << endl;
+    /** if handled improperly, then attempts to reset an invalidated ID can
+     * result in a segmentation fault, from dereferencing a null leash counter.
+     */
+    {
+      TestSharedID uid1(GOOD_ID1);
+      TS_ASSERT_EQUALS(uid1.use_count(), 1);
+      {
+        TestSharedID uid3(uid1);
+        uid1.reset();
+        // deleter not called on reset
+        TS_ASSERT_EQUALS(call_count, 0);
+      }
+      // deleter called on exit (uid3)
+      TS_ASSERT_EQUALS(call_count, 1);
+      TS_ASSERT(!uid1.isValid());
+      uid1.reset(); // should be a no-op
+    }
+    // the deleter was not called on exit (uid1 already invalid)
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_sharedID_increment_and_decrement() {
+    cout << "\ntest sharedID increment and decrement" << endl;
+
+    TestSharedID uid(GOOD_ID1);
+    std::size_t counts = uid.use_count();
+    constexpr std::size_t N = 10;
+    {
+      TestSharedID uids[N];
+      // up
+      for (std::size_t i = 0; i < N; i++) {
+        uids[i].reset(uid);
+        counts++;
+        TS_ASSERT_EQUALS(uid.use_count(), counts);
+      }
+
+      // down
+      for (std::size_t i = 0; i < N; i++) {
+        uids[i].reset();
+        counts--;
+        TS_ASSERT_EQUALS(uid.use_count(), counts);
+      }
+    }
+    TS_ASSERT_EQUALS(uid.use_count(), 1);
+  }
+
+  void test_sharedID_close_all_on_exit() {
+    cout << "\ntest sharedID all array elements closed on exit" << endl;
+
+    TestSharedID uid(GOOD_ID1);
+    std::size_t counts = uid.use_count();
+    constexpr std::size_t N = 10;
+    TestSharedID *puid; // this used to delete the array later
+    {
+      TestSharedID *uids = new TestSharedID[N];
+      for (std::size_t i = 0; i < N; i++) {
+        uids[i].reset(uid);
+        counts++;
+        TS_ASSERT_EQUALS(uid.use_count(), counts);
+      }
+      puid = uids; // save the pointer, to deleter it
+    }
+    // exiting scope does not clear the allocated array
+    TS_ASSERT_EQUALS(uid.use_count(), counts);
+    delete[] puid;
+    // deleting the allocated array clears those counts
+    TS_ASSERT_EQUALS(uid.use_count(), 1);
+  }
+
+  void test_sharedID_move_construct() {
+    cout << "\ntest sharedID move construct\n";
+    // move construct
+    hid_t test = GOOD_ID1;
+    {
+      TestSharedID uid1(test);
+      TS_ASSERT_EQUALS(uid1.use_count(), 1);
+      {
+        TestSharedID uid2(std::move(uid1));
+        TS_ASSERT_EQUALS(uid1.use_count(), 0);
+        TS_ASSERT_EQUALS(uid2.use_count(), 1);
+        TS_ASSERT_EQUALS(uid2.get(), test);
+      }
+      // uid2 out of scope, deleter called once
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    // ensure no double-delete
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_sharedID_assign_hid() {
+    // assign from hid_t
+    hid_t val1 = GOOD_ID1, val2 = GOOD_ID2;
+    {
+      TestSharedID uid(val1);
+      TS_ASSERT_EQUALS(uid.use_count(), 1);
+      TS_ASSERT_EQUALS(uid.get(), val1);
+      TS_ASSERT(uid.isValid());
+      // ASSIGN THE VALUE
+      uid = val2;
+      TS_ASSERT_EQUALS(uid.use_count(), 1);
+      TS_ASSERT_EQUALS(uid.get(), val2);
+      TS_ASSERT(uid.isValid());
+      TS_ASSERT_EQUALS(call_count, 1);
+    }
+    TS_ASSERT_EQUALS(call_count, 2);
+  }
+
+  void test_sharedID_thrice() {
+    cout << "\ntest a sharedId, thrice" << std::endl;
+
+    { // scoped fid
+      TestSharedID id1 = GOOD_ID1;
+      TestSharedID id2(id1);
+      TestSharedID id3(id2);
+      TS_ASSERT(id1.isValid());
+      TS_ASSERT(id2.isValid());
+      TS_ASSERT(id3.isValid());
+      TS_ASSERT_EQUALS(id1.use_count(), 3);
+      TS_ASSERT_EQUALS(id2.use_count(), 3);
+      TS_ASSERT_EQUALS(id3.use_count(), 3);
+      TS_ASSERT_EQUALS(id2.get(), id1.get());
+      TS_ASSERT_EQUALS(id3.get(), id1.get());
+      TS_ASSERT(id1 == id2);
+      TS_ASSERT(id1 == id3);
+      TS_ASSERT(id2 == id3);
+      // close fid1
+      id1.reset();
+      TS_ASSERT_EQUALS(call_count, 0);
+      TS_ASSERT(!id1.isValid());
+      TS_ASSERT(id2.isValid());
+      TS_ASSERT(id3.isValid());
+      TS_ASSERT_EQUALS(id1.use_count(), 0);
+      TS_ASSERT_EQUALS(id2.use_count(), 2);
+      TS_ASSERT_EQUALS(id3.use_count(), 2);
+      TS_ASSERT_EQUALS(id2.get(), id3.get());
+      TS_ASSERT(!(id1 == id2));
+      TS_ASSERT(!(id1 == id3));
+      TS_ASSERT(id2 == id3);
+      // close fid3
+      id3.reset();
+      TS_ASSERT_EQUALS(call_count, 0);
+      TS_ASSERT(!id1.isValid());
+      TS_ASSERT(id2.isValid());
+      TS_ASSERT(!id3.isValid());
+      TS_ASSERT_EQUALS(id1.use_count(), 0);
+      TS_ASSERT_EQUALS(id2.use_count(), 1);
+      TS_ASSERT_EQUALS(id3.use_count(), 0);
+      TS_ASSERT_DIFFERS(id2.get(), id3.get());
+      TS_ASSERT(!(id1 == id2));
+      TS_ASSERT(!(id2 == id3));
+    } // last id goes out of scope and deconstructor is called
+    // the destructor is now called
+    TS_ASSERT_EQUALS(call_count, 1);
+  }
+
+  void test_sharedID_files() {
+    cout << "\ntest the shared file id" << std::endl;
+
+    // create a file
+    FileResource resource("test_nexus_fid.nxs");
+    std::string filename(resource.fullPath());
+    ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+    // create and then close the file
+    {
+      UniqueFileID fid_temp = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+      TS_ASSERT(!hdf_file_is_closed(filename));
+    }
+    TS_ASSERT(hdf_file_is_closed(filename));
+    // now check sharing a file id
+    { // scoped fid
+      SharedFileID fid1 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+      SharedFileID fid2(fid1);
+      SharedFileID fid3(fid2);
+      TS_ASSERT_EQUALS(fid1.use_count(), 3);
+      TS_ASSERT_EQUALS(fid2.use_count(), 3);
+      TS_ASSERT_EQUALS(fid3.use_count(), 3);
+      TS_ASSERT_EQUALS(fid2.get(), fid1.get());
+      TS_ASSERT_EQUALS(fid3.get(), fid1.get());
+      TS_ASSERT(fid1 == fid2);
+      TS_ASSERT(fid2 == fid3);
+      TS_ASSERT(fid3 == fid1);
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      // close fid1
+      fid1.reset();
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid2.isValid());
+      TS_ASSERT(fid3.isValid());
+      TS_ASSERT(!(fid1 == fid2));
+      TS_ASSERT(!(fid1 == fid3));
+      TS_ASSERT(fid2 == fid3);
+      TS_ASSERT_EQUALS(fid3.use_count(), 2);
+      // close fid3
+      fid3.reset();
+      TS_ASSERT(!hdf_file_is_closed(filename));
+      TS_ASSERT(fid2.isValid());
+    } // last fid goes out of scope and destructor is called
+    // the file is now closed
+    TS_ASSERT(hdf_file_is_closed(filename));
+  }
+
+  void test_sharedId_thread_safety() {
+    constexpr int N{10};
+    TestSharedID id(GOOD_ID1);
+    std::vector<TestSharedID> ids(N);
+    std::vector<std::thread> threads;
+
+    // create some ids and increment count
+    std::function<void(int)> make_another = [&id, &ids](int i) { ids[i] = id; };
+    for (int i = 0; i < N; i++) {
+      threads.emplace_back(make_another, i);
+    }
+    for (int i = 0; i < N; i++) {
+      threads[i].join();
+    }
+    // now check
+    TS_ASSERT_EQUALS(id.use_count(), N + 1);
+
+    // delete some ids and verify counts
+    threads.clear();
+    std::function<void(int)> remove_more = [&ids](int i) { ids[i].reset(); };
+    for (int i = 0; i < N; ++i) {
+      threads.emplace_back(remove_more, i);
+    }
+    for (int i = 0; i < N; i++) {
+      threads[i].join();
+    }
+    // now check
+    TS_ASSERT_EQUALS(id.use_count(), 1);
   }
 };

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -727,13 +727,17 @@ public:
   }
 
   void test_sharedId_thread_safety() {
+// NOTE this warning causes build failures; suppress for now
+// the issue is caused by capturing variables of type TestSharedID,
+// which have a deleter method defined at global scope
+#pragma GCC diagnostic ignored "-Wsubobject-linkage"
     constexpr int N{10};
     TestSharedID id(GOOD_ID1);
     std::vector<TestSharedID> ids(N);
     std::vector<std::thread> threads;
 
     // create some ids and increment count
-    std::function<void(int)> make_another = [&id, &ids](int i) { ids[i] = id; };
+    std::function<void(int)> make_another = [&ids, &id](int i) { ids[i] = id; };
     for (int i = 0; i < N; i++) {
       threads.emplace_back(make_another, i);
     }

--- a/Framework/Nexus/test/test_helper.cpp
+++ b/Framework/Nexus/test/test_helper.cpp
@@ -51,8 +51,6 @@ std::string NexusTest::strmakef(const char *const fmt, ...) {
   return s;
 }
 
-using ssize_t = long int;
-
 bool NexusTest::hdf_file_is_closed(std::string const &filename) {
   ssize_t file_count = H5Fget_obj_count(H5F_OBJ_ALL, H5F_OBJ_FILE);
   if (file_count < 0) {

--- a/Framework/Nexus/test/test_helper.cpp
+++ b/Framework/Nexus/test/test_helper.cpp
@@ -1,6 +1,7 @@
 #include "test_helper.h"
 #include "MantidKernel/ConfigService.h"
 #include <cstdarg>
+#include <hdf5.h>
 #include <iostream>
 
 void NexusTest::removeFile(const std::string &filename) {
@@ -48,6 +49,38 @@ std::string NexusTest::strmakef(const char *const fmt, ...) {
   std::vsnprintf(&(*s.begin()), len + 1, fmt, args);
   va_end(args);
   return s;
+}
+
+using ssize_t = long int;
+
+bool NexusTest::hdf_file_is_closed(std::string const &filename) {
+  ssize_t file_count = H5Fget_obj_count(H5F_OBJ_ALL, H5F_OBJ_FILE);
+  if (file_count < 0) {
+    throw std::runtime_error("failure to get opened file count");
+  } else if (file_count == 0) {
+    // no files are opened
+    return true;
+  } else {
+    // some files are opened -- see if maybe ours is
+    std::vector<hid_t> file_ids(file_count);
+    ssize_t ret = H5Fget_obj_ids(H5F_OBJ_ALL, H5F_OBJ_FILE, file_count, file_ids.data());
+    if (ret < 0) {
+      throw std::runtime_error("failure to find opened files");
+    } else if (ret == 0) {
+      return true;
+    } else {
+      for (hid_t file_id : file_ids) {
+        // get the name and check it
+        ssize_t name_size = H5Fget_name(file_id, nullptr, 0);
+        std::string check_name(name_size, 'X');
+        H5Fget_name(file_id, check_name.data(), name_size + 1);
+        if (check_name == filename) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
 }
 
 NexusTest::FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debugMode(debugMode) {

--- a/Framework/Nexus/test/test_helper.h
+++ b/Framework/Nexus/test/test_helper.h
@@ -22,6 +22,14 @@ std::string getFullPath(const std::string &filename);
 std::string strmakef(char const *const fmt, ...);
 
 /**
+ * This will check if an HDF file is open.  It will first check if any files are open.
+ * If any are, it will looking for the given filename in the list of all opened files.
+ * @param filename the filename to check if opened
+ * @return true if the file has been closed; otherwise false
+ */
+bool hdf_file_is_closed(std::string const &filename);
+
+/**
  * Makes a temporary file in a proper temp folder an ensures deletion on creation and exit.
  * NOTE: this is a copy of a framework test helper, put here to simplify NexusTest build tree.
  */


### PR DESCRIPTION
### Description of work

Follows on from the Nexus refactor.  Due to the use of the HDF5 C-API within `Nexus::File`, there were several occasions that could lead to memory leaks.  Previously, this was addressed by the creation of `UniqueID`, mirroring `unique_ptr`, which ensures only one owner of HDF5 handles and that the correct close method is called on scope exit.  This was handled in PRs:
- https://github.com/mantidproject/mantid/pull/40368
- https://github.com/mantidproject/mantid/pull/40464
- https://github.com/mantidproject/mantid/pull/40474

To prevent memory leaks or premature file close errors across multiple owners opening the same file, `Nexus::File` was given a `shared_ptr` that pointed to a `UniqueID<&H5Fclose>` (that is, a file handle).  However, this was kind of a kludge to allow multiple ownership of a class designed for single ownership.

This PR creates a `SharedID`, similar to `UniqueID`, but allowing multiple ownership.  Owners are tracked through a counter, and all co-owners have a pointer to this counter.  When the number of leashes drops to zero, the corresponding closer method is called on the managed ID.  Tests help ensure this is thread safe.

### To test:

Build and run the `VanadiumAndFocusWithSolidAngleTest`:
```
ninja Framework && ./systemtest -R VanadiumAndFocusWithSolidAngleTest
```

Build and run the Multithreaded test:
```
ninja Framework && ./systemtest -R MultiThreadedLoadNeXusTest
```

Check the new tests, especially the tests of thread safety, to ensure the logic makes sense.

Try building and running this script:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import LoadNexusProcessed

dir = # path to biosans test data needs to go here
file1 = f'{dir}/CG3_127_5532_mBSub.h5'
file2 = f'{dir}/CG3_127_5562_mBSub.h5'
for i in range(3):
    ws1 = LoadNexusProcessed(Filename=file1, OutputWorkspace='sample', LoadHistory=False)
    ws2 = LoadNexusProcessed(Filename=file2, OutputWorkspace='Main_buffer', LoadHistory=False)
    ws1.delete()
    ws2.delete()
```
to check for no memory leaks during the load process.  Total memory usage should stay roughly constant, even if the `for`-loop is re-run multiple times.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
