### PR TITLE
AlignAndFocusPowderSlim: Add GroupingWorkspace input and allow arbitrary grouping

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/TimeSplitter.h"
 #include "MantidGeometry/IDTypes.h"
@@ -30,7 +31,10 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
-  API::MatrixWorkspace_sptr createOutputWorkspace();
+  API::MatrixWorkspace_sptr createOutputWorkspace(size_t num_hist);
+  SpectraProcessingData initializeSpectraProcessingData(const API::MatrixWorkspace_sptr &outputWS);
+  void storeSpectraProcessingData(const SpectraProcessingData &processingData,
+                                  const API::MatrixWorkspace_sptr &outputWS);
   API::MatrixWorkspace_sptr editInstrumentGeometry(API::MatrixWorkspace_sptr &wksp, const double l1,
                                                    const std::vector<double> &polars,
                                                    const std::vector<specnum_t> &specids,
@@ -69,6 +73,7 @@ const std::string FILENAME("Filename");
 const std::string CAL_FILE("CalFileName");
 const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
+const std::string GROUPING_WS("GroupingWorkspace");
 const std::string SPLITTER_WS("SplitterWorkspace");
 const std::string SPLITTER_RELATIVE("RelativeTime");
 const std::string CORRECTION_TO_SAMPLE("CorrectionToSample");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -77,7 +77,6 @@ private:
 namespace PropertyNames {
 const std::string FILENAME("Filename");
 const std::string CAL_FILE("CalFileName");
-const std::string CAL_FILE_USE_GROUPS("CalFileUseGrouping");
 const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
 const std::string GROUPING_WS("GroupingWorkspace");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -7,9 +7,11 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/TimeSplitter.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/TimeROI.h"
@@ -42,8 +44,10 @@ private:
                                                    const std::vector<double> &azimuthals);
   API::MatrixWorkspace_sptr convertToTOF(API::MatrixWorkspace_sptr &wksp);
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
-  void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
-                   const std::vector<double> &difc_focus);
+  void initCalibrationConstantsFromCalWS(const std::vector<double> &difc_focus,
+                                         const API::ITableWorkspace_sptr calibrationWS);
+  const API::ITableWorkspace_sptr loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
+                                              DataObjects::GroupingWorkspace_sptr groupingWS);
   void initScaleAtSample(const API::MatrixWorkspace_sptr &wksp);
   std::vector<std::pair<size_t, size_t>> determinePulseIndices(const API::MatrixWorkspace_sptr &wksp,
                                                                const Kernel::TimeROI &filterROI);

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -77,6 +77,7 @@ private:
 namespace PropertyNames {
 const std::string FILENAME("Filename");
 const std::string CAL_FILE("CalFileName");
+const std::string CAL_FILE_USE_GROUPS("CalFileUseGrouping");
 const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
 const std::string GROUPING_WS("GroupingWorkspace");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -33,7 +33,7 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
-  API::MatrixWorkspace_sptr createOutputWorkspace(size_t num_hist);
+  API::MatrixWorkspace_sptr createOutputWorkspace(const Geometry::Instrument_const_sptr inst, size_t num_hist);
   SpectraProcessingData initializeSpectraProcessingData(const API::MatrixWorkspace_sptr &outputWS);
   void storeSpectraProcessingData(const SpectraProcessingData &processingData,
                                   const API::MatrixWorkspace_sptr &outputWS);
@@ -47,7 +47,7 @@ private:
   void initCalibrationConstantsFromCalWS(const std::vector<double> &difc_focus,
                                          const API::ITableWorkspace_sptr calibrationWS);
   const API::ITableWorkspace_sptr loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
-                                              DataObjects::GroupingWorkspace_sptr groupingWS);
+                                              DataObjects::GroupingWorkspace_sptr &groupingWS);
   void initScaleAtSample(const API::MatrixWorkspace_sptr &wksp);
   std::vector<std::pair<size_t, size_t>> determinePulseIndices(const API::MatrixWorkspace_sptr &wksp,
                                                                const Kernel::TimeROI &filterROI);

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -65,6 +65,8 @@ private:
   std::vector<int64_t> loadStart;
   /// How much to load in the file
   std::vector<int64_t> loadSize;
+  // map of detectorID to output spectrum number
+  std::map<detid_t, size_t> detIDToSpecNum;
 };
 
 // these properties are public to simplify testing and calling from other code

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
@@ -60,6 +60,7 @@ public:
    * @param wksp_index Output group for finding grouping information.
    */
   BankCalibration getCalibration(const double time_conversion, const size_t wksp_index) const;
+  std::vector<BankCalibration> getCalibrations(const double time_conversion) const;
 
 private:
   const std::map<detid_t, double> &m_calibration_map;       ///< detid: difc/difc_focussed

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
@@ -24,7 +24,7 @@ constexpr double IGNORE_PIXEL{1.e6};
  */
 class MANTID_DATAHANDLING_DLL BankCalibration {
 public:
-  BankCalibration(const double time_conversion, const std::vector<detid_t> &det_in_group,
+  BankCalibration(const double time_conversion, const std::set<detid_t> &det_in_group,
                   const std::map<detid_t, double> &calibration_map, const std::map<detid_t, double> &scale_at_sample,
                   const std::set<detid_t> &mask);
 
@@ -36,10 +36,9 @@ public:
   double value_scale_at_sample(const detid_t detid) const;
   const detid_t &idmin() const;
   detid_t idmax() const;
+  bool empty() const;
 
 private:
-  const std::pair<detid_t, detid_t> getDetidRange(const std::vector<detid_t> &det_in_group,
-                                                  const std::map<detid_t, double> &calibration_map);
   bool detidInRange(const detid_t detid) const;
 
   std::vector<double> m_calibration;
@@ -51,22 +50,24 @@ class MANTID_DATAHANDLING_DLL BankCalibrationFactory {
 public:
   BankCalibrationFactory(const std::map<detid_t, double> &calibration_map,
                          const std::map<detid_t, double> &scale_at_sample,
-                         const std::map<size_t, std::vector<detid_t>> &grouping, const std::set<detid_t> &mask);
+                         const std::map<size_t, std::set<detid_t>> &grouping, const std::set<detid_t> &mask,
+                         const std::map<size_t, std::set<detid_t>> &bank_detids);
 
   /**
    * Select which detector ids go into the output group. This resets the internal state of the BankCalibration.
    * @param time_conversion Value to bundle into the calibration constant to account for converting the time-of-flight
    * into microseconds. Applying it here is effectively the same as applying it to each event time-of-flight.
-   * @param wksp_index Output group for finding grouping information.
+   * @param bank_index Output group for finding grouping information.
    */
-  BankCalibration getCalibration(const double time_conversion, const size_t wksp_index) const;
-  std::vector<BankCalibration> getCalibrations(const double time_conversion) const;
+  BankCalibration getCalibration(const double time_conversion, const size_t bank_index) const;
+  std::vector<BankCalibration> getCalibrations(const double time_conversion, const size_t bank_index) const;
 
 private:
-  const std::map<detid_t, double> &m_calibration_map;       ///< detid: difc/difc_focussed
-  const std::map<detid_t, double> &m_scale_at_sample;       ///< multiplicative 0<value<1 to move neutron TOF at sample
-  const std::map<size_t, std::vector<detid_t>> &m_grouping; ///< detector ids for output workspace index
+  const std::map<detid_t, double> &m_calibration_map;    ///< detid: difc/difc_focussed
+  const std::map<detid_t, double> &m_scale_at_sample;    ///< multiplicative 0<value<1 to move neutron TOF at sample
+  const std::map<size_t, std::set<detid_t>> &m_grouping; ///< detector ids for output workspace index
+  // const std::map<size_t, std::vector<detid_t>> &m_banks;    ///< detector ids for each bank
   const std::set<detid_t> &m_mask;
-  bool m_haveGrouping;
+  const std::map<size_t, std::set<detid_t>> &m_bank_detids;
 };
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
@@ -66,7 +66,6 @@ private:
   const std::map<detid_t, double> &m_calibration_map;    ///< detid: difc/difc_focussed
   const std::map<detid_t, double> &m_scale_at_sample;    ///< multiplicative 0<value<1 to move neutron TOF at sample
   const std::map<size_t, std::set<detid_t>> &m_grouping; ///< detector ids for output workspace index
-  // const std::map<size_t, std::vector<detid_t>> &m_banks;    ///< detector ids for each bank
   const std::set<detid_t> &m_mask;
   const std::map<size_t, std::set<detid_t>> &m_bank_detids;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTask.h
@@ -12,6 +12,7 @@
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidGeometry/IDTypes.h"
 #include <H5Cpp.h>
 #include <map>
@@ -24,7 +25,7 @@ namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 class ProcessBankTask : public ProcessBankTaskBase {
 public:
   ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file, std::shared_ptr<NexusLoader> loader,
-                  API::MatrixWorkspace_sptr &wksp, const BankCalibrationFactory &calibFactory,
+                  SpectraProcessingData &processingData, const BankCalibrationFactory &calibFactory,
                   const size_t events_per_chunk, const size_t grainsize_event,
                   std::shared_ptr<API::Progress> &progress);
 
@@ -32,7 +33,7 @@ public:
 
 private:
   H5::H5File m_h5file;
-  API::MatrixWorkspace_sptr m_wksp;
+  SpectraProcessingData &m_processingData;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   /// number of events to histogram in a single thread

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -19,6 +19,7 @@ public:
                       const BankCalibrationFactory &calibFactory);
   const std::string &bankName(const size_t wksp_index) const;
   BankCalibration getCalibration(const std::string &tof_unit, const size_t wksp_index) const;
+  std::vector<BankCalibration> getCalibrations(const std::string &tof_unit) const;
 
   /**
    *  Load detid and tof at the same time
@@ -39,6 +40,11 @@ public:
                                            std::unique_ptr<std::vector<uint64_t>> *event_index = nullptr) const;
   std::stack<std::pair<int, EventROI>> getEventIndexSplitRanges(H5::Group &event_group,
                                                                 const uint64_t number_events) const;
+
+  /**
+   * Returns a const reference to the calibration factory.
+   */
+  const BankCalibrationFactory &calibFactory() const { return m_calibFactory; }
 
 private:
   const std::vector<std::string> m_bankEntries;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -41,11 +41,6 @@ public:
   std::stack<std::pair<int, EventROI>> getEventIndexSplitRanges(H5::Group &event_group,
                                                                 const uint64_t number_events) const;
 
-  /**
-   * Returns a const reference to the calibration factory.
-   */
-  const BankCalibrationFactory &calibFactory() const { return m_calibFactory; }
-
 private:
   const std::vector<std::string> m_bankEntries;
   std::shared_ptr<const NexusLoader> m_loader;

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -19,7 +19,7 @@ public:
                       const BankCalibrationFactory &calibFactory);
   const std::string &bankName(const size_t wksp_index) const;
   BankCalibration getCalibration(const std::string &tof_unit, const size_t wksp_index) const;
-  std::vector<BankCalibration> getCalibrations(const std::string &tof_unit) const;
+  std::vector<BankCalibration> getCalibrations(const std::string &tof_unit, const size_t bank_index) const;
 
   /**
    *  Load detid and tof at the same time

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessEventsTask.h
@@ -26,6 +26,9 @@ public:
         m_calibration(other.m_calibration), m_binedges(other.m_binedges) {}
 
   void operator()(const tbb::blocked_range<size_t> &range) {
+    if (m_calibration->empty()) {
+      return;
+    }
     // Cache values to reduce number of function calls
     const auto &range_end = range.end();
     const auto &binedges_cbegin = m_binedges->cbegin();

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h
@@ -1,0 +1,20 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <atomic>
+#include <vector>
+
+namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
+struct SpectraProcessingData {
+  // There must be the same number of counts and binedges entries
+  std::vector<std::vector<std::atomic_uint32_t>> counts; // [spectrum][bin]
+  std::vector<const std::vector<double> *> binedges;
+  bool arbitraryGrouping{false};
+};
+
+} // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h
@@ -14,7 +14,6 @@ struct SpectraProcessingData {
   // There must be the same number of counts and binedges entries
   std::vector<std::vector<std::atomic_uint32_t>> counts; // [spectrum][bin]
   std::vector<const std::vector<double> *> binedges;
-  bool arbitraryGrouping{false};
 };
 
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -174,7 +174,8 @@ void AlignAndFocusPowderSlim::init() {
                   "The percentage of the average to use as the lower bound when filtering bad pulses.");
   declareProperty(std::make_unique<WorkspaceProperty<DataObjects::GroupingWorkspace>>(
                       PropertyNames::GROUPING_WS, "", Direction::Input, API::PropertyMode::Optional),
-                  "A GroupingWorkspace giving the grouping info.");
+                  "A GroupingWorkspace giving the grouping info. If not provided then the grouping is one per bank. "
+                  "You need to provide");
   const std::vector<std::string> cal_exts{".h5", ".hd5", ".hdf", ".cal"};
   declareProperty(std::make_unique<FileProperty>(PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad, cal_exts),
                   "The .cal file containing the position correction factors. Either this or OffsetsWorkspace needs to "
@@ -231,16 +232,16 @@ void AlignAndFocusPowderSlim::init() {
   positionArrayValidator->add(mandatoryDblArrayValidator);
   positionArrayValidator->add(mustBePosArr);
   declareProperty(std::make_unique<PropertyWithValue<double>>(PropertyNames::L1, EMPTY_DBL(), l1Validator),
-                  "The primary distance $\\ell_1$ from beam to sample");
+                  "The primary distance :math:`\\ell_1` from beam to sample");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::L2, std::vector<double>{}, positionArrayValidator),
-      "The secondary distances $\\ell_2$ from sample to focus group");
+      "The secondary distances :math:`\\ell_2` from sample to focus group");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::POLARS, std::vector<double>{}, positionArrayValidator),
-      "The effective polar angle (2$\\theta$) of each focus group");
+      "The effective polar angle (:math:`2\\theta`) of each focus group");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::AZIMUTHALS, std::vector<double>{}, mustBePosArr),
-      "The effective azimuthal angle $\\phi$ for each focus group");
+      "The effective azimuthal angle :math:`\\phi` for each focus group");
 }
 
 std::map<std::string, std::string> AlignAndFocusPowderSlim::validateInputs() {

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -93,7 +93,7 @@ double getFocussedPostion(const detid_t detid, const std::vector<double> &difc_f
   if (detIDToSpecNum.contains(detid)) {
     return difc_focus[detIDToSpecNum[detid]];
   } else {
-    throw std::runtime_error("Detector ID " + std::to_string(detid) + " not found in detIDToSpecNum map.");
+    return IGNORE_PIXEL;
   }
 }
 
@@ -740,8 +740,11 @@ void AlignAndFocusPowderSlim::initCalibrationConstants(API::MatrixWorkspace_sptr
   for (auto iter = detInfo.cbegin(); iter != detInfo.cend(); ++iter) {
     if (!iter->isMonitor()) {
       const auto difc_focussed = getFocussedPostion(static_cast<detid_t>(iter->detid()), difc_focus, detIDToSpecNum);
-      m_calibration.emplace(static_cast<detid_t>(iter->detid()),
-                            difc_focussed / detInfo.difcUncalibrated(iter->index()));
+      if (difc_focussed == IGNORE_PIXEL)
+        m_calibration.emplace(static_cast<detid_t>(iter->detid()), IGNORE_PIXEL);
+      else
+        m_calibration.emplace(static_cast<detid_t>(iter->detid()),
+                              difc_focussed / detInfo.difcUncalibrated(iter->index()));
     }
   }
 }
@@ -752,7 +755,10 @@ void AlignAndFocusPowderSlim::initCalibrationConstantsFromCalWS(const std::vecto
     const detid_t detid = calibrationWS->cell<int>(row, 0);
     const double detc = calibrationWS->cell<double>(row, 1);
     const auto difc_focussed = getFocussedPostion(detid, difc_focus, detIDToSpecNum);
-    m_calibration.emplace(detid, difc_focussed / detc);
+    if (difc_focussed == IGNORE_PIXEL)
+      m_calibration.emplace(detid, IGNORE_PIXEL);
+    else
+      m_calibration.emplace(detid, difc_focussed / detc);
   }
 }
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -332,7 +332,7 @@ void AlignAndFocusPowderSlim::exec() {
   loadStart.resize(1, 0);
   loadSize.resize(1, 0);
 
-  size_t num_hist = NUM_HIST;
+  size_t num_hist;
   std::map<size_t, std::set<detid_t>> grouping;
   GroupingWorkspace_sptr groupingWS = this->getProperty(PropertyNames::GROUPING_WS);
 
@@ -365,7 +365,7 @@ void AlignAndFocusPowderSlim::exec() {
   // temparary until we update splitting workflow to support arbitrary grouping
   API::Workspace_sptr splitter_ws = this->getProperty(PropertyNames::SPLITTER_WS);
   if (splitter_ws != nullptr) {
-    num_hist = 6;
+    num_hist = NUM_HIST;
   }
 
   this->progress(.0, "Create output workspace");

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -158,10 +158,11 @@ BankCalibration BankCalibrationFactory::getCalibration(const double time_convers
 
 std::vector<BankCalibration> BankCalibrationFactory::getCalibrations(const double time_conversion) const {
   std::vector<BankCalibration> calibrations;
-  for (const auto &pair : m_grouping) {
-    calibrations.emplace_back(
-        BankCalibration(time_conversion, pair.second, m_calibration_map, m_scale_at_sample, m_mask));
-  }
+  calibrations.reserve(m_grouping.size());
+  std::transform(m_grouping.begin(), m_grouping.end(), std::back_inserter(calibrations),
+                 [this, time_conversion](const auto &pair) {
+                   return BankCalibration(time_conversion, pair.second, m_calibration_map, m_scale_at_sample, m_mask);
+                 });
 
   return calibrations;
 }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -73,7 +73,7 @@ BankCalibration::BankCalibration(const double time_conversion, const std::set<de
 
   // mask values that are in the mask or not in the detector group
 
-  // mask anything that isn't int the group this assumes both are sorted
+  // mask anything that isn't in the group this assumes both are sorted
   // find the first and last detector id that is in the range being used
   for (size_t i = 0; i < m_calibration.size(); ++i) {
     if (m_calibration[i] != IGNORE_PIXEL) {

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -156,4 +156,14 @@ BankCalibration BankCalibrationFactory::getCalibration(const double time_convers
   }
 }
 
+std::vector<BankCalibration> BankCalibrationFactory::getCalibrations(const double time_conversion) const {
+  std::vector<BankCalibration> calibrations;
+  for (const auto &pair : m_grouping) {
+    calibrations.emplace_back(
+        BankCalibration(time_conversion, pair.second, m_calibration_map, m_scale_at_sample, m_mask));
+  }
+
+  return calibrations;
+}
+
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.cpp
@@ -38,8 +38,8 @@ ProcessBankSplitFullTimeTask::ProcessBankSplitFullTimeTask(
 
 void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
-  for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = this->bankName(wksp_index);
+  for (size_t bank_index = range.begin(); bank_index < range.end(); ++bank_index) {
+    const auto &bankName = this->bankName(bank_index);
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;
@@ -66,7 +66,7 @@ void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &
     std::vector<API::ISpectrum *> spectra;
     std::vector<std::vector<uint32_t>> y_temps;
     for (const auto &wksp : m_wksps) {
-      spectra.push_back(&wksp->getSpectrum(wksp_index));
+      spectra.push_back(&wksp->getSpectrum(bank_index));
       y_temps.emplace_back(spectra.back()->dataY().size());
     }
 
@@ -76,7 +76,7 @@ void ProcessBankSplitFullTimeTask::operator()(const tbb::blocked_range<size_t> &
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
-    const auto calibration = this->getCalibration(tof_unit, wksp_index);
+    const auto calibration = this->getCalibration(tof_unit, bank_index);
 
     const auto frequency_log =
         dynamic_cast<const Kernel::TimeSeriesProperty<double> *>(m_wksps.at(0)->run().getProperty("frequency"));

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankSplitTask.cpp
@@ -34,8 +34,8 @@ ProcessBankSplitTask::ProcessBankSplitTask(std::vector<std::string> &bankEntryNa
 
 void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
-  for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = this->bankName(wksp_index);
+  for (size_t bank_index = range.begin(); bank_index < range.end(); ++bank_index) {
+    const auto &bankName = this->bankName(bank_index);
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;
@@ -61,7 +61,7 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
     std::vector<API::ISpectrum *> spectra;
     std::vector<std::vector<uint32_t>> y_temps;
     for (const auto &wksp : m_wksps) {
-      spectra.push_back(&wksp->getSpectrum(wksp_index));
+      spectra.push_back(&wksp->getSpectrum(bank_index));
       y_temps.emplace_back(spectra.back()->dataY().size());
     }
 
@@ -73,7 +73,7 @@ void ProcessBankSplitTask::operator()(const tbb::blocked_range<size_t> &range) c
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
-    const auto calibration = this->getCalibration(tof_unit, wksp_index);
+    const auto calibration = this->getCalibration(tof_unit, bank_index);
 
     // declare arrays once so memory can be reused
     auto event_detid = std::make_unique<std::vector<uint32_t>>();       // uint32 for ORNL nexus file

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -14,6 +14,8 @@
 #include "tbb/parallel_for.h"
 #include "tbb/parallel_reduce.h"
 
+#include <iostream>
+
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 namespace {
@@ -23,16 +25,17 @@ auto g_log = Kernel::Logger("ProcessBankTask");
 
 } // namespace
 ProcessBankTask::ProcessBankTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
-                                 std::shared_ptr<NexusLoader> loader, API::MatrixWorkspace_sptr &wksp,
+                                 std::shared_ptr<NexusLoader> loader, SpectraProcessingData &processingData,
                                  const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
                                  const size_t grainsize_event, std::shared_ptr<API::Progress> &progress)
-    : ProcessBankTaskBase(bankEntryNames, loader, calibFactory), m_h5file(h5file), m_wksp(wksp),
+    : ProcessBankTaskBase(bankEntryNames, loader, calibFactory), m_h5file(h5file), m_processingData(processingData),
       m_events_per_chunk(events_per_chunk), m_grainsize_event(grainsize_event), m_progress(progress) {}
 
 void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const {
   auto entry = m_h5file.openGroup("entry"); // type=NXentry
-  for (size_t wksp_index = range.begin(); wksp_index < range.end(); ++wksp_index) {
-    const auto &bankName = this->bankName(wksp_index);
+  for (size_t bank_index = range.begin(); bank_index < range.end(); ++bank_index) {
+    const auto &bankName = this->bankName(bank_index);
+
     // empty bank names indicate spectra to skip; control should never get here, but just in case
     if (bankName.empty()) {
       continue;
@@ -53,14 +56,6 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
 
     auto eventRanges = this->getEventIndexRanges(event_group, total_events);
 
-    // create a histogrammer to process the events
-    auto &spectrum = m_wksp->getSpectrum(wksp_index);
-
-    // std::atomic allows for multi-threaded accumulation and who cares about floats when you are just
-    // counting things
-    // std::vector<std::atomic_uint32_t> y_temp(spectrum.dataY().size())
-    std::vector<uint32_t> y_temp(spectrum.dataY().size());
-
     // get handle to the data
     auto detID_SDS = event_group.openDataSet(NxsFieldNames::DETID);
     // auto tof_SDS = event_group.openDataSet(NxsFieldNames::TIME_OF_FLIGHT);
@@ -69,7 +64,14 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
-    const auto calibration = this->getCalibration(tof_unit, wksp_index);
+    std::unique_ptr<BankCalibration> calibration;
+    std::vector<BankCalibration> calibrations;
+
+    if (m_processingData.arbitraryGrouping) {
+      calibrations = this->getCalibrations(tof_unit);
+    } else {
+      calibration = std::make_unique<BankCalibration>(this->getCalibration(tof_unit, bank_index));
+    }
 
     // declare arrays once so memory can be reused
     auto event_detid = std::make_unique<std::vector<uint32_t>>();       // uint32 for ORNL nexus file
@@ -120,19 +122,39 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       // load detid and tof at the same time
       this->loadEvents(detID_SDS, tof_SDS, offsets, slabsizes, event_detid, event_time_of_flight);
 
-      // Create a local task for this thread
-      ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), &calibration, &spectrum.readX());
+      if (m_processingData.arbitraryGrouping) {
+        // Loop over all output spectra / groups
+        for (size_t output_index = 0; output_index < m_processingData.counts.size(); ++output_index) {
+          // Create a local task for this thread
+          ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), &calibrations.at(output_index),
+                                 m_processingData.binedges[output_index]);
 
-      // Non-blocking processing of the events
-      const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
-      tbb::parallel_reduce(range_info, task);
+          // Non-blocking processing of the events
+          const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
+          tbb::parallel_reduce(range_info, task);
 
-      // Accumulate results into shared y_temp to combine local histograms
-      std::transform(y_temp.begin(), y_temp.end(), task.y_temp.begin(), y_temp.begin(), std::plus<uint32_t>());
+          // Accumulate results into shared y_temp to combine local histograms
+          // Use atomic fetch_add to accumulate results into shared vectors
+          for (size_t i = 0; i < m_processingData.counts[output_index].size(); ++i) {
+            m_processingData.counts[output_index][i].fetch_add(task.y_temp[i], std::memory_order_relaxed);
+          }
+        }
+      } else {
+        // Create a local task for this thread
+        ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), calibration.get(),
+                               m_processingData.binedges[bank_index]);
+
+        // Non-blocking processing of the events
+        const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
+        tbb::parallel_reduce(range_info, task);
+
+        // Accumulate results into shared y_temp to combine local histograms
+        // Use atomic fetch_add to accumulate results into shared y_temp
+        for (size_t i = 0; i < m_processingData.counts[bank_index].size(); ++i) {
+          m_processingData.counts[bank_index][i].fetch_add(task.y_temp[i], std::memory_order_relaxed);
+        }
+      }
     }
-
-    // copy the data out into the correct spectrum and calculate errors
-    copyDataToSpectrum(y_temp, &spectrum);
 
     g_log.debug() << bankName << " stop " << timer << std::endl;
     m_progress->report();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -14,8 +14,6 @@
 #include "tbb/parallel_for.h"
 #include "tbb/parallel_reduce.h"
 
-#include <iostream>
-
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
 namespace {
@@ -37,9 +35,9 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     const auto &bankName = this->bankName(bank_index);
 
     // empty bank names indicate spectra to skip; control should never get here, but just in case
-    if (bankName.empty()) {
+    if (bankName.empty())
       continue;
-    }
+
     Kernel::Timer timer;
     g_log.debug() << bankName << " start" << std::endl;
 
@@ -68,7 +66,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     std::vector<BankCalibration> calibrations;
 
     if (m_processingData.arbitraryGrouping) {
-      calibrations = this->getCalibrations(tof_unit);
+      calibrations = this->getCalibrations(tof_unit, bank_index);
     } else {
       calibration = std::make_unique<BankCalibration>(this->getCalibration(tof_unit, bank_index));
     }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -62,14 +62,7 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
-    std::unique_ptr<BankCalibration> calibration;
-    std::vector<BankCalibration> calibrations;
-
-    if (m_processingData.arbitraryGrouping) {
-      calibrations = this->getCalibrations(tof_unit, bank_index);
-    } else {
-      calibration = std::make_unique<BankCalibration>(this->getCalibration(tof_unit, bank_index));
-    }
+    const auto calibrations = this->getCalibrations(tof_unit, bank_index);
 
     // declare arrays once so memory can be reused
     auto event_detid = std::make_unique<std::vector<uint32_t>>();       // uint32 for ORNL nexus file
@@ -120,41 +113,25 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
       // load detid and tof at the same time
       this->loadEvents(detID_SDS, tof_SDS, offsets, slabsizes, event_detid, event_time_of_flight);
 
-      if (m_processingData.arbitraryGrouping) {
-        // Loop over all output spectra / groups
-        tbb::parallel_for(
-            tbb::blocked_range<size_t>(0, m_processingData.counts.size()),
-            [&](const tbb::blocked_range<size_t> &output_range) {
-              for (size_t output_index = output_range.begin(); output_index < output_range.end(); ++output_index) {
-                // Create a local task for this thread
-                ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), &calibrations.at(output_index),
-                                       m_processingData.binedges[output_index]);
+      // Loop over all output spectra / groups
+      tbb::parallel_for(
+          tbb::blocked_range<size_t>(0, m_processingData.counts.size()),
+          [&](const tbb::blocked_range<size_t> &output_range) {
+            for (size_t output_index = output_range.begin(); output_index < output_range.end(); ++output_index) {
+              // Create a local task for this thread
+              ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), &calibrations.at(output_index),
+                                     m_processingData.binedges[output_index]);
 
-                const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
-                tbb::parallel_reduce(range_info, task);
+              const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
+              tbb::parallel_reduce(range_info, task);
 
-                // Accumulate results into shared y_temp to combine local histograms
-                // Use atomic fetch_add to accumulate results into shared vectors
-                for (size_t i = 0; i < m_processingData.counts[output_index].size(); ++i) {
-                  m_processingData.counts[output_index][i].fetch_add(task.y_temp[i], std::memory_order_relaxed);
-                }
+              // Accumulate results into shared y_temp to combine local histograms
+              // Use atomic fetch_add to accumulate results into shared vectors
+              for (size_t i = 0; i < m_processingData.counts[output_index].size(); ++i) {
+                m_processingData.counts[output_index][i].fetch_add(task.y_temp[i], std::memory_order_relaxed);
               }
-            });
-      } else {
-        // Create a local task for this thread
-        ProcessEventsTask task(event_detid.get(), event_time_of_flight.get(), calibration.get(),
-                               m_processingData.binedges[bank_index]);
-
-        // Non-blocking processing of the events
-        const tbb::blocked_range<size_t> range_info(0, event_time_of_flight->size(), m_grainsize_event);
-        tbb::parallel_reduce(range_info, task);
-
-        // Accumulate results into shared y_temp to combine local histograms
-        // Use atomic fetch_add to accumulate results into shared y_temp
-        for (size_t i = 0; i < m_processingData.counts[bank_index].size(); ++i) {
-          m_processingData.counts[bank_index][i].fetch_add(task.y_temp[i], std::memory_order_relaxed);
-        }
-      }
+            }
+          });
     }
 
     g_log.debug() << bankName << " stop " << timer << std::endl;

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -29,10 +29,11 @@ BankCalibration ProcessBankTaskBase::getCalibration(const std::string &tof_unit,
   return m_calibFactory.getCalibration(time_conversion, wksp_index);
 }
 
-std::vector<BankCalibration> ProcessBankTaskBase::getCalibrations(const std::string &tof_unit) const {
+std::vector<BankCalibration> ProcessBankTaskBase::getCalibrations(const std::string &tof_unit,
+                                                                  const size_t bank_index) const {
   // when arbitrary grouping is used, we need all calibrations
   const double time_conversion = Kernel::Units::timeConversionValue(tof_unit, MICROSEC);
-  return m_calibFactory.getCalibrations(time_conversion);
+  return m_calibFactory.getCalibrations(time_conversion, bank_index);
 }
 
 void ProcessBankTaskBase::loadEvents(H5::DataSet &detID_SDS, H5::DataSet &tof_SDS, const std::vector<size_t> &offsets,

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -29,6 +29,12 @@ BankCalibration ProcessBankTaskBase::getCalibration(const std::string &tof_unit,
   return m_calibFactory.getCalibration(time_conversion, wksp_index);
 }
 
+std::vector<BankCalibration> ProcessBankTaskBase::getCalibrations(const std::string &tof_unit) const {
+  // when arbitrary grouping is used, we need all calibrations
+  const double time_conversion = Kernel::Units::timeConversionValue(tof_unit, MICROSEC);
+  return m_calibFactory.getCalibrations(time_conversion);
+}
+
 void ProcessBankTaskBase::loadEvents(H5::DataSet &detID_SDS, H5::DataSet &tof_SDS, const std::vector<size_t> &offsets,
                                      const std::vector<size_t> &slabsizes,
                                      std::unique_ptr<std::vector<uint32_t>> &detId_vec,

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -1006,7 +1006,7 @@ public:
     load->execute();
 
     // Use GenerateGroupingPowder to create grouping workspace. This will have a many-to-many relationship between banks
-    // and output spectra. 10 degress gives us 12 groups for VULCAN
+    // and output spectra. 10 degrees gives us 12 groups for VULCAN
     auto gen = AlgorithmManager::Instance().createUnmanaged("GenerateGroupingPowder");
     gen->initialize();
     gen->setProperty("InputWorkspace", "instrument");
@@ -1053,7 +1053,7 @@ public:
     load->execute();
 
     // Use GenerateGroupingPowder to create grouping workspace. This will have a many-to-many relationship between banks
-    // and output spectra. 45 degress gives us 3 groups for VULCAN
+    // and output spectra. 45 degrees gives us 3 groups for VULCAN
     auto gen = AlgorithmManager::Instance().createUnmanaged("GenerateGroupingPowder");
     gen->initialize();
     gen->setProperty("InputWorkspace", "instrument");

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -33,6 +33,7 @@ using Mantid::API::Workspace_sptr;
 using Mantid::API::WorkspaceGroup;
 using Mantid::API::WorkspaceGroup_sptr;
 using Mantid::DataHandling::AlignAndFocusPowderSlim::AlignAndFocusPowderSlim;
+using Mantid::DataObjects::GroupingWorkspace;
 using Mantid::DataObjects::GroupingWorkspace_sptr;
 using Mantid::DataObjects::TableWorkspace_sptr;
 
@@ -77,6 +78,20 @@ public:
   // This means the constructor isn't called when running other tests
   static AlignAndFocusPowderSlimTest *createSuite() { return new AlignAndFocusPowderSlimTest(); }
   static void destroySuite(AlignAndFocusPowderSlimTest *suite) { delete suite; }
+
+  AlignAndFocusPowderSlimTest() {
+    // CreateGroupingWorkspace(InstrumentName="VULCAN", GroupDetectorsBy="bank", OutputWorkspace="groups")
+    auto gen = AlgorithmManager::Instance().createUnmanaged("CreateGroupingWorkspace");
+    gen->initialize();
+    gen->setProperty("InstrumentName", "VULCAN");
+    gen->setProperty("GroupDetectorsBy", "bank");
+    gen->setProperty("OutputWorkspace", "bank_groups");
+    gen->execute();
+    bank_grouping_ws =
+        std::dynamic_pointer_cast<GroupingWorkspace>(AnalysisDataService::Instance().retrieve("bank_groups"));
+  }
+
+  ~AlignAndFocusPowderSlimTest() { AnalysisDataService::Instance().remove("bank_groups"); }
 
   void test_Init() {
     AlignAndFocusPowderSlim alg;
@@ -191,6 +206,7 @@ public:
 
   void test_defaults() {
     TestConfig config;
+    config.groupingWS = bank_grouping_ws;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, config));
 
     constexpr size_t NUM_Y{1874}; // observed value
@@ -224,6 +240,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", VULCAN_218062));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("ReadSizeFromDisk", 1000000));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", bank_grouping_ws));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("L1", config.l1));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("L2", config.l2s));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Polar", config.twoTheta));
@@ -242,8 +259,38 @@ public:
     TS_ASSERT(result);
   }
 
+  void test_no_grouping() {
+    // this should result in 1 spectrum in the output when no grouping is given
+    TestConfig config;
+    config.l2s = {2.296};
+    config.twoTheta = {90};
+    config.phi = {0};
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, config));
+
+    constexpr size_t NUM_Y{1874}; // observed value
+
+    // verify the output
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outputWS->blocksize(), NUM_Y);
+    TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "TOF");
+    // default values in algorithm
+    TS_ASSERT_DELTA(outputWS->readX(0).front(), 1646., 1);
+    TS_ASSERT_DELTA(outputWS->readX(0).back(), 32925., 1);
+    // observed values from running
+    const auto y_values = outputWS->readY(0);
+    TS_ASSERT_EQUALS(y_values.size(), NUM_Y);
+    TS_ASSERT_EQUALS(y_values[0], 0.);
+    TS_ASSERT_EQUALS(y_values[NUM_Y / 2], 0.);
+    TS_ASSERT_EQUALS(y_values[NUM_Y - 1], 34622.); // expect larger value then before since all counts go to 1 spectrum
+    const auto e_values = outputWS->readE(0);
+    TS_ASSERT_DELTA(e_values[0], 0., 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y / 2], 0., 1e-10);
+    TS_ASSERT_DELTA(e_values[NUM_Y - 1], std::sqrt(34622.), 1e-10);
+  }
+
   void test_common_x() {
     TestConfig configuration({13000.}, {36000.}, {}, "Logarithmic", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     constexpr size_t NUM_Y{637}; // observed value
@@ -273,6 +320,7 @@ public:
   void test_ragged_bins_x_min_max() {
     TestConfig configuration({13000., 14000., 15000., 16000., 17000., 18000.},
                              {36000., 37000., 38000., 39000., 40000., 41000.}, {}, "Logarithmic", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
@@ -290,6 +338,7 @@ public:
 
   void test_ragged_bins_x_delta() {
     TestConfig configuration({13000.}, {36000.}, {1000., 2000., 3000., 4000., 5000., 6000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
@@ -349,6 +398,7 @@ public:
   void run_test_with_different_units(std::vector<double> xmin, std::vector<double> xmax, std::vector<double> xdelta,
                                      std::string units) {
     TestConfig configuration(xmin, xmax, xdelta, "Linear", units);
+    configuration.groupingWS = bank_grouping_ws;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
     // verify the output
@@ -364,6 +414,7 @@ public:
 
   void test_load_nexus_logs() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMin = 0.;
     configuration.timeMax = 300.;
     configuration.logListBlock = "skf*";
@@ -386,6 +437,7 @@ public:
 
   void test_start_stop_time_filtering() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMin = 200.;
     configuration.timeMax = 300.;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
@@ -420,6 +472,7 @@ public:
 
   void test_start_time_filtering() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMin = 200.;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
@@ -441,6 +494,7 @@ public:
 
   void test_stop_time_filtering() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMax = 300.;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
@@ -463,6 +517,7 @@ public:
   void test_all_time_filtering() {
     // run is only ~600 seconds long so this include all events
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMax = 3000.;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
@@ -485,6 +540,7 @@ public:
   void test_invalid_time_filtering() {
     // start time > stop time
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMin = 300.;
     configuration.timeMax = 200.;
     run_algorithm(VULCAN_218062, configuration, true);
@@ -910,6 +966,7 @@ public:
 
   void test_filter_bad_pulses() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.filterBadPulses = true;
     auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
@@ -932,6 +989,7 @@ public:
 
   void test_filter_bad_pulses_and_time_start_stop() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.filterBadPulses = true;
     configuration.timeMin = 200.;
     configuration.timeMax = 300.;
@@ -971,6 +1029,7 @@ public:
 
   void test_output_specnum() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF"); // bins set for single bin
+    configuration.groupingWS = bank_grouping_ws;
     constexpr int NUM_HIST{6};
     for (int i = 1; i <= NUM_HIST; i++) {
       configuration.outputSpecNum = i;
@@ -1139,4 +1198,7 @@ public:
   void xtest_exec10GB() { run_test(DATA_LOCATION + "VULCAN_218092.nxs.h5"); }
 
   void xtest_exec18GB() { run_test(DATA_LOCATION + "VULCAN_217967.nxs.h5"); }
+
+private:
+  GroupingWorkspace_sptr bank_grouping_ws;
 };

--- a/Framework/DataHandling/test/BankCalibrationTest.h
+++ b/Framework/DataHandling/test/BankCalibrationTest.h
@@ -42,7 +42,7 @@ public:
     detid_t DETID_MIN(2);
     detid_t DETID_MAX(4);
     // all detectors go into the bank
-    const std::vector<detid_t> det_in_group{2, 3, 4};
+    const std::set<detid_t> det_in_group{2, 3, 4};
 
     // only get a subset of pixels
     BankCalibration bankCalib(TIME_CONVERSION, det_in_group, calibration_map, scale_map, mask);
@@ -77,7 +77,7 @@ public:
     detid_t DETID_MIN(3);
     detid_t DETID_MAX(4);
     // all detectors go into the bank
-    const std::vector<detid_t> det_in_group{3, 4}; // skipping detid=2
+    const std::set<detid_t> det_in_group{3, 4}; // skipping detid=2
 
     // only get a subset of pixels
     BankCalibration bankCalib(TIME_CONVERSION, det_in_group, calibration_map, scale_map, mask);
@@ -109,8 +109,8 @@ public:
     // id range to use
     detid_t DETID_MIN(1);
     detid_t DETID_MAX(4);
-    // all detectors go into the bank implied by empty grouping
-    const std::vector<detid_t> det_in_group;
+    // all detectors go into the bank
+    const std::set<detid_t> det_in_group{1, 2, 3, 4};
 
     // only get a subset of pixels
     BankCalibration bankCalib(TIME_CONVERSION, det_in_group, calibration_map, scale_map, mask);

--- a/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
+++ b/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
@@ -91,8 +91,10 @@ public:
     const std::map<Mantid::detid_t, double> calibration{{1, 1.}, {2, 2.}};
     const std::map<Mantid::detid_t, double> scale_at_sample{{1, 1000.0}, {2, 1000.0}};
     const std::set<Mantid::detid_t> masked;
-    BankCalibrationFactory calibFactory(calibration, scale_at_sample, std::map<size_t, std::vector<Mantid::detid_t>>(),
-                                        masked);
+    std::map<size_t, std::set<Mantid::detid_t>> bank_detids;
+    bank_detids[0] = {1, 2}; // bank 0 has detIDs 1 and 2
+    BankCalibrationFactory calibFactory(calibration, scale_at_sample, std::map<size_t, std::set<Mantid::detid_t>>(),
+                                        masked, bank_detids);
     std::map<Mantid::Types::Core::DateAndTime, int> splitterMap;
     splitterMap.emplace(Mantid::Types::Core::DateAndTime("2024-01-01T00:00:00"), 0);
     splitterMap.emplace(Mantid::Types::Core::DateAndTime("2024-01-01T00:00:00.005"), 1);
@@ -142,8 +144,8 @@ public:
 
     // now test with different correction to sample
     const std::map<Mantid::detid_t, double> scale_at_sample2{{1, 1000.}, {2, 500.}};
-    BankCalibrationFactory calibFactory2(calibration, scale_at_sample2,
-                                         std::map<size_t, std::vector<Mantid::detid_t>>(), masked);
+    BankCalibrationFactory calibFactory2(calibration, scale_at_sample2, std::map<size_t, std::set<Mantid::detid_t>>(),
+                                         masked, bank_detids);
     ProcessBankSplitFullTimeTask task2(bankEntryNames, file, mockLoader, workspaceIndices, wksps, calibFactory2, 1000,
                                        100, splitterMap, progress);
 

--- a/Framework/DataHandling/test/ProcessEventsTaskTest.h
+++ b/Framework/DataHandling/test/ProcessEventsTaskTest.h
@@ -31,8 +31,8 @@ public:
     for (const auto &id : std::views::iota(1, 5))
       calibration_map[id] = id; // simple calibration: tof' = tof * detID for testing
 
-    std::set<detid_t> mask{4};                     // mask detID 4
-    std::vector<detid_t> det_in_group{1, 2, 3, 4}; // all detectors
+    std::set<detid_t> mask{4};                  // mask detID 4
+    std::set<detid_t> det_in_group{1, 2, 3, 4}; // all detectors
 
     BankCalibration bankCal(1., det_in_group, calibration_map, std::map<detid_t, double>(), mask);
 

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -43,7 +43,7 @@ public:
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup, int64_t &ngroups) const;
   int getTotalGroups() const;
   std::vector<int> getGroupIDs(const bool includeUnsetGroup = true) const;
-  std::vector<int> getDetectorIDsOfGroup(const int groupID) const;
+  std::vector<detid_t> getDetectorIDsOfGroup(const int groupID) const;
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -42,7 +42,7 @@ public:
   void makeDetectorIDToGroupMap(std::map<detid_t, int> &detIDToGroup, int64_t &ngroups) const;
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup, int64_t &ngroups) const;
   int getTotalGroups() const;
-  std::vector<int> getGroupIDs() const;
+  std::vector<int> getGroupIDs(const bool includeUnsetGroup = true) const;
   std::vector<int> getDetectorIDsOfGroup(const int groupID) const;
 
 protected:

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -94,12 +94,14 @@ void GroupingWorkspace::makeDetectorIDToGroupVector(std::vector<int> &detIDToGro
   }
 }
 
-std::vector<int> GroupingWorkspace::getGroupIDs() const {
+std::vector<int> GroupingWorkspace::getGroupIDs(const bool includeUnsetGroup) const {
   // collect all the group numbers
   std::set<int> groupIDs;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number
     auto group = this->translateToGroupID(static_cast<int>(this->y(wi).front()));
+    if (!includeUnsetGroup && group == UNSET_GROUP)
+      continue;
     groupIDs.insert(group);
   }
   std::vector<int> output(groupIDs.begin(), groupIDs.end());
@@ -112,8 +114,8 @@ int GroupingWorkspace::getTotalGroups() const {
   return static_cast<int>(groups.size());
 }
 
-std::vector<int> GroupingWorkspace::getDetectorIDsOfGroup(const int groupID) const {
-  std::vector<int> detectorIDs;
+std::vector<detid_t> GroupingWorkspace::getDetectorIDsOfGroup(const int groupID) const {
+  std::vector<detid_t> detectorIDs;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number
     const auto group = this->translateToGroupID(static_cast<int>(this->y(wi).front()));

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -116,6 +116,7 @@ public:
 
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const IComponent &comp) const;
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const std::string &bankName) const;
+  std::set<detid_t> getDetectorIDsInBank(const std::string &bankName) const;
 
   /// Returns a list containing the detector ids of monitors
   std::vector<detid_t> getMonitors() const;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -303,6 +303,17 @@ void Instrument::getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, con
   getDetectorsInBank(dets, *comp);
 }
 
+std::set<detid_t> Instrument::getDetectorIDsInBank(const std::string &bankName) const {
+  std::set<detid_t> detIDs;
+  std::vector<IDetector_const_sptr> detectors;
+  getDetectorsInBank(detectors, bankName);
+
+  for (const auto &det : detectors) {
+    detIDs.emplace(det->getID());
+  }
+  return detIDs;
+}
+
 /** Checks to see if the Instrument has a source.
  *   @returns True if the instrument has a source cache.
  */

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
@@ -34,7 +34,7 @@ void export_GroupingWorkspace() {
       .def("__init__", make_constructor(&createGroupingWorkspaceWithWS, default_call_policies()))
       .def("getTotalGroups", &GroupingWorkspace::getTotalGroups, (arg("self")))
       .def("getGroupIDs", &GroupingWorkspace::getGroupIDs, return_value_policy<Policies::VectorToNumpy>(),
-           (arg("self")))
+           (arg("self"), arg("includeUnsetGroup") = true))
       .def("getDetectorIDsOfGroup", &GroupingWorkspace::getDetectorIDsOfGroup,
            return_value_policy<Policies::VectorToNumpy>(), (arg("self,"), arg("groupID")));
 

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
@@ -36,7 +36,7 @@ void export_GroupingWorkspace() {
       .def("getGroupIDs", &GroupingWorkspace::getGroupIDs, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self"), arg("includeUnsetGroup") = true))
       .def("getDetectorIDsOfGroup", &GroupingWorkspace::getDetectorIDsOfGroup,
-           return_value_policy<Policies::VectorToNumpy>(), (arg("self,"), arg("groupID")));
+           return_value_policy<Policies::VectorToNumpy>(), (arg("self"), arg("groupID")));
 
   // register pointers
   RegisterWorkspacePtrToPython<GroupingWorkspace>();

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -141,7 +141,7 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
 
 **Example - using a GroupingWorkspace**
 
-You can provide a ``GroupingWorkspace`` to define how the detectors are grouped in the output workspace. By default each bank is treated as a group.
+You can provide a ``GroupingWorkspace`` to define how the detectors are grouped in the output workspace. If a ``GroupingWorkspace`` is not provided, the grouping from the calibration file will be used if provided, else a default grouping of one group per bank is used.
 
 The example done here is using :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` to create a grouping workspace. With an angle step of 45 degrees, this will create 3 groups.
 

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -22,7 +22,6 @@ As a result, there is a significantly smaller memory usage and the processing is
 Current limitations compared to ``AlignAndFocusPowderFromFiles``
 
 - only supports the VULCAN instrument
-- hard coded for 6 particular groups
 - does not support copping data
 - does not support removing prompt pulse
 
@@ -138,6 +137,25 @@ This algorithm accepts the same ``SplitterWorkspace`` inputs as :ref:`FilterEven
     ws2 = Rebin(ws2, "0,50000,50000", PreserveEvents=False)
 
     CompareWorkspaces(ws, ws2, CheckSpectraMap=False, CheckInstrument=False)
+
+
+**Example - using a GroupingWorkspace**
+
+You can provide a ``GroupingWorkspace`` to define how the detectors are grouped in the output workspace. By default each bank is treated as a group.
+
+The example done here is using :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` to create a grouping workspace. With an angle step of 45 degrees, this will create 3 groups.
+
+.. code-block:: python
+
+    inst = LoadEmptyInstrument(InstrumentName="VULCAN")
+    GenerateGroupingPowder(inst, GroupingWorkspace='powder_group', AngleStep=45)
+
+    ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", GroupingWorkspace="powder_group",
+                                 L1=43.755,
+                                 L2=[2, 2.25, 2.5],
+                                 Polar=[90]*3)
+
+    print(ws.getNumberHistograms())  # should be 3 histograms in the output workspace
 
 .. categories::
 

--- a/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40571.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40571.rst
@@ -1,0 +1,1 @@
+- A GroupingWorkspace can now be provided to :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` to define what detectors go to which output spectra.


### PR DESCRIPTION
### Description of work

This allows you to provide a `GroupingWorkspace` that will be used to group the events by detector id to the correct output spectra. This means a many-to-many relationtionship between bank and output spectra. By default without a `GroupingWorkspace` the events are put in a one-to-one bank to spectra mapping.

The current implementation only works when not using a splitter workpsace but that ability will be added next.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Refs:
 * [14299: Modify the code for arbitrary grouping - no splitting](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14299)
 * #40189

### To test:


#### Simple usgae example

```python
inst = LoadEmptyInstrument(InstrumentName="VULCAN")
GenerateGroupingPowder(inst, GroupingWorkspace='powder_group', AngleStep=45)

ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", GroupingWorkspace="powder_group",
                             L1=43.755,
                             L2=[2, 2.25, 2.5],
                             Polar=[90]*3)

print(ws.getNumberHistograms()) 
```


A easy way to test is to create a `GroupingWorkspace` with `GenerateGroupingPowder` which can then be compare to using `GroupDetectors`.

#### Using 10 degrees gives 12 output spectra

```python
ws = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)

GenerateGroupingPowder(ws, GroupingWorkspace='powder_group_10', AngleStep=10)

ws2 = GroupDetectors(ws, CopyGroupingFromWorkspace="powder_group_10")
ws2 = Rebin(ws2, "0,50000,50000", PreserveEvents=False)


ws3=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", GroupingWorkspace="powder_group_10", XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF",
                             L1=43.755,
                             L2=[2]*12,
                             Polar=[90]*12,
                             Azimuthal=[0]*12)

CompareWorkspaces(ws2, ws3, CheckSpectraMap=False, CheckInstrument=False)
```

This is what the grouping looks like

<img width="2769" height="418" alt="groups_10" src="https://github.com/user-attachments/assets/4cee7b08-960f-411c-8666-9fd29b3d0edf" />

#### Using 45 degrees gives only 3 output spectra

```python
ws = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)

GenerateGroupingPowder(ws, GroupingWorkspace='powder_group_45', AngleStep=45)

ws3 = GroupDetectors(ws, CopyGroupingFromWorkspace="powder_group_45")
ws3 = Rebin(ws3, "0,50000,50000", PreserveEvents=False)


ws4=AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5", GroupingWorkspace="powder_group_45", XMin=0, XMax=50000, XDelta=50000, BinningMode="Linear", BinningUnits="TOF",
                             L1=43.755,
                             L2=[2]*3,
                             Polar=[90]*3)

CompareWorkspaces(ws3, ws4, CheckSpectraMap=False, CheckInstrument=False)
```

The grouping looks like

<img width="2765" height="475" alt="groups_45" src="https://github.com/user-attachments/assets/49e67228-92ad-4232-9e08-568f60b14393" />


#### Grouping from calibartion file

If a calibration file but no GroupingWorkspace is provided then the grouping infortmation in the calibration file is used. _e.g._

```python
ws = AlignAndFocusPowderSlim(Filename="VULCAN_218062.nxs.h5",
                             CalFileName="B123456DIFCs-12Cross-3456Cal_v4.h5",
                             L1=43.755,
                             L2=[2.296, 2.296, 2.070, 2.070, 2.070, 2.530],
                             Polar=[90, 90, 120, 150, 157, 65.5],
                             Azimuthal=[180, 0, 0, 0, 0, 0])

```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
