### PR TITLE
Change `LoadNexusLogs` to inherit from `Algorithm`

### DIFF
--- a/Framework/API/inc/MantidAPI/NexusFileLoader.h
+++ b/Framework/API/inc/MantidAPI/NexusFileLoader.h
@@ -25,14 +25,15 @@ public:
                                                   const int &version = -1) override;
   virtual void setFileInfo(std::shared_ptr<Mantid::Nexus::NexusDescriptor> fileInfo);
 
-  /// Required to pass m_fileInfo to static functions
-  /// Keeping it shared_ptr to match setFileInfo signature (although passing
-  /// ownership is not the main goal).
-  virtual const std::shared_ptr<Mantid::Nexus::NexusDescriptor> getFileInfo() const noexcept;
-
   virtual int confidence(Nexus::NexusDescriptor &descriptor) const override = 0;
 
 private:
+  /// Required to pass m_fileInfo to static functions
+  /// Keeping it shared_ptr to match setFileInfo signature (although passing
+  /// ownership is not the main goal).
+  /// AVOID USING THIS.  Use methods in Nexus::File instead
+  virtual const std::shared_ptr<Mantid::Nexus::NexusDescriptor> getFileInfo() const noexcept { return m_fileInfo; };
+
   std::shared_ptr<Mantid::Nexus::NexusDescriptor> m_fileInfo;
 };
 } // namespace Mantid::API

--- a/Framework/API/src/NexusFileLoader.cpp
+++ b/Framework/API/src/NexusFileLoader.cpp
@@ -33,8 +33,6 @@ void NexusFileLoader::setFileInfo(std::shared_ptr<Nexus::NexusDescriptor> fileIn
   m_fileInfo = std::move(fileInfo);
 }
 
-const std::shared_ptr<Nexus::NexusDescriptor> NexusFileLoader::getFileInfo() const noexcept { return m_fileInfo; }
-
 std::string NexusFileLoader::getFilenamePropertyName() const { return "Filename"; }
 
 } // namespace Mantid::API

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -350,7 +350,6 @@ void makeTimeOfFlightDataFuzzy(Nexus::File &file, T localWorkspace, const std::s
  *modified.
  * @param entry_name :: An NXentry tag in the file
  * @param classType :: The type of the events: either detector or monitor
- * @param descriptor :: input descriptor carrying metadata information
  */
 template <typename T>
 void adjustTimeOfFlightISISLegacy(Nexus::File &file, T localWorkspace, const std::string &entry_name,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -8,7 +8,6 @@
 
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/InstrumentFileFinder.h"
-#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/BankPulseTimes.h"
 #include "MantidDataHandling/DllConfig.h"
@@ -355,18 +354,15 @@ void makeTimeOfFlightDataFuzzy(Nexus::File &file, T localWorkspace, const std::s
  */
 template <typename T>
 void adjustTimeOfFlightISISLegacy(Nexus::File &file, T localWorkspace, const std::string &entry_name,
-                                  const std::string &classType, const Nexus::NexusDescriptor *descriptor = nullptr) {
+                                  const std::string &classType) {
   bool done = false;
   // Go to the root, and then top entry
   file.openAddress("/");
   file.openGroup(entry_name, "NXentry");
 
-  // NexusDescriptor
-  if (descriptor != nullptr) {
-    // not an ISIS file
-    if (!file.hasAddress("/" + entry_name + "/detector_1_events")) {
-      return;
-    }
+  // not an ISIS file
+  if (!file.hasAddress("/" + entry_name + "/detector_1_events")) {
+    return;
   }
 
   using string_map_t = std::map<std::string, std::string>;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
@@ -9,7 +9,6 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IEventWorkspace.h"
 #include "MantidAPI/IFileLoader.h"
-#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusDescriptorLazy.h"

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusLogs.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/Algorithm.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidNexus/NexusFile.h"
 #include <vector>
@@ -34,7 +34,7 @@ data.</LI>
 
 @author Martyn Gigg, Tessella plc
 */
-class MANTID_DATAHANDLING_DLL LoadNexusLogs : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadNexusLogs : public API::Algorithm {
 public:
   /// Default constructor
   LoadNexusLogs();
@@ -52,13 +52,11 @@ public:
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "DataHandling\\Logs;DataHandling\\Nexus"; }
 
-  int confidence(Nexus::NexusDescriptor & /*descriptor*/) const override { return 0; }
-
 private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void execLoader() override;
+  void exec() override;
 
   /// Load log data from a group
   void loadLogs(Nexus::File &file, const std::string &absolute_entry_name, const std::string &entry_class,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -12,7 +12,6 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/Sample.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidHistogramData/BinEdges.h"

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -318,6 +318,11 @@ void AlignAndFocusPowderSlim::exec() {
   g_log.debug() << "Total banks to read: " << num_banks_to_read << "\n";
 
   H5::H5File h5file(filename, H5F_ACC_RDONLY, Nexus::H5Util::defaultFileAcc());
+  // Now we want to go through all the bankN_event entries
+  if (!descriptor.classTypeExists("NXevent_data")) {
+    h5file.close();
+    throw std::runtime_error("No NXevent_data entries found in file");
+  }
 
   // These give the limits in each file as to which events we actually load (when filtering by time).
   loadStart.resize(1, 0);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -318,11 +318,6 @@ void AlignAndFocusPowderSlim::exec() {
   g_log.debug() << "Total banks to read: " << num_banks_to_read << "\n";
 
   H5::H5File h5file(filename, H5F_ACC_RDONLY, Nexus::H5Util::defaultFileAcc());
-  // Now we want to go through all the bankN_event entries
-  if (!descriptor.classTypeExists("NXevent_data")) {
-    h5file.close();
-    throw std::runtime_error("No NXevent_data entries found in file");
-  }
 
   // These give the limits in each file as to which events we actually load (when filtering by time).
   loadStart.resize(1, 0);
@@ -622,14 +617,11 @@ void AlignAndFocusPowderSlim::determineBanksToLoad(const Nexus::NexusDescriptor 
                                                    std::vector<std::string> &bankEntryNames,
                                                    std::vector<std::string> &bankNames) {
   // Now we want to go through all the bankN_event entries
-  const std::map<std::string, std::set<std::string>> &allEntries = descriptor.getAllEntries();
-  auto itClassEntries = allEntries.find("NXevent_data");
 
-  if (itClassEntries == allEntries.end()) {
+  std::set<std::string> const classEntries = descriptor.allAddressesOfType("NXevent_data");
+  if (classEntries.empty()) {
     throw std::runtime_error("No NXevent_data entries found in file");
   }
-
-  const std::set<std::string> &classEntries = itClassEntries->second;
 
   const int bankNum = getProperty(PropertyNames::BANK_NUMBER);
 

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -248,7 +248,7 @@ void LoadEventAsWorkspace2D::exec() {
   // Now we want to go through all the bankN_event entrie
   prog->doReport("Reading and integrating data");
 
-  std::set<std::string> const classEntries = h5file.getEntriesByClass("Nxevent_data");
+  std::set<std::string> const classEntries = h5file.getEntriesByClass("NXevent_data");
   if (!classEntries.empty()) {
     const std::regex classRegex("(/entry/)([^/]*)");
     std::smatch groups;

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -245,14 +245,11 @@ void LoadEventAsWorkspace2D::exec() {
   h5file.openAddress("/");
   h5file.openGroup("entry", "NXentry");
 
-  // Now we want to go through all the bankN_event entries
-  const std::map<std::string, std::set<std::string>> &allEntries = descriptor.getAllEntries();
-
+  // Now we want to go through all the bankN_event entrie
   prog->doReport("Reading and integrating data");
-  auto itClassEntries = allEntries.find("NXevent_data");
-  if (itClassEntries != allEntries.end()) {
 
-    const std::set<std::string> &classEntries = itClassEntries->second;
+  std::set<std::string> const classEntries = h5file.getEntriesByClass("Nxevent_data");
+  if (!classEntries.empty()) {
     const std::regex classRegex("(/entry/)([^/]*)");
     std::smatch groups;
     for (const std::string &classEntry : classEntries) {

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1201,7 +1201,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
     m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
 
   // if there is time_of_flight load it
-  adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType, &descriptor);
+  adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType);
 
   if (m_is_time_filtered) {
     // events were filtered during read

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -77,13 +77,10 @@ void LoadMcStas::exec() {
   H5::H5File file(filename, H5F_ACC_RDONLY, Nexus::H5Util::defaultFileAcc());
 
   Nexus::NexusDescriptor const descriptor(filename);
-  auto const &allEntries = descriptor.getAllEntries();
-
-  auto const iterSDS = allEntries.find(Nexus::SCIENTIFIC_DATA_SET);
-  if (iterSDS == allEntries.cend()) {
+  std::set<std::string> const entries = descriptor.allAddressesOfType(Nexus::SCIENTIFIC_DATA_SET);
+  if (entries.empty()) {
     throw std::runtime_error("Could not find any entries.");
   }
-  auto const &entries = iterSDS->second;
 
   const char *attributeName = "long_name";
   std::vector<std::string> eventEntries;

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -85,7 +85,7 @@ void LoadMcStas::exec() {
   const char *attributeName = "long_name";
   std::vector<std::string> eventEntries;
   std::map<std::string, std::vector<std::string>> histogramEntries;
-  for (auto &entry : entries) {
+  for (std::string const &entry : entries) {
     if (entry.find("/entry1/data") == std::string::npos) {
       continue;
     }

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -94,7 +94,14 @@ public:
    * @return pataddressh A vector of strings giving address using UNIX-style address
    * separators (/), e.g. /raw_data_1, /entry/bank1
    */
-  std::set<std::string> allAddressesOfType(const std::string &type) const { return m_allEntries.at(type); }
+  std::set<std::string> allAddressesOfType(const std::string &type) const {
+    auto it = m_allEntries.find(type);
+    if (it != m_allEntries.cend()) {
+      return it->second;
+    } else {
+      return std::set<std::string>();
+    }
+  }
 
   /**
    * @param level A string specifying the parent address

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -94,7 +94,7 @@ public:
    * @return pataddressh A vector of strings giving address using UNIX-style address
    * separators (/), e.g. /raw_data_1, /entry/bank1
    */
-  std::set<std::string> allAddressesOfType(const std::string &type) const;
+  std::set<std::string> allAddressesOfType(const std::string &type) const {return m_allEntries.at(type)}
 
   /**
    * @param level A string specifying the parent address

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -94,7 +94,7 @@ public:
    * @return pataddressh A vector of strings giving address using UNIX-style address
    * separators (/), e.g. /raw_data_1, /entry/bank1
    */
-  std::set<std::string> allAddressesOfType(const std::string &type) const {return m_allEntries.at(type)}
+  std::set<std::string> allAddressesOfType(const std::string &type) const { return m_allEntries.at(type); }
 
   /**
    * @param level A string specifying the parent address

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -71,7 +71,7 @@ public:
    *          (e.g. /entry/log)
    * </pre>
    */
-  const std::map<std::string, std::set<std::string>> &getAllEntries() const noexcept;
+  const std::map<std::string, std::set<std::string>> &getAllEntries() const noexcept { return m_allEntries; }
 
   /**
    * Checks if a full-address entry exists for a particular groupClass in a Nexus

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptor.h
@@ -94,7 +94,7 @@ public:
    * @return pataddressh A vector of strings giving address using UNIX-style address
    * separators (/), e.g. /raw_data_1, /entry/bank1
    */
-  std::vector<std::string> allAddressesOfType(const std::string &type) const;
+  std::set<std::string> allAddressesOfType(const std::string &type) const;
 
   /**
    * @param level A string specifying the parent address

--- a/Framework/Nexus/inc/MantidNexus/NexusFile.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile.h
@@ -582,6 +582,8 @@ public:
    */
   std::set<std::string> getEntriesByClass(std::string const &class_type) const;
 
+  std::string classForEntry(std::string const &entry) const { return m_descriptor.classTypeForName(entry); }
+
   NexusDescriptor const &getFileDescriptor() const { return m_descriptor; }
 
   //------------------------------------------------------------------------------------------------------------------

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -90,10 +90,6 @@ const std::string &NexusDescriptor::filename() const noexcept { return m_filenam
 
 bool NexusDescriptor::hasRootAttr(const std::string &name) const { return (m_rootAttrs.count(name) == 1); }
 
-const std::map<std::string, std::set<std::string>> &NexusDescriptor::getAllEntries() const noexcept {
-  return m_allEntries;
-}
-
 void NexusDescriptor::addRootAttr(const std::string &name) { m_rootAttrs.insert(name); }
 
 void NexusDescriptor::addEntry(const std::string &entryName, const std::string &groupClass) {

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -169,10 +169,6 @@ bool NexusDescriptor::isEntry(const std::string &entryName) const noexcept {
                      [&entryName](const auto &entry) { return entry.second.count(entryName) == 1; });
 }
 
-std::set<std::string> NexusDescriptor::allAddressesOfType(const std::string &type) const {
-  return m_allEntries.at(type);
-}
-
 std::map<std::string, std::string> NexusDescriptor::allAddressesAtLevel(const std::string &level) const {
   std::map<std::string, std::string> result;
   for (auto itClass = m_allEntries.cbegin(); itClass != m_allEntries.cend(); itClass++) {

--- a/Framework/Nexus/src/NexusDescriptor.cpp
+++ b/Framework/Nexus/src/NexusDescriptor.cpp
@@ -173,13 +173,8 @@ bool NexusDescriptor::isEntry(const std::string &entryName) const noexcept {
                      [&entryName](const auto &entry) { return entry.second.count(entryName) == 1; });
 }
 
-std::vector<std::string> NexusDescriptor::allAddressesOfType(const std::string &type) const {
-  std::vector<std::string> result;
-  if (auto itClass = m_allEntries.find(type); itClass != m_allEntries.end()) {
-    result.assign(itClass->second.begin(), itClass->second.end());
-  }
-
-  return result;
+std::set<std::string> NexusDescriptor::allAddressesOfType(const std::string &type) const {
+  return m_allEntries.at(type);
 }
 
 std::map<std::string, std::string> NexusDescriptor::allAddressesAtLevel(const std::string &level) const {

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1405,8 +1405,7 @@ std::string File::getTopLevelEntryName() const {
 }
 
 std::set<std::string> File::getEntriesByClass(std::string const &class_type) const {
-  std::vector<std::string> allAddresses = m_descriptor.allAddressesOfType(class_type);
-  return std::set<std::string>(allAddresses.begin(), allAddresses.end());
+  return m_descriptor.allAddressesOfType(class_type);
 }
 
 //------------------------------------------------------------------------------------------------------------------

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
@@ -1,1 +1,1 @@
-- The :ref:`algm-Load`.algorithm, and the file loader search process, now uses a lazy file descriptor to check for the correct loading algorithm, further reducing times for :ref:`algm-Load`.
+- The :ref:`algm-Load` algorithm, and the file loader search process, now uses a lazy file descriptor to check for the correct loading algorithm, further reducing times for :ref:`algm-Load`.

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
@@ -1,1 +1,1 @@
-- The :ref:`algm-Load` algorithm, and the file loader search process, now uses a lazy file descriptor to check for the correct loading algorithm, further reducing times for :ref:`algm-Load`.
+- The :ref:`algm-Load` algorithm, and the file loader search process, now use a lazy file descriptor to check for the correct loading algorithm, further reducing time for :ref:`algm-Load`.

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-Load`.algorithm, and the file loader search process, now uses a lazy file descriptor to check for the correct loading algorithm, further reducing times for :ref:`algm-Load`.


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

This cleans up some loose ends.
1. removed the `NexusFileLoader.h` header where it was unnneded
2. The algo `LoadNexusLogs` did not need to be a `NexusFileLoader`, since it is really a mere `Algorithm`
3. Some methods were inlined, when they only returned a member variable
4. Code using `getAllEntries()` was cleaned up to avoid using that method
5. `allAddressesOfType()` returns a set, not a vector

[EWM 14485](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14485)

Closes #37164

### To test:

Build locally and run the `LoadLotsOfFile` system test.  This does not run on Jenkins, so you will need to run it manually.
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```
:warning:  This test is **NOT** run on the standard Jenkins CI/CD, so please run it.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
