### PR TITLE
Add Phi Slicing to SANSGUI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
@@ -148,7 +148,7 @@ class SANSSingleReduction(SANSSingleReductionBase):
         """
         Perform the main reduction.
         :param reduction_alg: SANSReductionCore algorithm
-        :param reduction_setting_bundles: a list of lists containing workspaces to be reduced.
+        :param reduction_setting_bundle: a list of lists containing workspaces to be reduced.
                                           The outer list is for compatibility with version 2
                                           and only contains one inner list
         :param use_optimizations: bool. If true, use can optimizations

--- a/docs/source/interfaces/isis_sans/Settings Tab.rst
+++ b/docs/source/interfaces/isis_sans/Settings Tab.rst
@@ -331,8 +331,10 @@ Phi limit
 """""""""
 .. _Phi_Limit:
 
-This group allows the user to specify an angle (pizza-slice) mask. The angles
-are in degree.
+This group allows the user to  specify either an angle (pizza-slice) mask or a series of angles. The angles
+are in degree. The method of slicing the angle is selected with the ``PhiSlicing type`` combo box. If ``MinMax`` is selected,
+a start and stop angle cut the slice. If ``Pairs`` is selected, a series of phi values can be introduced in pairs, separating
+each angle by a comma.
 
 +-----------------+---------------------------------------+
 | **Start angle** | The starting angle.                   |
@@ -340,6 +342,10 @@ are in degree.
 | **Stop angle**  | The stop angle.                       |
 +-----------------+---------------------------------------+
 | **Use mirror**  | If the mirror sector should be used.  |
++-----------------+---------------------------------------+
+| **Ranges**      | A set of phi ranges. This option only |
+|                 | appears if a ``Pairs`` is selected    |
+|                 | in ``PhiSlicing type`` combobox.      |
 +-----------------+---------------------------------------+
 
 

--- a/docs/source/release/v6.15.0/SANS/New_features/39596.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/39596.rst
@@ -1,0 +1,2 @@
+- New option for selecting a range of phi values in the masking tab of :ref:`ISIS SANS GUI <ISIS_Sans_interface_contents>` to generate multiple phi slices out of a single 1D reduction.
+- Add option in TOML :ref:`UserFiles<sans_toml_v1-ref>` to select a range of phi values to generate multiple phi slices in a single 1D reduction.

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -121,6 +121,18 @@ This is a required entry to specify the instrument name and `instrument.configur
   [instrument.configuration]
     # ...
 
+Phi Mask
+--------
+
+From Mantid 6.15, a new field for adding a range of phi slices is added to the phi mask. This is to automatize the process
+of reducing with different phi masks. A set of ranges as comma separated pairs can be input and there will be multiple reductions, each one with a different phi range.
+This settings overrides the phi start and stop angles, but is optional.
+
+..  code-block:: yaml
+
+  [mask.phi]
+    range = -15.0,15.0,45.0,90.0
+
 
 Conversion From Legacy User Files
 =================================

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -321,6 +321,7 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.background_subtraction_checkbox.stateChanged.connect(self._on_background_subtraction_selection)
 
         self.wavelength_step_type_combo_box.currentIndexChanged.connect(self._on_wavelength_step_type_changed)
+        self.phi_range_step_type_combo_box.currentIndexChanged.connect(self._on_phi_range_step_type_changed)
 
         self.process_selected_button.clicked.connect(self._process_selected_clicked)
         self.process_all_button.clicked.connect(self._process_all_clicked)
@@ -406,6 +407,12 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         elif self.wavelength_step_type == RangeStepType.LIN:
             self.wavelength_stacked_widget.setCurrentIndex(0)
             self.wavelength_step_label.setText("Step [\u00c5]")
+
+    def _on_phi_range_step_type_changed(self):
+        if self.phi_range_step_type == "MinMax":
+            self.phi_range_stacked_widget.setCurrentIndex(0)
+        elif self.phi_range_step_type == "Pairs":
+            self.phi_range_stacked_widget.setCurrentIndex(1)
 
     def create_data_table(self):
         # Delete an already existing table
@@ -1862,6 +1869,23 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.update_simple_line_edit_field(line_edit="phi_limit_max_line_edit", value=value)
 
     @property
+    def phi_range(self):
+        return str(self.phi_range_line_edit.text())
+
+    @phi_range.setter
+    def phi_range(self, value):
+        self.phi_range_line_edit.setText(value)
+
+    @property
+    def phi_range_step_type(self):
+        step_type_as_string = self.phi_range_step_type_combo_box.currentText()
+        return step_type_as_string
+
+    @phi_range_step_type.setter
+    def phi_range_step_type(self, value):
+        self.update_gui_combo_box(value=value, expected_type="MinMax", combo_box="phi_range_step_type_combo_box")
+
+    @property
     def phi_limit_use_mirror(self):
         return self.phi_limit_use_mirror_check_box.isChecked()
 
@@ -2031,6 +2055,8 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
         self.phi_limit_min_line_edit.setText("-90")
         self.phi_limit_max_line_edit.setText("90")
+        self.phi_range_line_edit.setText("")
+        self.phi_range_step_type_combo_box.setCurrentIndex(0)
         self.phi_limit_use_mirror_check_box.setChecked(True)
 
         self.wavelength_min_line_edit.setText("")

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -367,6 +367,10 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.fit_selection_combo_box.currentIndexChanged.connect(self._on_fit_selection_has_changed)
         self._on_fit_selection_has_changed()
 
+        # Set the transmission fit checkbox enabled
+        self.fit_sample_wavelength_combo_box.stateChanged.connect(self._on_fit_custom_range_checkbox_selected)
+        self.fit_can_wavelength_combo_box.stateChanged.connect(self._on_fit_custom_range_checkbox_selected)
+
         # Set the transmission polynomial order
         self.fit_sample_fit_type_combo_box.currentIndexChanged.connect(self._on_transmission_fit_type_has_changed)
         self.fit_can_fit_type_combo_box.currentIndexChanged.connect(self._on_transmission_fit_type_has_changed)
@@ -839,6 +843,16 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         index = 1 if is_rectangular else 0
         self.q_resolution_shape_combo_box.setCurrentIndex(index)
 
+    def _on_fit_custom_range_checkbox_selected(self):
+        if (name := self.sender().objectName()) in ["fit_sample_wavelength_combo_box", "fit_can_wavelength_combo_box"]:
+            checked = self.sender().isChecked()
+            if "sample" in name:
+                self.fit_sample_wavelength_min_line_edit.setEnabled(checked)
+                self.fit_sample_wavelength_max_line_edit.setEnabled(checked)
+            else:
+                self.fit_can_wavelength_min_line_edit.setEnabled(checked)
+                self.fit_can_wavelength_max_line_edit.setEnabled(checked)
+
     def _on_fit_selection_has_changed(self):
         fit_selection = self.fit_selection_combo_box.currentIndex()
         use_settings_for_sample_and_can = fit_selection == 0
@@ -855,6 +869,8 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.fit_can_fit_type_combo_box.setVisible(show_can)
         self.fit_can_wavelength_combo_box.setVisible(show_can)
         self.fit_can_polynomial_order_spin_box.setVisible(show_can)
+        self.fit_can_wavelength_min_line_edit.setVisible(show_can)
+        self.fit_can_wavelength_max_line_edit.setVisible(show_can)
 
     def set_fit_selection(self, use_separate):
         index = 1 if use_separate else 0

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -18,6 +18,7 @@ from enum import Enum
 from mantidqt import icons
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import load_ui
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 from mantidqt.widgets import jobtreeview, manageuserdirectories
 from reduction_gui.reduction.scripter import execute_script
 from sans.common.enums import ReductionDimensionality, OutputMode, SANSInstrument, RangeStepType, ReductionMode, FitType
@@ -1935,29 +1936,33 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
     # $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
     def _attach_validators(self):
-        # Setup the list of validators
-        double_validator = QDoubleValidator()
-        positive_double_validator = QDoubleValidator()
-        positive_double_validator.setBottom(0.0)
+        def create_line_edit_validator(line_edit, initial_value="", is_positive=False):
+            # Helper to create line edit double validator, more sturdy against wrong double values(e.g. `1e`)
+            dv = LineEditDoubleValidator(line_edit, initial_value)
+            if is_positive:
+                dv.setBottom(0.0)
+            line_edit.setValidator(dv)
+
+        # Setup the integer validator
         positive_integer_validator = QIntValidator()
         positive_integer_validator.setBottom(1)
 
         # -------------------------------
         # General tab
         # -------------------------------
-        self.merged_shift_line_edit.setValidator(double_validator)
-        self.merged_scale_line_edit.setValidator(double_validator)
-        self.merged_q_range_start_line_edit.setValidator(double_validator)
-        self.merged_q_range_stop_line_edit.setValidator(double_validator)
-        self.merged_max_line_edit.setValidator(double_validator)
-        self.merged_min_line_edit.setValidator(double_validator)
+        create_line_edit_validator(self.merged_shift_line_edit)
+        create_line_edit_validator(self.merged_scale_line_edit)
+        create_line_edit_validator(self.merged_q_range_start_line_edit)
+        create_line_edit_validator(self.merged_q_range_stop_line_edit)
+        create_line_edit_validator(self.merged_max_line_edit)
+        create_line_edit_validator(self.merged_min_line_edit)
 
-        self.wavelength_min_line_edit.setValidator(positive_double_validator)
-        self.wavelength_max_line_edit.setValidator(positive_double_validator)
-        self.wavelength_step_line_edit.setValidator(positive_double_validator)
+        create_line_edit_validator(self.wavelength_min_line_edit, is_positive=True)
+        create_line_edit_validator(self.wavelength_max_line_edit, is_positive=True)
+        create_line_edit_validator(self.wavelength_step_line_edit, is_positive=True)
 
-        self.absolute_scale_line_edit.setValidator(double_validator)
-        self.z_offset_line_edit.setValidator(double_validator)
+        create_line_edit_validator(self.z_offset_line_edit)
+        create_line_edit_validator(self.absolute_scale_line_edit)
 
         # --------------------------------
         # Adjustment tab
@@ -1965,41 +1970,41 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.monitor_normalization_line_edit.setValidator(positive_integer_validator)
         self.transmission_line_edit.setValidator(positive_integer_validator)
         self.transmission_monitor_line_edit.setValidator(positive_integer_validator)
-        self.transmission_radius_line_edit.setValidator(positive_double_validator)
-        self.transmission_mn_4_shift_line_edit.setValidator(double_validator)
-        self.transmission_mn_5_shift_line_edit.setValidator(double_validator)
+        create_line_edit_validator(self.transmission_radius_line_edit, "", is_positive=True)
+        create_line_edit_validator(self.transmission_mn_4_shift_line_edit, "")
+        create_line_edit_validator(self.transmission_mn_5_shift_line_edit, "")
 
-        self.fit_sample_wavelength_min_line_edit.setValidator(positive_double_validator)
-        self.fit_sample_wavelength_max_line_edit.setValidator(positive_double_validator)
-        self.fit_can_wavelength_min_line_edit.setValidator(positive_double_validator)
-        self.fit_can_wavelength_max_line_edit.setValidator(positive_double_validator)
+        create_line_edit_validator(self.fit_sample_wavelength_min_line_edit, is_positive=True)
+        create_line_edit_validator(self.fit_sample_wavelength_max_line_edit, is_positive=True)
+        create_line_edit_validator(self.fit_can_wavelength_min_line_edit, is_positive=True)
+        create_line_edit_validator(self.fit_can_wavelength_max_line_edit, is_positive=True)
 
         # --------------------------------
         # Q tab
         # --------------------------------
-        self.radius_limit_min_line_edit.setValidator(double_validator)
-        self.radius_limit_max_line_edit.setValidator(double_validator)
-        self.phi_limit_min_line_edit.setValidator(double_validator)
-        self.phi_limit_max_line_edit.setValidator(double_validator)
-        self.q_1d_min_line_edit.setValidator(double_validator)
-        self.q_1d_max_line_edit.setValidator(double_validator)
-        self.q_1d_step_line_edit.setValidator(positive_double_validator)
-        self.q_xy_max_line_edit.setValidator(positive_double_validator)  # Yes, this should be positive!
-        self.q_xy_step_line_edit.setValidator(positive_double_validator)
+        create_line_edit_validator(self.radius_limit_min_line_edit)
+        create_line_edit_validator(self.radius_limit_max_line_edit)
+        create_line_edit_validator(self.phi_limit_min_line_edit, "-90.0")
+        create_line_edit_validator(self.phi_limit_max_line_edit, "90.0")
+        create_line_edit_validator(self.q_1d_min_line_edit)
+        create_line_edit_validator(self.q_1d_max_line_edit)
 
-        self.r_cut_line_edit.setValidator(positive_double_validator)
-        self.w_cut_line_edit.setValidator(positive_double_validator)
+        create_line_edit_validator(self.q_1d_step_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_xy_max_line_edit, is_positive=True)  # Yes, this should be positive!
+        create_line_edit_validator(self.q_xy_step_line_edit, is_positive=True)
 
-        self.gravity_extra_length_line_edit.setValidator(double_validator)
+        create_line_edit_validator(self.r_cut_line_edit, is_positive=True)
+        create_line_edit_validator(self.w_cut_line_edit, is_positive=True)
 
-        self.q_resolution_source_a_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_sample_a_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_source_h_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_sample_h_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_source_w_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_sample_w_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_delta_r_line_edit.setValidator(positive_double_validator)
-        self.q_resolution_collimation_length_line_edit.setValidator(double_validator)
+        create_line_edit_validator(self.gravity_extra_length_line_edit)
+
+        create_line_edit_validator(self.q_resolution_source_a_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_sample_a_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_source_w_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_sample_w_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_source_h_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_sample_w_line_edit, is_positive=True)
+        create_line_edit_validator(self.q_resolution_collimation_length_line_edit)
 
     def reset_all_fields_to_default(self):
         # ------------------------------

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1977,6 +1977,10 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         # --------------------------------
         # Q tab
         # --------------------------------
+        self.radius_limit_min_line_edit.setValidator(double_validator)
+        self.radius_limit_max_line_edit.setValidator(double_validator)
+        self.phi_limit_min_line_edit.setValidator(double_validator)
+        self.phi_limit_max_line_edit.setValidator(double_validator)
         self.q_1d_min_line_edit.setValidator(double_validator)
         self.q_1d_max_line_edit.setValidator(double_validator)
         self.q_1d_step_line_edit.setValidator(positive_double_validator)

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1400</width>
-    <height>897</height>
+    <width>1544</width>
+    <height>808</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -32,43 +32,43 @@ QGroupBox::title {
 }</string>
   </property>
   <widget class="QWidget" name="widgetMainRow">
-   <layout class="QGridLayout" name="gridLayout_4">
-    <item row="0" column="0">
-     <layout class="QHBoxLayout" name="main_layout" stretch="0,1">
+   <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QVBoxLayout" name="tab_choice_layout">
-        <item>
-         <widget class="QListWidget" name="tab_choice_list">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>170</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>170</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="frameShape">
-           <enum>QFrame::Box</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-         </widget>
-        </item>
+       <widget class="QListWidget" name="tab_choice_list">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>170</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>170</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Box</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
         <item>
          <widget class="QPushButton" name="help_button">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -81,8 +81,8 @@ QGroupBox::title {
           </property>
           <property name="maximumSize">
            <size>
-            <width>25</width>
-            <height>25</height>
+            <width>50</width>
+            <height>30</height>
            </size>
           </property>
           <property name="text">
@@ -90,299 +90,61 @@ QGroupBox::title {
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
-      <item>
-       <widget class="QStackedWidget" name="main_stacked_widget">
-        <property name="currentIndex">
-         <number>1</number>
-        </property>
-        <widget class="QWidget" name="run_page">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+     </layout>
+    </item>
+    <item>
+     <widget class="QStackedWidget" name="main_stacked_widget">
+      <property name="currentIndex">
+       <number>1</number>
+      </property>
+      <widget class="QWidget" name="run_page">
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <layout class="QVBoxLayout" name="run_layout">
           <item>
-           <layout class="QVBoxLayout" name="run_layout">
-            <item>
-             <layout class="QGridLayout" name="header">
-              <property name="verticalSpacing">
-               <number>6</number>
+           <layout class="QGridLayout" name="header">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <item row="2" column="1">
+             <widget class="QLabel" name="batch_label">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
-              <item row="2" column="1">
-               <widget class="QLabel" name="batch_label">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Batch File:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <layout class="QHBoxLayout" name="horizontalLayout_2">
-                <item>
-                 <widget class="QLabel" name="instrument_type">
-                  <property name="text">
-                   <string>NoInstrument</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item row="1" column="4">
-               <widget class="QLineEdit" name="user_file_line_edit">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="instrument_label">
-                <property name="text">
-                 <string>Instrument:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QPushButton" name="manage_directories_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add directories to search for data, set your output directory, and manage data archive searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Manage Directories</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="4">
-               <widget class="QLabel" name="output_directory_location">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="4">
-               <widget class="QLineEdit" name="batch_line_edit">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QLabel" name="output_directory_label">
-                <property name="text">
-                 <string>Save Directory: </string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="6">
-               <widget class="QPushButton" name="process_selected_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Process selected rows only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Process Selected</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="6">
-               <widget class="QPushButton" name="user_file_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Load User File</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="6">
-               <widget class="QPushButton" name="process_all_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Process all rows, regardless of selection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Process All</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="user_file_label">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="text">
-                 <string>&amp;User File:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>masking_table</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="6">
-               <widget class="QPushButton" name="batch_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Load Batch File</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="6">
-               <widget class="QPushButton" name="load_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load data without processing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Load</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
+              <property name="text">
+               <string>Batch File:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item row="0" column="4">
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
               <item>
-               <widget class="QToolButton" name="insert_row_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Insert row&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
+               <widget class="QLabel" name="instrument_type">
                 <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
+                 <string>NoInstrument</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QToolButton" name="delete_row_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delete selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="Line" name="line_6">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="copy_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="cut_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cut selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="paste_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Paste rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="erase_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erase contents of selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="Line" name="line_7">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="export_table_button">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export the current table as a csv file. This can then be re-loaded at a later date.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_3">
+               <spacer name="horizontalSpacer">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
@@ -394,1998 +156,696 @@ QGroupBox::title {
                 </property>
                </spacer>
               </item>
-              <item>
-               <widget class="QCheckBox" name="multi_period_check_box">
-                <property name="text">
-                 <string>Multi-period</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="sample_geometry_checkbox">
-                <property name="text">
-                 <string>Sample Geometry</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="background_subtraction_checkbox">
-                <property name="text">
-                 <string>Scaled Background Subtraction</string>
-                </property>
-               </widget>
-              </item>
              </layout>
             </item>
-            <item>
-             <layout class="QVBoxLayout" name="data_processor_widget_layout"/>
+            <item row="1" column="4">
+             <widget class="QLineEdit" name="user_file_line_edit">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
             </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="instrument_label">
+              <property name="text">
+               <string>Instrument:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="6">
+             <widget class="QPushButton" name="manage_directories_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add directories to search for data, set your output directory, and manage data archive searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Manage Directories</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="4">
+             <widget class="QLabel" name="output_directory_location">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="4">
+             <widget class="QLineEdit" name="batch_line_edit">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="output_directory_label">
+              <property name="text">
+               <string>Save Directory: </string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="6">
+             <widget class="QPushButton" name="process_selected_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Process selected rows only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Process Selected</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="6">
+             <widget class="QPushButton" name="user_file_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Load User File</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="6">
+             <widget class="QPushButton" name="process_all_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Process all rows, regardless of selection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Process All</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="user_file_label">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="text">
+               <string>&amp;User File:</string>
+              </property>
+              <property name="buddy">
+               <cstring>masking_table</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="6">
+             <widget class="QPushButton" name="batch_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Load Batch File</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="6">
+             <widget class="QPushButton" name="load_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load data without processing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Load</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
             <item>
-             <widget class="QProgressBar" name="batch_progress_bar">
-              <property name="value">
-               <number>24</number>
+             <widget class="QToolButton" name="insert_row_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Insert row&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
               </property>
              </widget>
             </item>
             <item>
-             <layout class="QGridLayout" name="gridLayout_7">
-              <item row="0" column="3">
-               <widget class="QGroupBox" name="reduction_dimensionality_group_box">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="title">
-                 <string>Reduction</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <widget class="QToolButton" name="delete_row_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delete selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_6">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="copy_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="cut_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cut selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="paste_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Paste rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="erase_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erase contents of selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_7">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="export_table_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export the current table as a csv file. This can then be re-loaded at a later date.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="multi_period_check_box">
+              <property name="text">
+               <string>Multi-period</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="sample_geometry_checkbox">
+              <property name="text">
+               <string>Sample Geometry</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="background_subtraction_checkbox">
+              <property name="text">
+               <string>Scaled Background Subtraction</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="data_processor_widget_layout"/>
+          </item>
+          <item>
+           <widget class="QProgressBar" name="batch_progress_bar">
+            <property name="value">
+             <number>24</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout_7">
+            <item row="0" column="3">
+             <widget class="QGroupBox" name="reduction_dimensionality_group_box">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Reduction</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_8">
+               <item>
+                <widget class="QRadioButton" name="reduction_dimensionality_1D">
+                 <property name="text">
+                  <string>&amp;1D</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="reduction_dimensionality_2D">
+                 <property name="text">
+                  <string>&amp;2D</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="4" rowspan="3">
+             <widget class="QGroupBox" name="save_group_box">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="title">
+               <string>Save Options</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                <layout class="QHBoxLayout" name="save_layout">
                  <item>
-                  <widget class="QRadioButton" name="reduction_dimensionality_1D">
-                   <property name="text">
-                    <string>&amp;1D</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="reduction_dimensionality_2D">
-                   <property name="text">
-                    <string>&amp;2D</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item row="0" column="4" rowspan="3">
-               <widget class="QGroupBox" name="save_group_box">
-                <property name="styleSheet">
-                 <string notr="true"/>
-                </property>
-                <property name="title">
-                 <string>Save Options</string>
-                </property>
-                <property name="flat">
-                 <bool>false</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
-                 <item>
-                  <layout class="QHBoxLayout" name="save_layout">
+                  <layout class="QVBoxLayout" name="save_location_layout">
                    <item>
-                    <layout class="QVBoxLayout" name="save_location_layout">
-                     <item>
-                      <widget class="QRadioButton" name="output_mode_memory_radio_button">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Memor&amp;y</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QRadioButton" name="output_mode_file_radio_button">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>&amp;File</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QRadioButton" name="output_mode_both_radio_button">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Both</string>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QCheckBox" name="save_can_checkBox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, save the unsubtracted Can and Sam workspaces separately.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Save Can</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
+                    <widget class="QRadioButton" name="output_mode_memory_radio_button">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Memor&amp;y</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <layout class="QVBoxLayout" name="save_file_format_layout">
-                     <item>
-                      <widget class="QCheckBox" name="can_sas_checkbox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>CanSAS (1D)</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QCheckBox" name="nx_can_sas_checkbox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>NxCanSAS (1D/2D)</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QCheckBox" name="rkh_checkbox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>RKH (1D/2D)</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line_2">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
+                    <widget class="QRadioButton" name="output_mode_file_radio_button">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>&amp;File</string>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <layout class="QGridLayout" name="gridLayout">
-                     <item row="1" column="0">
-                      <widget class="QCheckBox" name="use_optimizations_checkbox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When optimizations are turned on then data is being stored in RAM and reused. The optimizations affect the raw data files and can reductions. Most of the time you will want these optimizations enabled. Disable the optimizations if you run a very long batch reduction where there might be the danger  that your RAM will max out.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Use Optimizations</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QCheckBox" name="save_zero_error_free">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled it will replace all entries with zero-valued errors with errors of magnitude 1e6. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Zero Error Free</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QCheckBox" name="plot_results_checkbox">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the 0th spectrum of each reduced workspace will be plotted as it is reduced.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Plot Results</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
+                    <widget class="QRadioButton" name="output_mode_both_radio_button">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save locations for the output of batch reductions are: Memory (RAM), File (Hard disk), Both (RAM and Hard disk).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Both</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="save_can_checkBox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, save the unsubtracted Can and Sam workspaces separately.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Save Can</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="Line" name="line">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="save_file_format_layout">
+                   <item>
+                    <widget class="QCheckBox" name="can_sas_checkbox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>CanSAS (1D)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="nx_can_sas_checkbox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>NxCanSAS (1D/2D)</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="rkh_checkbox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The save file formats. Note that different formats are suitable for different reduction dimensionalities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>RKH (1D/2D)</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="Line" name="line_2">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QGridLayout" name="gridLayout">
+                   <item row="1" column="0">
+                    <widget class="QCheckBox" name="use_optimizations_checkbox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When optimizations are turned on then data is being stored in RAM and reused. The optimizations affect the raw data files and can reductions. Most of the time you will want these optimizations enabled. Disable the optimizations if you run a very long batch reduction where there might be the danger  that your RAM will max out.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Use Optimizations</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0">
+                    <widget class="QCheckBox" name="save_zero_error_free">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled it will replace all entries with zero-valued errors with errors of magnitude 1e6. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Zero Error Free</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QCheckBox" name="plot_results_checkbox">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the 0th spectrum of each reduced workspace will be plotted as it is reduced.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Plot Results</string>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </item>
                 </layout>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="3">
-               <widget class="QPushButton" name="save_other_pushButton">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save a workspace as a CanSAS, NxCanSAS, or RKH file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Save Other</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="3">
+             <widget class="QPushButton" name="save_other_pushButton">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save a workspace as a CanSAS, NxCanSAS, or RKH file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Save Other</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
          </layout>
-        </widget>
-        <widget class="QWidget" name="settings_page">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QTabWidget" name="settings_tab_widget">
-            <property name="currentIndex">
-             <number>3</number>
-            </property>
-            <widget class="QWidget" name="general_tab">
-             <attribute name="title">
-              <string>General, Scale, Event Slice, Sample</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <item>
-               <layout class="QHBoxLayout" name="general_tab_horizontal_layout">
-                <item>
-                 <layout class="QVBoxLayout" name="general_tab_left_layout">
-                  <item>
-                   <widget class="QFrame" name="reduction_mode_frame">
-                    <property name="frameShape">
-                     <enum>QFrame::StyledPanel</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_21">
-                     <item row="0" column="0">
-                      <layout class="QVBoxLayout" name="general_vertical_layout">
-                       <item>
-                        <layout class="QGridLayout" name="general_grid">
-                         <item row="0" column="1">
-                          <widget class="QComboBox" name="reduction_mode_combo_box">
-                           <property name="toolTip">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The reduction mode. This can be either of the banks of your instrument. In the case of two banks there is also the &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode. &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; mode stitches the reductions from two banks together. &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode reduces both banks.&lt;/p&gt;&lt;p&gt;Note that by default the entries are &lt;span style=&quot; font-style:italic;&quot;&gt;LAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;HAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt;. Once you have specified data in the batch table, the entry names will be updated to reflect the naming of your instrument.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="reduction_mode_label">
-                           <property name="toolTip">
-                            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The reduction mode. This can be either of the banks of your instrument. In the case of two banks there is also the &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode. &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; mode stitches the reductions from two banks together. &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode reduces both banks.&lt;/p&gt;&lt;p&gt;Note that by default the entries are &lt;span style=&quot; font-style:italic;&quot;&gt;LAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;HAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt;. Once you have specified data in the batch table, the entry names will be updated to reflect the naming of your instrument.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                           </property>
-                           <property name="text">
-                            <string>Reduction Mode</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QGroupBox" name="merged_settings">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for a merged reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="title">
-                        <string>Merged Settings</string>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_12">
-                        <item row="1" column="2">
-                         <widget class="QLineEdit" name="merged_scale_line_edit">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scale which is used when merging two workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="3">
-                         <widget class="QLabel" name="label_4">
-                          <property name="text">
-                           <string>To</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="6">
-                         <widget class="Line" name="line_3">
-                          <property name="orientation">
-                           <enum>Qt::Vertical</enum>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="0">
-                         <widget class="QLabel" name="merged_shift_label">
-                          <property name="text">
-                           <string>Shift</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QLabel" name="merged_scale_label">
-                          <property name="text">
-                           <string>Scale</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="3">
-                         <widget class="QLabel" name="label_5">
-                          <property name="text">
-                           <string>To</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="3">
-                         <widget class="QCheckBox" name="merged_shift_use_fit_check_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the shift will be fit during the merge operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="text">
-                           <string>Use Fit</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="0">
-                         <widget class="QLabel" name="label">
-                          <property name="text">
-                           <string>Custom q range for fit:</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="2">
-                         <widget class="QLineEdit" name="merged_min_line_edit"/>
-                        </item>
-                        <item row="3" column="2">
-                         <widget class="QLineEdit" name="merged_q_range_start_line_edit">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower bound  of a custom q range. If none is specified, then the full range is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="11">
-                         <widget class="QCheckBox" name="merge_mask_check_box">
-                          <property name="text">
-                           <string>Use Range</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="4">
-                         <widget class="QLineEdit" name="merged_max_line_edit"/>
-                        </item>
-                        <item row="4" column="0">
-                         <widget class="QLabel" name="label_2">
-                          <property name="text">
-                           <string>Custom q range for merge:</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="4">
-                         <widget class="QLineEdit" name="merged_q_range_stop_line_edit">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upper bound  of a custom q range. If none is specified, then the full range is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="3">
-                         <widget class="QCheckBox" name="merged_scale_use_fit_check_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the scale will be fit during the merge operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="text">
-                           <string>Use Fit</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="2">
-                         <widget class="QLineEdit" name="merged_shift_line_edit">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shift which is used when merging two workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="3" column="1">
-                         <widget class="QLabel" name="label_3">
-                          <property name="text">
-                           <string>From</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="4" column="1">
-                         <widget class="QLabel" name="label_6">
-                          <property name="text">
-                           <string>From</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QFrame" name="event_settings_frame">
-                    <property name="frameShape">
-                     <enum>QFrame::StyledPanel</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_2">
-                     <item row="0" column="0">
-                      <layout class="QGridLayout" name="slice_event_grid_layout">
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="slice_event_label">
-                         <property name="text">
-                          <string>Slices:</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="2">
-                        <widget class="QLineEdit" name="slice_event_line_edit">
-                         <property name="enabled">
-                          <bool>true</bool>
-                         </property>
-                         <property name="toolTip">
-                          <string>
-                         &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the case of data which was measured in event-mode, it is possible to perform time-of-flight slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies time slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a time slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                         </string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="0">
-                        <widget class="QLabel" name="event_slice_optimisation_label">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the reduction workflow is changed to perform most operations on event workspaces before event slicing.  This speeds up reduction by not repeating operations for each event slice.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Leaving this unchecked will perform reductions as before.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Checking this, but also checking &lt;span style=&quot; font-weight:600;&quot;&gt;Use compatibility mode&lt;/span&gt;, will perform reductions as before.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                         <property name="text">
-                          <string>Optimize event slices</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="3">
-                        <spacer name="horizontalSpacer_5">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                       <item row="3" column="2">
-                        <widget class="QCheckBox" name="event_slice_optimisation_checkbox">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the reduction workflow is changed to perform most operations on event workspaces before event slicing.  This speeds up reduction by not repeating operations for each event slice.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Leaving this unchecked will perform reductions as before.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Checking this, but also checking &lt;span style=&quot; font-weight:600;&quot;&gt;Use compatibility mode&lt;/span&gt;, will perform reductions as before.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                         <property name="text">
-                          <string/>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QFrame" name="scale_frame">
-                    <property name="frameShape">
-                     <enum>QFrame::StyledPanel</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_19">
-                     <item row="0" column="0">
-                      <layout class="QGridLayout" name="gridLayout_5">
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="absolute_scale_label">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The absolute (and unitless) scale factor for the data reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                         <property name="text">
-                          <string>Absolute Scale</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QLineEdit" name="absolute_scale_line_edit">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The absolute (and unitless) scale factor for the data reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="z_offset_line_edit">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The z offset of the sample position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="z_offset_label">
-                         <property name="toolTip">
-                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The z offset of the sample position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                         </property>
-                         <property name="text">
-                          <string>Z Offset [mm]</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="2">
-                        <spacer name="horizontalSpacer_4">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                      </layout>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QGridLayout" name="scale_group_box"/>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="event_binning_group_box">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the data reduction will run in the compatibility mode. This means that the reduction workflow is equivalent to the legacy reduction workflow for histogram data. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="title">
-                     <string>&amp;Use compatibility mode</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_16">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="event_binning_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compatibility mode (i.e. when following the old reduction model). Note that this will only have an effect on event workspaces. If left blank then event workspaces will be rebinned to match the monitor workspace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Event binning</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QLineEdit" name="event_binning_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compatibility mode (i.e. when following the old reduction model). Note that this will only have an effect on event workspaces. If left blank then event workspaces will be rebinned to match the monitor workspace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="verticalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QVBoxLayout" name="general_tab_right_layout"/>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="mask_tab">
-             <attribute name="title">
-              <string>Mask</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_7">
-              <item>
-               <widget class="MaskingTable" name="masking_table" native="true">
-                <property name="minimumSize">
-                 <size>
-                  <width>400</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QVBoxLayout" name="mask_tab_right_layout">
-                <item>
-                 <widget class="QGroupBox" name="mask_file_input_group_box">
-                  <property name="title">
-                   <string>Mask File Input</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_7">
-                   <item row="0" column="0">
-                    <widget class="QLineEdit" name="mask_file_input_line_edit"/>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QPushButton" name="mask_file_browse_push_button">
-                     <property name="text">
-                      <string>Browse</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QPushButton" name="mask_file_add_push_button">
-                     <property name="text">
-                      <string>Add</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="verticalSpacer_4">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="adjustment_tab">
-             <attribute name="title">
-              <string>Adjustment</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
-              <item>
-               <layout class="QHBoxLayout" name="adjustment_tab_horizontal_layout">
-                <item>
-                 <layout class="QVBoxLayout" name="adjustment_tab_left_layout">
-                  <item>
-                   <widget class="QGroupBox" name="monitor_normalization_group_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="title">
-                     <string>Scattering</string>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_8">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="monitor_normalization_monitor_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Incident monitor</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="2">
-                      <widget class="QCheckBox" name="monitor_normalization_interpolating_rebin_check_box">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the type of rebin which is to be used during monitor normalization. If this is checked then a interpolating rebin operation is performed, else a standard rebin operation is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Use interpolating rebin</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QLineEdit" name="monitor_normalization_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="transmission_group_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="title">
-                     <string>Transmission</string>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_9">
-                     <item row="10" column="1">
-                      <widget class="QLabel" name="wide_angle_label">
-                       <property name="text">
-                        <string>Wide Angle Correction</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="1">
-                      <widget class="QLabel" name="transmission_mask_files_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of MASK files which define areas on the bank which are excluded from the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Mask Files</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="3">
-                      <widget class="QLineEdit" name="transmission_mn_4_shift_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between beamstop monitor and detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="1">
-                      <widget class="QLabel" name="transmission_mn_4_shift_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An option shift of the M4 monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Monitor 4 Shift [mm]</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="4">
-                      <widget class="QPushButton" name="transmission_roi_files_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="3">
-                      <widget class="QComboBox" name="transmission_target_combo_box">
-                       <item>
-                        <property name="text">
-                         <string>Transmission monitor</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Region of interest on bank</string>
-                        </property>
-                       </item>
-                      </widget>
-                     </item>
-                     <item row="4" column="3">
-                      <widget class="QLineEdit" name="transmission_monitor_line_edit"/>
-                     </item>
-                     <item row="7" column="1">
-                      <widget class="QLabel" name="transmission_radius_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A radius that defines a circle which includes all pixels on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Radius[mm]</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="4">
-                      <widget class="QCheckBox" name="transmission_interpolating_rebin_check_box">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the type of rebin which is to be used during transmission calculation. If this is checked then a interpolating rebin operation is performed, else a standard rebin operation is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Use interpolating rebin</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="7" column="3">
-                      <widget class="QLineEdit" name="transmission_radius_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A radius that defines a circle which includes all pixels on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="6" column="1">
-                      <widget class="QLabel" name="transmission_mn_5_shift_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An option shift of the M5 monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Monitor 5 Shift [mm]</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="3">
-                      <widget class="QLineEdit" name="transmission_roi_files_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of ROI files which define areas on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="3">
-                      <widget class="QLineEdit" name="transmission_mask_files_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of MASK files which define areas on the bank which are excluded from the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="4">
-                      <widget class="QPushButton" name="transmission_mask_files_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="1">
-                      <widget class="QLabel" name="transmission_monitor_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the transmission monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Transmission monitor</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="6" column="3">
-                      <widget class="QLineEdit" name="transmission_mn_5_shift_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between beamstop monitor and detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLabel" name="transmission_incident_monitor_target">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Incident monitor</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="3">
-                      <widget class="QLineEdit" name="transmission_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="1">
-                      <widget class="QLabel" name="transmission_roi_files_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of ROI files which define areas on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>ROI Files</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="1">
-                      <widget class="QLabel" name="transmission_target_label">
-                       <property name="text">
-                        <string>Transmission target</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="1" colspan="4">
-                      <widget class="QGroupBox" name="fit_combo_box">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fit options for the transmission calculation. These can be either set for both the Sample and the Can run or separately.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="title">
-                        <string>Fit</string>
-                       </property>
-                       <property name="flat">
-                        <bool>false</bool>
-                       </property>
-                       <property name="checkable">
-                        <bool>false</bool>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_22">
-                        <item row="0" column="3">
-                         <widget class="QLabel" name="fit_fit_type_label">
-                          <property name="text">
-                           <string>Fit type</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QComboBox" name="fit_selection_combo_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects if fit options should be the same (Both) for Sample and Can, or if the user should be able to set them separately (Separate).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <item>
-                           <property name="text">
-                            <string>Both</string>
-                           </property>
-                          </item>
-                          <item>
-                           <property name="text">
-                            <string>Separate</string>
-                           </property>
-                          </item>
-                         </widget>
-                        </item>
-                        <item row="2" column="3">
-                         <widget class="QComboBox" name="fit_can_fit_type_combo_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="2">
-                         <widget class="QCheckBox" name="fit_can_use_fit_check_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="text">
-                           <string>Use fit</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="1">
-                         <widget class="QLabel" name="fit_sample_label">
-                          <property name="text">
-                           <string>Sample              </string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="1">
-                         <widget class="QLabel" name="fit_can_label">
-                          <property name="text">
-                           <string>Can</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="5">
-                         <widget class="QGroupBox" name="fit_sample_wavelength_combo_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="title">
-                           <string>&amp;Use custom wavelength range [Å]</string>
-                          </property>
-                          <property name="checkable">
-                           <bool>true</bool>
-                          </property>
-                          <property name="checked">
-                           <bool>false</bool>
-                          </property>
-                          <layout class="QGridLayout" name="gridLayout_23">
-                           <item row="0" column="1">
-                            <widget class="QLineEdit" name="fit_sample_wavelength_min_line_edit">
-                             <property name="toolTip">
-                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="2">
-                            <widget class="QLabel" name="fit_sample_to_label">
-                             <property name="text">
-                              <string>to</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="0">
-                            <widget class="QLabel" name="fit_sample_from_label">
-                             <property name="text">
-                              <string>from</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="3">
-                            <widget class="QLineEdit" name="fit_sample_wavelength_max_line_edit">
-                             <property name="toolTip">
-                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                             </property>
-                            </widget>
-                           </item>
-                          </layout>
-                         </widget>
-                        </item>
-                        <item row="2" column="5">
-                         <widget class="QGroupBox" name="fit_can_wavelength_combo_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="title">
-                           <string>Use custom wavelength range [&amp;Å]</string>
-                          </property>
-                          <property name="checkable">
-                           <bool>true</bool>
-                          </property>
-                          <property name="checked">
-                           <bool>false</bool>
-                          </property>
-                          <layout class="QGridLayout" name="gridLayout_24">
-                           <item row="0" column="1">
-                            <widget class="QLineEdit" name="fit_can_wavelength_min_line_edit">
-                             <property name="toolTip">
-                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="0">
-                            <widget class="QLabel" name="fit_can_from_label">
-                             <property name="text">
-                              <string>from</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="2">
-                            <widget class="QLabel" name="fit_can_to_label">
-                             <property name="text">
-                              <string>to</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="3">
-                            <widget class="QLineEdit" name="fit_can_wavelength_max_line_edit">
-                             <property name="toolTip">
-                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                             </property>
-                            </widget>
-                           </item>
-                          </layout>
-                         </widget>
-                        </item>
-                        <item row="1" column="3">
-                         <widget class="QComboBox" name="fit_sample_fit_type_combo_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="4">
-                         <widget class="QSpinBox" name="fit_sample_polynomial_order_spin_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="minimum">
-                           <number>2</number>
-                          </property>
-                          <property name="maximum">
-                           <number>6</number>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="4">
-                         <widget class="QLabel" name="fit_polynomial_order_label">
-                          <property name="text">
-                           <string>Poly. order</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="4">
-                         <widget class="QSpinBox" name="fit_can_polynomial_order_spin_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="minimum">
-                           <number>2</number>
-                          </property>
-                          <property name="maximum">
-                           <number>6</number>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="2">
-                         <widget class="QCheckBox" name="fit_sample_use_fit_check_box">
-                          <property name="toolTip">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="text">
-                           <string>Use fit</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="10" column="3">
-                      <widget class="QCheckBox" name="wide_angle_check_box">
-                       <property name="toolTip">
-                        <string>Perform a wide angle correction to the transmission</string>
-                       </property>
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="pixel_adjustment_group_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pixel adjustment files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="title">
-                     <string>Pixel adjustment files</string>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_10">
-                     <item row="0" column="1">
-                      <widget class="QLineEdit" name="pixel_adjustment_det_1_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="pixel_adjustment_det_2_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Det1</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="2">
-                      <widget class="QPushButton" name="pixel_adjustment_det_1_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QPushButton" name="pixel_adjustment_det_2_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QLineEdit" name="pixel_adjustment_det_2_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="pixel_adjustement_det_1_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Det2</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="wavelength_adjustment_group_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The wavelength adjustment files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="title">
-                     <string>Wavelength efficiency files</string>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_11">
-                     <item row="0" column="1">
-                      <widget class="QLineEdit" name="wavelength_adjustment_det_1_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="wavelength_adjustment_det_1_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Det 1</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="wavelength_adjustment_det_2_label">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Det 2</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLineEdit" name="wavelength_adjustment_det_2_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="2">
-                      <widget class="QPushButton" name="wavelength_adjustment_det_1_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="2">
-                      <widget class="QPushButton" name="wavelength_adjustment_det_2_push_button">
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="verticalSpacer_2">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QVBoxLayout" name="adjustemnt_tab_right_layout"/>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="q_tab">
-             <attribute name="title">
-              <string>Q, Wavelength, Detector Limits</string>
-             </attribute>
-             <widget class="QWidget" name="layoutWidget">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>661</width>
-                <height>702</height>
-               </rect>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="settings_page">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <item>
+         <widget class="QTabWidget" name="settings_tab_widget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="currentIndex">
+           <number>2</number>
+          </property>
+          <widget class="QWidget" name="general_tab">
+           <attribute name="title">
+            <string>General, Scale, Event Slice, Sample</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <widget class="QFrame" name="reduction_mode_frame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
               </property>
-              <layout class="QVBoxLayout" name="q_tab_left_layout">
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
-                <widget class="QGroupBox" name="limits_group_box">
+                <layout class="QHBoxLayout" name="horizontalLayout_10">
+                 <item>
+                  <widget class="QLabel" name="reduction_mode_label">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The reduction mode. This can be either of the banks of your instrument. In the case of two banks there is also the &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode. &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; mode stitches the reductions from two banks together. &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode reduces both banks.&lt;/p&gt;&lt;p&gt;Note that by default the entries are &lt;span style=&quot; font-style:italic;&quot;&gt;LAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;HAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt;. Once you have specified data in the batch table, the entry names will be updated to reflect the naming of your instrument.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Reduction Mode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="reduction_mode_combo_box">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The reduction mode. This can be either of the banks of your instrument. In the case of two banks there is also the &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode. &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt; mode stitches the reductions from two banks together. &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt; mode reduces both banks.&lt;/p&gt;&lt;p&gt;Note that by default the entries are &lt;span style=&quot; font-style:italic;&quot;&gt;LAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;HAB&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;Merged&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;All&lt;/span&gt;. Once you have specified data in the batch table, the entry names will be updated to reflect the naming of your instrument.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="merged_settings">
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disk mask which is useful for the beam stop&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for a merged reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="title">
-                  <string/>
+                  <string>Merged Settings</string>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_14">
-                  <item row="0" column="1">
-                   <widget class="QLabel" name="radius_limit_min_label">
+                 <layout class="QGridLayout" name="gridLayout_12">
+                  <item row="1" column="2">
+                   <widget class="QLineEdit" name="merged_scale_line_edit">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scale which is used when merging two workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="3">
+                   <widget class="QLabel" name="label_4">
                     <property name="text">
-                     <string>Min [mm]</string>
+                     <string>To</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="6">
+                   <widget class="Line" name="line_3">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
                     </property>
                    </widget>
                   </item>
                   <item row="2" column="0">
-                   <widget class="QLabel" name="phi_limit">
+                   <widget class="QLabel" name="merged_shift_label">
                     <property name="text">
-                     <string>Phi Limit:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="4">
-                   <widget class="QLineEdit" name="radius_limit_max_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upper radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1" colspan="4">
-                   <widget class="QStackedWidget" name="phi_range_stacked_widget">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="currentIndex">
-                     <number>0</number>
-                    </property>
-                    <widget class="QWidget" name="page_min_max">
-                     <layout class="QHBoxLayout" name="horizontalLayout">
-                      <property name="leftMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="topMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="bottomMargin">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <widget class="QLabel" name="phi_limit_from_label">
-                        <property name="minimumSize">
-                         <size>
-                          <width>66</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>From</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="phi_limit_min_line_edit">
-                        <property name="minimumSize">
-                         <size>
-                          <width>125</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="toolTip">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="phi_limit_to_label">
-                        <property name="minimumSize">
-                         <size>
-                          <width>66</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>To</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="phi_limit_max_line_edit">
-                        <property name="minimumSize">
-                         <size>
-                          <width>125</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="toolTip">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stop angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                    <widget class="QWidget" name="page_ranges">
-                     <layout class="QHBoxLayout" name="horizontalLayout_6">
-                      <property name="leftMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="topMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="bottomMargin">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <widget class="QLabel" name="phi_range_label">
-                        <property name="text">
-                         <string>Ranges (e.g.-5.0,10.0, 75.0,90.0)</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLineEdit" name="phi_range_line_edit">
-                        <property name="toolTip">
-                         <string>Set a set of phi ranges as pairs: </string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QComboBox" name="phi_range_step_type_combo_box"/>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="cuts_label">
-                    <property name="text">
-                     <string>Cuts:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLabel" name="label_8">
-                    <property name="text">
-                     <string>Phi Step</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3">
-                   <widget class="QLabel" name="radius_limit_max_label">
-                    <property name="text">
-                     <string>Max [mm]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="radius_limit">
-                    <property name="text">
-                     <string>Radius Limit:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QLineEdit" name="radius_limit_min_line_edit">
-                    <property name="minimumSize">
-                     <size>
-                      <width>125</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QLabel" name="q_1d_label_2">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>RCut [mm]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="2">
-                   <widget class="QLineEdit" name="r_cut_line_edit"/>
-                  </item>
-                  <item row="3" column="3">
-                   <widget class="QLabel" name="q_1d_label_3">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>WCut [Å]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="4">
-                   <widget class="QLineEdit" name="w_cut_line_edit"/>
-                  </item>
-                  <item row="2" column="5">
-                   <widget class="QCheckBox" name="phi_limit_use_mirror_check_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the mirror sector should be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>use mirror sector</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="Line" name="line_9">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="wavelength_group_box">
-                 <property name="title">
-                  <string>Wavelength</string>
-                 </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_9">
-                  <item>
-                   <widget class="QStackedWidget" name="wavelength_stacked_widget">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>66</height>
-                     </size>
-                    </property>
-                    <property name="lineWidth">
-                     <number>0</number>
-                    </property>
-                    <property name="currentIndex">
-                     <number>0</number>
-                    </property>
-                    <widget class="QWidget" name="page">
-                     <layout class="QGridLayout" name="gridLayout_3">
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="wavelength_min_label">
-                        <property name="text">
-                         <string>Min [Å]</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
-                       <widget class="QLabel" name="wavelength_max_label">
-                        <property name="text">
-                         <string>Max  [Å]</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QLineEdit" name="wavelength_max_line_edit"/>
-                      </item>
-                      <item row="2" column="0">
-                       <widget class="QLineEdit" name="wavelength_min_line_edit"/>
-                      </item>
-                     </layout>
-                    </widget>
-                    <widget class="QWidget" name="page_2">
-                     <layout class="QGridLayout" name="gridLayout_6">
-                      <item row="2" column="0">
-                       <widget class="QLineEdit" name="wavelength_slices_line_edit">
-                        <property name="toolTip">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It is possible to perform wavelength slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies wavelength slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a wavelength slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;p&gt;A reduction will always be done between the maximum and minimum wavelengths of a given set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_7">
-                        <property name="toolTip">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It is possible to perform wavelength slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies wavelength slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a wavelength slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;p&gt;A reduction will always be done between the maximum and minimum wavelengths of a given set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                        <property name="text">
-                         <string>Ranges  [Å]  (e.g: 5-10,12:2:16,20-30)</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QWidget" name="wavelength_widget" native="true">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>66</height>
-                     </size>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_18">
-                     <item row="1" column="1">
-                      <widget class="QComboBox" name="wavelength_step_type_combo_box"/>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QLabel" name="wavelength_step_type_label">
-                       <property name="text">
-                        <string>Step Type</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLineEdit" name="wavelength_step_line_edit"/>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="wavelength_step_label">
-                       <property name="text">
-                        <string>Step  [Å]</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="q_limits_group_box">
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the momentum transfer limits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="title">
-                  <string>Q limits</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_15">
-                  <item row="3" column="4">
-                   <widget class="QLineEdit" name="q_xy_step_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step of the momentum transfer for a 2D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="4">
-                   <widget class="QLabel" name="q_xy_step_label">
-                    <property name="text">
-                     <string>Step [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QLabel" name="q_min_label">
-                    <property name="text">
-                     <string>Min [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="3">
-                   <widget class="QLabel" name="q_xy_max_label">
-                    <property name="text">
-                     <string>Max [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QLineEdit" name="q_1d_min_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The lower bound of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="3">
-                   <widget class="QLineEdit" name="q_1d_max_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The upper bound of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="5">
-                   <widget class="QComboBox" name="q_1d_step_type_combo_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step type of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="3">
-                   <widget class="QLineEdit" name="q_xy_max_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The upper bound of the momentum transfer for a 2D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="5">
-                   <widget class="QLabel" name="q_step_type_label">
-                    <property name="text">
-                     <string>Step type</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="4">
-                   <widget class="QLineEdit" name="q_1d_step_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3">
-                   <widget class="QLabel" name="q_max_label">
-                    <property name="text">
-                     <string>Max [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="4">
-                   <widget class="QLabel" name="q_step_label">
-                    <property name="text">
-                     <string>Step [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="q_xy_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 2D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Qxy</string>
+                     <string>Shift</string>
                     </property>
                    </widget>
                   </item>
                   <item row="1" column="0">
-                   <widget class="QLabel" name="q_1d_label">
+                   <widget class="QLabel" name="merged_scale_label">
+                    <property name="text">
+                     <string>Scale</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="3">
+                   <widget class="QLabel" name="label_5">
+                    <property name="text">
+                     <string>To</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="3">
+                   <widget class="QCheckBox" name="merged_shift_use_fit_check_box">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the shift will be fit during the merge operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="text">
-                     <string>Q1D</string>
+                     <string>Use Fit</string>
                     </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gravity_group_box">
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gravity settings. If checked then gravity will be accounted for in the reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="title">
-                  <string>Account &amp;for gravity</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_17">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="gravity_extra_length_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extra length for the gravity correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Extra length [m]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="gravity_extra_length_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extra length for the gravity correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="q_resolution_group_box">
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for Q resolution. If checked, then the Q resolution is used, else not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="title">
-                  <string>Q resolution</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_13">
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QComboBox" name="q_resolution_shape_combo_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selection of the aperture. This can be either a rectangular or a circular aperture&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>Pinhole</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Slit</string>
-                     </property>
-                    </item>
                    </widget>
                   </item>
                   <item row="3" column="0">
-                   <widget class="QLabel" name="q_resolution_source_a_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
+                   <widget class="QLabel" name="label">
                     <property name="text">
-                     <string>A1 [mm]</string>
+                     <string>Custom q range for fit:</string>
                     </property>
                    </widget>
+                  </item>
+                  <item row="4" column="2">
+                   <widget class="QLineEdit" name="merged_min_line_edit"/>
                   </item>
                   <item row="3" column="2">
-                   <widget class="QLabel" name="q_resolution_sample_a_label">
+                   <widget class="QLineEdit" name="merged_q_range_start_line_edit">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>A2 [mm]</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower bound  of a custom q range. If none is specified, then the full range is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="q_resolution_source_h_line_edit">
+                  <item row="4" column="11">
+                   <widget class="QCheckBox" name="merge_mask_check_box">
+                    <property name="text">
+                     <string>Use Range</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="4">
+                   <widget class="QLineEdit" name="merged_max_line_edit"/>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>Custom q range for merge:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="4">
+                   <widget class="QLineEdit" name="merged_q_range_stop_line_edit">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upper bound  of a custom q range. If none is specified, then the full range is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QCheckBox" name="merged_scale_use_fit_check_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the scale will be fit during the merge operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Use Fit</string>
                     </property>
                    </widget>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QLabel" name="q_resolution_sample_w_label">
+                   <widget class="QLineEdit" name="merged_shift_line_edit">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>W2 [mm]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="3">
-                   <widget class="QLineEdit" name="q_resolution_sample_w_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="q_resolution_collimation_length_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The collimation length.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Collimation length [m]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="2">
-                   <widget class="QLabel" name="q_resolution_delta_r_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delta r.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Delta r [mm]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1" colspan="2">
-                   <widget class="QLineEdit" name="q_resolution_moderator_file_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the moderator file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="3">
-                   <widget class="QPushButton" name="q_resolution_moderator_file_push_button">
-                    <property name="text">
-                     <string>Browse</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="q_resolution_moderator_file_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the moderator file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Moderator file</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QLineEdit" name="q_resolution_collimation_length_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The collimation length.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="3">
-                   <widget class="QLineEdit" name="q_resolution_delta_r_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delta r.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="3">
-                   <widget class="QLineEdit" name="q_resolution_sample_a_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shift which is used when merging two workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                    </widget>
                   </item>
                   <item row="3" column="1">
-                   <widget class="QLineEdit" name="q_resolution_source_a_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="q_resolution_source_w_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="q_resolution_source_h_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
+                   <widget class="QLabel" name="label_3">
                     <property name="text">
-                     <string>H1 [mm]</string>
+                     <string>From</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="3">
-                   <widget class="QLineEdit" name="q_resolution_sample_h_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="q_resolution_source_w_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
+                  <item row="4" column="1">
+                   <widget class="QLabel" name="label_6">
                     <property name="text">
-                     <string>W1 [mm]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QLabel" name="q_resolution_sample_h_label">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>H2 [mm]</string>
+                     <string>From</string>
                     </property>
                    </widget>
                   </item>
@@ -2394,22 +854,1624 @@ QGroupBox::title {
                </item>
               </layout>
              </widget>
-            </widget>
-            <widget class="SettingsDiagnosticTab" name="settings_diagnostic_tab">
-             <attribute name="title">
-              <string>State Diagnostic</string>
-             </attribute>
-            </widget>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="BeamCentre" name="beam_centre"/>
-        <widget class="AddRunsPage" name="add_runs_page"/>
-        <widget class="DiagnosticsPage" name="diagnostic_page"/>
-       </widget>
-      </item>
-     </layout>
+            </item>
+            <item>
+             <widget class="QFrame" name="event_settings_frame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="0" column="0">
+                <widget class="QLabel" name="slice_event_label">
+                 <property name="text">
+                  <string>Slices:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="slice_event_line_edit">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>
+                         &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the case of data which was measured in event-mode, it is possible to perform time-of-flight slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies time slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a time slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+                         </string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>544</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="event_slice_optimisation_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the reduction workflow is changed to perform most operations on event workspaces before event slicing.  This speeds up reduction by not repeating operations for each event slice.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Leaving this unchecked will perform reductions as before.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Checking this, but also checking &lt;span style=&quot; font-weight:600;&quot;&gt;Use compatibility mode&lt;/span&gt;, will perform reductions as before.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Optimize event slices</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="event_slice_optimisation_checkbox">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the reduction workflow is changed to perform most operations on event workspaces before event slicing.  This speeds up reduction by not repeating operations for each event slice.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Leaving this unchecked will perform reductions as before.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Checking this, but also checking &lt;span style=&quot; font-weight:600;&quot;&gt;Use compatibility mode&lt;/span&gt;, will perform reductions as before.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="scale_frame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_4">
+               <item row="0" column="0">
+                <widget class="QLabel" name="absolute_scale_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The absolute (and unitless) scale factor for the data reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Absolute Scale</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="absolute_scale_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The absolute (and unitless) scale factor for the data reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>563</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="z_offset_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The z offset of the sample position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Z Offset [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="z_offset_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The z offset of the sample position.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="event_binning_group_box">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the data reduction will run in the compatibility mode. This means that the reduction workflow is equivalent to the legacy reduction workflow for histogram data. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>&amp;Use compatibility mode</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_16">
+               <item row="0" column="0">
+                <widget class="QLabel" name="event_binning_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compatibility mode (i.e. when following the old reduction model). Note that this will only have an effect on event workspaces. If left blank then event workspaces will be rebinned to match the monitor workspace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Event binning</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="event_binning_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compatibility mode (i.e. when following the old reduction model). Note that this will only have an effect on event workspaces. If left blank then event workspaces will be rebinned to match the monitor workspace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Preferred</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>100</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="mask_tab">
+           <attribute name="title">
+            <string>Mask</string>
+           </attribute>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="MaskingTable" name="masking_table" native="true">
+              <property name="minimumSize">
+               <size>
+                <width>400</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <item>
+               <widget class="QGroupBox" name="mask_file_input_group_box">
+                <property name="title">
+                 <string>Mask File Input</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_7">
+                 <item row="0" column="0">
+                  <widget class="QLineEdit" name="mask_file_input_line_edit"/>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QPushButton" name="mask_file_browse_push_button">
+                   <property name="text">
+                    <string>Browse</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QPushButton" name="mask_file_add_push_button">
+                   <property name="text">
+                    <string>Add</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="adjustment_tab">
+           <attribute name="title">
+            <string>Adjustment</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,4,1,1">
+            <property name="spacing">
+             <number>1</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="monitor_normalization_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Scattering</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QLabel" name="monitor_normalization_monitor_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Incident monitor</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="monitor_normalization_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="monitor_normalization_interpolating_rebin_check_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the type of rebin which is to be used during monitor normalization. If this is checked then a interpolating rebin operation is performed, else a standard rebin operation is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Use interpolating rebin</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="transmission_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Transmission</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_5">
+               <property name="spacing">
+                <number>-1</number>
+               </property>
+               <item row="1" column="1">
+                <widget class="QComboBox" name="transmission_target_combo_box">
+                 <item>
+                  <property name="text">
+                   <string>Transmission monitor</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Region of interest on bank</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="transmission_mn_5_shift_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An option shift of the M5 monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Monitor 5 Shift [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLineEdit" name="transmission_mn_4_shift_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between beamstop monitor and detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="transmission_roi_files_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of ROI files which define areas on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>ROI Files</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLineEdit" name="transmission_radius_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A radius that defines a circle which includes all pixels on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QCheckBox" name="transmission_interpolating_rebin_check_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the type of rebin which is to be used during transmission calculation. If this is checked then a interpolating rebin operation is performed, else a standard rebin operation is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Use interpolating rebin</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="transmission_mn_4_shift_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An option shift of the M4 monitor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Monitor 4 Shift [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="transmission_incident_monitor_target">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Incident monitor</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="transmission_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the incident monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLineEdit" name="transmission_monitor_line_edit"/>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="transmission_monitor_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spectrum number of the transmission monitor which is used for transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Transmission monitor</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="transmission_radius_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A radius that defines a circle which includes all pixels on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Radius[mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="2">
+                <widget class="QPushButton" name="transmission_roi_files_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLineEdit" name="transmission_roi_files_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of ROI files which define areas on the bank which contribute to the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLineEdit" name="transmission_mn_5_shift_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between beamstop monitor and detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="transmission_target_label">
+                 <property name="text">
+                  <string>Transmission target</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="transmission_mask_files_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of MASK files which define areas on the bank which are excluded from the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Mask Files</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLineEdit" name="transmission_mask_files_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A comma-separated list of MASK files which define areas on the bank which are excluded from the transmission calculation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="2">
+                <widget class="QPushButton" name="transmission_mask_files_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="wide_angle_label">
+                 <property name="text">
+                  <string>Wide Angle Correction</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QCheckBox" name="wide_angle_check_box">
+                 <property name="toolTip">
+                  <string>Perform a wide angle correction to the transmission</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0" colspan="3">
+                <widget class="QGroupBox" name="fit_combo_box">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>140</height>
+                  </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fit options for the transmission calculation. These can be either set for both the Sample and the Can run or separately.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="title">
+                  <string>Fit</string>
+                 </property>
+                 <property name="flat">
+                  <bool>false</bool>
+                 </property>
+                 <property name="checkable">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_22">
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="horizontalSpacing">
+                   <number>-1</number>
+                  </property>
+                  <property name="verticalSpacing">
+                   <number>1</number>
+                  </property>
+                  <item row="0" column="4">
+                   <widget class="QLabel" name="fit_fit_type_label">
+                    <property name="text">
+                     <string>Fit type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="5">
+                   <widget class="QSpinBox" name="fit_can_polynomial_order_spin_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="minimum">
+                     <number>2</number>
+                    </property>
+                    <property name="maximum">
+                     <number>6</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="5">
+                   <widget class="QLabel" name="fit_polynomial_order_label">
+                    <property name="text">
+                     <string>Poly. order</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QLabel" name="fit_can_label">
+                    <property name="text">
+                     <string>Can</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="3">
+                   <widget class="QCheckBox" name="fit_can_use_fit_check_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Use fit</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="4">
+                   <widget class="QComboBox" name="fit_sample_fit_type_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="4">
+                   <widget class="QComboBox" name="fit_can_fit_type_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="5">
+                   <widget class="QSpinBox" name="fit_sample_polynomial_order_spin_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="minimum">
+                     <number>2</number>
+                    </property>
+                    <property name="maximum">
+                     <number>6</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="fit_selection_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects if fit options should be the same (Both) for Sample and Can, or if the user should be able to set them separately (Separate).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Both</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Separate</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="fit_sample_label">
+                    <property name="text">
+                     <string>Sample              </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QCheckBox" name="fit_sample_use_fit_check_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Use fit</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="6" rowspan="2">
+                   <widget class="QGroupBox" name="fit_sample_wavelength_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="title">
+                     <string>&amp;Use custom wavelength range [Å]</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_14">
+                     <property name="spacing">
+                      <number>1</number>
+                     </property>
+                     <property name="leftMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>10</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="fit_sample_from_label">
+                       <property name="text">
+                        <string>from</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="fit_sample_wavelength_min_line_edit">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="fit_sample_to_label">
+                       <property name="text">
+                        <string>to</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="fit_sample_wavelength_max_line_edit">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="3" column="6">
+                   <widget class="QGroupBox" name="fit_can_wavelength_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="title">
+                     <string>Use custom wavelength range [&amp;Å]</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_13">
+                     <property name="spacing">
+                      <number>1</number>
+                     </property>
+                     <property name="leftMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>10</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>10</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="fit_can_from_label">
+                       <property name="text">
+                        <string>from</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="fit_can_wavelength_min_line_edit">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="fit_can_to_label">
+                       <property name="text">
+                        <string>to</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="fit_can_wavelength_max_line_edit">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="wavelength_adjustment_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The wavelength adjustment files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Wavelength efficiency files</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_11">
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="wavelength_adjustment_det_1_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="wavelength_adjustment_det_1_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Det 1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="wavelength_adjustment_det_2_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Det 2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLineEdit" name="wavelength_adjustment_det_2_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the wavelength adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QPushButton" name="wavelength_adjustment_det_1_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QPushButton" name="wavelength_adjustment_det_2_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="pixel_adjustment_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pixel adjustment files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Pixel adjustment files</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_10">
+               <item row="1" column="2">
+                <widget class="QPushButton" name="pixel_adjustment_det_2_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="pixel_adjustment_det_2_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Det1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="pixel_adjustment_det_2_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="pixel_adjustement_det_1_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the second detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Det2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="pixel_adjustment_det_1_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The path to the pixel adjustment file for the first detector.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QPushButton" name="pixel_adjustment_det_1_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="q_tab">
+           <attribute name="title">
+            <string>Q, Wavelength, Detector Limits</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="2,1,2,1,3,0">
+            <property name="spacing">
+             <number>1</number>
+            </property>
+            <property name="leftMargin">
+             <number>11</number>
+            </property>
+            <property name="topMargin">
+             <number>11</number>
+            </property>
+            <property name="rightMargin">
+             <number>11</number>
+            </property>
+            <property name="bottomMargin">
+             <number>11</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="limits_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disk mask which is useful for the beam stop&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string/>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_14">
+               <item row="0" column="1">
+                <widget class="QLabel" name="radius_limit_min_label">
+                 <property name="text">
+                  <string>Min [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="phi_limit">
+                 <property name="text">
+                  <string>Phi Limit:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="4">
+                <widget class="QLineEdit" name="radius_limit_max_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upper radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1" colspan="4">
+                <widget class="QStackedWidget" name="phi_range_stacked_widget">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="currentIndex">
+                  <number>0</number>
+                 </property>
+                 <widget class="QWidget" name="page_min_max">
+                  <layout class="QHBoxLayout" name="horizontalLayout">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="phi_limit_from_label">
+                     <property name="minimumSize">
+                      <size>
+                       <width>78</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>From</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="phi_limit_min_line_edit">
+                     <property name="minimumSize">
+                      <size>
+                       <width>125</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="phi_limit_to_label">
+                     <property name="minimumSize">
+                      <size>
+                       <width>66</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>To</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="phi_limit_max_line_edit">
+                     <property name="minimumSize">
+                      <size>
+                       <width>125</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stop angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="page_ranges">
+                  <layout class="QHBoxLayout" name="horizontalLayout_6">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="phi_range_label">
+                     <property name="text">
+                      <string>Ranges (e.g.-5.0,10.0, 75.0,90.0)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="phi_range_line_edit">
+                     <property name="toolTip">
+                      <string>Set a set of phi ranges as pairs: </string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QComboBox" name="phi_range_step_type_combo_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PhiLimit type: if it is MinMax, the phi slice will be cut from a minimum (From) to a maximum (To). If pairs type is selected, the range can be input as pairs of numbers, each separated by comma (If input is: -15.0, 15.0, 45.0,90.0 two phi slices will be reduced: -15.0,15.0 and 45.0,90.0&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="cuts_label">
+                 <property name="text">
+                  <string>Cuts:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_8">
+                 <property name="toolTip">
+                  <string>Set the Phi limit type</string>
+                 </property>
+                 <property name="text">
+                  <string>PhiLimit type</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="radius_limit_max_label">
+                 <property name="text">
+                  <string>Max [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="radius_limit">
+                 <property name="text">
+                  <string>Radius Limit:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLineEdit" name="radius_limit_min_line_edit">
+                 <property name="minimumSize">
+                  <size>
+                   <width>125</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="q_1d_label_2">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>RCut [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QLineEdit" name="r_cut_line_edit"/>
+               </item>
+               <item row="3" column="3">
+                <widget class="QLabel" name="q_1d_label_3">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>WCut [Å]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="4">
+                <widget class="QLineEdit" name="w_cut_line_edit"/>
+               </item>
+               <item row="2" column="5">
+                <widget class="QCheckBox" name="phi_limit_use_mirror_check_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the mirror sector should be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>use mirror sector</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="wavelength_group_box">
+              <property name="title">
+               <string>Wavelength</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_9">
+               <item>
+                <widget class="QStackedWidget" name="wavelength_stacked_widget">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>66</height>
+                  </size>
+                 </property>
+                 <property name="lineWidth">
+                  <number>0</number>
+                 </property>
+                 <property name="currentIndex">
+                  <number>0</number>
+                 </property>
+                 <widget class="QWidget" name="page">
+                  <layout class="QGridLayout" name="gridLayout_3">
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="wavelength_min_label">
+                     <property name="text">
+                      <string>Min [Å]</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QLabel" name="wavelength_max_label">
+                     <property name="text">
+                      <string>Max  [Å]</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QLineEdit" name="wavelength_max_line_edit"/>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QLineEdit" name="wavelength_min_line_edit"/>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="page_2">
+                  <layout class="QGridLayout" name="gridLayout_6">
+                   <item row="2" column="0">
+                    <widget class="QLineEdit" name="wavelength_slices_line_edit">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It is possible to perform wavelength slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies wavelength slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a wavelength slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;p&gt;A reduction will always be done between the maximum and minimum wavelengths of a given set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_7">
+                     <property name="toolTip">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It is possible to perform wavelength slices of the data and reduce these separately.&lt;/p&gt;&lt;p&gt;Input can be:&lt;/p&gt;&lt;p&gt;-&lt;span style=&quot; font-style:italic;&quot;&gt; start:step:stop&lt;/span&gt; specifies wavelength slices from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value in steps of &lt;span style=&quot; font-style:italic;&quot;&gt;step&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;start-stop &lt;/span&gt;which specifies a wavelength slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start&lt;/span&gt; value to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop&lt;/span&gt; value&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;start&lt;/span&gt; specifies a slice from the &lt;span style=&quot; font-style:italic;&quot;&gt;start &lt;/span&gt;value to the end of the data set&lt;/p&gt;&lt;p&gt;- &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;lt;stop&lt;/span&gt; specifes a slice from the start of the data set to the &lt;span style=&quot; font-style:italic;&quot;&gt;stop &lt;/span&gt;value&lt;/p&gt;&lt;p&gt;In addition it is possible to concatenate these specifications using comma-separation. An example is:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;5-10,12:2:16,20-30&lt;/span&gt;&lt;/p&gt;&lt;p&gt;A reduction will always be done between the maximum and minimum wavelengths of a given set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                     <property name="text">
+                      <string>Ranges  [Å]  (e.g: 5-10,12:2:16,20-30)</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="wavelength_widget" native="true">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>66</height>
+                  </size>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_18">
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="wavelength_step_type_combo_box"/>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLabel" name="wavelength_step_type_label">
+                    <property name="text">
+                     <string>Step Type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLineEdit" name="wavelength_step_line_edit"/>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="wavelength_step_label">
+                    <property name="text">
+                     <string>Step  [Å]</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="q_limits_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the momentum transfer limits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Q limits</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_15">
+               <item row="3" column="4">
+                <widget class="QLineEdit" name="q_xy_step_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step of the momentum transfer for a 2D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="4">
+                <widget class="QLabel" name="q_xy_step_label">
+                 <property name="text">
+                  <string>Step [Å^-1]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLabel" name="q_min_label">
+                 <property name="text">
+                  <string>Min [Å^-1]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QLabel" name="q_xy_max_label">
+                 <property name="text">
+                  <string>Max [Å^-1]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QLineEdit" name="q_1d_min_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The lower bound of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLineEdit" name="q_1d_max_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The upper bound of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="5">
+                <widget class="QComboBox" name="q_1d_step_type_combo_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step type of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="3">
+                <widget class="QLineEdit" name="q_xy_max_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The upper bound of the momentum transfer for a 2D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="5">
+                <widget class="QLabel" name="q_step_type_label">
+                 <property name="text">
+                  <string>Step type</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="4">
+                <widget class="QLineEdit" name="q_1d_step_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step of the momentum transfer for a 1D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="q_max_label">
+                 <property name="text">
+                  <string>Max [Å^-1]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="4">
+                <widget class="QLabel" name="q_step_label">
+                 <property name="text">
+                  <string>Step [Å^-1]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="q_xy_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 2D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Qxy</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="q_1d_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Q1D</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="gravity_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gravity settings. If checked then gravity will be accounted for in the reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Account &amp;for gravity</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_17">
+               <item row="0" column="0">
+                <widget class="QLabel" name="gravity_extra_length_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extra length for the gravity correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Extra length [m]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="gravity_extra_length_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extra length for the gravity correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="q_resolution_group_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for Q resolution. If checked, then the Q resolution is used, else not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="title">
+               <string>Q resolution</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_13">
+               <item row="0" column="0" colspan="2">
+                <widget class="QComboBox" name="q_resolution_shape_combo_box">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selection of the aperture. This can be either a rectangular or a circular aperture&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>Pinhole</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Slit</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="q_resolution_source_a_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>A1 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QLabel" name="q_resolution_sample_a_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>A2 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="q_resolution_source_h_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QLabel" name="q_resolution_sample_w_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>W2 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QLineEdit" name="q_resolution_sample_w_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="q_resolution_collimation_length_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The collimation length.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Collimation length [m]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="2">
+                <widget class="QLabel" name="q_resolution_delta_r_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delta r.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Delta r [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1" colspan="2">
+                <widget class="QLineEdit" name="q_resolution_moderator_file_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the moderator file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="3">
+                <widget class="QPushButton" name="q_resolution_moderator_file_push_button">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="q_resolution_moderator_file_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to the moderator file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Moderator file</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLineEdit" name="q_resolution_collimation_length_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The collimation length.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="3">
+                <widget class="QLineEdit" name="q_resolution_delta_r_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delta r.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="3">
+                <widget class="QLineEdit" name="q_resolution_sample_a_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLineEdit" name="q_resolution_source_a_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of a circular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLineEdit" name="q_resolution_source_w_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="q_resolution_source_h_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>H1 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLineEdit" name="q_resolution_sample_h_line_edit">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="q_resolution_source_w_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of a rectangular source aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>W1 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QLabel" name="q_resolution_sample_h_label">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of a rectangular sample aperature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>H2 [mm]</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+          <widget class="SettingsDiagnosticTab" name="settings_diagnostic_tab">
+           <attribute name="title">
+            <string>State Diagnostic</string>
+           </attribute>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="BeamCentre" name="beam_centre"/>
+      <widget class="AddRunsPage" name="add_runs_page"/>
+      <widget class="DiagnosticsPage" name="diagnostic_page"/>
+     </widget>
     </item>
    </layout>
   </widget>
@@ -2478,27 +2540,14 @@ QGroupBox::title {
   <tabstop>transmission_mask_files_line_edit</tabstop>
   <tabstop>transmission_roi_files_push_button</tabstop>
   <tabstop>transmission_mask_files_push_button</tabstop>
-  <tabstop>fit_selection_combo_box</tabstop>
-  <tabstop>fit_sample_use_fit_check_box</tabstop>
-  <tabstop>fit_sample_fit_type_combo_box</tabstop>
-  <tabstop>fit_sample_polynomial_order_spin_box</tabstop>
-  <tabstop>fit_sample_wavelength_combo_box</tabstop>
   <tabstop>fit_sample_wavelength_min_line_edit</tabstop>
   <tabstop>fit_sample_wavelength_max_line_edit</tabstop>
-  <tabstop>fit_can_use_fit_check_box</tabstop>
-  <tabstop>fit_can_fit_type_combo_box</tabstop>
-  <tabstop>fit_can_polynomial_order_spin_box</tabstop>
-  <tabstop>fit_can_wavelength_combo_box</tabstop>
   <tabstop>fit_can_wavelength_min_line_edit</tabstop>
   <tabstop>fit_can_wavelength_max_line_edit</tabstop>
   <tabstop>pixel_adjustment_det_1_line_edit</tabstop>
   <tabstop>pixel_adjustment_det_1_push_button</tabstop>
   <tabstop>pixel_adjustment_det_2_line_edit</tabstop>
   <tabstop>pixel_adjustment_det_2_push_button</tabstop>
-  <tabstop>wavelength_adjustment_det_1_line_edit</tabstop>
-  <tabstop>wavelength_adjustment_det_1_push_button</tabstop>
-  <tabstop>wavelength_adjustment_det_2_line_edit</tabstop>
-  <tabstop>wavelength_adjustment_det_2_push_button</tabstop>
   <tabstop>q_1d_min_line_edit</tabstop>
   <tabstop>q_1d_max_line_edit</tabstop>
   <tabstop>q_1d_step_line_edit</tabstop>

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -655,7 +655,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>3</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">
@@ -1710,65 +1710,183 @@ QGroupBox::title {
                   <string/>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14">
-                  <property name="leftMargin">
-                   <number>6</number>
-                  </property>
-                  <item row="4" column="5">
-                   <widget class="QCheckBox" name="phi_limit_use_mirror_check_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the mirror sector should be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
+                  <item row="0" column="1">
+                   <widget class="QLabel" name="radius_limit_min_label">
                     <property name="text">
-                     <string>use mirror sector</string>
+                     <string>Min [mm]</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="2">
-                   <widget class="QLineEdit" name="phi_limit_min_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="cuts_label">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="phi_limit">
                     <property name="text">
-                     <string>Cuts:</string>
+                     <string>Phi Limit:</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="4">
-                   <widget class="QLineEdit" name="phi_limit_max_line_edit">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stop angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="4">
-                   <widget class="QLineEdit" name="w_cut_line_edit"/>
-                  </item>
-                  <item row="1" column="4">
+                  <item row="0" column="4">
                    <widget class="QLineEdit" name="radius_limit_max_line_edit">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upper radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="3">
+                  <item row="2" column="1" colspan="4">
+                   <widget class="QStackedWidget" name="phi_range_stacked_widget">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="currentIndex">
+                     <number>0</number>
+                    </property>
+                    <widget class="QWidget" name="page_min_max">
+                     <layout class="QHBoxLayout" name="horizontalLayout">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QLabel" name="phi_limit_from_label">
+                        <property name="minimumSize">
+                         <size>
+                          <width>66</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>From</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="phi_limit_min_line_edit">
+                        <property name="minimumSize">
+                         <size>
+                          <width>125</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="toolTip">
+                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="phi_limit_to_label">
+                        <property name="minimumSize">
+                         <size>
+                          <width>66</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>To</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="phi_limit_max_line_edit">
+                        <property name="minimumSize">
+                         <size>
+                          <width>125</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="toolTip">
+                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stop angle in degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="page_ranges">
+                     <layout class="QHBoxLayout" name="horizontalLayout_6">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QLabel" name="phi_range_label">
+                        <property name="text">
+                         <string>Ranges (e.g.-5.0,10.0, 75.0,90.0)</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="phi_range_line_edit">
+                        <property name="toolTip">
+                         <string>Set a set of phi ranges as pairs: </string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="phi_range_step_type_combo_box"/>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="cuts_label">
+                    <property name="text">
+                     <string>Cuts:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="label_8">
+                    <property name="text">
+                     <string>Phi Step</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
                    <widget class="QLabel" name="radius_limit_max_label">
                     <property name="text">
                      <string>Max [mm]</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="3">
-                   <widget class="QLabel" name="phi_limit_to_label">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="radius_limit">
                     <property name="text">
-                     <string>To</string>
+                     <string>Radius Limit:</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="1">
+                  <item row="0" column="2">
+                   <widget class="QLineEdit" name="radius_limit_min_line_edit">
+                    <property name="minimumSize">
+                     <size>
+                      <width>125</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
                    <widget class="QLabel" name="q_1d_label_2">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1778,7 +1896,10 @@ QGroupBox::title {
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="3">
+                  <item row="3" column="2">
+                   <widget class="QLineEdit" name="r_cut_line_edit"/>
+                  </item>
+                  <item row="3" column="3">
                    <widget class="QLabel" name="q_1d_label_3">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Momentum transfer settings for 1D reductions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1788,43 +1909,18 @@ QGroupBox::title {
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="radius_limit">
-                    <property name="text">
-                     <string>Radius Limit:</string>
-                    </property>
-                   </widget>
+                  <item row="3" column="4">
+                   <widget class="QLineEdit" name="w_cut_line_edit"/>
                   </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="phi_limit">
-                    <property name="text">
-                     <string>Phi Limit:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QLabel" name="phi_limit_from_label">
-                    <property name="text">
-                     <string>From</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QLineEdit" name="radius_limit_min_line_edit">
+                  <item row="2" column="5">
+                   <widget class="QCheckBox" name="phi_limit_use_mirror_check_box">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lower radius setting in mm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the mirror sector should be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLabel" name="radius_limit_min_label">
                     <property name="text">
-                     <string>Min [mm]</string>
+                     <string>use mirror sector</string>
                     </property>
                    </widget>
-                  </item>
-                  <item row="6" column="2">
-                   <widget class="QLineEdit" name="r_cut_line_edit"/>
                   </item>
                  </layout>
                 </widget>
@@ -1860,7 +1956,7 @@ QGroupBox::title {
                      <number>0</number>
                     </property>
                     <property name="currentIndex">
-                     <number>1</number>
+                     <number>0</number>
                     </property>
                     <widget class="QWidget" name="page">
                      <layout class="QGridLayout" name="gridLayout_3">

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1544</width>
-    <height>808</height>
+    <width>1346</width>
+    <height>806</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -1101,7 +1101,7 @@ QGroupBox::title {
            <attribute name="title">
             <string>Adjustment</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,4,1,1">
+           <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,4,1,1,0">
             <property name="spacing">
              <number>1</number>
             </property>
@@ -1359,97 +1359,8 @@ QGroupBox::title {
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_22">
-                  <property name="leftMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="horizontalSpacing">
-                   <number>-1</number>
-                  </property>
-                  <property name="verticalSpacing">
-                   <number>1</number>
-                  </property>
-                  <item row="0" column="4">
-                   <widget class="QLabel" name="fit_fit_type_label">
-                    <property name="text">
-                     <string>Fit type</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="5">
-                   <widget class="QSpinBox" name="fit_can_polynomial_order_spin_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="minimum">
-                     <number>2</number>
-                    </property>
-                    <property name="maximum">
-                     <number>6</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="5">
-                   <widget class="QLabel" name="fit_polynomial_order_label">
-                    <property name="text">
-                     <string>Poly. order</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QLabel" name="fit_can_label">
-                    <property name="text">
-                     <string>Can</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="3">
-                   <widget class="QCheckBox" name="fit_can_use_fit_check_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Use fit</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="4">
-                   <widget class="QComboBox" name="fit_sample_fit_type_combo_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="4">
-                   <widget class="QComboBox" name="fit_can_fit_type_combo_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="5">
-                   <widget class="QSpinBox" name="fit_sample_polynomial_order_spin_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="minimum">
-                     <number>2</number>
-                    </property>
-                    <property name="maximum">
-                     <number>6</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
+                 <layout class="QGridLayout" name="gridLayout_8">
+                  <item row="0" column="0">
                    <widget class="QComboBox" name="fit_selection_combo_box">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects if fit options should be the same (Both) for Sample and Can, or if the user should be able to set them separately (Separate).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1466,14 +1377,68 @@ QGroupBox::title {
                     </item>
                    </widget>
                   </item>
-                  <item row="1" column="1">
+                  <item row="0" column="1">
+                   <spacer name="horizontalSpacer_7">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>156</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="fit_fit_type_label">
+                    <property name="text">
+                     <string>Fit type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
+                   <widget class="QLabel" name="fit_polynomial_order_label">
+                    <property name="text">
+                     <string>Poly. order</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="4">
+                   <spacer name="horizontalSpacer_8">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>225</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="5">
+                   <widget class="QLabel" name="fit_sample_from_label">
+                    <property name="text">
+                     <string>from</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="6">
+                   <widget class="QLabel" name="fit_sample_to_label">
+                    <property name="text">
+                     <string>to</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
                    <widget class="QLabel" name="fit_sample_label">
                     <property name="text">
                      <string>Sample              </string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="3">
+                  <item row="1" column="1">
                    <widget class="QCheckBox" name="fit_sample_use_fit_check_box">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1483,126 +1448,109 @@ QGroupBox::title {
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="6" rowspan="2">
-                   <widget class="QGroupBox" name="fit_sample_wavelength_combo_box">
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="fit_sample_fit_type_combo_box">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
-                    <property name="title">
-                     <string>&amp;Use custom wavelength range [Å]</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_14">
-                     <property name="spacing">
-                      <number>1</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>10</number>
-                     </property>
-                     <item>
-                      <widget class="QLabel" name="fit_sample_from_label">
-                       <property name="text">
-                        <string>from</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="fit_sample_wavelength_min_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="fit_sample_to_label">
-                       <property name="text">
-                        <string>to</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="fit_sample_wavelength_max_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
                    </widget>
                   </item>
-                  <item row="3" column="6">
-                   <widget class="QGroupBox" name="fit_can_wavelength_combo_box">
+                  <item row="1" column="3">
+                   <widget class="QSpinBox" name="fit_sample_polynomial_order_spin_box">
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows for setting a custom wavelength range during fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
-                    <property name="title">
-                     <string>Use custom wavelength range [&amp;Å]</string>
+                    <property name="minimum">
+                     <number>2</number>
                     </property>
-                    <property name="checkable">
-                     <bool>true</bool>
+                    <property name="maximum">
+                     <number>6</number>
                     </property>
-                    <property name="checked">
-                     <bool>false</bool>
+                   </widget>
+                  </item>
+                  <item row="1" column="4">
+                   <widget class="QCheckBox" name="fit_sample_wavelength_combo_box">
+                    <property name="text">
+                     <string>Use Custom Wavelength range [&amp;Å] </string>
                     </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_13">
-                     <property name="spacing">
-                      <number>1</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>10</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>10</number>
-                     </property>
-                     <item>
-                      <widget class="QLabel" name="fit_can_from_label">
-                       <property name="text">
-                        <string>from</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="fit_can_wavelength_min_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="fit_can_to_label">
-                       <property name="text">
-                        <string>to</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="fit_can_wavelength_max_line_edit">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
+                   </widget>
+                  </item>
+                  <item row="1" column="5">
+                   <widget class="QLineEdit" name="fit_sample_wavelength_min_line_edit">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="6">
+                   <widget class="QLineEdit" name="fit_sample_wavelength_max_line_edit">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="fit_can_label">
+                    <property name="minimumSize">
+                     <size>
+                      <width>96</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Can</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QCheckBox" name="fit_can_use_fit_check_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Use fit</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QComboBox" name="fit_can_fit_type_combo_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If fitting should be used, then this allows for the selection of the fit type.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="3">
+                   <widget class="QSpinBox" name="fit_can_polynomial_order_spin_box">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If a polynomial fit type was selected, then the polynomial order of the fit can be specified here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="minimum">
+                     <number>2</number>
+                    </property>
+                    <property name="maximum">
+                     <number>6</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="4">
+                   <widget class="QCheckBox" name="fit_can_wavelength_combo_box">
+                    <property name="text">
+                     <string>Use Custom Wavelength range [&amp;Å] </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="5">
+                   <widget class="QLineEdit" name="fit_can_wavelength_min_line_edit">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The beginning of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="6">
+                   <widget class="QLineEdit" name="fit_can_wavelength_max_line_edit">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The end of the custom wavelength range.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -1730,6 +1678,19 @@ QGroupBox::title {
                </item>
               </layout>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>
@@ -2540,10 +2501,6 @@ QGroupBox::title {
   <tabstop>transmission_mask_files_line_edit</tabstop>
   <tabstop>transmission_roi_files_push_button</tabstop>
   <tabstop>transmission_mask_files_push_button</tabstop>
-  <tabstop>fit_sample_wavelength_min_line_edit</tabstop>
-  <tabstop>fit_sample_wavelength_max_line_edit</tabstop>
-  <tabstop>fit_can_wavelength_min_line_edit</tabstop>
-  <tabstop>fit_can_wavelength_max_line_edit</tabstop>
   <tabstop>pixel_adjustment_det_1_line_edit</tabstop>
   <tabstop>pixel_adjustment_det_1_push_button</tabstop>
   <tabstop>pixel_adjustment_det_2_line_edit</tabstop>

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -18,7 +18,7 @@ from sans.common.general_functions import (
     get_transmission_output_name,
     get_wav_range_from_ws,
 )
-from sans.common.enums import SANSDataType, SaveType, OutputMode, ReductionMode, DataType, CanonicalCoordinates
+from sans.common.enums import SANSDataType, SaveType, OutputMode, ReductionMode, DataType, CanonicalCoordinates, ReductionDimensionality
 from sans.common.constants import (
     TRANS_SUFFIX,
     SANS_SUFFIX,
@@ -705,10 +705,12 @@ def create_initial_reduction_packages(state, workspaces, monitors):
     for each one of these workspaces. Hence, we need to create a deep copy of them for each reduction package.
 
     The way multi-period files are handled over the different workspaces input types is:
-    1. The sample scatter period determines all other periods, i.e. if the sample scatter workspace is has only
+    1. The sample scatter period determines all other periods, i.e. if the sample scatter workspace has only
        one period, but the sample transmission has two, then only the first period is used.
     2. If the sample scatter period is not available on another workspace type, then the last period on that
        workspace type is used.
+
+    If multiple phi slices are selected, data is split in several reduction packages, one per slice.
 
     For the cases where the periods between the different workspaces types does not match, an information is logged.
 
@@ -742,16 +744,21 @@ def create_initial_reduction_packages(state, workspaces, monitors):
 
         # if we require multiple phi slicing
         phi_range = state.mask.phi_range if state.mask.phi_range else [state.mask.phi_min, state.mask.phi_max]
-        for phi_index in range(0, len(phi_range), 2):
-            phi_min = phi_range[phi_index]
-            phi_max = phi_range[phi_index + 1]
-            state_copy = deepcopy(state)
-            state_copy.mask.phi_min = phi_min
-            state_copy.mask.phi_max = phi_max
+        if len(phi_range) > 2 and state.reduction.reduction_dimensionality is not ReductionDimensionality.ONE_DIM:
+            # We select min and max of the whole range
+            phi_range = [min(phi_range), max(phi_range)]
 
-            # Set the period on the state
+        for phi_index in range(0, len(phi_range), 2):
+            # first set the period on state
+            state_copy = deepcopy(state)
             if requires_new_period_selection:
                 state_copy.data.sample_scatter_period = index + 1
+
+            # second set the phi slice
+            phi_min = phi_range[phi_index]
+            phi_max = phi_range[phi_index + 1]
+            state_copy.mask.phi_min = phi_min
+            state_copy.mask.phi_max = phi_max
 
             packages.append(
                 ReductionPackage(

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -739,20 +739,29 @@ def create_initial_reduction_packages(state, workspaces, monitors):
         for workspace_type, workspace_list in list(monitors.items()):
             workspace = get_workspace_for_index(index, workspace_list)
             monitors_for_package.update({workspace_type: workspace})
-        state_copy = deepcopy(state)
 
-        # Set the period on the state
-        if requires_new_period_selection:
-            state_copy.data.sample_scatter_period = index + 1
-        packages.append(
-            ReductionPackage(
-                state=state_copy,
-                workspaces=workspaces_for_package,
-                monitors=monitors_for_package,
-                is_part_of_wavelength_range_reduction=is_multi_wavelength,
-                is_part_of_multi_period_reduction=is_multi_period,
+        # if we require multiple phi slicing
+        phi_range = state.mask.phi_range if state.mask.phi_range else [state.mask.phi_min, state.mask.phi_max]
+        for phi_index in range(0, len(phi_range), 2):
+            phi_min = phi_range[phi_index]
+            phi_max = phi_range[phi_index + 1]
+            state_copy = deepcopy(state)
+            state_copy.mask.phi_min = phi_min
+            state_copy.mask.phi_max = phi_max
+
+            # Set the period on the state
+            if requires_new_period_selection:
+                state_copy.data.sample_scatter_period = index + 1
+
+            packages.append(
+                ReductionPackage(
+                    state=state_copy,
+                    workspaces=workspaces_for_package,
+                    monitors=monitors_for_package,
+                    is_part_of_wavelength_range_reduction=is_multi_wavelength,
+                    is_part_of_multi_period_reduction=is_multi_period,
+                )
             )
-        )
     return packages
 
 

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -607,6 +607,17 @@ def parse_event_slice_setting(string_to_parse):
     return parser.parse_user_input_range()
 
 
+def parse_simple_range_of_number_pairs(string_to_parse):
+    try:
+        number_str_list = string_to_parse.split(",")
+        if (list_length := len(number_str_list)) == 0 or list_length % 2 != 0:
+            raise ValueError("At least one pair of numbers separated by comma should be entered: eg: '-15.0,15.0'")
+        pair_list = [float(el) for el in number_str_list]
+    except ValueError as e:
+        raise ValueError(f"The provided string: '{string_to_parse}' , could not be converted to a list of pair of floats\n" + str(e))
+    return pair_list
+
+
 def get_ranges_from_event_slice_setting(string_to_parse):
     parsed_elements = parse_event_slice_setting(string_to_parse)
     return parsed_elements

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -13,7 +13,7 @@ are not available in the model associated with the data table.
 from typing import Union
 
 from sans.common.enums import ReductionDimensionality, ReductionMode, RangeStepType, SaveType, DetectorType, FitModeForMerge
-from sans.common.general_functions import get_ranges_from_event_slice_setting, wav_ranges_to_str
+from sans.common.general_functions import get_ranges_from_event_slice_setting, wav_ranges_to_str, parse_simple_range_of_number_pairs
 from sans.gui_logic.models.model_common import ModelCommon
 from sans.state.AllStates import AllStates
 from sans.gui_logic.gui_common import meter_2_millimeter, millimeter_2_meter, apply_selective_view_scaling, undo_selective_view_scaling
@@ -689,6 +689,7 @@ class StateGuiModel(ModelCommon):
 
     @phi_limit_min.setter
     def phi_limit_min(self, value):
+        self._all_states.mask.phi_range = [value, self._all_states.mask.phi_max]
         self._all_states.mask.phi_min = value
 
     @property
@@ -698,7 +699,17 @@ class StateGuiModel(ModelCommon):
 
     @phi_limit_max.setter
     def phi_limit_max(self, value):
+        self._all_states.mask.phi_range = [self._all_states.mask.phi_min, value]
         self._all_states.mask.phi_max = value
+
+    @property
+    def phi_range(self):
+        val = ",".join(map(str, self._all_states.mask.phi_range))
+        return self._get_val_or_default(val, "")
+
+    @phi_range.setter
+    def phi_range(self, value):
+        self._all_states.mask.phi_range = parse_simple_range_of_number_pairs(value)
 
     @property
     def phi_limit_use_mirror(self):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -285,6 +285,9 @@ class RunTabPresenter(PresenterCommon):
         sample_shape = ["Read from file", SampleShape.CYLINDER, SampleShape.FLAT_PLATE, SampleShape.DISC]
         self._view.sample_shape = sample_shape
 
+        phi_step_types = ["MinMax", "Pairs"]
+        self._view.phi_range_step_type = phi_step_types
+
         # Set the q range
         self._view.q_1d_step_type = [RangeStepType.LIN.value, RangeStepType.LOG.value]
 
@@ -507,7 +510,6 @@ class RunTabPresenter(PresenterCommon):
     def update_view_from_table_model(self):
         self._view.clear_table()
         self._view.hide_period_columns()
-
         num_rows = self._table_model.get_number_of_rows()
         for row_index in range(num_rows):
             row = self._table_model.get_row(row_index)
@@ -1039,6 +1041,7 @@ class RunTabPresenter(PresenterCommon):
         # Mask
         self._set_on_view("phi_limit_min")
         self._set_on_view("phi_limit_max")
+        self._set_on_view("phi_range")
         self._set_on_view("phi_limit_use_mirror")
         self._set_on_view("radius_limit_min", self.DEFAULT_DECIMAL_PLACES_MM)
         self._set_on_view("radius_limit_max", self.DEFAULT_DECIMAL_PLACES_MM)
@@ -1162,6 +1165,7 @@ class RunTabPresenter(PresenterCommon):
             self._set_on_custom_model("phi_limit_min", state_model)
             self._set_on_custom_model("phi_limit_max", state_model)
             self._set_on_custom_model("phi_limit_use_mirror", state_model)
+            self._set_on_custom_model("phi_range", state_model)
             self._set_on_custom_model("radius_limit_min", state_model)
             self._set_on_custom_model("radius_limit_max", state_model)
 

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -15,6 +15,7 @@ import time
 import traceback
 from contextlib import contextmanager
 from functools import wraps
+from itertools import chain
 from typing import Optional
 
 from mantidqt.utils.observer_pattern import GenericObserver
@@ -1109,77 +1110,87 @@ class RunTabPresenter(PresenterCommon):
 
         state_model.save_types = self._run_tab_model.get_save_types().to_all_states()
 
-        try:
-            # Run tab view
-            self._set_on_custom_model("zero_error_free", state_model)
-            self._set_on_custom_model("compatibility_mode", state_model)
-            self._set_on_custom_model("event_slice_optimisation", state_model)
-            self._set_on_custom_model("merge_scale", state_model)
-            self._set_on_custom_model("merge_shift", state_model)
-            self._set_on_custom_model("merge_scale_fit", state_model)
-            self._set_on_custom_model("merge_shift_fit", state_model)
-            self._set_on_custom_model("merge_q_range_start", state_model)
-            self._set_on_custom_model("merge_q_range_stop", state_model)
-            self._set_on_custom_model("merge_mask", state_model)
-            self._set_on_custom_model("merge_max", state_model)
-            self._set_on_custom_model("merge_min", state_model)
+        # This dictionary is flattened when updating the model, but is defined as a dict for clarity
+        state_model_properties = {
+            "run_tab": [
+                "zero_error_free",
+                "compatibility_mode",
+                "event_slice_optimisation",
+                "merge_scale",
+                "merge_shift",
+                "merge_scale_fit",
+                "merge_shift_fit",
+                "merge_q_range_start",
+                "merge_q_range_stop",
+                "merge_mask",
+                "merge_max",
+                "merge_min",
+            ],
+            "settings_tab": [
+                "reduction_dimensionality",
+                "reduction_mode",
+                "event_slices",
+                "event_binning",
+                "wavelength_min",
+                "wavelength_max",
+                "wavelength_range",
+                "wavelength_step",
+                "wavelength_step_type",
+                "absolute_scale",
+                "z_offset",
+            ],
+            "Q_tab": [
+                "q_xy_max",
+                "q_xy_step",
+                "gravity_on_off",
+                "gravity_extra_length",
+                "use_q_resolution",
+                "q_resolution_source_a",
+                "q_resolution_sample_a",
+                "q_resolution_source_h",
+                "q_resolution_sample_h",
+                "q_resolution_source_w",
+                "q_resolution_sample_w",
+                "q_resolution_delta_r",
+                "q_resolution_collimation_length",
+                "q_resolution_moderator_file",
+                "r_cut",
+                "w_cut",
+                "q_1d",
+            ],
+            "mask": ["phi_limit_min", "phi_limit_max", "phi_limit_use_mirror", "phi_range", "radius_limit_min", "radius_limit_max"],
+            "user_file": ["user_file", "batch_file"],
+            "beam_centre": ["rear_pos_1", "rear_pos_2", "front_pos_1", "front_pos_2"],
+        }
+        set_decimals_on_mm = ["z_offset", "q_resolution_delta_r", "r_cut", "radius_limit_min", "radius_limit_max"]
+        q_res = [
+            "q_resolution_source_a",
+            "q_resolution_sample_a",
+            "q_resolution_source_h",
+            "q_resolution_sample_h",
+            "q_resolution_source_w",
+            "q_resolution_sample_w",
+        ]
 
-            # Settings tab
-            self._set_on_custom_model("reduction_dimensionality", state_model)
-            self._set_on_custom_model("reduction_mode", state_model)
-            self._set_on_custom_model("event_slices", state_model)
-            self._set_on_custom_model("event_binning", state_model)
+        for model_prop in chain.from_iterable(state_model_properties.values()):
+            try:
+                if model_prop in state_model_properties["beam_centre"]:
+                    self._beam_centre_presenter.set_on_state_model(model_prop, state_model)
+                elif model_prop == "q_1d":
+                    self._set_on_state_model_q_1d_rebin_string(state_model)
+                else:
+                    self._set_on_custom_model(model_prop, state_model)
 
-            self._set_on_custom_model("wavelength_min", state_model)
-            self._set_on_custom_model("wavelength_max", state_model)
-            self._set_on_custom_model("wavelength_range", state_model)
-            self._set_on_custom_model("wavelength_step", state_model)
-            self._set_on_custom_model("wavelength_step_type", state_model)
-
-            self._set_on_custom_model("absolute_scale", state_model)
-            self._set_on_custom_model("z_offset", state_model)
-
-            # Q tab
-            self._set_on_state_model_q_1d_rebin_string(state_model)
-            self._set_on_custom_model("q_xy_max", state_model)
-            self._set_on_custom_model("q_xy_step", state_model)
-
-            self._set_on_custom_model("gravity_on_off", state_model)
-            self._set_on_custom_model("gravity_extra_length", state_model)
-
-            self._set_on_custom_model("use_q_resolution", state_model)
-            self._set_on_custom_model("q_resolution_source_a", state_model)
-            self._set_on_custom_model("q_resolution_sample_a", state_model)
-            self._set_on_custom_model("q_resolution_source_h", state_model)
-            self._set_on_custom_model("q_resolution_sample_h", state_model)
-            self._set_on_custom_model("q_resolution_source_w", state_model)
-            self._set_on_custom_model("q_resolution_sample_w", state_model)
-            self._set_on_custom_model("q_resolution_delta_r", state_model)
-            self._set_on_custom_model("q_resolution_collimation_length", state_model)
-            self._set_on_custom_model("q_resolution_moderator_file", state_model)
-
-            self._set_on_custom_model("r_cut", state_model)
-            self._set_on_custom_model("w_cut", state_model)
-
-            # Mask
-            self._set_on_custom_model("phi_limit_min", state_model)
-            self._set_on_custom_model("phi_limit_max", state_model)
-            self._set_on_custom_model("phi_limit_use_mirror", state_model)
-            self._set_on_custom_model("phi_range", state_model)
-            self._set_on_custom_model("radius_limit_min", state_model)
-            self._set_on_custom_model("radius_limit_max", state_model)
-
-            # User file and batch file
-            self._set_on_custom_model("user_file", state_model)
-            self._set_on_custom_model("batch_file", state_model)
-
-            # Beam Centre
-            self._beam_centre_presenter.set_on_state_model("rear_pos_1", state_model)
-            self._beam_centre_presenter.set_on_state_model("rear_pos_2", state_model)
-            self._beam_centre_presenter.set_on_state_model("front_pos_1", state_model)
-            self._beam_centre_presenter.set_on_state_model("front_pos_2", state_model)
-        except (RuntimeError, ValueError) as e:
-            self.display_warning_box(title="Invalid Settings Entered", text=str(e), detailed_text=str(e))
+            except (RuntimeError, ValueError) as e:
+                self.display_warning_box(title="Invalid Settings Entered", text=str(e), detailed_text=str(e))
+                if model_prop in set_decimals_on_mm:
+                    self._set_on_view(model_prop, self.DEFAULT_DECIMAL_PLACES_MM)
+                elif model_prop in q_res:
+                    self._set_on_view_q_resolution_aperture()
+                elif model_prop == "q_1d":
+                    self._set_on_view_q_rebin_string()
+                else:
+                    self._set_on_view(model_prop)
 
         return state_model
 

--- a/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
@@ -219,6 +219,7 @@ class StateMask(metaclass=JsonSerializable):
         self.phi_min = -90.0
         self.phi_max = 90.0
         self.use_mask_phi_mirror = True
+        self.phi_range: List[float] = []  # This attribute is not set from the user file, but from sans gui
 
         # Beam stop
         self.beam_stop_arm_width: float = 0.0

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -516,6 +516,8 @@ class TomlV1ParserImpl(TomlParserImplBase):
                 self.mask.phi_min = phi_mask["start"]
             if "stop" in phi_mask:
                 self.mask.phi_max = phi_mask["stop"]
+            if "range" in phi_mask:
+                self.mask.phi_range = phi_mask["range"]
 
     @staticmethod
     def _get_1d_min_max(one_d_binning: str):

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -103,7 +103,7 @@ class TomlSchemaV1Validator(TomlSchemaValidator):
         mask_keys = {
             "prompt_peak": {"start", "stop"},
             "mask_files": None,
-            "phi": {"mirror", "start", "stop"},
+            "phi": {"mirror", "start", "stop", "range"},
             "time": {"tof"},
             "spatial": {
                 "rear": {"detector_columns", "detector_rows", "detector_column_ranges", "detector_row_ranges"},

--- a/scripts/test/SANS/SansIsisGuiSettings.py
+++ b/scripts/test/SANS/SansIsisGuiSettings.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.simpleapi import config
-import ISISCommandInterface as i
+import ISISCommandInterface as ici
 
 MASKFILE = "MaskSANS2D.txt"
 
@@ -14,8 +14,8 @@ MASKFILE = "MaskSANS2D.txt"
 class Sans2DIsisGuiSettings(unittest.TestCase):
     def setUp(self):
         config["default.instrument"] = "SANS2D"
-        i.SANS2D()
-        i.MaskFile(MASKFILE)
+        ici.SANS2D()
+        ici.MaskFile(MASKFILE)
 
     def checkFloat(self, f1, f2):
         self.assertAlmostEqual(f1, f2)
@@ -30,28 +30,28 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         pass
 
     def test_read_set_gravity(self):  # GUI: gravity_check
-        i.Gravity(True)
-        self.assertTrue(i.ReductionSingleton().to_Q.get_gravity())
-        i.Gravity(False)
-        self.assertTrue(not i.ReductionSingleton().to_Q.get_gravity())
+        ici.Gravity(True)
+        self.assertTrue(ici.ReductionSingleton().to_Q.get_gravity())
+        ici.Gravity(False)
+        self.assertTrue(not ici.ReductionSingleton().to_Q.get_gravity())
 
     def test_read_set_radius(self):  # GUI: rad_min, rad_max
         min_value, max_value = 1.2, 18.9
-        i.ReductionSingleton().user_settings.readLimitValues("L/R %f %f" % (min_value, max_value), i.ReductionSingleton())
-        self.checkFloat(i.ReductionSingleton().mask.min_radius, min_value / 1000)
-        self.checkFloat(i.ReductionSingleton().mask.max_radius, max_value / 1000)
+        ici.ReductionSingleton().user_settings.readLimitValues("L/R %f %f" % (min_value, max_value), ici.ReductionSingleton())
+        self.checkFloat(ici.ReductionSingleton().mask.min_radius, min_value / 1000)
+        self.checkFloat(ici.ReductionSingleton().mask.max_radius, max_value / 1000)
 
     def test_read_set_wav(self):  # GUI: wav_min, wav_max, wav_dw, wav_dw_opt
         min_value, max_value, step, option = 1.2, 4.5, 0.1, "LIN"
-        i.LimitsWav(min_value, max_value, step, option)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_low, min_value)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_high, max_value)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_step, step)
+        ici.LimitsWav(min_value, max_value, step, option)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_low, min_value)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_high, max_value)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_step, step)
         min_value, max_value, step, option = 1.2, 4.5, 0.1, "LOG"
-        i.LimitsWav(min_value, max_value, step, option)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_low, min_value)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_high, max_value)
-        self.checkFloat(i.ReductionSingleton().to_wavelen.wav_step, -step)
+        ici.LimitsWav(min_value, max_value, step, option)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_low, min_value)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_high, max_value)
+        self.checkFloat(ici.ReductionSingleton().to_wavelen.wav_step, -step)
 
     def test_wavRanges(self):  # wavRanges, wav_stack, wav_dw_opt
         # it seems to be accessible only through gui, changing the reduction
@@ -76,39 +76,39 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         opt_pattern = "%f %f %f/%s"
         option = "LIN"
         min_max_step_option = opt_pattern % (min_value, max_value, step_value, option)
-        i.ReductionSingleton().user_settings.readLimitValues("L/Q " + min_max_step_option, i.ReductionSingleton())
-        checkvalues(min_value, max_value, step_value, i.ReductionSingleton().to_Q.binning)
+        ici.ReductionSingleton().user_settings.readLimitValues("L/Q " + min_max_step_option, ici.ReductionSingleton())
+        checkvalues(min_value, max_value, step_value, ici.ReductionSingleton().to_Q.binning)
 
         option = "LOG"
         min_max_step_option = opt_pattern % (min_value, max_value, step_value, option)
-        i.ReductionSingleton().user_settings.readLimitValues("L/Q " + min_max_step_option, i.ReductionSingleton())
-        checkvalues(min_value, max_value, -step_value, i.ReductionSingleton().to_Q.binning)
+        ici.ReductionSingleton().user_settings.readLimitValues("L/Q " + min_max_step_option, ici.ReductionSingleton())
+        checkvalues(min_value, max_value, -step_value, ici.ReductionSingleton().to_Q.binning)
 
         rebining_option = ".001,.001,.0126,-.08,.2"
-        i.ReductionSingleton().user_settings.readLimitValues("L/Q " + rebining_option, i.ReductionSingleton())
-        checklistvalues(rebining_option, i.ReductionSingleton().to_Q.binning)
+        ici.ReductionSingleton().user_settings.readLimitValues("L/Q " + rebining_option, ici.ReductionSingleton())
+        checklistvalues(rebining_option, ici.ReductionSingleton().to_Q.binning)
 
     def test_qy(self):  # qy_max, qy_dqy, qy_dqy_opt
         value_max, value_step = 0.06, 0.002
-        i.LimitsQXY(0.0, value_max, value_step)
-        self.checkFloat(i.ReductionSingleton().QXY2, value_max)
-        self.checkFloat(i.ReductionSingleton().DQXY, value_step)
+        ici.LimitsQXY(0.0, value_max, value_step)
+        self.checkFloat(ici.ReductionSingleton().QXY2, value_max)
+        self.checkFloat(ici.ReductionSingleton().DQXY, value_step)
 
     def test_fit(self):
         def checkEqualsOption(option, selector):
             if option[1] is not None:
-                self.checkFloat(i.ReductionSingleton().transmission_calculator.lambdaMin(selector), option[1])
+                self.checkFloat(ici.ReductionSingleton().transmission_calculator.lambdaMin(selector), option[1])
 
             if option[2] is not None:
-                self.checkFloat(i.ReductionSingleton().transmission_calculator.lambdaMax(selector), option[2])
-            self.checkObj(i.ReductionSingleton().transmission_calculator.fitMethod(selector), str(option[0]).upper())
+                self.checkFloat(ici.ReductionSingleton().transmission_calculator.lambdaMax(selector), option[2])
+            self.checkObj(ici.ReductionSingleton().transmission_calculator.fitMethod(selector), str(option[0]).upper())
 
         def checkNotEqualOption(option, selector):
-            self.assertTrue(not i.ReductionSingleton().transmission_calculator.fitMethod(selector) == str(option[0]).upper())
+            self.assertTrue(not ici.ReductionSingleton().transmission_calculator.fitMethod(selector) == str(option[0]).upper())
             if option[1] is not None:
-                self.assertTrue(not i.ReductionSingleton().transmission_calculator.lambdaMin(selector) == option[1])
+                self.assertTrue(not ici.ReductionSingleton().transmission_calculator.lambdaMin(selector) == option[1])
             if option[2] is not None:
-                self.assertTrue(not i.ReductionSingleton().transmission_calculator.lambdaMax(selector) == option[2])
+                self.assertTrue(not ici.ReductionSingleton().transmission_calculator.lambdaMax(selector) == option[2])
 
         def checkFitOption(option):
             if option[3] == "BOTH":
@@ -138,7 +138,7 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
 
         for option in options:
             print("Applying option ", str(option))
-            i.TransFit(mode=option[0], lambdamin=option[1], lambdamax=option[2], selector=option[3])
+            ici.TransFit(mode=option[0], lambdamin=option[1], lambdamax=option[2], selector=option[3])
             checkFitOption(option)
 
     def test_direct_files(self):  # direct_file, front_direct_file
@@ -146,31 +146,31 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         # It is changed only through the MaskFile
 
         ### THIS IS NOT DONE DIRECTLY THROUGH GHI ####
-        i.ReductionSingleton().instrument.getDetector("REAR").correction_file = "rear_file"
-        i.ReductionSingleton().instrument.getDetector("FRONT").correction_file = "front_file"
+        ici.ReductionSingleton().instrument.getDetector("REAR").correction_file = "rear_file"
+        ici.ReductionSingleton().instrument.getDetector("FRONT").correction_file = "front_file"
 
         ## This is done in the GUI ##
-        self.checkStr(i.ReductionSingleton().instrument.detector_file("rear"), "rear_file")
-        self.checkStr(i.ReductionSingleton().instrument.detector_file("front"), "front_file")
+        self.checkStr(ici.ReductionSingleton().instrument.detector_file("rear"), "rear_file")
+        self.checkStr(ici.ReductionSingleton().instrument.detector_file("front"), "front_file")
 
     def test_flood_files(self):  # floodRearFile, floolFrontFile
         options = [("REAR", "rear_file"), ("FRONT", "front_file"), ("REAR", ""), ("FRONT", "")]
 
         for option in options:
-            i.SetDetectorFloodFile(option[1], option[0])
-            self.checkStr(option[1], i.ReductionSingleton().prep_normalize.getPixelCorrFile(option[0]))
+            ici.SetDetectorFloodFile(option[1], option[0])
+            self.checkStr(option[1], ici.ReductionSingleton().prep_normalize.getPixelCorrFile(option[0]))
 
     def test_incident_monitors(self):  # monitor_spec, monitor_interp, trans_monitor, trans_interp
         options = [(2, True), (4, False), (3, True)]
 
         for option in options:
-            i.SetMonitorSpectrum(option[0], option[1])
-            self.checkFloat(i.ReductionSingleton().instrument.get_incident_mon(), option[0])
-            self.checkObj(i.ReductionSingleton().instrument.is_interpolating_norm(), option[1])
+            ici.SetMonitorSpectrum(option[0], option[1])
+            self.checkFloat(ici.ReductionSingleton().instrument.get_incident_mon(), option[0])
+            self.checkObj(ici.ReductionSingleton().instrument.is_interpolating_norm(), option[1])
 
-            i.SetTransSpectrum(option[0], option[1])
-            self.checkFloat(i.ReductionSingleton().instrument.incid_mon_4_trans_calc, option[0])
-            self.checkObj(i.ReductionSingleton().transmission_calculator.interpolate, option[1])
+            ici.SetTransSpectrum(option[0], option[1])
+            self.checkFloat(ici.ReductionSingleton().instrument.incid_mon_4_trans_calc, option[0])
+            self.checkObj(ici.ReductionSingleton().transmission_calculator.interpolate, option[1])
 
     def test_detector_selector(self):
         options = [
@@ -183,28 +183,28 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         ]
 
         for option in options:
-            i.ReductionSingleton().instrument.setDetector(option[0])
-            self.checkStr(i.ReductionSingleton().instrument.det_selection, option[0])
-            self.checkStr(i.ReductionSingleton().instrument.cur_detector().name(), option[1])
+            ici.ReductionSingleton().instrument.setDetector(option[0])
+            self.checkStr(ici.ReductionSingleton().instrument.det_selection, option[0])
+            self.checkStr(ici.ReductionSingleton().instrument.cur_detector().name(), option[1])
 
         # TODO: for LOQ
 
     def test_Phi(self):  # phi_min, phi_max, mirror_phi
         def checkPhiValues(option):
-            self.checkFloat(i.ReductionSingleton().mask.phi_min, option[0])
-            self.checkFloat(i.ReductionSingleton().mask.phi_max, option[1])
-            self.checkObj(i.ReductionSingleton().mask.phi_mirror, option[2])
+            self.checkFloat(ici.ReductionSingleton().mask.phi_min, option[0])
+            self.checkFloat(ici.ReductionSingleton().mask.phi_max, option[1])
+            self.checkObj(ici.ReductionSingleton().mask.phi_mirror, option[2])
 
         options = [(-88.0, 89.0, True), (-87.0, 88.5, False), (-90.0, 90.0, True)]
 
         for option in options:
-            i.SetPhiLimit(option[0], option[1], option[2])
+            ici.SetPhiLimit(option[0], option[1], option[2])
             checkPhiValues(option)
 
         for option in options:
             cmd = "L/PHI" if option[2] else "L/PHI/NOMIRROR"
             patter = "%s %f %f"
-            i.Mask(patter % (cmd, option[0], option[1]))
+            ici.Mask(patter % (cmd, option[0], option[1]))
             checkPhiValues(option)
 
     def test_scaling_options(self):
@@ -212,16 +212,16 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         # frontDetQmin, frontDetQmax, frontDetQrangeOnOff
 
         def testScalingValues(scale, shift, qMin=None, qMax=None, fitScale=False, fitShift=False):
-            self.checkFloat(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.scale, scale)
-            self.checkFloat(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.shift, shift)
-            self.checkObj(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.fitScale, fitScale)
-            self.checkObj(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.fitShift, fitShift)
+            self.checkFloat(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.scale, scale)
+            self.checkFloat(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.shift, shift)
+            self.checkObj(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.fitScale, fitScale)
+            self.checkObj(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.fitShift, fitShift)
             if qMin is not None:
-                self.assertTrue(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qRangeUserSelected)
-                self.checkFloat(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qMin, qMin)
-                self.checkFloat(i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qMax, qMax)
+                self.assertTrue(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qRangeUserSelected)
+                self.checkFloat(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qMin, qMin)
+                self.checkFloat(ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qMax, qMax)
             else:
-                self.assertTrue(not i.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qRangeUserSelected)
+                self.assertTrue(not ici.ReductionSingleton().instrument.getDetector("FRONT").rescaleAndShift.qRangeUserSelected)
 
         options = [
             {"scale": 1.2, "shift": 0.3},
@@ -232,14 +232,14 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         ]
 
         for option in options:
-            i.SetFrontDetRescaleShift(**option)
+            ici.SetFrontDetRescaleShift(**option)
             testScalingValues(**option)
 
     def test_BACK(self):
-        tofs = i.ReductionSingleton().instrument.get_TOFs(2)
+        tofs = ici.ReductionSingleton().instrument.get_TOFs(2)
         self.checkFloat(tofs[0], 85000)
         self.checkFloat(tofs[1], 98000)
-        tofs = i.ReductionSingleton().instrument.get_TOFs(1)
+        tofs = ici.ReductionSingleton().instrument.get_TOFs(1)
         self.checkFloat(tofs[0], 35000)
         self.checkFloat(tofs[1], 65000)
 
@@ -247,19 +247,19 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
         # Check for correct input
         shifts = "12, 13, 14"
         num_files = 4
-        output = i.check_time_shifts_for_added_event_files(number_of_files=num_files, time_shifts=shifts)
+        output = ici.check_time_shifts_for_added_event_files(number_of_files=num_files, time_shifts=shifts)
         self.assertTrue(not output)
 
         # Check warning is produced for mismatch in number of shifts and files, ideally #shifts = N-1 and #files=N
         shifts2 = "12, 13"
         num_files2 = 4
-        output2 = i.check_time_shifts_for_added_event_files(number_of_files=num_files2, time_shifts=shifts2)
+        output2 = ici.check_time_shifts_for_added_event_files(number_of_files=num_files2, time_shifts=shifts2)
         self.assertTrue(output2.startswith("Error: Expected N-1 time shifts "))
 
         # Check error is produced for lexically incorrect shifts, ie shifts which cannot be converted to float
         shifts3 = "12, 13, a"
         num_files3 = 4
-        output3 = i.check_time_shifts_for_added_event_files(number_of_files=num_files3, time_shifts=shifts3)
+        output3 = ici.check_time_shifts_for_added_event_files(number_of_files=num_files3, time_shifts=shifts3)
         self.assertTrue(output3.startswith("Error: Elements of the time"))
 
 

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -39,6 +39,7 @@ from sans.common.general_functions import (
     parse_event_slice_setting,
     wav_range_to_str,
     wav_ranges_to_str,
+    parse_simple_range_of_number_pairs,
 )
 from sans.state.StateObjects.StateData import StateData
 from sans.test_helper.test_director import TestDirector
@@ -676,6 +677,31 @@ class SANSEventSliceParsing(unittest.TestCase):
         )
         self.assertEqual([SANSDetector.ZOOM_LAB.value], get_detector_names_from_instrument(SANSInstrument.ZOOM))
         self.assertEqual([SANSDetector.LARMOR_LAB.value], get_detector_names_from_instrument(SANSInstrument.LARMOR))
+
+    def test_parse_number_pairs_fails_for_wrong_input(self):
+        test_strs = ["11.2e,11", "a,b"]
+
+        for test_str in test_strs:
+            with self.subTest(test_case=test_str):
+                err_msg = f"The provided string: '{test_str}' , could not be converted to a list of pair of floats"
+                self.assertRaisesRegex(ValueError, err_msg, parse_simple_range_of_number_pairs, test_str)
+
+    def test_parse_number_pairs_fails_for_odd_or_zero_input(self):
+        test_strs = ["", "1,2,3"]
+
+        for test_str in test_strs:
+            with self.subTest(test_case=test_str):
+                err_msg = "At least one pair of numbers separated by comma should be entered: eg: '-15.0,15.0'"
+                self.assertRaisesRegex(ValueError, err_msg, parse_simple_range_of_number_pairs, test_str)
+
+    def test_parse_number_pairs_for_pairs_that_are_convertible_to_float(self):
+        test_strs = ["1,2,3,4", "15.1,2", "-15.1,30.2", "2e1, 5e1"]
+        expected_results = [[1.0, 2.0, 3.0, 4.0], [15.1, 2.0], [-15.1, 30.2], [20.0, 50.0]]
+
+        for test_str, expected in zip(test_strs, expected_results):
+            with self.subTest(test_case=test_str):
+                result = parse_simple_range_of_number_pairs(test_str)
+                self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -516,6 +516,23 @@ class StateGuiModelTest(unittest.TestCase):
         self.assertEqual(state_gui_model.phi_limit_max, 13.0)
         self.assertTrue(state_gui_model.phi_limit_use_mirror)
 
+    def test_phi_range_is_empty_by_default(self):
+        state_gui_model = StateGuiModel(AllStates())
+        self.assertEqual(state_gui_model.phi_range, "")
+
+    def test_that_phi_range_can_be_set(self):
+        state_gui_model = StateGuiModel(AllStates())
+        state_gui_model.phi_range = "-15.0,15.0,75.0,90.0"
+        self.assertEqual(state_gui_model.phi_range, "-15.0,15.0,75.0,90.0")
+
+    def test_that_phi_range_is_set_when_updating_phi_min_or_phi_max(self):
+        state_gui_model = StateGuiModel(AllStates())
+        state_gui_model.phi_limit_min = 12.0
+
+        self.assertEqual(state_gui_model.phi_range, "12.0,90.0")
+        state_gui_model.phi_limit_max = 30.0
+        self.assertEqual(state_gui_model.phi_range, "12.0,30.0")
+
     # ------------------------------------------------------------------------------------------------------------------
     # Radius mask
     # ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of work
See #39596 for details. 
- There is a new QlineEdit on the `Q, Wavelength, Detector Limits` settings of the settings tab of the interface, to additionally apply a phi range instead of a minimum and maximum for the phi limit (this is changed by switching between `MinMax` and `Pairs` on the combobox just above phi limit setting). 
- This range is introduced as pairs of numbers separated by commas. 

Additionally, I have trim down the layout of the sans gui interface as some of the settings tab gui elements
were pinned to the QStackedWidget in a way more complicated than it should be. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39596 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Testing data can be the LOQ demo on the TrainingUserData set. 

- Open the example reduction mask and batch file. 
- On the `Q, Wavelength, Detector Limits` settings of the settings tab of the SANS GUI, whenever a Minimum(`From`) and Maximum(`To`) are added to the phi, the reduced workspace (in 1D reduction only) ends with a suffix specifying this range (something like `PhiMinAngle-MaxAngle`). In this branch, when adding a range of numbers in the phi limit setting, for example: `-45,10, 75,90` there would be two reductions, one with suffix `Phi-45_10` and the other `Phi75_90`). 
- Try with few different reductions (different wavelengths or time slicings) check that whenever there is a range of phi slices, the resulting 1D reductions are increased according to how many slices are specified in the ranges line edit. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
