### PR TITLE
Revert "Use gtest as a conda package instead (#40463)"

### DIFF
--- a/Framework/API/test/CMakeLists.txt
+++ b/Framework/API/test/CMakeLists.txt
@@ -19,14 +19,9 @@ if(CXXTEST_FOUND)
             Mantid::Nexus
             Mantid::NexusGeometry
             ${BCRYPT}
+            gmock
             Python::Python
   )
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(APITest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(APITest PRIVATE gmock gtest)
-  endif()
 
   add_framework_test_helpers(APITest)
 

--- a/Framework/Algorithms/test/CMakeLists.txt
+++ b/Framework/Algorithms/test/CMakeLists.txt
@@ -44,14 +44,8 @@ if(CXXTEST_FOUND)
             Mantid::Kernel
             Boost::boost
             ${BCRYPT}
+            gmock
   )
-
-  # Prefer imported GTest targets when available, otherwise fall back to plain targets
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(AlgorithmsTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(AlgorithmsTest PRIVATE gmock gtest)
-  endif()
 
   add_framework_test_helpers(AlgorithmsTest)
 

--- a/Framework/Beamline/test/CMakeLists.txt
+++ b/Framework/Beamline/test/CMakeLists.txt
@@ -3,15 +3,9 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(BeamlineTest ${TEST_FILES} ${GMOCK_TEST_FILES})
 
-  target_link_libraries(BeamlineTest PRIVATE Mantid::Beamline Mantid::Kernel)
+  target_link_libraries(BeamlineTest PRIVATE Mantid::Beamline Mantid::Kernel gmock)
 
   add_framework_test_helpers(BeamlineTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(BeamlineTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(BeamlineTest PRIVATE gmock gtest)
-  endif()
 
   add_dependencies(FrameworkTests BeamlineTest)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -140,7 +140,6 @@ if(NOT FULL_PACKAGE_BUILD)
   add_subdirectory(PostInstall)
 endif()
 
-include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${CMAKE_SOURCE_DIR}/buildconfig/CMake/MantidFrameworkConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfig.cmake

--- a/Framework/Catalog/test/CMakeLists.txt
+++ b/Framework/Catalog/test/CMakeLists.txt
@@ -3,15 +3,9 @@ if(CXXTEST_FOUND)
 
   # The actual test suite
   cxxtest_add_test(CatalogTest ${TEST_FILES})
-  target_link_libraries(CatalogTest PRIVATE Mantid::Catalog)
+  target_link_libraries(CatalogTest PRIVATE Mantid::Catalog gmock)
   add_dependencies(FrameworkTests CatalogTest)
   add_framework_test_helpers(CatalogTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(CatalogTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(CatalogTest PRIVATE gmock gtest)
-  endif()
 
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET CatalogTest PROPERTY FOLDER "UnitTests")

--- a/Framework/Crystal/test/CMakeLists.txt
+++ b/Framework/Crystal/test/CMakeLists.txt
@@ -8,13 +8,9 @@ if(CXXTEST_FOUND)
   # will go out of scope at the end of this file so doesn't need un-setting
 
   cxxtest_add_test(CrystalTest ${TEST_FILES})
-  target_link_libraries(CrystalTest PRIVATE Mantid::Crystal Mantid::DataHandling Mantid::MDAlgorithms Mantid::Nexus)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(CrystalTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(CrystalTest PRIVATE gmock gtest)
-  endif()
+  target_link_libraries(
+    CrystalTest PRIVATE Mantid::Crystal Mantid::DataHandling Mantid::MDAlgorithms Mantid::Nexus gmock
+  )
   add_framework_test_helpers(CrystalTest)
   add_dependencies(CrystalTest Algorithms CurveFitting)
   add_dependencies(FrameworkTests CrystalTest)

--- a/Framework/CurveFitting/test/CMakeLists.txt
+++ b/Framework/CurveFitting/test/CMakeLists.txt
@@ -3,15 +3,9 @@ if(CXXTEST_FOUND)
   # This variable is used within the cxxtest_add_test macro to build these helper classes into the test executable. It
   # will go out of scope at the end of this file so doesn't need un-setting
   cxxtest_add_test(CurveFittingTest ${TEST_FILES})
-  target_link_libraries(CurveFittingTest PRIVATE Mantid::CurveFitting Mantid::DataHandling)
+  target_link_libraries(CurveFittingTest PRIVATE Mantid::CurveFitting Mantid::DataHandling gmock)
 
   add_framework_test_helpers(CurveFittingTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(CurveFittingTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(CurveFittingTest PRIVATE gmock gtest)
-  endif()
 
   add_dependencies(CurveFittingTest Algorithms)
   add_dependencies(FrameworkTests CurveFittingTest)

--- a/Framework/DataHandling/test/CMakeLists.txt
+++ b/Framework/DataHandling/test/CMakeLists.txt
@@ -12,15 +12,15 @@ if(CXXTEST_FOUND)
   cxxtest_add_test(DataHandlingTest ${TEST_FILES})
 
   target_link_libraries(
-    DataHandlingTest PRIVATE Mantid::Kernel Mantid::Catalog Mantid::DataHandling Mantid::Nexus Mantid::NexusGeometry
-                             Mantid::HistogramData
+    DataHandlingTest
+    PRIVATE Mantid::Kernel
+            Mantid::Catalog
+            Mantid::DataHandling
+            Mantid::Nexus
+            Mantid::NexusGeometry
+            Mantid::HistogramData
+            gmock
   )
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(DataHandlingTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(DataHandlingTest PRIVATE gmock gtest)
-  endif()
 
   if(ENABLE_LIB3MF)
     target_link_libraries(DataHandlingTest LINK_PRIVATE ${LIB3MF_LIBRARIES})

--- a/Framework/DataObjects/test/CMakeLists.txt
+++ b/Framework/DataObjects/test/CMakeLists.txt
@@ -7,15 +7,9 @@ if(CXXTEST_FOUND)
   # This variable is used within the cxxtest_add_test macro to build this helper class into the test executable. It will
   # go out of scope at the end of this file so doesn't need un-setting
   cxxtest_add_test(DataObjectsTest ${TEST_FILES})
-  target_link_libraries(DataObjectsTest PRIVATE Mantid::DataObjects Mantid::Kernel Mantid::Nexus)
+  target_link_libraries(DataObjectsTest PRIVATE Mantid::DataObjects Mantid::Kernel Mantid::Nexus gmock)
 
   add_framework_test_helpers(DataObjectsTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(DataObjectsTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(DataObjectsTest PRIVATE gmock gtest)
-  endif()
   # Specify implicit dependency, but don't link to it
   add_dependencies(FrameworkTests DataObjectsTest)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/Geometry/test/CMakeLists.txt
+++ b/Framework/Geometry/test/CMakeLists.txt
@@ -11,14 +11,8 @@ if(CXXTEST_FOUND)
   cxxtest_add_test(GeometryTest ${TEST_FILES} ${GMOCK_TEST_FILES})
   target_compile_definitions(GeometryTest PRIVATE -D_SILENCE_FPOS_SEEKPOS_DEPRECATION_WARNING)
   target_link_libraries(
-    GeometryTest PRIVATE Mantid::Geometry Mantid::Beamline Mantid::Types Mantid::Kernel ${OpenGL_LIBRARIES}
+    GeometryTest PRIVATE Mantid::Geometry Mantid::Beamline Mantid::Types Mantid::Kernel ${OpenGL_LIBRARIES} gmock
   )
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(GeometryTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(GeometryTest PRIVATE gmock gtest)
-  endif()
 
   add_framework_test_helpers(GeometryTest)
   add_dependencies(FrameworkTests GeometryTest)

--- a/Framework/HistogramData/test/CMakeLists.txt
+++ b/Framework/HistogramData/test/CMakeLists.txt
@@ -3,15 +3,9 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(HistogramDataTest ${TEST_FILES} ${GMOCK_TEST_FILES})
 
-  target_link_libraries(HistogramDataTest PRIVATE Mantid::HistogramData Mantid::Kernel)
+  target_link_libraries(HistogramDataTest PRIVATE Mantid::HistogramData Mantid::Kernel gmock)
 
   add_framework_test_helpers(HistogramDataTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(HistogramDataTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(HistogramDataTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(FrameworkTests HistogramDataTest)
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET HistogramDataTest PROPERTY FOLDER "UnitTests")

--- a/Framework/ICat/test/CMakeLists.txt
+++ b/Framework/ICat/test/CMakeLists.txt
@@ -7,15 +7,9 @@ if(CXXTEST_FOUND)
 
   # The actual test suite
   cxxtest_add_test(ICatTest ${TEST_FILES})
-  target_link_libraries(ICatTest PRIVATE Mantid::ICat Mantid::API Mantid::DataObjects)
+  target_link_libraries(ICatTest PRIVATE Mantid::ICat Mantid::API Mantid::DataObjects gmock)
 
   add_framework_test_helpers(ICatTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(ICatTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(ICatTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(FrameworkTests ICatTest)
 
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/Indexing/test/CMakeLists.txt
+++ b/Framework/Indexing/test/CMakeLists.txt
@@ -4,15 +4,9 @@ if(CXXTEST_FOUND)
   # will go out of scope at the end of this file so doesn't need un-setting
 
   cxxtest_add_test(IndexingTest ${TEST_FILES} ${GMOCK_TEST_FILES})
-  target_link_libraries(IndexingTest PRIVATE Mantid::Types Mantid::Indexing)
+  target_link_libraries(IndexingTest PRIVATE Mantid::Types Mantid::Indexing gmock)
 
   add_framework_test_helpers(IndexingTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(IndexingTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(IndexingTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(FrameworkTests IndexingTest)
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET IndexingTest PROPERTY FOLDER "UnitTests")

--- a/Framework/Json/CMakeLists.txt
+++ b/Framework/Json/CMakeLists.txt
@@ -34,15 +34,9 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(JsonTest ${TEST_FILES})
   target_include_directories(JsonTest SYSTEM PRIVATE ${CXXTEST_INCLUDE_DIR} ${JSONCPP_INCLUDE_DIR})
-  target_link_libraries(JsonTest PUBLIC ${JSONCPP_LIBRARIES} Json)
+  target_link_libraries(JsonTest PUBLIC ${JSONCPP_LIBRARIES} gmock Json)
 
   add_dependencies(FrameworkTests JsonTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(JsonTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(JsonTest PRIVATE gmock gtest)
-  endif()
 
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET JsonTest PROPERTY FOLDER "UnitTests")

--- a/Framework/Kernel/test/CMakeLists.txt
+++ b/Framework/Kernel/test/CMakeLists.txt
@@ -5,14 +5,8 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(KernelTest ${TEST_FILES})
   target_include_directories(KernelTest SYSTEM PRIVATE ${CXXTEST_INCLUDE_DIR})
-  target_link_libraries(KernelTest PRIVATE Mantid::Types Mantid::Kernel Mantid::Json)
+  target_link_libraries(KernelTest PRIVATE Mantid::Types Mantid::Kernel Mantid::Json gmock)
   add_framework_test_helpers(KernelTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(KernelTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(KernelTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(FrameworkTests KernelTest)
   # Test data
   add_dependencies(KernelTest UnitTestData)

--- a/Framework/LegacyNexus/test/CMakeLists.txt
+++ b/Framework/LegacyNexus/test/CMakeLists.txt
@@ -5,14 +5,8 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(LegacyNexusTest ${TEST_FILES})
 
-  target_link_libraries(LegacyNexusTest PRIVATE Mantid::LegacyNexus)
+  target_link_libraries(LegacyNexusTest PRIVATE Mantid::LegacyNexus gmock)
   add_framework_test_helpers(LegacyNexusTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(LegacyNexusTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(LegacyNexusTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(FrameworkTests LegacyNexusTest)
   add_dependencies(LegacyNexusTest UnitTestData)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/LiveData/test/CMakeLists.txt
+++ b/Framework/LiveData/test/CMakeLists.txt
@@ -10,15 +10,9 @@ if(CXXTEST_FOUND)
   set(TESTHELPER_SRCS KafkaTesting.h KafkaTestThreadHelper.h TestDataListener.cpp TestGroupDataListener.cpp)
 
   cxxtest_add_test(LiveDataTest ${TEST_FILES})
-  target_link_libraries(LiveDataTest PRIVATE Mantid::LiveData)
+  target_link_libraries(LiveDataTest PRIVATE Mantid::LiveData gmock)
   target_include_directories(LiveDataTest PRIVATE ../src/)
   add_framework_test_helpers(LiveDataTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(LiveDataTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(LiveDataTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(LiveDataTest DataHandling Algorithms MDAlgorithms)
   add_dependencies(FrameworkTests LiveDataTest)
   # Test data

--- a/Framework/MDAlgorithms/test/CMakeLists.txt
+++ b/Framework/MDAlgorithms/test/CMakeLists.txt
@@ -11,14 +11,8 @@ if(CXXTEST_FOUND)
   cxxtest_add_test(MDAlgorithmsTest ${TEST_FILES} ${GMOCK_TEST_FILES})
   target_link_libraries(
     MDAlgorithmsTest PRIVATE Mantid::DataHandling Mantid::CurveFitting Mantid::MDAlgorithms Mantid::Nexus
-                             Mantid::Kernel
+                             Mantid::Kernel gmock
   )
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(MDAlgorithmsTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(MDAlgorithmsTest PRIVATE gmock gtest)
-  endif()
 
   target_include_directories(MDAlgorithmsTest PRIVATE CurveFitting DataHandling)
 

--- a/Framework/Muon/test/CMakeLists.txt
+++ b/Framework/Muon/test/CMakeLists.txt
@@ -8,14 +8,8 @@ if(CXXTEST_FOUND)
   # This variable is used within the cxxtest_add_test macro to build these helper classes into the test executable. It
   # will go out of scope at the end of this file so doesn't need un-setting
   cxxtest_add_test(MuonTest ${TEST_FILES})
-  target_link_libraries(MuonTest PRIVATE Mantid::Algorithms Mantid::DataHandling Mantid::Muon Mantid::DataObjects)
+  target_link_libraries(MuonTest PRIVATE Mantid::Algorithms Mantid::DataHandling Mantid::Muon Mantid::DataObjects gmock)
   add_framework_test_helpers(MuonTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(MuonTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(MuonTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(MuonTest Crystal CurveFitting)
   add_dependencies(FrameworkTests MuonTest)
   # Test data

--- a/Framework/Nexus/test/CMakeLists.txt
+++ b/Framework/Nexus/test/CMakeLists.txt
@@ -5,12 +5,7 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(NexusTest ${TEST_FILES})
 
-  target_link_libraries(NexusTest PRIVATE Mantid::Nexus Mantid::Kernel)
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(NexusTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(NexusTest PRIVATE gmock gtest)
-  endif()
+  target_link_libraries(NexusTest PRIVATE Mantid::Nexus gmock Mantid::Kernel)
   add_dependencies(FrameworkTests NexusTest)
   add_dependencies(NexusTest UnitTestData)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/NexusGeometry/test/CMakeLists.txt
+++ b/Framework/NexusGeometry/test/CMakeLists.txt
@@ -7,14 +7,9 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(NexusGeometryTest ${TEST_FILES})
 
-  target_link_libraries(NexusGeometryTest PRIVATE Mantid::NexusGeometry Mantid::Types Mantid::Kernel)
+  target_link_libraries(NexusGeometryTest PRIVATE Mantid::NexusGeometry Mantid::Types Mantid::Kernel gmock)
 
   add_framework_test_helpers(NexusGeometryTest)
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(NexusGeometryTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(NexusGeometryTest PRIVATE gmock gtest)
-  endif()
   add_dependencies(NexusGeometryTest Geometry)
   add_dependencies(FrameworkTests NexusGeometryTest)
   add_dependencies(NexusGeometryTest UnitTestData)

--- a/Framework/PythonInterface/test/cpp/CMakeLists.txt
+++ b/Framework/PythonInterface/test/cpp/CMakeLists.txt
@@ -35,18 +35,13 @@ if(CXXTEST_FOUND)
     PythonInterfaceCore
     PythonKernelModule
     PythonAPIModule
+    gmock
     ${OpenGL_LIBRARIES}
     ${TBB_LIBRARIES}
     ${Boost_LIBRARIES}
     ${POCO_LIBRARIES}
     Python::Python
   )
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(${_pythoninterface_test_target_name} PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(${_pythoninterface_test_target_name} PRIVATE gmock gtest)
-  endif()
 
   add_dependencies(FrameworkTests ${_pythoninterface_test_target_name})
   # Add to the 'UnitTests' group in VS

--- a/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
+++ b/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
@@ -35,14 +35,8 @@ target_link_libraries(
           Geometry
           ${Boost_LIBRARIES}
           ${POCO_LIBRARIES}
+          gmock
 )
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(PythonWorkspaceCreationHelper PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(PythonWorkspaceCreationHelper PRIVATE gmock gtest)
-endif()
 
 # Overall testhelpers target .pth file for discovery (only needed for development)
 set(_testhelpers_pth_src "${CMAKE_CURRENT_BINARY_DIR}/testhelpers.pth")

--- a/Framework/Reflectometry/test/CMakeLists.txt
+++ b/Framework/Reflectometry/test/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CXXTEST_FOUND)
   # will go out of scope at the end of this file so doesn't need un-setting
 
   cxxtest_add_test(ReflectometryTest ${TEST_FILES})
-  target_link_libraries(ReflectometryTest PRIVATE Mantid::Algorithms Mantid::Reflectometry)
+  target_link_libraries(ReflectometryTest PRIVATE Mantid::Algorithms Mantid::Reflectometry gmock)
 
   target_include_directories(ReflectometryTest PRIVATE Mantid::Algorithms Mantid::Reflectometry)
 
@@ -38,12 +38,6 @@ if(CXXTEST_FOUND)
   # Test data
   add_dependencies(ReflectometryTest UnitTestData)
   add_framework_test_helpers(ReflectometryTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(ReflectometryTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(ReflectometryTest PRIVATE gmock gtest)
-  endif()
 
   # Add to the 'ReflectometryTest' group in VS
   set_property(TARGET ReflectometryTest PROPERTY FOLDER "UnitTests")

--- a/Framework/SINQ/test/CMakeLists.txt
+++ b/Framework/SINQ/test/CMakeLists.txt
@@ -6,15 +6,11 @@ if(CXXTEST_FOUND)
   include_directories(SYSTEM ${CXXTEST_INCLUDE_DIR})
 
   cxxtest_add_test(PSISINQTest ${TEST_FILES} ${GMOCK_TEST_FILES})
-  target_link_libraries(PSISINQTest PRIVATE Mantid::SINQ Mantid::CurveFitting)
+  target_link_libraries(PSISINQTest PRIVATE Mantid::SINQ Mantid::CurveFitting gmock)
+
+  target_include_directories(PSISINQTest PRIVATE Mantid::CurveFitting Mantid::MDAlgorithms Mantid::Nexus Mantid::Nexus)
 
   add_framework_test_helpers(PSISINQTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(PSISINQTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(PSISINQTest PRIVATE gmock gtest)
-  endif()
 
   # Test data
   add_dependencies(PSISINQTest UnitTestData)

--- a/Framework/ScriptRepository/test/CMakeLists.txt
+++ b/Framework/ScriptRepository/test/CMakeLists.txt
@@ -4,15 +4,9 @@ if(CXXTEST_FOUND)
   include_directories(../)
 
   cxxtest_add_test(ScriptRepositoryTest ${TEST_FILES} ${GMOCK_TEST_FILES})
-  target_link_libraries(ScriptRepositoryTest PRIVATE Mantid::Types Mantid::ScriptRepository)
+  target_link_libraries(ScriptRepositoryTest PRIVATE Mantid::Types Mantid::ScriptRepository gmock)
 
   add_dependencies(FrameworkTests ScriptRepositoryTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(ScriptRepositoryTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(ScriptRepositoryTest PRIVATE gmock gtest)
-  endif()
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET ScriptRepositoryTest PROPERTY FOLDER "UnitTests")
 endif()

--- a/Framework/TestHelpers/CMakeLists.txt
+++ b/Framework/TestHelpers/CMakeLists.txt
@@ -90,13 +90,7 @@ target_link_libraries(
           Mantid::MDAlgorithms
           Mantid::Muon
           Mantid::NexusGeometry
+          gmock
 )
 
 target_include_directories(FrameworkTestHelpers PRIVATE ${CXXTEST_INCLUDE_DIR})
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(FrameworkTestHelpers PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(FrameworkTestHelpers PRIVATE gmock gtest)
-endif()

--- a/Framework/Types/test/CMakeLists.txt
+++ b/Framework/Types/test/CMakeLists.txt
@@ -2,15 +2,9 @@ if(CXXTEST_FOUND)
   include_directories(SYSTEM ${CXXTEST_INCLUDE_DIR})
 
   cxxtest_add_test(TypesTest ${TEST_FILES} ${GMOCK_TEST_FILES})
-  target_link_libraries(TypesTest PRIVATE Mantid::Types)
+  target_link_libraries(TypesTest PRIVATE Mantid::Types gmock)
 
   add_dependencies(FrameworkTests TypesTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(TypesTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(TypesTest PRIVATE gmock gtest)
-  endif()
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET TypesTest PROPERTY FOLDER "UnitTests")
 endif()

--- a/Framework/WorkflowAlgorithms/test/CMakeLists.txt
+++ b/Framework/WorkflowAlgorithms/test/CMakeLists.txt
@@ -19,19 +19,13 @@ if(CXXTEST_FOUND)
   # into the test executable. It will go out of scope at the end of this file so doesn't need un-setting
   cxxtest_add_test(WorkflowAlgorithmsTest ${TEST_FILES})
   target_link_libraries(
-    WorkflowAlgorithmsTest PRIVATE Mantid::WorkflowAlgorithms Mantid::Algorithms Mantid::DataHandling
+    WorkflowAlgorithmsTest PRIVATE Mantid::WorkflowAlgorithms Mantid::Algorithms Mantid::DataHandling gmock
   )
   add_dependencies(WorkflowAlgorithmsTest CurveFitting)
   add_dependencies(FrameworkTests WorkflowAlgorithmsTest)
   # Test data
   add_dependencies(WorkflowAlgorithmsTest UnitTestData)
   add_framework_test_helpers(WorkflowAlgorithmsTest)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(WorkflowAlgorithmsTest PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(WorkflowAlgorithmsTest PRIVATE gmock gtest)
-  endif()
 
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET WorkflowAlgorithmsTest PROPERTY FOLDER "UnitTests")

--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -2,9 +2,11 @@
 
 # Make gtest_version available everywhere
 set(gtest_version
-    "v1.17.0"
+    "v1.15.2"
     CACHE INTERNAL ""
 )
+
+include(FetchContent)
 
 # Prevent overriding the parent project's compiler/linker settings on Windows. Force overwrites previous cache value.
 set(gtest_force_shared_crt
@@ -12,7 +14,14 @@ set(gtest_force_shared_crt
     CACHE BOOL "" FORCE
 )
 
-find_package(GTest CONFIG REQUIRED)
+fetchcontent_declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG "${gtest_version}"
+  EXCLUDE_FROM_ALL
+)
+
+fetchcontent_makeavailable(googletest)
 
 mark_as_advanced(
   BUILD_GMOCK
@@ -28,33 +37,19 @@ mark_as_advanced(
 
 # Hide targets from "all" and put them in the UnitTests folder in MSVS
 foreach(target_var gmock gtest gmock_main gtest_main)
-  if(TARGET ${target_var})
-    set_target_properties(${target_var} PROPERTIES FOLDER "UnitTests/gmock")
-  endif()
+  set_target_properties(${target_var} PROPERTIES FOLDER "UnitTests/gmock")
 endforeach()
 
 # W4 logging doesn't work with MSVC address sanitizer, turn off sanitizer since not our code
 if(MSVC)
-  if(TARGET gmock)
-    get_target_property(opts gmock COMPILE_OPTIONS)
-    if(NOT opts OR opts STREQUAL "opts-NOTFOUND")
-      set(opts "")
-    endif()
-    list(APPEND opts "/DGTEST_HAS_PTHREAD=0")
-
-    # Add definition for linking against GTest DLL
-    list(APPEND opts "/DGTEST_LINKED_AS_SHARED_LIBRARY=1")
-
-    if(USE_SANITIZERS_LOWER STREQUAL "address")
-      string(REPLACE "/fsanitize=address" "" opts ${opts})
-    endif()
-    set_property(TARGET gmock PROPERTY COMPILE_OPTIONS ${opts})
+  get_target_property(opts gmock COMPILE_OPTIONS)
+  if(NOT opts OR opts STREQUAL "opts-NOTFOUND")
+    set(opts "")
   endif()
+  list(APPEND opts "/DGTEST_HAS_PTHREAD=0")
 
-  # Apply the same definition to other GTest targets if they exist
-  foreach(target_var gtest gmock_main gtest_main)
-    if(TARGET ${target_var})
-      target_compile_definitions(${target_var} PUBLIC GTEST_LINKED_AS_SHARED_LIBRARY=1)
-    endif()
-  endforeach()
+  if(USE_SANITIZERS_LOWER STREQUAL "address")
+    string(REPLACE "/fsanitize=address" "" opts ${opts})
+  endif()
+  set_property(TARGET gmock PROPERTY COMPILE_OPTIONS ${opts})
 endif()

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -49,12 +49,6 @@ gdk_pixbuf:
 graphviz:
   - '>=2.47.0'
 
-gmock:
-  - '==1.17.0'
-
-gtest:
-  - '==1.17.0'
-
 jemalloc:
   - '==5.2.0'   # [linux]
   - '5.2.*'     # [osx]

--- a/conda/recipes/mantid-developer/recipe.yaml
+++ b/conda/recipes/mantid-developer/recipe.yaml
@@ -19,8 +19,6 @@ requirements:
     - seekpath ==2.1.0 *2
     - graphviz ${{ graphviz }}
     - gsl ${{ gsl }}
-    - gtest ${{ gtest }}
-    - gmock ${{ gmock }}
     - h5py
     - hdf4 ${{ hdf4 }}
     - hdf5 ${{ hdf5 }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -31,8 +31,6 @@ requirements:
   host:
     - eigen ${{ eigen }}
     - gsl ${{ gsl }}
-    - gtest ${{ gtest }}
-    - gmock ${{ gmock }}
     - hdf4 ${{ hdf4 }}
     - h5py
     - hdf5 ${{ hdf5 }}

--- a/conda/recipes/mantiddocs/recipe.yaml
+++ b/conda/recipes/mantiddocs/recipe.yaml
@@ -21,8 +21,6 @@ requirements:
     - ${{ compiler("cxx") }}
     - cmake ${{ cmake }}
     - git
-    - gtest ${{ gtest }}
-    - gmock ${{ gmock }}
     - if: osx or linux
       then:
         - ninja ${{ ninja }}
@@ -34,7 +32,6 @@ requirements:
     - sphinx ${{ sphinx }}
     - sphinx_bootstrap_theme ${{ sphinx_bootstrap_theme }}
     - graphviz ${{ graphviz }}
-    - gtest ${{ gtest }}
     - pystog ${{ pystog }}
     - if: linux
       then:

--- a/pixi.lock
+++ b/pixi.lock
@@ -4,6 +4,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -85,7 +87,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.15.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.9-h86084c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
@@ -93,7 +94,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.8-hbf7d49c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.4.0-h6a38259_15.conda
@@ -481,13 +481,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.86.2-hc66c15f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.86.2-hb9d6e3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmock-1.15.2-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-13.1.2-hcd33d8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gsl-2.8-h8d0574d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.11-h3c5c1d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.11-hfe24232_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-h5febe37_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -798,13 +796,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.86.2-hde84fb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.86.2-he647baa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glslang-15.4.0-h5b34520_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.15.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-14.1.0-h4c50273_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.8-h5b8d9c4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.11-h3fe0a9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.11-h233a61a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py311hc40ba4b_101.conda
@@ -3102,33 +3098,6 @@ packages:
   license_family: BSD
   size: 5010650
   timestamp: 1751107584590
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.15.2-ha770c72_0.conda
-  sha256: cddaae3c433647872ddb8c93d195ffad927154c82f6abc17013c7764c02e5eb0
-  md5: 28f0e4e7ea2aa02d685b2cf71f1c7164
-  depends:
-  - gtest 1.15.2 h434a139_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6935
-  timestamp: 1722457788931
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmock-1.15.2-hce30654_0.conda
-  sha256: de03729626bed65e992b2bd7595d538358c80fb28b8fa6bf76e329a551b3498f
-  md5: 8dded26d3fd46cb00da3dd60b0bdea95
-  depends:
-  - gtest 1.15.2 h420ef59_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7030
-  timestamp: 1722458155746
-- conda: https://conda.anaconda.org/conda-forge/win-64/gmock-1.15.2-h57928b3_0.conda
-  sha256: 88b0582c94c433fe929e32dc88ddb38a24973e07c4f0e35345b257fe62b00290
-  md5: 1f94ef86a939ec4db1939186c002a621
-  depends:
-  - gtest 1.15.2 hc790b64_0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7364
-  timestamp: 1722458392601
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
@@ -3401,44 +3370,6 @@ packages:
   license_family: LGPL
   size: 3099976
   timestamp: 1745093701747
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
-  sha256: cf2ccc3bbaca3dba1c12087aeaf5cc8f7c665d8678d9a9815d87b360867fc952
-  md5: 0874e26e61c13ae001dc647a650a97ca
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  constrains:
-  - gmock 1.15.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 408202
-  timestamp: 1722457782806
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.15.2-h420ef59_0.conda
-  sha256: 7295d84430024bd36da657c5b82a2b9759d5a335b6d5ef9b7f4b58b96ba8b6c9
-  md5: 539e1126f517d18d5c26b7c460374297
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  constrains:
-  - gmock 1.15.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 373673
-  timestamp: 1722458126696
-- conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.15.2-hc790b64_0.conda
-  sha256: d2f8f770ad40c1e5857fd79d2cfdb087d45f3e7fdc922a0c81bdd215c350a8ad
-  md5: d3be2a4f511c28dc626bdb3c5dc297c6
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - gmock 1.15.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 502351
-  timestamp: 1722458363989
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
   sha256: d36263cbcbce34ec463ce92bd72efa198b55d987959eab6210cc256a0e79573b
   md5: 67d00e9cfe751cfe581726c5eff7c184

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,8 +17,6 @@ euphonic = ">=1.4.5,<2.0"
 seekpath = { version = "==2.1.0", build = "*2" }
 graphviz = ">=2.47.0"
 gsl = "2.8.*"
-gtest = "==1.17.0"
-gmock = "==1.17.0"
 hdf4 = "4.2.*"
 hdf5 = ">1.14.0,<1.15"
 jsoncpp = ">=1.9.4,<2"

--- a/qt/icons/CMakeLists.txt
+++ b/qt/icons/CMakeLists.txt
@@ -26,14 +26,7 @@ mtd_add_qt_tests(
   TARGET_NAME MantidQtIconsTest
   SRC ${QT5_TEST_FILES}
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/inc ${CMAKE_CURRENT_SOURCE_DIR}/../widgets/common/inc
-  LINK_LIBS ${TARGET_LIBRARIES} ${Boost_LIBRARIES}
+  LINK_LIBS ${TARGET_LIBRARIES} ${Boost_LIBRARIES} gmock
   MTD_QT_LINK_LIBS MantidQtIcons
   PARENT_DEPENDENCIES GUITests
 )
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtIconsTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtIconsTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/scientific_interfaces/Direct/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/test/CMakeLists.txt
@@ -17,16 +17,15 @@ mtd_add_qt_tests(
   SRC ${TEST_FILES}
   TEST_HELPER_SRCS ${TEST_HELPERS}
   INCLUDE_DIRS ../
-  LINK_LIBS Mantid::API Mantid::DataObjects Mantid::Geometry Mantid::Kernel Mantid::PythonInterfaceCore Python::Python
+  LINK_LIBS Mantid::API
+            Mantid::DataObjects
+            Mantid::Geometry
+            Mantid::Kernel
+            Mantid::PythonInterfaceCore
+            Python::Python
+            gmock
   MTD_QT_LINK_LIBS MantidScientificInterfacesDirect MantidQtWidgetsCommon MantidQtWidgetsInstrumentView
   PARENT_DEPENDENCIES GUITests
 )
 
 add_framework_test_helpers(MantidQtInterfacesDirectTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtInterfacesDirectTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtInterfacesDirectTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -61,7 +61,12 @@ mtd_add_qt_tests(
   SRC ${TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/CurveFitting/inc ../../../../Framework/DataObjects/inc ../GUI/Preview Preview
                Reduction
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::DataObjects ${POCO_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore
+  LINK_LIBS ${CORE_MANTIDLIBS}
+            Mantid::DataObjects
+            gmock
+            ${POCO_LIBRARIES}
+            ${Boost_LIBRARIES}
+            Mantid::PythonInterfaceCore
             Python::Python
   MTD_QT_LINK_LIBS MantidScientificInterfacesISISReflectometry MantidQtWidgetsCommon MantidQtWidgetsPlotting
                    MantidQtWidgetsInstrumentView MantidQtWidgetsMplCpp MantidQtWidgetsRegionSelector
@@ -69,10 +74,3 @@ mtd_add_qt_tests(
 )
 
 add_framework_test_helpers(MantidScientificInterfacesISISReflectometryTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidScientificInterfacesISISReflectometryTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidScientificInterfacesISISReflectometryTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -12,7 +12,12 @@ mtd_add_qt_tests(
   SRC ${ALL_TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
   TEST_HELPER_SRCS ${ALL_TEST_HELPERS}
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::DataObjects ${POCO_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore
+  LINK_LIBS ${CORE_MANTIDLIBS}
+            Mantid::DataObjects
+            gmock
+            ${POCO_LIBRARIES}
+            ${Boost_LIBRARIES}
+            Mantid::PythonInterfaceCore
             ${PYTHON_LIBRARIES}
   QT5_LINK_LIBS Qt5::OpenGL
   MTD_QT_LINK_LIBS MantidScientificInterfacesIndirect MantidQtWidgetsCommon MantidQtWidgetsPlotting
@@ -21,10 +26,3 @@ mtd_add_qt_tests(
 )
 
 add_framework_test_helpers(MantidQtInterfacesIndirectTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtInterfacesIndirectTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtInterfacesIndirectTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
@@ -17,7 +17,12 @@ mtd_add_qt_tests(
   SRC ${ALL_TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
   TEST_HELPER_SRCS ${ALL_TEST_HELPERS}
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::DataObjects ${POCO_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore
+  LINK_LIBS ${CORE_MANTIDLIBS}
+            Mantid::DataObjects
+            gmock
+            ${POCO_LIBRARIES}
+            ${Boost_LIBRARIES}
+            Mantid::PythonInterfaceCore
             ${PYTHON_LIBRARIES}
   QT5_LINK_LIBS Qt5::OpenGL
   MTD_QT_LINK_LIBS MantidScientificInterfacesInelastic MantidQtWidgetsCommon MantidQtWidgetsPlotting
@@ -26,9 +31,3 @@ mtd_add_qt_tests(
 )
 
 add_framework_test_helpers(MantidQtInterfacesInelasticTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-  target_link_libraries(MantidQtInterfacesInelasticTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtInterfacesInelasticTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/scientific_interfaces/Muon/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/test/CMakeLists.txt
@@ -20,7 +20,12 @@ mtd_add_qt_tests(
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::DataObjects ${POCO_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore
+  LINK_LIBS ${CORE_MANTIDLIBS}
+            Mantid::DataObjects
+            gmock
+            ${POCO_LIBRARIES}
+            ${Boost_LIBRARIES}
+            Mantid::PythonInterfaceCore
             Python::Python
   QT5_LINK_LIBS Qt5::Test Qt5::OpenGL
   MTD_QT_LINK_LIBS MantidScientificInterfacesMuon MantidQtWidgetsCommon MantidQtWidgetsMplCpp
@@ -28,10 +33,3 @@ mtd_add_qt_tests(
 )
 
 add_framework_test_helpers(MantidQtInterfacesMuonTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtInterfacesMuonTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtInterfacesMuonTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -784,18 +784,17 @@ if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
     QT_VERSION 5
     SRC ${QT5_TEST_FILES}
     INCLUDE_DIRS ../../../Framework/DataObjects/inc ../../../Framework/Crystal/inc
-    LINK_LIBS ${TARGET_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore Mantid::DataObjects Qt5::Test
+    LINK_LIBS ${TARGET_LIBRARIES}
+              ${Boost_LIBRARIES}
+              Mantid::PythonInterfaceCore
+              Mantid::DataObjects
+              gmock
+              Qt5::Test
               Python::Python
     MTD_QT_LINK_LIBS MantidQtWidgetsCommon
     PARENT_DEPENDENCIES GUITests
   )
 
   add_framework_test_helpers(MantidQtWidgetsCommonTestQt5)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(MantidQtWidgetsCommonTestQt5 PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(MantidQtWidgetsCommonTestQt5 PRIVATE gmock gtest)
-  endif()
   pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} MantidQtWidgetsCommonPyTest ${TEST_PY_FILES})
 endif()

--- a/qt/widgets/instrumentview/test/CMakeLists.txt
+++ b/qt/widgets/instrumentview/test/CMakeLists.txt
@@ -22,18 +22,16 @@ mtd_add_qt_tests(
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS ${MOCK_HEADER_DIRS} ../../../../Framework/DataObjects/inc
-  LINK_LIBS Python::Python ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore Mantid::DataObjects ${POCO_LIBRARIES}
+  LINK_LIBS Python::Python
+            ${CORE_MANTIDLIBS}
+            Mantid::PythonInterfaceCore
+            Mantid::DataObjects
+            ${POCO_LIBRARIES}
             ${Boost_LIBRARIES}
+            gmock
   QT5_LINK_LIBS Qt5::OpenGL
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsInstrumentView MantidQtWidgetsMplCpp MantidQtWidgetsPlotting
   PARENT_DEPENDENCIES GUITests
 )
 
 add_framework_test_helpers(MantidQtWidgetsInstrumentWidgetTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtWidgetsInstrumentWidgetTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtWidgetsInstrumentWidgetTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/widgets/mplcpp/test/CMakeLists.txt
+++ b/qt/widgets/mplcpp/test/CMakeLists.txt
@@ -33,13 +33,7 @@ mtd_add_qt_tests(
             ${Boost_LIBRARIES}
             ${POCO_LIBRARIES}
             Python::Python
+            gmock
   MTD_QT_LINK_LIBS MantidQtWidgetsMplCpp MantidQtWidgetsCommon
   PARENT_DEPENDENCIES GUITests
 )
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtWidgetsMplCppTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtWidgetsMplCppTestQt5 PRIVATE gmock gtest)
-endif()

--- a/qt/widgets/plotting/CMakeLists.txt
+++ b/qt/widgets/plotting/CMakeLists.txt
@@ -39,7 +39,7 @@ mtd_add_qt_library(
   NOMOC ${MPL_INC_FILES}
   DEFS IN_MANTIDQT_PLOTTING
   INCLUDE_DIRS inc
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore ${POCO_LIBRARIES} gmock gtest
+  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore ${POCO_LIBRARIES} gmock
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsMplCpp
   INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../MacOS @loader_path/../Frameworks
@@ -58,18 +58,16 @@ if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
     QT_VERSION 5
     INCLUDE_DIRS inc ../common/inc ../../../Framework/DataObjects/inc
     SRC ${TEST_FILES}
-    LINK_LIBS ${CORE_MANTIDLIBS} Mantid::DataObjects ${POCO_LIBRARIES} ${Boost_LIBRARIES} Mantid::PythonInterfaceCore
+    LINK_LIBS ${CORE_MANTIDLIBS}
+              Mantid::DataObjects
+              ${POCO_LIBRARIES}
+              ${Boost_LIBRARIES}
+              Mantid::PythonInterfaceCore
+              gmock
               Python::Python
     MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp
     PARENT_DEPENDENCIES GUITests
   )
 
   add_framework_test_helpers(MantidQtWidgetsPlottingTestQt5)
-
-  if(TARGET GTest::gmock AND TARGET GTest::gtest)
-    target_link_libraries(MantidQtWidgetsPlottingTestQt5 PRIVATE GTest::gmock GTest::gtest)
-  else()
-    target_link_libraries(MantidQtWidgetsPlottingTestQt5 PRIVATE gmock gtest)
-  endif()
-
 endif()

--- a/qt/widgets/spectroscopy/test/CMakeLists.txt
+++ b/qt/widgets/spectroscopy/test/CMakeLists.txt
@@ -22,17 +22,15 @@ mtd_add_qt_tests(
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS ${MOCK_HEADER_DIRS} ../../../../Framework/DataObjects/inc
-  LINK_LIBS Python::Python ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore Mantid::DataObjects ${POCO_LIBRARIES}
+  LINK_LIBS Python::Python
+            ${CORE_MANTIDLIBS}
+            Mantid::PythonInterfaceCore
+            Mantid::DataObjects
+            ${POCO_LIBRARIES}
             ${Boost_LIBRARIES}
+            gmock
   MTD_QT_LINK_LIBS MantidQtWidgetsSpectroscopy
   PARENT_DEPENDENCIES GUITests
 )
 
 add_framework_test_helpers(MantidQtWidgetsSpectroscopyTestQt5)
-
-if(TARGET GTest::gmock AND TARGET GTest::gtest)
-
-  target_link_libraries(MantidQtWidgetsSpectroscopyTestQt5 PRIVATE GTest::gmock GTest::gtest)
-else()
-  target_link_libraries(MantidQtWidgetsSpectroscopyTestQt5 PRIVATE gmock gtest)
-endif()


### PR DESCRIPTION
This reverts commit 713ca3291d92a4c656f7509adb3a7a0326995729.

### Description of work
Windows packaging is failing, which causes the nightly to fail (see [build log](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/1199/execution/node/289/log/)). This should be fixed on the `use-gtest-conda-package` before it can be merged in again. Here is a snippet of the error:
```
LINK : fatal error LNK1181: cannot open input file 'gmock.lib' [%SRC_DIR%\build\qt\widgets\plotting\MantidQtWidgetsPlottingQt5.vcxproj]
````
### To test:
CI should pass.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
