### PR TITLE
Add main to tools/DOI/authors.py

### DIFF
--- a/tools/DOI/authors.py
+++ b/tools/DOI/authors.py
@@ -469,7 +469,7 @@ def _authors_from_tag_info(tag_info):
         "--no-merges",  # ignore merge commits
         "--pretty=short",
         tag_info,
-        '--format="%aN"',
+        '--format="%aN"',  # only author name, ignore committer
         "--reverse",
     ]
     proc = subprocess.run(args, stdout=subprocess.PIPE, encoding="utf-8")


### PR DESCRIPTION
To make debugging the author mapping easier, add a main entrypoint to the authors tool. It also adds some flags to the `git log` call to make it more stable and skip merge commits.

There is no associated issue.

This is a trimmed down version of #40396 because we decided that having a mailmap file required finding a place to store/share it.

### To test:

This added the ability to get the authors directly from tools/DOI/authors.py and can be run without accidentally creating a DOI. Use tools/DOI/authors.py --help to find out how to use it and try the two modes.

*This does not require release notes* because it modifies how authors are generated for the DOI tool.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
