### PR TITLE
Ensure GitHub Actions workflows only run inside mantidproject

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   add-milestone:
+    # Do not run in forks.
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: benelan/milestone-action@v3

--- a/.github/workflows/close_issues.yml
+++ b/.github/workflows/close_issues.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   close-issue-on-pr-merge:
+    # Do not run in forks.
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - name: Closes issues related to a merged pull request.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
+    # Do not run in forks.
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
 
     # Set the permissions to the lowest permissions possible needed for your steps.

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -7,7 +7,6 @@ on:
       - reopened
   push:
     branches: [main]
-    repository: mantidproject.mantid
 
 jobs:
   doxygen:

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   label-conflicts:
+    # Do not run in forks.
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: prince-chrismc/label-merge-conflicts-action@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   stale:
+    # Do not run in forks.
+    if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10


### PR DESCRIPTION
### Description of work
Several workflows were not yet configured to run only inside the mantidproject organisation. Now they are.

Closes #40497 

### To test:
Read the changes. Ensure the relevant PR checks are run (`add-milesone`, `label_merge_conflicts`,  and `copilot-setup-steps` are the only three that have been changed and run on PRs).

*This does not require release notes* because it's a change to CI workflow files.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
