### PR TITLE
Fix reported bug in `LoadMD` not presenting logs

### DIFF
--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -430,8 +430,8 @@ void LoadMD::loadCoordinateSystem() {
     m_file->readData("coordinate_system", readCoord);
     m_coordSystem = static_cast<SpecialCoordinateSystem>(readCoord);
   } else {
-    std::string addressOnEntry = m_file->getAddress();
-    std::string newAddress = addressOnEntry + "/experiment0/logs/CoordinateSystem";
+    std::string const addressOnEntry = m_file->getAddress();
+    std::string const newAddress = addressOnEntry + "/experiment0/logs/CoordinateSystem";
     if (m_file->hasData(newAddress + "/value")) {
       int readCoord(0);
       m_file->openAddress(newAddress);

--- a/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -186,8 +186,12 @@ public:
     // ------ Make a ExperimentInfo entry ------------
     ExperimentInfo_sptr ei(new ExperimentInfo());
     ei->mutableRun().setProtonCharge(1.234);
+    ei->mutableRun().addLogData(new Mantid::Kernel::PropertyWithValue<int>("x", 1));
     // TODO: Add instrument
     ws1->addExperimentInfo(ei);
+
+    // check that there are logs before saving
+    TS_ASSERT(!ws1->getExperimentInfo(1)->run().getLogData().empty());
 
     // -------- Save it ---------------
     SaveMD2 saver;
@@ -226,6 +230,9 @@ public:
     TS_ASSERT(iws);
     if (!iws)
       return;
+
+    // check that the logs also loaded
+    TS_ASSERT(!iws->getExperimentInfo(1)->run().getLogData().empty())
 
     // Perform the full comparison
     auto ws = std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<nd>, nd>>(iws);

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -185,7 +185,7 @@ public:
    * \return A unix like address string pointing to the current
    *         position in the file
    */
-  std::string const &getAddress() const { return m_address.string(); };
+  std::string getAddress() const { return m_address.string(); };
 
   // CHECK ADDRESS EXISTENCE
 

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -802,6 +802,32 @@ public:
 
   /* NOTE for historical reasons, additional tests exist in NexusFileReadWriteTest.h*/
 
+  void test_getAddress_const() {
+    cout << "\ntest get_address doesn't move\n" << std::flush;
+    FileResource resource("test_nexus_file_grp.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    // make and open a group
+    file.makeGroup("abc", "NXclass", true);
+    // make another layer -- at "/acb/def"
+    file.makeGroup("def", "NXentry", true);
+    TS_ASSERT_EQUALS("/abc/def", file.getAddress());
+
+    // this function takes the return of file.getAddress() as an argument
+    // it will close a group (changing the file's address), then try to use the address.
+    // make sure the address parameter doesn't move from under us.
+    std::function<void(std::string const &)> test_func = [&file](std::string const &addr) {
+      file.closeGroup();
+      TS_ASSERT_EQUALS("/abc/def", addr);
+    };
+
+    std::string address = file.getAddress();
+    test_func(file.getAddress());
+
+    // the string is still okay
+    TS_ASSERT_EQUALS("/abc/def", address);
+  }
+
   void test_getAddress_groups() {
     cout << "\ntest get_address -- groups only\n" << std::flush;
     FileResource resource("test_nexus_file_grp.h5");


### PR DESCRIPTION
### Description of work

An error was reported when loading logs through `LoadMD`.  The workspace would load, but there would be no sample logs.

This error was tracked down to `MDBoxFlatTree::loadExperimentInfos()`, [L454](https://github.com/mantidproject/mantid/blob/17670966671bf15a5701c39a2ec470a8cac1456f/Framework/DataObjects/src/MDBoxFlatTree.cpp#L454), which passes the result of `Nexus::File::getAddress()` as a reference to another function.

`Nexus::File::getAddress()` was declared as 
``` cpp
std::string const &getAddress() const { return m_address.string(); };
```
that is, returning a constant reference to the address string.  However, if `Nexus::File` moves, then the returned reference will change in value.  That was causing errors, where the function passed `file->getAddress()` was editing the File's internal location before accessing its address parameter, so that it was pointing in the wrong spot.

This undoes that error and adds a test to guard against it.

[EWM 14369](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14369)

### To test:

To reproduce the error, run the following script in Mantid (must be nightly, or build from main HEAD):
``` python
from mantid.simpleapi import CreateMDWorkspace, SaveMD, LoadMD, AddSampleLog

# create the file
filename = '/tmp/test_loadmd_log.nxs'
mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
AddSampleLog(Workspace=mdws, LogName='x', LogText='hello world', LogType='String')
# it has a log
assert len(mdws.getExperimentInfo(0).run().keys()) != 0

# save the file
SaveMD(mdws, Filename=filename)

# reload the file
outws = LoadMD(Filename=filename)

# check
assert len(outws.getExperimentInfo(0).run().keys()) != 0
```
Pull and build this branch, and rerun the above.  The assertion should pass.

The added unit test captures the error.  Make sure it runs.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
