### PR TITLE
Instrument View 2.0: Add rectangular widget

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -448,9 +448,9 @@ class FullInstrumentViewModel:
     def overwrite_mask_to_current_workspace(self) -> None:
         # TODO: Check if copies are expensive with big workspaces
         temp_ws_name = f"__instrument_view_temp_{self._workspace.name()}"
-        CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name)
-        MaskDetectors(temp_ws_name, MaskedWorkspace=self.mask_ws)
-        RenameWorkspace(InputWorkspace=temp_ws_name, OutputWorkspace=self._workspace.name())
+        ws = CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name, StoreInADS=False)
+        MaskDetectors(ws, MaskedWorkspace=self.mask_ws)
+        RenameWorkspace(InputWorkspace=ws, OutputWorkspace=self._workspace.name())
 
     def get_mask_workspaces_in_ads(self) -> list[MaskWorkspace]:
         ads = AnalysisDataService.Instance()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -403,7 +403,7 @@ class FullInstrumentViewModel:
         return q_lab / np.linalg.norm(q_lab)
 
     def add_new_detector_mask(self, new_mask: list[bool]) -> str:
-        new_key = f"Mask {len(self._cached_masks_map) + 1}"
+        new_key = f"Mask {len(self._cached_masks_map) + 1} (unsaved)"
         mask_to_save = self._is_masked_in_ws.copy()
         mask_to_save[self.is_pickable] = new_mask
         self._cached_masks_map[new_key] = mask_to_save

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -448,9 +448,9 @@ class FullInstrumentViewModel:
     def overwrite_mask_to_current_workspace(self) -> None:
         # TODO: Check if copies are expensive with big workspaces
         temp_ws_name = f"__instrument_view_temp_{self._workspace.name()}"
-        ws = CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name, StoreInADS=False)
-        MaskDetectors(ws, MaskedWorkspace=self.mask_ws)
-        RenameWorkspace(InputWorkspace=ws, OutputWorkspace=self._workspace.name())
+        CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name)
+        MaskDetectors(temp_ws_name, MaskedWorkspace=self.mask_ws)
+        RenameWorkspace(InputWorkspace=temp_ws_name, OutputWorkspace=self._workspace.name())
 
     def get_mask_workspaces_in_ads(self) -> list[MaskWorkspace]:
         ads = AnalysisDataService.Instance()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -447,8 +447,9 @@ class FullInstrumentViewModel:
 
     def overwrite_mask_to_current_workspace(self) -> None:
         # TODO: Check if copies are expensive with big workspaces
+        temp_ws = CloneWorkspace(self._workspace.name(), StoreInADS=False)
         temp_ws_name = f"__instrument_view_temp_{self._workspace.name()}"
-        CloneWorkspace(self._workspace.name(), OutputWorkspace=temp_ws_name)
+        AnalysisDataService.addOrReplace(temp_ws_name, temp_ws)
         MaskDetectors(temp_ws_name, MaskedWorkspace=self.mask_ws)
         RenameWorkspace(InputWorkspace=temp_ws_name, OutputWorkspace=self._workspace.name())
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -241,9 +241,6 @@ class FullInstrumentViewPresenter:
         self._pickable_mesh[self._visible_label] = self._model.picked_visibility
         self._update_line_plot_ws_and_draw(self._view.current_selected_unit())
 
-    def on_add_cylinder_clicked(self) -> None:
-        self._view.add_cylinder_widget(self._detector_mesh_bounds)
-
     def on_add_mask_clicked(self) -> None:
         implicit_function = self._view.get_current_widget_implicit_function()
         if not implicit_function:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -20,7 +20,6 @@ from instrumentview.InstrumentViewADSObserver import InstrumentViewADSObserver
 from instrumentview.Peaks.WorkspaceDetectorPeaks import WorkspaceDetectorPeaks
 
 from vtkmodules.vtkRenderingCore import vtkCoordinate
-from vtkmodules.vtkCommonDataModel import vtkCylinder
 
 
 class SuppressRendering:
@@ -246,12 +245,10 @@ class FullInstrumentViewPresenter:
         self._view.add_cylinder_widget(self._detector_mesh_bounds)
 
     def on_cylinder_select_clicked(self) -> None:
-        widget = self._view.get_current_widget()
-        if widget is None:
+        implicit_function = self._view.get_current_widget_implicit_function()
+        if not implicit_function:
             return
-        cylinder = vtkCylinder()
-        widget.GetCylinderRepresentation().GetCylinder(cylinder)
-        mask = [(cylinder.FunctionValue(pt) < 0) for pt in self._detector_mesh.points]
+        mask = [(implicit_function.EvaluateFunction(pt) < 0) for pt in self._detector_mesh.points]
         new_key = self._model.add_new_detector_mask(mask)
         self._view.set_new_mask_key(new_key)
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -244,7 +244,7 @@ class FullInstrumentViewPresenter:
     def on_add_cylinder_clicked(self) -> None:
         self._view.add_cylinder_widget(self._detector_mesh_bounds)
 
-    def on_cylinder_select_clicked(self) -> None:
+    def on_add_mask_clicked(self) -> None:
         implicit_function = self._view.get_current_widget_implicit_function()
         if not implicit_function:
             return

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -244,7 +244,7 @@ class FullInstrumentViewWindow(QMainWindow):
         post_list_layout = QHBoxLayout()
         self._save_mask_to_ws = QPushButton("Export to ADS")
         self._save_mask_to_file = QPushButton("Save to XML")
-        self._overwrite_mask = QPushButton("Overwrite Permanently")
+        self._overwrite_mask = QPushButton("Apply Permanently")
         post_list_layout.addWidget(self._save_mask_to_ws)
         post_list_layout.addWidget(self._save_mask_to_file)
         post_list_layout.addWidget(self._overwrite_mask)

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -466,7 +466,7 @@ class FullInstrumentViewWindow(QMainWindow):
     def on_toggle_add_mask(self, checked):
         if checked:
             if self._shape_options.currentText() == WidgetType.Cylinder.value:
-                self._presenter.on_add_cylinder_clicked()
+                self.add_cylinder_widget()
             else:
                 self.add_rectangular_widget()
             self._add_mask.setDisabled(False)
@@ -656,7 +656,7 @@ class FullInstrumentViewWindow(QMainWindow):
         # RGB for dark grey is (64, 64, 64), normalised is (0.25, 0.25, 0.25)
         self.main_plotter.add_mesh(mesh, color=(0.25, 0.25, 0.25), pickable=False, render_points_as_spheres=True, point_size=15)
 
-    def add_cylinder_widget(self, bounds) -> None:
+    def add_cylinder_widget(self) -> None:
         cylinder_repr = vtkImplicitCylinderRepresentation()
         cylinder_repr.SetOutlineTranslation(False)
         # Set bounding box line to invisible
@@ -671,7 +671,7 @@ class FullInstrumentViewWindow(QMainWindow):
         cylinder_repr.SetRadius(np.sqrt((x - cx) ** 2 + (y - cy) ** 2))
 
         # Arbritary border factor for bounding box
-        xmin, xmax, ymin, ymax, _zmin, _zmax = bounds
+        xmin, xmax, ymin, ymax, _zmin, _zmax = self.main_plotter.bounds
         border = (np.sqrt((xmax - xmin) ** 2 + (ymax - ymin) ** 2)) / 2
         cylinder_repr.SetWidgetBounds([xmin - border, xmax + border, ymin - border, ymax + border, 0, 1])
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -53,6 +53,12 @@ from instrumentview.Projections.ProjectionType import ProjectionType
 
 import os
 from typing import Callable
+from enum import Enum
+
+
+class WidgetType(str, Enum):
+    Cylinder = "Circle"
+    Box = "Rectangle"
 
 
 class CylinderWidgetNoRotation(vtkImplicitCylinderWidget):
@@ -222,7 +228,7 @@ class FullInstrumentViewWindow(QMainWindow):
         shape_label.setFixedWidth(50)
         pre_list_layout = QHBoxLayout()
         self._shape_options = QComboBox()
-        self._shape_options.addItems(["Circle", "Rectangle"])
+        self._shape_options.addItems([w.value for w in WidgetType])
         self._add_widget = QPushButton("Add Shape")
         self._add_widget.setCheckable(True)
         self._add_mask = QPushButton("Add Mask")
@@ -458,12 +464,8 @@ class FullInstrumentViewWindow(QMainWindow):
         self._add_mask.setDisabled(True)
 
     def on_toggle_add_mask(self, checked):
-        """
-        Single slot that handles both selected and unselected states.
-        'checked' is True when button is selected, False when unselected.
-        """
         if checked:
-            if self._shape_options.currentText() == "Circle":
+            if self._shape_options.currentText() == WidgetType.Cylinder.value:
                 self._presenter.on_add_cylinder_clicked()
             else:
                 self.add_rectangular_widget()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -67,7 +67,7 @@ class CylinderWidgetNoRotation(vtkImplicitCylinderWidget):
         self.AddObserver(vtkCommand.StartInteractionEvent, lambda *_: self._on_interaction())
 
     def _on_interaction(self):
-        # Replace rotation state with translation state
+        # Replace rotation state (integer 4) with translation state (integer 3)
         if self.GetCylinderRepresentation().GetInteractionState() == 4:
             self.GetCylinderRepresentation().SetInteractionState(3)
             return
@@ -79,7 +79,7 @@ class RectangleWidgetNoRotation(vtkBoxWidget2):
         self.AddObserver(vtkCommand.StartInteractionEvent, lambda *_: self._on_interaction())
 
     def _on_interaction(self):
-        # Replace rotation state with translation state
+        # Replace rotation state (integer 8) with translation state (integer 7)
         if self.GetRepresentation().GetInteractionState() == 8:
             self.GetRepresentation().SetInteractionState(7)
             return
@@ -713,8 +713,8 @@ class FullInstrumentViewWindow(QMainWindow):
         renderer = self.main_plotter.renderer
         renderer.SetDisplayPoint(x, y, z)
         renderer.DisplayToWorld()
-        world_x, world_y, _world_z, world_w = renderer.GetWorldPoint()
-        return world_x / world_w, world_y / world_w, world_y / world_w
+        world_x, world_y, world_z, world_w = renderer.GetWorldPoint()
+        return world_x / world_w, world_y / world_w, world_z / world_w
 
     def get_current_widget_implicit_function(self) -> vtkImplicitFunction | None:
         if isinstance(self._current_widget, CylinderWidgetNoRotation):

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -594,7 +594,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         model._is_valid = np.array([True, True, True])
         model._is_masked = np.array([True, False, False])
         model.add_new_detector_mask([True, True])
-        np.testing.assert_array_equal(model._cached_masks_map["Mask 1"], np.array([True, True, True]))
+        np.testing.assert_array_equal(list(model._cached_masks_map.values())[0], np.array([True, True, True]))
 
     def test_apply_detector_mask(self):
         model, _ = self._setup_model([1, 2, 3])

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -224,7 +224,8 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         mock_repr_call.return_value = mock_repr
         self._view.main_plotter.renderer = MagicMock(GetSize=MagicMock(return_value=(1, 1)))
         self._view.display_to_world_coords = MagicMock(side_effect=[(-1, -2, 3), (1, 2, 3)])
-        self._view.add_cylinder_widget([1, 2, 1, 2, 1, 2])
+        self._view.main_plotter.bounds = [1, 2, 1, 2, 1, 2]
+        self._view.add_cylinder_widget()
         mock_repr.SetCenter.assert_called_with([-1, -2, 0.5])
         mock_repr.SetRadius.assert_called_with(np.sqrt(2**2 + 4**2))
         border = np.sqrt(1**2 + 1**2) / 2

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -8,6 +8,9 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
+from vtkmodules.vtkInteractionWidgets import vtkBoxRepresentation
+import numpy as np
+
 from mantidqt.utils.qt.testing import start_qapplication
 from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
 from mantid.simpleapi import CreateSampleWorkspace
@@ -201,6 +204,32 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
     def test_redraw_lineplot(self):
         self._view.redraw_lineplot()
         self._view._detector_figure_canvas.draw.assert_called_once()
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.vtkBoxRepresentation")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.RectangleWidgetNoRotation")
+    def test_add_rectangular_widget(self, mock_widget, mock_repr) -> None:
+        test_repr = vtkBoxRepresentation()
+        mock_repr.return_value = test_repr
+        self._view.main_plotter.renderer = MagicMock(GetSize=MagicMock(return_value=(1, 1)))
+        self._view.display_to_world_coords = MagicMock(side_effect=[(-1, -2, 3), (1, 2, 3)])
+        self._view.add_rectangular_widget()
+        self._view.display_to_world_coords.assert_called_with(2 / 3, 2 / 3, 0)
+        np.testing.assert_almost_equal(test_repr.bounds, [-1, 1, -2, 2, -0.1, 1])
+        self.assertEqual(self._view._current_widget, mock_widget())
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.vtkImplicitCylinderRepresentation")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.CylinderWidgetNoRotation")
+    def test_add_cylinder_widget(self, mock_cylinder_widget, mock_repr_call) -> None:
+        mock_repr = MagicMock()
+        mock_repr_call.return_value = mock_repr
+        self._view.main_plotter.renderer = MagicMock(GetSize=MagicMock(return_value=(1, 1)))
+        self._view.display_to_world_coords = MagicMock(side_effect=[(-1, -2, 3), (1, 2, 3)])
+        self._view.add_cylinder_widget([1, 2, 1, 2, 1, 2])
+        mock_repr.SetCenter.assert_called_with([-1, -2, 0.5])
+        mock_repr.SetRadius.assert_called_with(np.sqrt(2**2 + 4**2))
+        border = np.sqrt(1**2 + 1**2) / 2
+        mock_repr.SetWidgetBounds.assert_called_with([1 - border, 2 + border, 1 - border, 2 + border, 0, 1])
+        self.assertEqual(self._view._current_widget, mock_cylinder_widget())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
This PR:

- [x]  Adds a rectangular widget for selecting rectangular masks
- [x] Changes view to use dropdown for mask selection

I opted for using a dropdown instead of icons for now. This can be changed in future PRs if users prefer icons.
Closes #40048 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Use dropdown to apply masks in both circles and rectangles
- Toggle/Untoggle button `Add Shape` and check that widget is cancelled
- With `Add Shape` toggled, change to 3D projection, buttons should get disabled
- With `Add Shape` toggled, change to any non-3D projection, button should get untoggled
- Try the resizing the rectangle widget and moving it around a couple of times, I noticed issues with this previously
- Try to break view with other button combinations

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
