### PR TITLE
More tests of `UniqueID` and `SharedID`

### DIFF
--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -317,7 +317,7 @@ public:
     TS_ASSERT_EQUALS(call_count, 1);
   }
 
-#if defined(__GNUC__) && !(defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
@@ -335,7 +335,7 @@ public:
     // closer not called on self-move
     TS_ASSERT_EQUALS(call_count, 0);
   }
-#if defined(__GNUC__) && !(defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -682,6 +682,10 @@ public:
     TS_ASSERT(uid1 == uid2);
   }
 
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
   void test_sharedID_assign_self() {
     cout << "\ntest sharedID self assignment copy" << endl;
 
@@ -694,6 +698,9 @@ public:
     TS_ASSERT_EQUALS(uid.use_count(), 1);
     TS_ASSERT_EQUALS(call_count, 0);
   }
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
   void test_sharedID_move_assign() {
     cout << "\ntest sharedID move assignment" << endl;
@@ -714,7 +721,7 @@ public:
     TS_ASSERT(!(uid1 == uid2));
   }
 
-#if defined(__GNUC__) && !(defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
@@ -730,7 +737,7 @@ public:
     TS_ASSERT_EQUALS(uid.use_count(), 1);
     TS_ASSERT_EQUALS(call_count, 0);
   }
-#if defined(__GNUC__) && !(defined(__clang__))
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -697,7 +697,7 @@ public:
     TS_ASSERT(hdf_file_is_closed(filename));
     // now check sharing a file id
     { // scoped fid
-      SharedFileID fid1 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+      SharedFileID fid1 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
       SharedFileID fid2(fid1);
       SharedFileID fid3(fid2);
       TS_ASSERT_EQUALS(fid1.use_count(), 3);

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -317,6 +317,7 @@ public:
     TS_ASSERT_EQUALS(call_count, 1);
   }
 
+// NOTE this test performs self-move on purpose
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
@@ -682,6 +683,7 @@ public:
     TS_ASSERT(uid1 == uid2);
   }
 
+// NOTE this test performs self-assign on purpose
 #if defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
@@ -721,6 +723,7 @@ public:
     TS_ASSERT(!(uid1 == uid2));
   }
 
+// NOTE this test performs self-move on purpose
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"

--- a/Framework/Nexus/test/UniqueIDTest.h
+++ b/Framework/Nexus/test/UniqueIDTest.h
@@ -697,7 +697,7 @@ public:
     TS_ASSERT(hdf_file_is_closed(filename));
     // now check sharing a file id
     { // scoped fid
-      SharedFileID fid1 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+      SharedFileID fid1 = H5Fopen(filename.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
       SharedFileID fid2(fid1);
       SharedFileID fid3(fid2);
       TS_ASSERT_EQUALS(fid1.use_count(), 3);


### PR DESCRIPTION
### Description of work

In the previous PR #40485, a `SharedID` object was created, to complement the `UniqueID` created before.

This provides additional unit tests of `UniqueID` and `SharedID`.

### To test:

This PR is adding more tests, so make sure they all pass.

This does not require release notes because it is an internal change only visible to the test suite.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
