### PR TITLE
Exclude latest poldi h5f from system test LoadLotsOfFiles

### DIFF
--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -101,6 +101,7 @@ BANNED_FILES = [
     "poldi2014n019874.hdf",
     "poldi2014n019881.hdf",
     "poldi2015n000977.hdf",
+    "poldi2025n012174.hdf",
     "USER_SANS2D_143ZC_2p4_4m_M4_Knowles_12mm.txt",
     "USER_LARMOR_151B_LarmorTeam_80tubes_BenchRot1p4_M4_r3699.txt",
     "USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger.txt",

--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -331,6 +331,3 @@ class LoadLotsOfFiles(systemtesting.MantidSystemTest):
             raise RuntimeError("Failed to load %d of %d files" % (len(failed), len(files)))
         else:
             print("Successfully loaded %d files" % len(files))
-
-    def excludeInPullRequests(self):
-        return True


### PR DESCRIPTION
### Description of work

Exclude latest poldi h5f file added in PR #40599 from system test `LoadLotsOfFiles` that caused nightly to fall over
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/1223/testReport/junit/SystemTests/LoadLotsOfFiles/Build_and_test__Conda_packaging___build_and_test__linux_64___LoadLotsOfFiles/

### To test:

(1) CI passes

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
