### PR TITLE
Migrate `LoadEventNexus` for lazy file descriptor

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -23,6 +23,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 #include "MantidKernel/TimeSeriesProperty.h"
 
@@ -71,7 +72,7 @@ bool exists(const std::map<std::string, std::string> &entries, const std::string
 
   @date Sep 27, 2010
   */
-class MANTID_DATAHANDLING_DLL LoadEventNexus : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadEventNexus : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 
 public:
   LoadEventNexus();
@@ -92,7 +93,7 @@ public:
   /// Category
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
 
   template <typename T>
   static std::shared_ptr<BankPulseTimes>
@@ -192,7 +193,7 @@ private:
   void init() override;
 
   /// Execution code
-  void execLoader() override;
+  void exec() override;
 
   std::map<std::string, std::string> validateInputs() override;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -110,8 +110,7 @@ public:
                                       const int &nPeriods, const std::string &nexusfilename, std::string &status);
 
   template <typename T>
-  static void loadEntryMetadata(const std::string &nexusfilename, T WS, const std::string &entry_name,
-                                const Nexus::NexusDescriptor &descriptor);
+  static void loadEntryMetadata(const std::string &nexusfilename, T WS, const std::string &entry_name);
 
   /// Load instrument from Nexus file if possible, else from IDF spacified by Nexus file
   template <typename T>
@@ -364,7 +363,7 @@ void adjustTimeOfFlightISISLegacy(Nexus::File &file, T localWorkspace, const std
   // NexusDescriptor
   if (descriptor != nullptr) {
     // not an ISIS file
-    if (!descriptor->isEntry("/" + entry_name + "/detector_1_events")) {
+    if (!file.hasAddress("/" + entry_name + "/detector_1_events")) {
       return;
     }
   }
@@ -596,14 +595,13 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename, T local
 //-----------------------------------------------------------------------------
 /** Load the run number and other meta data from the given bank */
 template <typename T>
-void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, const std::string &entry_name,
-                                       const Nexus::NexusDescriptor &descriptor) {
+void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, const std::string &entry_name) {
   // Open the file
   Nexus::File file(nexusfilename);
   file.openGroup(entry_name, "NXentry");
 
   // get the title
-  if (descriptor.isEntry("/" + entry_name + "/title", "SDS")) {
+  if (file.hasData("/" + entry_name + "/title")) {
     file.openData("title");
     if (file.getInfo().type == NXnumtype::CHAR) {
       std::string title = file.getStrData();
@@ -614,7 +612,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
   }
 
   // get the notes
-  if (descriptor.isEntry("/" + entry_name + "/notes", "SDS")) {
+  if (file.hasData("/" + entry_name + "/notes")) {
     file.openData("notes");
     if (file.getInfo().type == NXnumtype::CHAR) {
       std::string notes = file.getStrData();
@@ -625,7 +623,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
   }
 
   // Get the run number
-  if (descriptor.isEntry("/" + entry_name + "/run_number", "SDS")) {
+  if (file.hasData("/" + entry_name + "/run_number")) {
     file.openData("run_number");
     std::string run;
     if (file.getInfo().type == NXnumtype::CHAR) {
@@ -644,7 +642,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
   }
 
   // get the experiment identifier
-  if (descriptor.isEntry("/" + entry_name + "/experiment_identifier", "SDS")) {
+  if (file.hasData("/" + entry_name + "/experiment_identifier")) {
     file.openData("experiment_identifier");
     std::string expId;
     if (file.getInfo().type == NXnumtype::CHAR) {
@@ -658,10 +656,10 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
 
   // get the sample name - nested try/catch to leave the handle in an
   // appropriate state
-  if (descriptor.isEntry("/" + entry_name + "/sample", "NXsample")) {
+  if (file.hasGroup("/" + entry_name + "/sample", "NXsample")) {
     file.openGroup("sample", "NXsample");
     try {
-      if (descriptor.isEntry("/" + entry_name + "/sample/name", "SDS")) {
+      if (file.hasData("/" + entry_name + "/sample/name")) {
         file.openData("name");
         const auto info = file.getInfo();
         std::string sampleName;
@@ -688,7 +686,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS, c
   }
 
   // get the duration
-  if (descriptor.isEntry("/" + entry_name + "/duration", "SDS")) {
+  if (file.hasData("/" + entry_name + "/duration")) {
     file.openData("duration");
     std::vector<double> duration;
     file.getDataCoerce(duration);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -375,7 +375,7 @@ void AlignAndFocusPowderSlim::exec() {
   this->progress(.01, "Loading metadata");
   // prog->doReport("Loading metadata"); TODO add progress bar stuff
   try {
-    LoadEventNexus::loadEntryMetadata(filename, wksp, ENTRY_TOP_LEVEL, descriptor);
+    LoadEventNexus::loadEntryMetadata(filename, wksp, ENTRY_TOP_LEVEL);
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
+++ b/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
@@ -78,7 +78,7 @@ void LoadErrorEventsNexus::exec() {
 
   // load run metadata
   try {
-    LoadEventNexus::loadEntryMetadata(filename, outWS, "entry", descriptor);
+    LoadEventNexus::loadEntryMetadata(filename, outWS, "entry");
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -180,7 +180,7 @@ void LoadEventAsWorkspace2D::exec() {
   // load run metadata
   prog->doReport("Loading metadata");
   try {
-    LoadEventNexus::loadEntryMetadata(filename, WS, "entry", descriptor);
+    LoadEventNexus::loadEntryMetadata(filename, WS, "entry");
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -49,7 +49,7 @@ using std::vector;
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadEventNexus)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadEventNexus)
 
 using namespace Kernel;
 using namespace DateAndTimeHelpers;
@@ -89,11 +89,9 @@ LoadEventNexus::LoadEventNexus()
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadEventNexus::confidence(Nexus::NexusDescriptor &descriptor) const {
-
+int LoadEventNexus::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   int confidence = 0;
-  const std::map<std::string, std::set<std::string>> &allEntries = descriptor.getAllEntries();
-  if (allEntries.count("NXevent_data") == 1) {
+  if (descriptor.classTypeExists("NXevent_data")) {
     if (descriptor.isEntry("/entry", "NXentry") || descriptor.isEntry("/raw_data_1", "NXentry")) {
       confidence = 80;
     }
@@ -404,7 +402,7 @@ LoadEventNexus::filterEventsByTime<EventWorkspaceCollection_sptr>(EventWorkspace
 /** Executes the algorithm. Reading in the file and creating and populating
  *  the output workspace
  */
-void LoadEventNexus::execLoader() {
+void LoadEventNexus::exec() {
   // Retrieve the filename from the properties
   m_filename = getPropertyValue("Filename");
 

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -166,9 +166,6 @@ void LoadNexusMonitors2::exec() {
   }
 
   m_top_entry_name = this->getPropertyValue("NXentryName");
-  // must be done here before the Nexus::File, HDF5 files can't have 2
-  // simultaneous handlers
-  Nexus::NexusDescriptor descriptor(m_filename);
 
   // top level file information
   Nexus::File file(m_filename);

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -340,7 +340,7 @@ void LoadNexusMonitors2::exec() {
   // Load the meta data, but don't stop on errors
   g_log.debug() << "Loading metadata\n";
   try {
-    LoadEventNexus::loadEntryMetadata<API::MatrixWorkspace_sptr>(m_filename, m_workspace, m_top_entry_name, descriptor);
+    LoadEventNexus::loadEntryMetadata<API::MatrixWorkspace_sptr>(m_filename, m_workspace, m_top_entry_name);
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -490,7 +490,7 @@ void LoadTOFRawNexus::exec() {
   Nexus::NexusDescriptor descriptor(filename);
 
   try {
-    LoadEventNexus::loadEntryMetadata(filename, WS, entry_name, descriptor);
+    LoadEventNexus::loadEntryMetadata(filename, WS, entry_name);
   } catch (std::exception &e) {
     g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
   }

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -487,7 +487,6 @@ void LoadTOFRawNexus::exec() {
   // Load the meta data, but don't stop on errors
   prog->report("Loading metadata");
   g_log.debug() << "Loading metadata\n";
-  Nexus::NexusDescriptor descriptor(filename);
 
   try {
     LoadEventNexus::loadEntryMetadata(filename, WS, entry_name);

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -16,7 +16,7 @@
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/StringTokenizer.h"
-#include "MantidNexus/NexusDescriptor.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 #include "MantidNexus/NexusException.h"
 #include "MantidNexus/NexusFile.h"
 
@@ -94,12 +94,10 @@ void UpdateInstrumentFromFile::exec() {
     LoadEventNexus eventNexus;
 
     // we open and close the HDF5 file.
-    // LoadEventNexus is still using NexusDescriptor rather than NexusDescriptorLazy, so need both
-    boost::scoped_ptr<Nexus::NexusDescriptor> descriptorNexusHDF5(new Nexus::NexusDescriptor(filename));
     boost::scoped_ptr<Nexus::NexusDescriptorLazy> descriptorNexusLazy(new Nexus::NexusDescriptorLazy(filename));
 
-    if (isisNexus.confidence(*descriptorNexusLazy) > 0 || eventNexus.confidence(*descriptorNexusHDF5) > 0) {
-      const auto &rootEntry = descriptorNexusHDF5->firstEntryNameType();
+    if (isisNexus.confidence(*descriptorNexusLazy) > 0 || eventNexus.confidence(*descriptorNexusLazy) > 0) {
+      const auto &rootEntry = descriptorNexusLazy->firstEntryNameType();
       Nexus::File nxFile(filename);
       nxFile.openGroup(rootEntry.first, rootEntry.second);
       updateFromNeXus(nxFile);

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -26,7 +26,7 @@
 static unsigned int const INIT_DEPTH = 1;
 static unsigned int const ENTRY_DEPTH = 2;
 static unsigned int const INSTR_DEPTH = 5;
-static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1"};
+static std::unordered_set<std::string> const SPECIAL_ADDRESS{"/entry", "/entry0", "/entry1", "/raw_data_1"};
 static std::string const NONEXISTENT = "NONEXISTENT"; // register failures as well
 static std::string const UNKNOWN_CLASS = "UNKNOWN_CLASS";
 

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -39,7 +39,7 @@ template <herr_t (*H5Xclose)(hid_t)> std::string readNXClass(Mantid::Nexus::Uniq
       Mantid::Nexus::UniqueID<&H5Tclose> atype(H5Aget_type(attrID));
       if (H5Tis_variable_str(atype)) {
         // variable length string
-        char *rdata;
+        char *rdata = nullptr;
         if (H5Aread(attrID, atype, &rdata) >= 0) {
           nxClass = std::string(rdata);
         }


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

Many algorithms could be migrated mechanically, as in PR #40583.

This PR is migrating the algorithm `LoadEventNExus` algorithm.   This inherited from `NexusFileLoader`, which requires a `NexusDescriptor` for the confidence check.   This object was being passed down multiple layers of loading objects.  Most of the work of this PR was undoing the dependency on this object as a parameter.

This also simplifies the use of `NexusDescriptor` in other files, to rely instead on the `Nexus::File`'s methods.

Related to Issue #37164 
[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

### To test:
Build and run the `LoadLotsOfFile` system test.  
:warning: This does not run on Jenkins, so you will need to run it manually. :warning:
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
