### PR TITLE
Fix broken LaTeX in ReorientUnitCell docs

### DIFF
--- a/docs/source/algorithms/ReorientUnitCell-v1.rst
+++ b/docs/source/algorithms/ReorientUnitCell-v1.rst
@@ -16,7 +16,7 @@ Thinking of the orthonormal reciprocal basis :math:`(\vec{u^{*}}, \vec{v^{*}}, \
 resulting from transforming the reciprocal lattice vectors by the Busing matrix :math:`B`,
 the algorithm will try the following alignment:
 
-- align :math:`\vec{u^{*} \equiv \vec{a^{*}}` with the neutron beam ( :math:`Z` axis)
+- align :math:`\vec{u^{*}} \equiv \vec{a^{*}}` with the neutron beam ( :math:`Z` axis)
 - align :math:`\vec{v^{*}}` with the horizontal axis ( :math:`X` axis)
 - align :math:`\vec{w^{*}}` with the vertical axis ( :math:`Y` axis)
 


### PR DESCRIPTION
### Description of work

Building the docs using `sphinx.ext.imgmath` fails due to this LaTeX error, interesting not picked up when building with `sphinx.ext.mathjax`.

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
