### PR TITLE
Pass bash options when calling a script with pixi run

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -168,13 +168,13 @@ fi
 set -o pipefail
 
 # Run the script that handles the build
-pixi run --frozen sh $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
+pixi run --frozen bash -ex $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
 
 # Return to original behaviour.
 set +o pipefail
 
 # Run unit and system tests
-pixi run --frozen sh $SCRIPT_DIR/run-tests $WORKSPACE $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS $BUILD_THREADS
+pixi run --frozen bash -ex $SCRIPT_DIR/run-tests $WORKSPACE $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS $BUILD_THREADS
 
 # elapsed time with second resolution
 end_time=$(date +%s)

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -86,14 +86,14 @@ fi
 
 if [[ $OSTYPE == 'msys'* ]]; then
     rm -fr *.exe
-    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen sh ${PACKAGING_SCRIPTS_DIR}/win/create_package.sh $PACKAGING_ARGS
+    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen bash -e ${PACKAGING_SCRIPTS_DIR}/win/create_package.sh $PACKAGING_ARGS
 elif [[ $OSTYPE == 'darwin'* ]]; then
     rm -fr *.dmg
     if [ -n "${PLATFORM}" ]; then
         PACKAGING_ARGS="${PACKAGING_ARGS} -p ${PLATFORM}"
     fi
-    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen sh ${PACKAGING_SCRIPTS_DIR}/osx/create_bundle.sh $PACKAGING_ARGS
+    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen bash ${PACKAGING_SCRIPTS_DIR}/osx/create_bundle.sh $PACKAGING_ARGS
 else
     rm -fr *.tar.xz
-    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen sh ${PACKAGING_SCRIPTS_DIR}/linux/create_tarball.sh $PACKAGING_ARGS
+    pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e package-standalone --frozen bash ${PACKAGING_SCRIPTS_DIR}/linux/create_tarball.sh $PACKAGING_ARGS
 fi


### PR DESCRIPTION
In the most recent nightly (https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/1200/) some tests failed but the nightly continue to the publishing stages. This is because when calling `run-tests`, `conda-buildscript` called using pixi like this:
```
pixi run --frozen sh .../run-tests
```
running with `sh` was needed for Windows which would otherwise complain that bash script like `run-tests` was not a valid Windows program. However this meant the shebang at the top of `run-tests` is ignored. This included the `-e` option which exits early with a command in the script fails (in this case `ctest`). Crucially this resulted in jenkins thinking that this step had run successfully.

This PR changes `sh` calls to `bash -<options>` (where `<options>` are the options specifiec by the shebang in the file being called).

### To test:

I've added a commit with a failing test to test using a `build_branch` job:
https://builds.mantidproject.org/job/build_branch/1437/

Will remove the commit once we can see that it's working.

Edit: Commit with failing test is now removed as the build looks correct

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
