### PR TITLE
Fix bug in rename workspaces

### DIFF
--- a/Framework/Algorithms/test/RenameWorkspaceTest.h
+++ b/Framework/Algorithms/test/RenameWorkspaceTest.h
@@ -83,6 +83,26 @@ public:
     AnalysisDataService::Instance().remove("InputWS");
   }
 
+  void testExecSameNamesDifferentCapitalization() {
+    AnalysisDataService::Instance().clear();
+    MatrixWorkspace_sptr inputWS = createWorkspace();
+    AnalysisDataService::Instance().add("InputWS", inputWS);
+
+    Mantid::Algorithms::RenameWorkspace alg3;
+    alg3.initialize();
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("InputWorkspace", "Inputws"));
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("OutputWorkspace", "InputWS"));
+
+    TS_ASSERT_THROWS_NOTHING(alg3.execute());
+    TS_ASSERT(alg3.isExecuted());
+
+    Workspace_sptr result;
+    TS_ASSERT_THROWS_NOTHING(result = AnalysisDataService::Instance().retrieveWS<Workspace>("Inputws"));
+    TS_ASSERT(result);
+
+    AnalysisDataService::Instance().remove("InputWS");
+  }
+
   void testExecNameAlreadyExists() {
     // Tests renaming a workspace to a name which is already used
     AnalysisDataService::Instance().clear();

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -279,12 +279,15 @@ public:
    */
   void rename(const std::string &oldName, const std::string &newName) {
     checkForEmptyName(newName);
+    bool caseInsensitiveMatch = false;
 
-    if (oldName == newName) {
-      g_log.warning("Rename: The existing name matches the new name");
-      return;
+    if (!strcasecmp(oldName.c_str(), newName.c_str())) {
+      if (oldName == newName) {
+        g_log.warning("Rename: The existing name matches the new name");
+        return;
+      }
+      caseInsensitiveMatch = true;
     }
-
     // Make DataService access thread-safe
     std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
@@ -296,7 +299,7 @@ public:
     }
 
     auto existingNameObject = std::move(existingNameIter->second);
-    auto targetNameIter = datamap.find(newName);
+    auto targetNameIter = caseInsensitiveMatch ? datamap.end() : datamap.find(newName);
 
     // If we are overriding send a notification for observers
     if (targetNameIter != datamap.end()) {

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -163,6 +163,14 @@ public:
     TSM_ASSERT_EQUALS("The observers should have been called once", notificationFlag, 1);
 
     notificationFlag = 0;
+    svc.rename("Two", "two");
+    TS_ASSERT_EQUALS(svc.size(), 2);
+    // as ads is case insensitive, this query does not change the result
+    TSM_ASSERT_EQUALS("Two should have been renamed to two", svc.retrieve("two"), svc.retrieve("Two"));
+    // There is just the rename notification, as it would appear as the key would be renamed as two
+    TSM_ASSERT_EQUALS("The observers should have been called 1 times in total", notificationFlag, 1);
+
+    notificationFlag = 0;
     svc.rename("Two", "anotherOne");
     TS_ASSERT_EQUALS(svc.size(), 1);
     TSM_ASSERT_THROWS("Two should have been renamed to anotherOne", svc.retrieve("two"),

--- a/docs/source/release/v6.15.0/Framework/Kernel/Bugfixes/40610.rst
+++ b/docs/source/release/v6.15.0/Framework/Kernel/Bugfixes/40610.rst
@@ -1,0 +1,1 @@
+- Fix a bug where renaming a workspace with same name but different capitalization would erase the workspace from the ADS.


### PR DESCRIPTION
### Description of work

This PR fixes #40610, description therein. 

The `std::map` holding the workspaces maps a case insensitive key to the workspace, the function does not cover the case of renaming to a workspace with same name but different capitalization and ends up deleting the workspace from the ads because the  rename function makes a case sensitive comparison before determining that two workspaces have the same name (and if they do, the function returns).

The solution has been to use the `strcasecmp` to determine if two strings are the same, which should be the correct way being that the map is case insensitive.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40610 , https://github.com/mantidproject/mslice/issues/1001 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

This script shouldn't make the workspace disappear: 
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

a = CreateWorkspace(DataX=[0], DataY=[1])
RenameWorkspace('a',OutputWorkspace='A')
```

Also, check that the mslice issue is not present anymore: https://github.com/mantidproject/mslice/issues/1001 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
