### PR TITLE
Improve robustness of system tests that use BayesQuasi and BayesStretch

### DIFF
--- a/Testing/SystemTests/tests/framework/BayesQuasiTest.py
+++ b/Testing/SystemTests/tests/framework/BayesQuasiTest.py
@@ -5,9 +5,11 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=no-init,attribute-defined-outside-init
+import tempfile
 
 from sys import platform
 from systemtesting import MantidSystemTest
+from mantid.kernel import config
 from mantid.simpleapi import BayesQuasi, CropWorkspace, Load
 
 
@@ -20,6 +22,8 @@ class BayesQuasiTest(MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         Load(Filename=f"{self._sample_name}.nxs", OutputWorkspace=self._sample_name, LoadHistory=False)
         Load(Filename=f"{self._resolution_name}.nxs", OutputWorkspace=self._resolution_name, LoadHistory=False)
         BayesQuasi(

--- a/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
@@ -8,6 +8,7 @@
 from abc import ABCMeta, abstractmethod
 import os
 import warnings
+import tempfile
 
 from mantid.api import AnalysisDataService
 from mantid.kernel import config
@@ -37,6 +38,8 @@ class QLresTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         prefix = "rt_"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
@@ -88,6 +91,8 @@ class QuestTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
 
@@ -128,6 +133,8 @@ class QSeTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
         e_min = -0.5
@@ -173,6 +180,8 @@ class QLDataTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_red"
         e_min = -0.5
@@ -224,6 +233,8 @@ class QLResNormTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
         rsname = "irs26173_graphite002_ResNorm"
@@ -279,6 +290,8 @@ class QLWidthTest(systemtesting.MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        workdir = tempfile.mkdtemp(prefix="bayes_")
+        config["defaultsave.directory"] = workdir
         prefix = "wt_"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"

--- a/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
@@ -13,7 +13,6 @@ import tempfile
 from mantid.api import AnalysisDataService
 from mantid.kernel import config
 from mantid.simpleapi import BayesStretch, BayesQuasi, ExtractSingleSpectrum, Fit, LoadNexusProcessed, Scale
-from sys import platform
 import systemtesting
 
 
@@ -34,9 +33,6 @@ def _cleanup_files(dirname, filenames):
 
 
 class QLresTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
@@ -87,9 +83,6 @@ class QLresTest(systemtesting.MantidSystemTest):
 
 
 class QuestTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
@@ -129,9 +122,6 @@ class QuestTest(systemtesting.MantidSystemTest):
 
 
 class QSeTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
@@ -176,9 +166,6 @@ class QSeTest(systemtesting.MantidSystemTest):
 
 
 class QLDataTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
@@ -229,9 +216,6 @@ class QLDataTest(systemtesting.MantidSystemTest):
 
 
 class QLResNormTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
@@ -286,9 +270,6 @@ class QLResNormTest(systemtesting.MantidSystemTest):
 
 
 class QLWidthTest(systemtesting.MantidSystemTest):
-    def skipTests(self):
-        return platform == "darwin"
-
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir


### PR DESCRIPTION
### Description of work
Several system tests consistently fail when attempting to run on a self-hosted github runner ([example failed job](https://github.com/thomashampson/mantid_github_actions_test/actions/runs/20370324402/job/58540826160)):
```
FAILED:
BayesQuasiTest.BayesQuasiTest
ISISIndirectBayesTest.QLDataTest
ISISIndirectBayesTest.QLResNormTest
ISISIndirectBayesTest.QLWidthTest
ISISIndirectBayesTest.QLresTest
ISISIndirectBayesTest.QSeTest
ISISIndirectBayesTest.QuestTest
```
The error message for these failures appears to be:
```
At line 7 of file ../src/quasielasticbayes/Util.f90 (unit = 2)
Fortran runtime error: File already opened in another unit
```
It turns out that these tests were already being [skipped on MacOS for this very reason](https://github.com/mantidproject/mantid/pull/37174).

There is no obvious reason for the tests to be passing on a Jenkins node and failing on a github runner - they both have the same base Alma9 docker image, and they're both running on very similar hardware. What I have done is to ensure that the files written by the algorithms, and subsequently used by the Fortran code, are written to different locations per system test. This seems to have resolved the issue on the self-hosted github runner (see point 2 in test instructions). I have therefore assumed that the fix here will also resolve the problem for the tests running on MacOS, so have removed the skip.

### To test:
1. Verify that the system tests inside `ISISIndirectBayesTest` are run and pass in this macOS build:  [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_branch&build=1443)](https://builds.mantidproject.org/job/build_branch/1443/)  (look [here](https://builds.mantidproject.org/job/build_branch/1443/testReport/SystemTests/ISISIndirectBayesTest/) for the specific tests)
2. The first commit in this PR also exists on this branch in my fork, where the self-hosted github runner is set up. Verify that the tests are run successfully in the latest run: https://github.com/thomashampson/mantid_github_actions_test/actions/runs/20378458124/job/58562880217?pr=3

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
