### PR TITLE
Application of multiple `IPropertySettings`

### DIFF
--- a/Framework/API/test/EnabledWhenWorkspaceIsTypeTest.h
+++ b/Framework/API/test/EnabledWhenWorkspaceIsTypeTest.h
@@ -57,17 +57,17 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Property always returns visible.", prop->getSettings()->isVisible(&alg))
+    TSM_ASSERT("Property always returns visible.", prop->getSettings()[0]->isVisible(&alg))
     TSM_ASSERT("Property always returns valid.", prop->isValid().empty())
 
-    TSM_ASSERT("Starts off enabled because empty", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off enabled because empty", prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty("InputWorkspace", "tester");
-    TSM_ASSERT("Becomes disabled when the workspace is the wrong type", !prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Becomes disabled when the workspace is the wrong type", !prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty("InputWorkspace", "testersub");
-    TSM_ASSERT("Becomes enabled when the workspace is correct type", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Becomes enabled when the workspace is correct type", prop->getSettings()[0]->isEnabled(&alg));
 
-    TSM_ASSERT("Starts disabled when the workspace is correct type", !prop2->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts disabled when the workspace is correct type", !prop2->getSettings()[0]->isEnabled(&alg));
     alg.setProperty("InputWorkspace", "tester");
-    TSM_ASSERT("Becomes enabled when the workspace is the wrong type", prop2->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Becomes enabled when the workspace is the wrong type", prop2->getSettings()[0]->isEnabled(&alg));
   }
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
@@ -131,7 +131,7 @@ public:
   bool isEnabled(const Mantid::Kernel::IPropertyManager *algo) const override;
   bool isConditionChanged(const Mantid::Kernel::IPropertyManager *algo,
                           const std::string &changedPropName = "") const override;
-  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &propName) override;
+  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &propName) const override;
 
   // interface needs it but if indeed proper clone used -- do not know.
   IPropertySettings *clone() const override {

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -72,7 +72,7 @@ bool MonIDPropChanger::isConditionChanged(const IPropertyManager *algo, const st
 }
 
 // function which modifies the allowed values for the list of monitors.
-bool MonIDPropChanger::applyChanges(const IPropertyManager *algo, const std::string &propName) {
+bool MonIDPropChanger::applyChanges(const IPropertyManager *algo, const std::string &propName) const {
   auto *piProp = dynamic_cast<Kernel::PropertyWithValue<int> *>(algo->getPointerToProperty(propName));
   if (!piProp) {
     throw(std::invalid_argument("modify allowed value has been called on wrong property"));

--- a/Framework/Algorithms/test/NormaliseToMonitorTest.h
+++ b/Framework/Algorithms/test/NormaliseToMonitorTest.h
@@ -355,11 +355,11 @@ public:
     Property *monSpec = norm6.getProperty("MonitorID");
     // this function is usually called by GUI when senning input workspace. It
     // should read monitors and report the condition changed
-    TS_ASSERT(monSpec->getSettings()->isConditionChanged(&norm6));
+    TS_ASSERT(monSpec->getSettings()[0]->isConditionChanged(&norm6));
     // this funciton is called by gui when the above is true. It should not
     // throw and change the validator
-    IPropertySettings *pSett(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSett = monSpec->getSettings());
+    IPropertySettings const *pSett(nullptr);
+    TS_ASSERT_THROWS_NOTHING(pSett = monSpec->getSettings()[0].get());
     TS_ASSERT_THROWS_NOTHING(pSett->applyChanges(&norm6, monSpec->name()));
     // it should return the list of allowed monitor ID-s
     std::vector<std::string> monitors = monSpec->allowedValues();
@@ -378,10 +378,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(norm6.setPropertyValue("InputWorkspace", "someWS"));
     // this function is usually called by GUI when setting an input workspace.
     // It should read monitors and report the condition changed
-    TS_ASSERT(monSpec->getSettings()->isConditionChanged(&norm6));
+    TS_ASSERT(monSpec->getSettings()[0]->isConditionChanged(&norm6));
     // this funciton is called by gui when the above is true. It should not
     // throw and change the validator
-    TS_ASSERT_THROWS_NOTHING(pSett = monSpec->getSettings());
+    TS_ASSERT_THROWS_NOTHING(pSett = monSpec->getSettings()[0].get());
     TS_ASSERT_THROWS_NOTHING(pSett->applyChanges(&norm6, monSpec->name()));
     // it should return the list of allowed monitor ID-s
     monitors = monSpec->allowedValues();

--- a/Framework/Kernel/inc/MantidKernel/EnabledWhenProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/EnabledWhenProperty.h
@@ -97,11 +97,6 @@ public:
   /// Other properties that this property depends on.
   std::vector<std::string> dependsOn(const std::string &thisProp) const override;
 
-#if 0 // *** DEBUG *** => this seems deprecated?
-  /// Stub function to satisfy the interface.
-  void modify_allowed_values(Property *const);
-#endif
-
   /// Make a copy of the present type of validator
   IPropertySettings *clone() const override;
 

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -320,7 +320,14 @@ public:
   /// Return the property manager serialized as a json object.
   virtual ::Json::Value asJson(bool withDefaultValues = false) const = 0;
 
-  void setPropertySettings(const std::string &name, std::unique_ptr<IPropertySettings> settings);
+  /// Add a PropertySettings instance to the chain of settings for a given property
+  void setPropertySettings(const std::string &name, std::unique_ptr<IPropertySettings const> settings);
+
+  /// Test if a given property should be enabled
+  bool isPropertyEnabled(const std::string &name) const;
+
+  /// Test if a given property should be visible
+  bool isPropertyVisible(const std::string &name) const;
 
   /** Set the group for a given property
    * @param name :: property name

--- a/Framework/Kernel/inc/MantidKernel/IPropertySettings.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertySettings.h
@@ -58,7 +58,7 @@ public:
    *
    *  @return: whether or not the current property was changed.
    */
-  virtual bool applyChanges(const IPropertyManager *algo, const std::string &currentPropName) {
+  virtual bool applyChanges(const IPropertyManager *algo, const std::string &currentPropName) const {
     UNUSED_ARG(algo);
     UNUSED_ARG(currentPropName);
     return false;

--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -111,13 +111,12 @@ public:
   virtual std::string isValid() const;
 
   /// Set the PropertySettings object
-  void setSettings(std::unique_ptr<IPropertySettings> settings);
+  void setSettings(std::unique_ptr<IPropertySettings const> settings);
 
-  /** @return the PropertySettings for this property */
-  const IPropertySettings *getSettings() const;
-  IPropertySettings *getSettings();
+  /** @return the vector of PropertySettings for this property */
+  std::vector<std::unique_ptr<IPropertySettings const>> const &getSettings() const;
 
-  /** Deletes the PropertySettings object contained */
+  /** Clears the vector of PropertySettings for this property */
   void clearSettings();
 
   /// Overriden function that returns if property has the same value that it was
@@ -229,7 +228,7 @@ private:
   std::string m_units;
 
   /// Property settings (enabled/visible)
-  std::unique_ptr<IPropertySettings> m_settings;
+  std::vector<std::unique_ptr<IPropertySettings const>> m_settings;
 
   /// Name of the "group" of this property, for grouping in the GUI. Default ""
   std::string m_group;

--- a/Framework/Kernel/inc/MantidKernel/SetDefaultWhenProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/SetDefaultWhenProperty.h
@@ -32,7 +32,7 @@ public:
 
   /// If a new value should be set, the change is applied here.
   /// Return true if current property was changed.
-  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &currentPropName) override;
+  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &currentPropName) const override;
 
   /// Other properties that this property depends on.
   std::vector<std::string> dependsOn(const std::string &thisProp) const override;

--- a/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/SetValueWhenProperty.h
@@ -32,7 +32,7 @@ public:
 
   /// If a new value should be set, the change is applied here.
   /// Return true if the current property was actually changed.
-  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &currentPropName) override;
+  bool applyChanges(const Mantid::Kernel::IPropertyManager *algo, const std::string &currentPropName) const override;
 
   /// Other properties that this property depends on.
   std::vector<std::string> dependsOn(const std::string &thisProp) const override;

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -91,11 +91,9 @@ void IPropertyManager::setPropertySettings(const std::string &name, std::unique_
  */
 bool IPropertyManager::isPropertyEnabled(const std::string &name) const {
   Property *prop = getPointerToProperty(name);
-  if (!prop->getSettings().empty())
-    // Allow any setting in the chain of settings to disable the property.
-    return std::all_of(prop->getSettings().begin(), prop->getSettings().end(),
-                       [this](auto const &ptr) { return ptr->isEnabled(this); });
-  return true;
+  // Allow any setting in the chain of settings to disable the property.
+  return std::all_of(prop->getSettings().begin(), prop->getSettings().end(),
+                     [this](auto const &ptr) { return ptr->isEnabled(this); });
 }
 
 /** Test if a given property should be visible,
@@ -110,7 +108,6 @@ bool IPropertyManager::isPropertyVisible(const std::string &name) const {
   // Allow any setting in the chain of settings to hide the property.
   return std::all_of(prop->getSettings().begin(), prop->getSettings().end(),
                      [this](auto const &ptr) { return ptr->isVisible(this); });
-  return true;
 }
 
 /**

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -8,6 +8,8 @@
 #include "MantidKernel/IPropertySettings.h"
 #include "MantidKernel/OptionalBool.h"
 
+#include <algorithm>
+
 ///@cond
 DEFINE_IPROPERTYMANAGER_GETVALUE(int16_t)
 DEFINE_IPROPERTYMANAGER_GETVALUE(uint16_t)
@@ -77,10 +79,38 @@ void IPropertyManager::updatePropertyValues(const IPropertyManager &other) {
  * property
  * @param name :: property name
  * @param settings :: IPropertySettings     */
-void IPropertyManager::setPropertySettings(const std::string &name, std::unique_ptr<IPropertySettings> settings) {
+void IPropertyManager::setPropertySettings(const std::string &name, std::unique_ptr<IPropertySettings const> settings) {
   Property *prop = getPointerToProperty(name);
   if (prop)
     prop->setSettings(std::move(settings));
+}
+
+/** Test if a given property should be enabled
+ * @param name :: property name
+ * @return True if the property should be enabled
+ */
+bool IPropertyManager::isPropertyEnabled(const std::string &name) const {
+  Property *prop = getPointerToProperty(name);
+  if (!prop->getSettings().empty())
+    // Allow any setting in the chain of settings to disable the property.
+    return std::all_of(prop->getSettings().begin(), prop->getSettings().end(),
+                       [this](auto const &ptr) { return ptr->isEnabled(this); });
+  return true;
+}
+
+/** Test if a given property should be visible,
+ *  according to its PropertySettings chain.
+ *  This may be overridden: in general, properties with errors
+ *  will be made visible by the `AlgorithmPropertiesWidget`.
+ * @param name :: property name
+ * @return True if the property should be visible
+ */
+bool IPropertyManager::isPropertyVisible(const std::string &name) const {
+  Property *prop = getPointerToProperty(name);
+  // Allow any setting in the chain of settings to hide the property.
+  return std::all_of(prop->getSettings().begin(), prop->getSettings().end(),
+                     [this](auto const &ptr) { return ptr->isVisible(this); });
+  return true;
 }
 
 /**

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -48,8 +48,10 @@ Property::Property(const Property &right)
   if (m_name.empty()) {
     throw std::invalid_argument("An empty property name is not permitted");
   }
-  if (right.m_settings)
-    m_settings.reset(right.m_settings->clone());
+  if (!right.m_settings.empty()) {
+    for (const auto &settings : right.m_settings)
+      m_settings.emplace_back(std::unique_ptr<IPropertySettings const>(settings->clone()));
+  }
 }
 
 /// Virtual destructor
@@ -100,19 +102,20 @@ std::string Property::isValid() const {
  * Takes ownership of the given object
  * @param settings A pointer to an object specifying the settings type
  */
-void Property::setSettings(std::unique_ptr<IPropertySettings> settings) { m_settings = std::move(settings); }
+void Property::setSettings(std::unique_ptr<IPropertySettings const> settings) {
+  m_settings.emplace_back(std::move(settings));
+}
 
 /**
  *
- * @return the PropertySettings for this property
+ * @return the vector of PropertySettings for this property
  */
-const IPropertySettings *Property::getSettings() const { return m_settings.get(); }
-IPropertySettings *Property::getSettings() { return m_settings.get(); }
+std::vector<std::unique_ptr<IPropertySettings const>> const &Property::getSettings() const { return m_settings; }
 
 /**
- * Deletes the PropertySettings object contained
+ * Clear the vector of PropertySettings for this property
  */
-void Property::clearSettings() { m_settings.reset(nullptr); }
+void Property::clearSettings() { m_settings.clear(); }
 
 /**
  * Whether to remember this property input

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -14,6 +14,8 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
+#include <algorithm>
+#include <iterator>
 #include <unordered_map>
 
 namespace Mantid {
@@ -45,13 +47,11 @@ Property::Property(const Property &right)
       m_direction(right.m_direction), m_units(right.m_units), m_group(right.m_group), m_remember(right.m_remember),
       m_autotrim(right.m_autotrim), m_disableReplaceWSButton(right.m_disableReplaceWSButton),
       m_isDynamicDefault(right.m_isDynamicDefault) {
-  if (m_name.empty()) {
+  if (m_name.empty())
     throw std::invalid_argument("An empty property name is not permitted");
-  }
-  if (!right.m_settings.empty()) {
-    for (const auto &settings : right.m_settings)
-      m_settings.emplace_back(std::unique_ptr<IPropertySettings const>(settings->clone()));
-  }
+
+  std::transform(right.m_settings.begin(), right.m_settings.end(), std::back_inserter(m_settings),
+                 [](auto const &settings) { return std::unique_ptr<IPropertySettings const>(settings->clone()); });
 }
 
 /// Virtual destructor

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -565,7 +565,7 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   ::Json::Value jsonMap;
   const auto count = static_cast<int>(propertyCount());
   for (int i = 0; i < count; ++i) {
-    Property *p = getPointerToPropertyOrdinal(i);
+    Property const *p = getPointerToPropertyOrdinal(i);
     if (isPropertyEnabled(p->name()) && p->isValueSerializable() && (withDefaultValues || !p->isDefault())) {
       jsonMap[p->name()] = p->valueAsJson();
     }

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -566,11 +566,7 @@ std::string PropertyManager::asString(bool withDefaultValues) const {
   const auto count = static_cast<int>(propertyCount());
   for (int i = 0; i < count; ++i) {
     Property *p = getPointerToPropertyOrdinal(i);
-    bool is_enabled = true;
-    if (p->getSettings()) {
-      is_enabled = p->getSettings()->isEnabled(this);
-    }
-    if (p->isValueSerializable() && (withDefaultValues || !p->isDefault()) && is_enabled) {
+    if (isPropertyEnabled(p->name()) && p->isValueSerializable() && (withDefaultValues || !p->isDefault())) {
       jsonMap[p->name()] = p->valueAsJson();
     }
   }

--- a/Framework/Kernel/src/SetDefaultWhenProperty.cpp
+++ b/Framework/Kernel/src/SetDefaultWhenProperty.cpp
@@ -39,7 +39,7 @@ bool SetDefaultWhenProperty::isConditionChanged(const IPropertyManager *algo,
   return changedPropName == m_watchedPropName;
 }
 
-bool SetDefaultWhenProperty::applyChanges(const IPropertyManager *algo, const std::string &currentPropName) {
+bool SetDefaultWhenProperty::applyChanges(const IPropertyManager *algo, const std::string &currentPropName) const {
   try {
     auto currentProperty = algo->getPointerToProperty(currentPropName);
     auto watchedProperty = algo->getPointerToProperty(m_watchedPropName);

--- a/Framework/Kernel/src/SetValueWhenProperty.cpp
+++ b/Framework/Kernel/src/SetValueWhenProperty.cpp
@@ -38,7 +38,7 @@ bool SetValueWhenProperty::isConditionChanged(const IPropertyManager *algo, cons
   return watchedProp->name() == changedPropName;
 }
 
-bool SetValueWhenProperty::applyChanges(const IPropertyManager *algo, const std::string &currentPropName) {
+bool SetValueWhenProperty::applyChanges(const IPropertyManager *algo, const std::string &currentPropName) const {
   try {
     auto *currentProperty = algo->getPointerToProperty(currentPropName);
     const auto *watchedProperty = algo->getPointerToProperty(m_watchedPropName);

--- a/Framework/Kernel/test/EnabledWhenPropertyTest.h
+++ b/Framework/Kernel/test/EnabledWhenPropertyTest.h
@@ -35,20 +35,20 @@ public:
     Property *prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
 
-    TSM_ASSERT("Property always returns visible.", prop->getSettings()->isVisible(&alg))
+    TSM_ASSERT("Property always returns visible.", prop->getSettings()[0]->isVisible(&alg))
     TSM_ASSERT("Property always returns valid.", prop->isValid().empty())
 
-    TSM_ASSERT("Starts off NOT enabled", !prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off NOT enabled", !prop->getSettings()[0]->isEnabled(&alg));
     // Change the property so it is no longer default
     alg.setProperty(m_propertyOneName, 234);
-    TSM_ASSERT("Becomes enabled when another property has been changed", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Becomes enabled when another property has been changed", prop->getSettings()[0]->isEnabled(&alg));
 
     alg.declareProperty(m_propertyTwoName, 456);
     alg.setPropertySettings(m_propertyTwoName, enabledWhenNotDefault());
     prop = alg.getPointerToProperty(m_propertyTwoName);
-    TSM_ASSERT("Starts off enabled", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off enabled", prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty(m_propertyOneName, 123);
-    TSM_ASSERT("Goes back to disabled", !prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Goes back to disabled", !prop->getSettings()[0]->isEnabled(&alg));
   }
 
   void test_when_IS_DEFAULT() {
@@ -63,9 +63,9 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off enabled", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off enabled", prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty(m_propertyOneName, -1);
-    TSM_ASSERT("Becomes disabled when another property has been changed", !prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Becomes disabled when another property has been changed", !prop->getSettings()[0]->isEnabled(&alg));
   }
 
   void test_when_IS_EQUAL_TO() {
@@ -78,10 +78,10 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off disabled", !prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off disabled", !prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty(m_propertyOneName, 234);
     TSM_ASSERT("Becomes enabled when the other property is equal to the given string",
-               prop->getSettings()->isEnabled(&alg));
+               prop->getSettings()[0]->isEnabled(&alg));
   }
 
   void test_when_IS_NOT_EQUAL_TO() {
@@ -94,10 +94,10 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off enabled", prop->getSettings()->isEnabled(&alg));
+    TSM_ASSERT("Starts off enabled", prop->getSettings()[0]->isEnabled(&alg));
     alg.setProperty(m_propertyOneName, 234);
     TSM_ASSERT("Becomes disabled when the other property is equal to the given string",
-               !prop->getSettings()->isEnabled(&alg));
+               !prop->getSettings()[0]->isEnabled(&alg));
   }
 
   void test_combination_AND() {
@@ -105,7 +105,7 @@ public:
     auto alg = setupCombinationTest(AND, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // AND should return true first
     TS_ASSERT(propSettings->isEnabled(&alg));
@@ -120,7 +120,7 @@ public:
     auto alg = setupCombinationTest(OR, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // OR should return true for both values on
     TS_ASSERT(propSettings->isEnabled(&alg));
@@ -145,7 +145,7 @@ public:
     auto alg = setupCombinationTest(XOR, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // With both set to the same value this should return false
     TS_ASSERT(!propSettings->isEnabled(&alg));

--- a/Framework/Kernel/test/PropertyTest.h
+++ b/Framework/Kernel/test/PropertyTest.h
@@ -8,13 +8,16 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidKernel/IPropertySettings.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/PropertyHistory.h"
 #include <json/value.h>
 
 using namespace Mantid::Kernel;
 
-// Helper class
+namespace {
+
+// Test helper class to allow access to `Property` methods.
 class PropertyHelper : public Property {
 public:
   PropertyHelper(const std::string &name = "Test") : Property(name, typeid(int)) {}
@@ -29,6 +32,52 @@ public:
   std::string getDefault() const override { return "Is not implemented in this class, should be overriden"; }
   Property &operator+=(Property const *) override { return *this; }
 };
+
+class MockPropertySettings : public IPropertySettings {
+public:
+  using ApplyCallback = std::function<bool(const IPropertyManager *, const std::string &)>;
+
+  bool isEnabled(const IPropertyManager *) const override { return m_isEnabledDefault; }
+
+  bool isVisible(const IPropertyManager *) const override { return m_isVisibleDefault; }
+
+  bool isConditionChanged(const IPropertyManager *, const std::string &) const override {
+    return m_isConditionChangedDefault;
+  }
+
+  bool applyChanges(const IPropertyManager *algo, const std::string &currentPropName) const override {
+    if (m_applyCallback)
+      return m_applyCallback(algo, currentPropName);
+    return false;
+  }
+
+  MockPropertySettings() = default;
+
+  IPropertySettings *clone() const override {
+    auto *copy = new MockPropertySettings();
+
+    // Copy configuration state
+    copy->m_isEnabledDefault = m_isEnabledDefault;
+    copy->m_isVisibleDefault = m_isVisibleDefault;
+    copy->m_isConditionChangedDefault = m_isConditionChangedDefault;
+    copy->m_applyCallback = m_applyCallback;
+
+    return copy;
+  }
+
+  void setIsEnabledReturn(bool v) { m_isEnabledDefault = v; }
+  void setIsVisibleReturn(bool v) { m_isVisibleDefault = v; }
+  void setIsConditionChangedReturn(bool v) { m_isConditionChangedDefault = v; }
+  void setApplyChangesCallback(ApplyCallback cb) { m_applyCallback = std::move(cb); }
+
+private:
+  bool m_isEnabledDefault{true};
+  bool m_isVisibleDefault{true};
+  bool m_isConditionChangedDefault{false};
+  ApplyCallback m_applyCallback;
+};
+
+} // namespace
 
 class PropertyTest : public CxxTest::TestSuite {
 public:
@@ -106,6 +155,38 @@ public:
     TS_ASSERT(p->disableReplaceWSButton());
     p->setDisableReplaceWSButton(false);
     TS_ASSERT(!p->disableReplaceWSButton());
+  }
+
+  /// Verify that `Property::getSettings()` with no attached `IPropertySettings`
+  /// returns an empty vector.
+  void test_getSettings_empty() {
+    auto p = std::make_unique<PropertyHelper>();
+    TS_ASSERT(p->getSettings().empty());
+  }
+
+  /// Verify that `Property::getSettings()` with multiple attached `IPropertySettings`
+  /// returns an vector of settings.
+  void test_getSettings_multiple() {
+    auto p = std::make_unique<PropertyHelper>();
+    TS_ASSERT(p->getSettings().empty());
+
+    const size_t N_settings = 5;
+    for (size_t n = 0; n < N_settings; ++n)
+      p->setSettings(std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    TS_ASSERT_EQUALS(p->getSettings().size(), N_settings);
+  }
+
+  /// Verify that `Property::clearSettings()` with multiple attached `IPropertySettings`
+  /// clears the settings vector.
+  void test_clearSettings() {
+    auto p = std::make_unique<PropertyHelper>();
+    const size_t N_settings = 5;
+    for (size_t n = 0; n < N_settings; ++n)
+      p->setSettings(std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    TS_ASSERT_EQUALS(p->getSettings().size(), N_settings);
+
+    p->clearSettings();
+    TS_ASSERT(p->getSettings().empty());
   }
 
 private:

--- a/Framework/Kernel/test/VisibleWhenPropertyTest.h
+++ b/Framework/Kernel/test/VisibleWhenPropertyTest.h
@@ -31,20 +31,20 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Property always returns enabled.", prop->getSettings()->isEnabled(&alg))
+    TSM_ASSERT("Property always returns enabled.", prop->getSettings()[0]->isEnabled(&alg))
     TSM_ASSERT("Property always returns valid.", prop->isValid().empty())
 
-    TSM_ASSERT("Starts off NOT Visible", !prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Starts off NOT Visible", !prop->getSettings()[0]->isVisible(&alg));
     alg.setProperty("MyIntProp", 234);
-    TSM_ASSERT("Becomes visible when another property has been changed", prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Becomes visible when another property has been changed", prop->getSettings()[0]->isVisible(&alg));
 
     alg.declareProperty("MySecondValidatorProp", 456);
     alg.setPropertySettings("MySecondValidatorProp",
                             std::make_unique<VisibleWhenProperty>("MyIntProp", IS_NOT_DEFAULT));
     prop = alg.getPointerToProperty("MySecondValidatorProp");
-    TSM_ASSERT("Starts off visible", prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Starts off visible", prop->getSettings()[0]->isVisible(&alg));
     alg.setProperty("MyIntProp", 123);
-    TSM_ASSERT("Goes back to not visible", !prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Goes back to not visible", !prop->getSettings()[0]->isVisible(&alg));
   }
 
   void test_when_IS_DEFAULT() {
@@ -58,9 +58,9 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off visible", prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Starts off visible", prop->getSettings()[0]->isVisible(&alg));
     alg.setProperty("MyIntProp", -1);
-    TSM_ASSERT("Becomes not visible when another property has been changed", !prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Becomes not visible when another property has been changed", !prop->getSettings()[0]->isVisible(&alg));
   }
 
   void test_when_IS_EQUAL_TO() {
@@ -72,10 +72,10 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off not visible", !prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Starts off not visible", !prop->getSettings()[0]->isVisible(&alg));
     alg.setProperty("MyIntProp", 234);
     TSM_ASSERT("Becomes visible when the other property is equal to the given string",
-               prop->getSettings()->isVisible(&alg));
+               prop->getSettings()[0]->isVisible(&alg));
   }
 
   void test_when_IS_NOT_EQUAL_TO() {
@@ -88,10 +88,10 @@ public:
     TS_ASSERT(prop);
     if (!prop)
       return;
-    TSM_ASSERT("Starts off not visible", prop->getSettings()->isVisible(&alg));
+    TSM_ASSERT("Starts off not visible", prop->getSettings()[0]->isVisible(&alg));
     alg.setProperty("MyIntProp", 234);
     TSM_ASSERT("Becomes visible when the other property is equal to the given string",
-               !prop->getSettings()->isVisible(&alg));
+               !prop->getSettings()[0]->isVisible(&alg));
   }
 
   void test_combination_AND() {
@@ -99,7 +99,7 @@ public:
     auto alg = setupCombinationTest(AND, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // AND should return true first
     TS_ASSERT(propSettings->isVisible(&alg));
@@ -115,7 +115,7 @@ public:
     auto alg = setupCombinationTest(OR, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // OR should return true for both values on
     TS_ASSERT(propSettings->isVisible(&alg));
@@ -140,7 +140,7 @@ public:
     auto alg = setupCombinationTest(XOR, true);
     const auto prop = alg.getPointerToProperty(m_resultPropName);
     TS_ASSERT(prop);
-    const auto propSettings = prop->getSettings();
+    const auto &propSettings = prop->getSettings()[0];
 
     // With both set to the same value this should return false
     TS_ASSERT(!propSettings->isVisible(&alg));

--- a/Framework/MDAlgorithms/test/SliceMDTest.h
+++ b/Framework/MDAlgorithms/test/SliceMDTest.h
@@ -69,11 +69,11 @@ private:
     */
     Mantid::Kernel::Property *p = alg.getProperty("MaxRecursionDepth");
     if (bTakeDepthFromInput) {
-      TSM_ASSERT_EQUALS("MaxRecusionDepth property should NOT be enabled", false, p->getSettings()->isEnabled(&alg));
+      TSM_ASSERT_EQUALS("MaxRecusionDepth property should NOT be enabled", false, p->getSettings()[0]->isEnabled(&alg));
       TSM_ASSERT_EQUALS("Should have passed the maxium depth onto the ouput workspace.",
                         in_ws->getBoxController()->getMaxDepth(), out->getBoxController()->getMaxDepth());
     } else {
-      TSM_ASSERT_EQUALS("MaxRecusionDepth property should be enabled", true, p->getSettings()->isEnabled(&alg));
+      TSM_ASSERT_EQUALS("MaxRecusionDepth property should be enabled", true, p->getSettings()[0]->isEnabled(&alg));
       TSM_ASSERT_EQUALS("Should have passed the maxium depth onto the ouput "
                         "workspace from the input workspace.",
                         size_t(maxDepth), out->getBoxController()->getMaxDepth());

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -119,7 +119,7 @@ void declareOrReplaceProperty(IPropertyManager &self, const std::string &name,
  */
 void setPropertySettings(IPropertyManager &self, const std::string &propName,
                          const IPropertySettings *settingsManager) {
-  self.setPropertySettings(propName, std::unique_ptr<IPropertySettings>(settingsManager->clone()));
+  self.setPropertySettings(propName, std::unique_ptr<IPropertySettings const>(settingsManager->clone()));
 }
 
 void deleteProperty(IPropertyManager &self, const std::string &propName) { self.removeProperty(propName); }
@@ -197,6 +197,12 @@ void export_IPropertyManager() {
 
       .def("setPropertySettings", &setPropertySettings, (arg("self"), arg("name"), arg("settingsManager")),
            "Assign the given IPropertySettings object to the  named property")
+
+      .def("isPropertyEnabled", &IPropertyManager::isPropertyEnabled, (arg("self"), arg("name")),
+           "Returns whether a property should be enabled, according to its settings")
+
+      .def("isPropertyVisible", &IPropertyManager::isPropertyVisible, (arg("self"), arg("name")),
+           "Returns whether a property should be visible, according to its settings")
 
       .def("setPropertyGroup", &IPropertyManager::setPropertyGroup, (arg("self"), arg("name"), arg("group")),
            "Set the group for a given property")

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -317,3 +317,7 @@ Once your algorithm is working from a script, and provided it is registered with
 ``EnableWhenProperty``, ``VisibleWhenProperty``, and ``InvisibleProperty`` can be used to hide or disable a property in the GUI dialog panel based on various conditions.
 
 ``SetValueWhenProperty``, and ``SetDefaultWhenProperty`` can be used to set the value of a property based on the value of another upstream property, or to emulate the effect of having a property's *default* value depend on the value of another property.  See :ref:`Dynamic dialog properties <DynamicProperties>` for example code showing how to use this feature.
+
+Multiple ``IPropertySettings`` can be attached to a single property, by applying either the ``IPropertyManager::setPropertySettings`` method of the algorithm, or the ``Property::setSettings`` method of the property itself, multiple times.  For this reason the property's ``getSettings`` method returns a *vector* of settings, which will be *empty* in the default no-settings case.
+
+With respect to the property's enabled and visibility states (on its owner widget), any setting in the vector of settings returning ``isEnabled`` or ``isVisible`` values of ``false``, results in disabling or hiding the property's widget.  In general, it is expected that only one instance of each of the ``EnabledWhenProperty`` and ``VisibleWhenProperty`` settings would be attached to a given property, in combination with any number of instances of other ``IPropertySettings``-derived types, although this behavior is not strictly enforced.

--- a/docs/source/release/v6.15.0/Framework/Kernel/New_features/40487.rst
+++ b/docs/source/release/v6.15.0/Framework/Kernel/New_features/40487.rst
@@ -1,0 +1,1 @@
+- :py:obj:`Property <mantid.kernel.Property>` and :py:obj:`IPropertyManager <mantid.kernel.IPropertyManager>` now support the application of multiple :py:obj:`IPropertySettings <mantid.kernel.IPropertySettings>` instances to a single property instance.  From Python, a property's ``getSettings`` method will now return a *vector* of ``IPropertySetting`` when appropriate.

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -742,6 +742,7 @@ set(CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/test/WidgetsCommonTes
 
 set(QT5_TEST_FILES
     test/AlgorithmRunnerTest.h
+    test/AlgorithmPropertiesWidgetTest.h
     test/BatchAlgorithmRunnerTest.h
     test/FileDialogHandlerTest.h
     test/FindFilesThreadPoolManagerTest.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmPropertiesWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmPropertiesWidget.h
@@ -52,6 +52,8 @@ public:
 
   void addEnabledAndDisableLists(const QStringList &enabled, const QStringList &disabled);
 
+  void shareErrorsMap(const QHash<QString, QString> &errors);
+
   void hideOrDisableProperties(const QString &changedPropName = "");
 
   void saveInput();
@@ -75,8 +77,18 @@ public slots:
   /// Replace WS button was clicked
   void replaceWSClicked(const QString &propName);
 
+protected:
+  // These methods are `protected` rather than `private` to facilitate unit testing:
+  //   they should really not be used outside of this dialog class.
+  // For the external methods, see `IPropertyManager::isPropertyEnabled` and
+  // `IPropertyManager::isPropertyVisible`.
+  bool isWidgetEnabled(const Mantid::Kernel::Property *prop) const;
+
+  bool isWidgetVisible(const Mantid::Kernel::Property *prop) const;
+
 private:
-  bool isWidgetEnabled(const Mantid::Kernel::Property *property, const QString &propName) const;
+  /// Check if there is any input workspace in the properties list
+  bool hasInputWS(const std::vector<Mantid::Kernel::Property *> &prop_list) const;
 
   /// Chosen algorithm name
   QString m_algoName;
@@ -90,9 +102,11 @@ private:
   /// The current grid widget for sub-boxes
   QGridLayout *m_currentGrid;
 
-  /// A map where key = property name; value = the error for this property (i.e.
+  /// A map where key = property name; value = any error for this property (i.e.
   /// it is not valid).
-  QHash<QString, QString> m_errors;
+  // The current widget is no longer responsible for setting property values, so this map points
+  // to the corresponding map from the parent dialog.
+  QHash<QString, QString> const *m_errors;
 
   /// A list of property names that are FORCED to stay enabled.
   QStringList m_enabled;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyWidget.h
@@ -88,7 +88,7 @@ public:
   QGridLayout *getGridLayout() { return m_gridLayout; }
 
   /// @return the row of the widgets in the Layout
-  int getGridRow() { return m_row; }
+  int getGridRow() const { return m_row; }
 
   void addReplaceWSButton();
 

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -436,15 +436,11 @@ bool AlgorithmDialog::isMessageAvailable() const { return !m_strMessage.isEmpty(
  * @param propName :: The name of the property
  */
 bool AlgorithmDialog::isWidgetEnabled(const QString &propName) const {
-  // TODO: these "to avoid errors" pre-checks may seem like a good idea, but they mask defects.
+  // TODO: these "to avoid errors" prechecks mask defects.
   // They really should be removed!!
 
   // To avoid errors
   if (propName.isEmpty())
-    return true;
-
-  Mantid::Kernel::Property *property = getAlgorithmProperty(propName);
-  if (!property)
     return true;
 
   if (!isForScript()) {

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -340,7 +340,7 @@ void AlgorithmPropertiesWidget::replaceWSClicked(const QString &propName) {
 
 //-------------------------------------------------------------------------------------------------
 /** Check if the control should be enabled for this property
- * @param property :: the property to check
+ * @param prop :: the property to check
  */
 bool AlgorithmPropertiesWidget::isWidgetEnabled(const Property *prop) const {
   if (!prop)
@@ -364,7 +364,7 @@ bool AlgorithmPropertiesWidget::isWidgetEnabled(const Property *prop) const {
 //-------------------------------------------------------------------------------------------------
 /** Compute if the control should be visible for this property based on settings and error state.
  *  WARNING: the GUI itself may override this visibility setting (e.g. if a parent widget is hidden).
- * @param property :: the property that allows to check for the settings.
+ * @param prop :: the property that allows to check for the settings.
  */
 bool AlgorithmPropertiesWidget::isWidgetVisible(const Property *prop) const {
   if (!prop)

--- a/qt/widgets/common/src/GenericDialog.cpp
+++ b/qt/widgets/common/src/GenericDialog.cpp
@@ -82,9 +82,12 @@ void GenericDialog::initLayout() {
   // Mark the properties that will be forced enabled or disabled
   QStringList enabled = m_enabled;
   QStringList disabled = m_disabled;
-  // Disabled the python arguments
+  // Disable any python arguments
   disabled += m_python_arguments;
   m_algoPropertiesWidget->addEnabledAndDisableLists(enabled, disabled);
+
+  // Share the errors map with the parent dialog
+  m_algoPropertiesWidget->shareErrorsMap(m_errors);
 
   // At this point, all the widgets have been added and are visible.
   // This makes sure the viewport does not get scaled smaller, even if some
@@ -161,9 +164,9 @@ void GenericDialog::accept() {
   } else {
     // Highlight the validators that are in error (combined from them + whole
     // algorithm)
-    // If got there, there were errors
+    // If we get to this clause, there are errors
     for (auto it = m_errors.begin(); it != m_errors.end(); it++) {
-      // if these assert is encounted, the property and validate keys may not
+      // if this assert is encountered, the property and validator keys may not
       // match (check case)
       assert(m_algoPropertiesWidget->m_propWidgets[it.key()]);
       m_algoPropertiesWidget->m_propWidgets[it.key()]->updateIconVisibility(it.value());

--- a/qt/widgets/common/test/AlgorithmPropertiesWidgetTest.h
+++ b/qt/widgets/common/test/AlgorithmPropertiesWidgetTest.h
@@ -1,0 +1,588 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/IPropertySettings.h"
+#include "MantidKernel/PropertyWithValue.h"
+#include "MantidQtWidgets/Common/AlgorithmPropertiesWidget.h"
+#include <QCoreApplication>
+#include <QWidget>
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Mock;
+using ::testing::Sequence;
+#include <gtest/gtest.h>
+
+// Tests for AlgorithmPropertiesWidget.
+
+// TODO: These tests are presently focused on hideOrDisableProperties
+// and IPropertySettings interaction.  More complete behavior tests should also
+// be implemented as time permits.
+
+namespace Mantid {
+namespace API {
+
+class TestAlgorithm final : public Algorithm {
+public:
+  /// Factory-style shared pointer typedef if needed
+  using sptr = std::shared_ptr<TestAlgorithm>;
+
+  TestAlgorithm() = default;
+  ~TestAlgorithm() override = default;
+
+  /// Algorithm information
+  const std::string name() const override { return "TestAlgorithm"; }
+  int version() const override { return 1; }
+  const std::string summary() const override { return "Test algorithm with three float input properties A, B, and C."; }
+
+protected:
+  /// Declare properties
+  void init() override {
+    using Mantid::Kernel::Direction;
+    using Mantid::Kernel::PropertyWithValue;
+
+    declareProperty(std::make_unique<PropertyWithValue<double>>("A", 0.0, Direction::Input), "Input value A");
+
+    declareProperty(std::make_unique<PropertyWithValue<double>>("B", 0.0, Direction::Input), "Input value B");
+
+    declareProperty(std::make_unique<PropertyWithValue<double>>("C", 0.0, Direction::Input), "Input value C");
+  }
+
+  /// Execution stub
+  void exec() override {
+    // Stub implementation for unit tests; do nothing or minimal access
+    // auto a = getProperty("A");
+    // auto b = getProperty("B");
+    // auto c = getProperty("C");
+  }
+};
+
+} // namespace API
+} // namespace Mantid
+
+namespace Mantid {
+namespace Kernel {
+
+class MockPropertySettings : public IPropertySettings {
+public:
+  using ApplyCallback = std::function<bool(const IPropertyManager *, const std::string &)>;
+
+  MOCK_METHOD(bool, isEnabled, (const IPropertyManager *), (const, override));
+  MOCK_METHOD(bool, isVisible, (const IPropertyManager *), (const, override));
+  MOCK_METHOD(bool, isConditionChanged, (const IPropertyManager *, const std::string &), (const, override));
+  MOCK_METHOD(bool, applyChanges, (const IPropertyManager *algo, const std::string &currentPropName),
+              (const, override));
+
+  MockPropertySettings() {
+    ON_CALL(*this, isEnabled(testing::_)).WillByDefault(testing::Invoke([this](const IPropertyManager *) {
+      return m_isEnabledDefault;
+    }));
+    ON_CALL(*this, isVisible(testing::_)).WillByDefault(testing::Invoke([this](const IPropertyManager *) {
+      return m_isVisibleDefault;
+    }));
+    ON_CALL(*this, isConditionChanged(testing::_, testing::_))
+        .WillByDefault(testing::Invoke(
+            [this](const IPropertyManager *, const std::string &) { return m_isConditionChangedDefault; }));
+    ON_CALL(*this, applyChanges(testing::_, testing::_))
+        .WillByDefault(testing::Invoke([this](const IPropertyManager *algo, const std::string &name) {
+          if (m_applyCallback)
+            return m_applyCallback(algo, name);
+          return false;
+        }));
+  }
+
+  IPropertySettings *clone() const override {
+    auto *copy = new ::testing::NiceMock<MockPropertySettings>();
+
+    // Copy configuration state
+    copy->m_isEnabledDefault = m_isEnabledDefault;
+    copy->m_isVisibleDefault = m_isVisibleDefault;
+    copy->m_isConditionChangedDefault = m_isConditionChangedDefault;
+    copy->m_applyCallback = m_applyCallback;
+
+    // Constructor of copy has already installed ON_CALLs that use its members.
+    return copy;
+  }
+
+  void setIsEnabledReturn(bool v) { m_isEnabledDefault = v; }
+  void setIsVisibleReturn(bool v) { m_isVisibleDefault = v; }
+  void setIsConditionChangedReturn(bool v) { m_isConditionChangedDefault = v; }
+  void setApplyChangesCallback(ApplyCallback cb) { m_applyCallback = std::move(cb); }
+
+private:
+  bool m_isEnabledDefault{true};
+  bool m_isVisibleDefault{true};
+  bool m_isConditionChangedDefault{false};
+  ApplyCallback m_applyCallback;
+};
+
+} // namespace Kernel
+} // namespace Mantid
+
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+using namespace MantidQt::API;
+
+class AlgorithmPropertiesWidgetTest : public CxxTest::TestSuite {
+public:
+  static AlgorithmPropertiesWidgetTest *createSuite() { return new AlgorithmPropertiesWidgetTest(); }
+  static void destroySuite(AlgorithmPropertiesWidgetTest *suite) { delete suite; }
+
+  void setUp() override {
+    // QApplication is initialized at `WidgetsCommonTestInitialization.h`
+    //   which should be automatically included by the test framework.
+
+    // Ensure widget is part of a shown hierarchy
+    m_parent = new QWidget();
+    m_parent->show();
+
+    m_algorithm = static_cast<IAlgorithm_sptr>(new TestAlgorithm());
+    m_algorithm->initialize();
+
+    m_widget = std::make_shared<TestableAlgorithmPropertiesWidget>(m_parent);
+    m_widget->setAlgorithm(m_algorithm);
+
+    QCoreApplication::processEvents();
+  }
+
+  void tearDown() override {
+    // Reset widget and any shared state.
+    m_widget.reset();
+    m_algorithm.reset();
+
+    delete m_parent;
+    m_parent = nullptr;
+  }
+
+  /// Tests focused on `hideOrDisableProperties` and `IPropertySettings` interaction.
+
+  /// Verifies that when a property has any `IPropertySettings` attached which
+  /// indicate the control should be disabled, `isWidgetEnabled()`
+  /// returns the correct value.
+  void testIsWidgetEnabled_DisablesPropertiesFromSettings() {
+    // WARNING: in a headless tests, it is problematic to test this directly using `QWidget::isEnabled()`.
+    // The private helper method `isWidgetEnabled` is verified instead.
+
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+
+    settings->setIsEnabledReturn(false);
+    TS_ASSERT(!m_widget->isWidgetEnabled(prop));
+
+    settings->setIsEnabledReturn(true);
+    TS_ASSERT(m_widget->isWidgetEnabled(prop));
+  }
+
+  /// Verifies that when a property has any `IPropertySettings` attached which
+  /// indicate the control should be hidden, `isWidgetVisible()`
+  /// returns the correct value.
+  void testIsWidgetVisible_HidesPropertiesFromSettings() {
+    // WARNING: in a headless tests, it is problematic to test visibility directly using `QWidget::isVisible()`.
+    // For this reason, the private helper method `isWidgetVisible` is verified instead.
+
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+
+    settings->setIsVisibleReturn(false);
+    TS_ASSERT(!m_widget->isWidgetVisible(prop));
+
+    settings->setIsVisibleReturn(true);
+    TS_ASSERT(m_widget->isWidgetVisible(prop));
+  }
+
+  /// Verifies that when a property's validators indicate an error condition,
+  /// `isWidgetVisible()` always returns `true`, regardless of property-settings' state.
+  void testIsWidgetVisible_DoesNotHideErrors() {
+    // Note: this behavior did not work previously. `AlgorithmDialog` and `AlgorithmPropertiesWidget` retained
+    //   separate `m_errors` maps, and the latter no longer actually set any properties values!
+
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+
+    settings->setIsVisibleReturn(false);
+    TS_ASSERT(!m_widget->isWidgetVisible(prop));
+
+    QHash<QString, QString> errors = {{"C", "something is not right!"}};
+    m_widget->shareErrorsMap(errors);
+    TS_ASSERT(m_widget->isWidgetVisible(prop));
+  }
+
+  /// Verifies that dynamic `IPropertySetting`s that modify validators or
+  /// properties cause the original PropertyWidget to be replaced by a new
+  /// widget instance when `applyChanges` returns true, and that the new
+  /// widget occupies the same layout position.
+  void testHideOrDisable_DynamicallyReplacesWidgets() {
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+
+    // First test the negative: widget remains the same when `applyChanges` returns `false`.
+    settings->setIsConditionChangedReturn(true);
+    MockPropertySettings::ApplyCallback cb0 = [](const IPropertyManager *, const std::string &) { return false; };
+    settings->setApplyChangesCallback(cb0);
+    const auto *originalWidget = m_widget->m_propWidgets["C"];
+    int originalRow = originalWidget->getGridRow();
+
+    m_widget->hideOrDisableProperties("A"); // in this test, the name of the upstream property doesn't matter
+    TS_ASSERT(m_widget->m_propWidgets["C"] == originalWidget);
+    TS_ASSERT(m_widget->m_propWidgets["C"]->getGridRow() == originalRow);
+
+    // Next verify that the `PropertyWidget` is replaced when the `IPropertySettings::applyChanges` returns `true`.
+    MockPropertySettings::ApplyCallback cb1 = [](const IPropertyManager *, const std::string &) { return true; };
+    settings->setApplyChangesCallback(cb1);
+    m_widget->hideOrDisableProperties("A"); // in this test, the name of the upstream property doesn't matter
+    TS_ASSERT(m_widget->m_propWidgets["C"] != originalWidget);
+    TS_ASSERT(m_widget->m_propWidgets["C"]->getGridRow() == originalRow);
+  }
+
+  /// Verifies that properties explicitly listed in the internal `m_enabled`
+  /// list remain enabled, regardless of `IPropertySettings` that might
+  /// otherwise disable them.
+  void testIsWidgetEnabled_EnabledWhenForcedEnabled() {
+    // For reasons discussed previously RE GUI testing:
+    //   we test `isWidgetEnabled(prop)` rather than `<property>.isEnabled()`.
+
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+    settings->setIsEnabledReturn(false);
+
+    {
+      QStringList enabled = {"C"}, disabled = {};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(m_widget->isWidgetEnabled(prop));
+    }
+
+    {
+      // negative case
+      QStringList enabled = {}, disabled = {};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(!m_widget->isWidgetEnabled(prop));
+    }
+  }
+
+  /// Verifies that properties explicitly listed in the internal `m_disabled`
+  /// list are disabled even if `IPropertySettings` would otherwise leave
+  /// them enabled.
+  void testIsWidgetEnabled_DisabledWhenForcedDisabled() {
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+    settings->setIsEnabledReturn(true);
+
+    {
+      QStringList enabled = {}, disabled = {"C"};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(!m_widget->isWidgetEnabled(prop));
+    }
+
+    {
+      // negative case
+      QStringList enabled = {}, disabled = {};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(m_widget->isWidgetEnabled(prop));
+    }
+  }
+
+  /// Verifies that properties explicitly listed in the internal `m_enabled`
+  /// list are enabled even if they are also listed in the `m_disabled` list.
+  void testIsWidgetEnabled_ForcedEnabledSupercedesForcedDisabled() {
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    {
+      QStringList enabled = {"C"}, disabled = {"C"};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(m_widget->isWidgetEnabled(prop));
+    }
+
+    {
+      // negative case
+      QStringList enabled = {"C"}, disabled = {};
+      m_widget->addEnabledAndDisableLists(enabled, disabled);
+      TS_ASSERT(m_widget->isWidgetEnabled(prop));
+    }
+  }
+
+  /// Verifies that when multiple `IPropertySettings` are attached to a
+  /// property, the enabled state computed by `isWidgetEnabled()` and then
+  /// applied in `hideOrDisableProperties()` is the logical AND of all
+  /// `settings->isEnabled(...)`, so that any single false disables the widget.
+  void testMultipleSettings_AnyDisabledDisablesWidget() {
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings1 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+    auto *settings2 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[1].get()));
+
+    // verify the AND truth table
+    settings1->setIsEnabledReturn(false);
+    settings2->setIsEnabledReturn(false);
+    TS_ASSERT_EQUALS(m_widget->isWidgetEnabled(prop), false);
+
+    settings1->setIsEnabledReturn(false);
+    settings2->setIsEnabledReturn(true);
+    TS_ASSERT_EQUALS(m_widget->isWidgetEnabled(prop), false);
+
+    settings1->setIsEnabledReturn(true);
+    settings2->setIsEnabledReturn(false);
+    TS_ASSERT_EQUALS(m_widget->isWidgetEnabled(prop), false);
+
+    settings1->setIsEnabledReturn(true);
+    settings2->setIsEnabledReturn(true);
+    TS_ASSERT_EQUALS(m_widget->isWidgetEnabled(prop), true);
+  }
+
+  /// Verifies that when no `IPropertySettings` are attached to a
+  /// property, the enabled state computed by `isWidgetEnabled()` is `true`.
+  void testSettings_WidgetEnabledByDefault() {
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    TS_ASSERT(prop->getSettings().empty());
+    TS_ASSERT_EQUALS(m_widget->isWidgetEnabled(prop), true);
+  }
+
+  /// Verifies that when multiple `IPropertySettings` are attached to a
+  /// property, the visible state computed by `isWidgetVisible` and then
+  /// applied in `hideOrDisableProperties()` is the logical AND of all
+  /// `settings->isVisible(...)`, so that any single false hides the widget.
+  void testMultipleSettings_AnyHiddenHidesWidget() {
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings1 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+    auto *settings2 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[1].get()));
+
+    // verify the AND truth table
+    settings1->setIsVisibleReturn(false);
+    settings2->setIsVisibleReturn(false);
+    TS_ASSERT_EQUALS(m_widget->isWidgetVisible(prop), false);
+
+    settings1->setIsVisibleReturn(false);
+    settings2->setIsVisibleReturn(true);
+    TS_ASSERT_EQUALS(m_widget->isWidgetVisible(prop), false);
+
+    settings1->setIsVisibleReturn(true);
+    settings2->setIsVisibleReturn(false);
+    TS_ASSERT_EQUALS(m_widget->isWidgetVisible(prop), false);
+
+    settings1->setIsVisibleReturn(true);
+    settings2->setIsVisibleReturn(true);
+    TS_ASSERT_EQUALS(m_widget->isWidgetVisible(prop), true);
+  }
+
+  /// Verifies that when no `IPropertySettings` are attached to a
+  /// property, the visibility state computed by `isWidgetVisible()` is `true`.
+  void testSettings_WidgetVisibleByDefault() {
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    TS_ASSERT(prop->getSettings().empty());
+    TS_ASSERT_EQUALS(m_widget->isWidgetVisible(prop), true);
+  }
+
+  /// Verifies that for each `IPropertySettings` instance attached to a
+  /// property, `hideOrDisableProperties()` calls `isConditionChanged(...)`
+  /// with the name of the changed property, and when it returns true,
+  /// subsequently calls `applyChanges(...)` for that same settings object.
+  void testSettingsConditionChange_DoesNotApplyWhenUnchanged() {
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop = m_algorithm->getPointerToProperty("C");
+    auto *settings1 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[0].get()));
+    auto *settings2 =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop->getSettings()[1].get()));
+
+    // Both positive and negative cases are checked.
+    settings1->setIsConditionChangedReturn(false);
+    settings2->setIsConditionChangedReturn(true);
+    EXPECT_CALL(*settings1, isConditionChanged(m_algorithm.get(), "A")).Times(1);
+    EXPECT_CALL(*settings1, applyChanges(_, _)).Times(0);
+    EXPECT_CALL(*settings2, isConditionChanged(m_algorithm.get(), "A")).Times(1);
+    EXPECT_CALL(*settings2, applyChanges(m_algorithm.get(), "C")).Times(1);
+
+    m_widget->hideOrDisableProperties("A");
+
+    // The following prevents unmet expectations from hanging the framework,
+    //   due to `ctest`, `gtest` and `Qt` interactions during shutdown.
+    Mock::VerifyAndClearExpectations(settings1);
+    Mock::VerifyAndClearExpectations(settings2);
+  }
+
+  /// Verifies that the  `IPropertySettings::isConditionChanged` => `IPropertySettings::applyChanges`
+  /// are called separately for each property in sequence, and are not executed as a composite.
+  void testHideOrDisable_AppliesChangesInSequence() {
+    // Implementation note: the primary purpose of this test is to provide a reality check, in case
+    // code is ever implemented that does a composite `isConditionChanged` check over all
+    // properties (and their settings), and then based on that calls all of the `applyChanges`.
+    // This *might* work out OK, but whether or not it leads to correct behavior in all cases
+    // needs to be carefully evaluated.
+
+    m_algorithm->setPropertySettings("B", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop_b = m_algorithm->getPointerToProperty("B");
+    auto *settings_b =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop_b->getSettings()[0].get()));
+    auto *prop_c = m_algorithm->getPointerToProperty("C");
+    auto *settings_c =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop_c->getSettings()[0].get()));
+    settings_b->setIsConditionChangedReturn(true);
+    settings_c->setIsConditionChangedReturn(true);
+
+    // The specific sequence of calls is checked,
+    // but we don't care about the ordering of the properties
+    // in the widget's list.
+    InSequence seq;
+    int count = 0;
+    for (auto &widget : m_widget->m_propWidgets) {
+      Mantid::Kernel::Property *prop = widget->getProperty();
+      auto *settings = dynamic_cast<MockPropertySettings *>(
+          const_cast<IPropertySettings *>(!prop->getSettings().empty() ? prop->getSettings()[0].get() : nullptr));
+      if (settings) {
+        EXPECT_CALL(*settings, isConditionChanged(m_algorithm.get(), "A")).Times(1);
+        EXPECT_CALL(*settings, applyChanges(m_algorithm.get(), prop->name())).Times(1);
+        ++count;
+      }
+    }
+    TS_ASSERT_EQUALS(count, 2);
+
+    m_widget->hideOrDisableProperties("A");
+
+    // The following prevents unmet expectations from hanging the framework,
+    //   due to `ctest`, `gtest` and `Qt` interactions during shutdown.
+    Mock::VerifyAndClearExpectations(settings_b);
+    Mock::VerifyAndClearExpectations(settings_c);
+  }
+
+  /// Verifies that `hideOrDisableProperties()` completes the first loop over
+  /// `IPropertySettings` (checking `isConditionChanged` and applying changes)
+  /// before performing the second loop that calculates and applies the
+  /// enabled and visible flags for widgets.
+  void testHideOrDisable_EvaluatesEnabledAndVisibleAfterApplyingAllChanges() {
+    m_algorithm->setPropertySettings("B", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    auto *prop_b = m_algorithm->getPointerToProperty("B");
+    auto *settings_b =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop_b->getSettings()[0].get()));
+    auto *prop_c = m_algorithm->getPointerToProperty("C");
+    auto *settings_c =
+        dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(prop_c->getSettings()[0].get()));
+    settings_b->setIsConditionChangedReturn(true);
+    settings_c->setIsConditionChangedReturn(true);
+
+    // The specific sequence of calls is checked,
+    // but we don't care about the ordering of the properties
+    // in the widget's list.
+    InSequence seq;
+    int count = 0;
+    for (auto &widget : m_widget->m_propWidgets) {
+      Mantid::Kernel::Property *prop = widget->getProperty();
+      auto *settings = dynamic_cast<MockPropertySettings *>(
+          const_cast<IPropertySettings *>(!prop->getSettings().empty() ? prop->getSettings()[0].get() : nullptr));
+      if (settings) {
+        EXPECT_CALL(*settings, isConditionChanged(m_algorithm.get(), "A")).Times(1);
+        EXPECT_CALL(*settings, applyChanges(m_algorithm.get(), prop->name())).Times(1);
+        ++count;
+      }
+    }
+    for (auto &widget : m_widget->m_propWidgets) {
+      Mantid::Kernel::Property *prop = widget->getProperty();
+      auto *settings = dynamic_cast<MockPropertySettings *>(
+          const_cast<IPropertySettings *>(!prop->getSettings().empty() ? prop->getSettings()[0].get() : nullptr));
+      if (settings) {
+        EXPECT_CALL(*settings, isEnabled(m_algorithm.get())).Times(1);
+        EXPECT_CALL(*settings, isVisible(m_algorithm.get())).Times(1);
+        ++count;
+      }
+    }
+    TS_ASSERT_EQUALS(count, 4);
+
+    m_widget->hideOrDisableProperties("A");
+
+    // The following prevents unmet expectations from hanging the framework,
+    //   due to `ctest`, `gtest` and `Qt` interactions during shutdown.
+    Mock::VerifyAndClearExpectations(settings_b);
+    Mock::VerifyAndClearExpectations(settings_c);
+  }
+
+  /// Verifies that `hideOrDisableProperties()` computes the enabled state
+  /// via `isWidgetEnabled` (iterating over all `settings->isEnabled()`)
+  /// and the visible state via `isWidgetVisible` (iterating over all `settings->isVisible()`)
+  /// in separate checks, so that enabling and visibility are controlled independently even when multiple
+  /// `IPropertySettings` are present.
+  void testHideOrDisable_SeparatesEnabledAndVisibleChecks() {
+    m_algorithm->setPropertySettings("B", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("B", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+    m_algorithm->setPropertySettings("C", std::unique_ptr<IPropertySettings const>(new MockPropertySettings()));
+
+    // The specific sequence of calls is checked,
+    // but we don't care about the ordering of the properties
+    // in the widget's list.
+    InSequence seq;
+    int count = 0;
+    for (auto &widget : m_widget->m_propWidgets) {
+      Mantid::Kernel::Property *prop = widget->getProperty();
+      // Verify that each settings chain for `isEnabled` and `isVisible` is iterated separately,
+      // and that they are not interspersed.
+      // (NOTE: with respect to the code itself,
+      //  we probably don't care that `isEnabled` is checked before or after `isVisible`.)
+      for (const auto &settings : prop->getSettings()) {
+        auto *settings_ = dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(settings.get()));
+        EXPECT_CALL(*settings_, isEnabled(m_algorithm.get())).Times(1);
+        ++count;
+      }
+      for (const auto &settings : prop->getSettings()) {
+        auto *settings_ = dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(settings.get()));
+        EXPECT_CALL(*settings_, isVisible(m_algorithm.get())).Times(1);
+        ++count;
+      }
+    }
+    TS_ASSERT_EQUALS(count, 8);
+
+    m_widget->hideOrDisableProperties("A");
+
+    // The following prevents unmet expectations from hanging the framework,
+    //   due to `ctest`, `gtest` and `Qt` interactions during shutdown.
+    for (auto &widget : m_widget->m_propWidgets) {
+      Mantid::Kernel::Property *prop = widget->getProperty();
+      for (const auto &settings : prop->getSettings()) {
+        auto *settings_ = dynamic_cast<MockPropertySettings *>(const_cast<IPropertySettings *>(settings.get()));
+        Mock::VerifyAndClearExpectations(settings_);
+      }
+    }
+  }
+
+private:
+  class TestableAlgorithmPropertiesWidget : public AlgorithmPropertiesWidget {
+    // This class allows verification of `isWidgetEnabled` and `isWidgetVisible`.
+    friend class AlgorithmPropertiesWidgetTest;
+
+  public:
+    TestableAlgorithmPropertiesWidget(QWidget *parent = nullptr) : AlgorithmPropertiesWidget(parent) {}
+    ~TestableAlgorithmPropertiesWidget() override = default;
+  };
+
+  QWidget *m_parent = nullptr;
+  std::shared_ptr<TestableAlgorithmPropertiesWidget> m_widget;
+  IAlgorithm_sptr m_algorithm;
+};


### PR DESCRIPTION
### Description of work

Multiple ``IPropertySettings`` can now be attached to a single property, by applying either ``IPropertyManager::setPropertySettings`` or the ``Property::setSettings``, multiple times.  ``Property::getSettings`` now returns a *vector* of settings, which will be *empty* in the default, no-settings case.  

It is expected that up to one instance of each of the ``EnabledWhenProperty`` and ``VisibleWhenProperty`` settings types would be attached to a given property, in combination with any number of instances of other ``IPropertySettings``-derived types, although this behavior is not strictly enforced.

### Explanation of work

This PR includes the following changes:

  * `Property::getSettings`, `setSettings`, `clearSettings`, `IPropertyManager::setPropertySettings` -- return, append to, or clear a `std::vector<std::unique_ptr<IPropertySettings const>>`;

  * With respect to the property's enabled and visibility states (on its owner widget), any setting in the vector of settings returning ``isEnabled`` or ``isVisible`` values of ``false``, results in disabling or hiding the property's widget. This behavior is centralized and enforced using the new `IPropertyManager::isPropertyEnabled`, `IPropertyManager::isPropertyVisible` methods.  The fact that these could not usefully be `IPropertySettings` methods is related to issues with the object-oriented design of the current `IPropertySettings` system, and the necessity to support legacy behavior in the codebase;

  * Where appropriate, `IPropertySettings` methods are now `const`;

  * New unit tests have been added for `AlgorithmPropertiesWidget`.  At present these tests have incomplete coverage.  Current tests focus on the required `hideAndDisableProperties` and `IPropertySettings`-related behaviors of this current PR.

Link: [EWM #14018](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14018) 

### To test:
New unit tests have been added to cover the changes.  (See especially `qt/widgets/common/test/AlgorithmPropertiesWidgetTest.h`.)  A simple test script [prePopulateScript_multi.py](https://github.com/user-attachments/files/24163076/prePopulateScript_multi.py) is attached.  This script should serve as a starting point to demonstrate the capabilities of the new changes.  (The current script changes a property's *dynamic default* value, using thresholds based on the values of several upstream properties.  Additional tests to try might involve adding an `EnabledWhenProperty`, or doing something like taking a sum of the upstream values.  :)  )

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
