### PR TITLE
AlignAndFocusPowderSlim: Do splitting and grouping at the same time

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -49,11 +49,9 @@ private:
   const API::ITableWorkspace_sptr loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
                                               DataObjects::GroupingWorkspace_sptr &groupingWS);
   void initScaleAtSample(const API::MatrixWorkspace_sptr &wksp);
-  std::vector<std::pair<size_t, size_t>> determinePulseIndices(const API::MatrixWorkspace_sptr &wksp,
-                                                               const Kernel::TimeROI &filterROI);
-  static std::vector<std::pair<int, std::pair<size_t, size_t>>>
-  determinePulseIndicesTargets(const API::MatrixWorkspace_sptr &wksp, const Kernel::TimeROI &filterROI,
-                               const DataObjects::TimeSplitter &timeSplitter);
+  std::vector<std::pair<size_t, size_t>> determinePulseIndices(const Kernel::TimeROI &filterROI);
+  std::vector<std::pair<int, std::pair<size_t, size_t>>>
+  determinePulseIndicesTargets(const Kernel::TimeROI &filterROI, const DataObjects::TimeSplitter &timeSplitter);
   Kernel::TimeROI getFilterROI(const API::MatrixWorkspace_sptr &wksp);
   DataObjects::TimeSplitter timeSplitterFromSplitterWorkspace(const Types::Core::DateAndTime &);
 
@@ -71,6 +69,8 @@ private:
   std::vector<int64_t> loadSize;
   // map of detectorID to output spectrum number
   std::map<detid_t, size_t> detIDToSpecNum;
+  // pulse times
+  std::shared_ptr<std::vector<Types::Core::DateAndTime>> m_pulse_times;
 };
 
 // these properties are public to simplify testing and calling from other code

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h
@@ -59,7 +59,6 @@ public:
    * into microseconds. Applying it here is effectively the same as applying it to each event time-of-flight.
    * @param bank_index Output group for finding grouping information.
    */
-  BankCalibration getCalibration(const double time_conversion, const size_t bank_index) const;
   std::vector<BankCalibration> getCalibrations(const double time_conversion, const size_t bank_index) const;
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitFullTimeTask.h
@@ -11,6 +11,7 @@
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/DateAndTime.h"
@@ -31,10 +32,11 @@ class MANTID_DATAHANDLING_DLL ProcessBankSplitFullTimeTask : public ProcessBankT
 public:
   ProcessBankSplitFullTimeTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
                                std::shared_ptr<NexusLoader> loader, std::vector<int> &workspaceIndices,
-                               std::vector<API::MatrixWorkspace_sptr> &wksps,
+                               std::vector<SpectraProcessingData> &processingDatas,
                                const BankCalibrationFactory &calibFactory, const size_t events_per_chunk,
                                const size_t grainsize_event,
                                const std::map<Mantid::Types::Core::DateAndTime, int> &splitterMap,
+                               std::shared_ptr<std::vector<Types::Core::DateAndTime>> pulse_times,
                                std::shared_ptr<API::Progress> &progress);
 
   void operator()(const tbb::blocked_range<size_t> &range) const;
@@ -42,12 +44,15 @@ public:
 private:
   H5::H5File m_h5file;
   std::vector<int> m_workspaceIndices;
-  std::vector<API::MatrixWorkspace_sptr> m_wksps;
+  // Do not copy the processing data (contains atomics which are not copyable).
+  // Store a reference to the externally-owned vector instead.
+  std::vector<SpectraProcessingData> &m_processingDatas;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   const std::map<Mantid::Types::Core::DateAndTime, int> m_splitterMap;
   /// number of events to histogram in a single thread
   const size_t m_grainsize_event;
+  std::shared_ptr<std::vector<Types::Core::DateAndTime>> m_pulse_times;
   std::shared_ptr<API::Progress> m_progress;
 };
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankSplitTask.h
@@ -11,6 +11,7 @@
 #include "MantidDataHandling/AlignAndFocusPowderSlim/BankCalibration.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/NexusLoader.h"
 #include "MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h"
+#include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidGeometry/IDTypes.h"
 #include <H5Cpp.h>
 #include <MantidAPI/Progress.h>
@@ -25,7 +26,7 @@ class ProcessBankSplitTask : public ProcessBankTaskBase {
 public:
   ProcessBankSplitTask(std::vector<std::string> &bankEntryNames, H5::H5File &h5file,
                        std::shared_ptr<NexusLoader> loader, std::vector<int> &workspaceIndices,
-                       std::vector<API::MatrixWorkspace_sptr> &wksps, const BankCalibrationFactory &calibFactory,
+                       std::vector<SpectraProcessingData> &processingDatas, const BankCalibrationFactory &calibFactory,
                        const size_t events_per_chunk, const size_t grainsize_event,
                        std::shared_ptr<API::Progress> &progress);
 
@@ -34,7 +35,7 @@ public:
 private:
   H5::H5File m_h5file;
   std::vector<int> m_workspaceIndices;
-  std::vector<API::MatrixWorkspace_sptr> m_wksps;
+  std::vector<SpectraProcessingData> &m_processingDatas;
   /// number of events to read from disk at one time
   const size_t m_events_per_chunk;
   /// number of events to histogram in a single thread

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim/ProcessBankTaskBase.h
@@ -18,7 +18,6 @@ public:
   ProcessBankTaskBase(std::vector<std::string> &bankEntryNames, std::shared_ptr<NexusLoader> loader,
                       const BankCalibrationFactory &calibFactory);
   const std::string &bankName(const size_t wksp_index) const;
-  BankCalibration getCalibration(const std::string &tof_unit, const size_t wksp_index) const;
   std::vector<BankCalibration> getCalibrations(const std::string &tof_unit, const size_t bank_index) const;
 
   /**
@@ -50,6 +49,4 @@ private:
 
 std::string toLogString(const std::string &bankName, const size_t total_events_to_read,
                         const std::vector<size_t> &offsets, const std::vector<size_t> &slabsizes);
-
-void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum);
 } // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -121,10 +121,6 @@ BankCalibrationFactory::BankCalibrationFactory(const std::map<detid_t, double> &
     : m_calibration_map(calibration_map), m_scale_at_sample(scale_at_sample), m_grouping(grouping), m_mask(mask),
       m_bank_detids(bank_detids) {}
 
-BankCalibration BankCalibrationFactory::getCalibration(const double time_conversion, const size_t bank_index) const {
-  return BankCalibration(time_conversion, m_bank_detids.at(bank_index), m_calibration_map, m_scale_at_sample, m_mask);
-}
-
 std::vector<BankCalibration> BankCalibrationFactory::getCalibrations(const double time_conversion,
                                                                      const size_t bank_index) const {
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTaskBase.cpp
@@ -20,14 +20,6 @@ ProcessBankTaskBase::ProcessBankTaskBase(std::vector<std::string> &bankEntryName
     : m_bankEntries(bankEntryNames), m_loader(std::move(loader)), m_calibFactory(calibFactory) {}
 
 const std::string &ProcessBankTaskBase::bankName(const size_t wksp_index) const { return m_bankEntries[wksp_index]; }
-BankCalibration ProcessBankTaskBase::getCalibration(const std::string &tof_unit, const size_t wksp_index) const {
-  // determine time conversion as a double
-  const double time_conversion = Kernel::Units::timeConversionValue(tof_unit, MICROSEC);
-
-  // now the calibration for the output group can be created
-  // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
-  return m_calibFactory.getCalibration(time_conversion, wksp_index);
-}
 
 std::vector<BankCalibration> ProcessBankTaskBase::getCalibrations(const std::string &tof_unit,
                                                                   const size_t bank_index) const {
@@ -72,12 +64,4 @@ std::string toLogString(const std::string &bankName, const size_t total_events_t
   return oss.str();
 }
 
-void copyDataToSpectrum(const std::vector<uint32_t> &y_temp, API::ISpectrum *spectrum) {
-  // copy the data out into the correct spectrum and calculate errors
-  auto &y_values = spectrum->dataY();
-  std::copy(y_temp.cbegin(), y_temp.cend(), y_values.begin());
-  auto &e_values = spectrum->dataE();
-  std::transform(y_temp.cbegin(), y_temp.cend(), e_values.begin(),
-                 [](uint32_t y) { return std::sqrt(static_cast<double>(y)); });
-}
 }; // namespace Mantid::DataHandling::AlignAndFocusPowderSlim

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -552,6 +552,7 @@ public:
 
   void test_splitter_table() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.relativeTime = true;
     configuration.splitterWS = create_splitter_table(configuration.relativeTime);
     for (bool processBankSplitTask : {false, true}) {
@@ -596,6 +597,7 @@ public:
 
   void test_splitter_table_absolute_time() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.relativeTime = false;
     configuration.splitterWS = create_splitter_table(configuration.relativeTime);
     for (bool processBankSplitTask : {false, true}) {
@@ -616,6 +618,7 @@ public:
 
   void test_splitter_table_multiple_targets() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.relativeTime = true;
     configuration.splitterWS = create_splitter_table(configuration.relativeTime, false);
     for (bool processBankSplitTask : {false, true}) {
@@ -682,6 +685,7 @@ public:
 
   void test_splitter_table_and_time_start_stop() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.timeMin = 15;
     configuration.timeMax = 300;
     configuration.relativeTime = true;
@@ -772,6 +776,7 @@ public:
         AnalysisDataService::Instance().retrieve("splitter"));
 
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.relativeTime = true;
     configuration.splitterWS = splitterWS;
 
@@ -839,6 +844,7 @@ public:
     createSplitter->execute();
 
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF");
+    configuration.groupingWS = bank_grouping_ws;
     configuration.useFullTime = true;
     configuration.relativeTime = true;
     configuration.splitterWS =


### PR DESCRIPTION
### Description of work

Following on from #40571, this allows you use a SplitterWorkspace and GroupingWorkspace together.

Refs:
 * [14333: Modify the code for arbitrary grouping - splitting](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14333)
 * #40189

### To test:

Comparing to `GroupDetectors`+`FilterEvents`. Can also check that this works with FullTime filtering and ProcessBankSplitTask.

```python
fullTime = False
processBankSplitTask = False

splitter = CreateEmptyTableWorkspace()
splitter.addColumn('float', 'start')
splitter.addColumn('float', 'stop')
splitter.addColumn('str', 'target')

splitter.addRow((10,20, '0'))
splitter.addRow((200,210, '1'))
splitter.addRow((400,410, '0'))

ws2 = LoadEventNexus("VULCAN_218062.nxs.h5", NumberOfBins=1)
GenerateGroupingPowder(ws2, GroupingWorkspace='powder_group', AngleStep=10)

# pass the splitter table to AlignAndFocusPowderSlim
ws = AlignAndFocusPowderSlim("VULCAN_218062.nxs.h5",
                             SplitterWorkspace=splitter, RelativeTime=True,
                             XMin=0, XMax=50000, XDelta=50000,
                             BinningMode="Linear",
                             BinningUnits="TOF",
                             L1=43.755,
                             L2=[2.296]*12,
                             Polar=[90]*12,
                             GroupingWorkspace="powder_group",
                             UseFullTime=fullTime,
                             ProcessBankSplitTask=processBankSplitTask)

# This is equivalent to using GroupDectors+FilterEvents with the same splitter table and GroupingWorkspace.
# But note that this example doesn't align the data so put everything in 1 big bin to compare.

ws2 = GroupDetectors(ws2, CopyGroupingFromWorkspace="powder_group")

FilterEvents(ws2,
             SplitterWorkspace=splitter, RelativeTime=True,
             FilterByPulseTime=not fullTime,
             OutputWorkspaceBaseName="filtered",
             GroupWorkspaces=True)
out = Rebin("filtered", "0,50000,50000", PreserveEvents=False)

CompareWorkspaces(ws, out, CheckSpectraMap=False, CheckInstrument=False)
```


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

*This does not require release notes* because the release notes from #40571 are inclusive of these changes.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
