### PR TITLE
Fix nightly docs publishing

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -46,7 +46,7 @@ echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/DocTest/' >> $WORKSPACE
 
 # Build the html docs
 export LC_ALL=C
-QT_QPA_PLATFORM=offscreen cmake --build . --target docs-html
+QT_QPA_PLATFORM=offscreen pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build cmake --build . --target docs-html
 
 # Publish. Clone current docs to publish directory
 # and rsync between built html in html directory and current
@@ -55,7 +55,7 @@ QT_QPA_PLATFORM=offscreen cmake --build . --target docs-html
 cd docs
 git clone --depth 1 ${DOCS_GIT_REPOSITORY} publish
 cd publish
-rsync --archive --recursive --delete ../html/* .
+pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build rsync --archive --recursive --delete ../html/* .
 # Push
 git config user.name ${GIT_USER_NAME}
 git config user.email ${GIT_USER_EMAIL}

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -16,6 +16,8 @@ REPO_ROOT_DIR=$SCRIPT_DIR/../..
 
 # pixi
 install_pixi
+# Allow newly published mantidqt package to be installed
+pixi update --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build mantidqt
 
 # Configure a clean build directory
 rm -rf build

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -42,7 +42,7 @@ pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build cmake -G Ninja \
 # Configure the 'datasearch.directories' in the Mantid.properties file so the test data is found
 # Docs should only require DocTestData which is a dependency of the target
 export STANDARD_TEST_DATA_DIR=$PWD/ExternalData/Testing/Data
-echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/DocTest/' >> $WORKSPACE/miniforge/envs/docs-build/bin/Mantid.properties
+echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/DocTest/' >> $WORKSPACE/source/.pixi/envs/docs-build/bin/Mantid.properties
 
 # Build the html docs
 export LC_ALL=C

--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -125,7 +125,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
                     + "."
                     + extension
                     + "\n"
-                    + "Possible matches"
+                    + "Possible matches "
                     + str(path_list)
                     + "\n"
                     + "Specify one using the "
@@ -166,6 +166,9 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         builddir = builddir.resolve()
 
         for dir_name, _, file_list in os.walk(self.source_root):
+            # Ignore files inside pixi environments that live within the source tree
+            if ".pixi" in dir_name:
+                continue
             if builddir in Path(dir_name).resolve().parents:
                 continue  # don't check or add to the cache
             for fname in file_list:


### PR DESCRIPTION
### Description of work
Since moving from mamba to pixi, the nightly docs were not publishing. The following things has to be fixed:
- Run `pixi update mantidqt` otherwise it will try to use the version specified in the lockfile - which will no longer be available.
- Update a hardcoded path to `Mantid.properties` from miniforge to pixi.
- Add `pixi run` commands where they were missing.
- Modify the `sourcelink` directive to ignore any files inside the `.pixi` directory. The directive raises an error if multiple files with the same name are found, which wasn't a problem with miniforge because the environment was located outside the source tree. Now the pixi environment lives inside the source tree.

### To test:
This is a `build_and_publish_docs` run that was triggered on this branch: [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_and_publish_docs&build=418)](https://builds.mantidproject.org/job/build_and_publish_docs/418/). Ensure that is passes. Inspect the logs to make sure it successfully builds the docs.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
