### PR TITLE
Migrate `LoadMcStas` for lazy file descriptor

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
@@ -12,13 +12,14 @@
 #include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include <H5Cpp.h>
 
 namespace Mantid {
 namespace DataHandling {
 
-class MANTID_DATAHANDLING_DLL LoadMcStas : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadMcStas : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose
@@ -29,11 +30,11 @@ public:
   const std::string category() const override;
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
 private:
   void init() override;
-  void execLoader() override;
+  void exec() override;
 
   API::WorkspaceGroup_sptr groupWorkspaces(const std::vector<std::string> &workspaces) const;
 

--- a/Framework/DataHandling/test/LoadMcStasTest.h
+++ b/Framework/DataHandling/test/LoadMcStasTest.h
@@ -16,6 +16,7 @@
 // These includes seem to make the difference between initialization of the
 // workspace names (workspace2D/1D etc), instrument classes and not for this
 // test case.
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadInstrument.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include <Poco/TemporaryFile.h>
@@ -126,6 +127,18 @@ public:
 
     outputGroup = load_test("mccode_multiple_scattering.h5", outputSpace);
     TS_ASSERT_EQUALS(outputGroup->getNumberOfEntries(), 3);
+  }
+
+  void test_willLoadWithLoad() {
+    // We are verifying that the confidence information provided by the loader is good
+    std::vector<std::string> inputFiles{"mcstas_event_hist.h5", "mccode_contains_one_bank.h5",
+                                        "mccode_multiple_scattering.h5"};
+    Load loader;
+    loader.initialize();
+    for (auto const &inputFile : inputFiles) {
+      loader.setProperty("Filename", inputFile);
+      TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), "LoadMcStas");
+    }
   }
 
 private:


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadMcStas` algorithm.  This inherited from `NexusFileLoader`, which requires a `NexusDescriptor` for the confidence check.  Because this does not use a `Nexus::File`, it can initialize its `NexusDescriptor` directly, and now it can inherit from `IFileLoader<NexusDescriptorLazy>`

This is different from the algorithm `LoadMcStasNexus`, which was migrated in PR #40589.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

Added unit tests ensure `Load` will find this algorithm for the test files that use it.

Build locally and run the `LoadLotsOfFile` system test.  This does not run on Jenkins, so you will need to run it manually.
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```
:warning:  This test is **NOT** run on the standard Jenkins CI/CD, so please run it.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
