### PR TITLE
Add focus position parameters as inputs to `AlignAndFocusPowderSlim`

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -87,6 +87,11 @@ const std::string EVENTS_PER_THREAD("EventsPerThread");
 const std::string ALLOW_LOGS("LogAllowList");
 const std::string BLOCK_LOGS("LogBlockList");
 const std::string OUTPUT_SPEC_NUM("OutputSpectrumNumber");
+// focus positions
+const std::string L1("L1");
+const std::string L2S("L2s");
+const std::string POLARS("TwoTheta");
+const std::string AZIMUTHALS("Phi");
 } // namespace PropertyNames
 
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -89,9 +89,9 @@ const std::string BLOCK_LOGS("LogBlockList");
 const std::string OUTPUT_SPEC_NUM("OutputSpectrumNumber");
 // focus positions
 const std::string L1("L1");
-const std::string L2S("L2s");
-const std::string POLARS("TwoTheta");
-const std::string AZIMUTHALS("Phi");
+const std::string L2("L2");
+const std::string POLARS("Polar");
+const std::string AZIMUTHALS("Azimuthal");
 } // namespace PropertyNames
 
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -236,10 +236,10 @@ void AlignAndFocusPowderSlim::init() {
   auto positionArrayValidator = std::make_shared<CompositeValidator>();
   positionArrayValidator->add(mandatoryDblArrayValidator);
   positionArrayValidator->add(mustBePosArr);
-  declareProperty(std::make_unique<PropertyWithValue<double>>(PropertyNames::L1, EMPTY_DBL(), positiveDblValidator),
+  declareProperty(std::make_unique<PropertyWithValue<double>>(PropertyNames::L1, EMPTY_DBL(), l1Validator),
                   "The primary distance $\\ell_1$ from beam to sample");
   declareProperty(
-      std::make_unique<ArrayProperty<double>>(PropertyNames::L2S, std::vector<double>{}, positionArrayValidator),
+      std::make_unique<ArrayProperty<double>>(PropertyNames::L2, std::vector<double>{}, positionArrayValidator),
       "The secondary distances $\\ell_2$ from sample to focus group");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::POLARS, std::vector<double>{}, positionArrayValidator),
@@ -289,18 +289,18 @@ std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {
   }
 
   // the focus group position parameters must have same lengths
-  std::vector<double> l2s = getProperty(PropertyNames::L2S);
+  std::vector<double> l2s = getProperty(PropertyNames::L2);
   std::vector<double> twoTheta = getProperty(PropertyNames::POLARS);
   if (l2s.size() != twoTheta.size()) {
-    errors[PropertyNames::L2S] = strmakef("L2S has inconsistent length %zu", l2s.size());
-    errors[PropertyNames::POLARS] = strmakef("TwoTheta has inconsistent length %zu", twoTheta.size());
+    errors[PropertyNames::L2] = strmakef("L2S has inconsistent length %zu", l2s.size());
+    errors[PropertyNames::POLARS] = strmakef("Polar has inconsistent length %zu", twoTheta.size());
   }
   // phi is optional, but if set must also have same size
   std::vector<double> phi = getProperty(PropertyNames::AZIMUTHALS);
   if (!phi.empty()) {
     if (l2s.size() != phi.size()) {
-      errors[PropertyNames::L2S] = strmakef("L2S has inconsistent length %zu", l2s.size());
-      errors[PropertyNames::AZIMUTHALS] = strmakef("Phi has inconsistent length %zu", phi.size());
+      errors[PropertyNames::L2] = strmakef("L2S has inconsistent length %zu", l2s.size());
+      errors[PropertyNames::AZIMUTHALS] = strmakef("Azimuthal has inconsistent length %zu", phi.size());
       ;
     }
   }
@@ -337,7 +337,7 @@ void AlignAndFocusPowderSlim::exec() {
 
   // TODO parameters should be input information
   const double l1 = getProperty(PropertyNames::L1);
-  const std::vector<double> l2s = getProperty(PropertyNames::L2S);
+  const std::vector<double> l2s = getProperty(PropertyNames::L2);
   const std::vector<double> polars = getProperty(PropertyNames::POLARS); // two-theta
   // set angle from positive x-axis; will be zero unless specified
   std::vector<double> setPhi(l2s.size(), 0.0);

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -89,14 +89,14 @@ public:
     TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L1", ""));
     TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L1", "-1."));
     // l2s is mandatory and must be nonnegative
-    TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L2S", ""));
-    TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L2S", "1., -1."));
+    TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L2", ""));
+    TS_ASSERT_THROWS_ANYTHING(alg.setPropertyValue("L2", "1., -1."));
     // twoTheta is mandatory and must be nonnegative
-    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("TwoTheta", ""));
-    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("TwoTheta", "1., -1."));
+    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("Polar", ""));
+    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("Polar", "1., -1."));
     // phi is optional, but if specified must be nonnegative
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Phi", ""));
-    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("Phi", "1., -1."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Azimuthal", ""));
+    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("Azimuthal", "1., -1."));
 
     // set everything to valid value to move on
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", VULCAN_218062));
@@ -104,17 +104,17 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("L1", defaults.l1));
 
     // // l2 and twoTheta must have the same length
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2S", "1., 2."));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("TwoTheta", "1., 2., 3."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2", "1., 2."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Polar", "1., 2., 3."));
     TS_ASSERT_THROWS_ASSERT(alg.execute(), std::runtime_error const &e,
-                            TS_ASSERT(strstr(e.what(), "TwoTheta has inconsistent length 3")));
+                            TS_ASSERT(strstr(e.what(), "Polar has inconsistent length 3")));
 
     // // if phi is given, must have same length as l2and twoTheta
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2S", "1., 2."));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("TwoTheta", "1., 2."));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Phi", "1., 2., 3."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2", "1., 2."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Polar", "1., 2."));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Azimuthal", "1., 2., 3."));
     TS_ASSERT_THROWS_ASSERT(alg.execute(), std::runtime_error const &e,
-                            TS_ASSERT(strstr(e.what(), "Phi has inconsistent length 3")));
+                            TS_ASSERT(strstr(e.what(), "Azimuthal has inconsistent length 3")));
   }
 
   // run the algorithm do some common checks and return output workspace name
@@ -165,7 +165,7 @@ public:
     }
     // set focus positions
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(L1, configuration.l1));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty(L2S, configuration.l2s));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(L2, configuration.l2s));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(POLARS, configuration.twoTheta));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(AZIMUTHALS, configuration.phi));
 
@@ -219,9 +219,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("ReadSizeFromDisk", 1000000));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("L1", config.l1));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2s", config.l2s));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("TwoTheta", config.twoTheta));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Phi", config.phi));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2", config.l2s));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Polar", config.twoTheta));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Azimuthal", config.phi));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
 
     Workspace_sptr outputWS2 = alg.getProperty("OutputWorkspace");

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -58,7 +58,11 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                                  SplitterWorkspace=splitter, RelativeTime=True,
                                  XMin=0, XMax=50000, XDelta=50000,
                                  BinningMode="Linear",
-                                 BinningUnits="TOF")
+                                 BinningUnits="TOF",
+                                 L1=43.755,
+                                 L2=[2.296, 2.296, 2.070, 2.070, 2.070, 2.530],
+                                 Polar=[90, 90, 120, 150, 157, 65.5],
+                                 Azimuthal=[180, 0, 0, 0, 0, 0])
 
     # This is equivalent to using FilterEvents with the same splitter table.
     # But note that this example doesn't align the data so put everything in 1 big bin to compare.
@@ -71,7 +75,7 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                  FilterByPulseTime=True,
                  OutputWorkspaceBaseName="filtered",
                  GroupWorkspaces=True)
-    out = Rebin("filtered_0", "0,50000,50000", PreserveEvents=False)
+    out = Rebin("filtered", "0,50000,50000", PreserveEvents=False)
 
     CompareWorkspaces(ws, out, CheckSpectraMap=False, CheckInstrument=False)
 
@@ -94,13 +98,21 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                          LogValueInterval=0.01)
 
     # Use the splitter table to filter the events during loading and output to workspace group
-    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter')
+    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", SplitterWorkspace='splitter',
+                                 L1=43.755,
+                                 L2=[2.296, 2.296, 2.070, 2.070, 2.070, 2.530],
+                                 Polar=[90, 90, 120, 150, 157, 65.5],
+                                 Azimuthal=[180, 0, 0, 0, 0, 0])
     print(ws.getNumberOfEntries())  # should be 6 workspaces in the group
 
     # By default the events are split based on pulsetime of the events. If you want to split based on full time (pulsetime + tof), set UseFullTime=False.
     ws2 = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
                                   SplitterWorkspace='splitter',
-                                  UseFullTime=True)
+                                  UseFullTime=True,
+                                  L1=43.755,
+                                  L2=[2.296, 2.296, 2.070, 2.070, 2.070, 2.530],
+                                  Polar=[90, 90, 120, 150, 157, 65.5],
+                                  Azimuthal=[180, 0, 0, 0, 0, 0])
 
 
 **Example - filter bad pulses**
@@ -111,7 +123,11 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
                                  XMin=0, XMax=50000, XDelta=50000,
                                  BinningMode="Linear",
                                  BinningUnits="TOF",
-                                 FilterBadPulses=True)
+                                 FilterBadPulses=True,
+                                 L1=43.755,
+                                 L2=[2.296, 2.296, 2.070, 2.070, 2.070, 2.530],
+                                 Polar=[90, 90, 120, 150, 157, 65.5],
+                                 Azimuthal=[180, 0, 0, 0, 0, 0])
 
     # This is equivalent to using FilterBadPulses.
     # But note that this example doesn't align the data so put everything in 1 big bin to compare.


### PR DESCRIPTION
### Description of work

The values for the focus group position were previously hard-coded to specific values.  This allows them to be passed as parameters.

The expectation is for all of these to be mandatory, except $\phi$.  If $\phi$ is not specified, then it should be zero.

Since all three arrays, $\ell_2$, $2\theta$, and $\phi$ specify a property of a focus group, then they should all have the same length.  A validator checks this.

A new test makes sure the validation is occurring as expected.

Related to [EWM 14300](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14300)

### To test:

Make sure original tests pass.

This does not require release notes because it is part of an algorithm still in beta.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
