### PR TITLE
Add further checks before performing ISIS event shift

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -73,25 +73,22 @@ const std::string BAD_PULSES_CUTOFF("FilterBadPulsesLowerCutoff");
 } // namespace
 
 bool doPerformISISEventShift(Nexus::File &file, std::string &topEntryName) {
-  std::string DETECTOR_EVENTS_ADDR = std::format("/{}/detector_1_events", topEntryName);
-  if (!file.hasAddress(DETECTOR_EVENTS_ADDR)) { // not an isis file
+  std::string detectorEventsAddr = std::format("/{}/detector_1_events", topEntryName);
+  if (!file.hasAddress(detectorEventsAddr)) { // not an isis file
     return false;
   }
 
-  const std::string EVENT_TIME_SHIFT_ADDR(DETECTOR_EVENTS_ADDR + "/event_time_offset_shift");
-  if (file.hasAddress(EVENT_TIME_SHIFT_ADDR)) { // almost certainly an isis file
+  const std::string eventTimeShiftAddr(detectorEventsAddr + "/event_time_offset_shift");
+  if (file.hasAddress(eventTimeShiftAddr)) { // almost certainly an isis file
     std::string eventShiftType;
-    file.readData(EVENT_TIME_SHIFT_ADDR, eventShiftType);
-    if (eventShiftType == "random") { // event correction already applied
-      return false;
-    }
-    return true;
+    file.readData(eventTimeShiftAddr, eventShiftType);
+    return !(eventShiftType == "random"); // event correction already applied
   }
 
-  const std::string PROGRAM_NAME_ADDR = std::format("/{}/program_name", topEntryName);
-  if (file.hasAddress(PROGRAM_NAME_ADDR)) { // check for ISIS control program
+  const std::string programNameAddr = std::format("/{}/program_name", topEntryName);
+  if (file.hasAddress(programNameAddr)) { // check for ISIS control program
     std::string program_name;
-    file.readData(PROGRAM_NAME_ADDR, program_name);
+    file.readData(programNameAddr, program_name);
     if (program_name == "ISISICP.EXE") {
       return true;
     }

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -279,7 +279,11 @@ void LoadNexusMonitors2::exec() {
 
     // a certain generation of ISIS files modify the time-of-flight
     const std::string currentAddress = file.getAddress();
-    adjustTimeOfFlightISISLegacy(file, eventWS, m_top_entry_name, "NXmonitor");
+
+    if (doPerformISISEventShift(file, m_top_entry_name)) {
+      adjustTimeOfFlightISISLegacy(file, eventWS, m_top_entry_name, "NXmonitor");
+    }
+
     file.openAddress(currentAddress); // reset to where it was earlier
   }
 

--- a/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40629.rst
+++ b/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40629.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadEventNexus <algm-LoadEventNexus>` will no longer error when loading files originating outside of ISIS that contain the ``detector_1_events`` group.


### PR DESCRIPTION
### Description of work

This PR adds additional protection before corrections are applied to wide event shifts to make sure that the dataset is indeed an ISIS dataset, and that the application of the correction is appropriate.

We now:
- Check if the relevant groups are present `/raw_data_1/detector_1_events`, `/raw_data_1/detector_1_events/event_time_offset_shift`
- Check if the program used is the ISIS control program `/raw_data_1/program_name == "ISISICP.EXE"`
- Checks if randomised events have already been applied

Closes #40490

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Contact me for files to load; user has not provided specific files to test the bug in question.

Test coverage is good already due to the relevance of this algorithm in unrelated unit/system tests.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
