### PR TITLE
AlignAndFocusPowderSlim set uncertainties

### DIFF
--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -259,10 +259,13 @@ void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &
           });
     }
 
-    // copy the data out into the correct spectrum
+    // copy the data out into the correct spectrum and calculate errors
     tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) {
       auto &y_values = spectra[i]->dataY();
       std::copy(y_temps[i].cbegin(), y_temps[i].cend(), y_values.begin());
+      auto &e_values = spectra[i]->dataE();
+      std::transform(y_temps[i].cbegin(), y_temps[i].cend(), e_values.begin(),
+                     [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
     });
 
     g_log.debug() << bankName << " stop" << timer << std::endl;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -190,10 +190,13 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
           });
     }
 
-    // copy the data out into the correct spectrum
+    // copy the data out into the correct spectrum and calculate errors
     tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) {
       auto &y_values = spectra[i]->dataY();
       std::copy(y_temps[i].cbegin(), y_temps[i].cend(), y_values.begin());
+      auto &e_values = spectra[i]->dataE();
+      std::transform(y_temps[i].cbegin(), y_temps[i].cend(), e_values.begin(),
+                     [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
     });
 
     g_log.debug() << bankName << " stop " << timer << std::endl;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -157,9 +157,12 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       std::transform(y_temp.begin(), y_temp.end(), task.y_temp.begin(), y_temp.begin(), std::plus<uint32_t>());
     }
 
-    // copy the data out into the correct spectrum
+    // copy the data out into the correct spectrum and calculate errors
     auto &y_values = spectrum.dataY();
     std::copy(y_temp.cbegin(), y_temp.cend(), y_values.begin());
+    auto &e_values = spectrum.dataE();
+    std::transform(y_temp.cbegin(), y_temp.cend(), e_values.begin(),
+                   [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
 
     g_log.debug() << bankName << " stop " << timer << std::endl;
     m_progress->report();

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -155,6 +155,10 @@ public:
     TS_ASSERT_EQUALS(y_values[0], 0.);
     TS_ASSERT_EQUALS(y_values[NUM_Y / 2], 0.);
     TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 4744.);
+    const auto e_values = outputWS->readE(0);
+    TS_ASSERT_DELTA(e_values[0], 0., 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y / 2], 0., 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y - 1], std::sqrt(4744.), 1e-10);
 
     // do not need to cleanup because workspace did not go into the ADS
 
@@ -201,6 +205,10 @@ public:
     TS_ASSERT_EQUALS(y_values[0], 0.);
     TS_ASSERT_EQUALS(y_values[NUM_Y / 2], 55374.); // observed
     TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 0.);
+    const auto e_values = outputWS->readE(0);
+    TS_ASSERT_DELTA(e_values[0], 0., 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y / 2], std::sqrt(55374.), 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y - 1], 0., 1e-10);
 
     // do not need to cleanup because workspace did not go into the ADS
   }
@@ -464,6 +472,12 @@ public:
       TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 909955);
       TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 310676);
       TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 590230);
+      TS_ASSERT_DELTA(outputWS0->readE(0).front(), std::sqrt(807206), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(1).front(), std::sqrt(805367), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(2).front(), std::sqrt(920983), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(3).front(), std::sqrt(909955), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(4).front(), std::sqrt(310676), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(5).front(), std::sqrt(590230), 1e-10);
     }
   }
 
@@ -511,6 +525,12 @@ public:
       TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 63299);
       TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 22917);
       TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 43843);
+      TS_ASSERT_DELTA(outputWS0->readE(0).front(), std::sqrt(59561), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(1).front(), std::sqrt(59358), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(2).front(), std::sqrt(63952), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(3).front(), std::sqrt(63299), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(4).front(), std::sqrt(22917), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(5).front(), std::sqrt(43843), 1e-10);
 
       /* expected results came from running
 
@@ -737,6 +757,12 @@ public:
       TS_ASSERT_EQUALS(outputWS0->readY(3).front(), 228);
       TS_ASSERT_EQUALS(outputWS0->readY(4).front(), 71);
       TS_ASSERT_EQUALS(outputWS0->readY(5).front(), 144);
+      TS_ASSERT_DELTA(outputWS0->readE(0).front(), std::sqrt(214), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(1).front(), std::sqrt(219), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(2).front(), std::sqrt(269), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(3).front(), std::sqrt(228), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(4).front(), std::sqrt(71), 1e-10);
+      TS_ASSERT_DELTA(outputWS0->readE(5).front(), std::sqrt(144), 1e-10);
 
       auto outputWS1 = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(1));
       TS_ASSERT_EQUALS(outputWS1->readY(0).front(), 171);

--- a/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
+++ b/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
@@ -130,6 +130,11 @@ public:
     TS_ASSERT_EQUALS(ws->readY(0)[1], 3.0);
     TS_ASSERT_EQUALS(ws2->readY(0)[0], 3.0);
     TS_ASSERT_EQUALS(ws2->readY(0)[1], 0.0);
+    // error will be sqrt of counts
+    TS_ASSERT_DELTA(ws->readE(0)[0], std::sqrt(7.0), 1e-10);
+    TS_ASSERT_DELTA(ws->readE(0)[1], std::sqrt(3.0), 1e-10);
+    TS_ASSERT_DELTA(ws2->readE(0)[0], std::sqrt(3.0), 1e-10);
+    TS_ASSERT_DELTA(ws2->readE(0)[1], 0.0, 1e-10);
 
     // now test with different correction to sample
     const std::map<Mantid::detid_t, double> scale_at_sample2{{1, 1000.}, {2, 500.}};
@@ -169,5 +174,10 @@ public:
     TS_ASSERT_EQUALS(ws->readY(0)[1], 2.0);
     TS_ASSERT_EQUALS(ws2->readY(0)[0], 3.0);
     TS_ASSERT_EQUALS(ws2->readY(0)[1], 2.0);
+    // error will be sqrt of counts
+    TS_ASSERT_DELTA(ws->readE(0)[0], std::sqrt(7.0), 1e-10);
+    TS_ASSERT_DELTA(ws->readE(0)[1], std::sqrt(2.0), 1e-10);
+    TS_ASSERT_DELTA(ws2->readE(0)[0], std::sqrt(3.0), 1e-10);
+    TS_ASSERT_DELTA(ws2->readE(0)[1], std::sqrt(2.0), 1e-10);
   }
 };

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -73,7 +73,7 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                  GroupWorkspaces=True)
     out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)
 
-    CompareWorkspaces(ws, out, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
+    CompareWorkspaces(ws, out, CheckSpectraMap=False, CheckInstrument=False)
 
 **Example - splitting events based on log values**
 
@@ -121,7 +121,7 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
     ws2 = FilterBadPulses(ws2)
     ws2 = Rebin(ws2, "0,50000,50000", PreserveEvents=False)
 
-    CompareWorkspaces(ws, ws2, CheckUncertainty=False, CheckSpectraMap=False, CheckInstrument=False)
+    CompareWorkspaces(ws, ws2, CheckSpectraMap=False, CheckInstrument=False)
 
 .. categories::
 

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40493.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40493.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` will now set the uncertainty values on the output workspace.


### PR DESCRIPTION
### Description of work

The errors on the histograms are now set correctly.

### To test:

You should be able to run the usage examples from https://docs.mantidproject.org/nightly/algorithms/AlignAndFocusPowderSlim-v1.html where `CompareWorkspaces` is used but now with `CheckUncertainty=True`.


or simply

```python
ws=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF")

ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
grp = CreateGroupingWorkspace(ws2, GroupDetectorsBy='bank')
ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="grp")
ws2 = Rebin(ws2, "0,50000,50000", PreserveEvents=False)

CompareWorkspaces(ws, ws2, CheckUncertainty=True, CheckSpectraMap=False, CheckInstrument=False)
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
