### PR TITLE
PDFFourierTransform2: Allow setting minimum limit on output

### DIFF
--- a/docs/source/algorithms/PDFFourierTransform-v2.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v2.rst
@@ -16,8 +16,8 @@ spectral density :math:`S(Q)`, :math:`S(Q)-1`, or :math:`Q[S(Q)-1]`
 reduced pair distribution function :math:`G(r)`, the pair distribution function :math:`g(r)`, the
 radial distribution function :math:`RDF(r)`, and the total radial distribution function :math:`G_k(r)`.
 
-The output from this algorithm will have an x-range between 0.0 and the maximum parameter of the output,
-i.e. if converting from `g(r)` to `S(Q)` the output will be between 0.0 and `Qmax`.
+The output from this algorithm will have an x-range between the minimum and maximum parameter of the output,
+i.e. if converting from `g(r)` to `S(Q)` the output will be between `Qmin` and `Qmax`.
 
 The spectrum density should be in the Q-space (\ **MomentumTransfer**\ ) :ref:`units <Unit Factory>` .
 (d-spacing is not supported any more. Contact development team to fix that and enable **dSpacing** again)

--- a/docs/source/release/v6.15.0/Diffraction/Powder/New_features/39975.rst
+++ b/docs/source/release/v6.15.0/Diffraction/Powder/New_features/39975.rst
@@ -1,0 +1,1 @@
+- Implement minimum range limit for :ref:`algm-PDFFourierTransform` algorithm, e.g. ``Rmin`` for ``Direction="Forward"``  and ``Qmin`` for ``Direction="Backward"``.


### PR DESCRIPTION
### Description of work

For forwards mode allow setting Rmin
For backwards mode allow setting Qmin

Uses both outMax and outMin when creating output workspace and bin edges

`r_lims` param to POLARIS `generate_ts_pdf()` gets passed through to `PDFFourierTransform` already.

Closes #39975 


### To test:

Use the file from #39975
```
ws_sqm1_merged = LoadNexus("/home/sam/mantid-data/POLARIS/s_of_q_minus_one_merged.nxs")

ws_gr =       PDFFourierTransform(InputWorkspace=ws_sqm1_merged, SofQType='S(Q)-1', PDFType='g(r)', DeltaR=0.05, RMin=None, RMax=None, Filter=True)
ws_gr_rmin = PDFFourierTransform(InputWorkspace=ws_sqm1_merged, SofQType='S(Q)-1', PDFType='g(r)', DeltaR=0.05, RMin=0.5,  RMax=None, Filter=True)
ws_gr_rmin_max = PDFFourierTransform(InputWorkspace=ws_sqm1_merged, SofQType='S(Q)-1', PDFType='g(r)', DeltaR=0.05, RMin=2,  RMax=10, Filter=True)

fig, axes = plt.subplots(1, 1, subplot_kw={'projection': 'mantid'})

axes.plot(ws_gr, color='red', marker='x', label='ws_gr', wkspIndex=0)
axes.plot(ws_gr_rmin, color='blue', marker='+', label='ws_gr_rmin', wkspIndex=0)
axes.plot(ws_gr_rmin_max, color='green', marker='o', label='ws_gr_rmin_max', wkspIndex=0)
plt.legend()
plt.show()
```
The script plots with 3 different limits in R. If you zoom in to the plot the 3 outputs have the same curve, but are truncated to the limits.

<img width="896" height="672" alt="image" src="https://github.com/user-attachments/assets/8c96ea74-f896-457a-871f-3fabc928fd93" />



<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
