### PR TITLE
Make BayesQuasi respect the result and prob workspace name outputs

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -160,7 +160,7 @@ class BayesQuasi(PythonAlgorithm):
         self._loop = self.getProperty("Loop").value
         self._output_fit_name = self.getPropertyValue("OutputWorkspaceFit")
         self._output_result_name = self.getPropertyValue("OutputWorkspaceResult")
-        self._output_prop_name = self.getPropertyValue("OutputWorkspaceProb")
+        self._output_prob_name = self.getPropertyValue("OutputWorkspaceProb")
 
     # pylint: disable=too-many-locals,too-many-statements
     def PyExec(self):
@@ -239,7 +239,7 @@ class BayesQuasi(PythonAlgorithm):
 
         setup_prog.report("Establishing output workspace name")
         fname = self._samWS[:-4] + "_" + prog
-        probWS = self._output_prop_name if self._output_prop_name else fname + "_Prob"
+        probWS = self._output_prob_name if self._output_prob_name else fname + "_Prob"
         fitWS = self._output_fit_name if self._output_result_name else fname + "_Fit"
         wrks = os.path.join(workdir, self._samWS[:-4])
         logger.information(" lptfile : " + wrks + "_" + prog + ".lpt")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -159,6 +159,8 @@ class BayesQuasi(PythonAlgorithm):
         self._wfile = self.getPropertyValue("WidthFile")
         self._loop = self.getProperty("Loop").value
         self._output_fit_name = self.getPropertyValue("OutputWorkspaceFit")
+        self._output_result_name = self.getPropertyValue("OutputWorkspaceResult")
+        self._output_prop_name = self.getPropertyValue("OutputWorkspaceProb")
 
     # pylint: disable=too-many-locals,too-many-statements
     def PyExec(self):
@@ -237,8 +239,8 @@ class BayesQuasi(PythonAlgorithm):
 
         setup_prog.report("Establishing output workspace name")
         fname = self._samWS[:-4] + "_" + prog
-        probWS = fname + "_Prob"
-        fitWS = fname + "_Fit"
+        probWS = self._output_prop_name if self._output_prop_name else fname + "_Prob"
+        fitWS = self._output_fit_name if self._output_result_name else fname + "_Fit"
         wrks = os.path.join(workdir, self._samWS[:-4])
         logger.information(" lptfile : " + wrks + "_" + prog + ".lpt")
         lwrk = len(wrks)
@@ -351,7 +353,6 @@ class BayesQuasi(PythonAlgorithm):
                 prob3.append(yprob[3])
 
             # create result workspace
-            fitWS = self._output_fit_name
             fout = fname + "_Workspace_" + str(spectrum)
 
             workflow_prog.report("Creating OutputWorkspace")
@@ -472,7 +473,7 @@ class BayesQuasi(PythonAlgorithm):
         log_alg.execute()
 
     def C2Se(self, sname):
-        outWS = sname + "_Result"
+        outWS = self._output_result_name if self._output_result_name else sname + "_Result"
         asc = self._read_ascii_file(sname + ".qse")
         var = asc[3].split()  # split line on spaces
         nspec = var[0]
@@ -647,7 +648,7 @@ class BayesQuasi(PythonAlgorithm):
         return widthY, widthE
 
     def C2Fw(self, sname):
-        output_workspace = sname + "_Result"
+        output_workspace = self._output_result_name if self._output_result_name else sname + "_Result"
         num_spectra = 0
         axis_names = []
         x, y, e = [], [], []

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -131,6 +131,23 @@ class BayesQuasiTest(unittest.TestCase):
         self.assertTrue(np.allclose(expected_eisf, eisf))
         self.assertTrue(np.allclose(expected_eisf_error, eisf_error))
 
+    def test_output_workspace_names_are_respected(self):
+        fit_group, result, prob = BayesQuasi(
+            SampleWorkspace=self._sample_ws,
+            ResolutionWorkspace=self._res_ws,
+            MinRange=-0.54760699999999995,
+            MaxRange=0.54411200000000004,
+            Elastic=False,
+            Background="Sloping",
+            FixedWidth=False,
+            OutputWorkspaceFit="test_name_fit",
+            OutputWorkspaceResult="test_name_result",
+            OutputWorkspaceProb="test_name_prob",
+        )
+        self.assertEqual(fit_group.getName(), "test_name_fit")
+        self.assertEqual(result.getName(), "test_name_result")
+        self.assertEqual(prob.getName(), "test_name_prob")
+
     # --------------------------------Validate results------------------------------------------------
 
     def _validate_QLr_shape(self, result, probability, group):

--- a/Testing/SystemTests/tests/framework/BayesQuasiTest.py
+++ b/Testing/SystemTests/tests/framework/BayesQuasiTest.py
@@ -17,6 +17,10 @@ class BayesQuasiTest(MantidSystemTest):
     _sample_name = "irs26176_graphite002_red"
     _resolution_name = "irs26173_graphite002_res"
     _reference_result_file_name = "irs26176_graphite002_QLr_Result.nxs"
+    _reference_prob_file_name = "irs26176_graphite002_QLr_Prob.nxs"
+    _fit_ws_name = "irs26176_graphite002_QLr_Fit"
+    _result_ws_name = "irs26176_graphite002_QLr_Result"
+    _prob_ws_name = "irs26176_graphite002_QLr_Prob"
 
     def skipTests(self):
         return platform == "darwin"
@@ -34,9 +38,9 @@ class BayesQuasiTest(MantidSystemTest):
             Elastic=False,
             Background="Sloping",
             FixedWidth=False,
-            OutputWorkspaceFit=f"{self._sample_name}_QLr_quasielasticbayes_Fit",
-            OutputWorkspaceResult=f"{self._sample_name}_QLr_Result",
-            OutputWorkspaceProb=f"{self._sample_name}_QLr_Prob",
+            OutputWorkspaceFit=self._fit_ws_name,
+            OutputWorkspaceResult=self._result_ws_name,
+            OutputWorkspaceProb=self._prob_ws_name,
         )
 
     def validate(self):
@@ -46,10 +50,10 @@ class BayesQuasiTest(MantidSystemTest):
         self.tolerance = 1e-10
 
         return (
-            "irs26176_graphite002_QLr_Result",
+            self._result_ws_name,
             self._reference_result_file_name,
-            "irs26176_graphite002_QLr_Prob",
-            "irs26176_graphite002_QLr_Prob.nxs",
+            self._prob_ws_name,
+            self._reference_prob_file_name,
         )
 
     def validateMethod(self):
@@ -81,7 +85,7 @@ class BayesQuasiTest(MantidSystemTest):
             EndWorkspaceIndex=max_spectrum_index,
         )
         CropWorkspace(
-            InputWorkspace="irs26176_graphite002_QLr_Result",
+            InputWorkspace=self._result_ws_name,
             OutputWorkspace="bayesquasi_result_cropped",
             XMax=max_q,
             EndWorkspaceIndex=max_spectrum_index,

--- a/docs/source/release/v6.15.0/Inelastic/Algorithms/Bugfixes/39267.rst
+++ b/docs/source/release/v6.15.0/Inelastic/Algorithms/Bugfixes/39267.rst
@@ -1,0 +1,1 @@
+- ref:`<algm-BayesQuasi>` now respects the ``OutputWorkspaceResult`` and ``OutputWorkspaceResult`` parameters.

--- a/docs/source/release/v6.15.0/Inelastic/Algorithms/Bugfixes/39267.rst
+++ b/docs/source/release/v6.15.0/Inelastic/Algorithms/Bugfixes/39267.rst
@@ -1,1 +1,1 @@
-- ref:`<algm-BayesQuasi>` now respects the ``OutputWorkspaceResult`` and ``OutputWorkspaceResult`` parameters.
+- ref:`<algm-BayesQuasi>` now respects the ``OutputWorkspaceProb`` and ``OutputWorkspaceResult`` parameters.


### PR DESCRIPTION
### Description of work



Closes #39267

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run test script from issue and check that the output workspaces are named as expected

```
from mantid.simpleapi import BayesQuasi

BayesQuasi(
    SampleWorkspace="irs26176_graphite002_red",
    ResolutionWorkspace="irs26173_graphite002_res",
    MinRange=-0.54760699999999995,
    MaxRange=0.54411200000000004,
    Elastic=False,
    Background="Sloping",
    FixedWidth=False,
    OutputWorkspaceFit="hello_fit",
    OutputWorkspaceResult="hello_result",
    OutputWorkspaceProb="hello_prob",
)
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
