### PR TITLE
Added an additional guard clause to fix the bug that causes an IndexError while interacting with the plots in the FitPropertyBrowser widget

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/Bugfixes/40426.rst
+++ b/docs/source/release/v6.15.0/Workbench/Bugfixes/40426.rst
@@ -1,0 +1,1 @@
+- Added an additional guard clause to fix the bug that causes an IndexError while interacting with the plots in the ``FitPropertyBrowser`` widget.

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -300,7 +300,11 @@ class FitPropertyBrowserPlotInteraction(QObject):
         :param removed_prefix: Prefix of the function removed e.g f0
         :return:
         """
-        if not self.guess_lines or removed_prefix[1] == len(self.guess_lines):
+        if not self.guess_lines:
+            return
+        if len(removed_prefix) < 2:
+            return
+        if removed_prefix[1] == len(self.guess_lines):
             return
         for prefixed_function in reversed(list(self.guess_lines)):
             prefix_and_function = prefixed_function.split(".")

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -300,11 +300,10 @@ class FitPropertyBrowserPlotInteraction(QObject):
         :param removed_prefix: Prefix of the function removed e.g f0
         :return:
         """
-        if not self.guess_lines:
+        if (not self.guess_lines or 
+            (len(removed_prefix) < 2) or
+            (removed_prefix[1] == len(self.guess_lines))):
             return
-        if len(removed_prefix) < 2:
-            return
-        if removed_prefix[1] == len(self.guess_lines):
             return
         for prefixed_function in reversed(list(self.guess_lines)):
             prefix_and_function = prefixed_function.split(".")

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -300,10 +300,7 @@ class FitPropertyBrowserPlotInteraction(QObject):
         :param removed_prefix: Prefix of the function removed e.g f0
         :return:
         """
-        if (not self.guess_lines or 
-            (len(removed_prefix) < 2) or
-            (removed_prefix[1] == len(self.guess_lines))):
-            return
+        if not self.guess_lines or (len(removed_prefix) < 2) or (removed_prefix[1] == len(self.guess_lines)):
             return
         for prefixed_function in reversed(list(self.guess_lines)):
             prefix_and_function = prefixed_function.split(".")

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
@@ -170,6 +170,14 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
 
         self.assertEqual(list(self.browser_plot_interaction.guess_lines.keys()), ["f0.FlatBackground", "f1.GausOsc"])
 
+    def test_shift_stored_prefixes_returns_when_prefix_len_is_less_than_two(self):
+        self.create_mock_guess_lines()
+        self.setup_mock_fit_browser(
+            workspace_creator=self.create_workspace2D, workspace_name="test_workspace", function=FULL_FUNCTION, function_prefix="f"
+        )
+        self.browser_plot_interaction.slot_for_function_removed()
+        self.assertEqual(list(self.browser_plot_interaction.guess_lines.keys()), ["f0.FlatBackground", "f1.LinearBackground", "f2.GausOsc"])
+
     def test_remove_function_correctly_removes_line(self):
         workspace_name = "test_workspace"
         prefix = "f1"


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40426. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
The error was reported by a user through the error reporter. It is hard to reproduce but the stack trace clearly identifies the line to fix.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
