### PR TITLE
Return release date as DateAndTime object

### DIFF
--- a/Framework/DataHandling/src/CheckMantidVersion.cpp
+++ b/Framework/DataHandling/src/CheckMantidVersion.cpp
@@ -227,11 +227,9 @@ std::string CheckMantidVersion::getVersionsFromGitHub(const std::string &url) {
 
   Kernel::GitHubApiHelper inetHelper;
   std::ostringstream os;
-  int tzd = 0;
 
-  inetHelper.addHeader("if-modified-since",
-                       Poco::DateTimeFormatter::format(Poco::DateTimeParser::parse(MantidVersion::releaseDate(), tzd),
-                                                       Poco::DateTimeFormat::HTTP_FORMAT));
+  const auto releaseDate = MantidVersion::releaseDateAndTime();
+  inetHelper.addHeader("if-modified-since", releaseDate.toHttpFormat());
   inetHelper.sendRequest(url, os);
   std::string retVal = os.str();
 

--- a/Framework/Kernel/inc/MantidKernel/MantidVersion.h
+++ b/Framework/Kernel/inc/MantidKernel/MantidVersion.h
@@ -27,13 +27,13 @@ public:
     std::string tweak;
   };
 
-  static const char *version();           ///< The full version number
-  static const char *versionShort();      ///< The version number of the last full version
+  static std::string version();           ///< The full version number
+  static std::string versionShort();      ///< The version number of the last full version
   static const VersionInfo versionInfo(); ///< A data structure containing the full version info.
   static std::string releaseNotes();      ///< The url to the most applicable release notes
-  static const char *revision();          ///< The abbreviated SHA-1 of the last commit
-  static const char *revisionFull();      ///< The full SHA-1 of the last commit
-  static const char *releaseDate();       ///< The date of the last commit
+  static std::string revision();          ///< The abbreviated SHA-1 of the last commit
+  static std::string revisionFull();      ///< The full SHA-1 of the last commit
+  static std::string releaseDate();       ///< The date of the last commit
   static std::string doi();               ///< The DOI for this release of Mantid.
   static std::string paperCitation();     ///< The citation for the Mantid paper
   static std::string versionForReleaseNotes(const VersionInfo &); ///< The version of mantid for the release notes url.

--- a/Framework/Kernel/inc/MantidKernel/MantidVersion.h
+++ b/Framework/Kernel/inc/MantidKernel/MantidVersion.h
@@ -27,16 +27,16 @@ public:
     std::string tweak;
   };
 
-  static std::string version();                         ///< The full version number
-  static std::string versionShort();                    ///< The version number of the last full version
+  static const std::string &version();                  ///< The full version number
+  static const std::string &versionShort();             ///< The version number of the last full version
   static const VersionInfo versionInfo();               ///< A data structure containing the full version info.
   static std::string releaseNotes();                    ///< The url to the most applicable release notes
-  static std::string revision();                        ///< The abbreviated SHA-1 of the last commit
-  static std::string revisionFull();                    ///< The full SHA-1 of the last commit
+  static const std::string &revision();                 ///< The abbreviated SHA-1 of the last commit
+  static const std::string &revisionFull();             ///< The full SHA-1 of the last commit
   static Types::Core::DateAndTime releaseDateAndTime(); ///< The DateAndTime of the last commit
   static std::string releaseDate();                     ///< The date of the last commit
   static std::string doi();                             ///< The DOI for this release of Mantid.
-  static std::string paperCitation();                   ///< The citation for the Mantid paper
+  static const std::string &paperCitation();            ///< The citation for the Mantid paper
   static std::string versionForReleaseNotes(const VersionInfo &); ///< The version of mantid for the release notes url.
 
 private:

--- a/Framework/Kernel/inc/MantidKernel/MantidVersion.h
+++ b/Framework/Kernel/inc/MantidKernel/MantidVersion.h
@@ -10,7 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidKernel/DllConfig.h"
-
+#include "MantidTypes/Core/DateAndTime.h"
 #include <string>
 
 namespace Mantid {
@@ -27,15 +27,16 @@ public:
     std::string tweak;
   };
 
-  static std::string version();           ///< The full version number
-  static std::string versionShort();      ///< The version number of the last full version
-  static const VersionInfo versionInfo(); ///< A data structure containing the full version info.
-  static std::string releaseNotes();      ///< The url to the most applicable release notes
-  static std::string revision();          ///< The abbreviated SHA-1 of the last commit
-  static std::string revisionFull();      ///< The full SHA-1 of the last commit
-  static std::string releaseDate();       ///< The date of the last commit
-  static std::string doi();               ///< The DOI for this release of Mantid.
-  static std::string paperCitation();     ///< The citation for the Mantid paper
+  static std::string version();                         ///< The full version number
+  static std::string versionShort();                    ///< The version number of the last full version
+  static const VersionInfo versionInfo();               ///< A data structure containing the full version info.
+  static std::string releaseNotes();                    ///< The url to the most applicable release notes
+  static std::string revision();                        ///< The abbreviated SHA-1 of the last commit
+  static std::string revisionFull();                    ///< The full SHA-1 of the last commit
+  static Types::Core::DateAndTime releaseDateAndTime(); ///< The DateAndTime of the last commit
+  static std::string releaseDate();                     ///< The date of the last commit
+  static std::string doi();                             ///< The DOI for this release of Mantid.
+  static std::string paperCitation();                   ///< The citation for the Mantid paper
   static std::string versionForReleaseNotes(const VersionInfo &); ///< The version of mantid for the release notes url.
 
 private:

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -12,8 +12,12 @@
 /********** Source = MantidVersion.cpp.in *****************************************************/
 
 #include "MantidKernel/MantidVersion.h"
-
+#include "MantidTypes/Core/DateAndTime.h"
+#include <chrono>
+#include <iostream>
 #include <sstream>
+
+namespace Mantid::Kernel {
 
 namespace {
   const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
@@ -22,9 +26,39 @@ namespace {
   const std::string REVISION_SHORT{"@REVISION_SHORT@"};
   const std::string REVISION_FULL{"@REVISION_FULL@"};
   const std::string REVISION_DATE{"@REVISION_DATE@"};
-}
 
-namespace Mantid::Kernel {
+  /**
+   * The input month should only be the first 3 characters of the month name
+   */
+  std::chrono::month to_month(const std::string &month) {
+    if (month == "Jan")
+      return std::chrono::January;
+    else if (month == "Feb")
+      return std::chrono::February;
+    else if (month == "Mar")
+      return std::chrono::March;
+    else if (month == "Apr")
+      return std::chrono::April;
+    else if (month == "May")
+      return std::chrono::May;
+    else if (month == "Jun")
+      return std::chrono::June;
+    else if (month == "Jul")
+      return std::chrono::July;
+    else if (month == "Aug")
+      return std::chrono::August;
+    else if (month == "Sep")
+      return std::chrono::September;
+    else if (month == "Oct")
+      return std::chrono::October;
+    else if (month == "Nov")
+      return std::chrono::November;
+    else if (month == "Dec")
+      return std::chrono::December;
+    else // should never get here
+      throw std::runtime_error("Cannot convert \"" + month + "\" to a month object");
+  }
+}
 
 /**
  * See buildconfig/CMake/VersionNumber.cmake for more information on the meaning
@@ -92,7 +126,22 @@ std::string MantidVersion::revisionFull()
 
 std::string MantidVersion::releaseDate()
 {
-  return REVISION_DATE;
+  // pull apart string into year, month, and day objects
+  // WARNING if the format changes this will break
+  const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4,2)));
+  const auto month = to_month(REVISION_DATE.substr(7,3));
+  const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11,4)));
+  std::string time = REVISION_DATE.substr(15);
+  // create a proper chrono from it
+  std::chrono::year_month_day ymd(year, month, day);
+  // convert to iso8601 to get to DateAndTime
+  std::stringstream isostr;
+  isostr << ymd;
+  isostr << "T00:01"; // add the time-of-day so the string can be parsed
+  Types::Core::DateAndTime revisionDateAndTime(isostr.str());
+
+  const std::string GIT_DATE_FMT("%a, %e %b %Y");
+  return revisionDateAndTime.toFormattedString(GIT_DATE_FMT);
 }
 
 std::string MantidVersion::doi()

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -8,7 +8,6 @@
 // Includes
 //----------------------------------------------------------------------
 
-@AUTO_GENERATE_WARNING@
 /********** Source = MantidVersion.cpp.in *****************************************************/
 
 #include "MantidKernel/MantidVersion.h"
@@ -19,66 +18,60 @@
 namespace Mantid::Kernel {
 
 namespace {
-  const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
-  const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@"};
-  const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
-  const std::string REVISION_SHORT{"@REVISION_SHORT@"};
-  const std::string REVISION_FULL{"@REVISION_FULL@"};
-  const std::string REVISION_DATE{"@REVISION_DATE@"};
+const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
+const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@"};
+const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
+const std::string REVISION_SHORT{"@REVISION_SHORT@"};
+const std::string REVISION_FULL{"@REVISION_FULL@"};
+const std::string REVISION_DATE{"@REVISION_DATE@"};
 
-  /**
-   * The input month should only be the first 3 characters of the month name
-   */
-  std::chrono::month to_month(const std::string &month) {
-    if (month == "Jan")
-      return std::chrono::January;
-    else if (month == "Feb")
-      return std::chrono::February;
-    else if (month == "Mar")
-      return std::chrono::March;
-    else if (month == "Apr")
-      return std::chrono::April;
-    else if (month == "May")
-      return std::chrono::May;
-    else if (month == "Jun")
-      return std::chrono::June;
-    else if (month == "Jul")
-      return std::chrono::July;
-    else if (month == "Aug")
-      return std::chrono::August;
-    else if (month == "Sep")
-      return std::chrono::September;
-    else if (month == "Oct")
-      return std::chrono::October;
-    else if (month == "Nov")
-      return std::chrono::November;
-    else if (month == "Dec")
-      return std::chrono::December;
-    else // should never get here
-      throw std::runtime_error("Cannot convert \"" + month + "\" to a month object");
-  }
+/**
+ * The input month should only be the first 3 characters of the month name
+ */
+std::chrono::month to_month(const std::string &month) {
+  if (month == "Jan")
+    return std::chrono::January;
+  else if (month == "Feb")
+    return std::chrono::February;
+  else if (month == "Mar")
+    return std::chrono::March;
+  else if (month == "Apr")
+    return std::chrono::April;
+  else if (month == "May")
+    return std::chrono::May;
+  else if (month == "Jun")
+    return std::chrono::June;
+  else if (month == "Jul")
+    return std::chrono::July;
+  else if (month == "Aug")
+    return std::chrono::August;
+  else if (month == "Sep")
+    return std::chrono::September;
+  else if (month == "Oct")
+    return std::chrono::October;
+  else if (month == "Nov")
+    return std::chrono::November;
+  else if (month == "Dec")
+    return std::chrono::December;
+  else // should never get here
+    throw std::runtime_error("Cannot convert \"" + month + "\" to a month object");
 }
+} // namespace
 
 /**
  * See buildconfig/CMake/VersionNumber.cmake for more information on the meaning
  * of the version number elements
  */
 
-std::string MantidVersion::version()
-{
-  return VERSION_FULL;
-}
+std::string MantidVersion::version() { return VERSION_FULL; }
 
-std::string MantidVersion::versionShort()
-{
-  return VERSION_SHORT;
-}
+std::string MantidVersion::versionShort() { return VERSION_SHORT; }
 
 const MantidVersion::VersionInfo MantidVersion::versionInfo() {
   return {"@VERSION_MAJOR@", "@VERSION_MINOR@", "@VERSION_PATCH@", "@VERSION_TWEAK@"};
 }
 
-std::string MantidVersion::versionForReleaseNotes(const VersionInfo& version) {
+std::string MantidVersion::versionForReleaseNotes(const VersionInfo &version) {
   // Convert here in those cases where patch number is of the form "20131022.1356".
   const unsigned long patchVersion = std::stoul(version.patch);
   // For major/minor/patch/rc/local releases we point users to a specific release-notes.
@@ -87,22 +80,18 @@ std::string MantidVersion::versionForReleaseNotes(const VersionInfo& version) {
 
   std::stringstream versionLabel;
 
-  if ( (patchVersion < 100 && version.tweak.empty())
-      || version.tweak[0] == '+'
-      || version.tweak.substr(0, 2) == "rc") {
+  if ((patchVersion < 100 && version.tweak.empty()) || version.tweak[0] == '+' || version.tweak.substr(0, 2) == "rc") {
     versionLabel << version.major << "." << version.minor;
     versionLabel << "." << patchVersion;
-  }
-  else {
+  } else {
     const unsigned long minorVersion = std::stoul(version.minor);
-    versionLabel << version.major << "." << minorVersion + 1  << "." << "0";
+    versionLabel << version.major << "." << minorVersion + 1 << "." << "0";
   }
 
   return versionLabel.str();
 }
 
-std::string MantidVersion::releaseNotes()
-{
+std::string MantidVersion::releaseNotes() {
   const std::string STEM = "release/v";
   const std::string END = "/index.html";
 
@@ -113,15 +102,9 @@ std::string MantidVersion::releaseNotes()
   return url.str();
 }
 
-std::string MantidVersion::revision()
-{
-  return REVISION_SHORT;
-}
+std::string MantidVersion::revision() { return REVISION_SHORT; }
 
-std::string MantidVersion::revisionFull()
-{
-  return REVISION_FULL;
-}
+std::string MantidVersion::revisionFull() { return REVISION_FULL; }
 
 Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
   if (REVISION_DATE == "UNKNOWN") {
@@ -131,9 +114,9 @@ Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
   } else {
     // pull apart string into year, month, and day objects
     // WARNING if the format changes this will break
-    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4,2)));
-    const auto month = to_month(REVISION_DATE.substr(7,3));
-    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11,4)));
+    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4, 2)));
+    const auto month = to_month(REVISION_DATE.substr(7, 3));
+    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11, 4)));
     std::string time = REVISION_DATE.substr(16);
     if (time.empty()) {
       time = "00:01"; // assume one minute past midnight
@@ -152,40 +135,35 @@ Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
   }
 }
 
-std::string MantidVersion::releaseDate()
-{
+std::string MantidVersion::releaseDate() {
   const std::string GIT_DATE_FMT("%a, %e %b %Y");
   const auto release = releaseDateAndTime();
   return release.toFormattedString(GIT_DATE_FMT);
 }
 
-std::string MantidVersion::doi()
-{
+std::string MantidVersion::doi() {
   const std::string MAIN = "http://dx.doi.org/10.5286/Software/Mantid";
   // Cast here in those cases where patch number is of the form 20131022.1356.
-  const unsigned int patchVersion = static_cast<unsigned int>(@VERSION_PATCH@);
+  const unsigned int patchVersion = static_cast<unsigned int>(@VERSION_PATCH @);
 
   // For major/minor/patch releases we point users to a specific release-notes DOI, for
   // dev versions we just point to the main DOI.  A simple way to see whether or not
   // we're currently in a dev version is to check if the patch version is larger than
   // some arbitrarily low value.
   const std::string tweakVersion("@VERSION_TWEAK@");
-  if( patchVersion > 100 || !tweakVersion.empty())
+  if (patchVersion > 100 || !tweakVersion.empty())
     return MAIN;
 
   std::stringstream doi;
-  doi << MAIN << @VERSION_MAJOR@ << "." << @VERSION_MINOR@;
+  doi << MAIN << @VERSION_MAJOR @ << "." << @VERSION_MINOR @;
 
   // Keep to the convention where we write a version number like "3.0.0" as "3.0".
-  if( patchVersion != 0 )
+  if (patchVersion != 0)
     doi << "." << patchVersion;
 
   return doi.str();
 }
 
-std::string MantidVersion::paperCitation()
-{
-  return DOI;
-}
+std::string MantidVersion::paperCitation() { return DOI; }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -12,7 +12,6 @@
 /********** Source = MantidVersion.cpp.in *****************************************************/
 
 #include "MantidKernel/MantidVersion.h"
-#include "MantidTypes/Core/DateAndTime.h"
 #include <chrono>
 #include <iostream>
 #include <sstream>
@@ -124,24 +123,40 @@ std::string MantidVersion::revisionFull()
   return REVISION_FULL;
 }
 
+Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
+  if (REVISION_DATE == "UNKNOWN") {
+    // something went wrong in VersionNumber.cmake so give the default constructor result
+    Types::Core::DateAndTime release;
+    return release;
+  } else {
+    // pull apart string into year, month, and day objects
+    // WARNING if the format changes this will break
+    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4,2)));
+    const auto month = to_month(REVISION_DATE.substr(7,3));
+    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11,4)));
+    std::string time = REVISION_DATE.substr(16);
+    if (time.empty()) {
+      time = "00:01"; // assume one minute past midnight
+    } else {
+      time.erase(find_if(time.begin(), time.end(), isspace));
+    }
+
+    // create a proper chrono from it
+    std::chrono::year_month_day ymd(year, month, day);
+    // convert to iso8601 string to get to DateAndTime
+    std::stringstream isostr;
+    isostr << ymd << "T" << time;
+
+    Types::Core::DateAndTime release(isostr.str());
+    return release;
+  }
+}
+
 std::string MantidVersion::releaseDate()
 {
-  // pull apart string into year, month, and day objects
-  // WARNING if the format changes this will break
-  const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4,2)));
-  const auto month = to_month(REVISION_DATE.substr(7,3));
-  const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11,4)));
-  std::string time = REVISION_DATE.substr(15);
-  // create a proper chrono from it
-  std::chrono::year_month_day ymd(year, month, day);
-  // convert to iso8601 to get to DateAndTime
-  std::stringstream isostr;
-  isostr << ymd;
-  isostr << "T00:01"; // add the time-of-day so the string can be parsed
-  Types::Core::DateAndTime revisionDateAndTime(isostr.str());
-
   const std::string GIT_DATE_FMT("%a, %e %b %Y");
-  return revisionDateAndTime.toFormattedString(GIT_DATE_FMT);
+  const auto release = releaseDateAndTime();
+  return release.toFormattedString(GIT_DATE_FMT);
 }
 
 std::string MantidVersion::doi()

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -15,6 +15,15 @@
 
 #include <sstream>
 
+namespace {
+  const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
+  const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@"};
+  const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
+  const std::string REVISION_SHORT{"@REVISION_SHORT@"};
+  const std::string REVISION_FULL{"@REVISION_FULL@"};
+  const std::string REVISION_DATE{"@REVISION_DATE@"};
+}
+
 namespace Mantid::Kernel {
 
 /**
@@ -22,14 +31,14 @@ namespace Mantid::Kernel {
  * of the version number elements
  */
 
-const char* MantidVersion::version()
+std::string MantidVersion::version()
 {
-  return "@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@";
+  return VERSION_FULL;
 }
 
-const char* MantidVersion::versionShort()
+std::string MantidVersion::versionShort()
 {
-  return "@VERSION_MAJOR@.@VERSION_MINOR@";
+  return VERSION_SHORT;
 }
 
 const MantidVersion::VersionInfo MantidVersion::versionInfo() {
@@ -71,19 +80,19 @@ std::string MantidVersion::releaseNotes()
   return url.str();
 }
 
-const char* MantidVersion::revision()
+std::string MantidVersion::revision()
 {
-  return "@REVISION_SHORT@";
+  return REVISION_SHORT;
 }
 
-const char* MantidVersion::revisionFull()
+std::string MantidVersion::revisionFull()
 {
-  return "@REVISION_FULL@";
+  return REVISION_FULL;
 }
 
-const char* MantidVersion::releaseDate()
+std::string MantidVersion::releaseDate()
 {
-  return "@REVISION_DATE@";
+  return REVISION_DATE;
 }
 
 std::string MantidVersion::doi()
@@ -112,7 +121,7 @@ std::string MantidVersion::doi()
 
 std::string MantidVersion::paperCitation()
 {
-  return "http://dx.doi.org/10.1016/j.nima.2014.07.029";
+  return DOI;
 }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -8,6 +8,7 @@
 // Includes
 //----------------------------------------------------------------------
 
+@AUTO_GENERATE_WARNING@
 /********** Source = MantidVersion.cpp.in *****************************************************/
 
 #include "MantidKernel/MantidVersion.h"
@@ -23,7 +24,6 @@ const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@
 const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
 const std::string REVISION_SHORT{"@REVISION_SHORT@"};
 const std::string REVISION_FULL{"@REVISION_FULL@"};
-const std::string REVISION_DATE{"@REVISION_DATE@"};
 
 /**
  * The input month should only be the first 3 characters of the month name
@@ -56,6 +56,39 @@ std::chrono::month to_month(const std::string &month) {
   else // should never get here
     throw std::runtime_error("Cannot convert \"" + month + "\" to a month object");
 }
+
+Types::Core::DateAndTime create_releaseDateAndTime() {
+  const std::string REVISION_DATE{"@REVISION_DATE@"};
+
+  Types::Core::DateAndTime release;
+  if (REVISION_DATE == "UNKNOWN") {
+    // something went wrong in VersionNumber.cmake so give the default constructor result
+  } else {
+    // pull apart string into year, month, and day objects
+    // WARNING if the format changes this will break
+    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4, 2)));
+    const auto month = to_month(REVISION_DATE.substr(7, 3));
+    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11, 4)));
+    std::string time = REVISION_DATE.substr(16);
+    if (time.empty()) {
+      time = "00:01"; // assume one minute past midnight
+    } else {
+      time.erase(find_if(time.begin(), time.end(), isspace));
+    }
+
+    // create a proper chrono from it
+    std::chrono::year_month_day ymd(year, month, day);
+    // convert to iso8601 string to get to DateAndTime
+    std::stringstream isostr;
+    isostr << ymd << "T" << time;
+
+    release. setFromISO8601(isostr.str());
+  }
+  return release;
+}
+
+const Types::Core::DateAndTime REVISION_DATE_AND_TIME = create_releaseDateAndTime();
+
 } // namespace
 
 /**
@@ -107,32 +140,7 @@ std::string MantidVersion::revision() { return REVISION_SHORT; }
 std::string MantidVersion::revisionFull() { return REVISION_FULL; }
 
 Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
-  if (REVISION_DATE == "UNKNOWN") {
-    // something went wrong in VersionNumber.cmake so give the default constructor result
-    Types::Core::DateAndTime release;
-    return release;
-  } else {
-    // pull apart string into year, month, and day objects
-    // WARNING if the format changes this will break
-    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4, 2)));
-    const auto month = to_month(REVISION_DATE.substr(7, 3));
-    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11, 4)));
-    std::string time = REVISION_DATE.substr(16);
-    if (time.empty()) {
-      time = "00:01"; // assume one minute past midnight
-    } else {
-      time.erase(find_if(time.begin(), time.end(), isspace));
-    }
-
-    // create a proper chrono from it
-    std::chrono::year_month_day ymd(year, month, day);
-    // convert to iso8601 string to get to DateAndTime
-    std::stringstream isostr;
-    isostr << ymd << "T" << time;
-
-    Types::Core::DateAndTime release(isostr.str());
-    return release;
-  }
+  return REVISION_DATE_AND_TIME;
 }
 
 std::string MantidVersion::releaseDate() {
@@ -144,7 +152,7 @@ std::string MantidVersion::releaseDate() {
 std::string MantidVersion::doi() {
   const std::string MAIN = "http://dx.doi.org/10.5286/Software/Mantid";
   // Cast here in those cases where patch number is of the form 20131022.1356.
-  const unsigned int patchVersion = static_cast<unsigned int>(@VERSION_PATCH @);
+  const unsigned int patchVersion = static_cast<unsigned int>(@VERSION_PATCH@);
 
   // For major/minor/patch releases we point users to a specific release-notes DOI, for
   // dev versions we just point to the main DOI.  A simple way to see whether or not
@@ -155,7 +163,7 @@ std::string MantidVersion::doi() {
     return MAIN;
 
   std::stringstream doi;
-  doi << MAIN << @VERSION_MAJOR @ << "." << @VERSION_MINOR @;
+  doi << MAIN << @VERSION_MAJOR@ << "." << @VERSION_MINOR@;
 
   // Keep to the convention where we write a version number like "3.0.0" as "3.0".
   if (patchVersion != 0)

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -19,11 +19,6 @@
 namespace Mantid::Kernel {
 
 namespace {
-const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
-const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@"};
-const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
-const std::string REVISION_SHORT{"@REVISION_SHORT@"};
-const std::string REVISION_FULL{"@REVISION_FULL@"};
 
 /**
  * The input month should only be the first 3 characters of the month name
@@ -61,6 +56,7 @@ Types::Core::DateAndTime create_releaseDateAndTime() {
   const std::string REVISION_DATE{"@REVISION_DATE@"};
 
   Types::Core::DateAndTime release;
+  // cppcheck-suppress knownConditionTrueFalse
   if (REVISION_DATE == "UNKNOWN") {
     // something went wrong in VersionNumber.cmake so give the default constructor result
   } else {
@@ -87,6 +83,11 @@ Types::Core::DateAndTime create_releaseDateAndTime() {
   return release;
 }
 
+const std::string DOI{"http://dx.doi.org/10.1016/j.nima.2014.07.029"};
+const std::string VERSION_FULL{"@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@@VERSION_TWEAK@"};
+const std::string VERSION_SHORT{"@VERSION_MAJOR@.@VERSION_MINOR@"};
+const std::string REVISION_SHORT{"@REVISION_SHORT@"};
+const std::string REVISION_FULL{"@REVISION_FULL@"};
 const Types::Core::DateAndTime REVISION_DATE_AND_TIME = create_releaseDateAndTime();
 
 } // namespace
@@ -96,9 +97,9 @@ const Types::Core::DateAndTime REVISION_DATE_AND_TIME = create_releaseDateAndTim
  * of the version number elements
  */
 
-std::string MantidVersion::version() { return VERSION_FULL; }
+const std::string &MantidVersion::version() { return VERSION_FULL; }
 
-std::string MantidVersion::versionShort() { return VERSION_SHORT; }
+const std::string &MantidVersion::versionShort() { return VERSION_SHORT; }
 
 const MantidVersion::VersionInfo MantidVersion::versionInfo() {
   return {"@VERSION_MAJOR@", "@VERSION_MINOR@", "@VERSION_PATCH@", "@VERSION_TWEAK@"};
@@ -135,9 +136,9 @@ std::string MantidVersion::releaseNotes() {
   return url.str();
 }
 
-std::string MantidVersion::revision() { return REVISION_SHORT; }
+const std::string &MantidVersion::revision() { return REVISION_SHORT; }
 
-std::string MantidVersion::revisionFull() { return REVISION_FULL; }
+const std::string &MantidVersion::revisionFull() { return REVISION_FULL; }
 
 Types::Core::DateAndTime MantidVersion::releaseDateAndTime() {
   return REVISION_DATE_AND_TIME;
@@ -159,6 +160,7 @@ std::string MantidVersion::doi() {
   // we're currently in a dev version is to check if the patch version is larger than
   // some arbitrarily low value.
   const std::string tweakVersion("@VERSION_TWEAK@");
+  // cppcheck-suppress knownConditionTrueFalse
   if (patchVersion > 100 || !tweakVersion.empty())
     return MAIN;
 
@@ -172,6 +174,6 @@ std::string MantidVersion::doi() {
   return doi.str();
 }
 
-std::string MantidVersion::paperCitation() { return DOI; }
+const std::string &MantidVersion::paperCitation() { return DOI; }
 
 } // namespace Mantid::Kernel

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/MantidVersion.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/MantidVersion.cpp
@@ -51,6 +51,8 @@ void export_MantidVersion() {
   def("revision", &Mantid::Kernel::MantidVersion::revision, "Returns the abbreviated SHA-1 of the last commit");
   def("revision_full", &Mantid::Kernel::MantidVersion::revisionFull, "Returns the full SHA-1 of the last commit");
   def("release_date", &Mantid::Kernel::MantidVersion::releaseDate, "Returns the date of the last commit");
+  def("release_date_and_time", &Mantid::Kernel::MantidVersion::releaseDateAndTime,
+      "Returns the DateAndTime of the last commit");
   def("doi", &Mantid::Kernel::MantidVersion::doi, "Returns the DOI for this release of Mantid");
   def("paper_citation", &Mantid::Kernel::MantidVersion::paperCitation, "Returns The citation for the Mantid paper");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/MantidVersion.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/MantidVersion.cpp
@@ -5,14 +5,15 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
+#include "MantidKernel/MantidVersion.h"
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/docstring_options.hpp>
 #include <boost/python/make_function.hpp>
 #include <boost/python/module.hpp>
+#include <boost/python/return_value_policy.hpp>
 #include <boost/python/type_id.hpp>
-
-#include "MantidKernel/MantidVersion.h"
 
 using namespace boost::python;
 using Mantid::Kernel::MantidVersion;
@@ -42,17 +43,20 @@ void export_MantidVersion() {
       .add_property("tweak", make_function(&getTweak), "The tweak release version")
       .def("__str__", make_function(&getStr), "The version in the standard form: {Major}.{Minor}.{Patch}{Tweak}");
 
-  def("version_str", &Mantid::Kernel::MantidVersion::version,
+  def("version_str", &Mantid::Kernel::MantidVersion::version, return_value_policy<copy_const_reference>(),
       "Returns the Mantid version string in the form \"{Major}.{Minor}.{Patch}{Tweak}\"");
   def("version", &Mantid::Kernel::MantidVersion::versionInfo,
       "Returns a data structure containing the major, minor, patch, and tweak parts of the version.");
   def("release_notes_url", &Mantid::Kernel::MantidVersion::releaseNotes,
       "Returns the url to the most applicable release notes");
-  def("revision", &Mantid::Kernel::MantidVersion::revision, "Returns the abbreviated SHA-1 of the last commit");
-  def("revision_full", &Mantid::Kernel::MantidVersion::revisionFull, "Returns the full SHA-1 of the last commit");
+  def("revision", &Mantid::Kernel::MantidVersion::revision, return_value_policy<copy_const_reference>(),
+      "Returns the abbreviated SHA-1 of the last commit");
+  def("revision_full", &Mantid::Kernel::MantidVersion::revisionFull, return_value_policy<copy_const_reference>(),
+      "Returns the full SHA-1 of the last commit");
   def("release_date", &Mantid::Kernel::MantidVersion::releaseDate, "Returns the date of the last commit");
   def("release_date_and_time", &Mantid::Kernel::MantidVersion::releaseDateAndTime,
       "Returns the DateAndTime of the last commit");
   def("doi", &Mantid::Kernel::MantidVersion::doi, "Returns the DOI for this release of Mantid");
-  def("paper_citation", &Mantid::Kernel::MantidVersion::paperCitation, "Returns The citation for the Mantid paper");
+  def("paper_citation", &Mantid::Kernel::MantidVersion::paperCitation, return_value_policy<copy_const_reference>(),
+      "Returns The citation for the Mantid paper");
 }

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
@@ -59,6 +59,7 @@ public:
   std::string toSimpleString() const;
   std::string toFormattedString(const std::string &format = "%Y-%b-%d %H:%M:%S") const;
   std::string toISO8601String() const;
+  std::string toHttpFormat() const;
 
   /// Stream output operator
   friend MANTID_TYPES_DLL std::ostream &operator<<(std::ostream &stream, const DateAndTime &t);

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -438,6 +438,20 @@ std::string DateAndTime::toFormattedString(const std::string &format) const {
  */
 std::string DateAndTime::toISO8601String() const { return boost::posix_time::to_iso_extended_string(to_ptime()); }
 
+/**
+ * Convert to RFC2616.
+ *
+ * Examples (from Poco::DateTimeFormat)
+ * Sat, 01 Jan 2005 12:00:00 +0100
+ * Sat, 01 Jan 2005 11:00:00 GMT
+ */
+std::string DateAndTime::toHttpFormat() const {
+  // time zone information doesn't come through correctly
+  // seconds should be included, but that isn't playing nice either
+  const std::string FORMAT("%a, %e %b %Y %H:%M");
+  return this->toFormattedString(FORMAT) + ":00 GMT";
+}
+
 //------------------------------------------------------------------------------------------------
 /** Get the year of this date.
  * @return the year

--- a/Framework/Types/test/DateAndTimeTest.h
+++ b/Framework/Types/test/DateAndTimeTest.h
@@ -370,6 +370,11 @@ public:
     TS_ASSERT_DELTA(DateAndTime::secondsFromDuration(time_no_tz - time_negative_tz2), 0.0, 1e-4);
   }
 
+  void test_httpFormat() {
+    DateAndTime time_no_tz = DateAndTime("2010-03-24T14:12:51.562"); // seconds and microseconds are ignored for now
+    TS_ASSERT_EQUALS(time_no_tz.toHttpFormat(), "Wed, 24 Mar 2010 14:12:00 GMT");
+  }
+
   void testDurations() {
     time_duration onesec = time_duration(0, 0, 1, 0);
     TS_ASSERT_EQUALS(DateAndTime::secondsFromDuration(onesec), 1.0);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -137,7 +137,6 @@ nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/GitHubApiHelp
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/GitHubApiHelper.cpp:168
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/GitHubApiHelper.cpp:169
 returnStdMoveLocal:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogParser.cpp:256
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/MantidVersion.cpp:100
 invalidLifetime:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:142
 variableScope:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Statistics.cpp:58
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Strings.cpp:1033

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -98,9 +98,6 @@ execute_process(
 )
 if(REVISION_DATE STREQUAL "")
   set(REVISION_DATE "UNKNOWN")
-else()
-  # only the last portion of the datetime
-  string(SUBSTRING ${REVISION_DATE} 0 15 REVISION_DATE)
 endif()
 
 message(STATUS "Git revision ${REVISION_FULL} on ${REVISION_DATE}")

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -100,7 +100,7 @@ if(REVISION_DATE STREQUAL "")
   set(REVISION_DATE "UNKNOWN")
 else()
   # only the last portion of the datetime
-  string(SUBSTRING ${REVISION_DATE} 0 16 REVISION_DATE)
+  string(SUBSTRING ${REVISION_DATE} 0 15 REVISION_DATE)
 endif()
 
 message(STATUS "Git revision ${REVISION_FULL} on ${REVISION_DATE}")


### PR DESCRIPTION
To localize parsing the date/time of the release, move the code into `MantidVersion` and expand some of the functionality of `DateAndTime` itself. Because I was there, I changed the various values from `MantidVersion` to return `std::string` rather than `char *`.

There is no associated issue

### To test:

The "big" check to do is to run `DownloadInstrument()` algorithm and see that it still functions. The unit tests use a mock object for the internet calls and exercising the real call is appropriate.

*This does not require release notes* because it is more of a refactor than anything else.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
