### PR TITLE
Fix bug in parsing release date when the day has two digits

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -62,13 +62,25 @@ Types::Core::DateAndTime create_releaseDateAndTime() {
   } else {
     // pull apart string into year, month, and day objects
     // WARNING if the format changes this will break
-    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(4, 2)));
-    const auto month = to_month(REVISION_DATE.substr(7, 3));
-    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(11, 4)));
-    std::string time = REVISION_DATE.substr(16);
+
+    // skip day of week
+    const auto start = REVISION_DATE.find(", ") + 2;
+    // find when month starts so we can get the right part of day
+    const auto month_start = REVISION_DATE.find(" ", start) + 1;
+    // day is the next element by whitespace
+    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(start, month_start-1)));
+    // then comes 3 character month
+    const auto month = to_month(REVISION_DATE.substr(month_start, 3));
+    // then 4 digit year
+    const auto year_start = REVISION_DATE.find(" ", month_start) + 1;
+    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(year_start, 4)));
+    // everything past that is time
+    const auto time_start = REVISION_DATE.find(" ", year_start) + 1;
+    std::string time = REVISION_DATE.substr(time_start);
     if (time.empty()) {
       time = "00:01"; // assume one minute past midnight
     } else {
+      // remove whitespace that is internal to the time
       time.erase(find_if(time.begin(), time.end(), isspace));
     }
 
@@ -78,7 +90,8 @@ Types::Core::DateAndTime create_releaseDateAndTime() {
     std::stringstream isostr;
     isostr << ymd << "T" << time;
 
-    release. setFromISO8601(isostr.str());
+    // convert to a proper object
+    release.setFromISO8601(isostr.str());
   }
   return release;
 }

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -14,6 +14,7 @@
 #include "MantidKernel/MantidVersion.h"
 #include <chrono>
 #include <iostream>
+#include <regex>
 #include <sstream>
 
 namespace Mantid::Kernel {
@@ -61,37 +62,40 @@ Types::Core::DateAndTime create_releaseDateAndTime() {
     // something went wrong in VersionNumber.cmake so give the default constructor result
   } else {
     // pull apart string into year, month, and day objects
-    // WARNING if the format changes this will break
+    // WARNING if the format changes this will break and default DateAndTime is returned
+    std::regex format(R"(^.+,\s+(\d{1,2})\s+(\w{3})\s+(\d{4})\s+(.+)\s*$)");
+    std::smatch matches;
+    if (std::regex_search(REVISION_DATE, matches, format)) {
+      constexpr size_t INDEX_DAY{1};
+      constexpr size_t INDEX_MONTH{2};
+      constexpr size_t INDEX_YEAR{3};
+      constexpr size_t INDEX_TIME{4};
 
-    // skip day of week
-    const auto start = REVISION_DATE.find(", ") + 2;
-    // find when month starts so we can get the right part of day
-    const auto month_start = REVISION_DATE.find(" ", start) + 1;
-    // day is the next element by whitespace
-    const auto day = std::chrono::day(std::stoi(REVISION_DATE.substr(start, month_start-1)));
-    // then comes 3 character month
-    const auto month = to_month(REVISION_DATE.substr(month_start, 3));
-    // then 4 digit year
-    const auto year_start = REVISION_DATE.find(" ", month_start) + 1;
-    const auto year = std::chrono::year(std::stoi(REVISION_DATE.substr(year_start, 4)));
-    // everything past that is time
-    const auto time_start = REVISION_DATE.find(" ", year_start) + 1;
-    std::string time = REVISION_DATE.substr(time_start);
-    if (time.empty()) {
-      time = "00:01"; // assume one minute past midnight
-    } else {
-      // remove whitespace that is internal to the time
-      time.erase(find_if(time.begin(), time.end(), isspace));
-    }
+      // day is the next element by whitespace
+      const auto day = std::chrono::day(std::stoi(matches[INDEX_DAY].str()));
+      // then comes 3 character month
+      const auto month = to_month(matches[INDEX_MONTH].str());
+      // then 4 digit year
+      const auto year = std::chrono::year(std::stoi(matches[INDEX_YEAR].str()));
+      // everything past that is time
+      std::string time = matches[INDEX_TIME].str();
+      if (time.empty()) {
+	time = "00:01"; // assume one minute past midnight
+      } else {
+	// remove whitespace that is internal to the time
+	time.erase(find_if(time.begin(), time.end(), isspace));
+      }
 
-    // create a proper chrono from it
-    std::chrono::year_month_day ymd(year, month, day);
-    // convert to iso8601 string to get to DateAndTime
-    std::stringstream isostr;
-    isostr << ymd << "T" << time;
+      // create a proper chrono from it
+      std::chrono::year_month_day ymd(year, month, day);
 
-    // convert to a proper object
-    release.setFromISO8601(isostr.str());
+      // convert to iso8601 string to get to DateAndTime
+      std::stringstream isostr;
+      isostr << ymd << "T" << time;
+
+      // convert to a proper object
+      release.setFromISO8601(isostr.str());
+    } // otherwise it will remain the default value
   }
   return release;
 }


### PR DESCRIPTION
#40592 introduced a feature to get a `DateAndTime` object from the mantid version. Unfortunately, it was using specific character positions for decomposing the string into components. This changes to breaking up the string based on whitespace.

### To test:

The builds should pass again.

You can see the results by running
```python
import mantid.kernel
print(mantid.kernel.release_date()) # string
print(str(mantid.kernel.release_date_and_time())) # Kernel.DateAndTime
```

*This does not require release notes* because it is a bugfix to a feature within the release cycle.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
