### PR TITLE
POLARIS generate_ts_pdf: Add options to force S(Q)-1 to tend to zero

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -414,6 +414,24 @@ class TotalScatteringMergedTest(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 4.5325, places=3)
 
 
+class TotalScatteringForceSofQMinusOneToZeroTest(systemtesting.MantidSystemTest):
+    pdf_output = None
+
+    def runTest(self):
+        setup_mantid_paths()
+        # Load Focused ws
+        mantid.LoadNexus(Filename=total_scattering_input_file, OutputWorkspace="98533-ResultTOF")
+        q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
+        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, enforce_high_q_to_1=True, debug=True)
+
+    def validate(self):
+        s_of_q_minus_one_group = AnalysisDataService.retrieve("s_of_q_minus_one")
+        for ws in s_of_q_minus_one_group:
+            self.assertLessThan(abs(ws.readY(0)[-1]), 0.3)
+        self.assertAlmostEqual(ws.readY(0)[-1], 0, places=6)  # end of last ws should be zero
+        AnalysisDataService.remove("s_of_q_minus_one_group")
+
+
 class TotalScatteringMergedPerDetTest(systemtesting.MantidSystemTest):
     pdf_output = None
 

--- a/docs/source/release/v6.15.0/Diffraction/Powder/Bugfixes/40639.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/Bugfixes/40639.rst
@@ -1,0 +1,1 @@
+- Add ``force_high_q_to_1`` option to POLARIS ``create_total_scattering_pdf`` to work around a `normalisation bug <https://github.com/mantidproject/mantid/issues/40566>`__

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -55,6 +55,7 @@ The following methods can be executed on a POLARIS object:
 - :ref:`create_vanadium_polaris_isis-powder-diffraction-ref`
 - :ref:`focus_polaris_isis-powder-diffraction-ref`
 - :ref:`set_sample_polaris_isis-powder-diffraction-ref`
+- :ref:`create_total_scattering_pdf_polaris-isis-powder-ref`
 
 For information on creating a POLARIS object see:
 :ref:`creating_polaris_object_isis-powder-diffraction-ref`
@@ -161,7 +162,6 @@ Example
   polaris_example.set_sample(sample=sample_obj)
 
 .. _create_total_scattering_pdf_polaris-isis-powder-ref:
-
 
 create_total_scattering_pdf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,6 +915,14 @@ On POLARIS this is set to the following:
                               (800, 19995),  # Bank 4
                               (800, 19995),  # Bank 5
                              ]
+
+.. _enforce_high_q_to_1_polaris_isis-powder-diffraction-ref:
+
+enforce_high_q_to_1
+^^^^^^^^^^^^^^^^^^^
+This is a work around for a known issue in the normalisation of total scattering data. It will likely be removed once the issue is resolved. Check that it is appropriate to use for your data.
+
+S(Q) should tend to 1 at high Q if normalisation and conversion are done correctly. This option forces S(Q) to 1 by subtracting the final value of S(Q)-1 of the back-scattering bank (last focussed spectrum) from all values, i.e. subtracting a constant, before computing the pair distribution function (PDFFourierTransform).
 
 .. _vanadium_sample_details_polaris_isis-powder-diffraction-ref:
 

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -111,6 +111,7 @@ class Polaris(AbstractInst):
             pdf_output_name=self._inst_settings.pdf_output_name,
             wavelength_lims=self._inst_settings.wavelength_lims,
             r_lims=self._inst_settings.r_lims,
+            enforce_high_q_to_1=self._inst_settings.enforce_high_q_to_1,
         )
         return pdf_output
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -64,5 +64,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="pdf_output_name", int_name="pdf_output_name", optional=True),
     ParamMapEntry(ext_name="wavelength_lims", int_name="wavelength_lims", optional=True),
     ParamMapEntry(ext_name="r_lims", int_name="r_lims", optional=True),
+    ParamMapEntry(ext_name="enforce_high_q_to_1", int_name="enforce_high_q_to_1", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)


### PR DESCRIPTION
### Description of work

This subtracts the final value of S(Q)-1 of the back-scattering bank (last focussed spectrum) from all values, i.e. subtracting a constant, before running PDFFourierTransform.

The debug workspace is created after the subtraction and the cropping, which was also requested by scientists.

To work around a suspected issue with normalisation of total scattering data on POLARIS

To do/check:
* Is test sufficient, it does not check output, only the `s_of_q_minus_one` debug workspace
* I could not see output during system tests if I used `logger.warning()`, so have used print

Closes #40631 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Test script on #40566


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
