### PR TITLE
Extension of Pawley classes for POLDI workflow

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
+++ b/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
@@ -17,6 +17,7 @@ from joblib import Parallel, delayed
 from functools import reduce
 from operator import iadd
 from itertools import islice
+from multiprocessing import cpu_count
 
 
 class PoldiAutoCorrelation(PythonAlgorithm):
@@ -124,7 +125,7 @@ class PoldiAutoCorrelation(PythonAlgorithm):
             do_autocorr = _autocorr_spec_linear
         else:
             do_autocorr = _autocorr_spec_nearest
-        generator = Parallel(n_jobs=-2, prefer="threads", return_as="generator")(
+        generator = Parallel(n_jobs=min(4, cpu_count()), prefer="threads", return_as="generator")(
             delayed(do_autocorr)(ws.readY(ispec), tof_d1Ang[ispec], dspacs, offsets, bin_width, progress) for ispec in range(nspec)
         )
         # sum over spectra in each group

--- a/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
+++ b/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
@@ -138,6 +138,11 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         ws_corr = self.exec_child_alg(
             "CreateWorkspace", DataX=dspacs, DataY=corr, UnitX="dSpacing", YUnitLabel="Intensity (a.u.)", NSpec=ngroups, ParentWorkspace=ws
         )
+        # assign detector IDs to autocorr
+        detids_in_groups = np.array_split(ws_corr.detectorInfo().detectorIDs(), ngroups)
+        for ispec, detids in enumerate(detids_in_groups):
+            spec = ws_corr.getSpectrum(ispec)
+            [spec.addDetectorID(int(detid)) for detid in detids]
         ws_corr = self.exec_child_alg("ConvertUnits", InputWorkspace=ws_corr, Target="MomentumTransfer")
         self.setProperty("OutputWorkspace", ws_corr)
 

--- a/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
+++ b/Framework/PythonInterface/plugins/algorithms/PoldiAutoCorrelation6.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm, Progress
-from mantid.kernel import Direction, FloatBoundedValidator, UnitParams, StringListValidator
+from mantid.kernel import Direction, IntBoundedValidator, FloatBoundedValidator, UnitParams, StringListValidator
 import numpy as np
 from plugins.algorithms.poldi_utils import (
     get_instrument_settings_from_log,
@@ -16,6 +16,7 @@ from plugins.algorithms.poldi_utils import (
 from joblib import Parallel, delayed
 from functools import reduce
 from operator import iadd
+from itertools import islice
 
 
 class PoldiAutoCorrelation(PythonAlgorithm):
@@ -62,6 +63,13 @@ class PoldiAutoCorrelation(PythonAlgorithm):
             doc="Interpolation used when adding intensity to a given bin in correlation function - "
             "'Nearest' is quicker but potentially less accurate.",
         )
+        self.declareProperty(
+            "NGroups",
+            defaultValue=1,
+            direction=Direction.Input,
+            validator=IntBoundedValidator(lower=1),
+            doc="Number of groups to split poldi detectors into (returns a spectrum per group)",
+        )
 
     def validateInputs(self):
         issues = dict()
@@ -86,6 +94,7 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         ws = self.getProperty("InputWorkspace").value
         lambda_min = self.getProperty("WavelengthMin").value
         lambda_max = self.getProperty("WavelengthMax").value
+        ngroups = self.getProperty("NGroups").value
 
         cycle_time, slit_offsets, t0_const, l1_chop = get_instrument_settings_from_log(ws)
         # get detector positions from IDF
@@ -115,16 +124,19 @@ class PoldiAutoCorrelation(PythonAlgorithm):
             do_autocorr = _autocorr_spec_linear
         else:
             do_autocorr = _autocorr_spec_nearest
-        inter_corr = reduce(
-            iadd,
-            Parallel(n_jobs=-2, prefer="threads", return_as="generator_unordered")(
-                delayed(do_autocorr)(ws.readY(ispec), tof_d1Ang[ispec], dspacs, offsets, bin_width, progress) for ispec in range(nspec)
-            ),
-        )  # npulses*nslits
-        # average of inverse intermediate correlation func (Eq.8 in POLDI concept paper)
-        with np.errstate(divide="ignore", invalid="ignore"):
-            corr = 1 / np.nansum(1 / inter_corr, axis=1)
-        ws_corr = self.exec_child_alg("CreateWorkspace", DataX=dspacs, DataY=corr, UnitX="dSpacing", YUnitLabel="Intensity (a.u.)")
+        generator = Parallel(n_jobs=-2, prefer="threads", return_as="generator")(
+            delayed(do_autocorr)(ws.readY(ispec), tof_d1Ang[ispec], dspacs, offsets, bin_width, progress) for ispec in range(nspec)
+        )
+        # sum over spectra in each group
+        corr = np.zeros((ngroups, len(dspacs)))
+        nspectra_per_group = nspec // ngroups
+        for igroup in range(ngroups - 1):
+            corr[igroup, :] = _sum_over_intermediate_correlation_func(islice(generator, nspectra_per_group))
+        # eval last grouping with remainder of generator
+        corr[ngroups - 1, :] = _sum_over_intermediate_correlation_func(generator)
+        ws_corr = self.exec_child_alg(
+            "CreateWorkspace", DataX=dspacs, DataY=corr, UnitX="dSpacing", YUnitLabel="Intensity (a.u.)", NSpec=ngroups, ParentWorkspace=ws
+        )
         ws_corr = self.exec_child_alg("ConvertUnits", InputWorkspace=ws_corr, Target="MomentumTransfer")
         self.setProperty("OutputWorkspace", ws_corr)
 
@@ -136,6 +148,14 @@ class PoldiAutoCorrelation(PythonAlgorithm):
         alg.execute()
         out_props = tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
         return out_props[0] if len(out_props) == 1 else out_props
+
+
+def _sum_over_intermediate_correlation_func(generator):
+    inter_corr = reduce(iadd, generator)  # sum over spectra (output has shape len(dspacs) x npulses*nslits)
+    # average of inverse intermediate correlation func (Eq.8 in POLDI concept paper)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        corr = 1 / np.nansum(1 / inter_corr, axis=1)
+    return corr
 
 
 def _autocorr_spec_linear(y, tof_d1Ang, dspacs, offsets, bin_width, progress):

--- a/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
+++ b/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
@@ -95,7 +95,15 @@ def load_poldi_h5f(
         for bank_name in ["south", "north"]:
             dat.append(np.asarray(f.get(f"entry1/POLDI/detector_{bank_name}/histogram_folded")))
         chopper_speed = f.get("entry1/POLDI/chopper/rotation_speed_target")[0]
-        monitor_count = f.get("entry1/monitors/monitor_before_sample")[0]
+        if np.allclose([bank.sum() for bank in dat], 0):
+            monitor_count = 0  # can be error in detector electronics where no data but erroneous monitor counts
+        else:
+            monitor_count = 1
+            # check different fields as monitor name has changed
+            if "entry1/monitors/monitor_before_sample" in f:
+                monitor_count = f.get("entry1/monitors/monitor_before_sample")[0]
+            elif "entry1/monitors/monitor3" in f:
+                monitor_count = f.get("entry1/monitors/monitor3")[0]
     dat = np.vstack(dat)
     # calculate time bins
     cycle_time = _calc_cycle_time_from_chopper_speed(chopper_speed)

--- a/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
+++ b/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
@@ -240,7 +240,7 @@ def get_max_tof_from_chopper(l1: float, l1_chop: float, l2s: Sequence[float], tt
 
 
 def simulate_2d_data(
-    ws_2d: Workspace2D, ws_1d: Workspace2D, output_workspace: Optional[str] = None, lambda_max: float = 5.0
+    ws_2d: Workspace2D, ws_1d: Workspace2D, output_workspace: Optional[str] = None, lambda_max: float = 5.0, ispec=0
 ) -> Workspace2D:
     """
     Function to simulate 2D pulse overlap data given 1D spectrum in d-spacing (i.e. powder pattern).
@@ -257,7 +257,11 @@ def simulate_2d_data(
         ws_1d = exec_alg("ConvertToPointData", InputWorkspace=ws_1d)
     if output_workspace is None:
         output_workspace = ws_2d.name() + "_simulated"
-    ws_sim = exec_alg("CloneWorkspace", InputWorkspace=ws_2d)
+    if not ws_1d.spectrumInfo().hasDetectors(ispec) or ws_1d.getNumberHistograms() == 1:
+        ws_sim = exec_alg("CloneWorkspace", InputWorkspace=ws_2d)
+    else:
+        # simulate only detector IDs of interest
+        ws_sim = exec_alg("ExtractSpectra", InputWorkspace=ws_2d, DetectorList=np.array(ws_1d.getSpectrum(ispec).getDetectorIDs()))
     # get instrument settings
     cycle_time, slit_offsets, t0_const, l1_chop = get_instrument_settings_from_log(ws_sim)
     si = ws_sim.spectrumInfo()

--- a/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
+++ b/Framework/PythonInterface/plugins/algorithms/poldi_utils.py
@@ -92,7 +92,7 @@ def load_poldi_h5f(
     # read in data
     dat = []
     with h5py.File(fpath_data, "r") as f:
-        for bank_name in {"south", "north"}:
+        for bank_name in ["south", "north"]:
             dat.append(np.asarray(f.get(f"entry1/POLDI/detector_{bank_name}/histogram_folded")))
         chopper_speed = f.get("entry1/POLDI/chopper/rotation_speed_target")[0]
         monitor_count = f.get("entry1/monitors/monitor_before_sample")[0]

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
@@ -5,6 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+import numpy as np
 from mantid.simpleapi import PoldiAutoCorrelation, AnalysisDataService
 from mantid.api import FileFinder
 from plugins.algorithms.poldi_utils import load_poldi
@@ -41,6 +43,19 @@ class PoldiAutoCorrelation6Test(unittest.TestCase):
         # assert bin width/number bins
         self.assertEqual(ws_corr.blocksize(), 1748)
 
+    def test_exec_ngroups(self):
+        ngroups = 3
+        ws_corr = PoldiAutoCorrelation(InputWorkspace=self.ws, OutputWorkspace="ws_corr", NGroups=ngroups, Version=6)
+
+        # assert two-theta of spectra
+        self.assertEqual(ws_corr.getNumberHistograms(), ngroups)
+        si = ws_corr.spectrumInfo()
+        tths = np.degrees([si.twoTheta(ispec) for ispec in range(ws_corr.getNumberHistograms())])
+        assert_array_almost_equal(tths, np.array([79.19, 89.73, 100.26]), decimal=2)
+        # assert number fo detectors associated with each spectrum
+        ndets = [len(ws_corr.getSpectrum(ispec).getDetectorIDs()) for ispec in range(ws_corr.getNumberHistograms())]
+        assert_array_equal(ndets, np.array([150, 149, 149]))
+
     def _assert_auto_corr_workspace(self, ws_corr):
         # assert min/max Q
         self.assertAlmostEqual(ws_corr.readX(0)[0], 1.5144, delta=1e-3)
@@ -50,6 +65,8 @@ class PoldiAutoCorrelation6Test(unittest.TestCase):
         # assert max y-value at Bragg peak Q
         _, imax = ws_corr.findY(ws_corr.readY(0).max())
         self.assertAlmostEqual(ws_corr.readX(0)[imax], 3.272, delta=1e-2)  # (220) peak @ d = 1.920 Ang
+        # assert spectra have detectorIDs
+        self.assertTrue(ws_corr.spectrumInfo().hasDetectors(0))
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PoldiAutoCorrelation6Test.py
@@ -52,7 +52,7 @@ class PoldiAutoCorrelation6Test(unittest.TestCase):
         si = ws_corr.spectrumInfo()
         tths = np.degrees([si.twoTheta(ispec) for ispec in range(ws_corr.getNumberHistograms())])
         assert_array_almost_equal(tths, np.array([79.19, 89.73, 100.26]), decimal=2)
-        # assert number fo detectors associated with each spectrum
+        # assert number of detectors associated with each spectrum
         ndets = [len(ws_corr.getSpectrum(ispec).getDetectorIDs()) for ispec in range(ws_corr.getNumberHistograms())]
         assert_array_equal(ndets, np.array([150, 149, 149]))
 

--- a/Testing/Data/SystemTest/poldi2025n012174.hdf.md5
+++ b/Testing/Data/SystemTest/poldi2025n012174.hdf.md5
@@ -1,0 +1,1 @@
+ea0bcbf1bbf1e6fa41ecef524bc2c6a6

--- a/Testing/SystemTests/tests/framework/CMakeLists.txt
+++ b/Testing/SystemTests/tests/framework/CMakeLists.txt
@@ -162,6 +162,7 @@ set(SYSTEST_NAMES
     POLDIFitPeaks2DTest.py
     POLDILoadRunsTest.py
     POLDIMergeTest.py
+    POLDIPawleyTest.py
     POLDIPeakSearchTest.py
     POLDITruncateDataTest.py
     PolrefExample.py

--- a/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40599.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40599.rst
@@ -1,0 +1,14 @@
+- Added calibrated IDF for POLDI (PSI) post upgrade in December 2025
+- New loader ``load_poldi_h5f`` for h5f file produced by POLDI post instrument upgrade in ``plugins.algorithms.poldi_utils``
+- New features in :ref:`algm-PoldiAutoCorrelation-v6`
+
+  - Add parameter ``NGroups```  to split POLDI detectors into groups and produce a autocorrelation spectrum per grouping
+  - Associate detector IDs with autocorrelation spectra in output workspace
+
+- New features in ``PawleyPattern1D`` class in ``Engineering.pawley_utils``
+
+  - Method to perform 'free' fit - i.e. do not constrain peak centres to predicted positions
+  - Improvements to robustness of background estimation
+  - Method to fit background function to 1D data using one-sided 'robust' cost function that is biased to minimize negative residuals.
+
+- Added class ``PawleyPattern2DNoConstraints`` in ``Engineering.pawley_utils`` to do a 'free' 2D refinement of POLDI data

--- a/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40599.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Engineering/New_features/40599.rst
@@ -9,6 +9,6 @@
 
   - Method to perform 'free' fit - i.e. do not constrain peak centres to predicted positions
   - Improvements to robustness of background estimation
-  - Method to fit background function to 1D data using one-sided 'robust' cost function that is biased to minimize negative residuals.
+  - Method to fit background function to 1D data using a cost function that is biased to be less sensitive to positive outliers.
 
 - Added class ``PawleyPattern2DNoConstraints`` in ``Engineering.pawley_utils`` to do a 'free' 2D refinement of POLDI data

--- a/instrument/POLDI_Definition_896.xml
+++ b/instrument/POLDI_Definition_896.xml
@@ -344,8 +344,8 @@
 
 <type name="detector-block">
   <component type="detector-pixel">
-  <locations x="0.07875" x-end="0.00125" n-elements="32" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel" name-count-start="1"/>
-  <locations x="-0.00125" x-end="-0.07875" n-elements="32" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel" name-count-start="33"/>
+  <locations x="0.07875" x-end="0.00125" n-elements="32" y="0" z="0" rot="-90" name="pixel" name-count-start="1"/>
+  <locations x="-0.00125" x-end="-0.07875" n-elements="32" y="0" z="0" name="pixel" name-count-start="33"/>
   </component>
 </type>
 

--- a/instrument/POLDI_Definition_896.xml
+++ b/instrument/POLDI_Definition_896.xml
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- For help on the notation used to specify an Instrument Definition File 
+     see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+ name="POLDI" valid-from   ="2025-12-03 23:59:59"
+                           valid-to     ="2100-01-31 23:59:59"
+		           last-modified="2026-01-09 16:00:00">
+<!-- Instrument description for POLDI with new detector, Gergely Nemeth 2024 -->
+<defaults>
+  <length unit="meter" />
+  <angle unit="degree" />
+  <reference-frame>
+    <along-beam axis="z" />
+    <pointing-up axis="y" />
+    <handedness val="right" />
+  </reference-frame>
+  <default-view view="3D"/>
+  <!-- Comment 'components-are-facing' out if you don't want the
+  components defined in this file to face a position by default -->    
+  <!-- <components-are-facing x="0.0" y="0.0" z="0.0" />-->
+</defaults>
+<!-- POLDI description starts here -->
+<!-- Two banks (north & south), each bank made of 7 modules, each module made of 64 pixels -->
+<!-- The process of facing is: Make the xy-plane of the geometric shape of the component face
+     the specified location by rotating the z-axis of this component so that the z-axis points
+     in the direction from the location to this component.  -->
+
+<!-- First, the source, sample and monitors -->
+<type name="source" is="Source" />
+<component type="source" name="source">
+        <location z="-12.0000" />
+        <parameter name="PoldiSpectrum:WavelengthDistribution" type="fitting">
+            <!--
+                This is the POLDI neutron wavelength distribution. The intensities
+                are given such that Mean(I) = 1.0.
+            -->
+            <lookuptable x-unit="Wavelength">
+                <point x="0.986430049" y="0.0379200461685" />
+                <point x="1.01097" y="0.0647900877564" />
+                <point x="1.03552008" y="0.158472779233" />
+                <point x="1.06007004" y="0.519912166374" />
+                <point x="1.08460999" y="1.61236820184" />
+                <point x="1.10916007" y="2.92556206166" />
+                <point x="1.13371003" y="3.01527151822" />
+                <point x="1.15825999" y="3.08617045167" />
+                <point x="1.18280005" y="3.3797870393" />
+                <point x="1.20735002" y="3.54669731732" />
+                <point x="1.23189998" y="3.6408488786" />
+                <point x="1.25644004" y="3.61670774172" />
+                <point x="1.28099" y="3.74104456034" />
+                <point x="1.30553997" y="3.85943944836" />
+                <point x="1.33009005" y="3.75758537926" />
+                <point x="1.35462999" y="3.72106056606" />
+                <point x="1.37918007" y="3.73501609979" />
+                <point x="1.40373003" y="3.80737158413" />
+                <point x="1.42826998" y="3.74757696126" />
+                <point x="1.45282006" y="3.79171629046" />
+                <point x="1.47737002" y="3.70519039935" />
+                <point x="1.50190997" y="3.64835854136" />
+                <point x="1.52646005" y="3.58509014427" />
+                <point x="1.55101001" y="3.52528432718" />
+                <point x="1.57554996" y="3.58574587753" />
+                <point x="1.60010004" y="3.52296612136" />
+                <point x="1.62465" y="3.48146692706" />
+                <point x="1.64919996" y="3.29247486904" />
+                <point x="1.67374003" y="3.18613505977" />
+                <point x="1.69828999" y="3.11493402243" />
+                <point x="1.72284007" y="3.019974154" />
+                <point x="1.74738002" y="2.95223419475" />
+                <point x="1.77192998" y="2.87013941439" />
+                <point x="1.79648006" y="2.8518896839" />
+                <point x="1.82102001" y="2.81334596521" />
+                <point x="1.84556997" y="2.79063867035" />
+                <point x="1.87012005" y="2.73278925933" />
+                <point x="1.89467001" y="2.70067519099" />
+                <point x="1.91921008" y="2.6032279618" />
+                <point x="1.94376004" y="2.49786056822" />
+                <point x="1.96831" y="2.3271600338" />
+                <point x="1.99285007" y="2.34552390934" />
+                <point x="2.01740003" y="2.22035491325" />
+                <point x="2.04194999" y="2.29464387452" />
+                <point x="2.06648993" y="2.20015866926" />
+                <point x="2.09104013" y="2.1126010471" />
+                <point x="2.1155901" y="2.03543605117" />
+                <point x="2.14014006" y="2.03696461356" />
+                <point x="2.16468" y="2.02314915783" />
+                <point x="2.18922997" y="1.92865797498" />
+                <point x="2.21377993" y="1.76339003593" />
+                <point x="2.23832011" y="1.70948140257" />
+                <point x="2.26287007" y="1.70655034399" />
+                <point x="2.28742003" y="1.63185257524" />
+                <point x="2.31195998" y="1.6101119067" />
+                <point x="2.33650994" y="1.52402877822" />
+                <point x="2.3610599" y="1.41765223428" />
+                <point x="2.3856101" y="1.41372656581" />
+                <point x="2.41015005" y="1.37861914774" />
+                <point x="2.43470001" y="1.39547907016" />
+                <point x="2.45924997" y="1.32522954793" />
+                <point x="2.48378992" y="1.3747536237" />
+                <point x="2.50834012" y="1.26342285426" />
+                <point x="2.53289008" y="1.1961405706" />
+                <point x="2.55743003" y="1.15607902115" />
+                <point x="2.58197999" y="1.09374471504" />
+                <point x="2.60652995" y="1.08882219384" />
+                <point x="2.63107991" y="1.08884830502" />
+                <point x="2.6556201" y="1.05670290487" />
+                <point x="2.68017006" y="1.02406197103" />
+                <point x="2.70472002" y="0.989440668677" />
+                <point x="2.72925997" y="1.00035277903" />
+                <point x="2.75380993" y="0.95038734642" />
+                <point x="2.77836013" y="0.869240260323" />
+                <point x="2.80291009" y="0.836101367713" />
+                <point x="2.82745004" y="0.832658084227" />
+                <point x="2.852" y="0.784670032334" />
+                <point x="2.87654996" y="0.789144670394" />
+                <point x="2.90108991" y="0.725317653441" />
+                <point x="2.92564011" y="0.737710213048" />
+                <point x="2.95019007" y="0.742183265093" />
+                <point x="2.97473001" y="0.692213030379" />
+                <point x="2.99927998" y="0.653130845445" />
+                <point x="3.02382994" y="0.658097474694" />
+                <point x="3.04837012" y="0.629903015127" />
+                <point x="3.07292008" y="0.620515648311" />
+                <point x="3.09747005" y="0.59182542276" />
+                <point x="3.12202001" y="0.596295491013" />
+                <point x="3.14655995" y="0.553251221336" />
+                <point x="3.17110991" y="0.561185043087" />
+                <point x="3.19566011" y="0.509726198752" />
+                <point x="3.22020006" y="0.497861766253" />
+                <point x="3.24475002" y="0.500350162334" />
+                <point x="3.26929998" y="0.462253499734" />
+                <point x="3.29383993" y="0.448903255167" />
+                <point x="3.31839013" y="0.442976704117" />
+                <point x="3.34293699" y="0.410906557596" />
+                <point x="3.36748409" y="0.400728656223" />
+                <point x="3.39203095" y="0.390802883239" />
+                <point x="3.41657805" y="0.381123104847" />
+                <point x="3.44112492" y="0.371682888874" />
+                <point x="3.46567202" y="0.362476568119" />
+                <point x="3.49021912" y="0.35349822306" />
+                <point x="3.51476598" y="0.34474241879" />
+                <point x="3.53931308" y="0.336203424027" />
+                <point x="3.56385994" y="0.327875851925" />
+                <point x="3.58840704" y="0.319754644057" />
+                <point x="3.61295295" y="0.311834601816" />
+                <point x="3.637501" y="0.304110594682" />
+                <point x="3.66204691" y="0.296578008794" />
+                <point x="3.68659401" y="0.289232018017" />
+                <point x="3.71114111" y="0.282067934396" />
+                <point x="3.73568797" y="0.275081354334" />
+                <point x="3.76023507" y="0.268267710027" />
+                <point x="3.78478193" y="0.261622986372" />
+                <point x="3.80932903" y="0.255142781777" />
+                <point x="3.83387613" y="0.248823039086" />
+                <point x="3.85842299" y="0.242659933438" />
+                <point x="3.88297009" y="0.236649455739" />
+                <point x="3.90751696" y="0.230787759101" />
+                <point x="3.93206406" y="0.225071303024" />
+                <point x="3.95661092" y="0.219496468911" />
+                <point x="3.98115826" y="0.214059716263" />
+                <point x="4.0057044" y="0.208757618724" />
+                <point x="4.03025055" y="0.203586864087" />
+                <point x="4.0547986" y="0.198544166977" />
+                <point x="4.0793457" y="0.193626378592" />
+                <point x="4.10389137" y="0.188830387379" />
+                <point x="4.12843847" y="0.184153209345" />
+                <point x="4.15298653" y="0.179591790409" />
+                <point x="4.17753267" y="0.17514353127" />
+                <point x="4.20207977" y="0.170805354615" />
+                <point x="4.2266264" y="0.166574544595" />
+                <point x="4.2511735" y="0.162448630069" />
+                <point x="4.2757206" y="0.158424976688" />
+                <point x="4.3002677" y="0.154500833359" />
+                <point x="4.32481432" y="0.150673962236" />
+                <point x="4.34936142" y="0.146941962269" />
+                <point x="4.37390852" y="0.143302256984" />
+                <point x="4.39845562" y="0.139752771944" />
+                <point x="4.42300272" y="0.136291257291" />
+                <point x="4.44754934" y="0.132915370247" />
+                <point x="4.47209644" y="0.129623152325" />
+                <point x="4.49664354" y="0.126412482228" />
+                <point x="4.52119064" y="0.123281343393" />
+                <point x="4.54573774" y="0.120227765918" />
+                <point x="4.57028341" y="0.11724980313" />
+                <point x="4.59483051" y="0.114345613286" />
+                <point x="4.61937857" y="0.111513366463" />
+                <point x="4.64392471" y="0.108751267379" />
+                <point x="4.66847134" y="0.106057579427" />
+                <point x="4.69301844" y="0.103430600844" />
+                <point x="4.71756554" y="0.100868711172" />
+                <point x="4.74211264" y="0.0983702671227" />
+                <point x="4.76665974" y="0.0959336772731" />
+                <point x="4.79120636" y="0.093557508202" />
+                <point x="4.81575346" y="0.0912401628801" />
+                <point x="4.84030056" y="0.0889801784484" />
+                <point x="4.86484766" y="0.0867762492478" />
+                <point x="4.88939476" y="0.084626860153" />
+                <point x="4.91394138" y="0.0825306822753" />
+                <point x="4.93848753" y="0.0804864976671" />
+                <point x="4.96303558" y="0.0784929071503" />
+                <point x="4.98758268" y="0.0765486581333" />
+                <point x="5.01212931" y="0.0746526079641" />
+                <point x="5.03667545" y="0.0728035212728" />
+                <point x="5.06122255" y="0.0710002323781" />
+                <point x="5.08577061" y="0.0692416164508" />
+                <point x="5.11031771" y="0.0675265194243" />
+                <point x="5.13486338" y="0.0658539680618" />
+                <point x="5.15941048" y="0.0642228143046" />
+                <point x="5.18395853" y="0.0626320322489" />
+                <point x="5.20850468" y="0.0610807125393" />
+                <point x="5.23305178" y="0.0595677948282" />
+                <point x="5.2575984" y="0.0580923114862" />
+                <point x="5.2821455" y="0.0566534406688" />
+                <point x="5.3066926" y="0.0552501801025" />
+                <point x="5.3312397" y="0.0538816494685" />
+                <point x="5.35578632" y="0.0525470679748" />
+                <point x="5.38033342" y="0.0512454914214" />
+                <point x="5.40488052" y="0.049976179668" />
+                <point x="5.42942762" y="0.0487383282922" />
+                <point x="5.45397472" y="0.0475310954243" />
+                <point x="5.47852135" y="0.0463537841787" />
+                <point x="5.50306749" y="0.0452056576189" />
+                <point x="5.52761555" y="0.044085928745" />
+                <point x="5.55216265" y="0.0429939565424" />
+                <point x="5.60125542" y="0.0408904789888" />
+                <point x="5.62580252" y="0.0398776505566" />
+                <point x="5.65034962" y="0.0388899122071" />
+                <point x="5.69944334" y="0.0369872268062" />
+                <point x="5.72399044" y="0.0360710788288" />
+                <point x="5.77308464" y="0.0343063026735" />
+                <point x="5.79763174" y="0.0334565608805" />
+                <point x="5.82217836" y="0.0326278676345" />
+                <point x="5.87127256" y="0.0310315517468" />
+                <point x="5.89581966" y="0.0302629090089" />
+                <point x="5.94491243" y="0.0287823115682" />
+                <point x="5.96946049" y="0.0280693832282" />
+                <point x="5.99400759" y="0.0273741231399" />
+            </lookuptable>
+        </parameter>
+</component>
+<component type="chopper" name="chopper">
+     <location />
+     <parameter name="z">
+          <value val="-11.8000" />
+     </parameter>
+     <parameter name="rotation_speed">
+          <logfile id="chopperspeed" extract-single-value-as="first_value" />
+     </parameter>
+</component>
+<component type="sample" name="sample">
+    <location x="0.0" y="0.0" z="0.0" />
+</component>
+<type name="sample" is="SamplePos" />
+<type name="chopper" is="ChopperPos">
+   <component type="chopperSlit">
+     <location x="0.000000" name="slit0" />
+     <location x="0.162156" name="slit1" />
+     <location x="0.250867" name="slit2" />
+     <location x="0.3704" name="slit3" />
+     <location x="0.439811" name="slit4" />
+     <location x="0.588455" name="slit5" />
+     <location x="0.761389" name="slit6" />
+     <location x="0.895667" name="slit7" />
+   </component>
+</type>
+<type name="chopperSlit" />
+<type name="some source type" is="Source">
+  <properties />
+</type>
+<type name="sample position" is="SamplePos">
+  <properties />
+</type>
+
+<!-- Monitor locations are approximate guesses for now! -->
+ 
+<component name="SouthBank" type="detector-bank" idlist="south_bank_ids">
+      <location x="-0.003042" y="0.000000" z="0.004631">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-89.80190056716243">
+          <rot axis-x="0" axis-y="0" axis-z="1" val="0.0">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="-0.0"/>
+          </rot>
+        </rot>
+      </location>
+</component>
+
+<component name="NorthBank" type="detector-bank-rotated" idlist="north_bank_ids">
+      <location x="0.008203" y="0.000000" z="0.003910">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.26614361940025">
+          <rot axis-x="0" axis-y="0" axis-z="1" val="0.0">
+            <rot axis-x="0" axis-y="1" axis-z="0" val="0.0"/>
+          </rot>
+        </rot>
+      </location>
+</component>
+
+
+<type name="detector-bank">
+  <component type="reference-sphere-1">
+    <location  x="0.585" y="0.21848" z="2.00093" rot="0" axis-x="1" axis-y="0" axis-z="0"/>
+  </component>
+  <component type="reference-sphere-2">
+    <location  x="-0.585" y="0.21848" z="2.00093" rot="0" axis-x="1" axis-y="0" axis-z="0"/>
+  </component>
+</type>
+
+<type name="detector-bank-rotated">
+  <component type="detector-bank">
+    <location  x="0.0" y="0.0" z="0.0" rot="180" axis-x="0" axis-y="0" axis-z="1"/>
+  </component>
+</type>
+
+
+<type name="reference-sphere-1">
+
+  <component type="detector-block" name="block1">
+    <location  x="-0.10515" y="-0.21848" z="0.0"> </location>
+  </component>
+  <component type="detector-block" name="block2">
+    <location  x="-0.2651" y="-0.21848" z="0.0"> </location>
+  </component>
+  <component type="detector-block" name="block3">
+    <location  x="-0.4251" y="-0.21848" z="0.0"> </location>
+  </component>
+  <component type="detector-block" name="block4">
+    <location  x="-0.585" y="-0.21848" z="0.0"> </location>
+  </component>
+
+</type>
+
+<type name="reference-sphere-2">
+  <component type="detector-block" name="block5">
+    <location  x="0.42508" y="-0.21848" z="0.0"> </location>
+  </component>
+  <component type="detector-block" name="block6">
+    <location  x="0.26519" y="-0.21848" z="0.0"> </location>
+  </component>
+  <component type="detector-block" name="block7">
+    <location  x="0.10513" y="-0.21848" z="0.0"> </location>
+  </component>
+
+</type>
+
+<type name="detector-block">
+  <component type="detector-pixel">
+  <location x="0.07875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel1" />
+  <location x="0.07625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel2" />
+  <location x="0.07375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel3" />
+  <location x="0.07125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel4" />
+  <location x="0.06875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel5" />
+  <location x="0.06625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel6" />
+  <location x="0.06375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel7" />
+  <location x="0.06125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel8" />
+  <location x="0.05875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel9" />
+  <location x="0.05625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel10" />
+  <location x="0.05375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel11" />
+  <location x="0.05125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel12" />
+  <location x="0.04875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel13" />
+  <location x="0.04625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel14" />
+  <location x="0.04375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel15" />
+  <location x="0.04125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel16" />
+  <location x="0.03875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel17" />
+  <location x="0.03625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel18" />
+  <location x="0.03375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel19" />
+  <location x="0.03125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel20" />
+  <location x="0.02875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel21" />
+  <location x="0.02625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel22" />
+  <location x="0.02375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel23" />
+  <location x="0.02125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel24" />
+  <location x="0.01875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel25" />
+  <location x="0.01625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel26" />
+  <location x="0.01375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel27" />
+  <location x="0.01125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel28" />
+  <location x="0.00875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel29" />
+  <location x="0.00625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel30" />
+  <location x="0.00375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel31" />
+  <location x="0.00125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel32" />
+
+  <location x="-0.00125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel33" />
+  <location x="-0.00375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel34" />
+  <location x="-0.00625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel35" />
+  <location x="-0.00875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel36" />
+  <location x="-0.01125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel37" />
+  <location x="-0.01375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel38" />
+  <location x="-0.01625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel39" />
+  <location x="-0.01875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel40" />
+  <location x="-0.02125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel41" />
+  <location x="-0.02375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel42" />
+  <location x="-0.02625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel43" />
+  <location x="-0.02875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel44" />
+  <location x="-0.03125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel45" />
+  <location x="-0.03375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel46" />
+  <location x="-0.03625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel47" />
+  <location x="-0.03875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel48" />
+  <location x="-0.04125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel49" />
+  <location x="-0.04375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel50" />
+  <location x="-0.04625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel51" />
+  <location x="-0.04875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel52" />
+  <location x="-0.05125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel53" />
+  <location x="-0.05375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel54" />
+  <location x="-0.05625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel55" />
+  <location x="-0.05875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel56" />
+  <location x="-0.06125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel57" />
+  <location x="-0.06375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel58" />
+  <location x="-0.06625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel59" />
+  <location x="-0.06875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel60" />
+  <location x="-0.07125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel61" />
+  <location x="-0.07375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel62" />
+  <location x="-0.07625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel63" /> 
+  <location x="-0.07875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel64" />
+  </component>
+</type>
+
+
+
+<type name="detector-pixel" is="detector">
+  <slice-of-cylinder-ring id="shape">
+    <inner-radius val="2.000925"/>
+    <outer-radius val="2.000935"/>
+    <depth val="0.0025"/>
+    <arc val="11.4591559"/>
+  </slice-of-cylinder-ring>
+  <algebra val="shape" />
+</type>
+
+
+<idlist idname="south_bank_ids">
+  <id start="111001" end="111064"/>
+  <id start="112001" end="112064"/>
+  <id start="113001" end="113064"/>
+  <id start="114001" end="114064"/>
+  <id start="185001" end="185064"/>
+  <id start="186001" end="186064"/>
+  <id start="187001" end="187064"/>
+</idlist>
+
+<idlist idname="north_bank_ids">
+  <id start="211001" end="211064"/>
+  <id start="212001" end="212064"/>
+  <id start="213001" end="213064"/>
+  <id start="214001" end="214064"/>
+  <id start="285001" end="285064"/>
+  <id start="286001" end="286064"/>
+  <id start="287001" end="287064"/>
+</idlist>
+
+
+</instrument>

--- a/instrument/POLDI_Definition_896.xml
+++ b/instrument/POLDI_Definition_896.xml
@@ -344,71 +344,8 @@
 
 <type name="detector-block">
   <component type="detector-pixel">
-  <location x="0.07875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel1" />
-  <location x="0.07625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel2" />
-  <location x="0.07375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel3" />
-  <location x="0.07125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel4" />
-  <location x="0.06875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel5" />
-  <location x="0.06625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel6" />
-  <location x="0.06375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel7" />
-  <location x="0.06125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel8" />
-  <location x="0.05875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel9" />
-  <location x="0.05625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel10" />
-  <location x="0.05375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel11" />
-  <location x="0.05125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel12" />
-  <location x="0.04875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel13" />
-  <location x="0.04625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel14" />
-  <location x="0.04375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel15" />
-  <location x="0.04125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel16" />
-  <location x="0.03875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel17" />
-  <location x="0.03625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel18" />
-  <location x="0.03375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel19" />
-  <location x="0.03125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel20" />
-  <location x="0.02875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel21" />
-  <location x="0.02625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel22" />
-  <location x="0.02375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel23" />
-  <location x="0.02125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel24" />
-  <location x="0.01875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel25" />
-  <location x="0.01625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel26" />
-  <location x="0.01375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel27" />
-  <location x="0.01125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel28" />
-  <location x="0.00875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel29" />
-  <location x="0.00625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel30" />
-  <location x="0.00375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel31" />
-  <location x="0.00125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel32" />
-
-  <location x="-0.00125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel33" />
-  <location x="-0.00375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel34" />
-  <location x="-0.00625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel35" />
-  <location x="-0.00875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel36" />
-  <location x="-0.01125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel37" />
-  <location x="-0.01375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel38" />
-  <location x="-0.01625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel39" />
-  <location x="-0.01875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel40" />
-  <location x="-0.02125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel41" />
-  <location x="-0.02375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel42" />
-  <location x="-0.02625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel43" />
-  <location x="-0.02875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel44" />
-  <location x="-0.03125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel45" />
-  <location x="-0.03375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel46" />
-  <location x="-0.03625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel47" />
-  <location x="-0.03875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel48" />
-  <location x="-0.04125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel49" />
-  <location x="-0.04375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel50" />
-  <location x="-0.04625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel51" />
-  <location x="-0.04875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel52" />
-  <location x="-0.05125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel53" />
-  <location x="-0.05375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel54" />
-  <location x="-0.05625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel55" />
-  <location x="-0.05875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel56" />
-  <location x="-0.06125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel57" />
-  <location x="-0.06375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel58" />
-  <location x="-0.06625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel59" />
-  <location x="-0.06875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel60" />
-  <location x="-0.07125" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel61" />
-  <location x="-0.07375" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel62" />
-  <location x="-0.07625" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel63" /> 
-  <location x="-0.07875" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel64" />
+  <locations x="0.07875" x-end="0.00125" n-elements="32" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel" name-count-start="1"/>
+  <locations x="-0.00125" x-end="-0.07875" n-elements="32" y="0" z="0" rot="-90" axis-x="0" axis-y="1" axis-z="0" name="pixel" name-count-start="33"/>
   </component>
 </type>
 

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -214,19 +214,19 @@ class MtdFuncMixin:
     PawleyPattern2DNoConstraints (although the getters may also be helpful for debugging PawleyPattern2D fits
     """
 
-    def get_peak_centers(self):
+    def get_peak_centers(self) -> np.ndarray[float]:
         cen_par_name = self.comp_func[0].function.getCentreParameterName()
         return self.get_peak_params(cen_par_name)
 
-    def get_peak_params(self, param_name: str):
+    def get_peak_params(self, param_name: str) -> np.ndarray[float]:
         bg_func_names = FunctionFactory.Instance().getBackgroundFunctionNames()
         return np.array([f.function.getParameterValue(param_name) for f in self.comp_func if f.name not in bg_func_names])
 
-    def get_peak_fwhm(self):
+    def get_peak_fwhm(self) -> np.ndarray[float]:
         bg_func_names = FunctionFactory.Instance().getBackgroundFunctionNames()
         return np.array([f.function.fwhm() for f in self.comp_func if f.name not in bg_func_names])
 
-    def get_peak_intensities(self):
+    def get_peak_intensities(self) -> np.ndarray[float]:
         bg_func_names = FunctionFactory.Instance().getBackgroundFunctionNames()
         return np.array([f.function.intensity() for f in self.comp_func if f.name not in bg_func_names])
 

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -521,6 +521,11 @@ class PawleyPattern2D(Poldi2DEvalMixin, PawleyPatternBase):
     def create_no_constriants_fit(self):
         return PawleyPattern2DNoConstraints(self.ws, self.comp_func, self.global_scale, self.lambda_max)
 
+    def fit(self, *args, **kwargs):
+        res = super().fit(*args, **kwargs)
+        self.eval_2d(res.x)  # ensure 2D simulated workspace up to date
+        return res
+
 
 class PawleyPattern2DNoConstraints(MtdFuncMixin, Poldi2DEvalMixin):
     def __init__(self, ws: Workspace2D, func: FunctionWrapper, global_scale: bool = True, lambda_max: float = 5.0):
@@ -591,6 +596,6 @@ class PawleyPattern2DNoConstraints(MtdFuncMixin, Poldi2DEvalMixin):
         kwargs = {**default_kwargs, **kwargs}
         self.initial_params = self.get_free_params()
         res = least_squares(lambda p: self.eval_resids(p), self.initial_params, **kwargs)
-        # update parameters
-        self.set_free_params(res.x)
+        # update parameters and ensure 2D simulated workspace up to date
+        self.eval_2d(res.x)
         return res


### PR DESCRIPTION
### Description of work
 
Apologies for slightly large PR - could have `PoldiAutoCorrelation` work in a separate PR but that part isn't actually that large.

New features:
- Calibrated IDF for POLDI post instrument upgrade
- New loader for h5f file produced by POLDI -  not yet algorithm as could be subject to change!
- Add parameter `NGroups` to `PoldiAutoCorrelation` to split POLDI detectors into groups (with little overhead)
- Associate detector IDs with autocorrelation spectra in  `PoldiAutoCorrelation` (required for texture)
- Method in `PawleyPattern1D` to perform 'free' fit - i.e. do not constrain peak centres to predicted positions - this uses the mantid `Fit` algorithm.
- Improvements to background estimation in 1D
- Method to fit background function to 1D data using one-sided 'robust' cost function (similar to demo in Mantid developer meeting)
- Add class to do a unconstrained 2D refinement

Changes for developers
 -  Refactored Pawley classes (including a base class for 1D and 2D Pawley and Mixin classes for common code where inheritance is unsuitable)
- System tests for basic Pawley workflow on POLDI


Closes #40184

**Report to:** Florencia (POLDI,PSI)

### To test:

(1) Run this script to check changes to 1D Pawley refinement with this data
[ENGINX00193749_foc.nxs.txt](https://github.com/user-attachments/files/24568635/ENGINX00193749_foc.nxs.txt)


```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from Engineering.pawley_utils import BackToBackGauss, PawleyPattern1D, Phase, PeakProfile
from scipy.optimize import least_squares

ws_ceria = Load(Filename = "ENGINX00193749_foc.nxs")

ispec = 0

phase = Phase.from_cif(r"C:\mantid-conda\mantid\scripts\Engineering\ENGINX\phase_info\CEO2.cif")
dmin, dmax = 0.69, 2.75
phase.set_hkls_from_dspac_limits(dmin, min(ws_ceria.readX(ispec)[-1], dmax))
phase.merge_reflections()

# Pawley
pawley = PawleyPattern1D(ws_ceria, [phase], profile=BackToBackGauss(), bg_func=Chebyshev(n=8), ispec=ispec)
pawley.estimate_initial_params()
ws_bg_est = pawley.get_eval_workspace(OutputWorkspace=f"ParamsEstimated")
pawley.fit_background()
ws_bg_fit = pawley.get_eval_workspace(OutputWorkspace=f"BgFitted")
 
 # plot inital background
fig, axes = plt.subplots(dpi=156.0, edgecolor='#ffffff', num='ParamsEstimated_0-1', subplot_kw={'projection': 'mantid'})
fig.set_figwidth(1.5*fig.get_figwidth())
axes.plot(ws_bg_est, color='#1f77b4', wkspIndex=0)
axes.plot(ws_bg_est, color='#ff7f0e',  wkspIndex=1)
axes.plot(ws_bg_fit, color='tab:green',  wkspIndex=1)
legend = axes.legend(fontsize=8.0).set_draggable(True).legend
axes.set_ylim(0,3)
fig.show()

# fit intens
pawley.bg_isfree[:] = False
pawley.profile_isfree[0][:] = False
pawley.alatt_isfree[0][:] = False
res = pawley.fit()
# optimise alatt and profile
pawley.bg_isfree[:] = True
pawley.profile_isfree[0][:] = [False, True, True, False, True, True, True] # sig0=0, sig1, sig2, alpha_0=0, alpha_1, beta_0, beta_1
res = pawley.fit()
ws_pawley = pawley.get_eval_workspace(OutputWorkspace=f"PawleyFit")

# Non-Pawley fit with A and B fixed
pawley.set_mantid_peak_param_isfree(["A", "B"], False)
res_mtd = pawley.fit_no_constraints(CreateOutput=False)
pawley.set_mantid_peak_param_isfree(["B"], True)
res_mtd = pawley.fit_no_constraints(CreateOutput=False)
pawley.set_mantid_peak_param_isfree(["A"], True)
res_mtd = pawley.fit_no_constraints(Output=f"FreeFit")

# make a plot
fig, axes = plt.subplots(2, 1, sharex=True, subplot_kw={'projection': 'mantid'})
fig.set_figwidth(1.5*fig.get_figwidth())
axes[0].errorbar(res_mtd.OutputWorkspace, 'o', color='k', capsize=2, markersize=3, zorder=0, label='Data', wkspIndex=0)
axes[0].plot(ws_pawley, color='tab:orange', label='PawleyFit', wkspIndex=1)
axes[0].plot(res_mtd.OutputWorkspace, color='tab:green', ls='--', label='FreeFit', wkspIndex=1)
axes[1].plot(ws_pawley, color='tab:orange', label='Pawley', wkspIndex=2)
axes[1].plot(res_mtd.OutputWorkspace, color='tab:green', ls='--', label='FreeFit_Workspace: Calc', wkspIndex=2)
legend = axes[0].legend(fontsize=8.0).set_draggable(True).legend
axes[1].set_xlabel(axes[0].get_xlabel())
axes[1].set_ylabel("Resid.")
axes[1].axhline(0, color=3*[0.7])
fig.show()
```
The initial background fitted (green)
<img width="1497" height="742" alt="image" src="https://github.com/user-attachments/assets/32c09aff-87e2-42d2-ba53-a2b9966ff816" />

The final fits
<img width="1497" height="742" alt="image" src="https://github.com/user-attachments/assets/92fde0ed-f475-4509-b140-ff8e43c07689" />

(2) 2D fitting should be covered by system test - run this locally

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
