### PR TITLE
Migrate `LoadNexusProcessed` for lazy file descriptor

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -18,6 +18,7 @@
 #include "MantidHistogramData/BinEdges.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidNexus/NexusClasses_fwd.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 #include <map>
 #include <memory>
 #include <vector>
@@ -42,7 +43,7 @@ Required Properties:
 <LI> InputWorkspace - The name of the workspace to put the data </LI>
 </UL>
 */
-class MANTID_DATAHANDLING_DLL LoadNexusProcessed : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadNexusProcessed : public API::IFileLoader<Mantid::Nexus::NexusDescriptorLazy> {
 
 public:
   /// Default constructor
@@ -66,7 +67,7 @@ public:
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 protected:
   /// Read the spectra
@@ -80,7 +81,7 @@ private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void execLoader() override;
+  void exec() override;
 
   void reinitSpecialWorkspace2D(std::shared_ptr<Mantid::DataObjects::SpecialWorkspace2D> specialLocalWorkspace);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
@@ -11,7 +11,7 @@
 #include "MantidDataHandling/LoadNexusProcessed.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidIndexing/SpectrumNumber.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 #include <string>
 #include <unordered_map>
 
@@ -41,7 +41,7 @@ public:
   // const std::string name() const override;
 
   int version() const override;
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void readSpectraToDetectorMapping(Mantid::Nexus::NXEntry &mtd_entry, Mantid::API::MatrixWorkspace &ws) override;

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -52,7 +52,7 @@
 namespace Mantid::DataHandling {
 
 // Register the algorithm into the algorithm factory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNexusProcessed)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadNexusProcessed)
 
 using namespace Mantid::Nexus;
 using namespace DataObjects;
@@ -194,7 +194,7 @@ LoadNexusProcessed::~LoadNexusProcessed() = default;
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadNexusProcessed::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadNexusProcessed::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.isEntry("/mantid_workspace_1"))
     return 80;
   else
@@ -374,7 +374,7 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(NXRoot &root
  *
  *  @throw runtime_error Thrown if algorithm cannot execute
  */
-void LoadNexusProcessed::execLoader() {
+void LoadNexusProcessed::exec() {
 
   API::Workspace_sptr tempWS;
   size_t nWorkspaceEntries = 0;
@@ -1936,8 +1936,7 @@ API::Workspace_sptr LoadNexusProcessed::loadEntry(NXRoot &root, const std::strin
     // For workspaces saved via SaveNexusESS, these warnings are not
     // relevant. Such workspaces will contain an `NXinstrument` entry
     // with the name of the instrument.
-    const auto &entries = getFileInfo()->getAllEntries();
-    if (version() < 2 || entries.find("NXinstrument") == entries.end()) {
+    if (version() < 2 || m_nexusFile->classTypeExists("NXinstrument")) {
       g_log.warning("Error loading Instrument section of nxs file");
       g_log.warning(e.what());
       g_log.warning("Try running LoadInstrument Algorithm on the Workspace to "

--- a/Framework/DataHandling/src/LoadNexusProcessed2.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed2.cpp
@@ -24,7 +24,7 @@ using Mantid::API::WorkspaceProperty;
 using Mantid::Kernel::Direction;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNexusProcessed2)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadNexusProcessed2)
 //----------------------------------------------------------------------------------------------
 
 namespace {
@@ -235,7 +235,7 @@ bool LoadNexusProcessed2::loadNexusGeometry(API::Workspace &ws, size_t entryNumb
   return false;
 }
 
-int LoadNexusProcessed2::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadNexusProcessed2::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   if (descriptor.isEntry("/mantid_workspace_1"))
     return LoadNexusProcessed::confidence(descriptor) + 1; // incrementally better than v1.
   else

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -568,6 +568,13 @@ public:
    */
   std::string getTopLevelEntryName() const;
 
+  /** Check if a class type exists in the file
+   *
+   * \param class_type The class type to check for
+   * \return true if the class type exists
+   */
+  bool classTypeExists(std::string const &class_type) const { return m_descriptor.classTypeExists(class_type); }
+
   //------------------------------------------------------------------------------------------------------------------
   // ATTRIBUTE METHODS
   //------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadNexusProcessed` algorithm.   Its confidence check is trivially portable.  However, this inherited from `NexusFileLoader`, which requires a `NexusDescriptor` for the confidence check.   One location in the code relied on the inherited `NexusDescriptor`, so that it could not be trivially migrated to use the lazy version.

This adds a new method to `Nexus::File` which passes through to the `NexusDescriptor` to call its `classNameExists` method, which is what is actually needed inside this load algo.  With that, the `NexusDecriptor` is no longer needed and this can be set to inherit from `IFileLoader<NexusDescriptorLazy>`.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

This is a refactor, so ensure all current tests works. A test of the confidence calculation already existed, and a new one was added to make sure `Load` can still correctly find this loader.

Especially look at the `LoadLotsOfFiles` system test.

Tests in PR #40570 verified that `Load` is able to find load algorithms with a lazy descriptor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
