### PR TITLE
Fixed a Mantidworkbench freeze after calling savefig on a matplotlib

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
@@ -1,1 +1,1 @@
-- Calling ``fig.savefig()`` immediately after ``fig.show()` will no longer cause a deadlock in Qt event loop. This has been fixed by ensuring that all queued GUI events are safely processed before moving on to the next operation.
+- Calling ``fig.savefig()`` immediately after ``fig.show()`` will no longer cause a deadlock in Qt event loop. This has been fixed by ensuring that all queued GUI events are safely processed before moving on to the next operation.

--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
@@ -1,1 +1,1 @@
-- Calling ``fig.savefig()`` immadiately after ``fig.show()`` which internally calls ``canvas.draw_idle()``, used cause a deadlock in Qt event loop. This has been fixed by ensuring that all queued GUI events are safely processed before moving on to the next operation.
+- Calling ``fig.savefig()`` immediately after ``fig.show()` will no longer cause a deadlock in Qt event loop. This has been fixed by ensuring that all queued GUI events are safely processed before moving on to the next operation.

--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
@@ -1,3 +1,1 @@
-- Mantidworkbench used to hang when ``fig.savefig()`` is called immediately after ``fig.show()`` which ended up making a deferred call to schedule a draw via ``canvas.draw_idle()``.
-- Calling ``fig.savefig()`` immadiately after ``fig.show()`` used cause a deadlock in Qt event loop.
-- The fix added here make sure all queued  GUI events are safely processed before moving on to the next opration
+- Calling ``fig.savefig()`` immadiately after ``fig.show()`` which internally calls ``canvas.draw_idle()``, used cause a deadlock in Qt event loop. This has been fixed by ensuring that all queued GUI events are safely processed before moving on to the next operation.

--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40436.rst
@@ -1,0 +1,3 @@
+- Mantidworkbench used to hang when ``fig.savefig()`` is called immediately after ``fig.show()`` which ended up making a deferred call to schedule a draw via ``canvas.draw_idle()``.
+- Calling ``fig.savefig()`` immadiately after ``fig.show()`` used cause a deadlock in Qt event loop.
+- The fix added here make sure all queued  GUI events are safely processed before moving on to the next opration

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -306,6 +306,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         # Hack to ensure the canvas is up to date
         self.canvas.draw_idle()
+        self.canvas.flush_events()
 
         if self.toolbar:
             self.toolbar.set_buttons_visibility(self.canvas.figure)

--- a/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
@@ -68,6 +68,20 @@ class FigureManagerWorkbenchTest(unittest.TestCase):
             fig_mgr.show()
             ax.title.add_callback.assert_called_once_with(callback_mock)
 
+    @patch("workbench.plotting.figuremanager.FigureManagerWorkbench._set_up_axes_title_change_callbacks")
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_canvas_flush_event_on_show(self, mock_qappthread, mock_set_up_axes_title_change_cb):
+        mock_qappthread.return_value = mock_qappthread
+        fig = MagicMock()
+        fig.bbox.max = [1, 1]
+        canvas = MantidFigureCanvas(fig)
+        canvas.flush_events = MagicMock()
+        fig_mgr = FigureManagerWorkbench(canvas, 1)
+
+        fig_mgr.show()
+
+        canvas.flush_events.assert_called_once()
+
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_ax_callback_will_set_window_title_with_new_title(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread


### PR DESCRIPTION
### Description of work
Mantidworkbench used to freeze when calling `fig.savefig()` immediately after `fig.show()`. This issue can be see **even** in `Mantid v6.12`. 

This was because `fig.show()` defers draw events on Qt eventloop via `canvas.draw_idle()` and calling `fig.savefig()` (synchronous call) aquire the resources that were scheduled and not yet executed immediately after triggered a deadlock at the Qt event loop. 

As a fix, all queued GUI events are forced to be processed safely via a flush event after `canvas.draw_idle()` by `canvas.flush_events()`

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40436. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run below code snipped and observe no GUI freezes and the figure should be saved properly.

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt

a = [1,2,3,4]
b = [5,6,7,9]

ws = CreateWorkspace(a,b)

fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
axes.plot(ws, color='#1f77b4', label='label', marker='o', markersize=3.0, wkspIndex=0)
axes.set_title('test_data')
axes.set_xlabel('y-scale')
axes.set_ylabel('x-scale')
axes.set_xlim([0, 5])
axes.set_ylim([0, 10])
fig.show()
fig.savefig('plot1.png')

```
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
