### PR TITLE
Improvements to pixi pre commit script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,8 @@ repos:
           (?x)^(
           ^conda/recipes/mantid-developer/recipe.yaml$|
           ^conda/recipes/conda_build_config.yaml$|
-          ^pixi.toml$
+          ^pixi.toml$|
+          ^pixi.lock$
           )$
         additional_dependencies:
           - pyyaml

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -158,9 +158,9 @@ def remove_from_pixi_manifest(package: str, os_name: str):
 
 
 def _run_pixi_command(command: List[str]):
-    process = run(command, check=True, text=True, stderr=subprocess.PIPE)
+    process = run(command, text=True, stderr=subprocess.PIPE)
     if process.returncode != 0:
-        print(f'Tried to run "{"".join(command)}" but encountered a problem:')
+        print(f'Tried to run "{" ".join(command)}" but encountered a problem:')
         print(process.stderr)
 
 

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -21,6 +21,9 @@ MANTID_DEVELOPER_RECIPE_PATH = Path("conda/recipes/mantid-developer/recipe.yaml"
 PIXI_TOML = Path("pixi.toml")
 PIXI_LOCK = Path("pixi.lock")
 
+EXIT_CODE_SUCCESS = 0
+EXIT_CODE_ERROR = 1
+
 # package name: {'linux' : '>3.0', 'osx': '>3.1.0'}
 # package name: {'all': '==3.2.1'}
 # occt: {'all': '7.* novtk*'} (example for which uses a build number, just stores the version string from conda)
@@ -160,7 +163,9 @@ def remove_from_pixi_manifest(package: str, os_name: str):
 def _run_pixi_command(command: List[str]):
     print(f'Running "{" ".join(command)}" ...')
     process = run(command, text=True, stderr=subprocess.PIPE)
-    if process.returncode != 0:
+    if process.returncode == 127:
+        print(f'Tried to run "{" ".join(command)}" but pixi is not installed')
+    elif process.returncode != 0:
         print(f'Tried to run "{" ".join(command)}" but encountered a problem:')
         print(process.stderr)
 
@@ -264,21 +269,21 @@ def main(argv: Sequence[str] = None) -> int:
 
     if (BUILD_CONFIG_PATH in changed_files or MANTID_DEVELOPER_RECIPE_PATH in changed_files) and PIXI_TOML not in changed_files:
         if update_pixi_from_conda_changes(conda_env, pixi_env):
-            return 1
+            return EXIT_CODE_ERROR
 
     if warning_messages := compare_conda_and_pixi_envs(conda_env, pixi_env):
         print("Mismatch between conda and pixi environments found:")
         print("\n".join(warning_messages))
-        return 1
+        return EXIT_CODE_ERROR
 
     if PIXI_TOML in changed_files and PIXI_LOCK not in changed_files:
         # simple command to force pixi to update the lock file if the env definition has changed
         command = ["pixi", "install"]
         print("Invoking pixi environment to update pixi.lock")
         _run_pixi_command(command)
-        return 1
+        return EXIT_CODE_ERROR
 
-    return 0
+    return EXIT_CODE_SUCCESS
 
 
 if __name__ == "__main__":

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -272,7 +272,7 @@ def main(argv: Sequence[str] = None) -> int:
 
     if PIXI_TOML in changed_files and PIXI_LOCK not in changed_files:
         # simple command to force pixi to update the lock file if the env definition has changed
-        command = ["pixi", "run", "ls"]
+        command = ["pixi", "install"]
         print("Invoking pixi environment to update pixi.lock")
         _run_pixi_command(command)
         return 1

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -19,6 +19,7 @@ from typing import Sequence, Dict, NewType, List
 BUILD_CONFIG_PATH = Path("conda/recipes/conda_build_config.yaml")
 MANTID_DEVELOPER_RECIPE_PATH = Path("conda/recipes/mantid-developer/recipe.yaml")
 PIXI_TOML = Path("pixi.toml")
+PIXI_LOCK = Path("pixi.lock")
 
 # package name: {'linux' : '>3.0', 'osx': '>3.1.0'}
 # package name: {'all': '==3.2.1'}
@@ -267,6 +268,14 @@ def main(argv: Sequence[str] = None) -> int:
         print("Mismatch between conda and pixi environments found:")
         print("\n".join(warning_messages))
         return 1
+
+    if PIXI_TOML in changed_files and PIXI_LOCK not in changed_files:
+        # simple command to force pixi to update the lock file if the env definition has changed
+        command = ["pixi", "run", "ls"]
+        print("Invoking pixi environment to update pixi.lock")
+        _run_pixi_command(command)
+        return 1
+
     return 0
 
 

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -176,7 +176,8 @@ def update_pixi_from_conda_changes(conda_env: DependencyPins, pixi_env: Dependen
     made_change_to_pixi = False
     for package, pixi_versions in pixi_env.items():
         if package not in conda_env.keys():
-            remove_from_pixi_manifest(package, "all")
+            for os_name in pixi_versions.keys():
+                remove_from_pixi_manifest(package, os_name)
             made_change_to_pixi = True
         else:
             conda_versions = conda_env.get(package, {})

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -158,6 +158,7 @@ def remove_from_pixi_manifest(package: str, os_name: str):
 
 
 def _run_pixi_command(command: List[str]):
+    print(f'Running "{" ".join(command)}" ...')
     process = run(command, text=True, stderr=subprocess.PIPE)
     if process.returncode != 0:
         print(f'Tried to run "{" ".join(command)}" but encountered a problem:')


### PR DESCRIPTION
### Description of work

- Fixed an edge case where if a platform specific package was removed from the conda recipe, it would not be removed from the pixi toml automatically.
- Added a check for if the pixi.toml has been altered but the pixi.lock has not, in this case run a simple pixi command to get the lock to update.

### To test:

- Add changes where you have altered the conda recipe and pixi toml in the same way. Run pre-commit (`.git/hooks/pre-commit`) and the check should fail and the lock file updated.
- From the conda recipe, remove a platform specific package (I tested with `jemalloc` on linux), add and run pre-commit, check should fail and the package should automatically be removed from pixi.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
