### PR TITLE
Refl live data angle change

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -66,9 +66,9 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         )
         self.declareProperty(
             name="ExperimentSettingsState",
-            defaultValue={},
+            defaultValue="",
             direction=Direction.Input,
-            doc="A json serializable object representing the experiment settings table in the reflectometry GUI",
+            doc="A JSON string representing the experiment settings table in the reflectometry GUI",
         )
 
         self._child_properties = [

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -21,18 +21,18 @@ class Field:
 
 
 EXPERIMENT_SETTINGS_FIELDS = {
-    "ANGLE": Field(1),
-    "TITLE": Field(2),
-    "TRANS_RUN_1": Field(3, "FirstTransmissionRunList"),
-    "TRANS_RUN_2": Field(4, "SecondTransmissionRunList"),
-    "TRANS_SPECTRA": Field(5, "TransmissionProcessingInstructions"),
-    "Q_MIN": Field(6, "MomentumTransferMin"),
-    "Q_MAX": Field(7, "MomentumTransferMax"),
-    "Q_STEP": Field(8, "MomentumTransferStep"),
-    "SCALE": Field(9, "ScaleFactor"),
-    "ROI": Field(10, "ProcessingInstructions"),
-    "BACKGROUND": Field(11, "BackgroundProcessingInstructions"),
-    "ROI_DET_ID": Field(12, "ROIDetectorIDs"),
+    "ANGLE": Field(0),
+    "TITLE": Field(1),
+    "TRANS_RUN_1": Field(2, "FirstTransmissionRunList"),
+    "TRANS_RUN_2": Field(3, "SecondTransmissionRunList"),
+    "TRANS_SPECTRA": Field(4, "TransmissionProcessingInstructions"),
+    "Q_MIN": Field(5, "MomentumTransferMin"),
+    "Q_MAX": Field(6, "MomentumTransferMax"),
+    "Q_STEP": Field(7, "MomentumTransferStep"),
+    "SCALE": Field(8, "ScaleFactor"),
+    "ROI": Field(9, "ProcessingInstructions"),
+    "BACKGROUND": Field(10, "BackgroundProcessingInstructions"),
+    "ROI_DET_ID": Field(11, "ROIDetectorIDs"),
 }
 
 
@@ -191,7 +191,8 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
                 selected_row = row
                 break
         selected_row = wildcard_row if not selected_row else selected_row
-        self._set_properties_from_row(alg, selected_row)
+        if selected_row:
+            self._set_properties_from_row(alg, selected_row)
 
     def _set_properties_from_row(self, alg, row):
         for field in EXPERIMENT_SETTINGS_FIELDS.values():

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -281,7 +281,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             self._s2vg_name(): LiveValue(
                 None, "m", self._alternative_s2vg_name(), LiveValue.LOG_TYPE_NUM_SERIES, LiveValue.PROP_TYPE_BLOCK
             ),
-            self._title_name(): LiveValue(None, "", self._alternative_title_name(), LiveValue.LOG_TYPE_STRING, LiveValue.PROP_TYPE_RUN),
+            self._title_name(): LiveValue(None, None, self._alternative_title_name(), LiveValue.LOG_TYPE_STRING, LiveValue.PROP_TYPE_RUN),
         }
         return liveValues
 

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -175,8 +175,8 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         return liveValues
 
     def _set_properties_from_experiment_settings(self, alg, live_values):
-        theta = live_values[self._theta_name()]
-        title = live_values[self._title_name()]
+        theta = live_values[self._theta_name()].value
+        title = live_values[self._title_name()].value
         live_opts = self.getPropertyValue("ExperimentSettingsState")
         opts = json.loads(live_opts)
         wildcard_row = None
@@ -185,9 +185,8 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             if not row[EXPERIMENT_SETTINGS_FIELDS["ANGLE"].index] and not row[EXPERIMENT_SETTINGS_FIELDS["TITLE"].index]:
                 wildcard_row = row
                 continue
-            if float(row[EXPERIMENT_SETTINGS_FIELDS["ANGLE"].index]) == theta and re.search(
-                row[EXPERIMENT_SETTINGS_FIELDS["TITLE"].index], title
-            ):
+            title_regex = row[EXPERIMENT_SETTINGS_FIELDS["TITLE"].index]
+            if float(row[EXPERIMENT_SETTINGS_FIELDS["ANGLE"].index]) == float(theta) and (not title_regex or re.search(title_regex, title)):
                 selected_row = row
                 break
         selected_row = wildcard_row if not selected_row else selected_row

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -178,7 +178,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         theta = live_values[self._theta_name()].value
         title = live_values[self._title_name()].value
         live_opts = self.getPropertyValue("ExperimentSettingsState")
-        opts = json.loads(live_opts)
+        opts = json.loads(live_opts) if live_opts else []
         wildcard_row = None
         selected_row = None
         for row in opts:

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -201,8 +201,8 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
     def _setup_reduction_algorithm(self, live_values):
         """Set up the reduction algorithm"""
         alg = self.createChildAlgorithm("ReflectometryISISLoadAndProcess")
-        self._set_properties_from_experiment_settings(alg, live_values)
         self._copy_property_values_to(alg)
+        self._set_properties_from_experiment_settings(alg, live_values)
         alg.setProperty("InputRunList", self._temp_ws_name)
         alg.setProperty("ThetaLogName", "Theta")
         alg.setProperty("GroupTOFWorkspaces", False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -289,8 +289,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         # We only output an IvsLam workspace from the reduction when workspace groups are correctly handled this way.
         self.assertTrue(AnalysisDataService.doesExist("IvsLam"))
 
-    def test_experiment_setting_state_is_parsed(self):
-        workspace = self._run_algorithm_with_experiment_settings_state()
+    def _assert_exp_setting_outout_ws_correct(self, workspace):
         self.assertEqual(workspace.dataX(0).size, 36)
         self._assert_delta(workspace.dataX(0)[2], 0.0022)
         self._assert_delta(workspace.dataX(0)[15], 0.0035)
@@ -298,6 +297,23 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self._assert_delta(workspace.dataY(0)[2], 3.24424e-5)
         self._assert_delta(workspace.dataY(0)[15], 2.35158e-6)
         self._assert_delta(workspace.dataY(0)[31], 2.01589e-7)
+
+    def test_experiment_setting_state_is_parsed_one_entry(self):
+        state = '[["0.5","test_title","","","","0.002","0.0055","-0.0001","","","",""]]'
+        workspace = self._run_algorithm_with_experiment_settings_state(state)
+        self._assert_exp_setting_outout_ws_correct(workspace)
+
+    def test_experiment_setting_state_is_parsed_two_entry(self):
+        state = (
+            '[["0.5","false_title","","","","","","","","","",""], ["0.5","test_title","","","","0.002","0.0055","-0.0001","","","",""]]'
+        )
+        workspace = self._run_algorithm_with_experiment_settings_state(state)
+        self._assert_exp_setting_outout_ws_correct(workspace)
+
+    def test_experiment_setting_state_is_parsed_wildcard_entry(self):
+        state = '[["0.5","false_title","","","","","","","","","",""], ["","","","","","0.002","0.0055","-0.0001","","","",""]]'
+        workspace = self._run_algorithm_with_experiment_settings_state(state)
+        self._assert_exp_setting_outout_ws_correct(workspace)
 
     def _setup_environment(self):
         self._old_facility = config["default.facility"]
@@ -560,9 +576,9 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         args["GetLiveValueAlgorithm"] = "GetFakeLiveInstrumentValuesWithZeroTheta"
         return self._run_algorithm(args)
 
-    def _run_algorithm_with_experiment_settings_state(self):
+    def _run_algorithm_with_experiment_settings_state(self, state):
         args = self._default_args
-        args["ExperimentSettingsState"] = '[["0.5","test_title","","","","0.002","0.0055","-0.0001","","","",""]]'
+        args["ExperimentSettingsState"] = state
         return self._run_algorithm(args)
 
     def _run_algorithm(self, args):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -21,6 +21,7 @@ class GetFakeLiveInstrumentValue(DataProcessorAlgorithm):
         self._theta_name = "THETA"
         self._s1vg_name = "S1VG"
         self._s2vg_name = "S2VG"
+        self._title_name = "TITLE"
 
     def PyInit(self):
         self._declare_properties()
@@ -68,6 +69,8 @@ class GetFakeLiveInstrumentValue(DataProcessorAlgorithm):
             self.setProperty("Value", "1.001")
         elif propertyName == self._s2vg_name:
             self.setProperty("Value", "0.5")
+        elif propertyName == self._title_name:
+            self.setProperty("Value", "test_title")
         else:
             raise RuntimeError("Requested live value for unexpected property name " + propertyName)
 
@@ -164,6 +167,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
             "GetFakeLiveInstrumentValue",
             "GetFakeLiveInstrumentValue",
             "GetFakeLiveInstrumentValue",
+            "GetFakeLiveInstrumentValue",
             "AddSampleLogMultiple",
             "LoadInstrument",
             "SetInstrumentParameter",
@@ -255,6 +259,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         workspace = self._run_algorithm_with_zero_theta()
         expected = [
             "CloneWorkspace",
+            "GetFakeLiveInstrumentValuesWithZeroTheta",
             "GetFakeLiveInstrumentValuesWithZeroTheta",
             "GetFakeLiveInstrumentValuesWithZeroTheta",
             "GetFakeLiveInstrumentValuesWithZeroTheta",

--- a/docs/source/release/v6.15.0/Reflectometry/New_features/40523.rst
+++ b/docs/source/release/v6.15.0/Reflectometry/New_features/40523.rst
@@ -1,0 +1,1 @@
+- The ISIS Reflectometry GUI will now apply angle-title specific settings from the lookup table on Experiment Settings tab when processing live data. Previously it was necessary to ensure a wildcard row was present in table that would be applied uniformly to all live data.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -236,6 +236,10 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> BatchJobManager::rowProcess
   return RowProcessing::createAlgorithmRuntimeProps(m_batch);
 }
 
+std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> BatchJobManager::rowProcessingPropertiesDefault() const {
+  return RowProcessing::createAlgorithmRuntimePropsDefault(m_batch);
+}
+
 void BatchJobManager::algorithmStarted(IConfiguredAlgorithm_sptr algorithm) {
   auto item = getRunsTableItem(algorithm);
   assert(item);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
@@ -60,6 +60,7 @@ public:
 
   std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() override;
   std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
+  std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingPropertiesDefault() const override;
 
   bool getProcessPartial() const override;
   bool getProcessAll() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -423,4 +423,9 @@ std::optional<ProcessingInstructions> BatchPresenter::getMatchingROIDetectorIDsF
   }
   return std::nullopt;
 }
+
+std::string BatchPresenter::getBatchState(const std::string &jsonKey) const {
+  return m_mainPresenter->encodeBatchToStr(jsonKey);
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -424,7 +424,7 @@ std::optional<ProcessingInstructions> BatchPresenter::getMatchingROIDetectorIDsF
   return std::nullopt;
 }
 
-std::string BatchPresenter::getBatchState(const std::string &jsonKey) const {
+std::string BatchPresenter::getBatchState(const std::vector<std::string> &jsonKey) const {
   return m_mainPresenter->encodeBatchToStr(jsonKey);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -369,6 +369,10 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> BatchPresenter::rowProcessi
   return m_jobManager->rowProcessingProperties();
 }
 
+std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> BatchPresenter::rowProcessingPropertiesDefault() const {
+  return m_jobManager->rowProcessingPropertiesDefault();
+}
+
 void BatchPresenter::postDeleteHandle(const std::string &wsName) {
   auto const item = m_jobManager->notifyWorkspaceDeleted(wsName);
   m_runsPresenter->notifyRowModelChanged(item);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -97,6 +97,7 @@ public:
   void notifyPreviewApplyRequested() override;
   std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const override;
   std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const override;
+  std::string getBatchState(const std::string &jsonKey) const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -98,6 +98,7 @@ public:
   std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const override;
   std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const override;
   std::string getBatchState(const std::vector<std::string> &jsonKey) const override;
+  std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingPropertiesDefault() const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -97,7 +97,7 @@ public:
   void notifyPreviewApplyRequested() override;
   std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const override;
   std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const override;
-  std::string getBatchState(const std::string &jsonKey) const override;
+  std::string getBatchState(const std::vector<std::string> &jsonKey) const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
@@ -46,6 +46,7 @@ public:
   virtual void notifyAllWorkspacesDeleted() = 0;
   virtual std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() = 0;
   virtual std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingProperties() const = 0;
+  virtual std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingPropertiesDefault() const = 0;
   virtual bool getProcessPartial() const = 0;
   virtual bool getProcessAll() const = 0;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -78,6 +78,7 @@ public:
   virtual std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const = 0;
   virtual std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const = 0;
   virtual std::string getBatchState(const std::vector<std::string> &jsonKey) const = 0;
+  virtual std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingPropertiesDefault() const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -77,6 +77,7 @@ public:
 
   virtual std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const = 0;
   virtual std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const = 0;
+  virtual std::string getBatchState(const std::string &jsonKey) const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -77,7 +77,7 @@ public:
 
   virtual std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const = 0;
   virtual std::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const = 0;
-  virtual std::string getBatchState(const std::string &jsonKey) const = 0;
+  virtual std::string getBatchState(const std::vector<std::string> &jsonKey) const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -406,4 +406,17 @@ createAlgorithmRuntimeProps(IBatch const &model, std::optional<std::reference_wr
   }
   return properties;
 }
+
+/** This function gets the canonical set of properties for performing the reduction, using defaults
+ *
+ * @param model : the Batch model containing all of the default settings and the lookup table
+ * @returns : a custom PropertyManager class with all of the algorithm properties set
+ */
+std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePropsDefault(IBatch const &model) {
+  auto properties = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
+  // Update properties from settings in the event, experiment and instrument tabs
+  updatePropertiesFromBatchModel(*properties, model);
+  return properties;
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::RowProcessing

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -43,4 +43,6 @@ MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr createCo
                                                                                                   Row &row);
 MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>
 createAlgorithmRuntimeProps(IBatch const &model, std::optional<std::reference_wrapper<Row const>> row = std::nullopt);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>
+createAlgorithmRuntimePropsDefault(IBatch const &model);
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::RowProcessing

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -53,6 +53,26 @@ QMap<QString, QVariant> Encoder::encode(const QWidget *gui, const std::string &d
 
 QList<QString> Encoder::tags() { return QList<QString>({QString("ISIS Reflectometry")}); }
 
+QVariant Encoder::extractFromEncoding(const QVariant &vMap, const std::vector<std::string> &jsonKey) const {
+  QVariantMap map;
+  QVariant extract = vMap;
+  for (auto &key : jsonKey) {
+    if (extract.type() == 8 && extract.canConvert(8)) { // 8 = map - is there an enum?
+      map = extract.toMap();
+      auto qKey = QString::fromStdString(key);
+      if (map.contains(qKey)) {
+        extract = map.value(qKey);
+      } else {
+        throw std::invalid_argument("Invalid json key provided. Json key not in map. Invalid element: " + key);
+      }
+    } else {
+      throw std::invalid_argument(
+          "Invalid json key provided. Json key must allow traversal of nested QMaps. Invalid element: " + key);
+    }
+  }
+  return extract;
+}
+
 QMap<QString, QVariant> Encoder::encodeBatch(const IMainWindowView *mwv, int batchIndex, bool projectSave) {
   auto gui = dynamic_cast<const QtBatchView *>(mwv->batches()[batchIndex]);
   auto batchPresenter = findBatchPresenter(gui, mwv);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.h
@@ -49,6 +49,7 @@ public:
   QMap<QString, QVariant> encode(const QWidget *window, const std::string &directory) override;
   QList<QString> tags() override;
   QMap<QString, QVariant> encodeBatch(const IMainWindowView *mwv, int batchIndex, bool projectSave = false) override;
+  QVariant extractFromEncoding(const QVariant &vMap, const std::vector<std::string> &jsonKey) const override;
 
 private:
   BatchPresenter *findBatchPresenter(const QtBatchView *gui, const IMainWindowView *mwv);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IEncoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IEncoder.h
@@ -25,6 +25,7 @@ class IEncoder {
 public:
   virtual ~IEncoder() {};
   virtual QMap<QString, QVariant> encodeBatch(const IMainWindowView *mwv, int batchIndex, bool projectSave = false) = 0;
+  virtual QVariant extractFromEncoding(const QVariant &vMap, const std::vector<std::string> &jsonKey) const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -48,7 +48,7 @@ public:
   virtual Mantid::Geometry::Instrument_const_sptr instrument() const = 0;
   virtual std::string instrumentName() const = 0;
   virtual bool discardChanges(std::string const &message) const = 0;
-  virtual std::string encodeBatchToStr(const std::string &jsonKey) const = 0;
+  virtual std::string encodeBatchToStr(const std::vector<std::string> &jsonKey) const = 0;
 
   virtual ~IMainWindowPresenter() = default;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -48,6 +48,8 @@ public:
   virtual Mantid::Geometry::Instrument_const_sptr instrument() const = 0;
   virtual std::string instrumentName() const = 0;
   virtual bool discardChanges(std::string const &message) const = 0;
+  virtual std::string encodeBatchToStr(const std::string &jsonKey) const = 0;
+
   virtual ~IMainWindowPresenter() = default;
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
@@ -45,6 +45,7 @@ public:
   virtual void enableSaveAndLoadBatch() = 0;
   virtual void acceptCloseEvent() = 0;
   virtual void ignoreCloseEvent() = 0;
+  virtual int getTabIndex() const = 0;
 
   virtual ~IMainWindowView() = default;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -285,18 +285,23 @@ void MainWindowPresenter::showHelp() {
 std::string MainWindowPresenter::encodeBatchToStr(const std::vector<std::string> &jsonKey) const {
   auto tabIndex = m_view->getTabIndex();
   QVariant vMap = m_encoder->encodeBatch(m_view, tabIndex, false);
-  QVariantMap map{};
+  QVariantMap map;
+  bool err = false;
   for (auto &key : jsonKey) {
     if (vMap.type() == 8 && vMap.canConvert(8)) { // 8 = map - is there an enum?
       map = vMap.toMap();
-      vMap = map.value(QString::fromStdString(key));
+      auto qKey = QString::fromStdString(key);
+      if (map.contains(qKey)) {
+        vMap = map.value(qKey);
+      } else {
+        throw std::invalid_argument("Invalid json key provided. Json key not in map. Invalid element: " + key);
+      }
     } else {
       throw std::invalid_argument(
           "Invalid json key provided. Json key must allow traversal of nested QMaps. Invalid element: " + key);
     }
   }
-  map = vMap.toMap();
-  return MantidQt::API::outputJsonToString(map);
+  return MantidQt::API::outputJsonToString(vMap);
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -286,7 +286,6 @@ std::string MainWindowPresenter::encodeBatchToStr(const std::vector<std::string>
   auto tabIndex = m_view->getTabIndex();
   QVariant vMap = m_encoder->encodeBatch(m_view, tabIndex, false);
   QVariantMap map;
-  bool err = false;
   for (auto &key : jsonKey) {
     if (vMap.type() == 8 && vMap.canConvert(8)) { // 8 = map - is there an enum?
       map = vMap.toMap();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -285,22 +285,8 @@ void MainWindowPresenter::showHelp() {
 std::string MainWindowPresenter::encodeBatchToStr(const std::vector<std::string> &jsonKey) const {
   auto tabIndex = m_view->getTabIndex();
   QVariant vMap = m_encoder->encodeBatch(m_view, tabIndex, false);
-  QVariantMap map;
-  for (auto &key : jsonKey) {
-    if (vMap.type() == 8 && vMap.canConvert(8)) { // 8 = map - is there an enum?
-      map = vMap.toMap();
-      auto qKey = QString::fromStdString(key);
-      if (map.contains(qKey)) {
-        vMap = map.value(qKey);
-      } else {
-        throw std::invalid_argument("Invalid json key provided. Json key not in map. Invalid element: " + key);
-      }
-    } else {
-      throw std::invalid_argument(
-          "Invalid json key provided. Json key must allow traversal of nested QMaps. Invalid element: " + key);
-    }
-  }
-  return MantidQt::API::outputJsonToString(vMap);
+  QVariant extract = m_encoder->extractFromEncoding(vMap, jsonKey);
+  return MantidQt::API::outputJsonToString(extract);
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -18,6 +18,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/ISlitCalculator.h"
+#include "MantidQtWidgets/Common/QtJSONUtils.h"
 #include "Reduction/Batch.h"
 
 #include <algorithm>
@@ -279,6 +280,12 @@ void MainWindowPresenter::initNewBatch(IBatchPresenter *batchPresenter, std::str
 
 void MainWindowPresenter::showHelp() {
   MantidQt::API::HelpWindow::showCustomInterface(std::string("ISIS Reflectometry"), std::string("reflectometry"));
+}
+
+std::string MainWindowPresenter::encodeBatchToStr(const std::string &jsonKey) const {
+  auto tabIndex = m_view->getTabIndex();
+  auto map = m_encoder->encodeBatch(m_view, tabIndex, false); // need to use jsonKey to only pass part of the map.
+  return MantidQt::API::outputJsonToString(map);
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -282,9 +282,20 @@ void MainWindowPresenter::showHelp() {
   MantidQt::API::HelpWindow::showCustomInterface(std::string("ISIS Reflectometry"), std::string("reflectometry"));
 }
 
-std::string MainWindowPresenter::encodeBatchToStr(const std::string &jsonKey) const {
+std::string MainWindowPresenter::encodeBatchToStr(const std::vector<std::string> &jsonKey) const {
   auto tabIndex = m_view->getTabIndex();
-  auto map = m_encoder->encodeBatch(m_view, tabIndex, false); // need to use jsonKey to only pass part of the map.
+  QVariant vMap = m_encoder->encodeBatch(m_view, tabIndex, false);
+  QVariantMap map{};
+  for (auto &key : jsonKey) {
+    if (vMap.type() == 8 && vMap.canConvert(8)) { // 8 = map - is there an enum?
+      map = vMap.toMap();
+      vMap = map.value(QString::fromStdString(key));
+    } else {
+      throw std::invalid_argument(
+          "Invalid json key provided. Json key must allow traversal of nested QMaps. Invalid element: " + key);
+    }
+  }
+  map = vMap.toMap();
   return MantidQt::API::outputJsonToString(map);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -68,7 +68,7 @@ public:
   Mantid::Geometry::Instrument_const_sptr instrument() const override;
   std::string instrumentName() const override;
   bool discardChanges(std::string const &message) const override;
-  std::string encodeBatchToStr(const std::string &jsonKey) const override;
+  std::string encodeBatchToStr(const std::vector<std::string> &jsonKey) const override;
 
   // MainWindowSubscriber overrides
   void notifyHelpPressed() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -68,6 +68,7 @@ public:
   Mantid::Geometry::Instrument_const_sptr instrument() const override;
   std::string instrumentName() const override;
   bool discardChanges(std::string const &message) const override;
+  std::string encodeBatchToStr(const std::string &jsonKey) const override;
 
   // MainWindowSubscriber overrides
   void notifyHelpPressed() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -268,5 +268,7 @@ std::string QtMainWindowView::getFullFilePath(const std::string &filename) const
   }
 }
 
+int QtMainWindowView::getTabIndex() const { return m_ui.mainTabs->currentIndex(); };
+
 } // namespace CustomInterfaces::ISISReflectometry
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
@@ -76,6 +76,7 @@ public:
   void saveCSVToFile(std::string const &filename, std::string const &content) const override;
   bool fileExists(std::string const &filepath) const override;
   std::string getFullFilePath(std::string const &filename) const override;
+  int getTabIndex() const override;
 
 public slots:
   void helpPressed();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -526,7 +526,6 @@ std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWork
   options->setPropertyValue("Instrument", instrument);
   options->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
   options->setPropertyValue("ExperimentSettingsState", experimentState);
-
   return convertAlgPropsToString(*options);
 }
 
@@ -544,7 +543,6 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("UpdateEvery", static_cast<double>(updateInterval));
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
-  // TODO pass state angle into post progressing alg?
   alg->setProperty("PostProcessingProperties", liveDataReductionOptions(inputWorkspace, instrument));
   alg->setProperty("RunTransitionBehavior", "Restart");
   auto errorMap = alg->validateInputs();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -519,7 +519,7 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
   auto options = m_mainPresenter->rowProcessingProperties();
-  auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults"});
+  auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults", "rows"});
 
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -12,6 +12,7 @@
 #include "GUI/RunsTable/RunsTablePresenter.h"
 #include "IRunsView.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/ProgressPresenter.h"
 #include "MantidQtWidgets/Common/QtAlgorithmRunner.h"
@@ -518,7 +519,9 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
-  auto options = m_mainPresenter->rowProcessingProperties();
+  auto options =
+      std::make_unique<Mantid::API::AlgorithmRuntimeProps>(); // Pass default props as live data reduction alg will
+                                                              // parse experiment view for user specified props.
   auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults", "rows"});
 
   // Add other required input properties to the live data reduction algorithnm

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -12,7 +12,6 @@
 #include "GUI/RunsTable/RunsTablePresenter.h"
 #include "IRunsView.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/ProgressPresenter.h"
 #include "MantidQtWidgets/Common/QtAlgorithmRunner.h"
@@ -519,9 +518,7 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
-  auto options =
-      std::make_unique<Mantid::API::AlgorithmRuntimeProps>(); // Pass default props as live data reduction alg will
-                                                              // parse experiment view for user specified props.
+  auto options = m_mainPresenter->rowProcessingPropertiesDefault();
   auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults", "rows"});
 
   // Add other required input properties to the live data reduction algorithnm

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -518,12 +518,15 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
-  g_log.warning("Note that lookup of experiment settings by angle/title is not supported for live data.");
   auto options = m_mainPresenter->rowProcessingProperties();
+  auto experimentState = m_mainPresenter->getBatchState(
+      "experimentView/perAngleDefaults/rows"); // replace with string that represents where to start the state
+
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);
   options->setPropertyValue("Instrument", instrument);
   options->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
+  options->setPropertyValue("ExperimentSettingsState", experimentState);
 
   return convertAlgPropsToString(*options);
 }
@@ -542,6 +545,7 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("UpdateEvery", static_cast<double>(updateInterval));
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
+  // TODO pass state angle into post progressing alg?
   alg->setProperty("PostProcessingProperties", liveDataReductionOptions(inputWorkspace, instrument));
   alg->setProperty("RunTransitionBehavior", "Restart");
   auto errorMap = alg->validateInputs();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -519,8 +519,7 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
   auto options = m_mainPresenter->rowProcessingProperties();
-  auto experimentState = m_mainPresenter->getBatchState(
-      "experimentView/perAngleDefaults/rows"); // replace with string that represents where to start the state
+  auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults"});
 
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/EncoderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/EncoderTest.h
@@ -57,6 +57,40 @@ public:
     auto constexpr expectedVersion = "2";
     TS_ASSERT_EQUALS(expectedVersion, map[QString("version")].toString().toStdString())
   }
+
+  void test_extractFromEncodingValidKey() {
+    QVariantMap subItem{{"testsubkey", "testsubval"}};
+    QVariantMap m{{"testkey", "testval"}, {"testkey1", subItem}, {"testkey2", "testval2"}};
+
+    Encoder encoder;
+    std::vector<std::string> key1{"testkey"};
+    auto extract1 = encoder.extractFromEncoding(m, key1);
+
+    std::vector<std::string> key2{"testkey1", "testsubkey"};
+    auto extract2 = encoder.extractFromEncoding(m, key2);
+
+    TS_ASSERT_EQUALS("testval", extract1)
+    TS_ASSERT_EQUALS("testsubval", extract2)
+  }
+
+  void test_extractFromEncodingInvalidKey() {
+    QVariantMap m{{"testkey", "testval"}};
+
+    Encoder encoder;
+    std::vector<std::string> key{"testkeyfalse"};
+    TS_ASSERT_THROWS_EQUALS(encoder.extractFromEncoding(m, key), const std::invalid_argument &e, std::string(e.what()),
+                            "Invalid json key provided. Json key not in map. Invalid element: testkeyfalse")
+  }
+
+  void test_extractFromEncodingInvalidPath() {
+    QVariantMap m{{"testkey", "testval"}};
+
+    Encoder encoder;
+    std::vector<std::string> key{"testkey", "falsepath"};
+    TS_ASSERT_THROWS_EQUALS(
+        encoder.extractFromEncoding(m, key), const std::invalid_argument &e, std::string(e.what()),
+        "Invalid json key provided. Json key must allow traversal of nested QMaps. Invalid element: falsepath")
+  }
 };
 
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
@@ -45,6 +45,7 @@ public:
   MOCK_CONST_METHOD0(instrument, Mantid::Geometry::Instrument_const_sptr());
   MOCK_CONST_METHOD0(instrumentName, std::string());
   MOCK_CONST_METHOD1(discardChanges, bool(std::string const &));
+  MOCK_CONST_METHOD1(encodeBatchToStr, std::string(const std::vector<std::string> &));
 
   ~MockMainWindowPresenter() override {};
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowView.h
@@ -29,6 +29,8 @@ public:
   MOCK_CONST_METHOD0(batches, std::vector<IBatchView *>());
   MOCK_METHOD0(acceptCloseEvent, void());
   MOCK_METHOD0(ignoreCloseEvent, void());
+  MOCK_CONST_METHOD0(getTabIndex, int());
+
   ~MockMainWindowView() override {};
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -316,6 +316,7 @@ public:
 class MockEncoder : public IEncoder {
 public:
   MOCK_METHOD3(encodeBatch, QMap<QString, QVariant>(const IMainWindowView *, int, bool));
+  MOCK_CONST_METHOD2(extractFromEncoding, QVariant(const QVariant &, const std::vector<std::string> &));
 };
 
 class MockDecoder : public IDecoder {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -101,6 +101,7 @@ public:
   MOCK_METHOD1(setUnsavedBatchFlag, void(bool));
   MOCK_CONST_METHOD0(percentComplete, int());
   MOCK_CONST_METHOD0(rowProcessingProperties, std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>());
+  MOCK_CONST_METHOD0(rowProcessingPropertiesDefault, std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>());
   MOCK_CONST_METHOD0(requestClose, bool());
   MOCK_CONST_METHOD0(instrument, Mantid::Geometry::Instrument_const_sptr());
   MOCK_CONST_METHOD0(instrumentName, std::string());
@@ -110,6 +111,7 @@ public:
   MOCK_METHOD0(notifyPreviewApplyRequested, void());
   MOCK_CONST_METHOD0(getMatchingProcessingInstructionsForPreviewRow, std::map<ROIType, ProcessingInstructions>());
   MOCK_CONST_METHOD0(getMatchingROIDetectorIDsForPreviewRow, std::optional<ProcessingInstructions>());
+  MOCK_CONST_METHOD1(getBatchState, std::string(const std::vector<std::string> &));
 };
 
 class MockRunsPresenter : public IRunsPresenter {
@@ -367,6 +369,7 @@ public:
   MOCK_METHOD0(notifyAllWorkspacesDeleted, void());
   MOCK_METHOD0(getAlgorithms, std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>());
   MOCK_CONST_METHOD0(rowProcessingProperties, std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>());
+  MOCK_CONST_METHOD0(rowProcessingPropertiesDefault, std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps>());
   MOCK_CONST_METHOD0(getProcessPartial, bool());
   MOCK_CONST_METHOD0(getProcessAll, bool());
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -888,7 +888,9 @@ private:
     auto props = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
     props->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
     props->setPropertyValue("InputWorkspace", "TOF_live");
+
     props->setPropertyValue("Instrument", instrument);
+    props->setPropertyValue("ExperimentSettingsState", "");
     return props;
   }
 
@@ -1155,7 +1157,9 @@ private:
                            std::string const &instrument = std::string("OFFSPEC"), int const &updateInterval = 15) {
     expectSearchInstrument(instrument);
     expectGetUpdateInterval(updateInterval);
-    EXPECT_CALL(m_mainPresenter, rowProcessingProperties()).Times(1).WillOnce(Return(ByMove(std::move(options))));
+    EXPECT_CALL(m_mainPresenter, rowProcessingPropertiesDefault())
+        .Times(1)
+        .WillOnce(Return(ByMove(std::move(options))));
   }
 
   void expectGetLiveDataOptions(std::string const &instrument, const int &updateInterval) {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
@@ -22,5 +22,7 @@ QMap<QString, QVariant> EXPORT_OPT_MANTIDQT_COMMON loadJSONFromFile(const QStrin
 
 QMap<QString, QVariant> EXPORT_OPT_MANTIDQT_COMMON loadJSONFromString(const QString &jsonString);
 
+std::string EXPORT_OPT_MANTIDQT_COMMON outputJsonToString(const QMap<QString, QVariant> &map);
+
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
@@ -22,7 +22,7 @@ QMap<QString, QVariant> EXPORT_OPT_MANTIDQT_COMMON loadJSONFromFile(const QStrin
 
 QMap<QString, QVariant> EXPORT_OPT_MANTIDQT_COMMON loadJSONFromString(const QString &jsonString);
 
-std::string EXPORT_OPT_MANTIDQT_COMMON outputJsonToString(const QMap<QString, QVariant> &map);
+std::string EXPORT_OPT_MANTIDQT_COMMON outputJsonToString(QVariant &v);
 
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -78,4 +78,9 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
   return jsonObj.toVariantMap();
 }
 
+std::string outputJsonToString(const QMap<QString, QVariant> &map) {
+  (void)map;
+  return {};
+}
+
 } // namespace MantidQt::API

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -78,8 +78,14 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
   return jsonObj.toVariantMap();
 }
 
-std::string outputJsonToString(const QMap<QString, QVariant> &map) {
-  QJsonDocument doc(QJsonObject::fromVariantMap(map));
+std::string outputJsonToString(QVariant &v) {
+  QJsonDocument doc;
+  if (v.type() == 8 && v.canConvert(8)) { // 8 = map - is there an enum?
+    QVariantMap map = v.toMap();
+    doc = QJsonDocument{QJsonObject::fromVariantMap(map)};
+  } else {
+    doc = QJsonDocument::fromVariant(v);
+  }
   QString jsonString(doc.toJson(QJsonDocument::Compact));
   return jsonString.toStdString();
 }

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -83,6 +83,8 @@ std::string outputJsonToString(QVariant &v) {
   if (v.type() == 8 && v.canConvert(8)) { // 8 = map - is there an enum?
     QVariantMap map = v.toMap();
     doc = QJsonDocument{QJsonObject::fromVariantMap(map)};
+  } else if (v.canConvert<QString>()) {
+    return v.toString().toStdString();
   } else {
     doc = QJsonDocument::fromVariant(v);
   }

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -79,8 +79,9 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
 }
 
 std::string outputJsonToString(const QMap<QString, QVariant> &map) {
-  (void)map;
-  return {};
+  QJsonDocument doc(QJsonObject::fromVariantMap(map));
+  QString jsonString(doc.toJson(QJsonDocument::Compact));
+  return jsonString.toStdString();
 }
 
 } // namespace MantidQt::API

--- a/qt/widgets/common/test/QtJSONUtilsTest.h
+++ b/qt/widgets/common/test/QtJSONUtilsTest.h
@@ -44,6 +44,26 @@ public:
     testMaps(map, constructJSONMap());
   }
 
+  void test_outputJSONToStringQVariantMap() {
+    QVariantMap m{{"testkey", "testval"}, {"testkey1", "testval1"}, {"testkey2", "testval2"}};
+    QVariant v{m};
+    std::string output = MantidQt::API::outputJsonToString(v);
+    TS_ASSERT_EQUALS("{\"testkey\":\"testval\",\"testkey1\":\"testval1\",\"testkey2\":\"testval2\"}", output);
+  }
+
+  void test_outputJSONToStringQVariantList() {
+    QVariantList l{"teststr", "teststr1", "teststr2"};
+    QVariant v{l};
+    std::string output = MantidQt::API::outputJsonToString(v);
+    TS_ASSERT_EQUALS("[\"teststr\",\"teststr1\",\"teststr2\"]", output);
+  }
+
+  void test_outputJSONToStringQVariantString() {
+    QVariant v{"teststr"};
+    std::string output = MantidQt::API::outputJsonToString(v);
+    TS_ASSERT_EQUALS("teststr", output);
+  }
+
 private:
   QMap<QString, QVariant> constructJSONMap() {
     QMap<QString, QVariant> map;


### PR DESCRIPTION
### Description of work

Currently when conducting live data reduction using the Reflectometry GUI, settings provided in the lookup table in the Experiments Settings tab are only used if provided in a wildcard row.

This PR updates the `ReflectometryReductionOneLiveData` algorithm to expect the lookup table to be passed as a json string.

Settings can therefore be parsed and applied dynamically from this table depending upon the live angle value extracted by the live data algorithm.

#33641 suggests an alternative, certainly more time consuming approach be taken, where all reduction settings are passed to the algorithm as a single state object (similar to SANS). This may be considered in the future, and some functionality implemented here may aid that, but it is not considered a good use of resource at this time.

Closes #33641


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

This is a hard one to test, as the DAE is currently off and no live data available. I have tested it during cycle and it looked to be functioning correctly.

Added functionality is covered by unit tests; this should provide some confidence. If you requireme more testing, we can look at possible ways to simulate live data.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
