### PR TITLE
Change `Nexus::File::getDataCoerce` to use native HDF5 method

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -80,6 +80,12 @@ public:
   static unsigned short constexpr BINARY = 0xF1u;  // 11 0001 = 0xF1
   static unsigned short constexpr BAD = 0xFFu;     // 11 1111 = 0xFF
 
+  // for &'ing with a type to check what it is:
+  // type & FLOAT_TYPE will return 0 if it is not a float
+  // type & SPECIAL_TYPE will return 0 of it is not a special (char, binary, or bad)
+  static unsigned short constexpr FLOAT_TYPE = 0x20u;
+  static unsigned short constexpr SPECIAL_TYPE = 0x80u;
+
 private:
   int m_val;
   static int validate_val(int const x);

--- a/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFile_fwd.h
@@ -81,8 +81,7 @@ public:
   static unsigned short constexpr BAD = 0xFFu;     // 11 1111 = 0xFF
 
   // for &'ing with a type to check what it is:
-  // type & FLOAT_TYPE will return 0 if it is not a float
-  // type & SPECIAL_TYPE will return 0 of it is not a special (char, binary, or bad)
+  // & will be true (nonzero) if it is of type indicated; false (zero) else
   static unsigned short constexpr FLOAT_TYPE = 0x20u;
   static unsigned short constexpr SPECIAL_TYPE = 0x80u;
 
@@ -96,6 +95,11 @@ public:
   NXnumtype &operator=(int const);
   operator int() const;
   operator std::string() const;
+
+  // Will return true if the type is a float
+  bool isFloat() { return m_val & FLOAT_TYPE; }
+  // Will return true if the type is a special (char, binary, or bad)
+  bool isSpecial() { return m_val & SPECIAL_TYPE; }
 };
 
 MANTID_NEXUS_DLL std::ostream &operator<<(std::ostream &os, const NXnumtype &value);

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -340,8 +340,12 @@ bool hasAttribute(const H5::H5Object &object, const char *attributeName) {
 }
 
 void readStringAttribute(const H5::H5Object &object, const std::string &attributeName, std::string &output) {
-  const auto attribute = object.openAttribute(attributeName);
-  attribute.read(attribute.getDataType(), output);
+  if (object.attrExists(attributeName)) {
+    const auto attribute = object.openAttribute(attributeName);
+    attribute.read(attribute.getDataType(), output);
+  } else {
+    throw H5::Exception("H5Util::readStringAttribute: no attribute with name " + attributeName);
+  }
 }
 
 // This method avoids a copy on return so should be preferred to its sibling method

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -344,7 +344,7 @@ void readStringAttribute(const H5::H5Object &object, const std::string &attribut
     const auto attribute = object.openAttribute(attributeName);
     attribute.read(attribute.getDataType(), output);
   } else {
-    throw H5::Exception("H5Util::readStringAttribute: no attribute with name " + attributeName);
+    throw H5::Exception("H5Util::readStringAttribute", "no attribute with name " + attributeName);
   }
 }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1484,7 +1484,7 @@ template <typename NumT> void File::getAttr(const std::string &name, NumT &value
       throw NXEXCEPTION(e.getDetailMsg());
     }
   } else {
-    NXEXCEPTION("Attribute " + name + " does not exist");
+    throw NXEXCEPTION("Attribute " + name + " does not exist");
   }
 }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1132,7 +1132,7 @@ template <typename NumT> void File::getSlab(NumT *data, DimVector const &start, 
 void File::getDataCoerce(vector<int> &data) {
   Info info = this->getInfo();
   // if it is not a float or special
-  if (!(info.type & 0x20u) && !(info.type & 0x80u)) {
+  if (!(info.type & NXnumtype::FLOAT_TYPE) && !(info.type & NXnumtype::SPECIAL_TYPE)) {
     if (H5Iis_valid(m_current_data_id) <= 0) {
       throw NXEXCEPTION("No dataset open");
     }
@@ -1164,7 +1164,7 @@ void File::getDataCoerce(vector<int> &data) {
 void File::getDataCoerce(vector<double> &data) {
   Info info = this->getInfo();
   // if it is not a special
-  if (!(info.type & 0x80)) {
+  if (!(info.type & NXnumtype::SPECIAL_TYPE)) {
     if (H5Iis_valid(m_current_data_id) <= 0) {
       throw NXEXCEPTION("No dataset open");
     }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1132,7 +1132,7 @@ template <typename NumT> void File::getSlab(NumT *data, DimVector const &start, 
 void File::getDataCoerce(vector<int> &data) {
   Info info = this->getInfo();
   // if it is not a float or special
-  if (!(info.type & NXnumtype::FLOAT_TYPE) && !(info.type & NXnumtype::SPECIAL_TYPE)) {
+  if (!info.type.isFloat() && !info.type.isSpecial()) {
     if (H5Iis_valid(m_current_data_id) <= 0) {
       throw NXEXCEPTION("No dataset open");
     }
@@ -1164,7 +1164,7 @@ void File::getDataCoerce(vector<int> &data) {
 void File::getDataCoerce(vector<double> &data) {
   Info info = this->getInfo();
   // if it is not a special
-  if (!(info.type & NXnumtype::SPECIAL_TYPE)) {
+  if (!info.type.isSpecial()) {
     if (H5Iis_valid(m_current_data_id) <= 0) {
       throw NXEXCEPTION("No dataset open");
     }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1131,30 +1131,31 @@ template <typename NumT> void File::getSlab(NumT *data, DimVector const &start, 
 
 void File::getDataCoerce(vector<int> &data) {
   Info info = this->getInfo();
-  if (info.type == NXnumtype::INT8) {
-    vector<int8_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT8) {
-    vector<uint8_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::INT16) {
-    vector<int16_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT16) {
-    vector<uint16_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::INT32) {
-    vector<int32_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT32) {
-    vector<uint32_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
+  // if it is not a float or special
+  if (!(info.type & 0x20u) && !(info.type & 0x80u)) {
+    if (H5Iis_valid(m_current_data_id) <= 0) {
+      throw NXEXCEPTION("No dataset open");
+    }
+
+    size_t length =
+        std::accumulate(info.dims.cbegin(), info.dims.cend(), static_cast<size_t>(1),
+                        [](auto const subtotal, auto const &value) { return subtotal * static_cast<size_t>(value); });
+    data.resize(length);
+
+    hsize_t ndims = H5Sget_simple_extent_ndims(m_current_space_id);
+    DataTypeID datatype = H5Tcopy(H5T_NATIVE_INT);
+    herr_t ret = -1;
+    if (ndims == 0) {
+      DataSpaceID filespace = H5Dget_space(m_current_data_id);
+      DataSpaceID memspace = H5Screate(H5S_SCALAR);
+      H5Sselect_all(filespace);
+      ret = H5Dread(m_current_data_id, datatype, memspace, filespace, H5P_DEFAULT, data.data());
+    } else {
+      ret = H5Dread(m_current_data_id, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data());
+    }
+    if (ret < 0) {
+      throw NXEXCEPTION("Failed to read dataset");
+    }
   } else {
     throw NXEXCEPTION("NexusFile::getDataCoerce(): Could not coerce to int.");
   }
@@ -1162,36 +1163,30 @@ void File::getDataCoerce(vector<int> &data) {
 
 void File::getDataCoerce(vector<double> &data) {
   Info info = this->getInfo();
-  if (info.type == NXnumtype::INT8) {
-    vector<int8_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT8) {
-    vector<uint8_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::INT16) {
-    vector<int16_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT16) {
-    vector<uint16_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::INT32) {
-    vector<int32_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::UINT32) {
-    vector<uint32_t> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::FLOAT32) {
-    vector<float> result;
-    this->getData(result);
-    data.assign(result.begin(), result.end());
-  } else if (info.type == NXnumtype::FLOAT64) {
-    this->getData(data);
+  // if it is not a special
+  if (!(info.type & 0x80)) {
+    if (H5Iis_valid(m_current_data_id) <= 0) {
+      throw NXEXCEPTION("No dataset open");
+    }
+    size_t length =
+        std::accumulate(info.dims.cbegin(), info.dims.cend(), static_cast<size_t>(1),
+                        [](auto const subtotal, auto const &value) { return subtotal * static_cast<size_t>(value); });
+    data.resize(length);
+
+    hsize_t ndims = H5Sget_simple_extent_ndims(m_current_space_id);
+    DataTypeID datatype = H5Tcopy(H5T_NATIVE_DOUBLE);
+    herr_t ret = -1;
+    if (ndims == 0) {
+      DataSpaceID filespace = H5Dget_space(m_current_data_id);
+      DataSpaceID memspace = H5Screate(H5S_SCALAR);
+      H5Sselect_all(filespace);
+      ret = H5Dread(m_current_data_id, datatype, memspace, filespace, H5P_DEFAULT, data.data());
+    } else {
+      ret = H5Dread(m_current_data_id, datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data());
+    }
+    if (ret < 0) {
+      throw NXEXCEPTION("Failed to read dataset");
+    }
   } else {
     throw NXEXCEPTION("NexusFile::getDataCoerce(): Could not coerce to double.");
   }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -1482,10 +1482,14 @@ template <> MANTID_NEXUS_DLL void File::getAttr(const std::string &name, std::st
 
 template <typename NumT> void File::getAttr(const std::string &name, NumT &value) {
   auto current = getCurrentObject();
-  try {
-    value = H5Util::readNumAttributeCoerce<NumT>(*current, name);
-  } catch (H5::Exception const &e) {
-    throw NXEXCEPTION(e.getDetailMsg());
+  if (current->attrExists(name)) {
+    try {
+      value = H5Util::readNumAttributeCoerce<NumT>(*current, name);
+    } catch (H5::Exception const &e) {
+      throw NXEXCEPTION(e.getDetailMsg());
+    }
+  } else {
+    NXEXCEPTION("Attribute " + name + " does not exist");
   }
 }
 


### PR DESCRIPTION
### Description of work

The method `Nexus::File::getDataCoerce()` was written for the case where data is saved to the file as one kind of data type, and we want to read it as another data type.   Previously, this was handled by forming a temp vector of the file native type and then copying/transforming the temp vector to the desired type.

However, according to the HDF5 documentation, the [DataSet::read()](https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_set.html#abd6abb69a307378b118871dbd6ebb14c) method is able to perform this conversion directly on read by specifying a different `DataType`; testing has shown this is also true of the [H5Dread()](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d.html#ga8287d5a7be7b8e55ffeff68f7d26811c) function of the C-API.

This PR rewrites the `File::getDataCoerce()` method to use HDF5's `H5Dread()` function directly to specify the desired output type and read directly into the output vector, to avoid possibly expensive copy operations.  The transformation should be happening on read, and hopefully consumes fewer resources.

In the process, some better error checking was added around reading attributes; they will not check if an attribute exists before trying to read it.

### To test:

Try running the scripts posted in the comments below, on main and this branch, and reporting times.  Make sure this is faster, or at least not worse.

Run the system test `LoadLotsOfFiles`:
```
ninja Framework && ./systemtest -R LoadLotsOfFiles
```
Run on main and this branch, and record the times.

:warning: This test is not run as part of the CI/CD, so run it manually :warning:

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
