### PR TITLE
Add .pixi to PyCharm excluded directories

### DIFF
--- a/dev-docs/source/PyCharm.rst
+++ b/dev-docs/source/PyCharm.rst
@@ -47,6 +47,7 @@ We use ``DebugWithRelRuntime`` for conda specific builds to allow debugging due 
     - ``{SOURCE}/qt/python/mantidqtinterfaces``
 
 - In the file tree select your build directory and mark as excluded by clicking the ``Excluded`` button whilst it's selected.
+- If the ``.pixi`` directory exists, mark it as excluded.
 - On Windows, select the ``{BUILD}/bin/DebugWithRelRuntime`` directory and mark as source by clicking the ``Sources`` button whilst it's selected.
 - On Linux or MacOS, select your ``{BUILD}/bin`` directory and mark as source by clicking the ``Sources`` button whilst it's selected.
 - Click Apply, and then OK to close the window.


### PR DESCRIPTION
### Description of work
The `.pixi` folder exists inside the source root, so we need to exclude it from the project.

### To test:
Check the changes.

*This does not require release notes* because it is developer documentation.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
