### PR TITLE
New Instrument View in a Jupyter Notebook

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/40579.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/40579.rst
@@ -1,0 +1,1 @@
+- New Python interface to use the new Instrument View in a Jupyter Notebook

--- a/qt/python/instrumentview/CMakeLists.txt
+++ b/qt/python/instrumentview/CMakeLists.txt
@@ -12,6 +12,8 @@ set(PYTHON_TEST_FILES
     instrumentview/test/test_view.py
     instrumentview/test/test_instruments.py
     instrumentview/test/test_interactor_styles.py
+    instrumentview/test/test_notebook_view.py
+    instrumentview/test/test_notebook_presenter.py
     instrumentview/Peaks/test/test_peak.py
     instrumentview/Peaks/test/test_detector_peaks.py
     instrumentview/Projections/test/test_projection.py

--- a/qt/python/instrumentview/instrumentview/NotebookPresenter.py
+++ b/qt/python/instrumentview/instrumentview/NotebookPresenter.py
@@ -45,4 +45,6 @@ class NotebookPresenter:
         self._model.negate_picked_visibility(mask)
         self._pickable_mesh[self._visible_label] = self._model.picked_visibility
         self._model.extract_spectra_for_line_plot(self._model.workspace_x_unit, sum_spectra)
-        return self._view._plot_spectra(self._model.line_plot_workspace, sum_spectra)
+        if self._model.line_plot_workspace is None or self._model.line_plot_workspace.getNumberHistograms() == 0:
+            return None
+        return self._view.plot_spectra(self._model.line_plot_workspace, sum_spectra)

--- a/qt/python/instrumentview/instrumentview/NotebookPresenter.py
+++ b/qt/python/instrumentview/instrumentview/NotebookPresenter.py
@@ -1,0 +1,28 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from instrumentview.NotebookView import NotebookView
+from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
+
+import pyvista as pv
+
+
+class NotebookPresenter:
+    def __init__(self, view: NotebookView, model: FullInstrumentViewModel) -> None:
+        self._view = view
+        self._model = model
+        self._counts_label = "Integrated Counts"
+        self._model.setup()
+        self.setup()
+
+    def setup(self):
+        self._view.subscribe_presenter(self)
+        self._view.show_axes()
+        self._detector_mesh = pv.PolyData(self._model.detector_positions)
+        self._detector_mesh[self._counts_label] = self._model.detector_counts
+        self._view.add_detector_mesh(self._detector_mesh, is_projection=self._model.is_2d_projection, scalars=self._counts_label)
+        self._view.reset_camera()

--- a/qt/python/instrumentview/instrumentview/NotebookPresenter.py
+++ b/qt/python/instrumentview/instrumentview/NotebookPresenter.py
@@ -8,6 +8,7 @@
 from instrumentview.NotebookView import NotebookView
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 
+import numpy as np
 import pyvista as pv
 
 
@@ -16,13 +17,29 @@ class NotebookPresenter:
         self._view = view
         self._model = model
         self._counts_label = "Integrated Counts"
+        self._visible_label = "Visible Picked"
         self._model.setup()
         self.setup()
 
-    def setup(self):
+    def setup(self) -> None:
         self._view.subscribe_presenter(self)
         self._view.show_axes()
         self._detector_mesh = pv.PolyData(self._model.detector_positions)
         self._detector_mesh[self._counts_label] = self._model.detector_counts
         self._view.add_detector_mesh(self._detector_mesh, is_projection=self._model.is_2d_projection, scalars=self._counts_label)
+        self._pickable_mesh = pv.PolyData(self._model.detector_positions)
+        self._pickable_mesh[self._visible_label] = self._model.picked_visibility
+        self._view.add_pickable_mesh(self._pickable_mesh, scalars=self._visible_label)
         self._view.reset_camera()
+
+    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool) -> None:
+        indices = np.where(np.isin(self._model.detector_ids, detector_ids))[0]
+        if len(indices) == 0:
+            print("Detectors not found!")
+            return
+        mask = np.full(self._model.detector_ids.shape, False)
+        mask[indices] = True
+        self._model.negate_picked_visibility(mask)
+        self._pickable_mesh[self._visible_label] = self._model.picked_visibility
+        self._model.extract_spectra_for_line_plot(self._model.workspace_x_unit, sum_spectra)
+        return self._view._plot_spectra(self._model.line_plot_workspace, sum_spectra)

--- a/qt/python/instrumentview/instrumentview/NotebookPresenter.py
+++ b/qt/python/instrumentview/instrumentview/NotebookPresenter.py
@@ -8,8 +8,11 @@
 from instrumentview.NotebookView import NotebookView
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 
+from matplotlib.axes import Axes
 import numpy as np
 import pyvista as pv
+from typing import Optional
+import warnings
 
 
 class NotebookPresenter:
@@ -29,13 +32,13 @@ class NotebookPresenter:
         self._view.add_detector_mesh(self._detector_mesh, is_projection=self._model.is_2d_projection, scalars=self._counts_label)
         self._pickable_mesh = pv.PolyData(self._model.detector_positions)
         self._pickable_mesh[self._visible_label] = self._model.picked_visibility
-        self._view.add_pickable_mesh(self._pickable_mesh, scalars=self._visible_label)
+        self._view.add_selection_mesh(self._pickable_mesh, scalars=self._visible_label)
         self._view.reset_camera()
 
-    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool) -> None:
+    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool) -> Optional[Axes]:
         indices = np.where(np.isin(self._model.detector_ids, detector_ids))[0]
         if len(indices) == 0:
-            print("Detectors not found!")
+            warnings.warn(f"Detectors not found for IDs: {detector_ids}")
             return
         mask = np.full(self._model.detector_ids.shape, False)
         mask[indices] = True

--- a/qt/python/instrumentview/instrumentview/NotebookUtils.py
+++ b/qt/python/instrumentview/instrumentview/NotebookUtils.py
@@ -1,0 +1,40 @@
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
+from instrumentview.NotebookView import NotebookView
+from instrumentview.NotebookPresenter import NotebookPresenter
+from mantid.dataobjects import Workspace2D
+from mantid.simpleapi import Load
+from pathlib import Path
+from typing import Optional
+import pyvista as pv
+
+
+def _load_file(file_path: Path) -> Optional[Workspace2D]:
+    ws = Load(str(file_path))
+    if (
+        not ws.getInstrument()
+        or not ws.getInstrument().getName()
+        or not ws.getAxis(1).isSpectra()
+        or (ws.detectorInfo().detectorIDs().size == 0)
+    ):
+        raise RuntimeError(f"Could not open instrument for {file_path}. Check that instrument and detectors are present in the workspace.")
+    return ws
+
+
+def create_notebook_window(file_path_or_workspace: Path | Workspace2D) -> NotebookView:
+    if isinstance(file_path_or_workspace, Path) or isinstance(file_path_or_workspace, str):
+        ws = _load_file(file_path_or_workspace)
+        if ws is None:
+            return
+    elif isinstance(file_path_or_workspace, Workspace2D):
+        ws = file_path_or_workspace
+    else:
+        raise RuntimeError("Unknown type, must be a path to a workspace or a workspace object")
+    pv.set_jupyter_backend("trame")
+    model = FullInstrumentViewModel(ws)
+    window = NotebookView()
+    NotebookPresenter(window, model)
+    return window

--- a/qt/python/instrumentview/instrumentview/NotebookUtils.py
+++ b/qt/python/instrumentview/instrumentview/NotebookUtils.py
@@ -8,11 +8,10 @@ from instrumentview.NotebookPresenter import NotebookPresenter
 from mantid.dataobjects import Workspace2D
 from mantid.simpleapi import Load
 from pathlib import Path
-from typing import Optional
 import pyvista as pv
 
 
-def _load_file(file_path: Path) -> Optional[Workspace2D]:
+def _load_file(file_path: Path) -> Workspace2D:
     ws = Load(str(file_path))
     if (
         not ws.getInstrument()
@@ -24,15 +23,13 @@ def _load_file(file_path: Path) -> Optional[Workspace2D]:
     return ws
 
 
-def create_notebook_window(file_path_or_workspace: Path | Workspace2D) -> NotebookView:
+def create_notebook_window(file_path_or_workspace: Path | str | Workspace2D) -> NotebookView:
     if isinstance(file_path_or_workspace, Path) or isinstance(file_path_or_workspace, str):
         ws = _load_file(file_path_or_workspace)
-        if ws is None:
-            return
     elif isinstance(file_path_or_workspace, Workspace2D):
         ws = file_path_or_workspace
     else:
-        raise RuntimeError("Unknown type, must be a path to a workspace or a workspace object")
+        raise TypeError("Unknown type, must be a Path, str, or Workspace2D")
     pv.set_jupyter_backend("trame")
     model = FullInstrumentViewModel(ws)
     window = NotebookView()

--- a/qt/python/instrumentview/instrumentview/NotebookView.py
+++ b/qt/python/instrumentview/instrumentview/NotebookView.py
@@ -60,12 +60,11 @@ class NotebookView:
     def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool = True) -> Optional[Axes]:
         return self._presenter.pick_detectors(detector_ids, sum_spectra)
 
-    def _plot_spectra(self, workspace: Workspace2D, sum_spectra: bool) -> Axes:
-        if workspace is not None and workspace.getNumberHistograms() > 0:
-            spectra = workspace.getSpectrumNumbers()
-            _, detector_spectrum_axes = plt.subplots(subplot_kw={"projection": "mantid"})
-            for spec in spectra:
-                detector_spectrum_axes.plot(workspace, specNum=spec, label=f"Spectrum {spec}" if not sum_spectra else None)
-            if not sum_spectra:
-                detector_spectrum_axes.legend(fontsize=8.0).set_draggable(True)
-            return detector_spectrum_axes
+    def plot_spectra(self, workspace: Workspace2D, sum_spectra: bool) -> Axes:
+        spectra = workspace.getSpectrumNumbers()
+        _, detector_spectrum_axes = plt.subplots(subplot_kw={"projection": "mantid"})
+        for spec in spectra:
+            detector_spectrum_axes.plot(workspace, specNum=spec, label=f"Spectrum {spec}" if not sum_spectra else None)
+        if not sum_spectra:
+            detector_spectrum_axes.legend(fontsize=8.0).set_draggable(True)
+        return detector_spectrum_axes

--- a/qt/python/instrumentview/instrumentview/NotebookView.py
+++ b/qt/python/instrumentview/instrumentview/NotebookView.py
@@ -5,6 +5,11 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
+from mantid.dataobjects import Workspace2D
+
+from matplotlib.axes import Axes
+import matplotlib.pyplot as plt
+import numpy as np
 import pyvista as pv
 
 
@@ -33,8 +38,33 @@ class NotebookView:
         self._plotter.enable_parallel_projection()
         self._plotter.enable_zoom_style()
 
+    def add_pickable_mesh(self, point_cloud: pv.PolyData, scalars: np.ndarray | str) -> None:
+        self._plotter.add_mesh(
+            point_cloud,
+            scalars=scalars,
+            opacity=[0.0, 0.3],
+            show_scalar_bar=False,
+            pickable=False,
+            cmap="Oranges",
+            point_size=30,
+            render_points_as_spheres=True,
+        )
+
     def reset_camera(self) -> None:
         self._plotter.reset_camera()
 
     def show_axes(self) -> None:
         self._plotter.show_axes()
+
+    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool = True) -> None:
+        self._presenter.pick_detectors(detector_ids, sum_spectra)
+
+    def _plot_spectra(self, workspace: Workspace2D, sum_spectra: bool) -> Axes:
+        if workspace is not None and workspace.getNumberHistograms() > 0:
+            spectra = workspace.getSpectrumNumbers()
+            _, detector_spectrum_axes = plt.subplots(subplot_kw={"projection": "mantid"})
+            for spec in spectra:
+                detector_spectrum_axes.plot(workspace, specNum=spec, label=f"Spectrum {spec}" if not sum_spectra else None)
+            if not sum_spectra:
+                detector_spectrum_axes.legend(fontsize=8.0).set_draggable(True)
+            return detector_spectrum_axes

--- a/qt/python/instrumentview/instrumentview/NotebookView.py
+++ b/qt/python/instrumentview/instrumentview/NotebookView.py
@@ -11,6 +11,7 @@ from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
+from typing import Optional
 
 
 class NotebookView:
@@ -38,7 +39,7 @@ class NotebookView:
         self._plotter.enable_parallel_projection()
         self._plotter.enable_zoom_style()
 
-    def add_pickable_mesh(self, point_cloud: pv.PolyData, scalars: np.ndarray | str) -> None:
+    def add_selection_mesh(self, point_cloud: pv.PolyData, scalars: np.ndarray | str) -> None:
         self._plotter.add_mesh(
             point_cloud,
             scalars=scalars,
@@ -56,8 +57,8 @@ class NotebookView:
     def show_axes(self) -> None:
         self._plotter.show_axes()
 
-    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool = True) -> None:
-        self._presenter.pick_detectors(detector_ids, sum_spectra)
+    def pick_detectors(self, detector_ids: list[int] | np.ndarray, sum_spectra: bool = True) -> Optional[Axes]:
+        return self._presenter.pick_detectors(detector_ids, sum_spectra)
 
     def _plot_spectra(self, workspace: Workspace2D, sum_spectra: bool) -> Axes:
         if workspace is not None and workspace.getNumberHistograms() > 0:

--- a/qt/python/instrumentview/instrumentview/NotebookView.py
+++ b/qt/python/instrumentview/instrumentview/NotebookView.py
@@ -1,0 +1,40 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import pyvista as pv
+
+
+class NotebookView:
+    def __init__(self) -> None:
+        pv.global_theme.background = "black"
+        pv.global_theme.font.color = "white"
+        self._plotter = pv.Plotter(notebook=True)
+        self._plotter.show(jupyter_backend="trame")
+
+    def subscribe_presenter(self, presenter) -> None:
+        self._presenter = presenter
+
+    def add_detector_mesh(self, mesh: pv.PolyData, is_projection: bool, scalars=None) -> None:
+        """Draw the given mesh in the main plotter window"""
+        scalar_bar_args = dict(interactive=True, vertical=False, title_font_size=15, label_font_size=12) if scalars is not None else None
+        self._plotter.add_mesh(
+            mesh, pickable=False, scalars=scalars, render_points_as_spheres=True, point_size=15, scalar_bar_args=scalar_bar_args
+        )
+
+        if not is_projection:
+            self._plotter.enable_trackball_style()
+            return
+
+        self._plotter.view_xy()
+        self._plotter.enable_parallel_projection()
+        self._plotter.enable_zoom_style()
+
+    def reset_camera(self) -> None:
+        self._plotter.reset_camera()
+
+    def show_axes(self) -> None:
+        self._plotter.show_axes()

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
@@ -55,15 +55,15 @@ class TestNotebookPresenter(unittest.TestCase):
         self._presenter._pickable_mesh.__setitem__.assert_called_with("Visible Picked", self.mock_model.picked_visibility)
         self.mock_model.extract_spectra_for_line_plot.assert_called_once_with(self.mock_model.workspace_x_unit, True)
 
-        self.mock_view._plot_spectra.assert_called_once_with(self.mock_model.line_plot_workspace, True)
-        self.assertEqual(result, self.mock_view._plot_spectra.return_value)
+        self.mock_view.plot_spectra.assert_called_once_with(self.mock_model.line_plot_workspace, True)
+        self.assertEqual(result, self.mock_view.plot_spectra.return_value)
 
     def test_pick_detectors_with_invalid_ids_prints_message_and_returns_none(self):
         with patch("instrumentview.NotebookPresenter.np.where", return_value=(np.array([]), 0)):
             result = self._presenter.pick_detectors([999], sum_spectra=False)
 
         self.mock_model.negate_picked_visibility.assert_not_called()
-        self.mock_view._plot_spectra.assert_not_called()
+        self.mock_view.plot_spectra.assert_not_called()
         self.assertIsNone(result)
 
 

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
@@ -1,0 +1,71 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from instrumentview.NotebookPresenter import NotebookPresenter
+
+import unittest
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+
+class TestNotebookPresenter(unittest.TestCase):
+    def setUp(self):
+        self.mock_view = MagicMock()
+        self.mock_model = MagicMock()
+        self.mock_model.detector_positions = np.array([[0, 0, 0], [1, 1, 1]])
+        self.mock_model.detector_counts = np.array([10, 20])
+        self.mock_model.picked_visibility = np.array([True, False])
+        self.mock_model.is_2d_projection = True
+        self.mock_model.detector_ids = np.array([101, 102])
+        self.mock_model.workspace_x_unit = "Wavelength"
+        self.mock_model.line_plot_workspace = MagicMock()
+        with patch("instrumentview.NotebookPresenter.pv"):
+            self._presenter = NotebookPresenter(self.mock_view, self.mock_model)
+
+    def test_init_calls_model_setup_and_setup(self):
+        self.mock_model.setup.assert_called_once()
+        self.mock_view.subscribe_presenter.assert_called_once_with(self._presenter)
+
+    def test_setup_creates_meshes_and_calls_view_methods(self):
+        detector_mesh = self._presenter._detector_mesh
+        detector_mesh.__setitem__.assert_any_call("Integrated Counts", self.mock_model.detector_counts)
+        pickable_mesh = self._presenter._pickable_mesh
+        pickable_mesh.__setitem__.assert_any_call("Visible Picked", self.mock_model.picked_visibility)
+        self.mock_view.show_axes.assert_called_once()
+        self.mock_view.add_detector_mesh.assert_called_once_with(
+            detector_mesh, is_projection=self.mock_model.is_2d_projection, scalars="Integrated Counts"
+        )
+        self.mock_view.add_pickable_mesh.assert_called_once_with(pickable_mesh, scalars="Visible Picked")
+        self.mock_view.reset_camera.assert_called_once()
+
+    def test_pick_detectors_with_valid_ids_updates_visibility_and_calls_plot(self):
+        detector_ids = [101]
+        indices = (np.array([0]), 0)
+        with patch("instrumentview.NotebookPresenter.np.where", return_value=indices):
+            result = self._presenter.pick_detectors(detector_ids, sum_spectra=True)
+
+        expected_mask = np.array([True, False])
+        self.mock_model.negate_picked_visibility.assert_called_once()
+        np.testing.assert_array_equal(self.mock_model.negate_picked_visibility.call_args[0][0], expected_mask)
+
+        self._presenter._pickable_mesh.__setitem__.assert_called_with("Visible Picked", self.mock_model.picked_visibility)
+        self.mock_model.extract_spectra_for_line_plot.assert_called_once_with(self.mock_model.workspace_x_unit, True)
+
+        self.mock_view._plot_spectra.assert_called_once_with(self.mock_model.line_plot_workspace, True)
+        self.assertEqual(result, self.mock_view._plot_spectra.return_value)
+
+    def test_pick_detectors_with_invalid_ids_prints_message_and_returns_none(self):
+        with patch("instrumentview.NotebookPresenter.np.where", return_value=(np.array([]), 0)):
+            result = self._presenter.pick_detectors([999], sum_spectra=False)
+
+        self.mock_model.negate_picked_visibility.assert_not_called()
+        self.mock_view._plot_spectra.assert_not_called()
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_presenter.py
@@ -39,7 +39,7 @@ class TestNotebookPresenter(unittest.TestCase):
         self.mock_view.add_detector_mesh.assert_called_once_with(
             detector_mesh, is_projection=self.mock_model.is_2d_projection, scalars="Integrated Counts"
         )
-        self.mock_view.add_pickable_mesh.assert_called_once_with(pickable_mesh, scalars="Visible Picked")
+        self.mock_view.add_selection_mesh.assert_called_once_with(pickable_mesh, scalars="Visible Picked")
         self.mock_view.reset_camera.assert_called_once()
 
     def test_pick_detectors_with_valid_ids_updates_visibility_and_calls_plot(self):

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
@@ -54,14 +54,8 @@ class TestNotebookView(unittest.TestCase):
         by _plot_spectra: getNumberHistograms() and getSpectrumNumbers().
         """
         ws = MagicMock()
-        ws.getNumberHistograms.return_value = num_hists
         ws.getSpectrumNumbers.return_value = spectra
         return ws
-
-    def test_plot_spectra_returns_none_for_empty_or_none_workspace(self):
-        self.assertIsNone(self._view._plot_spectra(None, sum_spectra=True))
-        ws = self._make_fake_workspace(num_hists=0, spectra=[])
-        self.assertIsNone(self._view._plot_spectra(ws, sum_spectra=False))
 
     def test_plot_spectra_summed_does_not_set_labels_or_legend(self):
         ws = self._make_fake_workspace(num_hists=3, spectra=[10, 11, 12])
@@ -69,7 +63,7 @@ class TestNotebookView(unittest.TestCase):
         with patch("instrumentview.NotebookView.plt.subplots") as subplots:
             axes = MagicMock()
             subplots.return_value = (MagicMock(name="fig"), axes)
-            result_axes = self._view._plot_spectra(ws, sum_spectra=True)
+            result_axes = self._view.plot_spectra(ws, sum_spectra=True)
             subplots.assert_called_once_with(subplot_kw={"projection": "mantid"})
             # Called once per spectrum, label should be None when sum_spectra=True
             expected_calls = [
@@ -93,7 +87,7 @@ class TestNotebookView(unittest.TestCase):
             legend = MagicMock()
             axes.legend.return_value = legend
             subplots.return_value = (MagicMock(name="fig"), axes)
-            result_axes = self._view._plot_spectra(ws, sum_spectra=False)
+            result_axes = self._view.plot_spectra(ws, sum_spectra=False)
             expected_calls = [
                 call(ws, specNum=1, label="Spectrum 1"),
                 call(ws, specNum=2, label="Spectrum 2"),

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
@@ -1,0 +1,112 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from instrumentview.NotebookView import NotebookView
+
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+
+class TestNotebookView(unittest.TestCase):
+    def setUp(self) -> None:
+        with patch("instrumentview.NotebookView.pv"):
+            self._view = NotebookView()
+
+    def test_add_pickable_mesh_calls_pyvista_with_expected_parameters(self):
+        cloud = MagicMock(name="cloud")
+        scalars = "my_scalars"
+
+        self._view.add_pickable_mesh(cloud, scalars)
+        self._view._plotter.add_mesh.assert_called_once_with(
+            cloud,
+            scalars=scalars,
+            opacity=[0.0, 0.3],
+            show_scalar_bar=False,
+            pickable=False,
+            cmap="Oranges",
+            point_size=30,
+            render_points_as_spheres=True,
+        )
+
+    def test_reset_camera_delegates_to_plotter(self):
+        self._view.reset_camera()
+        self._view._plotter.reset_camera.assert_called_once()
+
+    def test_show_axes_delegates_to_plotter(self):
+        self._view.show_axes()
+        self._view._plotter.show_axes.assert_called_once()
+
+    def test_pick_detectors_delegates_to_presenter(self):
+        presenter = MagicMock()
+        self._view.subscribe_presenter(presenter)
+
+        ids = [1, 2, 3]
+        self._view.pick_detectors(ids, sum_spectra=True)
+        presenter.pick_detectors.assert_called_once_with(ids, True)
+
+    def _make_fake_workspace(self, num_hists, spectra):
+        """
+        Build a minimal fake Workspace-like object with the methods used
+        by _plot_spectra: getNumberHistograms() and getSpectrumNumbers().
+        """
+        ws = MagicMock()
+        ws.getNumberHistograms.return_value = num_hists
+        ws.getSpectrumNumbers.return_value = spectra
+        return ws
+
+    def test_plot_spectra_returns_none_for_empty_or_none_workspace(self):
+        self.assertIsNone(self._view._plot_spectra(None, sum_spectra=True))
+        ws = self._make_fake_workspace(num_hists=0, spectra=[])
+        self.assertIsNone(self._view._plot_spectra(ws, sum_spectra=False))
+
+    def test_plot_spectra_summed_does_not_set_labels_or_legend(self):
+        ws = self._make_fake_workspace(num_hists=3, spectra=[10, 11, 12])
+
+        with patch("instrumentview.NotebookView.plt.subplots") as subplots:
+            axes = MagicMock()
+            subplots.return_value = (MagicMock(name="fig"), axes)
+            result_axes = self._view._plot_spectra(ws, sum_spectra=True)
+            subplots.assert_called_once_with(subplot_kw={"projection": "mantid"})
+            # Called once per spectrum, label should be None when sum_spectra=True
+            expected_calls = [
+                call(ws, specNum=10, label=None),
+                call(ws, specNum=11, label=None),
+                call(ws, specNum=12, label=None),
+            ]
+            call_list = axes.plot.call_args_list
+            self.assertEquals(len(expected_calls), len(call_list))
+            for idx in range(len(expected_calls)):
+                self.assertEquals(call_list[idx], expected_calls[idx])
+            # No legend when summed
+            axes.legend.assert_not_called()
+            self.assertEquals(axes, result_axes)
+
+    def test_plot_spectra_not_summed_sets_labels_and_draggable_legend(self):
+        ws = self._make_fake_workspace(num_hists=2, spectra=[1, 2])
+
+        with patch("instrumentview.NotebookView.plt.subplots") as subplots:
+            axes = MagicMock()
+            legend = MagicMock()
+            axes.legend.return_value = legend
+            subplots.return_value = (MagicMock(name="fig"), axes)
+            result_axes = self._view._plot_spectra(ws, sum_spectra=False)
+            expected_calls = [
+                call(ws, specNum=1, label="Spectrum 1"),
+                call(ws, specNum=2, label="Spectrum 2"),
+            ]
+            call_list = axes.plot.call_args_list
+            self.assertEquals(len(expected_calls), len(call_list))
+            for idx in range(len(expected_calls)):
+                self.assertEquals(call_list[idx], expected_calls[idx])
+            # Legend created with fontsize=8.0 and made draggable
+            axes.legend.assert_called_once_with(fontsize=8.0)
+            legend.set_draggable.assert_called_once_with(True)
+            self.assertEquals(axes, result_axes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_notebook_view.py
@@ -16,11 +16,11 @@ class TestNotebookView(unittest.TestCase):
         with patch("instrumentview.NotebookView.pv"):
             self._view = NotebookView()
 
-    def test_add_pickable_mesh_calls_pyvista_with_expected_parameters(self):
+    def test_add_selection_mesh_calls_pyvista_with_expected_parameters(self):
         cloud = MagicMock(name="cloud")
         scalars = "my_scalars"
 
-        self._view.add_pickable_mesh(cloud, scalars)
+        self._view.add_selection_mesh(cloud, scalars)
         self._view._plotter.add_mesh.assert_called_once_with(
             cloud,
             scalars=scalars,
@@ -78,12 +78,12 @@ class TestNotebookView(unittest.TestCase):
                 call(ws, specNum=12, label=None),
             ]
             call_list = axes.plot.call_args_list
-            self.assertEquals(len(expected_calls), len(call_list))
+            self.assertEqual(len(expected_calls), len(call_list))
             for idx in range(len(expected_calls)):
-                self.assertEquals(call_list[idx], expected_calls[idx])
+                self.assertEqual(call_list[idx], expected_calls[idx])
             # No legend when summed
             axes.legend.assert_not_called()
-            self.assertEquals(axes, result_axes)
+            self.assertEqual(axes, result_axes)
 
     def test_plot_spectra_not_summed_sets_labels_and_draggable_legend(self):
         ws = self._make_fake_workspace(num_hists=2, spectra=[1, 2])
@@ -99,13 +99,13 @@ class TestNotebookView(unittest.TestCase):
                 call(ws, specNum=2, label="Spectrum 2"),
             ]
             call_list = axes.plot.call_args_list
-            self.assertEquals(len(expected_calls), len(call_list))
+            self.assertEqual(len(expected_calls), len(call_list))
             for idx in range(len(expected_calls)):
-                self.assertEquals(call_list[idx], expected_calls[idx])
+                self.assertEqual(call_list[idx], expected_calls[idx])
             # Legend created with fontsize=8.0 and made draggable
             axes.legend.assert_called_once_with(fontsize=8.0)
             legend.set_draggable.assert_called_once_with(True)
-            self.assertEquals(axes, result_axes)
+            self.assertEqual(axes, result_axes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a basic interface to include an interactive Instrument View within a Jupyter Notebook.

There are only two methods you can call at the moment, but now it's set up it will be easy to add further features, everything is going through the existing model.

Closes #40579 

### To test:

You need to add the following to your python environment: `jupyterlab, trame, trame-vtk, jupyter-server-proxy, trame-vuetify
`.

Create a Jupyter Notebook and add the following:

``` python
import sys

mantid_path = "<path to dev build>\\build\\bin"
if mantid_path not in sys.path:
    sys.path.append(mantid_path)

from instrumentview.NotebookUtils import create_notebook_window
from pathlib import Path

workspace_path = Path("<path to workspace file>")
# You can also load a workspace here and give it the workspace directly

iv = create_notebook_window(workspace_path)

# Replace with actual detector IDs
iv.pick_detectors([4102, 2724], True)

```

The 3D view will be interactive, but the line plot from `pick_detectors` will not be.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
