### PR TITLE
Fix nightly docs publish

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -ex
+
 # Steps:
 #   - Install conda packages
 #   - Build HTML docs

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -22,7 +22,7 @@ mkdir build && cd build
 # unset LD_PRELOAD as this causes cmake to segfault
 LD_PRELOAD="" \
 # Generate build files
-pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build --frozen cmake -G Ninja \
+pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build cmake -G Ninja \
   -DDATA_STORE_MIRROR=${DATA_MIRROR} \
   -DMANTID_FRAMEWORK_LIB=SYSTEM \
   -DMANTID_QT_LIB=SYSTEM \


### PR DESCRIPTION
We need to allow the lock file to update, as we have just published a new set of mantid packages.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
