### PR TITLE
Refactor ProcessBank*Task into base class for AAFPSlim

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -213,6 +213,7 @@ set(SRC_FILES
     src/RotateSampleShape.cpp
     src/AlignAndFocusPowderSlim/NexusLoader.cpp
     src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+    src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
     src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
     src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
     src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -436,6 +437,7 @@ set(INC_FILES
     src/LoadRaw/vms_convert.h
     inc/MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h
     inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+    inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
     inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
     inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
     inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h
@@ -32,13 +32,14 @@ public:
   virtual ~NexusLoader();
 
   virtual void loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<uint32_t>> &data,
-                        const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes);
+                        const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) const;
   virtual void loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<float>> &data, const std::vector<size_t> &offsets,
-                        const std::vector<size_t> &slabsizes);
+                        const std::vector<size_t> &slabsizes) const;
 
   virtual std::stack<EventROI> getEventIndexRanges(H5::Group &event_group, const uint64_t number_events,
                                                    std::unique_ptr<std::vector<uint64_t>> *event_index = nullptr) const;
-  std::stack<std::pair<int, EventROI>> getEventIndexSplitRanges(H5::Group &event_group, const uint64_t number_events);
+  std::stack<std::pair<int, EventROI>> getEventIndexSplitRanges(H5::Group &event_group,
+                                                                const uint64_t number_events) const;
 
 private:
   template <typename Type>
@@ -46,7 +47,7 @@ private:
                         const std::vector<size_t> &slabsizes) const;
   const bool m_is_time_filtered;
   const std::vector<PulseROI> m_pulse_indices;
-  std::vector<std::pair<int, PulseROI>> m_target_to_pulse_indices;
+  const std::vector<std::pair<int, PulseROI>> m_target_to_pulse_indices;
   void loadEventIndex(H5::Group &event_group, std::unique_ptr<std::vector<uint64_t>> &data) const;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -5,9 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
+#pragma once
+
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/DateAndTime.h"
@@ -24,7 +27,7 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 // This is in nanoseconds. So four pulses of 1/60s is 66666666 ns.
 const int64_t PULSETIME_OFFSET = 66666666;
 
-class MANTID_DATAHANDLING_DLL ProcessBankSplitFullTimeTask {
+class MANTID_DATAHANDLING_DLL ProcessBankSplitFullTimeTask : public ProcessBankTaskBase {
 public:
   ProcessBankSplitFullTimeTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
                                const bool is_time_filtered, std::vector<int> &workspaceIndices,
@@ -47,7 +50,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  const std::vector<std::string> m_bankEntries;
   std::shared_ptr<NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -30,15 +30,6 @@ const int64_t PULSETIME_OFFSET = 66666666;
 class MANTID_DATAHANDLING_DLL ProcessBankSplitFullTimeTask : public ProcessBankTaskBase {
 public:
   ProcessBankSplitFullTimeTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
-                               const bool is_time_filtered, std::vector<int> &workspaceIndices,
-                               std::vector<API::MatrixWorkspace_sptr> &wksps,
-                               const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
-                               const size_t grainsize_event, const std::vector<PulseROI> &pulse_indices,
-                               const std::map<Mantid::Types::Core::DateAndTime, int> &splitterMap,
-                               std::shared_ptr<API::Progress> &progress);
-
-  // Constructor with custom loader to allow mocking in tests
-  ProcessBankSplitFullTimeTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
                                std::shared_ptr<NexusLoader> loader, std::vector<int> &workspaceIndices,
                                std::vector<API::MatrixWorkspace_sptr> &wksps,
                                const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -50,7 +50,7 @@ public:
 
 private:
   H5::H5File m_h5file;
-  std::shared_ptr<NexusLoader> m_loader;
+  std::shared_ptr<const NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
   /// number of events to read from disk at one time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -53,8 +53,6 @@ private:
   std::shared_ptr<NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
-  /// used to generate actual calibration
-  const BankCalibrationFactory &m_calibFactory;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   const std::map<Mantid::Types::Core::DateAndTime, int> m_splitterMap;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -41,7 +41,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  std::shared_ptr<const NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
   /// number of events to read from disk at one time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -36,8 +36,6 @@ private:
   mutable NexusLoader m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
-  /// used to generate actual calibration
-  const BankCalibrationFactory &m_calibFactory;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   /// number of events to histogram in a single thread

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -5,9 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
+#pragma once
+
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidGeometry/IDTypes.h"
 #include <H5Cpp.h>
 #include <MantidAPI/Progress.h>
@@ -18,7 +21,7 @@
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
-class ProcessBankSplitTask {
+class ProcessBankSplitTask : public ProcessBankTaskBase {
 public:
   ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
                        std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
@@ -30,7 +33,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  const std::vector<std::string> m_bankEntries;
   mutable NexusLoader m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -23,17 +23,17 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 class ProcessBankSplitTask : public ProcessBankTaskBase {
 public:
-  ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
-                       std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
-                       const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
-                       const size_t grainsize_event, std::vector<std::pair<int, PulseROI>> target_to_pulse_indices,
+  ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
+                       std::shared_ptr<NexusLoader> loader, std::vector<int> &workspaceIndices,
+                       std::vector<API::MatrixWorkspace_sptr> &wksps, const BankCalibrationFactory &calibFactory,
+                       const size_t events_per_chunk, const size_t grainsize_event,
                        std::shared_ptr<API::Progress> &progress);
 
   void operator()(const tbb::blocked_range<size_t> &range) const;
 
 private:
   H5::H5File m_h5file;
-  const NexusLoader m_loader;
+  std::shared_ptr<const NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
   /// number of events to read from disk at one time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -33,7 +33,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  std::shared_ptr<const NexusLoader> m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
   /// number of events to read from disk at one time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -33,7 +33,7 @@ public:
 
 private:
   H5::H5File m_h5file;
-  mutable NexusLoader m_loader;
+  const NexusLoader m_loader;
   std::vector<int> m_workspaceIndices;
   std::vector<API::MatrixWorkspace_sptr> m_wksps;
   /// number of events to read from disk at one time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -23,16 +23,16 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 class ProcessBankTask : public ProcessBankTaskBase {
 public:
-  ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
+  ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, std::shared_ptr<NexusLoader> loader,
                   API::MatrixWorkspace_sptr &wksp, const BankCalibrationFactory &calibFactory,
-                  const size_t events_per_chunk, const size_t grainsize_event, std::vector<PulseROI> pulse_indices,
+                  const size_t events_per_chunk, const size_t grainsize_event,
                   std::shared_ptr<API::Progress> &progress);
 
   void operator()(const tbb::blocked_range<size_t> &range) const;
 
 private:
   H5::H5File m_h5file;
-  const NexusLoader m_loader;
+  std::shared_ptr<const NexusLoader> m_loader;
   API::MatrixWorkspace_sptr m_wksp;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -32,7 +32,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  std::shared_ptr<const NexusLoader> m_loader;
   API::MatrixWorkspace_sptr m_wksp;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -32,7 +32,7 @@ public:
 
 private:
   H5::H5File m_h5file;
-  mutable NexusLoader m_loader;
+  const NexusLoader m_loader;
   API::MatrixWorkspace_sptr m_wksp;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -5,10 +5,13 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
+#pragma once
+
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidGeometry/IDTypes.h"
 #include <H5Cpp.h>
 #include <map>
@@ -18,7 +21,7 @@
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
-class ProcessBankTask {
+class ProcessBankTask : public ProcessBankTaskBase {
 public:
   ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
                   API::MatrixWorkspace_sptr &wksp, const BankCalibrationFactory &calibFactory,
@@ -29,7 +32,6 @@ public:
 
 private:
   H5::H5File m_h5file;
-  const std::vector<std::string> m_bankEntries;
   mutable NexusLoader m_loader;
   API::MatrixWorkspace_sptr m_wksp;
   /// used to generate actual calibration

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -34,8 +34,6 @@ private:
   H5::H5File m_h5file;
   mutable NexusLoader m_loader;
   API::MatrixWorkspace_sptr m_wksp;
-  /// used to generate actual calibration
-  const BankCalibrationFactory &m_calibFactory;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   /// number of events to histogram in a single thread

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -1,0 +1,23 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+#include "MantidAPI/ISpectrum.h"
+
+namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
+
+class ProcessBankTaskBase {
+public:
+  ProcessBankTaskBase(std::vector<std::string> &bankEntryNames);
+  const std::string &bankName(const size_t wksp_index) const;
+
+private:
+  const std::vector<std::string> m_bankEntries;
+};
+
+void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum);
+} // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -8,17 +8,41 @@
 #pragma once
 #include "MantidAPI/ISpectrum.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
+#include <H5Cpp.h>
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 class ProcessBankTaskBase {
 public:
-  ProcessBankTaskBase(std::vector<std::string> &bankEntryNames, const BankCalibrationFactory &calibFactory);
+  ProcessBankTaskBase(std::vector<std::string> &bankEntryNames, std::shared_ptr<NexusLoader> loader,
+                      const BankCalibrationFactory &calibFactory);
   const std::string &bankName(const size_t wksp_index) const;
   BankCalibration getCalibration(const std::string &tof_unit, const size_t wksp_index) const;
 
+  /**
+   *  Load detid and tof at the same time
+   *
+   *  @param detID_SDS : HDF5 dataset for detector IDs
+   *  @param tof_SDS : HDF5 dataset for time-of-flights
+   *  @param offsets : offsets to read from each dataset
+   *  @param slabsizes : slab sizes to read from each dataset
+   *  @param detId_vec : output vector for detector IDs
+   *  @param tof_vec : output vector for time-of-flights
+   */
+  void loadEvents(H5::DataSet &detID_SDS, H5::DataSet &tof_SDS, const std::vector<size_t> &offsets,
+                  const std::vector<size_t> &slabsizes, std::unique_ptr<std::vector<uint32_t>> &detId_vec,
+                  std::unique_ptr<std::vector<float>> &tof_vec) const;
+
+  // these methods simply forward the calls to NexusLoader
+  std::stack<EventROI> getEventIndexRanges(H5::Group &event_group, const uint64_t number_events,
+                                           std::unique_ptr<std::vector<uint64_t>> *event_index = nullptr) const;
+  std::stack<std::pair<int, EventROI>> getEventIndexSplitRanges(H5::Group &event_group,
+                                                                const uint64_t number_events) const;
+
 private:
   const std::vector<std::string> m_bankEntries;
+  std::shared_ptr<const NexusLoader> m_loader;
   /// used to generate actual calibration
   const BankCalibrationFactory &m_calibFactory;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -7,16 +7,20 @@
 
 #pragma once
 #include "MantidAPI/ISpectrum.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 class ProcessBankTaskBase {
 public:
-  ProcessBankTaskBase(std::vector<std::string> &bankEntryNames);
+  ProcessBankTaskBase(std::vector<std::string> &bankEntryNames, const BankCalibrationFactory &calibFactory);
   const std::string &bankName(const size_t wksp_index) const;
+  BankCalibration getCalibration(const std::string &tof_unit, const size_t wksp_index) const;
 
 private:
   const std::vector<std::string> m_bankEntries;
+  /// used to generate actual calibration
+  const BankCalibrationFactory &m_calibFactory;
 };
 
 void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum);

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -47,5 +47,8 @@ private:
   const BankCalibrationFactory &m_calibFactory;
 };
 
+std::string toLogString(const std::string &bankName, const size_t total_events_to_read,
+                        const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes);
+
 void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum);
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/NexusLoader.cpp
@@ -19,12 +19,12 @@ NexusLoader::NexusLoader(const bool is_time_filtered, const std::vector<PulseROI
       m_target_to_pulse_indices(target_to_pulse_indices) {}
 
 void NexusLoader::loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<uint32_t>> &data,
-                           const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) {
+                           const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) const {
   loadDataInternal(SDS, data, offsets, slabsizes);
 }
 
 void NexusLoader::loadData(H5::DataSet &SDS, std::unique_ptr<std::vector<float>> &data,
-                           const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) {
+                           const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) const {
   loadDataInternal(SDS, data, offsets, slabsizes);
 }
 
@@ -98,7 +98,7 @@ std::stack<EventROI> NexusLoader::getEventIndexRanges(H5::Group &event_group, co
 }
 
 std::stack<std::pair<int, EventROI>> NexusLoader::getEventIndexSplitRanges(H5::Group &event_group,
-                                                                           const uint64_t number_events) {
+                                                                           const uint64_t number_events) const {
   // This will return a stack of pairs, where each pair is the start and stop index of the event ranges with a mapping
   // to target, taking intersection with m_pulse_indices
   std::stack<std::pair<int, EventROI>> ranges;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -127,13 +127,11 @@ void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &
       }
 
       // log the event ranges being processed
-      std::ostringstream oss;
-      oss << "Processing " << bankName << " with " << total_events_to_read << " events in the ranges: ";
-      for (size_t i = 0; i < offsets.size(); ++i) {
-        oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
+      g_log.debug(toLogString(bankName, total_events_to_read, offsets, slabsizes));
+
+      if (total_events_to_read == 0) {
+        continue; // nothing to do
       }
-      oss << "\n";
-      g_log.debug() << oss.str();
 
       // load detid and tof at the same time
       this->loadEvents(detID_SDS, tof_SDS, offsets, slabsizes, event_detid, event_time_of_flight);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -7,6 +7,7 @@
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h"
 #include "MantidAPI/Run.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -249,13 +250,7 @@ void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &
     }
 
     // copy the data out into the correct spectrum and calculate errors
-    tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) {
-      auto &y_values = spectra[i]->dataY();
-      std::copy(y_temps[i].cbegin(), y_temps[i].cend(), y_values.begin());
-      auto &e_values = spectra[i]->dataE();
-      std::transform(y_temps[i].cbegin(), y_temps[i].cend(), e_values.begin(),
-                     [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
-    });
+    tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) { copyDataToSpectrum(y_temps[i], spectra[i]); });
 
     g_log.debug() << bankName << " stop" << timer << std::endl;
     m_progress->report();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -26,16 +26,6 @@ namespace {
 auto g_log = Kernel::Logger("ProcessBankSplitFullTimeTask");
 
 } // namespace
-ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
-    std::vector<std::string> &bankEntryNames, H5::H5File &h5file, const bool is_time_filtered,
-    std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
-    const BankCalibrationFactory &calibFactory, const size_t events_per_chunk, const size_t grainsize_event,
-    const std::vector<PulseROI> &pulse_indices, const std::map<Mantid::Types::Core::DateAndTime, int> &splitterMap,
-    std::shared_ptr<API::Progress> &progress)
-    : ProcessBankTaskBase(bankEntryNames, calibFactory), m_h5file(h5file),
-      m_loader(std::make_shared<NexusLoader>(is_time_filtered, pulse_indices)), m_workspaceIndices(workspaceIndices),
-      m_wksps(wksps), m_events_per_chunk(events_per_chunk), m_splitterMap(splitterMap),
-      m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
     std::vector<std::string> &bankEntryNames, H5::H5File &h5file, std::shared_ptr<NexusLoader> loader,

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -7,7 +7,6 @@
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h"
 #include "MantidAPI/Run.h"
-#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -36,7 +35,7 @@ ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
     const BankCalibrationFactory &calibFactory, const size_t events_per_chunk, const size_t grainsize_event,
     const std::vector<PulseROI> &pulse_indices, const std::map<Mantid::Types::Core::DateAndTime, int> &splitterMap,
     std::shared_ptr<API::Progress> &progress)
-    : m_h5file(h5file), m_bankEntries(bankEntryNames),
+    : ProcessBankTaskBase(bankEntryNames), m_h5file(h5file),
       m_loader(std::make_shared<NexusLoader>(is_time_filtered, pulse_indices)), m_workspaceIndices(workspaceIndices),
       m_wksps(wksps), m_calibFactory(calibFactory), m_events_per_chunk(events_per_chunk), m_splitterMap(splitterMap),
       m_grainsize_event(grainsize_event), m_progress(progress) {}
@@ -46,7 +45,7 @@ ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
     std::vector<int> &workspaceIndices, std::vector<API::MatrixWorkspace_sptr> &wksps,
     const BankCalibrationFactory &calibFactory, const size_t events_per_chunk, const size_t grainsize_event,
     const std::map<Mantid::Types::Core::DateAndTime, int> &splitterMap, std::shared_ptr<API::Progress> &progress)
-    : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(std::move(loader)),
+    : ProcessBankTaskBase(bankEntryNames), m_h5file(h5file), m_loader(std::move(loader)),
       m_workspaceIndices(workspaceIndices), m_wksps(wksps), m_calibFactory(calibFactory),
       m_events_per_chunk(events_per_chunk), m_splitterMap(splitterMap), m_grainsize_event(grainsize_event),
       m_progress(progress) {}
@@ -54,7 +53,7 @@ ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
 void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
   for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = m_bankEntries[wksp_index];
+    const auto &bankName = this->bankName(wksp_index);
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -120,13 +120,11 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
       }
 
       // log the event ranges being processed
-      std::ostringstream oss;
-      oss << "Processing " << bankName << " with " << total_events_to_read << " events in the ranges: ";
-      for (size_t i = 0; i < offsets.size(); ++i) {
-        oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
+      g_log.debug(toLogString(bankName, total_events_to_read, offsets, slabsizes));
+
+      if (total_events_to_read == 0) {
+        continue; // nothing to do
       }
-      oss << "\n";
-      g_log.debug() << oss.str();
 
       // load detid and tof at the same time
       this->loadEvents(detID_SDS, tof_SDS, offsets, slabsizes, event_detid, event_time_of_flight);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -183,13 +184,7 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
     }
 
     // copy the data out into the correct spectrum and calculate errors
-    tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) {
-      auto &y_values = spectra[i]->dataY();
-      std::copy(y_temps[i].cbegin(), y_temps[i].cend(), y_values.begin());
-      auto &e_values = spectra[i]->dataE();
-      std::transform(y_temps[i].cbegin(), y_temps[i].cend(), e_values.begin(),
-                     [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
-    });
+    tbb::parallel_for(size_t(0), m_wksps.size(), [&](size_t i) { copyDataToSpectrum(y_temps[i], spectra[i]); });
 
     g_log.debug() << bankName << " stop " << timer << std::endl;
     m_progress->report();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h"
-#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -35,14 +34,14 @@ ProcessBankSplitTask::ProcessBankSplitTask(std::vector<std::string> &bankEntryNa
                                            const size_t grainsize_event,
                                            std::vector<std::pair<int, PulseROI>> target_to_pulse_indices,
                                            std::shared_ptr<API::Progress> &progress)
-    : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(is_time_filtered, {}, target_to_pulse_indices),
+    : ProcessBankTaskBase(bankEntryNames), m_h5file(h5file), m_loader(is_time_filtered, {}, target_to_pulse_indices),
       m_workspaceIndices(workspaceIndices), m_wksps(wksps), m_calibFactory(calibFactory),
       m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
   for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = m_bankEntries[wksp_index];
+    const auto &bankName = this->bankName(wksp_index);
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -23,12 +23,11 @@ auto g_log = Kernel::Logger("ProcessBankTask");
 
 } // namespace
 ProcessBankTask::ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
-                                 const bool is_time_filtered, API::MatrixWorkspace_sptr &wksp,
+                                 std::shared_ptr<NexusLoader> loader, API::MatrixWorkspace_sptr &wksp,
                                  const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
-                                 const size_t grainsize_event, std::vector<PulseROI> pulse_indices,
-                                 std::shared_ptr<API::Progress> &progress)
-    : ProcessBankTaskBase(bankEntryNames, calibFactory), m_h5file(h5file), m_loader(is_time_filtered, pulse_indices),
-      m_wksp(wksp), m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
+                                 const size_t grainsize_event, std::shared_ptr<API::Progress> &progress)
+    : ProcessBankTaskBase(bankEntryNames, calibFactory), m_h5file(h5file), m_loader(std::move(loader)), m_wksp(wksp),
+      m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
@@ -52,7 +51,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       continue;
     }
 
-    auto eventRanges = m_loader.getEventIndexRanges(event_group, total_events);
+    auto eventRanges = m_loader->getEventIndexRanges(event_group, total_events);
 
     // create a histogrammer to process the events
     auto &spectrum = m_wksp->getSpectrum(wksp_index);
@@ -124,11 +123,11 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       tbb::parallel_invoke(
           [&] { // load detid
             // event_detid->clear();
-            m_loader.loadData(detID_SDS, event_detid, offsets, slabsizes);
+            m_loader->loadData(detID_SDS, event_detid, offsets, slabsizes);
           },
           [&] { // load time-of-flight
             // event_time_of_flight->clear();
-            m_loader.loadData(tof_SDS, event_time_of_flight, offsets, slabsizes);
+            m_loader->loadData(tof_SDS, event_time_of_flight, offsets, slabsizes);
           });
 
       // Create a local task for this thread

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h"
-#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -31,14 +30,14 @@ ProcessBankTask::ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H
                                  const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
                                  const size_t grainsize_event, std::vector<PulseROI> pulse_indices,
                                  std::shared_ptr<API::Progress> &progress)
-    : m_h5file(h5file), m_bankEntries(bankEntryNames), m_loader(is_time_filtered, pulse_indices), m_wksp(wksp),
+    : ProcessBankTaskBase(bankEntryNames), m_h5file(h5file), m_loader(is_time_filtered, pulse_indices), m_wksp(wksp),
       m_calibFactory(calibFactory), m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event),
       m_progress(progress) {}
 
 void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
   for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = m_bankEntries[wksp_index];
+    const auto &bankName = this->bankName(wksp_index);
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParallelMinMax.h"
@@ -149,11 +150,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     }
 
     // copy the data out into the correct spectrum and calculate errors
-    auto &y_values = spectrum.dataY();
-    std::copy(y_temp.cbegin(), y_temp.cend(), y_values.begin());
-    auto &e_values = spectrum.dataE();
-    std::transform(y_temp.cbegin(), y_temp.cend(), e_values.begin(),
-                   [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
+    copyDataToSpectrum(y_temp, &spectrum);
 
     g_log.debug() << bankName << " stop " << timer << std::endl;
     m_progress->report();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -111,13 +111,11 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       }
 
       // log the event ranges being processed
-      std::ostringstream oss;
-      oss << "Processing " << bankName << " with " << total_events_to_read << " events in the ranges: ";
-      for (size_t i = 0; i < offsets.size(); ++i) {
-        oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
+      g_log.debug(toLogString(bankName, total_events_to_read, offsets, slabsizes));
+
+      if (total_events_to_read == 0) {
+        continue; // nothing to do
       }
-      oss << "\n";
-      g_log.debug() << oss.str();
 
       // load detid and tof at the same time
       this->loadEvents(detID_SDS, tof_SDS, offsets, slabsizes, event_detid, event_time_of_flight);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -6,11 +6,26 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
+#include "MantidKernel/Unit.h"
+
+namespace {
+const std::string MICROSEC("microseconds");
+}
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
-ProcessBankTaskBase::ProcessBankTaskBase(std::vector<std::string> &bankEntryNames) : m_bankEntries(bankEntryNames) {}
+ProcessBankTaskBase::ProcessBankTaskBase(std::vector<std::string> &bankEntryNames,
+                                         const BankCalibrationFactory &calibFactory)
+    : m_bankEntries(bankEntryNames), m_calibFactory(calibFactory) {}
 
 const std::string &ProcessBankTaskBase::bankName(const size_t wksp_index) const { return m_bankEntries[wksp_index]; }
+BankCalibration ProcessBankTaskBase::getCalibration(const std::string &tof_unit, const size_t wksp_index) const {
+  // determine time conversion as a double
+  const double time_conversion = Kernel::Units::timeConversionValue(tof_unit, MICROSEC);
+
+  // now the calibration for the output group can be created
+  // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
+  return m_calibFactory.getCalibration(time_conversion, wksp_index);
+}
 
 void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum) {
   // copy the data out into the correct spectrum and calculate errors

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -1,0 +1,23 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
+
+namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
+ProcessBankTaskBase::ProcessBankTaskBase(std::vector<std::string> &bankEntryNames) : m_bankEntries(bankEntryNames) {}
+
+const std::string &ProcessBankTaskBase::bankName(const size_t wksp_index) const { return m_bankEntries[wksp_index]; }
+
+void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum) {
+  // copy the data out into the correct spectrum and calculate errors
+  auto &y_values = spectrum->dataY();
+  std::copy(y_temp.cbegin(), y_temp.cend(), y_values.begin());
+  auto &e_values = spectrum->dataE();
+  std::transform(y_temp.cbegin(), y_temp.cend(), e_values.begin(),
+                 [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
+}
+}; // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -7,6 +7,7 @@
 
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
 #include "MantidKernel/Unit.h"
+#include <sstream>
 #include <tbb/tbb.h>
 
 namespace {
@@ -50,6 +51,18 @@ ProcessBankTaskBase::getEventIndexRanges(H5::Group &event_group, const uint64_t 
 std::stack<std::pair<int, EventROI>> ProcessBankTaskBase::getEventIndexSplitRanges(H5::Group &event_group,
                                                                                    const uint64_t number_events) const {
   return m_loader->getEventIndexSplitRanges(event_group, number_events);
+}
+
+std::string toLogString(const std::string &bankName, const size_t total_events_to_read,
+                        const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes) {
+  std::ostringstream oss;
+  oss << "Processing " << bankName << " with " << total_events_to_read << " events in the ranges: ";
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    oss << "[" << offsets[i] << ", " << (offsets[i] + slabsizes[i]) << "), ";
+  }
+  oss << "\n";
+
+  return oss.str();
 }
 
 void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum) {

--- a/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
+++ b/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
@@ -37,7 +37,7 @@ public:
   }
 
   void loadData(H5::DataSet & /*SDS*/, std::unique_ptr<std::vector<uint32_t>> &data,
-                const std::vector<size_t> & /*offsets*/, const std::vector<size_t> & /*slabsizes*/) override {
+                const std::vector<size_t> & /*offsets*/, const std::vector<size_t> & /*slabsizes*/) const override {
     // add detIDs
     data->resize(15);
     for (size_t i = 0; i < 15; ++i) {
@@ -46,7 +46,7 @@ public:
   }
 
   void loadData(H5::DataSet & /*SDS*/, std::unique_ptr<std::vector<float>> &data,
-                const std::vector<size_t> & /*offsets*/, const std::vector<size_t> & /*slabsizes*/) override {
+                const std::vector<size_t> & /*offsets*/, const std::vector<size_t> & /*slabsizes*/) const override {
     // add TOFS
     data->resize(15);
     for (size_t i = 0; i < 15; ++i) {


### PR DESCRIPTION
There was a fair amount of duplicate code between the various `AlignAndFocusPowderSlim/ProcessBank*Task` classes. This creates a base class with some of that duplicate code. Part of this is also moving where/how `NexusLoader` is created to reduce the number of parameters supplied to the constructors. As a side effect, it is significantly easier to mock the `NexusLoader` in unit tests for the `ProcessBank*Task` classes.

Refs #40189 

Side note: for me, `VULCAN_217967` (17GB) processing went from ~10s to ~8s with these. However, I sporadically experience better performance of a similar magnitude, only to have it disappear with subsequent attempts.

### To test:

This is a refactor so existing tests should continue to work as usual.

*This does not require release notes* because it is a refactor of the code to reduce duplication. 

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
