### PR TITLE
Remove hard-code VULCAN assumptions from AlignAndFocusPowderSlim 

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -15,6 +15,7 @@
 #include "MantidDataObjects/TimeSplitter.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/TimeROI.h"
+#include "MantidNexus/NexusDescriptor.h"
 
 namespace Mantid::DataHandling::AlignAndFocusPowderSlim {
 
@@ -33,6 +34,8 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
+  void determineBanksToLoad(const Mantid::Nexus::NexusDescriptor &descriptor, std::vector<std::string> &bankEntryNames,
+                            std::vector<std::string> &bankNames);
   void initializeOutputWorkspace(const API::MatrixWorkspace_sptr &wksp, size_t num_hist);
   SpectraProcessingData initializeSpectraProcessingData(const API::MatrixWorkspace_sptr &outputWS);
   void storeSpectraProcessingData(const SpectraProcessingData &processingData,

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -97,7 +97,7 @@ const std::string READ_SIZE_FROM_DISK("ReadSizeFromDisk");
 const std::string EVENTS_PER_THREAD("EventsPerThread");
 const std::string ALLOW_LOGS("LogAllowList");
 const std::string BLOCK_LOGS("LogBlockList");
-const std::string OUTPUT_SPEC_NUM("OutputSpectrumNumber");
+const std::string BANK_NUMBER("BankNumber");
 // focus positions
 const std::string L1("L1");
 const std::string L2("L2");

--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -33,7 +33,7 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   void exec() override;
 
-  API::MatrixWorkspace_sptr createOutputWorkspace(const Geometry::Instrument_const_sptr inst, size_t num_hist);
+  void initializeOutputWorkspace(const API::MatrixWorkspace_sptr &wksp, size_t num_hist);
   SpectraProcessingData initializeSpectraProcessingData(const API::MatrixWorkspace_sptr &outputWS);
   void storeSpectraProcessingData(const SpectraProcessingData &processingData,
                                   const API::MatrixWorkspace_sptr &outputWS);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -351,6 +351,9 @@ void AlignAndFocusPowderSlim::exec() {
 
   int outputSpecNum = getProperty(PropertyNames::OUTPUT_SPEC_NUM);
   if (outputSpecNum != EMPTY_INT()) {
+    if (static_cast<size_t>(outputSpecNum) > num_banks_to_read || outputSpecNum < 1) {
+      throw std::runtime_error("OutputSpecNum is out of range");
+    }
     // fill this vector with blanks -- this is for the ProcessBankTask to correctly access it
     for (size_t bankNumber = 1; bankNumber <= num_banks_to_read; ++bankNumber) {
       if (bankNumber == static_cast<size_t>(outputSpecNum))

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -677,7 +677,7 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
     UNUSED_ARG(
         Kernel::VectorHelper::createAxisFromRebinParams(params, XValues.mutableRawData(), resize_xnew, full_bins_only));
   } else {
-    const std::vector<double> params{x_min[0], -1. * x_delta[0], x_max[0]};
+    const std::vector<double> params{x_min[0], -1. * std::abs(x_delta[0]), x_max[0]};
     UNUSED_ARG(
         Kernel::VectorHelper::createAxisFromRebinParams(params, XValues.mutableRawData(), resize_xnew, full_bins_only));
   }
@@ -700,7 +700,7 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
         Kernel::VectorHelper::createAxisFromRebinParams(params, XValues_new.mutableRawData(), resize_xnew,
                                                         full_bins_only);
       } else {
-        const std::vector<double> params{x_min[i], -1. * x_delta[i], x_max[i]};
+        const std::vector<double> params{x_min[i], -1. * std::abs(x_delta[i]), x_max[i]};
         Kernel::VectorHelper::createAxisFromRebinParams(params, XValues_new.mutableRawData(), resize_xnew,
                                                         full_bins_only);
       }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/BankCalibration.cpp
@@ -124,11 +124,15 @@ BankCalibrationFactory::BankCalibrationFactory(const std::map<detid_t, double> &
 std::vector<BankCalibration> BankCalibrationFactory::getCalibrations(const double time_conversion,
                                                                      const size_t bank_index) const {
 
+  std::vector<BankCalibration> calibrations;
+
   // When arbitrary grouping is used, we need to calculate the intersection of each group with the bank detids. The
   // intersection may be empty which means that no detectors from that bank are in this group.
+  if (!m_bank_detids.contains(bank_index))
+    return calibrations; // empty
+
   const auto &bank_detids = m_bank_detids.at(bank_index);
 
-  std::vector<BankCalibration> calibrations;
   calibrations.reserve(m_grouping.size());
 
   std::transform(m_grouping.begin(), m_grouping.end(), std::back_inserter(calibrations),

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -60,7 +60,7 @@ struct TestConfig {
   GroupingWorkspace_sptr groupingWS = nullptr;
   std::string logListBlock = "";
   std::string logListAllow = "";
-  int outputSpecNum = -10;
+  int bankNum = -10;
   bool processBankSplitTask = false;
   bool useFullTime = false;
   bool correctToSample = false;
@@ -181,8 +181,8 @@ public:
     if (configuration.groupingWS != nullptr) {
       TS_ASSERT_THROWS_NOTHING(alg.setProperty(GROUPING_WS, configuration.groupingWS));
     }
-    if (configuration.outputSpecNum != -10) {
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty(OUTPUT_SPEC_NUM, configuration.outputSpecNum));
+    if (configuration.bankNum != -10) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(BANK_NUMBER, configuration.bankNum));
     }
     // set focus positions
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(L1, configuration.l1));
@@ -1019,26 +1019,26 @@ public:
     TS_ASSERT_EQUALS(outputWS->readY(5).front(), 2729481);
   }
 
-  void test_output_specnum_validation() {
+  void test_bank_number_validation() {
     using namespace Mantid::DataHandling::AlignAndFocusPowderSlim::PropertyNames;
     AlignAndFocusPowderSlim alg;
     // Don't put output in ADS by default
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS(alg.setProperty(OUTPUT_SPEC_NUM, -1), std::invalid_argument const &);
-    TS_ASSERT_THROWS(alg.setProperty(OUTPUT_SPEC_NUM, 0), std::invalid_argument const &);
+    TS_ASSERT_THROWS(alg.setProperty(BANK_NUMBER, -1), std::invalid_argument const &);
+    TS_ASSERT_THROWS(alg.setProperty(BANK_NUMBER, 0), std::invalid_argument const &);
     for (int i = 1; i <= 6; i++) {
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty(OUTPUT_SPEC_NUM, i));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(BANK_NUMBER, i));
     }
   }
 
-  void test_output_specnum() {
+  void test_bank_number() {
     TestConfig configuration({0.}, {50000.}, {50000.}, "Linear", "TOF"); // bins set for single bin
     configuration.groupingWS = bank_grouping_ws;
     constexpr int NUM_HIST{6};
     for (int i = 1; i <= NUM_HIST; i++) {
-      configuration.outputSpecNum = i;
+      configuration.bankNum = i;
       auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm(VULCAN_218062, configuration));
 
       // verify the output -- all spectra exist

--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -1181,6 +1181,23 @@ public:
     TS_ASSERT_EQUALS(outputWS->readY(1).front(), 260);
   }
 
+  void test_PG3() {
+    TestConfig config;
+    config.l1 = 60.0;
+    config.l2s = {3.18};
+    config.twoTheta = {90.0};
+    config.phi = {0.0};
+    auto outputWS = std::dynamic_pointer_cast<MatrixWorkspace>(run_algorithm("PG3_4871_event.nxs", config));
+
+    TS_ASSERT_EQUALS(outputWS->getInstrument()->getName(), "POWGEN");
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 1874);
+    TS_ASSERT_DELTA(outputWS->readX(0).front(), 2258.57547, 1e-5);
+    TS_ASSERT_DELTA(outputWS->readX(0).back(), 45171.50931, 1e-5);
+    TS_ASSERT_EQUALS(outputWS->readY(0).front(), 0);
+    TS_ASSERT_EQUALS(outputWS->readY(0).back(), 60723);
+  }
+
   // ==================================
   // TODO things below this point are for benchmarking and will be removed later
   // ==================================

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderSlimTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderSlimTest.py
@@ -1,0 +1,185 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=no-init,invalid-name,attribute-defined-outside-init
+import systemtesting
+from mantid.simpleapi import (
+    AlignAndFocusPowderSlim,
+    AlignAndFocusPowderFromFiles,
+    PDLoadCharacterizations,
+    MaskBins,
+    CreateGroupingWorkspace,
+)
+
+
+class PG3_compare_AlignAndFocusPowderFromFiles_with_FilterBadPulses_and_LogBinning(systemtesting.MantidSystemTest):
+    cal_file = "PG3_FERNS_d4832_2011_08_24.cal"
+    char_file = "PG3_characterization_2012_02_23-HR-ILL.txt"
+    data_file = "PG3_9829_event.nxs"
+
+    def requiredMemoryMB(self):
+        return 1024
+
+    def requiredFiles(self):
+        return [self.cal_file, self.char_file, self.data_file]
+
+    def runTest(self):
+        characterizations = PDLoadCharacterizations(Filename=self.char_file)
+
+        self.aafpff = "AlignAndFocusPowderSlimTest_PG3_AAFPowderFromFiles"
+        self.aafps = "AlignAndFocusPowderSlimTest_PG3_AAFPowderSlim"
+
+        AlignAndFocusPowderFromFiles(
+            Filename=self.data_file,
+            OutputWorkspace=self.aafpff,
+            Characterizations="characterizations",
+            CalFileName=self.cal_file,
+            Params="0.1,-0.0016,2.0",
+            PrimaryFlightPath=characterizations.PrimaryFlightPath,
+            L2=characterizations.L2,
+            Polar=characterizations.Polar,
+            Azimuthal=characterizations.Azimuthal,
+            PreserveEvents=False,
+            FilterBadPulses=95,
+        )
+
+        AlignAndFocusPowderSlim(
+            Filename=self.data_file,
+            OutputWorkspace=self.aafps,
+            CalFileName=self.cal_file,
+            L1=characterizations.PrimaryFlightPath,
+            L2=characterizations.L2,
+            Polar=characterizations.Polar,
+            Azimuthal=characterizations.Azimuthal,
+            FilterBadPulses=True,
+        )
+
+        # we need to mask a few bins at the start and end of the data so that the workspaces match
+        MaskBins(self.aafpff, OutputWorkspace=self.aafpff, XMin=6232, XMax=6240)
+        MaskBins(self.aafpff, OutputWorkspace=self.aafpff, XMin=45000, XMax=50000)
+        MaskBins(self.aafps, OutputWorkspace=self.aafps, XMin=6232, XMax=6240)
+        MaskBins(self.aafps, OutputWorkspace=self.aafps, XMin=45000, XMax=50000)
+
+    def validateMethod(self):
+        self.tolerance = 0.1
+        self.tolerance_is_rel_err = True
+        return "ValidateWorkspaceToWorkspace"
+
+    def validate(self):
+        return (self.aafpff, self.aafps)
+
+
+class SNAP_compare_AlignAndFocusPowderFromFiles_with_LogBinning_and_GroupingWorkspace(systemtesting.MantidSystemTest):
+    data_file = "SNAP_45874"
+
+    def requiredMemoryMB(self):
+        return 1024
+
+    def requiredFiles(self):
+        return [self.data_file]
+
+    def runTest(self):
+        self.aafpff = "AlignAndFocusPowderSlimTest_SNAP_AAFPowderFromFiles"
+        self.aafps = "AlignAndFocusPowderSlimTest_SNAP_AAFPowderSlim"
+
+        L1 = 15
+        L2 = [0.191317, 0.191317]
+        Polar = [90.0, 90.0]
+        Azimuthal = [0.0, 0.0]
+
+        CreateGroupingWorkspace(InstrumentFilename="SNAP_Definition.xml", GroupDetectorsBy="Group", OutputWorkspace="groups")
+
+        AlignAndFocusPowderFromFiles(
+            Filename=self.data_file,
+            Params=(0.5, -0.008, 2),
+            GroupingWorkspace="groups",
+            PrimaryFlightPath=L1,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            PreserveEvents=False,
+            OutputWorkspace=self.aafpff,
+        )
+
+        AlignAndFocusPowderSlim(
+            Filename=self.data_file,
+            XMin=0.5,
+            XMax=2,
+            XDelta=0.008,
+            GroupingWorkspace="groups",
+            L1=L1,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            OutputWorkspace=self.aafps,
+        )
+
+    def validateMethod(self):
+        self.tolerance = 0.1
+        self.tolerance_is_rel_err = True
+        return "ValidateWorkspaceToWorkspace"
+
+    def validate(self):
+        return (self.aafps, self.aafpff)
+
+
+class VULCAN_compare_AlignAndFocusPowderFromFiles_with_RaggedBinning(systemtesting.MantidSystemTest):
+    data_file = "VULCAN_189186"
+    cal_file = "VULCAN_calibrate_2019_06_27.h5"
+
+    def requiredMemoryMB(self):
+        return 1024
+
+    def requiredFiles(self):
+        return [self.data_file, self.cal_file]
+
+    def runTest(self):
+        self.aafpff = "AlignAndFocusPowderSlimTest_VULCAN_AAFPowderFromFiles"
+        self.aafps = "AlignAndFocusPowderSlimTest_VULCAN_AAFPowderSlim"
+
+        L1 = 43.755
+        L2 = [2.0145, 2.0145, 2.0156]
+        Polar = [90, 90, 150]
+        Azimuthal = [180, 0, 0]
+
+        dmin = [0.306, 0.306, 0.22]
+        dmax = [2.0, 2.2, 2.0]
+        delta = [-0.001, -0.001, -0.0003]
+
+        AlignAndFocusPowderFromFiles(
+            Filename=self.data_file,
+            CalFileName=self.cal_file,
+            PreserveEvents=False,
+            Dspacing=True,
+            DMin=dmin,
+            DMax=dmax,
+            DeltaRagged=delta,
+            PrimaryFlightPath=L1,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            OutputWorkspace=self.aafpff,
+        )
+
+        AlignAndFocusPowderSlim(
+            Filename=self.data_file,
+            CalFileName=self.cal_file,
+            L1=43.755,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            XMin=dmin,
+            XMax=dmax,
+            XDelta=delta,
+            OutputWorkspace=self.aafps,
+        )
+
+    def validateMethod(self):
+        self.tolerance = 1e-8
+        return "ValidateWorkspaceToWorkspace"
+
+    def validate(self):
+        return (self.aafps, self.aafpff)

--- a/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowderSlim-v1.rst
@@ -21,7 +21,6 @@ As a result, there is a significantly smaller memory usage and the processing is
 
 Current limitations compared to ``AlignAndFocusPowderFromFiles``
 
-- only supports the VULCAN instrument
 - does not support copping data
 - does not support removing prompt pulse
 

--- a/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40643.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/New_features/40643.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` is no longer hard-coded for the VULCAN instrument.


### PR DESCRIPTION
### Description of work

This removes any hard-coding for the VULCAN instrument. Tests have been added using POWGEN and SNAP.

Refs:
 * [14651: Make AlignAndFocusPowderSlim work with NOMAD and POWGEN data](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14651)
 * #40189

### To test:

Using systemtests data you can compare `AlignAndFocusPowderSlim` to `AlignAndFocusPowderFromFiles`.

```python
cal_file = "./ExternalData/Testing/Data/SystemTest/PG3_FERNS_d4832_2011_08_24.cal"
char_file = "./ExternalData/Testing/Data/SystemTest/PG3_characterization_2012_02_23-HR-ILL.txt"
data_file = "./ExternalData/Testing/Data/SystemTest/PG3_9829_event.nxs"

results = PDLoadCharacterizations(Filename=char_file, OutputWorkspace="characterizations")

AlignAndFocusPowderFromFiles(
    Filename=data_file,
    OutputWorkspace="AAFPFF",
    Characterizations="characterizations",
    CalFileName=cal_file,
    Params="0.1,-0.0016,2.0",
    PrimaryFlightPath=results.PrimaryFlightPath,
    L2=results.L2,
    Polar=results.Polar,
    Azimuthal=results.Azimuthal,
    PreserveEvents=False,
)

AlignAndFocusPowderSlim(Filename=data_file,
                        OutputWorkspace="AAFPS",
                        CalFileName=cal_file,
                        L1=results.PrimaryFlightPath,
                        L2=results.L2,
                        Polar=results.Polar,
                        Azimuthal=results.Azimuthal)
```

Plotting it shows how similar they are.

<img width="896" height="672" alt="AAFPFF,_AAFPS" src="https://github.com/user-attachments/assets/c11dfd4c-6797-465d-be12-045076bcefff" />


Have a look at the system tests for other examples.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
