### PR TITLE
Fix small memory leak in `Nexus::File`

### DIFF
--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1520,6 +1520,7 @@ std::vector<AttrInfo> File::getAttrInfos() {
     cname[namelen] = '\0'; // ensure null termination
     // do not include the group class spec
     if (GROUP_CLASS_SPEC == cname) {
+      delete[] cname;
       continue;
     }
     // 2. get the attribute type
@@ -1530,6 +1531,7 @@ std::vector<AttrInfo> File::getAttrInfos() {
     DataSpaceID attrspace = H5Aget_space(attr);
     int rank = H5Sget_simple_extent_ndims(attrspace);
     if (rank > 2 || (rank == 2 && type != NXnumtype::CHAR)) {
+      delete[] cname;
       throw NXEXCEPTION("ERROR iterating through attributes found array attribute not understood by this api");
     }
     DimVector dims(rank, 0);


### PR DESCRIPTION
### Description of work

There was a small memory leak in `Nexus::File::getAttrInfos()`.  This function is only called from within one test, so this was not impacting Mantid performance, but it is good to clean it up anyway.

### To test:

There isn't really a way to test that the leak was fixed, except running `SaveNexusProcessedTest` under `valgrind`.  Instead, just make sure the `SaveNexusProcessedTest` unit tests still pass.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
