### PR TITLE
Fix calculation of MatrixWorkspace::getMemorySize() for ragged workspaces

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1347,8 +1347,18 @@ std::shared_ptr<MatrixWorkspace> MatrixWorkspace::monitorWorkspace() const { ret
  * @return bytes used.
  */
 size_t MatrixWorkspace::getMemorySize() const {
-  // 3 doubles per histogram bin.
-  return 3 * size() * sizeof(double) + run().getMemorySize();
+  const size_t runMemSize = run().getMemorySize();
+  if (this->isRaggedWorkspace()) {
+    const auto numHist = this->getNumberHistograms();
+    size_t total{0};
+    for (size_t i = 0; i < numHist; ++i) {
+      total += this->getSpectrum(i).getMemorySize();
+    }
+    return total + runMemSize;
+  } else {
+    // 3 doubles per histogram bin.
+    return 3 * size() * sizeof(double) + runMemSize;
+  }
 }
 
 /** Returns the memory used (in bytes) by the X axes, handling ragged bins.

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -52,8 +52,6 @@ public:
 
   std::size_t blocksize() const override;
 
-  size_t getMemorySize() const override;
-
   /// Returns the number of bins for a given histogram index.
   std::size_t getNumberBins(const std::size_t &index) const override;
   /// Returns the maximum number of bins in a workspace (works on ragged data).

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -51,6 +51,9 @@ public:
   std::size_t size() const override;
 
   std::size_t blocksize() const override;
+
+  size_t getMemorySize() const override;
+
   /// Returns the number of bins for a given histogram index.
   std::size_t getNumberBins(const std::size_t &index) const override;
   /// Returns the maximum number of bins in a workspace (works on ragged data).

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -7,6 +7,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/RefAxis.h"
+#include "MantidAPI/Run.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidHistogramData/LinearGenerator.h"
@@ -132,6 +133,17 @@ size_t Workspace2D::blocksize() const {
     if (it != data.cend())
       throw std::length_error("blocksize undefined because size of histograms is not equal");
     return numBins;
+  }
+}
+
+size_t Workspace2D::getMemorySize() const {
+  if (this->isRaggedWorkspace()) {
+    size_t total = std::accumulate(data.begin(), data.end(), size_t{0},
+                                   [](size_t total, auto const &list) { return total + list->getMemorySize(); });
+    return total + run().getMemorySize();
+  } else {
+    // MatrixWorkspace is correct for non-ragged
+    return MatrixWorkspace::getMemorySize();
   }
 }
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -136,17 +136,6 @@ size_t Workspace2D::blocksize() const {
   }
 }
 
-size_t Workspace2D::getMemorySize() const {
-  if (this->isRaggedWorkspace()) {
-    size_t total = std::accumulate(data.begin(), data.end(), size_t{0},
-                                   [](size_t total, auto const &list) { return total + list->getMemorySize(); });
-    return total + run().getMemorySize();
-  } else {
-    // MatrixWorkspace is correct for non-ragged
-    return MatrixWorkspace::getMemorySize();
-  }
-}
-
 /** Returns the number of bins for a given histogram index.
  * @param index :: The histogram index to check for the number of bins.
  * @return the number of bins for a given histogram index.

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -247,6 +247,16 @@ public:
     TS_ASSERT_EQUALS(ws->getMemorySizeForXAxes(), nhist * (nbins + 1) * sizeof(double));
   }
 
+  void test_getMemorySizeRagged() {
+    ws = create2DWorkspaceBinned(nhist, nbins);
+    ws->setHistogram(0, Points(0), Counts(0)); // make first spectrum empty
+    TS_ASSERT(ws->isRaggedWorkspace());
+
+    // first spectrum is empty - others have nbins for y/e, and nbins+1 for x
+    size_t totalMem = (nhist - 1) * (2 * nbins + (nbins + 1)) * sizeof(double) + ws->run().getMemorySize();
+    TS_ASSERT_EQUALS(ws->getMemorySize(), totalMem);
+  }
+
   /** Refs #3003: very odd bug when getting detector in parallel only!
    * This does not reproduce it :( */
   void test_getDetector_parallel() {

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -257,6 +257,20 @@ public:
     TS_ASSERT_EQUALS(ws->getMemorySize(), totalMem);
   }
 
+  void test_getMemorySizeRagged2() {
+    ws = create2DWorkspaceBinned(nhist, nhist);
+    size_t expMemFromHistograms = 0; // calculate the memory as we go
+    for (size_t i = 0; i < static_cast<size_t>(nhist); ++i) {
+      ws->setHistogram(i, BinEdges(i + 2), Counts(i + 1));  // make every spectra different
+      expMemFromHistograms += (i + 1) * sizeof(double) * 2; // y + e
+      expMemFromHistograms += (i + 2) * sizeof(double);     // x
+    }
+    TS_ASSERT(ws->isRaggedWorkspace());
+
+    size_t expTotalMem = expMemFromHistograms + ws->run().getMemorySize();
+    TS_ASSERT_EQUALS(ws->getMemorySize(), expTotalMem);
+  }
+
   /** Refs #3003: very odd bug when getting detector in parallel only!
    * This does not reproduce it :( */
   void test_getDetector_parallel() {

--- a/docs/source/release/v6.15.0/Framework/Data_Objects/Bugfixes/40551.rst
+++ b/docs/source/release/v6.15.0/Framework/Data_Objects/Bugfixes/40551.rst
@@ -1,1 +1,1 @@
-- Fix issue where ``Workspace2D.getMemorySize()`` reported the wrong value for :ref:`ragged workspaces <Ragged_Workspace>`
+- Fix issue where ``MatrixWorkspace.getMemorySize()`` reported the wrong value for :ref:`ragged workspaces <Ragged_Workspace>`

--- a/docs/source/release/v6.15.0/Framework/Data_Objects/Bugfixes/40551.rst
+++ b/docs/source/release/v6.15.0/Framework/Data_Objects/Bugfixes/40551.rst
@@ -1,0 +1,1 @@
+- Fix issue where ``Workspace2D.getMemorySize()`` reported the wrong value for :ref:`ragged workspaces <Ragged_Workspace>`


### PR DESCRIPTION
This is a version of #40551 into `ornl-next`