### PR TITLE
Migrate `LoadNXSPE` for lazy file descriptor

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNXSPE.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/Objects/CSGObject.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -26,7 +26,7 @@ namespace DataHandling {
   @author Andrei Savici, ORNL
   @date 2011-08-14
 */
-class MANTID_DATAHANDLING_DLL LoadNXSPE : public API::IFileLoader<Nexus::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadNXSPE : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   /// Algorithm's name for identification
   const std::string name() const override { return "LoadNXSPE"; };
@@ -42,7 +42,7 @@ public:
   }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
   /// Confidence in identifier.
   static int identiferConfidence(const std::string &value);

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -44,15 +44,16 @@ using Mantid::HistogramData::BinEdges;
  * @return confidence 0 - 100%
  */
 int LoadNXSPE::identiferConfidence(const std::string &value) {
-  int identifierConfidence = 0;
+  int identifierConfidence(0);
   if (value.empty()) {
-    // do nothing
+    identifierConfidence = 0;
   } else if (value == "NXSPE") {
     identifierConfidence = 99;
   } else {
     // convert to be uppercase for case insensitive comparison
     std::string valueUpper = value;
-    std::transform(valueUpper.begin(), valueUpper.end(), valueUpper.begin(), ::toupper);
+    std::transform(valueUpper.begin(), valueUpper.end(), valueUpper.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
     if (valueUpper.starts_with("NXSP")) {
       identifierConfidence = 95;
     }

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -24,8 +24,6 @@
 #include "MantidNexus/NexusException.h"
 #include "MantidNexus/NexusFile.h"
 
-#include <boost/regex.hpp>
-
 #include <filesystem>
 #include <map>
 #include <sstream>
@@ -34,25 +32,28 @@
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNXSPE)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadNXSPE)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using Mantid::HistogramData::BinEdges;
 
 /**
- * Calculate the confidence in the string value. This is used for file
- * identification.
+ * Calculate the confidence in the string value. This is used for file identification.
  * @param value
  * @return confidence 0 - 100%
  */
 int LoadNXSPE::identiferConfidence(const std::string &value) {
   int identifierConfidence = 0;
-  if (value == "NXSPE") {
+  if (value.empty()) {
+    // do nothing
+  } else if (value == "NXSPE") {
     identifierConfidence = 99;
   } else {
-    boost::regex re("^NXSP", boost::regex::icase);
-    if (boost::regex_match(value, re)) {
+    // convert to be uppercase for case insensitive comparison
+    std::string valueUpper = value;
+    std::transform(valueUpper.begin(), valueUpper.end(), valueUpper.begin(), ::toupper);
+    if (valueUpper.starts_with("NXSP")) {
       identifierConfidence = 95;
     }
   }
@@ -65,21 +66,21 @@ int LoadNXSPE::identiferConfidence(const std::string &value) {
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadNXSPE::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadNXSPE::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence(0);
-  using string_map_t = std::map<std::string, std::string>;
-  try {
-    Nexus::File file = Nexus::File(descriptor.filename());
-    string_map_t entries = file.getEntries();
-    for (string_map_t::const_iterator it = entries.begin(); it != entries.end(); ++it) {
-      if (it->second == "NXentry") {
-        file.openGroup(it->first, it->second);
-        file.openData("definition");
-        const std::string value = file.getStrData();
-        confidence = identiferConfidence(value);
+  auto entries = descriptor.getAllEntries();
+  // look for a group of type NXentry with a dataset called definition
+  for (const auto &it : entries) {
+    if (it.second == "NXentry") {
+      std::string defAddress = it.first + "/definition";
+      if (descriptor.isEntry(defAddress, Mantid::Nexus::SCIENTIFIC_DATA_SET)) {
+        // check the dataset to see if it matches the definition we are looking for
+        confidence = identiferConfidence(descriptor.getStrData(defAddress));
       }
     }
-  } catch (Nexus::Exception const &) {
+    if (confidence > 80) {
+      break; // no need to continue checking
+    }
   }
   return confidence;
 }

--- a/Framework/DataHandling/test/LoadNXSPETest.h
+++ b/Framework/DataHandling/test/LoadNXSPETest.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>
 
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadNXSPE.h"
 
 using namespace Mantid;
@@ -51,6 +52,14 @@ public:
     TS_ASSERT_EQUALS(ws->getEMode(), Kernel::DeltaEMode::Indirect);
 
     AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  /// Test that this algorithm will be selected from Load algorithm
+  void test_load_from_Load() {
+    Mantid::DataHandling::Load load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    TS_ASSERT_THROWS_NOTHING(load.setPropertyValue("Filename", "NXSPEData.nxspe"));
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadNXSPE");
   }
 
   void test_identifier_confidence() {

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -95,6 +95,9 @@ public:
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(std::string const &classType) const;
 
+  /// @brief Get string data from a dataset at address
+  /// @param address Full HDF5 address of the dataset
+  /// @return string data at this address, if it is string dataset, else empty
   std::string getStrData(std::string const &address);
 
 private:

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -95,6 +95,8 @@ public:
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(std::string const &classType) const;
 
+  std::string getStrData(std::string const &address);
+
 private:
   /**
    * Sets m_allEntries, called in HDF5 constructor.

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -110,6 +110,8 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression 
 // forward declare
 namespace Mantid::Nexus {
 
+std::string const SCIENTIFIC_DATA_SET("SDS");
+
 typedef hsize_t dimsize_t;
 typedef std::vector<dimsize_t> DimVector;
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -110,7 +110,7 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression 
 // forward declare
 namespace Mantid::Nexus {
 
-std::string const SCIENTIFIC_DATA_SET("SDS");
+inline std::string const SCIENTIFIC_DATA_SET("SDS");
 
 typedef hsize_t dimsize_t;
 typedef std::vector<dimsize_t> DimVector;

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -10,6 +10,7 @@
 #include "MantidNexus/NexusException.h"
 #include "MantidNexus/UniqueID.h"
 
+#include "MantidNexus/NexusFile_fwd.h"
 #include <H5Cpp.h>
 #include <hdf5.h>
 
@@ -27,7 +28,6 @@ static unsigned int const INSTR_DEPTH = 5;
 static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1"};
 static std::string const NONEXISTENT = "NONEXISTENT"; // register failures as well
 static std::string const UNKNOWN_CLASS = "UNKNOWN_CLASS";
-static std::string const SCIENTIFIC_DATA_SET = "SDS";
 
 namespace {
 template <herr_t (*H5Xclose)(hid_t)> std::string readNXClass(Mantid::Nexus::UniqueID<H5Xclose> const &oid) {
@@ -101,6 +101,25 @@ bool NexusDescriptorLazy::hasRootAttr(std::string const &name) {
       return false;
     }
   }
+}
+
+/**
+ * Get string data from a dataset at address
+ * @param address Full HDF5 address of the dataset
+ * @return string data
+ */
+std::string NexusDescriptorLazy::getStrData(std::string const &address) {
+  std::string strData;
+  if (isEntry(address, SCIENTIFIC_DATA_SET)) {
+    // open the data set and get its string data
+    H5::H5File file(m_fileID.get());
+    H5::DataSet dataset = file.openDataSet(address);
+    H5::DataType dtype = dataset.getDataType();
+    if (dtype.isVariableStr() || dtype.getClass() == H5T_STRING) {
+      dataset.read(strData, dtype, dataset.getSpace());
+    }
+  }
+  return strData;
 }
 
 // PRIVATE

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -103,11 +103,7 @@ bool NexusDescriptorLazy::hasRootAttr(std::string const &name) {
   }
 }
 
-/**
- * Get string data from a dataset at address
- * @param address Full HDF5 address of the dataset
- * @return string data
- */
+/// Get string data from a dataset at address
 std::string NexusDescriptorLazy::getStrData(std::string const &address) {
   std::string strData;
   if (isEntry(address, SCIENTIFIC_DATA_SET)) {

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -112,8 +112,9 @@ std::string NexusDescriptorLazy::getStrData(std::string const &address) {
   std::string strData;
   if (isEntry(address, SCIENTIFIC_DATA_SET)) {
     // open the data set and get its string data
-    H5::H5File file(m_fileID.get());
-    H5::DataSet dataset = file.openDataSet(address);
+    // using H5Cpp interface because trying to read string data is an absolute nightmare with the C API
+    UniqueID<&H5Dclose> did(H5Dopen(m_fileID, address.c_str(), H5P_DEFAULT));
+    H5::DataSet dataset(did);
     H5::DataType dtype = dataset.getDataType();
     if (dtype.isVariableStr() || dtype.getClass() == H5T_STRING) {
       dataset.read(strData, dtype, dataset.getSpace());

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -48,7 +48,6 @@ namespace { // anonymous namespace to keep it in the file
 
 std::string const GROUP_CLASS_SPEC("NX_class");
 std::string const TARGET_ATTR_NAME("target");
-std::string const SCIENTIFIC_DATA_SET("SDS");
 std::string const UNKNOWN_GROUP_SPEC("NX_UNKNOWN_GROUP");
 constexpr int DEFAULT_DEFLATE_LEVEL(6);
 

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -110,4 +110,17 @@ public:
     // verify that non-existing root attributes are not there
     TS_ASSERT_EQUALS(descriptor.hasRootAttr("not_an_attr"), false);
   }
+
+  void test_getStrData() {
+    std::cout << "\nTesting getStrData in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    const std::string filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    // verify that existing data can be read
+    TS_ASSERT_EQUALS(descriptor.getStrData("/entry/instrument/name"), "EQ-SANS");
+
+    // verify that non-existing data throws
+    TS_ASSERT_EQUALS(descriptor.getStrData("/entry/instrument/not_a_data"), "");
+  }
 };

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -120,7 +120,7 @@ public:
     // verify that existing data can be read
     TS_ASSERT_EQUALS(descriptor.getStrData("/entry/instrument/name"), "EQ-SANS");
 
-    // verify that non-existing data throws
+    // verify that non-existing data returns empty string
     TS_ASSERT_EQUALS(descriptor.getStrData("/entry/instrument/not_a_data"), "");
   }
 };


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadNXSPE` algorithm.   Part of its confidence check looks for a `"definition"` dataset off of an `NXEntry` group, and then verifies the definition is equal to `"NXSPE"` or similar.

To make this work, this added a new method to `NexusDescriptorLazy` to load string data.  Thus made use of the `H5Cpp` package because frankly trying to read string data is a complete nightmare using the C-API.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

This is a refactor, so ensure all current tests works. A test of the confidence calculation already existed, and a new one was added to make sure `Load` can still correctly find this loader.

Especially look at the `LoadLotsOfFiles` system test.

Tests in PR #40570 verified that `Load` is able to find load algorithms with a lazy descriptor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
