### PR TITLE
Set mantid-builder as the author of pixi.lock updates

### DIFF
--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -26,14 +26,15 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MANTID_BUILDER_TOKEN }}
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
           body-path: diff.md
           branch: update-pixi
-          base: main  # change this to the default branch of your repository
+          base: main
           labels: |
             pixi
             Maintenanance
+            DevOps
           delete-branch: true
           add-paths: pixi.lock


### PR DESCRIPTION
### Description of work
Set `mantid-builder` as the author of pixi.lock update PRs so that the PR checks will automatically run without approval. This means that the pixi.lock update PRs should be ready for review/merge when we start work in the morning.

### To test:
Inspect the changes. Once merged, we can manually trigger the workflow to see what happens, and revert is necessary.

*This does not require release notes* because it's not user facing in any way.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
