### PR TITLE
Only use non-masked peaks in overlay

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -136,7 +136,7 @@ class FullInstrumentViewModel:
 
     @property
     def spectrum_nos(self) -> np.ndarray:
-        return self._spectrum_nos[self._is_valid]
+        return self._spectrum_nos[self.is_pickable]
 
     @property
     def monitor_positions(self) -> np.ndarray:
@@ -380,7 +380,7 @@ class FullInstrumentViewModel:
             # groupby groups consecutive matches, so must be sorted
             peaks.sort(key=lambda x: x.spectrum_no)
             for spec_no, peaks_for_spec in groupby(peaks, lambda x: x.spectrum_no):
-                if spec_no in self._spectrum_nos:
+                if spec_no in self.spectrum_nos:
                     detector_peaks.append(DetectorPeaks(list(peaks_for_spec)))
 
             peaks_grouped_by_ws.append(detector_peaks)

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -452,6 +452,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         # Everything on spectrum number 1
         model._spectrum_nos = np.array([test_spectrum_no, test_spectrum_no, test_spectrum_no])
         model._is_valid = np.array([True, True, True])
+        model._is_masked = np.array([False, False, False])
         peaks = model.peak_overlay_points()
         # Should get one peak with detector ID 4 and spectrum
         # number 1
@@ -622,6 +623,17 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         model, _ = self._setup_model([1, 2, 3])
         model.save_xml_mask("file")
         mock_save_mask.assert_called_with(model._mask_ws, OutputFile="file.xml")
+
+    def test_masked_spectrum_peak_not_included(self):
+        model = FullInstrumentViewModel(self._ws)
+        peaks_ws = CreatePeaksWorkspace(self._ws, 2)
+        model._selected_peaks_workspaces = [peaks_ws]
+        model._detector_ids = np.array([100])
+        model._spectrum_nos = np.array([2])
+        model._is_valid = np.array([True])
+        model._is_masked = np.array([True])
+        peaks = model.peak_overlay_points()
+        self.assertEqual(0, len(peaks[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix bug where masked peaks were still being returned in the list of peaks, resulting in indexing errors.

### To test:

Load a workspace with a corresponding peaks workspace, e.g.
``` python
ws = Load('SXD23767')
FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace='peaks_conv')
```
Open the new instrument view and select the peaks workspace to overlay, then play about with adding and removing masks. Should be no errors.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
