### PR TITLE
Migrate many load algos to `NexusDescriptorLazy`

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
@@ -18,7 +18,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/FileDescriptor.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -93,7 +93,7 @@ protected:
 // the instantiation and linking did not behave consistently across platforms.
 
 extern template class LoadEMU<Kernel::FileDescriptor>;
-extern template class LoadEMU<Nexus::NexusDescriptor>;
+extern template class LoadEMU<Nexus::NexusDescriptorLazy>;
 
 /** LoadEMUTar : Loads a merged ANSTO EMU Hdf and event file into a workspace.
 
@@ -153,14 +153,14 @@ Optional Properties:
 </UL>
 
 */
-class MANTID_DATAHANDLING_DLL LoadEMUHdf : public LoadEMU<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadEMUHdf : public LoadEMU<Nexus::NexusDescriptorLazy> {
 public:
   int version() const override;
   const std::vector<std::string> seeAlso() const override;
   const std::string category() const override;
   const std::string name() const override;
   const std::string summary() const override;
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void exec() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -13,7 +13,7 @@
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/V3D.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -22,14 +22,14 @@ namespace DataHandling {
 
   @date 15/05/17
 */
-class MANTID_DATAHANDLING_DLL LoadILLDiffraction : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLDiffraction : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   const std::string name() const override;
   int version() const override;
   const std::vector<std::string> seeAlso() const override { return {"LoadNexus"}; }
   const std::string category() const override;
   const std::string summary() const override;
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
   LoadILLDiffraction();
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -17,11 +17,11 @@ namespace DataHandling {
 /**
   Loads an ILL IN16B nexus file into a Mantid workspace.
 */
-class MANTID_DATAHANDLING_DLL LoadILLIndirect2 : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLIndirect2 : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   LoadILLIndirect2();
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
   /// Algorithm's version for identification. @see Algorithm::version
   int version() const override { return 2; }

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLLagrange.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLLagrange.h
@@ -8,7 +8,7 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <H5Cpp.h>
 
@@ -17,14 +17,14 @@ namespace DataHandling {
 
 /** LoadILLLagrange : Loads nexus files from ILL instrument LAGRANGE.
  */
-class MANTID_DATAHANDLING_DLL LoadILLLagrange : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLLagrange : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   const std::string name() const override;
   int version() const override;
   const std::vector<std::string> seeAlso() const override { return {"LagrangeILLReduction"}; }
   const std::string category() const override;
   const std::string summary() const override;
-  int confidence(Nexus::NexusDescriptor &) const override;
+  int confidence(Nexus::NexusDescriptorLazy &) const override;
   LoadILLLagrange();
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLPolarizedDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLPolarizedDiffraction.h
@@ -11,7 +11,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <utility>
 
@@ -23,14 +23,14 @@ namespace DataHandling {
 
   @date 15/05/20
 */
-class MANTID_DATAHANDLING_DLL LoadILLPolarizedDiffraction : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLPolarizedDiffraction : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   const std::string name() const override;
   int version() const override;
   const std::vector<std::string> seeAlso() const override { return {"LoadNexus"}; }
   const std::string category() const override;
   const std::string summary() const override;
-  int confidence(Nexus::NexusDescriptor &) const override;
+  int confidence(Nexus::NexusDescriptorLazy &) const override;
   LoadILLPolarizedDiffraction();
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
@@ -10,7 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 #include "MantidTypes/Core/DateAndTime.h"
 
 namespace Mantid {
@@ -18,11 +18,11 @@ namespace DataHandling {
 
 /*! LoadILLReflectometry : Loads an ILL reflectometry Nexus data file.
  */
-class MANTID_DATAHANDLING_DLL LoadILLReflectometry : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLReflectometry : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   LoadILLReflectometry() = default;
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
   /// Algorithm's name for identification. @see Algorithm::name
   const std::string name() const override { return "LoadILLReflectometry"; }
   /// Algorithm's version for identification. @see Algorithm::version

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLSALSA.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLSALSA.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <H5Cpp.h>
 
@@ -22,7 +22,7 @@ namespace DataHandling {
 /**
  Loads an ILL SALSA NeXus file into a Mantid workspace.
  */
-class MANTID_DATAHANDLING_DLL LoadILLSALSA : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLSALSA : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Algorithm's name
   const std::string name() const override { return "LoadILLSALSA"; }
@@ -34,7 +34,7 @@ public:
   /// Algorithm's category for identification
   const std::string category() const override { return "DataHandling\\Nexus;ILL\\Strain"; }
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   // Number of pixel on the detector in the vertical dimension

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <H5Cpp.h>
 
@@ -19,7 +19,7 @@ namespace DataHandling {
 /** LoadILLSANS; supports D11, D22 and D33 (TOF/monochromatic)
  */
 
-class MANTID_DATAHANDLING_DLL LoadILLSANS : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLSANS : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   LoadILLSANS();
   const std::string name() const override;
@@ -28,7 +28,7 @@ public:
   const std::vector<std::string> seeAlso() const override { return {"LoadNexus"}; }
   const std::string category() const override;
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   enum MultichannelType { TOF, KINETIC, SCAN };

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF3.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF3.h
@@ -10,14 +10,14 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidNexus/NexusClasses.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
 /**
  Loads an ILL IN4/5/6/Panther NeXus file into a Mantid workspace.
  */
-class MANTID_DATAHANDLING_DLL LoadILLTOF3 : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadILLTOF3 : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Constructor
   LoadILLTOF3();
@@ -33,7 +33,7 @@ public:
   const std::string category() const override { return "DataHandling\\Nexus;ILL\\Direct"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   // Initialisation code

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/Objects/CSGObject.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -26,7 +26,7 @@ namespace DataHandling {
   @author Andrei Savici, ORNL
   @date 2011-08-14
 */
-class MANTID_DATAHANDLING_DLL LoadNXSPE : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadNXSPE : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Algorithm's name for identification
   const std::string name() const override { return "LoadNXSPE"; };
@@ -42,7 +42,7 @@ public:
   }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
   /// Confidence in identifier.
   static int identiferConfidence(const std::string &value);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNXcanSAS.h
@@ -12,7 +12,7 @@
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataHandling/NXcanSASUtil.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace H5 {
 class Group;
@@ -23,7 +23,7 @@ namespace Mantid::DataHandling::NXcanSAS {
 /** LoadNXcanSAS : Tries to load an NXcanSAS file type into a Workspace2D.
  *  This can load either 1D or 2D data
  */
-class MANTID_DATAHANDLING_DLL LoadNXcanSAS : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadNXcanSAS : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Constructor
   LoadNXcanSAS();
@@ -40,7 +40,7 @@ public:
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   /// Loads the transmission runs

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
@@ -23,7 +23,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -55,7 +55,7 @@ Optional Properties:
 </UL>
 
 */
-class MANTID_DATAHANDLING_DLL LoadPLN : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadPLN : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 
 public:
   int version() const override;
@@ -63,7 +63,7 @@ public:
   const std::string category() const override;
   const std::string name() const override;
   const std::string summary() const override;
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void exec() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
@@ -13,7 +13,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusClasses_fwd.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -27,7 +27,7 @@ namespace DataHandling {
  <LI> Workspace - The name to give to the output workspace </LI>
  </UL>
  */
-class MANTID_DATAHANDLING_DLL LoadSINQFocus : public API::IFileLoader<Nexus::NexusDescriptor>,
+class MANTID_DATAHANDLING_DLL LoadSINQFocus : public API::IFileLoader<Nexus::NexusDescriptorLazy>,
                                               public API::DeprecatedAlgorithm {
 public:
   LoadSINQFocus();
@@ -40,7 +40,7 @@ public:
   const std::string category() const override;
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void init() override;

--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -1359,6 +1359,6 @@ void LoadEMUTar::exec() {
 
 // register the algorithms into the AlgorithmFactory
 DECLARE_FILELOADER_ALGORITHM(LoadEMUTar)
-// DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadEMUHdf)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadEMUHdf)
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -1163,7 +1163,7 @@ template <typename FD> void LoadEMU<FD>::loadInstrument() {
 
 // Instantiate base class for LoadEMU's
 template class LoadEMU<Kernel::FileDescriptor>;
-template class LoadEMU<Nexus::NexusDescriptor>;
+template class LoadEMU<Nexus::NexusDescriptorLazy>;
 
 // -------- EMU Hdf loader -----------------------
 
@@ -1183,7 +1183,7 @@ const std::string LoadEMUHdf::summary() const { return "Loads an EMU Hdf and lin
 
 /// Return the confidence as an integer value that this algorithm can
 /// load the file \p descriptor.
-int LoadEMUHdf::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadEMUHdf::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.extension() != ".hdf")
     return 0;
 
@@ -1201,7 +1201,7 @@ int LoadEMUHdf::confidence(Nexus::NexusDescriptor &descriptor) const {
 
 /// Initialise the algorithm and declare the properties for the
 /// nexus descriptor.
-void LoadEMUHdf::init() { LoadEMU<Nexus::NexusDescriptor>::init(true); }
+void LoadEMUHdf::init() { LoadEMU<Nexus::NexusDescriptorLazy>::init(true); }
 
 /// Execute the algorithm. Establishes the filepath to the event file
 /// from the HDF link and the path provided and invokes the common
@@ -1254,7 +1254,7 @@ void LoadEMUHdf::exec() {
     throw std::runtime_error(msg);
   }
 
-  LoadEMU<Nexus::NexusDescriptor>::exec(hdfFile, evtPath);
+  LoadEMU<Nexus::NexusDescriptorLazy>::exec(hdfFile, evtPath);
 }
 
 // -------- EMU Tar loader -----------------------
@@ -1359,6 +1359,6 @@ void LoadEMUTar::exec() {
 
 // register the algorithms into the AlgorithmFactory
 DECLARE_FILELOADER_ALGORITHM(LoadEMUTar)
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadEMUHdf)
+// DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadEMUHdf)
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -59,10 +59,10 @@ constexpr double WAVE_TO_E = 81.8;
 } // namespace
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLDiffraction)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLDiffraction)
 
 /// Returns confidence. @see IFileLoader::confidence
-int LoadILLDiffraction::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLDiffraction::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL Diffraction
   // the second one is to recognize D1B, Tx field eliminates SALSA
@@ -90,8 +90,7 @@ const std::string LoadILLDiffraction::summary() const { return "Loads ILL diffra
 /**
  * Constructor
  */
-LoadILLDiffraction::LoadILLDiffraction()
-    : IFileLoader<Nexus::NexusDescriptor>(), m_instNames({"D20", "D2B", "D1B", "D4C", "IN5", "PANTHER", "SHARP"}) {}
+LoadILLDiffraction::LoadILLDiffraction() : m_instNames({"D20", "D2B", "D1B", "D4C", "IN5", "PANTHER", "SHARP"}) {}
 /**
  * Initialize the algorithm's properties.
  */

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -35,7 +35,7 @@ using namespace API;
 using namespace Nexus;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLIndirect2)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLIndirect2)
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -59,7 +59,7 @@ const std::string LoadILLIndirect2::category() const { return "DataHandling\\Nex
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadILLIndirect2::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLIndirect2::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL
   if (descriptor.isEntry("/entry0/wavelength")               // ILL

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -29,10 +29,10 @@ using namespace Nexus;
 using Types::Core::DateAndTime;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLLagrange)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLLagrange)
 
 /// Returns confidence. @see IFileLoader::confidence
-int LoadILLLagrange::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLLagrange::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL Diffraction
   if (descriptor.isEntry("/entry0/IN1")) {
@@ -57,7 +57,7 @@ const std::string LoadILLLagrange::summary() const { return "Loads ILL Lagrange 
 /**
  * Constructor
  */
-LoadILLLagrange::LoadILLLagrange() : IFileLoader<Nexus::NexusDescriptor>() {}
+LoadILLLagrange::LoadILLLagrange() : IFileLoader<Nexus::NexusDescriptorLazy>() {}
 
 /**
  * Initialize the algorithm's properties.

--- a/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
@@ -48,10 +48,10 @@ constexpr size_t TOF_MODE_ON = 1;
 } // namespace
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLPolarizedDiffraction)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLPolarizedDiffraction)
 
 /// Returns confidence. @see IFileLoader::confidence
-int LoadILLPolarizedDiffraction::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLPolarizedDiffraction::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL Diffraction
   if (descriptor.isEntry("/entry0/D7")) {
@@ -78,7 +78,7 @@ const std::string LoadILLPolarizedDiffraction::summary() const {
 /**
  * Constructor
  */
-LoadILLPolarizedDiffraction::LoadILLPolarizedDiffraction() : IFileLoader<Nexus::NexusDescriptor>() {}
+LoadILLPolarizedDiffraction::LoadILLPolarizedDiffraction() : IFileLoader<Nexus::NexusDescriptorLazy>() {}
 
 /**
  * Initialize the algorithm's properties.

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -146,7 +146,7 @@ using namespace Nexus;
 using Mantid::Types::Core::DateAndTime;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLReflectometry)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLReflectometry)
 
 /**
  * Return the confidence with this algorithm can load the file
@@ -154,7 +154,7 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLReflectometry)
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadILLReflectometry::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLReflectometry::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL
   if ((descriptor.isEntry("/entry0/wavelength") || // ILL D17

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -22,7 +22,7 @@
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLSALSA)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLSALSA)
 
 const size_t LoadILLSALSA::VERTICAL_NUMBER_PIXELS = 256;
 const size_t LoadILLSALSA::HORIZONTAL_NUMBER_PIXELS = 256;
@@ -34,7 +34,7 @@ const size_t LoadILLSALSA::HORIZONTAL_NUMBER_PIXELS = 256;
  *
  * @return An integer specifying the confidence level. 0 indicates it will not be used
  */
-int LoadILLSALSA::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLSALSA::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if ((descriptor.isEntry("/entry0/data_scan") || descriptor.isEntry("/entry0/data")) &&
       descriptor.isEntry("/entry0/instrument/Tx") && descriptor.isEntry("/entry0/instrument/Ty") &&
       descriptor.isEntry("/entry0/instrument/Tz"))

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -37,7 +37,7 @@ using namespace Kernel;
 using namespace API;
 using namespace Nexus;
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLSANS)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLSANS)
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -69,7 +69,7 @@ const std::string LoadILLSANS::summary() const {
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadILLSANS::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLSANS::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   // fields existent only at the ILL for SANS machines
   if (descriptor.isEntry("/entry0/mode") &&
       ((descriptor.isEntry("/entry0/reactor_power") && descriptor.isEntry("/entry0/instrument_name")) ||

--- a/Framework/DataHandling/src/LoadILLTOF3.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF3.cpp
@@ -30,7 +30,7 @@ using namespace API;
 using namespace Nexus;
 using namespace HistogramData;
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLTOF3)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadILLTOF3)
 
 /**
  * Return the confidence with with this algorithm can load the file
@@ -40,7 +40,7 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLTOF3)
  * @return An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadILLTOF3::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadILLTOF3::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the ILL
   if ((descriptor.isEntry("/entry0/wavelength") && descriptor.isEntry("/entry0/experiment_identifier") &&
@@ -58,7 +58,7 @@ int LoadILLTOF3::confidence(Nexus::NexusDescriptor &descriptor) const {
   }
 }
 
-LoadILLTOF3::LoadILLTOF3() : API::IFileLoader<Nexus::NexusDescriptor>() {}
+LoadILLTOF3::LoadILLTOF3() : API::IFileLoader<Nexus::NexusDescriptorLazy>() {}
 
 /**
  * Initialises the algorithm

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -34,7 +34,7 @@
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNXSPE)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadNXSPE)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -65,7 +65,7 @@ int LoadNXSPE::identiferConfidence(const std::string &value) {
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadNXSPE::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadNXSPE::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence(0);
   using string_map_t = std::map<std::string, std::string>;
   try {

--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -475,12 +475,12 @@ void loadTransmissionData(const H5::Group &transmission, const Mantid::API::Matr
 
 namespace Mantid::DataHandling::NXcanSAS {
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNXcanSAS)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadNXcanSAS)
 
 /// constructor
 LoadNXcanSAS::LoadNXcanSAS() = default;
 
-int LoadNXcanSAS::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadNXcanSAS::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   const std::string &extn = descriptor.extension();
   if (extn != ".nxs" && extn != ".h5") {
     return 0;

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -826,7 +826,7 @@ const std::string LoadPLN::summary() const { return "Loads a PLN Hdf and linked 
 
 /// Return the confidence as an integer value that this algorithm can
 /// load the file \p descriptor.
-int LoadPLN::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadPLN::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.extension() != ".hdf")
     return 0;
 
@@ -911,6 +911,6 @@ void LoadPLN::exec() {
 }
 
 // register the algorithms into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadPLN)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadPLN)
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -30,7 +30,7 @@ using namespace Kernel;
 using namespace API;
 using namespace Nexus;
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadSINQFocus)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadSINQFocus)
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -61,7 +61,7 @@ const std::string LoadSINQFocus::category() const { return "DataHandling\\Nexus"
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadSINQFocus::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadSINQFocus::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
 
   // fields existent only at the SINQ (to date Loader only valid for focus)
   if (descriptor.isEntry("/entry1/FOCUS/SINQ")) {

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -229,5 +229,6 @@ public:
     TS_ASSERT(algToBeTested.isExecuted());
     eventWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(outputSpace);
     TS_ASSERT_EQUALS(eventWS->getNumberEvents(), goodEvents - 1);
+    std::cout << "Temporary file used: " << tempPath << std::endl;
   }
 };

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -229,6 +229,5 @@ public:
     TS_ASSERT(algToBeTested.isExecuted());
     eventWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(outputSpace);
     TS_ASSERT_EQUALS(eventWS->getNumberEvents(), goodEvents - 1);
-    std::cout << "Temporary file used: " << tempPath << std::endl;
   }
 };

--- a/Framework/DataHandling/test/LoadILLIndirect2Test.h
+++ b/Framework/DataHandling/test/LoadILLIndirect2Test.h
@@ -61,7 +61,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
     alg.setPropertyValue("Filename", file);
-    Mantid::Nexus::NexusDescriptor descr(alg.getPropertyValue("Filename"));
+    Mantid::Nexus::NexusDescriptorLazy descr(alg.getPropertyValue("Filename"));
     TS_ASSERT_EQUALS(alg.confidence(descr), 80);
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -83,9 +83,9 @@ variableScope:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/ChebfunBa
 duplicateCondition:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp:120
 constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp:69
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadHFIRSANS.cpp:432
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:567
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:593
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:611
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:566
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:592
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLDiffraction.cpp:610
 mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadInstrument.cpp:148
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPLN.cpp:659
 integerOverflowCond:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/byte_rel_comp.cpp:59


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.  There, only a few algorithms were migrated over.

In this PR, we migrate over the following to use the new file descriptor:
- `LoadEMU.h`
- `LoadILLDiffraction.h`
- `LoadILLIndirect2.h`
- `LoadILLLagrange.h`
- `LoadILLPolarizedDiffraction.h`
- `LoadILLReflectometry.h`
- `LoadILLSALSA.h`
- `LoadILLSANS.h`
- `LoadILLTOF3.h`
- `LoadNXcanSAS.h`
- `LoadNXSPE.h`
- `LoadPLN.h`
- `LoadSINQFocus.h`


Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)


### To test:

This is a refactor, so ensure all current tests works.

Especially look at the `LoadLotsOfFiles` system test.

Tests in PR #40570 verified that `Load` is able to find load algorithms with a lazy descriptor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
