### PR TITLE
Create `NexusDescriptorLazy` for shallower, lazier confidence checking

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -132,7 +132,7 @@ public:
   void loadInstrumentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr);
   /// Load the instrument from an open NeXus file without reading any parameters
   void loadInstrumentInfoNexus(const std::string &nxFilename, Nexus::File *file);
-  /// Load instrument parameters from an open Nexus file in Instument group if found there
+  /// Load instrument parameters from an open Nexus file in Instrument group if found there
   void loadInstrumentParametersNexus(Nexus::File *file, std::string &parameterStr);
 
   /// Load the sample and log info from an open NeXus file.

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -73,8 +73,7 @@ public:
   /// Returns the parameterized instrument
   Geometry::Instrument_const_sptr getInstrument() const;
 
-  /// Returns the set of parameters modifying the base instrument
-  /// (const-version)
+  /// Returns the set of parameters modifying the base instrument (const-version)
   const Geometry::ParameterMap &instrumentParameters() const;
   /// Returns a modifiable set of instrument parameters
   Geometry::ParameterMap &instrumentParameters();
@@ -133,12 +132,11 @@ public:
   void loadInstrumentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr);
   /// Load the instrument from an open NeXus file without reading any parameters
   void loadInstrumentInfoNexus(const std::string &nxFilename, Nexus::File *file);
-  /// Load instrument parameters from an open Nexus file in Instument group if
-  /// found there
+  /// Load instrument parameters from an open Nexus file in Instument group if found there
   void loadInstrumentParametersNexus(Nexus::File *file, std::string &parameterStr);
 
-  /// Load the sample and log info from an open NeXus file. Overload that uses NexusDescriptor for faster metadata
-  /// lookup
+  /// Load the sample and log info from an open NeXus file.
+  /// Overload that uses NexusDescriptor for faster metadata lookup
   void loadSampleAndLogInfoNexus(Nexus::File *file, const Mantid::Nexus::NexusDescriptor &fileInfo,
                                  const std::string &prefix);
   /// Load the sample and log info from an open NeXus file.
@@ -146,8 +144,7 @@ public:
   /// Populate the parameter map given a string
   void readParameterMap(const std::string &parameterStr);
 
-  /// Returns the start date for this experiment (or current time if no info
-  /// available)
+  /// Returns the start date for this experiment (or current time if no info available)
   std::string getWorkspaceStartDate() const;
 
   // run/experiment stat time if available, empty otherwise
@@ -186,12 +183,10 @@ private:
                              const std::string &name, const Geometry::XMLInstrumentParameter &paramInfo,
                              const Run &runData);
 
-  /// Attempt to load instrument embedded in Nexus file. *file must have
-  /// instrument group open.
+  /// Attempt to load instrument embedded in Nexus file. *file must have instrument group open.
   void loadEmbeddedInstrumentInfoNexus(Nexus::File *file, std::string &instrumentName, std::string &instrumentXml);
 
-  /// Set the instrument given the name and XML leading from IDF file if XML
-  /// string is empty
+  /// Set the instrument given the name and XML leading from IDF file if XML string is empty
   void setInstumentFromXML(const std::string &nxFilename, std::string &instrumentName, std::string &instrumentXml);
 
   // Loads the xml from an instrument file with some basic error handling
@@ -211,8 +206,7 @@ private:
   mutable std::unique_ptr<Beamline::SpectrumInfo> m_spectrumInfo;
   mutable std::unique_ptr<SpectrumInfo> m_spectrumInfoWrapper;
   mutable std::mutex m_spectrumInfoMutex;
-  // This vector stores boolean flags but uses char to do so since
-  // std::vector<bool> is not thread-safe.
+  // This vector stores boolean flags but uses char to do so since std::vector<bool> is not thread-safe.
   mutable std::vector<char> m_spectrumDefinitionNeedsUpdate;
 };
 

--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -12,6 +12,7 @@
 #include "MantidKernel/LegacyNexusDescriptor.h"
 #include "MantidKernel/SingletonHolder.h"
 #include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #ifndef Q_MOC_RUN
 #include <type_traits>
@@ -32,17 +33,15 @@ class IAlgorithm;
 
 /**
 Keeps a registry of algorithm's that are file loading algorithms to allow them
-to be searched
-to find the correct one to load a particular file.
+to be searched to find the correct one to load a particular file.
 
-A macro, DECLARE_FILELOADER_ALGORITHM is defined in RegisterFileLoader.h. Use
-this in place of the standard
-DECLARE_ALGORITHM macro
+A macro, DECLARE_FILELOADER_ALGORITHM is defined in RegisterFileLoader.h.
+Use this in place of the standard DECLARE_ALGORITHM macro
  */
 class MANTID_API_DLL FileLoaderRegistryImpl {
 public:
   /// Defines types of possible file
-  enum LoaderFormat { LegacyNexus, Generic, Nexus };
+  enum LoaderFormat { LegacyNexus = 0, Generic, Nexus, NexusLazy, enum_count };
 
 public:
   /// @returns the number of entries in the registry
@@ -103,6 +102,17 @@ private:
               "' registered as Nexus loader but it does not inherit from API::IFileLoader<Kernel::NexusDescriptor>");
         }
         break;
+      case NexusLazy:
+        printf("Checking NexusLazy loader base class\n");
+        fflush(stdout);
+        if (!std::is_base_of<IFileLoader<Nexus::NexusDescriptorLazy>, T>::value) {
+          throw std::runtime_error(std::string("FileLoaderRegistryImpl::subscribe - Class '") + typeid(T).name() +
+                                   "' registered as NexusLazy loader but it does not inherit from "
+                                   "API::IFileLoader<Nexus::NexusDescriptorLazy>");
+        }
+        printf("Done %s\n", typeid(T).name());
+        fflush(stdout);
+        break;
       case Generic:
         if (!std::is_base_of<IFileLoader<Kernel::FileDescriptor>, T>::value) {
           throw std::runtime_error(
@@ -121,7 +131,7 @@ private:
 
   /// The list of names. The index pointed to by LoaderFormat defines a set for
   /// that format. The length is equal to the length of the LoaderFormat enum
-  std::array<std::multimap<std::string, int>, 3> m_names;
+  std::array<std::multimap<std::string, int>, enum_count> m_names;
   /// Total number of names registered
   size_t m_totalSize;
 

--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -103,15 +103,11 @@ private:
         }
         break;
       case NexusLazy:
-        printf("Checking NexusLazy loader base class\n");
-        fflush(stdout);
         if (!std::is_base_of<IFileLoader<Nexus::NexusDescriptorLazy>, T>::value) {
           throw std::runtime_error(std::string("FileLoaderRegistryImpl::subscribe - Class '") + typeid(T).name() +
                                    "' registered as NexusLazy loader but it does not inherit from "
                                    "API::IFileLoader<Nexus::NexusDescriptorLazy>");
         }
-        printf("Done %s\n", typeid(T).name());
-        fflush(stdout);
         break;
       case Generic:
         if (!std::is_base_of<IFileLoader<Kernel::FileDescriptor>, T>::value) {

--- a/Framework/API/inc/MantidAPI/RegisterFileLoader.h
+++ b/Framework/API/inc/MantidAPI/RegisterFileLoader.h
@@ -51,3 +51,18 @@
       (Mantid::API::FileLoaderRegistry::Instance().subscribe<classname>(Mantid::API::FileLoaderRegistryImpl::Nexus),   \
        0));                                                                                                            \
   }
+
+/**
+ * DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM should be used in place of the
+ * standard DECLARE_ALGORITHM macro when writing a file loading algorithm that
+ * loads data using the Nexus API with a lazy descriptor
+ * It both registers the algorithm as usual and subscribes it to the
+ * registry.
+ */
+#define DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(classname)                                                             \
+  namespace {                                                                                                          \
+  Mantid::Kernel::RegistrationHelper                                                                                   \
+      reg_hdf_loader_##classname((Mantid::API::FileLoaderRegistry::Instance().subscribe<classname>(                    \
+                                      Mantid::API::FileLoaderRegistryImpl::NexusLazy),                                 \
+                                  0));                                                                                 \
+  }

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -107,8 +107,8 @@ public:
   /// Save the run to a NeXus file with a given group name
   void saveNexus(Nexus::File *file, const std::string &group, bool keepOpen = false) const override;
 
-  /// Load the run from a NeXus file with a given group name. Overload that uses NexusDescriptor for faster metadata
-  /// lookup
+  /// Load the run from a NeXus file with a given group name.
+  /// Overload that uses NexusDescriptor for faster metadata lookup
   void loadNexus(Nexus::File *file, const std::string &group, const Mantid::Nexus::NexusDescriptor &fileInfo,
                  const std::string &prefix, bool keepOpen = false) override;
   /// Load the run from a NeXus file with a given group name

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -971,10 +971,8 @@ void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file) {
 void ExperimentInfo::loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file,
                                              std::string &parameterStr, const Nexus::NexusDescriptor &fileInfo,
                                              const std::string &prefix) {
-  // TODO
-  // load sample and log info
+  // TODO load sample and log info
   loadSampleAndLogInfoNexus(file, fileInfo, prefix);
-
   loadInstrumentInfoNexus(nxFilename, file, parameterStr);
 }
 

--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -185,10 +185,11 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName, const std
 
   // Check if it is in one of our lists
   const bool legacynexus = (m_names[LegacyNexus].find(algorithmName) != m_names[LegacyNexus].end());
+  const bool lazyNexus = (m_names[NexusLazy].find(algorithmName) != m_names[NexusLazy].end());
   const bool nexus = (m_names[Nexus].find(algorithmName) != m_names[Nexus].end());
   const bool nonHDF = (m_names[Generic].find(algorithmName) != m_names[Generic].end());
 
-  if (!(legacynexus || nexus || nonHDF))
+  if (!(legacynexus || nexus || nonHDF || lazyNexus))
     throw std::invalid_argument("FileLoaderRegistryImpl::canLoad - Algorithm '" + algorithmName +
                                 "' is not registered as a loader.");
 
@@ -206,6 +207,16 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName, const std
         loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(filename, names, m_log).first;
       } catch (const std::invalid_argument &e) {
         m_log.debug() << "Error in looking for HDF5 based NeXus files: " << e.what() << '\n';
+      }
+    }
+  } else if (lazyNexus) {
+    if (H5::H5File::isHdf5(filename)) {
+      try {
+        loader =
+            searchForLoader<Nexus::NexusDescriptorLazy, IFileLoader<Nexus::NexusDescriptorLazy>>(filename, names, m_log)
+                .first;
+      } catch (const std::invalid_argument &e) {
+        m_log.debug() << "Error in looking for lazy HDF5 based NeXus files: " << e.what() << '\n';
       }
     }
   } else if (nonHDF) {

--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -10,6 +10,7 @@
 
 #include <H5Cpp.h>
 #include <Poco/File.h>
+#include <algorithm>
 
 namespace Mantid::API {
 namespace {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBBY2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBBY2.h
@@ -10,14 +10,13 @@
 // Includes
 //---------------------------------------------------
 
-// #include "MantidAPI/IFileLoader.h"
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataHandling/LoadANSTOHelper.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -30,7 +29,7 @@ to recognise a file as the one containing Bilby data.
 @date 11/07/2014
 */
 
-class MANTID_DATAHANDLING_DLL LoadBBY2 : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadBBY2 : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 
   struct InstrumentInfo {
     // core values or non standard conversion
@@ -58,13 +57,13 @@ public:
   const std::string summary() const override { return "Loads a Bilby data file into a workspace."; }
 
   // returns a confidence value that this algorithm can load a specified file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 protected:
   // initialisation
   void init() override;
   // execution
-  void execLoader() override;
+  void exec() override;
 
 private:
   // region of interest

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -16,7 +16,7 @@
 #include "MantidDataObjects/Workspace2D_fwd.h"
 #include "MantidHistogramData/HistogramX.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 #include "MantidNexus/NexusFile.h"
 
 #include <boost/scoped_ptr.hpp>
@@ -56,7 +56,7 @@ multi-period file)
 
 @author Roman Tolchenov, Tessella plc
 */
-class MANTID_DATAHANDLING_DLL LoadISISNexus2 : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadISISNexus2 : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Default constructor
   LoadISISNexus2();
@@ -71,7 +71,7 @@ public:
   const std::string summary() const override { return "Loads a file in ISIS NeXus format."; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
   /// Spectra block descriptor
   struct SpectraBlock {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
@@ -12,14 +12,14 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
 /**
     LoadMLZ : Loads MLZ nexus or hdf file into a Mantid workspace.
  */
-class MANTID_DATAHANDLING_DLL LoadMLZ : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadMLZ : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   LoadMLZ();
 
@@ -31,7 +31,7 @@ public:
   const std::string summary() const override { return "Loads a nexus file from MLZ facility."; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void init() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
@@ -5,11 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataHandling/LoadMuonStrategy.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidNexus/NexusDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -35,7 +36,7 @@ OutputWorkspace_PeriodNo)
 @author Stephen Smith, ISIS
 */
 
-class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::IFileLoader<Nexus::NexusDescriptor> {
 public:
   // Default constructor
   LoadMuonNexusV2();
@@ -60,7 +61,7 @@ private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void execLoader() override;
+  void exec() override;
   // Determines whether entry contains multi period data
   void isEntryMultiPeriod();
   // Run child algorithm LoadISISNexus2

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
@@ -5,12 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include "MantidAPI/IFileLoader.h"
+#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataHandling/LoadMuonStrategy.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidNexus/NexusDescriptor.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -36,7 +35,7 @@ OutputWorkspace_PeriodNo)
 @author Stephen Smith, ISIS
 */
 
-class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::NexusFileLoader {
 public:
   // Default constructor
   LoadMuonNexusV2();
@@ -61,7 +60,7 @@ private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void exec() override;
+  void execLoader() override;
   // Determines whether entry contains multi period data
   void isEntryMultiPeriod();
   // Run child algorithm LoadISISNexus2

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadQKK.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadQKK.h
@@ -11,7 +11,7 @@
 //---------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -23,7 +23,7 @@ namespace DataHandling {
      @author Roman Tolchenov, Tessella plc
      @date 31/10/2011
   */
-class MANTID_DATAHANDLING_DLL LoadQKK : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadQKK : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Algorithm's name
   const std::string name() const override { return "LoadQKK"; }
@@ -37,7 +37,7 @@ public:
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   /// Initialisation code

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
@@ -13,7 +13,7 @@
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <H5Cpp.h>
 
@@ -42,7 +42,7 @@ class LoadDataSet
 };
 */
 
-class MANTID_DATAHANDLING_DLL LoadSassena : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadSassena : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Algorithm's name
   const std::string name() const override { return "LoadSassena"; }
@@ -55,7 +55,7 @@ public:
   const std::string category() const override { return "DataHandling\\Sassena"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 protected:
   /// Add a workspace to the group and register in the analysis data service

--- a/Framework/DataHandling/src/LoadBBY2.cpp
+++ b/Framework/DataHandling/src/LoadBBY2.cpp
@@ -50,7 +50,7 @@ using namespace API;
 using namespace Nexus;
 
 // register the algorithm
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadBBY2)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadBBY2)
 
 // consts
 static const int LAST_INDEX = -1;
@@ -140,7 +140,7 @@ LoadBBY2::LoadBBY2() {}
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadBBY2::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadBBY2::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   static const std::set<std::string> requiredEntries = {"/entry1/program_name",
                                                         "/entry1/experiment/gumtree_version",
@@ -227,7 +227,7 @@ void LoadBBY2::init() {
 /**
  * Execute the algorithm.
  */
-void LoadBBY2::execLoader() {
+void LoadBBY2::exec() {
 
   // Delete the output workspace name if it existed
   std::string outName = getPropertyValue("OutputWorkspace");

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -57,7 +57,7 @@ Mantid::DataHandling::DataBlockComposite getMonitorsFromComposite(Mantid::DataHa
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadISISNexus2)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadISISNexus2)
 
 using namespace Kernel;
 using namespace API;
@@ -78,7 +78,7 @@ LoadISISNexus2::LoadISISNexus2()
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadISISNexus2::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadISISNexus2::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.isEntry("/raw_data_1", "NXentry")) {
     // It also could be an Event Nexus file or a TOFRaw file,
     // so confidence is set to less than 80.

--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -36,7 +36,7 @@ using HistogramData::BinEdges;
 using HistogramData::Counts;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMLZ)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadMLZ)
 
 /** Constructor
  */
@@ -99,7 +99,7 @@ void LoadMLZ::exec() {
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadMLZ::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadMLZ::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   // fields existent only at the MLZ
   if (descriptor.isEntry("/Scan/wavelength") && descriptor.isEntry("/Scan/title") && descriptor.isEntry("/Scan/mode")) {
     return 80;

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -133,7 +133,7 @@ void LoadMuonNexusV2::init() {
                   "Table or a group of tables with information about the "
                   "detector grouping.");
 }
-void LoadMuonNexusV2::exec() {
+void LoadMuonNexusV2::execLoader() {
   // prepare nexus entry
   m_entrynumber = getProperty("EntryNumber");
   m_filename = getPropertyValue("Filename");

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -133,7 +133,7 @@ void LoadMuonNexusV2::init() {
                   "Table or a group of tables with information about the "
                   "detector grouping.");
 }
-void LoadMuonNexusV2::execLoader() {
+void LoadMuonNexusV2::exec() {
   // prepare nexus entry
   m_entrynumber = getProperty("EntryNumber");
   m_filename = getPropertyValue("Filename");

--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -28,7 +28,7 @@ using namespace Mantid::Kernel;
 namespace Mantid::DataHandling {
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadQKK)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadQKK)
 
 /**
  * Return the confidence with with this algorithm can load the file
@@ -36,7 +36,7 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadQKK)
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadQKK::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadQKK::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   const auto &firstEntryName = descriptor.firstEntryNameType().first;
   if (descriptor.isEntry("/" + firstEntryName + "/data/hmm_xy"))
     return 80;

--- a/Framework/DataHandling/src/LoadSassena.cpp
+++ b/Framework/DataHandling/src/LoadSassena.cpp
@@ -23,7 +23,7 @@
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadSassena)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadSassena)
 
 /**
  * Return the confidence with with this algorithm can load the file
@@ -31,7 +31,7 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadSassena)
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadSassena::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadSassena::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.hasRootAttr("sassena_version") || descriptor.isEntry("/qvectors")) {
     return 99;
   }

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -95,8 +95,9 @@ void UpdateInstrumentFromFile::exec() {
 
     // we open and close the HDF5 file.
     boost::scoped_ptr<Nexus::NexusDescriptor> descriptorNexusHDF5(new Nexus::NexusDescriptor(filename));
+    boost::scoped_ptr<Nexus::NexusDescriptorLazy> descriptorNexusLazy(new Nexus::NexusDescriptorLazy(filename));
 
-    if (isisNexus.confidence(*descriptorNexusHDF5) > 0 || eventNexus.confidence(*descriptorNexusHDF5) > 0) {
+    if (isisNexus.confidence(*descriptorNexusLazy) > 0 || eventNexus.confidence(*descriptorNexusHDF5) > 0) {
       const auto &rootEntry = descriptorNexusHDF5->firstEntryNameType();
       Nexus::File nxFile(filename);
       nxFile.openGroup(rootEntry.first, rootEntry.second);

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -94,6 +94,7 @@ void UpdateInstrumentFromFile::exec() {
     LoadEventNexus eventNexus;
 
     // we open and close the HDF5 file.
+    // LoadEventNexus is still using NexusDescriptor rather than NexusDescriptorLazy, so need both
     boost::scoped_ptr<Nexus::NexusDescriptor> descriptorNexusHDF5(new Nexus::NexusDescriptor(filename));
     boost::scoped_ptr<Nexus::NexusDescriptorLazy> descriptorNexusLazy(new Nexus::NexusDescriptorLazy(filename));
 

--- a/Framework/DataHandling/test/LoadBBY2Test.h
+++ b/Framework/DataHandling/test/LoadBBY2Test.h
@@ -20,6 +20,7 @@ using namespace Mantid::DataObjects;
 class LoadBBY2Test : public CxxTest::TestSuite {
 public:
   void test_load_bby2_algorithm_init() {
+    std::cout << "\nTesting LoadBBY2 algorithm initialization" << std::endl;
     LoadBBY2 algToBeTested;
 
     TS_ASSERT_THROWS_NOTHING(algToBeTested.initialize());
@@ -27,6 +28,7 @@ public:
   }
 
   void test_load_bby2_algorithm() {
+    std::cout << "\nTesting LoadBBY2 algorithm execution" << std::endl;
     LoadBBY2 algToBeTested;
 
     if (!algToBeTested.isInitialized())
@@ -69,5 +71,6 @@ public:
     TS_ASSERT_DELTA(logpm("L2_det_value"), 7.023, 1.0e-3);
     TS_ASSERT_DELTA(logpm("Ltof_det_value"), 25.444, 1.0e-3);
     AnalysisDataService::Instance().remove(outputSpace);
+    std::cout << "LoadBBY2Test completed successfully." << std::endl;
   }
 };

--- a/Framework/DataHandling/test/LoadBBY2Test.h
+++ b/Framework/DataHandling/test/LoadBBY2Test.h
@@ -10,6 +10,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Run.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadBBY2.h"
 
 using namespace Mantid::API;
@@ -72,5 +73,18 @@ public:
     TS_ASSERT_DELTA(logpm("Ltof_det_value"), 25.444, 1.0e-3);
     AnalysisDataService::Instance().remove(outputSpace);
     std::cout << "LoadBBY2Test completed successfully." << std::endl;
+  }
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    std::string wsName = "BBY2Testdata_from_Load";
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    load.setPropertyValue("Filename", "BBY0081723.nxs");
+    load.setPropertyValue("OutputWorkspace", wsName);
+    load.execute();
+    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadBBY2");
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "1"); // NOTE LoadBBY2 is NOT version of LoadBBY
   }
 };

--- a/Framework/DataHandling/test/LoadBBY2Test.h
+++ b/Framework/DataHandling/test/LoadBBY2Test.h
@@ -81,6 +81,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(load.initialize());
     TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "BBY0081723.nxs"));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadBBY2");
-    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "1"); // NOTE LoadBBY2 is NOT version of LoadBBY
+    // NOTE LoadBBY2 is a separate loader.  It is NOT version 2 of LoadBBY.
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "1");
   }
 };

--- a/Framework/DataHandling/test/LoadBBY2Test.h
+++ b/Framework/DataHandling/test/LoadBBY2Test.h
@@ -77,13 +77,9 @@ public:
 
   /// Test that this algorithm will be selected from Load algorithm
   void test_load_from_Load() {
-    std::string wsName = "BBY2Testdata_from_Load";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
-    load.setPropertyValue("Filename", "BBY0081723.nxs");
-    load.setPropertyValue("OutputWorkspace", wsName);
-    load.execute();
-    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "BBY0081723.nxs"));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadBBY2");
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "1"); // NOTE LoadBBY2 is NOT version of LoadBBY
   }

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -47,6 +47,9 @@ void replaceValue(std::string &tarPath, int offset, char invalid) {
 class LoadBBYTest : public CxxTest::TestSuite {
 public:
   void test_load_bby_algorithm_init() {
+    std::cout << "\nTesting LoadBBY algorithm initialization" << std::endl;
+    printf("HELLO\n");
+    fflush(stdout);
     LoadBBY algToBeTested;
 
     TS_ASSERT_THROWS_NOTHING(algToBeTested.initialize());
@@ -54,6 +57,7 @@ public:
   }
 
   void test_load_bby_algorithm() {
+    std::cout << "\nTesting LoadBBY algorithm execution" << std::endl;
     LoadBBY algToBeTested;
 
     if (!algToBeTested.isInitialized())
@@ -127,6 +131,7 @@ public:
   }
 
   void test_filter_bby_algorithm() {
+    std::cout << "\nTesting LoadBBY algorithm with time filtering" << std::endl;
     LoadBBY algToBeTested;
 
     if (!algToBeTested.isInitialized())
@@ -165,6 +170,7 @@ public:
   }
 
   void test_default_parameters_logged() {
+    std::cout << "\nTesting LoadBBY algorithm default parameter logging" << std::endl;
     LoadBBY algToBeTested;
 
     if (!algToBeTested.isInitialized())
@@ -193,6 +199,7 @@ public:
   }
 
   void test_invalid_event_logged() {
+    std::cout << "\nTesting LoadBBY algorithm with invalid event handling" << std::endl;
     LoadBBY algToBeTested;
 
     if (!algToBeTested.isInitialized())
@@ -224,5 +231,6 @@ public:
     TS_ASSERT(algToBeTested.isExecuted());
     eventWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(outputSpace);
     TS_ASSERT_EQUALS(eventWS->getNumberEvents(), goodEvents - 1);
+    std::cout << "Temporary file used: " << tempPath << std::endl;
   }
 };

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -229,6 +229,5 @@ public:
     TS_ASSERT(algToBeTested.isExecuted());
     eventWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(outputSpace);
     TS_ASSERT_EQUALS(eventWS->getNumberEvents(), goodEvents - 1);
-    std::cout << "Temporary file used: " << tempPath << std::endl;
   }
 };

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -48,8 +48,6 @@ class LoadBBYTest : public CxxTest::TestSuite {
 public:
   void test_load_bby_algorithm_init() {
     std::cout << "\nTesting LoadBBY algorithm initialization" << std::endl;
-    printf("HELLO\n");
-    fflush(stdout);
     LoadBBY algToBeTested;
 
     TS_ASSERT_THROWS_NOTHING(algToBeTested.initialize());

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -1497,13 +1497,9 @@ public:
 
   /// Test that this algorithm will be selected from Load algorithm
   void test_load_from_Load() {
-    std::string wsName = "LoadFromLoadWS";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
-    load.setPropertyValue("Filename", "LOQ49886.nxs");
-    load.setPropertyValue("OutputWorkspace", wsName);
-    load.execute();
-    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "LOQ49886.nxs"));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadISISNexus");
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "2");
   }

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadISISNexus2.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -1492,6 +1493,19 @@ public:
 
     MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("outWS");
     TS_ASSERT_EQUALS(ws->getComment(), "");
+  }
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    std::string wsName = "LoadFromLoadWS";
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    load.setPropertyValue("Filename", "LOQ49886.nxs");
+    load.setPropertyValue("OutputWorkspace", wsName);
+    load.execute();
+    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadISISNexus");
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderVersion"), "2");
   }
 };
 

--- a/Framework/DataHandling/test/LoadMLZTest.h
+++ b/Framework/DataHandling/test/LoadMLZTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadMLZ.h"
 #include "MantidGeometry/Instrument.h"
 #include <cxxtest/TestSuite.h>
@@ -63,6 +64,18 @@ public:
     TS_ASSERT_DELTA(efixed, 2.272, 0.001);
 
     AnalysisDataService::Instance().clear();
+  }
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    std::string wsName = "TOFTOFTestdata_from_Load";
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    load.setPropertyValue("Filename", m_dataFile);
+    load.setPropertyValue("OutputWorkspace", wsName);
+    load.execute();
+    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadMLZ");
   }
 
 private:

--- a/Framework/DataHandling/test/LoadMLZTest.h
+++ b/Framework/DataHandling/test/LoadMLZTest.h
@@ -71,10 +71,7 @@ public:
     std::string wsName = "TOFTOFTestdata_from_Load";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
-    load.setPropertyValue("Filename", m_dataFile);
-    load.setPropertyValue("OutputWorkspace", wsName);
-    load.execute();
-    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", m_dataFile));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadMLZ");
   }
 

--- a/Framework/DataHandling/test/LoadMLZTest.h
+++ b/Framework/DataHandling/test/LoadMLZTest.h
@@ -68,7 +68,6 @@ public:
 
   /// Test that this algorithm will be selected from Load algorithm
   void test_load_from_Load() {
-    std::string wsName = "TOFTOFTestdata_from_Load";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
     TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", m_dataFile));

--- a/Framework/DataHandling/test/LoadQKKTest.h
+++ b/Framework/DataHandling/test/LoadQKKTest.h
@@ -74,13 +74,9 @@ public:
 
   /// Test that this algorithm will be selected from Load algorithm
   void test_load_from_Load() {
-    std::string wsName = "QKK0029775_from_Load";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
-    load.setPropertyValue("Filename", "QKK0029775.nx.hdf");
-    load.setPropertyValue("OutputWorkspace", wsName);
-    load.execute();
-    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "QKK0029775.nx.hdf"));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadQKK");
   }
 };

--- a/Framework/DataHandling/test/LoadQKKTest.h
+++ b/Framework/DataHandling/test/LoadQKKTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadQKK.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ConfigService.h"
@@ -69,5 +70,17 @@ public:
       const auto &e = data->e(i);
       TS_ASSERT_DIFFERS(e[0], 0.0);
     }
+  }
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    std::string wsName = "QKK0029775_from_Load";
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    load.setPropertyValue("Filename", "QKK0029775.nx.hdf");
+    load.setPropertyValue("OutputWorkspace", wsName);
+    load.execute();
+    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadQKK");
   }
 };

--- a/Framework/DataHandling/test/LoadQKKTest.h
+++ b/Framework/DataHandling/test/LoadQKKTest.h
@@ -30,7 +30,7 @@ public:
     loader.initialize();
     loader.setPropertyValue("Filename",
                             "QKK0029775.nx.hdf"); // find the full path
-    Mantid::Nexus::NexusDescriptor descr(loader.getPropertyValue("Filename"));
+    Mantid::Nexus::NexusDescriptorLazy descr(loader.getPropertyValue("Filename"));
     TS_ASSERT_EQUALS(80, loader.confidence(descr));
   }
 

--- a/Framework/DataHandling/test/LoadSassenaTest.h
+++ b/Framework/DataHandling/test/LoadSassenaTest.h
@@ -87,13 +87,9 @@ public:
 
   /// Test that this algorithm will be selected from Load algorithm
   void test_load_from_Load() {
-    std::string wsName = "SassenaTestdata_from_Load";
     Mantid::DataHandling::Load load;
     TS_ASSERT_THROWS_NOTHING(load.initialize());
-    load.setPropertyValue("Filename", m_inputFile);
-    load.setPropertyValue("OutputWorkspace", wsName);
-    load.execute();
-    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", m_inputFile));
     TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadSassena");
   }
 

--- a/Framework/DataHandling/test/LoadSassenaTest.h
+++ b/Framework/DataHandling/test/LoadSassenaTest.h
@@ -29,7 +29,7 @@ public:
     if (!m_alg.isInitialized())
       m_alg.initialize();
     m_alg.setPropertyValue("Filename", m_inputFile);
-    Mantid::Nexus::NexusDescriptor descr(m_alg.getPropertyValue("Filename"));
+    Mantid::Nexus::NexusDescriptorLazy descr(m_alg.getPropertyValue("Filename"));
     TS_ASSERT_EQUALS(m_alg.confidence(descr), 99);
   }
 

--- a/Framework/DataHandling/test/LoadSassenaTest.h
+++ b/Framework/DataHandling/test/LoadSassenaTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadSassena.h"
 #include <cxxtest/TestSuite.h>
 
@@ -83,6 +84,18 @@ public:
     TS_ASSERT_DELTA(ws->y(4)[14], 656.82368, 1e-05);
 
   } // end of testExec
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    std::string wsName = "SassenaTestdata_from_Load";
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    load.setPropertyValue("Filename", m_inputFile);
+    load.setPropertyValue("OutputWorkspace", wsName);
+    load.execute();
+    TS_ASSERT(load.isExecuted());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadSassena");
+  }
 
 private:
   std::string m_inputFile;

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus2.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus2.h
@@ -12,9 +12,15 @@
 #include "MantidDataObjects/Histogram1D.h"
 #include "MantidKernel/DateAndTimeHelpers.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-#include "MantidLegacyNexus/NexusClasses.h"
 #include "MantidMuon/DllConfig.h"
 #include "MantidMuon/LoadMuonNexus.h"
+
+// forward declarations from legacy NexusClasses
+namespace Mantid::LegacyNexus {
+template <typename T> class NXDataSetTyped;
+class NXEntry;
+using NXInt = NXDataSetTyped<int>;
+} // namespace Mantid::LegacyNexus
 
 namespace Mantid {
 

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRC_FILES
     src/inverted_napi.cpp
     src/hdf5_type_helper.cpp
     src/NexusDescriptor.cpp
+    src/NexusDescriptorLazy.cpp
     src/NexusException.cpp
     src/NexusFile.cpp
     src/NexusAddress.cpp
@@ -18,6 +19,7 @@ set(INC_FILES
     inc/MantidNexus/inverted_napi.h
     inc/MantidNexus/hdf5_type_helper.h
     inc/MantidNexus/NexusDescriptor.h
+    inc/MantidNexus/NexusDescriptorLazy.h
     inc/MantidNexus/NexusException.h
     inc/MantidNexus/NexusFile.h
     inc/MantidNexus/NexusAddress.h
@@ -29,6 +31,7 @@ set(TEST_FILES
     NexusIOHelperTest.h
     NexusClassesTest.h
     NexusDescriptorTest.h
+    NexusDescriptorLazyTest.h
     NexusFileTest.h
     NexusFileLeakTest.h
     NexusFileNapiTest.h

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -54,7 +54,7 @@ public:
   inline std::string const &extension() const noexcept { return m_extension; }
 
   /// Returns the name & type of the first entry in the file
-  std::pair<std::string, std::string> const &firstEntryNameType() const { return m_firstEntryNameType; };
+  std::pair<std::string, std::string> const &firstEntryNameType() const noexcept { return m_firstEntryNameType; };
 
   /// Query if the given attribute exists on the root node
   bool hasRootAttr(std::string const &name);

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -1,0 +1,124 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidNexus/DllConfig.h"
+#include "MantidNexus/UniqueID.h"
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace Mantid {
+namespace Nexus {
+
+class MANTID_NEXUS_DLL NexusDescriptorLazy {
+
+public:
+  /**
+   * Unique constructor
+   * @param filename input HDF5 Nexus file name
+   */
+  NexusDescriptorLazy(std::string const &filename);
+
+  NexusDescriptorLazy() = delete;
+
+  NexusDescriptorLazy &operator=(NexusDescriptorLazy const &nd) = default;
+
+  NexusDescriptorLazy(NexusDescriptorLazy const &nd) = default;
+
+  /**
+   * Using RAII components, no need to deallocate explicitly
+   */
+  ~NexusDescriptorLazy() = default;
+
+  /**
+   * Returns a copy of the current file name
+   * @return
+   */
+  inline std::string const &filename() const noexcept { return m_filename; }
+
+  /**
+   * Access the file extension. Defined as the string after and including the
+   * last period character
+   * @returns A reference to a const string containing the file extension
+   */
+  inline std::string const &extension() const noexcept { return m_extension; }
+
+  /// Query if the given attribute exists on the root node
+  bool hasRootAttr(std::string const &name);
+
+  /**
+   * Returns a const reference of the internal map holding all entries in the
+   * Nexus HDF5 file
+   * @return map holding all entries by group class
+   * <pre>
+   *   key: group_class (e.g. NXentry, NXlog)
+   *   value: set with absolute entry names for the group_class key
+   *          (e.g. /entry/log)
+   * </pre>
+   */
+  std::unordered_map<std::string, std::string> const &getAllEntries() const noexcept { return m_allEntries; }
+
+  /**
+   * Checks if a full-address entry exists for a particular groupClass in a Nexus
+   * dataset
+   * @param groupClass e.g. NxLog , Nexus entry attribute
+   * @param entryName full address for an entry name /entry/NXlogs
+   * @return true: entryName exists for a groupClass, otherwise false
+   */
+  bool isEntry(std::string const &entryName, std::string const &groupClass) {
+    if (isEntry(entryName)) {
+      if (m_allEntries.at(entryName) == groupClass) {
+        return true;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if a full-address entry exists in a Nexus dataset
+   * @param entryName full address for an entry name /entry/NXlogs
+   * @return true: entryName exists, otherwise false
+   */
+  bool isEntry(std::string const &entryName);
+
+  /// Query if a given type exists somewhere in the file
+  bool classTypeExists(std::string const &classType) const;
+
+private:
+  /**
+   * Sets m_allEntries, called in HDF5 constructor.
+   * m_filename must be set
+   */
+  std::unordered_map<std::string, std::string> initAllEntries();
+  void loadGroups(std::unordered_map<std::string, std::string> &allEntries, std::string const &address,
+                  unsigned int depth, const unsigned int maxDepth);
+
+  /** Nexus HDF5 file name */
+  std::string const m_filename;
+  /// Extension
+  std::string const m_extension;
+  /// HDF5 File Handle
+  UniqueID<&H5Fclose> m_fileID;
+  /// Root attributes
+  std::unordered_set<std::string> m_rootAttrs;
+
+  /**
+   * All entries metadata
+   * <pre>
+   *   key: group address
+   *   value: group class (e.g. NXentry, NXlog)
+   * </pre>
+   */
+  std::unordered_map<std::string, std::string> m_allEntries;
+};
+
+} // namespace Nexus
+} // namespace Mantid

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -42,7 +42,7 @@ public:
 
   /**
    * Returns a constant reference to the current file name
-   * @return
+   * @return A reference to a const string containing the file name
    */
   inline std::string const &filename() const noexcept { return m_filename; }
 
@@ -64,9 +64,8 @@ public:
    * Nexus HDF5 file
    * @return map holding all entries by group class
    * <pre>
-   *   key: group_class (e.g. NXentry, NXlog)
-   *   value: set with absolute entry names for the group_class key
-   *          (e.g. /entry/log)
+   *   key: group address (absolute entry name, e.g., /entry/log)
+   *   value: group class (e.g., NXentry, NXlog)
    * </pre>
    */
   std::map<std::string, std::string> const &getAllEntries() const noexcept { return m_allEntries; }

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -9,8 +9,8 @@
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexus/UniqueID.h"
 
+#include <map>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -69,7 +69,7 @@ public:
    *          (e.g. /entry/log)
    * </pre>
    */
-  std::unordered_map<std::string, std::string> const &getAllEntries() const noexcept { return m_allEntries; }
+  std::map<std::string, std::string> const &getAllEntries() const noexcept { return m_allEntries; }
 
   /**
    * Checks if a full-address entry exists for a particular groupClass in a Nexus
@@ -101,9 +101,9 @@ private:
    * Sets m_allEntries, called in HDF5 constructor.
    * m_filename must be set
    */
-  std::unordered_map<std::string, std::string> initAllEntries();
-  void loadGroups(std::unordered_map<std::string, std::string> &allEntries, std::string const &address,
-                  unsigned int depth, const unsigned int maxDepth);
+  std::map<std::string, std::string> initAllEntries();
+  void loadGroups(std::map<std::string, std::string> &allEntries, std::string const &address, unsigned int depth,
+                  const unsigned int maxDepth);
 
   /** Nexus HDF5 file name */
   std::string const m_filename;
@@ -123,7 +123,7 @@ private:
    *   value: group class (e.g. NXentry, NXlog)
    * </pre>
    */
-  std::unordered_map<std::string, std::string> m_allEntries;
+  std::map<std::string, std::string> m_allEntries;
 };
 
 } // namespace Nexus

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -53,6 +53,9 @@ public:
    */
   inline std::string const &extension() const noexcept { return m_extension; }
 
+  /// Returns the name & type of the first entry in the file
+  std::pair<std::string, std::string> const &firstEntryNameType() const { return m_firstEntryNameType; };
+
   /// Query if the given attribute exists on the root node
   bool hasRootAttr(std::string const &name);
 
@@ -110,6 +113,8 @@ private:
   UniqueID<&H5Fclose> m_fileID;
   /// Root attributes
   std::unordered_set<std::string> m_rootAttrs;
+
+  std::pair<std::string, std::string> m_firstEntryNameType;
 
   /**
    * All entries metadata

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -38,7 +38,7 @@ public:
   ~NexusDescriptorLazy() = default;
 
   /**
-   * Returns a copy of the current file name
+   * Returns a constant reference to the current file name
    * @return
    */
   inline std::string const &filename() const noexcept { return m_filename; }
@@ -68,15 +68,13 @@ public:
   /**
    * Checks if a full-address entry exists for a particular groupClass in a Nexus
    * dataset
-   * @param groupClass e.g. NxLog , Nexus entry attribute
    * @param entryName full address for an entry name /entry/NXlogs
+   * @param groupClass e.g. NxLog , Nexus entry attribute
    * @return true: entryName exists for a groupClass, otherwise false
    */
   bool isEntry(std::string const &entryName, std::string const &groupClass) {
     if (isEntry(entryName)) {
-      if (m_allEntries.at(entryName) == groupClass) {
-        return true;
-      }
+      return m_allEntries.at(entryName) == groupClass;
     } else {
       return false;
     }

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -28,9 +28,12 @@ public:
 
   NexusDescriptorLazy() = delete;
 
-  NexusDescriptorLazy &operator=(NexusDescriptorLazy const &nd) = default;
-
-  NexusDescriptorLazy(NexusDescriptorLazy const &nd) = default;
+  // there is no reason to copy this object
+  NexusDescriptorLazy &operator=(NexusDescriptorLazy const &nd) = delete;
+  NexusDescriptorLazy(NexusDescriptorLazy const &nd) = delete;
+  // there is no reason to move this object
+  NexusDescriptorLazy &operator=(NexusDescriptorLazy &&nd) = delete;
+  NexusDescriptorLazy(NexusDescriptorLazy &&nd) = delete;
 
   /**
    * Using RAII components, no need to deallocate explicitly

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -119,7 +119,7 @@ void NexusDescriptorLazy::loadGroups(std::unordered_map<std::string, std::string
     return;
 
   // iterate over members
-  hsize_t numObjs;
+  hsize_t numObjs = 0;
   H5Gget_num_objs(groupID.get(), &numObjs);
   for (hsize_t i = 0; i < numObjs; i++) {
     H5G_obj_t type = H5Gget_objtype_by_idx(groupID, i);
@@ -164,8 +164,12 @@ std::unordered_map<std::string, std::string> NexusDescriptorLazy::initAllEntries
     unsigned int depth = 0;
     loadGroups(allEntries, "/", depth, INIT_DEPTH);
     // set the first entry name/type
-    m_firstEntryNameType = *(allEntries.begin()++);
-    m_firstEntryNameType.first = m_firstEntryNameType.first.substr(1); // remove leading /
+    if (allEntries.size() > 2) {
+      m_firstEntryNameType = *(allEntries.begin()++);
+      m_firstEntryNameType.first = m_firstEntryNameType.first.substr(1); // remove leading /
+    } else {
+      m_firstEntryNameType = std::make_pair("", UNKNOWN_CLASS);
+    }
 
     // for levels beyond 2, only load special entries
     depth = INIT_DEPTH;

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -1,0 +1,184 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidNexus/NexusDescriptorLazy.h"
+#include "MantidNexus/H5Util.h"
+#include "MantidNexus/NexusException.h"
+#include "MantidNexus/UniqueID.h"
+
+#include <H5Cpp.h>
+#include <boost/multi_index/detail/index_matcher.hpp>
+#include <hdf5.h>
+
+#include <cstdlib> // malloc, calloc
+#include <cstring> // strcpy
+#include <filesystem>
+#include <stdexcept> // std::invalid_argument
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+using boost::multi_index::detail::index_matcher::entry;
+
+static unsigned int const INIT_DEPTH = 1;
+static unsigned int const ENTRY_DEPTH = 2;
+static unsigned int const INSTR_DEPTH = 5;
+static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry0", "/entry1"};
+static std::string const NONEXISTENT = "NONEXISTENT"; // register failures as well
+static std::string const UNKNOWN_CLASS = "UNKNOWN_CLASS";
+static std::string const SCIENTIFIC_DATA_SET = "SDS";
+
+namespace Mantid::Nexus {
+
+// PUBLIC
+
+NexusDescriptorLazy::NexusDescriptorLazy(std::string const &filename)
+    : m_filename(filename), m_extension(std::filesystem::path(m_filename).extension().string()),
+      m_allEntries(initAllEntries()) {}
+
+bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
+  if (m_allEntries.contains(entryName)) {
+    return m_allEntries[entryName] != NONEXISTENT;
+  } else {
+    UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
+    if (entryID.isValid()) {
+      m_allEntries[entryName] = UNKNOWN_CLASS;
+      H5O_info2_t oinfo;
+      H5Oget_info(entryID, &oinfo, H5O_INFO_BASIC);
+      if (oinfo.type == H5O_TYPE_DATASET) {
+        m_allEntries[entryName] = SCIENTIFIC_DATA_SET;
+      } else {
+        // read NX_class attribute
+        UniqueID<&H5Aclose> attrID = H5Aopen_name(entryID, "NX_class");
+        if (attrID.isValid()) {
+          H5A_info_t ainfo;
+          H5Aget_info(attrID, &ainfo);
+          m_allEntries[entryName].resize(ainfo.data_size + 1); // +1 for null terminator
+          H5Aread(attrID, H5Aget_type(attrID), m_allEntries[entryName].data());
+        }
+      }
+      return true;
+    } else {
+      // register failure
+      m_allEntries[entryName] = NONEXISTENT;
+      return false;
+    }
+  }
+  return false;
+}
+
+bool NexusDescriptorLazy::classTypeExists(std::string const &classType) const {
+  throw std::logic_error("NexusDescriptorLazy::classTypeExists not implemented yet");
+}
+
+bool NexusDescriptorLazy::hasRootAttr(std::string const &name) {
+  if (m_rootAttrs.count(name) == 1) {
+    return true;
+  } else {
+    if (H5Aexists(m_fileID, name.c_str()) > 0) {
+      m_rootAttrs.emplace(name);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+// PRIVATE
+
+void NexusDescriptorLazy::loadGroups(std::unordered_map<std::string, std::string> &allEntries,
+                                     std::string const &address, unsigned int depth, const unsigned int maxDepth) {
+  if (depth >= maxDepth)
+    return;
+
+  UniqueID<&H5Gclose> groupID(H5Gopen(m_fileID, address.c_str(), H5P_DEFAULT));
+  if (!groupID.isValid())
+    return;
+
+  // get NX_class attribute
+  std::string nxClass = UNKNOWN_CLASS;
+  if (H5Aexists(groupID.get(), "NX_class")) {
+    UniqueID<&H5Aclose> attrID = H5Aopen_name(groupID, "NX_class");
+    if (attrID.isValid()) {
+      int strlen = H5Aread(attrID, H5T_C_S1, nullptr);
+      nxClass.resize(strlen + 1); // +1 for null terminator
+      H5Aread(attrID, H5T_C_S1, nxClass.data());
+    }
+  }
+  allEntries[address] = nxClass;
+
+  // iterate over members
+  hsize_t numObjs;
+  H5Gget_num_objs(groupID.get(), &numObjs);
+  for (hsize_t i = 0; i < numObjs; i++) {
+    H5G_obj_t type = H5Gget_objtype_by_idx(groupID, i);
+    ssize_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
+    if (name_len <= 0)
+      continue;
+    std::string memberName(name_len + 1, 'X'); // +1 for null terminator, fill with X for obvious errors
+    H5Gget_objname_by_idx(groupID, i, memberName.data(), name_len + 1);
+    std::string memberAddress = address;
+    if (!memberAddress.ends_with("/"))
+      memberAddress += "/";
+    memberAddress += memberName;
+
+    if (type == H5G_GROUP) {
+      loadGroups(allEntries, memberAddress, depth + 1, maxDepth);
+    } else if (type == H5G_DATASET) {
+      allEntries[memberAddress] = "SDS";
+    }
+  }
+}
+
+std::unordered_map<std::string, std::string> NexusDescriptorLazy::initAllEntries() {
+
+  H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
+
+  std::unordered_map<std::string, std::string> allEntries;
+
+  // if the file exists read it
+  if (std::filesystem::exists(m_filename)) {
+    // if the file exists but cannot be opened, throw invalid
+    // NOTE must be std::invalid_argument for expected errors to be raised in python API
+    if (!H5::H5File::isAccessible(m_filename, Mantid::Nexus::H5Util::defaultFileAcc())) {
+      throw std::invalid_argument("ERROR: NexusDescriptorLazy couldn't open hdf5 file " + m_filename + "\n");
+    } else {
+      m_fileID = H5Fopen(m_filename.c_str(), H5F_ACC_RDONLY, Mantid::Nexus::H5Util::defaultFileAcc().getId());
+    }
+    if (!m_fileID.isValid()) {
+      throw std::invalid_argument("ERROR: NexusDescriptorLazy couldn't open hdf5 file " + m_filename + "\n");
+    }
+
+    // get all top-level entries
+    unsigned int depth = 0;
+    loadGroups(allEntries, "/", depth, INIT_DEPTH);
+
+    // for levels beyond 2, only load special entries
+    depth = 1;
+    for (std::string const &specialAddress : SPECIAL_ADDRESS) {
+      if (isEntry(specialAddress))
+        loadGroups(allEntries, specialAddress, depth, ENTRY_DEPTH);
+    }
+
+    // get instrument up to a depth of 5
+    depth = 2;
+    for (std::string const &specialAddress : SPECIAL_ADDRESS) {
+      if (isEntry(specialAddress)) {
+        std::string instrumentAddress = specialAddress + "/instrument";
+        if (isEntry(instrumentAddress)) {
+          loadGroups(allEntries, instrumentAddress, depth, INSTR_DEPTH);
+        }
+      }
+    }
+  } else {
+    // if the file does not exist, then leave allEntries empty
+  }
+  // rely on move semantics for single return
+  return allEntries;
+}
+
+} // namespace Mantid::Nexus

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -16,8 +16,8 @@
 #include <cstdlib> // malloc, calloc
 #include <cstring> // strcpy
 #include <filesystem>
+#include <map>
 #include <stdexcept> // std::invalid_argument
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -105,8 +105,8 @@ bool NexusDescriptorLazy::hasRootAttr(std::string const &name) {
 
 // PRIVATE
 
-void NexusDescriptorLazy::loadGroups(std::unordered_map<std::string, std::string> &allEntries,
-                                     std::string const &address, unsigned int depth, const unsigned int maxDepth) {
+void NexusDescriptorLazy::loadGroups(std::map<std::string, std::string> &allEntries, std::string const &address,
+                                     unsigned int depth, const unsigned int maxDepth) {
   UniqueID<&H5Gclose> groupID(H5Gopen(m_fileID, address.c_str(), H5P_DEFAULT));
   if (!groupID.isValid()) {
     return;
@@ -141,11 +141,11 @@ void NexusDescriptorLazy::loadGroups(std::unordered_map<std::string, std::string
   }
 }
 
-std::unordered_map<std::string, std::string> NexusDescriptorLazy::initAllEntries() {
+std::map<std::string, std::string> NexusDescriptorLazy::initAllEntries() {
 
   H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
 
-  std::unordered_map<std::string, std::string> allEntries;
+  std::map<std::string, std::string> allEntries;
 
   // if the file exists read it
   if (std::filesystem::exists(m_filename)) {
@@ -164,8 +164,8 @@ std::unordered_map<std::string, std::string> NexusDescriptorLazy::initAllEntries
     unsigned int depth = 0;
     loadGroups(allEntries, "/", depth, INIT_DEPTH);
     // set the first entry name/type
-    if (allEntries.size() > 2) {
-      m_firstEntryNameType = *(allEntries.begin()++);
+    if (allEntries.size() > 1) {
+      m_firstEntryNameType = *(++allEntries.begin());
       m_firstEntryNameType.first = m_firstEntryNameType.first.substr(1); // remove leading /
     } else {
       m_firstEntryNameType = std::make_pair("", UNKNOWN_CLASS);

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -1,0 +1,82 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/ConfigService.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
+#include "test_helper.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <cstddef> // std::size_t
+
+#include <cxxtest/TestSuite.h>
+
+using Mantid::Nexus::NexusDescriptorLazy;
+
+class NexusDescriptorLazyTest : public CxxTest::TestSuite {
+
+public:
+  void test_fails_bad_file() {
+    std::cout << "\nTesting bad file handling in NexusDescriptorLazy" << std::endl;
+    // test opening a file that exists, but is unreadable
+    std::string filename = NexusTest::getFullPath("Test_characterizations_char.txt");
+    TS_ASSERT_THROWS(Mantid::Nexus::NexusDescriptorLazy nd(filename), std::invalid_argument const &);
+
+    filename = "fake_empty_file.nxs.h5";
+    std::ofstream file(filename);
+    file << "mock";
+    file.close();
+    TS_ASSERT_THROWS(Mantid::Nexus::NexusDescriptorLazy nd(filename), std::invalid_argument const &);
+  }
+
+  void test_extension() {
+    std::cout << "\nTesting extension retrieval in NexusDescriptorLazy" << std::endl;
+    std::string const filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+    TS_ASSERT_EQUALS(descriptor.extension(), ".h5");
+  }
+
+  void test_filename() {
+    std::cout << "\nTesting filename retrieval in NexusDescriptorLazy" << std::endl;
+    std::string const filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+    TS_ASSERT_EQUALS(descriptor.filename(), filename);
+  }
+
+  void test_isEntry() {
+    std::cout << "\nTesting isEntry in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    std::string const filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    // verify that existing groups are there
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/DASlogs"), true);
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/user1/facility_user_id"), true);
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/instrument/bank39"), true);
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/instrument/bank39/total_counts"), true);
+
+    // verify that non-existing groups are not there
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/shorts"), false);
+    TS_ASSERT_EQUALS(descriptor.isEntry("/entry/instrument/pants"), false);
+  }
+
+  void test_hasRootAttr() {
+    std::cout << "\nTesting hasRootAttr in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    const std::string filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    // verify that existing root attributes are there
+    TS_ASSERT_EQUALS(descriptor.hasRootAttr("file_name"), true);
+    TS_ASSERT_EQUALS(descriptor.hasRootAttr("file_time"), true);
+
+    // verify that non-existing root attributes are not there
+    TS_ASSERT_EQUALS(descriptor.hasRootAttr("not_an_attr"), false);
+  }
+};

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -48,6 +48,39 @@ public:
     TS_ASSERT_EQUALS(descriptor.filename(), filename);
   }
 
+  void test_init_loads() {
+    std::cout << "\nTesting initialization in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    std::string const filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    auto entries = descriptor.getAllEntries();
+
+    // verify that entries were loaded
+    TS_ASSERT_EQUALS(entries.count("/entry"), 1);
+    TS_ASSERT_EQUALS(entries.count("/entry/instrument"), 1);
+    TS_ASSERT_EQUALS(entries.count("/entry/instrument/bank39/total_counts"), 1);
+
+    // verify entries have correct classes
+    TS_ASSERT_EQUALS(entries["/entry"], "NXentry");
+    TS_ASSERT_EQUALS(entries["/entry/instrument"], "NXinstrument");
+    TS_ASSERT_EQUALS(entries["/entry/instrument/bank39/total_counts"], "SDS");
+
+    // verify that non-existing groups are not there
+    TS_ASSERT_EQUALS(entries.count("/entry/shorts"), 0);
+    TS_ASSERT_EQUALS(entries.count("/entry/instrument/pants"), 0);
+  }
+
+  void test_firstEntryNameType() {
+    std::cout << "\nTesting firstEntryNameType in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    std::string const filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+    const auto &firstEntry = descriptor.firstEntryNameType();
+    TS_ASSERT_EQUALS(firstEntry.first, "entry");
+    TS_ASSERT_EQUALS(firstEntry.second, "NXentry");
+  }
+
   void test_isEntry() {
     std::cout << "\nTesting isEntry in NexusDescriptorLazy" << std::endl;
     // create a descriptor with the correct values

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -13,8 +13,6 @@
 #include <filesystem>
 #include <fstream>
 
-#include <cstddef> // std::size_t
-
 #include <cxxtest/TestSuite.h>
 
 using Mantid::Nexus::NexusDescriptorLazy;
@@ -33,6 +31,7 @@ public:
     file << "mock";
     file.close();
     TS_ASSERT_THROWS(Mantid::Nexus::NexusDescriptorLazy nd(filename), std::invalid_argument const &);
+    std::filesystem::remove(filename);
   }
 
   void test_extension() {

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidKernel/ConfigService.h"
 #include "MantidNexus/NexusDescriptorLazy.h"
 #include "test_helper.h"
 


### PR DESCRIPTION
### Description of work

Currently, the `Load` algorithm (and similar) calculate confidence levels for all possible load algorithms, and picks the one with highest confidence.  To do this, it first creates a `NexusDescriptor` object which is passed to a static `confidence()` method in each loading algorithm, which then checks for various entries or attributes inside the descriptor.

It was pointed out that `NexusDecriptor` loads the entire file tree, when often only the first few layers are really needed for the confidence check.  Since some files have thousands of entries, it can be a huge time saver to load some minimum amount of entries.

This PR introduces a lazy nexus descriptor.  It maintains a file handle.  It loads all of the top level entries.  It was noted that most of the larger checked addresses begin with either `/entry0` or `/entry1`, so it loads more layers based off of these addresses.  It was also noted that the longest checked addresses (5 layers) tend to be inside the instrument definition, so the instrument definition is also loaded to 5 layers.

All of the loaded entries are stored in a dictionary holding their address and NX_class type.

Following that, any time an address is checked, the lazy descriptor first looks in the cache; and if not in the cache it checks inside the file; and if not there either, it returns false.  Paths which are checked and *not* found in the file are also registered, so reduce as much as possible filesystem access.

This migrates the following files:
- `LoadBBY2`
- `LoadISISNexus2`
- `LoadMLZ`
- `LoadQKK`
- `LoadSassena`

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

Check the unit tests.  Especially check unit tests in `DataHandlingTest` target.

All of the migrated loaders have had their tests updated with a new unit test, checking that `Load` will correctly select them for the files they expect.

Also check this system test:
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
