### PR TITLE
Improve `LoadNXcanSAS` file scoring method

### DIFF
--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -48,29 +48,6 @@ std::string getNameOfEntry(const H5::H5File &root) {
   return root.getObjnameByIdx(0);
 }
 
-/**
- * Tries to find a nexus or sas entry definition on the loaded file to provide a confidence estimation for the loader.
- * @param file: Reference to loaded file
- */
-bool findDefinition(Mantid::Nexus::File &file) {
-  bool foundDefinition = false;
-  const auto entries = file.getEntries();
-  for (const auto &[sasEntry, nxEntry] : entries) {
-    if (nxEntry == sasEntryClassAttr || nxEntry == nxEntryClassAttr) {
-      file.openGroup(sasEntry, nxEntry);
-      file.openData(sasEntryDefinition);
-      const auto definitionFromFile = file.getStrData();
-      if (definitionFromFile == sasEntryDefinitionFormat) {
-        foundDefinition = true;
-        break;
-      }
-      file.closeData();
-      file.closeGroup();
-    }
-  }
-  return foundDefinition;
-}
-
 Mantid::API::MatrixWorkspace_sptr createWorkspace(const DataSpaceInformation &dimInfo, const bool asHistogram = false) {
   const auto &[dimSpectrumAxis, dimBin, _] = dimInfo;
   // Create a workspace based on the dataSpace information
@@ -486,15 +463,19 @@ int LoadNXcanSAS::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
     return 0;
   }
   int confidence = 0;
-  Mantid::Nexus::File file(descriptor.filename());
-  // Check if there is an entry root/SASentry/definition->NXcanSAS
-  try {
-    if (findDefinition(file)) {
-      confidence = 95;
+  auto const &entries = descriptor.getAllEntries();
+  for (auto const &[sasEntry, nxClass] : entries) {
+    if (nxClass == sasEntryClassAttr || nxClass == nxEntryClassAttr) {
+      std::string const dataAddress = sasEntry + "/" + sasEntryDefinition;
+      std::string const definitionFromFile = descriptor.getStrData(dataAddress);
+      // NOTE: for reasons I don't care to investigate, even if this has the correct definition,
+      // comparing as strings can still lead to mismatch unless compared as C-strings
+      if (strcmp(definitionFromFile.c_str(), sasEntryDefinitionFormat.c_str()) == 0) {
+        confidence = 95;
+        break;
+      }
     }
-  } catch (...) {
   }
-
   return confidence;
 }
 

--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -22,6 +22,7 @@
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NexusFile.h"
 #include <H5Cpp.h>
+#include <cstring>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -470,7 +471,7 @@ int LoadNXcanSAS::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
       std::string const definitionFromFile = descriptor.getStrData(dataAddress);
       // NOTE: for reasons I don't care to investigate, even if this has the correct definition,
       // comparing as strings can still lead to mismatch unless compared as C-strings
-      if (strcmp(definitionFromFile.c_str(), sasEntryDefinitionFormat.c_str()) == 0) {
+      if (std::strcmp(definitionFromFile.c_str(), sasEntryDefinitionFormat.c_str()) == 0) {
         confidence = 95;
         break;
       }

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -17,6 +17,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/Load.h"
 #include "MantidDataHandling/LoadNXcanSAS.h"
 #include "MantidDataHandling/NXcanSASDefinitions.h"
 #include "MantidKernel/Unit.h"
@@ -261,6 +262,27 @@ public:
 
     // Assert
     do_assert_polarized_groups(groupIn, groupOut);
+  }
+
+  void test_load_will_load() {
+    // create a file
+    m_parameters.detectors.emplace_back("front-detector");
+    m_parameters.detectors.emplace_back("rear-detector");
+    m_parameters.invalidDetectors = false;
+    m_parameters.is2dData = true;
+    m_parameters.hasDx = false;
+
+    const auto ws = provide2DWorkspace(m_parameters);
+    set2DValues(ws);
+    m_parameters.idf = getIDFfromWorkspace(ws);
+
+    save_file_no_issues(ws);
+
+    // now try to load it with NxcanSAS
+    Mantid::DataHandling::Load load;
+    load.initialize();
+    load.setPropertyValue("Filename", m_parameters.filePath());
+    TS_ASSERT_EQUALS(load.getPropertyValue("LoaderName"), "LoadNXcanSAS");
   }
 
 private:

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -137,6 +137,9 @@ private:
 
   /// mutex to protect reading from file after initialization in const methods
   mutable std::shared_mutex m_readNexusMutex;
+
+  /// the set of non-existent entries that have been checked
+  mutable std::unordered_set<std::string> m_allMisses;
 };
 
 } // namespace Nexus

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -65,7 +65,7 @@ NexusDescriptorLazy::NexusDescriptorLazy(std::string const &filename)
       m_allEntries(initAllEntries()), m_allMisses() {}
 
 // open the object to determine its type
-bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
+bool NexusDescriptorLazy::isEntry(std::string const &entryName) const {
   bool known_miss = false, known_hit = false;
   {
     // wait for any writes to m_allMisses to end
@@ -74,7 +74,7 @@ bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
     known_hit = m_allEntries.contains(entryName);
   }
   if (known_miss) {
-    // if we know this doesn't exist, return earliy
+    // if we know this doesn't exist, return early
     return false;
   } else if (known_hit) {
     // if we know it does exist, return
@@ -82,7 +82,7 @@ bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
   } else {
     if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) > 0) {
       // if it is there, save the correct class type for it
-      std::string nxclass = UNKNOWN_CLASS;
+      std::string nxclass;
       H5O_info_t oinfo;
       // otherwise, try to open this group and see if it is there
       UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -26,8 +26,7 @@
 static unsigned int const INIT_DEPTH = 1;
 static unsigned int const ENTRY_DEPTH = 2;
 static unsigned int const INSTR_DEPTH = 5;
-static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1", "/raw_data_1"};
-static std::string const NONEXISTENT = "NONEXISTENT"; // register failures as well
+static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1"};
 static std::string const UNKNOWN_CLASS = "UNKNOWN_CLASS";
 
 namespace {

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -26,7 +26,7 @@
 static unsigned int const INIT_DEPTH = 1;
 static unsigned int const ENTRY_DEPTH = 2;
 static unsigned int const INSTR_DEPTH = 5;
-static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1"};
+static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1", "/raw_data_1"};
 static std::string const UNKNOWN_CLASS = "UNKNOWN_CLASS";
 
 namespace {

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -63,45 +63,45 @@ namespace Mantid::Nexus {
 
 NexusDescriptorLazy::NexusDescriptorLazy(std::string const &filename)
     : m_filename(filename), m_extension(std::filesystem::path(m_filename).extension().string()), m_firstEntryNameType(),
-      m_allEntries(initAllEntries()) {}
+      m_allEntries(initAllEntries()), m_allMisses() {}
 
-bool NexusDescriptorLazy::isEntry(std::string const &entryName) const {
-
-  std::map<std::string, std::string>::iterator it; // get it out of the lock scope
+// open the object to determine its type
+bool NexusDescriptorLazy::isEntry(std::string const &entryName) {
+  bool known_miss = false, known_hit = false;
   {
-    // wait for writes to end
+    // wait for any writes to m_allMisses to end
     std::shared_lock<std::shared_mutex> lock(m_readNexusMutex);
-    it = m_allEntries.find(entryName);
+    known_miss = m_allMisses.contains(entryName);
+    known_hit = m_allEntries.contains(entryName);
   }
-  if (it != m_allEntries.end()) {
-    return it->second != NONEXISTENT;
+  if (known_miss) {
+    // if we know this doesn't exist, return earliy
+    return false;
+  } else if (known_hit) {
+    // if we know it does exist, return
+    return true;
   } else {
-    // modifying m_allEntries, need write lock
-    std::lock_guard<std::shared_mutex> lock(m_readNexusMutex);
-
-    // see if something with the name exists
-    if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0) {
-      // register failure
-      m_allEntries[entryName] = NONEXISTENT;
-      return false;
-    }
-
-    // open the object to determine its type
-    UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
-    if (entryID.isValid()) {
-      m_allEntries[entryName] = UNKNOWN_CLASS;
+    if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) > 0) {
+      // if it is there, save the correct class type for it
+      std::string nxclass = UNKNOWN_CLASS;
       H5O_info_t oinfo;
+      // otherwise, try to open this group and see if it is there
+      UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
       H5Oget_info(entryID, &oinfo, H5O_INFO_BASIC);
       if (oinfo.type == H5O_TYPE_DATASET) {
-        m_allEntries[entryName] = SCIENTIFIC_DATA_SET;
+        nxclass = SCIENTIFIC_DATA_SET;
       } else {
         // read NX_class attribute
-        m_allEntries[entryName] = readNXClass(entryID);
+        nxclass = readNXClass(entryID);
       }
+      // modifying m_allEntries, need write lock
+      std::lock_guard<std::shared_mutex> lock(m_readNexusMutex);
+      m_allEntries[entryName] = std::move(nxclass);
       return true;
     } else {
-      // register failure
-      m_allEntries[entryName] = NONEXISTENT;
+      // otherwise register failure, need write lock
+      std::lock_guard<std::shared_mutex> lock(m_readNexusMutex);
+      m_allMisses.insert(entryName);
       return false;
     }
   }
@@ -111,6 +111,8 @@ bool NexusDescriptorLazy::isEntry(std::string const &entryName) const {
 /// @param classType the NX_class type to check for
 /// @return true if the class type exists anywhere in the file
 bool NexusDescriptorLazy::classTypeExists(std::string const &classType) const {
+  // wait for writes to end
+  std::shared_lock<std::shared_mutex> lock(m_readNexusMutex);
   return std::any_of(m_allEntries.begin(), m_allEntries.end(),
                      [&classType](auto const &entry) { return entry.second == classType; });
 }
@@ -135,18 +137,18 @@ bool NexusDescriptorLazy::classTypeExistsChild(const std::string &parentPath, co
 }
 
 bool NexusDescriptorLazy::hasRootAttr(std::string const &name) const {
+  bool known_hit = false;
   { // wait for writes to end
     std::shared_lock<std::shared_mutex> lock(m_readNexusMutex);
-    if (m_rootAttrs.count(name) == 1) {
-      return true;
-    }
+    known_hit = m_rootAttrs.contains(name);
   }
-  // check the file since it wasn't in the cache
-  {
-    // mutex has the wrong name, but it's what we have
-    std::lock_guard<std::shared_mutex> lock(m_readNexusMutex);
-
+  if (known_hit) {
+    return true;
+  } else {
+    // check the file since it wasn't in the cache
     if (H5Aexists(m_fileID, name.c_str()) > 0) {
+      // mutex has the wrong name, but it's what we have
+      std::lock_guard<std::shared_mutex> lock(m_readNexusMutex);
       m_rootAttrs.emplace(name);
       return true;
     } else {


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This algo was already migrated.  However, its confidence check used to construct a `Nexus::File` object to look for a data string.  Since `Nexus::File` initializes a `NexusDescriptor`, it sort of defeated the purpose of the change.

The work in Pr #40591  introduced the `getStrData()` method to `NexusDescriptorLazy`, which now `LoadNXcanSAS` can use.

Also, since some algos still make use of the `getAllEntries()` method, and since this contains failures *and* hits, and the misses could confuse a naive user that the entry was present, the misses were moved to a separate cache.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:

Added unit tests ensure `Load` will find this algorithm for the test files that use it.

Build locally and run the `LoadLotsOfFile` system test.  This does not run on Jenkins, so you will need to run it manually.
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```
:warning:  This test is **NOT** run on the standard Jenkins CI/CD, so please run it.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
