### PR TITLE
Migrate `LoadMcStasNexus` for lazy nexus descriptor confidence

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStasNexus.h
@@ -8,14 +8,14 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
 
 /** LoadMcStasNexus : TODO: DESCRIPTION
  */
-class MANTID_DATAHANDLING_DLL LoadMcStasNexus : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadMcStasNexus : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose
@@ -26,7 +26,7 @@ public:
   const std::string category() const override;
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void init() override;

--- a/Framework/DataHandling/src/LoadMcStasNexus.cpp
+++ b/Framework/DataHandling/src/LoadMcStasNexus.cpp
@@ -19,7 +19,7 @@ namespace Mantid::DataHandling {
 using namespace Kernel;
 using namespace API;
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMcStasNexus)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadMcStasNexus)
 
 //----------------------------------------------------------------------------------------------
 /// Algorithm's name for identification. @see Algorithm::name
@@ -37,16 +37,11 @@ const std::string LoadMcStasNexus::category() const { return "DataHandling\\Nexu
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadMcStasNexus::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadMcStasNexus::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence(0);
-  const auto &entries = descriptor.getAllEntries();
-  for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
-    const auto grouped_entries = iter->second;
-    if (std::any_of(grouped_entries.cbegin(), grouped_entries.cend(),
-                    [](const auto &address) { return address.ends_with("information"); })) {
-      confidence = 40;
-      break;
-    }
+  std::string const firstEntry = descriptor.firstEntryNameType().first;
+  if (descriptor.isEntry("/" + firstEntry + "/instrument/information", "SDS")) {
+    confidence = 40;
   }
   return confidence;
 }

--- a/Framework/DataHandling/test/LoadMcStasNexusTest.h
+++ b/Framework/DataHandling/test/LoadMcStasNexusTest.h
@@ -10,6 +10,7 @@
 #include <fstream>
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadMcStasNexus.h"
@@ -32,6 +33,13 @@ public:
   void testInit() {
     TS_ASSERT_THROWS_NOTHING(algToBeTested.initialize());
     TS_ASSERT(algToBeTested.isInitialized());
+  }
+
+  void testConfidence() {
+    std::string filepath = FileFinder::Instance().getFullPath("mcstas.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filepath);
+    int confidence = algToBeTested.confidence(descriptor);
+    TS_ASSERT_EQUALS(confidence, 40);
   }
 
   void testExec() {
@@ -82,7 +90,7 @@ public:
 
   void test_cannot_run_via_load() {
     // We are verifying that the confidence information provided by the loader is idenfiying unsuitable files
-    std::string inputFile = "POLREF00014966.nxs";
+    std::string inputFile = "mcstas_event_hist.h5";
     Load loader;
     loader.initialize();
     loader.setChild(true);


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadMcStasNexus` algorithm.  This is different from the `LoadMcStas` algorithm.  It was first implemented thirteen years ago in PR #1, and marked as experimental.  And so it has stayed.  There is apparently a pre-release paper about this algo. https://arxiv.org/abs/1607.02498

In Issue #7768, it was given a test data file.  More discussion is available at [this ticket](https://trac.mantidproject.org/mantid/ticket/6922).

The confidence check for `LoadMcStasNexus` was first added in PR #32006.  According to comments there, it is enough to check for an `information` dataset written by McCode:
``` cpp
// Mccode writes an information dataset so can be reasonably confident if we find it
```

This PR has pinpointed one particular place to check for that dataset, namely off of the instrument address.  This seems to work, rather than checking literally the entire file tree.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)


### To test:

This is a refactor, so ensure all current tests works.  A new test was added to make sure the confidence method is calculating correctly for the only example of a file needing this algorithm that anyone knows of.

Especially look at the `LoadLotsOfFiles` system test.

Tests in PR #40570 verified that `Load` is able to find load algorithms with a lazy descriptor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
