### PR TITLE
Revert "Move doxygen-publish work into main doxygen workflow"

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,4 +35,3 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
           manifest-path: pixi.toml
-          frozen: true

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -5,13 +5,9 @@ on:
       - opened
       - synchronize
       - reopened
-  push:
-    branches: [main]
-    repository: mantidproject.mantid
 
 jobs:
   doxygen:
-    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,7 +21,6 @@ jobs:
             doxygen:
               - '**/*.cpp'
               - '**/*.h'
-              - '**/*.hxx'
               - 'Framework/Doxygen/**'
               - 'conda/recipes/mantid-developer/**'
               - 'conda/recipes/conda_build_config.yaml'
@@ -40,33 +35,9 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.3
         if: steps.changes.outputs.doxygen == 'true'
         with:
-          frozen: true
+          pixi-version: v0.59.0
 
       - name: build doxygen
         if: steps.changes.outputs.doxygen == 'true'
         run: |
           $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE
-
-      # publish documentation if on main branch of mantidproject/mantid
-      - name: Checkout Doxygen repository
-        if: ${{ github.ref_name == 'main' && steps.changes.outputs.doxygen == 'true' }}
-        env:
-          DOXYGEN_REPO_TOKEN: ${{ secrets.DOXYGEN_REPO_TOKEN }}
-        run: |
-          git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
-          rm -rf doxygen_repo/*
-
-      - name: Copy Doxygen artifacts
-        if: ${{ github.ref_name == 'main' && steps.changes.outputs.doxygen == 'true' }}
-        run: |
-          cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
-
-      - name: Commit Doxygen and push
-        if: ${{ github.ref_name == 'main' && steps.changes.outputs.doxygen == 'true' }}
-        working-directory: doxygen_repo
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "Update Doxygen docs"
-          git push origin main

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -1,0 +1,54 @@
+name: Publish Doxygen artifacts to website
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+        - '**.cpp'
+        - '**.h'
+        - 'Framework/Doxygen/**'
+        - 'conda/recipes/mantid-developer/**'
+        - 'conda/recipes/conda_build_config.yaml'
+        - 'buildconfig/Jenkins/Conda/doxygen.sh'
+        - '.github/workflows/doxygen.yml'
+
+jobs:
+    build_and_publish_doxygen:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                shell: bash -l {0}
+
+        steps:
+        -   uses: actions/checkout@v6
+            with:
+                fetch-depth: 0
+
+        -   uses: prefix-dev/setup-pixi@v0.9.3
+            with:
+              pixi-version: v0.59.0
+
+        -   name: Build Doxygen
+            run:
+                $GITHUB_WORKSPACE/buildconfig/Jenkins/Conda/doxygen.sh $GITHUB_WORKSPACE
+
+        -   name: Checkout Doxygen repository
+            env:
+                DOXYGEN_REPO_TOKEN: ${{ secrets.DOXYGEN_REPO_TOKEN }}
+            run: |
+                git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
+                rm -rf doxygen_repo/*
+
+        -   name: Copy Doxygen artifacts
+            run: |
+                cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
+
+        -   name: Commit and push
+            working-directory: doxygen_repo
+            run: |
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+                git add .
+                git commit -m "Update Doxygen docs"
+                git push origin main

--- a/buildconfig/Jenkins/check_for_changes
+++ b/buildconfig/Jenkins/check_for_changes
@@ -19,7 +19,6 @@ case "$TYPE" in
     ;;
     cpp)
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.h || exit $FOUND
-        git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.hxx || exit $FOUND
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.cpp || exit $FOUND
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.cxx || exit $FOUND
         git diff --quiet ${BRANCH_TIP} ${BRANCH_BASE} -- \*\.tcc || exit $FOUND


### PR DESCRIPTION
Reverts mantidproject/mantid#40519

It turns out that this does not work on main because there is no .git folder when the paths-filter action tries to run.