### PR TITLE
Migrate `LoadMD` for lazy file descriptor

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -15,7 +15,6 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/V3D.h"
 #include "MantidKernel/cow_ptr.h"
-#include "MantidNexus/NexusDescriptor.h"
 
 #include <mutex>
 
@@ -124,7 +123,7 @@ public:
   void saveExperimentInfoNexus(Nexus::File *file, bool saveInstrument, bool saveSample, bool saveLogs) const;
 
   void loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr,
-                               const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &prefix);
+                               const std::string &prefix);
 
   /// Loads an experiment description from the open NeXus file
   void loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr);
@@ -136,9 +135,8 @@ public:
   void loadInstrumentParametersNexus(Nexus::File *file, std::string &parameterStr);
 
   /// Load the sample and log info from an open NeXus file.
-  /// Overload that uses NexusDescriptor for faster metadata lookup
-  void loadSampleAndLogInfoNexus(Nexus::File *file, const Mantid::Nexus::NexusDescriptor &fileInfo,
-                                 const std::string &prefix);
+  /// Overload that uses the file's NexusDescriptor for faster metadata lookup
+  void loadSampleAndLogInfoNexus(Nexus::File *file, std::string const &prefix);
   /// Load the sample and log info from an open NeXus file.
   void loadSampleAndLogInfoNexus(Nexus::File *file);
   /// Populate the parameter map given a string

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -122,8 +122,8 @@ public:
   /// Saves this experiment description to the open NeXus file
   void saveExperimentInfoNexus(Nexus::File *file, bool saveInstrument, bool saveSample, bool saveLogs) const;
 
-  void loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr,
-                               const std::string &prefix);
+  void loadExperimentInfoNexus(std::string const &nxFilename, Nexus::File *file, std::string &parameterStr,
+                               std::string const &prefix);
 
   /// Loads an experiment description from the open NeXus file
   void loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file, std::string &parameterStr);

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -183,10 +183,9 @@ public:
   virtual void saveNexus(Nexus::File *file, const std::string &group, bool keepOpen = false) const;
 
   /// Load the run from a NeXus file with a given group name. Overload that uses NexusDescriptor for faster
-  virtual void loadNexus(Nexus::File *file, const std::string &group, const Mantid::Nexus::NexusDescriptor &fileInfo,
-                         const std::string &prefix, bool keepOpen = false);
+  virtual void loadNexus(Nexus::File *file, std::string const &group, std::string const &prefix, bool keepOpen = false);
   /// Load the run from a NeXus file with a given group name
-  virtual void loadNexus(Nexus::File *file, const std::string &group, bool keepOpen);
+  virtual void loadNexus(Nexus::File *file, std::string const &group, bool keepOpen);
   /// Clear the logs
   void clearLogs();
 

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -186,7 +186,7 @@ public:
   virtual void loadNexus(Nexus::File *file, const std::string &group, const Mantid::Nexus::NexusDescriptor &fileInfo,
                          const std::string &prefix, bool keepOpen = false);
   /// Load the run from a NeXus file with a given group name
-  virtual void loadNexus(Nexus::File *file, const std::string &group, bool keepOpen = false);
+  virtual void loadNexus(Nexus::File *file, const std::string &group, bool keepOpen);
   /// Clear the logs
   void clearLogs();
 
@@ -210,7 +210,7 @@ protected:
   bool hasEndTime() const;
   bool hasValidProtonChargeLog(std::string &error) const;
 
-  void loadNexus(Nexus::File *file, const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &prefix);
+  void loadNexus(Nexus::File *file, const std::string &prefix);
   /// Load the run from a NeXus file with a given group name
   void loadNexus(Nexus::File *file, const std::map<std::string, std::string> &entries);
   /// A pointer to a property manager

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -9,7 +9,6 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/Statistics.h"
-#include "MantidNexus/NexusDescriptor.h"
 
 #include <memory>
 #include <vector>
@@ -182,7 +181,7 @@ public:
   /// Save the run to a NeXus file with a given group name
   virtual void saveNexus(Nexus::File *file, const std::string &group, bool keepOpen = false) const;
 
-  /// Load the run from a NeXus file with a given group name. Overload that uses NexusDescriptor for faster
+  /// Load the run from a NeXus file with a given group name. Overload that uses the file's NexusDescriptor for faster
   virtual void loadNexus(Nexus::File *file, std::string const &group, std::string const &prefix, bool keepOpen = false);
   /// Load the run from a NeXus file with a given group name
   virtual void loadNexus(Nexus::File *file, std::string const &group, bool keepOpen);

--- a/Framework/API/inc/MantidAPI/PolSANSWorkspaceValidator.h
+++ b/Framework/API/inc/MantidAPI/PolSANSWorkspaceValidator.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/TypedValidator.h"
+#include <unordered_set>
 
 namespace Mantid {
 namespace API {

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -109,8 +109,8 @@ public:
 
   /// Load the run from a NeXus file with a given group name.
   /// Overload that uses NexusDescriptor for faster metadata lookup
-  void loadNexus(Nexus::File *file, const std::string &group, const Mantid::Nexus::NexusDescriptor &fileInfo,
-                 const std::string &prefix, bool keepOpen = false) override;
+  void loadNexus(Nexus::File *file, const std::string &group, const std::string &prefix,
+                 bool keepOpen = false) override;
   /// Load the run from a NeXus file with a given group name
   void loadNexus(Nexus::File *file, const std::string &group, bool keepOpen = false) override;
 

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -108,7 +108,7 @@ public:
   void saveNexus(Nexus::File *file, const std::string &group, bool keepOpen = false) const override;
 
   /// Load the run from a NeXus file with a given group name.
-  /// Overload that uses NexusDescriptor for faster metadata lookup
+  /// Overload that uses the file's NexusDescriptor for faster metadata lookup
   void loadNexus(Nexus::File *file, const std::string &group, const std::string &prefix,
                  bool keepOpen = false) override;
   /// Load the run from a NeXus file with a given group name

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -931,7 +931,6 @@ void ExperimentInfo::saveExperimentInfoNexus(Nexus::File *file, bool saveInstrum
 
 /** Load the sample and log info from an open NeXus file.
  * @param file :: open NeXus file object
- * @param fileInfo :: The file info descriptor corresponding to the provided file
  * @param prefix :: The prefix of the file
  */
 void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, std::string const &prefix) {

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -934,8 +934,7 @@ void ExperimentInfo::saveExperimentInfoNexus(Nexus::File *file, bool saveInstrum
  * @param fileInfo :: The file info descriptor corresponding to the provided file
  * @param prefix :: The prefix of the file
  */
-void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, const Nexus::NexusDescriptor & /*fileInfo*/,
-                                               const std::string &prefix) {
+void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, std::string const &prefix) {
   // First, the sample and then the logs
   int sampleVersion = mutableSample().loadNexus(file, "sample");
   if (sampleVersion == 0) {
@@ -969,10 +968,9 @@ void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file) {
 }
 
 void ExperimentInfo::loadExperimentInfoNexus(const std::string &nxFilename, Nexus::File *file,
-                                             std::string &parameterStr, const Nexus::NexusDescriptor &fileInfo,
-                                             const std::string &prefix) {
+                                             std::string &parameterStr, const std::string &prefix) {
   // TODO load sample and log info
-  loadSampleAndLogInfoNexus(file, fileInfo, prefix);
+  loadSampleAndLogInfoNexus(file, prefix);
   loadInstrumentInfoNexus(nxFilename, file, parameterStr);
 }
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -934,7 +934,7 @@ void ExperimentInfo::saveExperimentInfoNexus(Nexus::File *file, bool saveInstrum
  * @param fileInfo :: The file info descriptor corresponding to the provided file
  * @param prefix :: The prefix of the file
  */
-void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, const Nexus::NexusDescriptor &fileInfo,
+void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, const Nexus::NexusDescriptor & /*fileInfo*/,
                                                const std::string &prefix) {
   // First, the sample and then the logs
   int sampleVersion = mutableSample().loadNexus(file, "sample");
@@ -942,11 +942,11 @@ void ExperimentInfo::loadSampleAndLogInfoNexus(Nexus::File *file, const Nexus::N
     // Old-style (before Sep-9-2011) NXS processed
     // sample field contains both the logs and the sample details
     file->openGroup("sample", "NXsample");
-    this->mutableRun().loadNexus(file, "", fileInfo, prefix);
+    this->mutableRun().loadNexus(file, "", prefix);
     file->closeGroup();
   } else {
     // Newer style: separate "logs" field for the Run object
-    this->mutableRun().loadNexus(file, "logs", fileInfo, prefix);
+    this->mutableRun().loadNexus(file, "logs", prefix);
   }
 }
 

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -672,7 +672,7 @@ void LogManager::loadNexus(Nexus::File *file, const Nexus::NexusDescriptor &file
     }
     const std::string nameClass = absoluteEntryName.substr(absoluteEntryName.find_last_of('/') + 1);
 
-    auto prop = PropertyNexus::loadProperty(file, nameClass, fileInfo, prefix);
+    auto prop = PropertyNexus::loadProperty(file, nameClass, prefix);
     if (prop) {
       // get TimeROI
       if (prop->name() == Kernel::TimeROI::NAME) {

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -646,12 +646,10 @@ void LogManager::loadNexus(Nexus::File *file, const std::string &group, bool kee
   }
 }
 
-void LogManager::loadNexus(Nexus::File *file, const Nexus::NexusDescriptor &fileInfo, const std::string &prefix) {
+void LogManager::loadNexus(Nexus::File *file, const Nexus::NexusDescriptor &, const std::string &prefix) {
 
   // Only load from NXlog entries
-  const auto &allEntries = fileInfo.getAllEntries();
-  auto itNxLogEntries = allEntries.find("NXlog");
-  const auto nxLogEntries = (itNxLogEntries != allEntries.end()) ? itNxLogEntries->second : std::set<std::string>{};
+  auto const nxLogEntries = file->getEntriesByClass("NXlog");
 
   const auto levels = std::count(prefix.begin(), prefix.end(), '/');
 

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -612,14 +612,12 @@ void LogManager::saveNexus(Nexus::File *file, const std::string &group, bool kee
  * @param file :: open NeXus file
  * @param group :: name of the group to open. Pass an empty string to NOT open a
  * group
- * @param fileInfo :: The corresponding Nexus HDF5 file descriptor
  * @param prefix :: The prefix of the provided file
  * @param keepOpen :: do not close group on exit to allow overloading and child
  * classes reading from the same group
  * load any NXlog in the current open group.
  */
-void LogManager::loadNexus(Nexus::File * /*file*/, const std::string & /*group*/,
-                           const Nexus::NexusDescriptor & /*fileInfo*/, const std::string & /*prefix*/,
+void LogManager::loadNexus(Nexus::File * /*file*/, std::string const & /*group*/, std::string const & /*prefix*/,
                            bool /*keepOpen*/) {
   throw std::runtime_error("LogManager::loadNexus should not be used");
 }

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -687,8 +687,7 @@ void LogManager::loadNexus(Nexus::File *file, std::string const &prefix) {
 }
 
 //--------------------------------------------------------------------------------------------
-/** Load the object from an open NeXus file. Avoid multiple expensive calls to
- * getEntries().
+/** Load the object from an open NeXus file. Avoid multiple expensive calls to getEntries().
  * @param file :: open NeXus file
  * @param entries :: The entries available in the current place in the file.
  * load any NXlog in the current open group.

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -646,7 +646,7 @@ void LogManager::loadNexus(Nexus::File *file, const std::string &group, bool kee
   }
 }
 
-void LogManager::loadNexus(Nexus::File *file, const Nexus::NexusDescriptor &, const std::string &prefix) {
+void LogManager::loadNexus(Nexus::File *file, std::string const &prefix) {
 
   // Only load from NXlog entries
   auto const nxLogEntries = file->getEntriesByClass("NXlog");

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -706,7 +706,7 @@ void Run::loadNexus(Nexus::File *file, const std::string &group, const Nexus::Ne
 
   // Example: /MDEventWorkspace/experiment4 + / + logs
   const std::string absoluteGroupName = prefix + "/" + group;
-  LogManager::loadNexus(file, fileInfo, absoluteGroupName);
+  LogManager::loadNexus(file, absoluteGroupName);
 
   // group hierarchy levels
   const auto levels = std::count(absoluteGroupName.begin(), absoluteGroupName.end(), '/');

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -691,9 +691,8 @@ void Run::saveNexus(Nexus::File *file, const std::string &group, bool keepOpen) 
 //--------------------------------------------------------------------------------------------
 /** Load the object from an open NeXus file.
  * @param file :: open NeXus file
- * @param group :: name of the group to open. Empty string to NOT open a group,
- * but load any NXlog in the current open group.
- * @param fileInfo descriptor with in-memory index with all entries
+ * @param group :: name of the group to open. Empty string to NOT open a group, but load any NXlog in the current open
+ * group.
  * @param prefix indicates current group location in file (absolute name)
  * @param keepOpen :: If true, then the file is left open after doing to load
  */
@@ -712,40 +711,6 @@ void Run::loadNexus(Nexus::File *file, std::string const &group, std::string con
   for (auto const &entry : entries) {
     loadNexusCommon(file, entry.first);
   }
-
-  // group hierarchy levels
-  // const auto levels = std::count(absoluteGroupName.begin(), absoluteGroupName.end(), '/');
-
-  // const auto &allEntries = fileInfo.getAllEntries();
-  // loop through nxClass sets
-  // for (const auto &nxClassPair : allEntries) {
-  //   const std::set<std::string> &nxClassEntries = nxClassPair.second;
-
-  //   // since std::set is ordered, just find the iterators
-  //   // for the bounds of the current experiment number
-  //   // take advantage of the fact that std::set is sorted, find by prefix bounds
-  //   auto itLower = nxClassEntries.lower_bound(absoluteGroupName);
-  //   // not prefixed
-  //   if (itLower == nxClassEntries.end()) {
-  //     continue;
-  //   }
-  //   if (itLower->compare(0, absoluteGroupName.size(), absoluteGroupName) != 0) {
-  //     continue;
-  //   }
-
-  //   // loop through the set with prefix absoluteGroupName
-  //   for (auto it = itLower;
-  //        it != nxClassEntries.end() && it->compare(0, absoluteGroupName.size(), absoluteGroupName) == 0; ++it) {
-
-  //     // only next level entries
-  //     const std::string &absoluteEntryName = *it;
-  //     if (std::count(absoluteEntryName.begin(), absoluteEntryName.end(), '/') != levels + 1) {
-  //       continue;
-  //     }
-  //     const std::string nameClass = absoluteEntryName.substr(absoluteEntryName.find_last_of('/') + 1);
-  //     loadNexusCommon(file, nameClass);
-  //   }
-  // }
 
   if (!(group.empty() || keepOpen))
     file->closeGroup();

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -586,7 +586,7 @@ public:
     // ---- Now re-load the same and compare ------
     th.reopenFile();
     LogManager run2;
-    run2.loadNexus(th.file.get(), "logs");
+    run2.loadNexus(th.file.get(), "logs", false);
     TS_ASSERT(run2.hasProperty("double_series"));
     TS_ASSERT(run2.hasProperty("int_val"));
     TS_ASSERT(run2.hasProperty("string_val"));
@@ -597,7 +597,7 @@ public:
     // files)
     LogManager run3;
     th.file.get()->openGroup("logs", "NXgroup");
-    run3.loadNexus(th.file.get(), "");
+    run3.loadNexus(th.file.get(), "", false);
     TS_ASSERT(run3.hasProperty("double_series"));
     TS_ASSERT(run3.hasProperty("int_val"));
     TS_ASSERT(run3.hasProperty("string_val"));
@@ -613,7 +613,7 @@ public:
     th.reopenFile();
     th.file->openGroup("sample", "NXsample");
     LogManager run3;
-    run3.loadNexus(th.file.get(), "");
+    run3.loadNexus(th.file.get(), "", false);
   }
 
   void test_operator_equals() {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -116,8 +116,7 @@ public:
   // load experiment infos, previously saved through the saveExperimentInfo
   // function. Overload version that uses file's NexusDescriptor for LoadMD
   static void loadExperimentInfos(Mantid::Nexus::File *const file, const std::string &filename,
-                                  std::shared_ptr<API::MultipleExperimentInfos> mei,
-                                  const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &currentGroup,
+                                  std::shared_ptr<API::MultipleExperimentInfos> mei, const std::string &currentGroup,
                                   bool lazy = false);
 
   // load experiment infos, previously saved through the saveExperimentInfo

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -11,7 +11,6 @@
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidDataObjects/MDGridBox.h"
 #include "MantidKernel/Matrix.h"
-#include "MantidNexus/NexusDescriptor.h"
 
 namespace Mantid {
 namespace DataObjects {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -114,7 +114,7 @@ public:
   static void saveExperimentInfos(Mantid::Nexus::File *const file, const API::IMDEventWorkspace_const_sptr &ws);
 
   // load experiment infos, previously saved through the saveExperimentInfo
-  // function. Overload version that uses NexusDescriptor for LoadMD
+  // function. Overload version that uses file's NexusDescriptor for LoadMD
   static void loadExperimentInfos(Mantid::Nexus::File *const file, const std::string &filename,
                                   std::shared_ptr<API::MultipleExperimentInfos> mei,
                                   const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &currentGroup,

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -412,14 +412,10 @@ void MDBoxFlatTree::saveExperimentInfos(Mantid::Nexus::File *const file, const A
 
 void MDBoxFlatTree::loadExperimentInfos(Mantid::Nexus::File *const file, const std::string &filename,
                                         std::shared_ptr<Mantid::API::MultipleExperimentInfos> mei,
-                                        const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &currentGroup,
-                                        bool lazy) {
+                                        const std::string &currentGroup, bool lazy) {
 
   // First, find how many experimentX blocks there are
-  const auto &allEntries = fileInfo.getAllEntries();
-  auto itNXgroup = allEntries.find("NXgroup");
-  const std::set<std::string> &nxGroupEntries =
-      (itNXgroup != allEntries.end()) ? itNXgroup->second : std::set<std::string>{};
+  std::set<std::string> nxGroupEntries = file->getEntriesByClass("NXgroup");
 
   std::list<uint16_t> experimentBlockNum;
   for (const std::string &entry : nxGroupEntries) {

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -451,7 +451,7 @@ void MDBoxFlatTree::loadExperimentInfos(Mantid::Nexus::File *const file, const s
       std::string parameterStr;
       try {
         // Get the sample, logs, instrument
-        ei->loadExperimentInfoNexus(filename, file, parameterStr, fileInfo, file->getAddress());
+        ei->loadExperimentInfoNexus(filename, file, parameterStr, file->getAddress());
         // Now do the parameter map
         if (parameterStr.empty()) {
           ei->populateInstrumentParameters();

--- a/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "MantidKernel/System.h"
-#include "MantidNexus/NexusDescriptor.h"
 #include <memory>
 #include <string>
 
@@ -35,12 +34,11 @@ namespace PropertyNexus {
  *
  * @param file currently opened NeXus file
  * @param group current group (relative name)
- * @param fileInfo descriptor with in-memory index with all entries
  * @param prefix indicates current group location in file (absolute name)
  * @return std::unique_ptr<Property>
  */
 DLLExport std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &group,
-                                                 const Nexus::NexusDescriptor &fileInfo, const std::string &prefix);
+                                                 const std::string &prefix);
 
 DLLExport std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &group);
 

--- a/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
@@ -29,9 +29,7 @@ class Property;
 namespace PropertyNexus {
 
 /**
- * @brief Opens a NXlog group in a nexus file and creates the correct Property object from it. Overload that uses
- * NexusDescriptor for faster metadata lookup.
- *
+ * @brief Opens a NXlog group in a nexus file and creates the correct Property object from it.
  * @param file currently opened NeXus file
  * @param group current group (relative name)
  * @param prefix indicates current group location in file (absolute name)

--- a/Framework/Kernel/src/PropertyNexus.cpp
+++ b/Framework/Kernel/src/PropertyNexus.cpp
@@ -238,12 +238,6 @@ std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &gro
     getTimeAndStart(file, timeSec, startStr);
   }
 
-  // // Get the entries so that you can check if the "time" field is present
-  // std::map<std::string, std::string> entries = file->getEntries();
-  // if (entries.find("time") != entries.end()) {
-  //   getTimeAndStart(file, timeSec, startStr);
-  // }
-
   return loadPropertyCommon(file, group, timeSec, startStr);
 }
 

--- a/Framework/Kernel/src/PropertyNexus.cpp
+++ b/Framework/Kernel/src/PropertyNexus.cpp
@@ -201,8 +201,7 @@ std::unique_ptr<Property> loadPropertyCommon(Nexus::File *file, const std::strin
 } // namespace
 //----------------------------------------------------------------------------------------------
 
-std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &group,
-                                       const Mantid::Nexus::NexusDescriptor &fileInfo, const std::string &prefix) {
+std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &group, const std::string &prefix) {
   file->openGroup(group, "NXlog");
 
   // Times in second offsets
@@ -210,7 +209,7 @@ std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &gro
   std::string startStr;
 
   // Check if the "time" field is present
-  if (fileInfo.isEntry(prefix + "/" + group + "/time")) {
+  if (file->hasAddress(prefix + "/" + group + "/time")) {
     getTimeAndStart(file, timeSec, startStr);
   }
 
@@ -232,11 +231,18 @@ std::unique_ptr<Property> loadProperty(Nexus::File *file, const std::string &gro
   std::vector<double> timeSec;
   std::string startStr;
 
-  // Get the entries so that you can check if the "time" field is present
-  std::map<std::string, std::string> entries = file->getEntries();
-  if (entries.find("time") != entries.end()) {
+  // find the time entry
+  std::string const currentAddress = file->getAddress();
+  std::string timeAddress = currentAddress + "/time";
+  if (file->hasAddress(timeAddress)) {
     getTimeAndStart(file, timeSec, startStr);
   }
+
+  // // Get the entries so that you can check if the "time" field is present
+  // std::map<std::string, std::string> entries = file->getEntries();
+  // if (entries.find("time") != entries.end()) {
+  //   getTimeAndStart(file, timeSec, startStr);
+  // }
 
   return loadPropertyCommon(file, group, timeSec, startStr);
 }

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -9,10 +9,9 @@
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/IMDEventWorkspace_fwd.h"
-#include "MantidAPI/NexusFileLoader.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidMDAlgorithms/DllConfig.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <boost/scoped_ptr.hpp>
 #include <optional>
@@ -25,7 +24,7 @@ namespace MDAlgorithms {
   @author Janik Zikovsky
   @date 2011-07-12
 */
-class MANTID_MDALGORITHMS_DLL LoadMD : public API::NexusFileLoader {
+class MANTID_MDALGORITHMS_DLL LoadMD : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   LoadMD();
 
@@ -41,13 +40,13 @@ public:
   const std::string category() const override { return "MDAlgorithms\\DataHandling"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   /// Initialise the properties
   void init() override;
   /// Run the algorithm
-  void execLoader() override;
+  void exec() override;
 
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
   std::string convention;

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -137,9 +137,6 @@ void LoadMD::execLoader() {
   if (!m_file)
     throw Kernel::Exception::FileError("Can not open file " + for_access, m_filename);
 
-  // The main entry
-  const std::shared_ptr<Mantid::Nexus::NexusDescriptor> fileInfo = getFileInfo();
-
   std::string entryName;
   if (m_file->hasGroup("/MDEventWorkspace", "NXentry")) {
     entryName = "MDEventWorkspace";
@@ -207,7 +204,7 @@ void LoadMD::execLoader() {
     auto prog = std::make_unique<Progress>(this, 0.0, 0.1, 1);
     prog->report("Load experiment information.");
     bool lazyLoadExpt = fileBacked;
-    MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws, *fileInfo.get(), "MDEventWorkspace", lazyLoadExpt);
+    MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws, "MDEventWorkspace", lazyLoadExpt);
 
     // Wrapper to cast to MDEventWorkspace then call the function
     CALL_MDEVENT_FUNCTION(this->doLoad, ws);

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -62,8 +62,10 @@ LoadMD::LoadMD()
  */
 int LoadMD::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence = 0;
-  if (descriptor.isEntry("/MDEventWorkspace", "NXentry") || descriptor.isEntry("/MDHistoWorkspace", "NXentry")) {
-    confidence = 95;
+  if (descriptor.classTypeExists("NXentry")) {
+    if (descriptor.isEntry("/MDEventWorkspace") || descriptor.isEntry("/MDHistoWorkspace")) {
+      confidence = 95;
+    }
   }
   return confidence;
 }

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -44,7 +44,7 @@ using file_holder_type = std::unique_ptr<Mantid::DataObjects::BoxControllerNeXus
 
 namespace Mantid::MDAlgorithms {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMD)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadMD)
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -60,15 +60,11 @@ LoadMD::LoadMD()
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadMD::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadMD::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence = 0;
-  const std::map<std::string, std::set<std::string>> &allEntries = descriptor.getAllEntries();
-  if (allEntries.count("NXentry") == 1) {
-    if (descriptor.isEntry("/MDEventWorkspace") || descriptor.isEntry("/MDHistoWorkspace")) {
-      confidence = 95;
-    }
+  if (descriptor.isEntry("/MDEventWorkspace", "NXentry") || descriptor.isEntry("/MDHistoWorkspace", "NXentry")) {
+    confidence = 95;
   }
-
   return confidence;
 }
 
@@ -108,7 +104,7 @@ void LoadMD::init() {
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
-void LoadMD::execLoader() {
+void LoadMD::exec() {
   m_filename = getPropertyValue("Filename");
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   // Start loading

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -574,6 +574,12 @@ public:
    * \return true if the class type exists
    */
   bool classTypeExists(std::string const &class_type) const { return m_descriptor.classTypeExists(class_type); }
+  /**
+   * Return all entries of a given class type in the current location
+   * \param class_type The class type to search for (e.g. "NXentry")
+   * \return A set of string names of all entries of the given class type
+   */
+  std::set<std::string> getEntriesByClass(std::string const &class_type) const;
 
   //------------------------------------------------------------------------------------------------------------------
   // ATTRIBUTE METHODS

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -7,6 +7,7 @@
 #include "MantidNexus/UniqueID.h"
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -580,6 +581,8 @@ public:
    * \return A set of string names of all entries of the given class type
    */
   std::set<std::string> getEntriesByClass(std::string const &class_type) const;
+
+  NexusDescriptor const &getFileDescriptor() const { return m_descriptor; }
 
   //------------------------------------------------------------------------------------------------------------------
   // ATTRIBUTE METHODS

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -110,6 +110,8 @@ MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXcompression 
 // forward declare
 namespace Mantid::Nexus {
 
+inline std::string const GROUP_CLASS_SPEC("NX_class");
+inline std::string const UNKNOWN_GROUP_SPEC("NX_UNKNOWN_GROUP");
 inline std::string const SCIENTIFIC_DATA_SET("SDS");
 
 typedef hsize_t dimsize_t;

--- a/Framework/Nexus/src/NexusAddress.cpp
+++ b/Framework/Nexus/src/NexusAddress.cpp
@@ -84,7 +84,7 @@ NexusAddress NexusAddress::parent_path() const { return NexusAddress(m_path.pare
 
 NexusAddress NexusAddress::fromRoot() const { return NexusAddress(nxroot / m_path); }
 
-NexusAddress NexusAddress::stem() const { return NexusAddress(m_path.stem()); }
+NexusAddress NexusAddress::stem() const { return NexusAddress(m_path.filename()); }
 
 NexusAddress NexusAddress::root() { return NexusAddress(nxroot); }
 

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -33,10 +33,10 @@ void getGroup(H5::Group groupID, std::map<std::string, std::set<std::string>> &a
    * Return the NX_class attribute associate with objectName group entry
    */
   auto lf_getNxClassAttribute = [&](H5::Group groupID) -> std::string {
-    std::string attribute = "";
+    std::string attribute = UNKNOWN_GROUP_SPEC;
 
-    if (groupID.attrExists("NX_class")) {
-      const auto attributeID = groupID.openAttribute("NX_class");
+    if (groupID.attrExists(GROUP_CLASS_SPEC)) {
+      const auto attributeID = groupID.openAttribute(GROUP_CLASS_SPEC);
       attributeID.read(attributeID.getDataType(), attribute);
     }
 

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -14,6 +14,7 @@
 #include <H5Cpp.h>
 #include <hdf5.h>
 
+#include <algorithm>
 #include <cstdlib> // malloc, calloc
 #include <cstring> // strcpy
 #include <filesystem>
@@ -82,12 +83,12 @@ bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
   }
 }
 
-/// @brief not implemented yet
+/// @brief Check if a class type exists in the file
 /// @param classType the NX_class type to check for
 /// @return true if the class type exists anywhere in the file
-/// @throws std::logic_error always
-bool NexusDescriptorLazy::classTypeExists(std::string const &) const {
-  throw std::logic_error("NexusDescriptorLazy::classTypeExists not implemented yet");
+bool NexusDescriptorLazy::classTypeExists(std::string const &classType) const {
+  return std::any_of(m_allEntries.begin(), m_allEntries.end(),
+                     [&classType](auto const &entry) { return entry.second == classType; });
 }
 
 bool NexusDescriptorLazy::hasRootAttr(std::string const &name) {

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -34,14 +34,15 @@ namespace {
 template <herr_t (*H5Xclose)(hid_t)> std::string readNXClass(Mantid::Nexus::UniqueID<H5Xclose> const &oid) {
   std::string nxClass = UNKNOWN_CLASS;
   if (H5Aexists(oid, Mantid::Nexus::GROUP_CLASS_SPEC.c_str()) > 0) {
-    Mantid::Nexus::UniqueID<&H5Aclose> attrID = H5Aopen_name(oid, Mantid::Nexus::GROUP_CLASS_SPEC.c_str());
+    Mantid::Nexus::UniqueID<&H5Aclose> attrID = H5Aopen(oid, Mantid::Nexus::GROUP_CLASS_SPEC.c_str(), H5P_DEFAULT);
     if (attrID.isValid()) {
       Mantid::Nexus::UniqueID<&H5Tclose> atype(H5Aget_type(attrID));
       if (H5Tis_variable_str(atype)) {
         // variable length string
         char *rdata;
-        H5Aread(attrID, atype, &rdata);
-        nxClass = std::string(rdata);
+        if (H5Aread(attrID, atype, &rdata) >= 0) {
+          nxClass = std::string(rdata);
+        }
         // reclaim memory allocated for rdata by HDF5
         H5free_memory(rdata);
       } else {

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1372,7 +1372,6 @@ void File::getEntries(Entries &result) const {
   for (auto const &entry : m_descriptor.getAllEntries()) {
     for (NexusAddress const addr : entry.second) { // cppcheck-suppress iterateByValue
       if (addr.parent_path() == currentAddress) {
-        printf("Entry: %s | %s | %s\n", addr.c_str(), entry.first.c_str(), addr.stem().c_str());
         result.emplace(addr.stem(), entry.first);
       }
     }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1368,24 +1368,14 @@ Entries File::getEntries() const {
 
 void File::getEntries(Entries &result) const {
   result.clear();
-  auto current = getCurrentObject();
-  for (size_t i = 0; i < current->getNumObjs(); i++) {
-    std::string name = current->getObjnameByIdx(i);
-    std::string className;
-    H5G_obj_t type = current->getObjTypeByIdx(i);
-    if (type == H5G_GROUP) {
-      H5::Group grp = current->openGroup(name);
-      if (grp.attrExists(GROUP_CLASS_SPEC)) {
-        H5::Attribute attr = grp.openAttribute(GROUP_CLASS_SPEC);
-        attr.read(attr.getDataType(), className);
-      } else {
-        className = UNKNOWN_GROUP_SPEC;
+  NexusAddress const currentAddress = m_address;
+  for (auto const &entry : m_descriptor.getAllEntries()) {
+    for (NexusAddress const addr : entry.second) { // cppcheck-suppress iterateByValue
+      if (addr.parent_path() == currentAddress) {
+        printf("Entry: %s | %s | %s\n", addr.c_str(), entry.first.c_str(), addr.stem().c_str());
+        result.emplace(addr.stem(), entry.first);
       }
-    } else if (type == H5G_DATASET) {
-      className = SCIENTIFIC_DATA_SET;
     }
-    if (!className.empty())
-      result[name] = std::move(className);
   }
 }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1406,6 +1406,11 @@ std::string File::getTopLevelEntryName() const {
   return top;
 }
 
+std::set<std::string> File::getEntriesByClass(std::string const &class_type) const {
+  std::vector<std::string> allAddresses = m_descriptor.allAddressesOfType(class_type);
+  return std::set<std::string>(allAddresses.begin(), allAddresses.end());
+}
+
 //------------------------------------------------------------------------------------------------------------------
 // ATTRIBUTE METHODS
 //------------------------------------------------------------------------------------------------------------------

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -46,9 +46,7 @@ const auto g_log = &Poco::Logger::get("NexusFile");
 
 namespace { // anonymous namespace to keep it in the file
 
-std::string const GROUP_CLASS_SPEC("NX_class");
 std::string const TARGET_ATTR_NAME("target");
-std::string const UNKNOWN_GROUP_SPEC("NX_UNKNOWN_GROUP");
 constexpr int DEFAULT_DEFLATE_LEVEL(6);
 
 template <typename NumT> static string toString(const vector<NumT> &data) {

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -123,4 +123,17 @@ public:
     // verify that non-existing data returns empty string
     TS_ASSERT_EQUALS(descriptor.getStrData("/entry/instrument/not_a_data"), "");
   }
+
+  void test_init_loads_class() {
+    std::cout << "\nTesting classTypeExists in NexusDescriptorLazy" << std::endl;
+    // create a descriptor with the correct values
+    std::string const filename = NexusTest::getFullPath("HB3A_data.nxs");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    auto const &entries = descriptor.getAllEntries();
+    // verify that class types are correctly identified
+    TS_ASSERT_EQUALS(descriptor.classTypeExists("NXentry"), true);
+    TS_ASSERT(descriptor.isEntry("/MDHistoWorkspace"));
+    TS_ASSERT(descriptor.isEntry("/MDHistoWorkspace", "NXentry"));
+  }
 };

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -129,8 +129,6 @@ public:
     // create a descriptor with the correct values
     std::string const filename = NexusTest::getFullPath("HB3A_data.nxs");
     Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
-
-    auto const &entries = descriptor.getAllEntries();
     // verify that class types are correctly identified
     TS_ASSERT_EQUALS(descriptor.classTypeExists("NXentry"), true);
     TS_ASSERT(descriptor.isEntry("/MDHistoWorkspace"));


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadMD` algorithm.   This inherited from `NexusFileLoader`, which requires a `NexusDescriptor` for the confidence check.   This object was being passed down multiple layers of loading objects.  Most of the work of this PR was undoing the dependency on this object as a parameter.

This adds a new method to `Nexus::File` which returns all of the entries with a given class name.  That, plus the already-existing `Nexus::File::getEntries()` method are all that are needed at the various levels of this load process.    Now the `NexusDecriptor` is no longer needed and this can be set to inherit from `IFileLoader<NexusDescriptorLazy>`.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

:warning: This PR has the potential to destroy everything.  **Review carefully** :warning:

Firstly, this has the potential to make the `Run` object disappear.  Build and run this script:
``` python
from mantid.simpleapi import CreateMDWorkspace, SaveMD, LoadMD, AddSampleLog
# create the file
filename = '/tmp/test_loadmd_log.nxs'
mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
AddSampleLog(Workspace=mdws, LogName='x', LogText='hello world', LogType='String')
# it has a log
assert len(mdws.getExperimentInfo(0).run().keys()) != 0
# save the file
SaveMD(mdws, Filename=filename)
# reload the file
outws = LoadMD(Filename=filename)
# check
assert len(outws.getExperimentInfo(0).run().keys()) != 0
``` 
That should ensure that the run is loaded.  Or, run the reproduction script at Issue #39954 for a real file.

Also, make sure there has been no performance regression.  Run this script:
``` python
from mantid.simpleapi import *
import mantid
import time
import os
import matplotlib.pyplot as plt

sizes = ['4.64527e+05', '1.64527e+06', '4.64527e+06', '1.64527e+07', '4.64527e+07', '1.64527e+08']
save_times = []
load_times = []
workspace_sizes = []
memories = []

kbToGB = 1024 * 1024

for size in sizes:
    CreateMDWorkspace(
        Dimensions=4,
        Extents='-10,10,-10,10,-10,10,-10,10',
        Names='a,b,c,d', Units='rlu,rlu,rlu,meV',
        MaxRecursionDepth=1,
        OutputWorkspace='w_new_slice')
    FakeMDEventData(InputWorkspace='w_new_slice', UniformParams=size)

    output_filename = f'~/Documents/dm1_sliced_{mantid.__version__}.nxs'
    start_time = time.time()
    SaveMD(InputWorkspace='w_new_slice', Filename=output_filename)
    save_times.append(time.time() - start_time)
    workspace_sizes.append(mtd["w_new_slice"].getMemorySize()/kbToGB)
    start_time = time.time()
    LoadMD(Filename=output_filename, OutputWorkspace = "reloaded_ws")
    load_times.append(time.time() - start_time)
    memories.append(os.path.getsize(os.path.expanduser(output_filename))/kbToGB)

plt.xscale('log')
plt.yscale('log')
plt.plot(workspace_sizes, save_times, "go-", label="SaveMD")
plt.plot(workspace_sizes, load_times, "bo-", label="LoadMD")
plt.xlabel("workspace size")
plt.ylabel("time")
plt.title("Time for SaveMD/LoadMD")
x = np.linspace(workspace_sizes[0], workspace_sizes[-1], num=100)
plt.plot(x, 3.e-3 * x, label="O(N)")
plt.plot(x, 3.e-4 * x * x, label="O(N^2)")
plt.legend()
plt.show()

```
If this worked correctly, then the load time line on the graph should be parallel to the $O(N)$ line.

Next, build and run the `LoadLotsOfFile` system test.  This does not run on Jenkins, so you will need to run it manually.
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
