### PR TITLE
Add ability to be able to swap between quasielasticbayes and quickbayes backends in Bayes Fitting gui

### DIFF
--- a/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
@@ -26,7 +26,7 @@ Settings
   Opens this help page.
 
 Backend selection box
-  This drop down selects weather to use the ``quasielasticbayes`` or ``quickbayes``
+  This drop down selects whether to use the ``quasielasticbayes`` or ``quickbayes``
   package as the underlying model for the Quasi and Stretch tabs.
 
 Manage Directories

--- a/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
@@ -25,6 +25,10 @@ Settings
 ?
   Opens this help page.
 
+Backend selection box
+  This drop down selects weather to use the ``quasielasticbayes`` or ``quickbayes``
+  package as the underlying model for the Quasi and Stretch tabs.
+
 Manage Directories
   Opens the Manage Directories dialog allowing you to change your search directories
   and default save directory and enable/disable data archive search.

--- a/docs/source/release/v6.15.0/Inelastic/New_features/36373.rst
+++ b/docs/source/release/v6.15.0/Inelastic/New_features/36373.rst
@@ -1,0 +1,1 @@
+- Added a combo box to the :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` to swap between using the ``quasielasticbayes`` backend and the ``quickbayes`` backend. Changing this box won't effect the functionality of the ResNorm tab, which already uses ``quickbayes``.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
@@ -1,0 +1,15 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2010 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+enum class BayesBackendType { QUASI_ELASTIC_BAYES, QUICK_BAYES };
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -18,7 +18,8 @@ namespace MantidQt::CustomInterfaces {
 DECLARE_SUBWINDOW(BayesFitting)
 
 BayesFitting::BayesFitting(QWidget *parent)
-    : InelasticInterface(parent), m_changeObserver(*this, &BayesFitting::handleDirectoryChange) {
+    : InelasticInterface(parent), m_changeObserver(*this, &BayesFitting::handleDirectoryChange),
+      m_backend(BayesBackendType::QUASI_ELASTIC_BAYES) {
   m_uiForm.setupUi(this);
   m_uiForm.pbSettings->setIcon(Settings::icon());
 
@@ -53,9 +54,8 @@ std::unique_ptr<MantidQt::API::AlgorithmRunner> BayesFitting::createAlgorithmRun
 
 void BayesFitting::initLayout() {
   // Connect each tab to the actions available in this GUI
-  std::map<unsigned int, BayesFittingTab *>::iterator iter;
-  for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
-    connect(iter->second, &BayesFittingTab::showMessageBox, this, &BayesFitting::showMessageBox);
+  for (const auto &tab : m_bayesTabs) {
+    connect(tab.second, &BayesFittingTab::showMessageBox, this, &BayesFitting::showMessageBox);
   }
 
   loadSettings();
@@ -63,6 +63,7 @@ void BayesFitting::initLayout() {
   connect(m_uiForm.pbSettings, &QPushButton::clicked, this, &BayesFitting::settings);
   connect(m_uiForm.pbHelp, &QPushButton::clicked, this, &BayesFitting::help);
   connect(m_uiForm.pbManageDirs, &QPushButton::clicked, this, &BayesFitting::manageUserDirectories);
+  connect(m_uiForm.backendChoice, &QComboBox::currentTextChanged, this, &BayesFitting::setBackend);
 
   InelasticInterface::initLayout();
 }
@@ -116,6 +117,21 @@ void BayesFitting::applySettings(std::map<std::string, QVariant> const &settings
 }
 
 std::string BayesFitting::documentationPage() const { return "Inelastic Bayes Fitting"; }
+
+void BayesFitting::setBackend(const QString &text) {
+  BayesBackendType newBackend;
+  if (text == "quasielasticbayes") {
+    newBackend = BayesBackendType::QUASI_ELASTIC_BAYES;
+  } else if (text == "quickbayes") {
+    newBackend = BayesBackendType::QUICK_BAYES;
+  }
+  if (newBackend != m_backend) {
+    m_backend = newBackend;
+    for (const auto &tab : m_bayesTabs) {
+      tab.second->notifyBackendChanged(m_backend);
+    }
+  }
+}
 
 BayesFitting::~BayesFitting() = default;
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -122,8 +122,12 @@ void BayesFitting::setBackend(const QString &text) {
   BayesBackendType newBackend = m_backend;
   if (text == "quasielasticbayes") {
     newBackend = BayesBackendType::QUASI_ELASTIC_BAYES;
+    m_uiForm.warningLabel->setHidden(false);
+    m_uiForm.backendChoice->setToolTip("Old Fortran library");
   } else if (text == "quickbayes") {
     newBackend = BayesBackendType::QUICK_BAYES;
+    m_uiForm.warningLabel->setHidden(true);
+    m_uiForm.backendChoice->setToolTip("New Python library");
   }
   if (newBackend != m_backend) {
     m_backend = newBackend;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -119,7 +119,7 @@ void BayesFitting::applySettings(std::map<std::string, QVariant> const &settings
 std::string BayesFitting::documentationPage() const { return "Inelastic Bayes Fitting"; }
 
 void BayesFitting::setBackend(const QString &text) {
-  BayesBackendType newBackend;
+  BayesBackendType newBackend = m_backend;
   if (text == "quasielasticbayes") {
     newBackend = BayesBackendType::QUASI_ELASTIC_BAYES;
   } else if (text == "quickbayes") {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "ui_BayesFitting.h"
 
+#include "BayesBackendType.h"
 #include "BayesFittingTab.h"
 #include "DllConfig.h"
 #include "MantidQtWidgets/Spectroscopy/InelasticInterface.h"
@@ -64,6 +65,10 @@ private:
   Poco::NObserver<BayesFitting, Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
   /// Main interface window
   Ui::BayesFitting m_uiForm;
+  BayesBackendType m_backend;
+
+private slots:
+  void setBackend(const QString &text);
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
@@ -113,6 +113,8 @@
    </layout>
   </widget>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../icons/resources/icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
@@ -85,7 +85,24 @@
        </spacer>
       </item>
       <item>
+       <widget class="QLabel" name="warningLabel">
+        <property name="styleSheet">
+         <string notr="true">QLabel { color : red; }</string>
+        </property>
+        <property name="text">
+         <string>Warning: quasielasticbayes (old Fortran library) is deprecated
+and will be removed in a future release</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::AutoText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QComboBox" name="backendChoice">
+        <property name="toolTip">
+         <string>Old Fortran library</string>
+        </property>
         <property name="currentIndex">
          <number>0</number>
         </property>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
@@ -85,6 +85,23 @@
        </spacer>
       </item>
       <item>
+       <widget class="QComboBox" name="backendChoice">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>quasielasticbayes</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>quickbayes</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="pbManageDirs">
         <property name="text">
          <string>Manage Directories</string>
@@ -96,8 +113,6 @@
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="../../../MantidPlot/icons/icons.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -9,7 +9,7 @@
 namespace MantidQt::CustomInterfaces {
 
 BayesFittingTab::BayesFittingTab(QWidget *parent, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner)
-    : InelasticTab(parent), m_propTree(new QtTreePropertyBrowser()) {
+    : InelasticTab(parent), m_propTree(new QtTreePropertyBrowser()), m_useQuickBayes(false) {
 
   m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
   // Temporary until all Bayes Fitting tabs are refactored as MVP

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "BayesBackendType.h"
 #include "DllConfig.h"
 #include "MantidQtWidgets/Spectroscopy/InelasticTab.h"
 
@@ -72,6 +73,8 @@ public:
   virtual void applySettings(std::map<std::string, QVariant> const &settings);
   void notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) override;
 
+  virtual void notifyBackendChanged(const BayesBackendType &backend) = 0;
+
 protected slots:
   /// Slot to update the guides when the range properties change
   virtual void updateProperties(QtProperty *prop, double val);
@@ -86,6 +89,7 @@ protected:
   /// Tree of the properties
   QtTreePropertyBrowser *m_propTree;
   std::unique_ptr<MantidQt::API::IAlgorithmRunner> m_algorithmRunner;
+  bool m_useQuickBayes;
 
 private:
   virtual void setFileExtensionsByName(bool filter);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/CMakeLists.txt
@@ -14,7 +14,15 @@ set(SRC_FILES
     StretchModel.cpp
 )
 
-set(INC_FILES ResNormPresenter.h ResNormModel.h QuasiModel.h QuasiPresenter.h StretchPresenter.h StretchModel.h)
+set(INC_FILES
+    BayesBackendType.h
+    ResNormPresenter.h
+    ResNormModel.h
+    QuasiModel.h
+    QuasiPresenter.h
+    StretchPresenter.h
+    StretchModel.h
+)
 
 set(MOC_FILES BayesFitting.h BayesFittingTab.h QuasiView.h ResNormView.h StretchView.h)
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiPresenter.cpp
@@ -182,17 +182,14 @@ void QuasiPresenter::handleRun() {
   auto const eMin = m_view->eMin();
   auto const eMax = m_view->eMax();
 
-  // Temporary developer flag to allow the testing of quickBayes in the Bayes fitting interface
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-
   // Construct an output base name for the output workspaces
   auto const resType = resolutionName.substr(resolutionName.length() - 3);
   auto const programName = program == "QL" ? resType == "res" ? "QLr" : "QLd" : program;
-  auto const algoType = useQuickBayes ? "_quickbayes" : "_quasielasticbayes";
+  auto const algoType = m_useQuickBayes ? "_quickbayes" : "_quasielasticbayes";
   auto const baseName = sampleName.substr(0, sampleName.length() - 3) + programName + algoType;
 
   API::IConfiguredAlgorithm_sptr bayesQuasiAlgorithm;
-  if (useQuickBayes) {
+  if (m_useQuickBayes) {
     bayesQuasiAlgorithm =
         m_model->setupBayesQuasi2Algorithm(program, baseName, background, eMin, eMax, m_view->elasticPeak());
   } else {
@@ -203,6 +200,11 @@ void QuasiPresenter::handleRun() {
   }
 
   m_algorithmRunner->execute(bayesQuasiAlgorithm);
+}
+
+void QuasiPresenter::notifyBackendChanged(const BayesBackendType &backend) {
+  m_useQuickBayes = (backend == BayesBackendType::QUICK_BAYES);
+  m_view->updateBackend(m_useQuickBayes);
 }
 
 void QuasiPresenter::runComplete(IAlgorithm_sptr const &algorithm, bool const error) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiPresenter.h
@@ -63,6 +63,8 @@ public:
 
   void loadSettings(const QSettings &settings) override;
 
+  void notifyBackendChanged(const BayesBackendType &backend) override;
+
 protected:
   void runComplete(IAlgorithm_sptr const &algorithm, bool const error) override;
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
@@ -50,16 +50,13 @@ QColor toQColor(std::string const &colour) {
 namespace MantidQt::CustomInterfaces {
 using namespace InterfaceUtils;
 
-QuasiView::QuasiView(QWidget *parent)
+QuasiView::QuasiView(QWidget *parent, bool useQuickBayes)
     : QWidget(parent), m_dblManager(new QtDoublePropertyManager()), m_propTree(new QtTreePropertyBrowser()),
       m_properties(), m_dblEditorFactory(new DoubleEditorFactory()), m_presenter() {
   m_uiForm.setupUi(parent);
 
   m_propTree->setFactoryForManager(m_dblManager, m_dblEditorFactory);
-
-  setupFitOptions();
-  setupPropertyBrowser();
-  setupPlotOptions();
+  updateBackend(useQuickBayes);
 
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("QuasiERange");
   connect(eRangeSelector, &MantidWidgets::RangeSelector::minValueChanged, this, &QuasiView::minEValueChanged);
@@ -101,9 +98,13 @@ DataSelector *QuasiView::resNormSelector() const { return m_uiForm.dsResNorm; }
 
 FileFinderWidget *QuasiView::fixWidthFileFinder() const { return m_uiForm.mwFixWidthDat; }
 
-void QuasiView::setupFitOptions() {
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+void QuasiView::updateBackend(bool useQuickBayes) {
+  setupFitOptions(useQuickBayes);
+  setupPropertyBrowser(useQuickBayes);
+  setupPlotOptions(useQuickBayes);
+}
 
+void QuasiView::setupFitOptions(bool useQuickBayes) {
   m_uiForm.cbBackground->clear();
   if (useQuickBayes) {
     m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::LINEAR));
@@ -132,9 +133,7 @@ void QuasiView::setupFitOptions() {
   }
 }
 
-void QuasiView::setupPropertyBrowser() {
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-
+void QuasiView::setupPropertyBrowser(bool useQuickBayes) {
   m_properties.clear();
   m_dblManager->clear();
   m_propTree->clear();
@@ -167,9 +166,7 @@ void QuasiView::setupPropertyBrowser() {
   InterfaceUtils::formatTreeWidget(m_propTree, m_properties);
 }
 
-void QuasiView::setupPlotOptions() {
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-
+void QuasiView::setupPlotOptions(bool useQuickBayes) {
   m_uiForm.cbPlot->clear();
   if (useQuickBayes) {
     m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::ALL));

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.h
@@ -80,13 +80,14 @@ public:
   virtual void setLoadHistory(bool const loadHistory) = 0;
 
   virtual void loadSettings(const QSettings &settings) = 0;
+  virtual void updateBackend(bool useQuickBayes) = 0;
 };
 
 class QuasiView final : public QWidget, public IQuasiView {
   Q_OBJECT
 
 public:
-  QuasiView(QWidget *parent = nullptr);
+  QuasiView(QWidget *parent = nullptr, bool useQuickBayes = false);
   ~QuasiView() override = default;
 
   void subscribe(IQuasiPresenter *presenter) override;
@@ -137,6 +138,7 @@ public:
   void setLoadHistory(bool const loadHistory) override;
 
   void loadSettings(const QSettings &settings) override;
+  void updateBackend(bool useQuickBayes) override;
 
 private slots:
   void minEValueChanged(double const min);
@@ -156,9 +158,9 @@ private slots:
   void notifyPlotClicked();
 
 private:
-  void setupFitOptions();
-  void setupPropertyBrowser();
-  void setupPlotOptions();
+  void setupFitOptions(bool useQuickBayes);
+  void setupPropertyBrowser(bool useQuickBayes);
+  void setupPlotOptions(bool useQuickBayes);
 
   Ui::Quasi m_uiForm;
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormPresenter.h
@@ -50,6 +50,8 @@ public:
 
   const std::string getSubscriberName() const override { return "ResNorm"; }
 
+  void notifyBackendChanged(const BayesBackendType &backend) override { (void)backend; };
+
 protected:
   void runComplete(IAlgorithm_sptr const &algorithm, bool const error) override;
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -53,9 +53,13 @@ void StretchPresenter::handleRun() {
   m_fitWorkspaceName = baseName + "_Stretch_Fit";
   m_contourWorkspaceName = baseName + "_Stretch_Contour";
 
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-  auto stretch = m_model->stretchAlgorithm(algParams, m_fitWorkspaceName, m_contourWorkspaceName, useQuickBayes);
+  auto stretch = m_model->stretchAlgorithm(algParams, m_fitWorkspaceName, m_contourWorkspaceName, m_useQuickBayes);
   m_algorithmRunner->execute(stretch);
+}
+
+void StretchPresenter::notifyBackendChanged(const BayesBackendType &backend) {
+  m_useQuickBayes = (backend == BayesBackendType::QUICK_BAYES);
+  m_view->updateBackend(m_useQuickBayes);
 }
 
 void StretchPresenter::runComplete(IAlgorithm_sptr const &algorithm, bool const error) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.h
@@ -45,6 +45,8 @@ public:
   void notifyPlotCurrentPreviewClicked() override;
   void notifyPreviewSpecChanged(int specNum) override;
 
+  void notifyBackendChanged(const BayesBackendType &backend) override;
+
 protected:
   void runComplete(IAlgorithm_sptr const &algorithm, bool const error) override;
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
@@ -43,9 +43,10 @@ public:
   virtual std::string getPlotContour() const = 0;
   virtual IRunView *getRunWidget() const = 0;
 
-  virtual void setupFitOptions() = 0;
-  virtual void setupPropertyBrowser() = 0;
-  virtual void setupPlotOptions() = 0;
+  virtual void updateBackend(bool useQuickBayes) = 0;
+  virtual void setupFitOptions(bool useQuickBayes) = 0;
+  virtual void setupPropertyBrowser(bool useQuickBayes) = 0;
+  virtual void setupPlotOptions(bool useQuickBayes) = 0;
 
   virtual void setFileExtensionsByName(bool filter) = 0;
   virtual void setLoadHistory(bool doLoadHistory) = 0;
@@ -65,7 +66,7 @@ public:
 class MANTIDQT_INELASTIC_DLL StretchView : public QWidget, public IStretchView {
   Q_OBJECT
 public:
-  explicit StretchView(QWidget *parent = nullptr);
+  explicit StretchView(QWidget *parent = nullptr, bool useQuickBayes = false);
   ~StretchView() override = default;
 
   void subscribePresenter(IStretchViewSubscriber *presenter) override;
@@ -79,9 +80,10 @@ public:
   std::string getPlotContour() const override;
   IRunView *getRunWidget() const override;
 
-  void setupFitOptions() override;
-  void setupPropertyBrowser() override;
-  void setupPlotOptions() override;
+  void updateBackend(bool useQuickBayes) override;
+  void setupFitOptions(bool useQuickBayes) override;
+  void setupPropertyBrowser(bool useQuickBayes) override;
+  void setupPlotOptions(bool useQuickBayes) override;
 
   void setFileExtensionsByName(bool filter) override;
   void setLoadHistory(bool doLoadHistory) override;

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/MockObjects.h
@@ -41,9 +41,10 @@ public:
   MOCK_METHOD(std::string, getPlotContour, (), (const, override));
   MOCK_METHOD(IRunView *, getRunWidget, (), (const, override));
 
-  MOCK_METHOD(void, setupFitOptions, (), (override));
-  MOCK_METHOD(void, setupPropertyBrowser, (), (override));
-  MOCK_METHOD(void, setupPlotOptions, (), (override));
+  MOCK_METHOD(void, updateBackend, (bool useQuickBayes), (override));
+  MOCK_METHOD(void, setupFitOptions, (bool useQuickBayes), (override));
+  MOCK_METHOD(void, setupPropertyBrowser, (bool useQuickBayes), (override));
+  MOCK_METHOD(void, setupPlotOptions, (bool useQuickBayes), (override));
 
   MOCK_METHOD(void, setFileExtensionsByName, (bool filter), (override));
   MOCK_METHOD(void, setLoadHistory, (bool doLoadHistory), (override));
@@ -115,6 +116,7 @@ public:
   MOCK_METHOD(void, setFileExtensionsByName, (bool const filter), (override));
   MOCK_METHOD(void, setLoadHistory, (bool const loadHistory), (override));
   MOCK_METHOD(void, loadSettings, (const QSettings &settings), (override));
+  MOCK_METHOD(void, updateBackend, (bool useQuickBayes), (override));
 };
 
 class MockQuasiModel : public IQuasiModel {

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
@@ -157,6 +157,7 @@ public:
   }
 
   void test_notifyBackendChanged_alters_the_model_call() {
+    ON_CALL(*m_view, resolutionName()).WillByDefault(Return("res_ws"));
     EXPECT_CALL(*m_model, setupBayesQuasi2Algorithm(_, _, _, _, _, _)).Times(1);
 
     m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
@@ -146,6 +146,28 @@ public:
     m_presenter->setLoadHistory(loadHistory);
   }
 
+  void test_notifyBackendChanged_calls_view() {
+    EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+
+    EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+  }
+
+  void test_notifyBackendChanged_alters_the_model_call() {
+    EXPECT_CALL(*m_model, setupBayesQuasi2Algorithm(_, _, _, _, _, _)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->handleRun();
+
+    EXPECT_CALL(*m_model, setupBayesQuasiAlgorithm(_, _, _, _, _, _, _, _, _, _, _, _, _)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->handleRun();
+  }
+
 private:
   void expectUpdateMiniPlot() {
     std::size_t const spectrum(0u);

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -140,6 +140,31 @@ public:
     m_presenter->notifySaveClicked();
   }
 
+  void test_notifyBackendChanged_calls_view() {
+    EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+
+    EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+  }
+
+  void test_notifyBackendChanged_changes_stretchAlgorithm_call() {
+    StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
+
+    ON_CALL(*m_view, getRunData()).WillByDefault(Return(runData));
+    EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, true)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->handleRun();
+
+    EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, false)).Times(1);
+
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->handleRun();
+  }
+
 private:
   NiceMock<MockAlgorithmRunner> *m_algorithmRunner;
   NiceMock<MockStretchModel> *m_model;


### PR DESCRIPTION
### Description of work

For a while now the Quasi and Stretch tabs for the bayes fitting interface have had the hidden option to use the newer bayes algorithms based on the quickBayes package. This was accessed via a developer flag.

This pr exposes this option to the user via a combo box added to the bottom of the interface, allowing them to stop between the two backends as they wish.

Closes #36373

### To test:

Spencer has offered to test this build: https://builds.mantidproject.org/job/build_branch/1448/artifact/

 - Open Inelastic Bayes Fitting interface
 - Swap between the quasielasticbayes and quickbayes options on the new combo box (bottom right) and notice:
   - Tool tip changes
   - Options on the Quasi and Fit tabs change
   - Warning appears when using quasielasticbayes

You could run the manual test instructions using quickbayes https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
