### PR TITLE
Fix hang in new Instrument View

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40682.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40682.rst
@@ -1,0 +1,1 @@
+- In the new Instrument View, fixed a bug that caused Mantid to hang when an algorithm was run on the workspace currently open in the interface.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -153,7 +153,7 @@ class FullInstrumentViewPresenter:
 
     def update_plotter(self) -> None:
         """Update the projection based on the selected option."""
-        self._model.projection_type = self._view.current_selected_projection()
+        self._model.projection_type = QAppThreadCall(self._view.current_selected_projection)()
         with SuppressRendering(self._view.main_plotter):
             self._update_view_main_plotter()
             self.update_detector_picker()
@@ -287,20 +287,20 @@ class FullInstrumentViewPresenter:
         self._update_peak_buttons()
 
     def _on_add_mask_clicked(self) -> None:
-        implicit_function = self._view.get_current_widget_implicit_function()
+        implicit_function = QAppThreadCall(self._view.get_current_widget_implicit_function)()
         if not implicit_function:
             return
         mask = [(implicit_function.EvaluateFunction(pt) < 0) for pt in self._detector_mesh.points]
         new_key = self._model.add_new_detector_mask(mask)
-        self._view.set_new_mask_key(new_key)
+        QAppThreadCall(self._view.set_new_mask_key)(new_key)
 
     def on_add_mask_clicked(self) -> None:
         self._callback_queue.put((self._on_add_mask_clicked, ()))
 
     def _on_mask_item_selected(self) -> None:
-        self._model.apply_detector_masks(self._view.selected_masks())
+        self._model.apply_detector_masks(QAppThreadCall(self._view.selected_masks)())
         self.update_plotter()
-        self._update_line_plot_ws_and_draw(self._view.current_selected_unit())
+        self._update_line_plot_ws_and_draw(QAppThreadCall(self._view.current_selected_unit)())
         self._update_peak_buttons()
 
     def on_mask_item_selected(self) -> None:
@@ -339,7 +339,7 @@ class FullInstrumentViewPresenter:
         return self._model.cached_masks_keys
 
     def _update_line_plot_ws_and_draw(self, unit: str) -> None:
-        self._model.extract_spectra_for_line_plot(unit, self._view.sum_spectra_selected())
+        self._model.extract_spectra_for_line_plot(unit, QAppThreadCall(self._view.sum_spectra_selected)())
         QAppThreadCall(self._view.show_plot_for_detectors)(self._model.line_plot_workspace)
         QAppThreadCall(self._view.set_selected_detector_info)(self._model.picked_detectors_info_text())
         self._update_relative_detector_angle()
@@ -449,7 +449,7 @@ class FullInstrumentViewPresenter:
         self._peaks_grouped_by_ws = peaks_grouped_by_ws
 
     def on_peaks_workspace_selected(self) -> None:
-        self._model.set_peaks_workspaces(self._view.selected_peaks_workspaces())
+        self._model.set_peaks_workspaces(QAppThreadCall(self._view.selected_peaks_workspaces)())
         QAppThreadCall(self._view.clear_overlay_meshes)()
         self._update_peaks_workspaces()
         self.refresh_lineplot_peaks()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -508,6 +508,7 @@ class FullInstrumentViewPresenter:
         x_in_workspace_unit = self._model.convert_units(self._view.current_selected_unit(), self._model.workspace_x_unit, 0, x)
         if self._peak_interaction_status == PeakInteractionStatus.Adding:
             peaks_ws = self._model.add_peak(x_in_workspace_unit, self._view.selected_peaks_workspaces())
+            QAppThreadCall(self._view.refresh_peaks_ws_list)()
             QAppThreadCall(self._view.select_peaks_workspace)(peaks_ws)
         elif self._peak_interaction_status == PeakInteractionStatus.Deleting:
             self._model.delete_peak(x_in_workspace_unit)

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -411,6 +411,7 @@ class FullInstrumentViewPresenter:
                 return
             self._model._workspace = AnalysisDataService.retrieve(ws_name)
             self._model.setup()
+            self.update_plotter()
 
     def replace_workspace_callback(self, ws_name, ws):
         self._callback_queue.put((self._replace_workspace_callback, (ws_name, ws)))

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -69,7 +69,8 @@ class FullInstrumentViewPresenter:
         self.setup()
         self._callback_queue = Queue()
         self._callback_stop_sentinel = object()
-        Thread(None, self._callback_worker, daemon=True).start()
+        self._callback_thread = Thread(None, self._callback_worker, daemon=True)
+        self._callback_thread.start()
 
     def _callback_worker(self):
         while True:
@@ -426,6 +427,8 @@ class FullInstrumentViewPresenter:
     def handle_close(self):
         if hasattr(self, "_callback_queue"):
             self._callback_queue.put(self._callback_stop_sentinel)
+            if hasattr(self, "_callback_thread"):
+                self._callback_thread.join(timeout=1)
         # The observers are unsubscribed on object deletion, it's safer to manually
         # delete the observer rather than wait for the garbage collector, because
         # we don't want stale workspace references hanging around.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -17,7 +17,6 @@ from mantid import mtd
 from mantid.kernel import logger, ConfigService
 from mantid.simpleapi import AnalysisDataService
 from mantidqt.io import open_a_file_dialog
-from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
@@ -149,31 +148,29 @@ class FullInstrumentViewPresenter:
         self.set_view_contour_limits()
 
     def set_view_contour_limits(self) -> None:
-        QAppThreadCall(self._view.set_plotter_scalar_bar_range)(self._model.counts_limits, self._counts_label)
+        self._view.set_plotter_scalar_bar_range(self._model.counts_limits, self._counts_label)
 
     def update_plotter(self) -> None:
         """Update the projection based on the selected option."""
-        self._model.projection_type = QAppThreadCall(self._view.current_selected_projection)()
+        self._model.projection_type = self._view.current_selected_projection()
         with SuppressRendering(self._view.main_plotter):
             self._update_view_main_plotter()
             self.update_detector_picker()
             self.on_peaks_workspace_selected()
 
     def _update_view_main_plotter(self):
-        QAppThreadCall(self._view.clear_main_plotter)()
+        self._view.clear_main_plotter()
 
         self._detector_mesh = self.create_poly_data_mesh(self._model.detector_positions)
         self._detector_mesh[self._counts_label] = self._model.detector_counts
-        QAppThreadCall(self._view.add_detector_mesh)(
-            self._detector_mesh, is_projection=self._model.is_2d_projection, scalars=self._counts_label
-        )
+        self._view.add_detector_mesh(self._detector_mesh, is_projection=self._model.is_2d_projection, scalars=self._counts_label)
 
         self._pickable_mesh = self.create_poly_data_mesh(self._model.detector_positions)
         self._pickable_mesh[self._visible_label] = self._model.picked_visibility
-        QAppThreadCall(self._view.add_pickable_mesh)(self._pickable_mesh, scalars=self._visible_label)
+        self._view.add_pickable_mesh(self._pickable_mesh, scalars=self._visible_label)
 
         self._masked_mesh = self.create_poly_data_mesh(self._model.masked_positions)
-        QAppThreadCall(self._view.add_masked_mesh)(self._masked_mesh)
+        self._view.add_masked_mesh(self._masked_mesh)
 
         monitor_mesh = self._create_and_add_monitor_mesh()
 
@@ -186,13 +183,13 @@ class FullInstrumentViewPresenter:
         if monitor_mesh is not None:
             monitor_mesh.transform(self._transform, inplace=True)
 
-        QAppThreadCall(self._view.enable_or_disable_mask_widgets)()
-        QAppThreadCall(self._view.enable_or_disable_aspect_ratio_box)()
+        self._view.enable_or_disable_mask_widgets()
+        self._view.enable_or_disable_aspect_ratio_box()
         self.set_view_contour_limits()
         self.set_view_integration_limits()
 
-        QAppThreadCall(self._view.cache_camera_position)()
-        QAppThreadCall(self._view.reset_camera)()
+        self._view.cache_camera_position()
+        self._view.reset_camera()
 
     def _update_transform(self) -> None:
         if not self._model.is_2d_projection or self._view.is_maintain_aspect_ratio_checkbox_checked():
@@ -259,7 +256,7 @@ class FullInstrumentViewPresenter:
                 selected_mask = selected_mesh.point_data["SelectedPoints"].view(bool)
                 self.update_picked_detectors(selected_mask)
 
-            QAppThreadCall(self._view.enable_rectangle_picking)(self._model.is_2d_projection, callback=rectangle_picked)
+            self._view.enable_rectangle_picking(self._model.is_2d_projection, callback=rectangle_picked)
             self._peak_interaction_status = PeakInteractionStatus.Disabled
             self._update_peak_buttons()
         else:
@@ -272,7 +269,7 @@ class FullInstrumentViewPresenter:
                 picked_mask[point_index] = True
                 self.update_picked_detectors(picked_mask)
 
-            QAppThreadCall(self._view.enable_point_picking)(self._model.is_2d_projection, callback=point_picked)
+            self._view.enable_point_picking(self._model.is_2d_projection, callback=point_picked)
 
     def update_picked_detectors(self, picked_mask: np.ndarray) -> None:
         if not np.any(picked_mask):
@@ -283,24 +280,24 @@ class FullInstrumentViewPresenter:
         self._pickable_mesh[self._visible_label] = self._model.picked_visibility
         self._update_line_plot_ws_and_draw(self._view.current_selected_unit())
         self._peak_interaction_status = PeakInteractionStatus.Disabled
-        QAppThreadCall(self._view.remove_peak_cursor_from_lineplot)()
+        self._view.remove_peak_cursor_from_lineplot()
         self._update_peak_buttons()
 
     def _on_add_mask_clicked(self) -> None:
-        implicit_function = QAppThreadCall(self._view.get_current_widget_implicit_function)()
+        implicit_function = self._view.get_current_widget_implicit_function()
         if not implicit_function:
             return
         mask = [(implicit_function.EvaluateFunction(pt) < 0) for pt in self._detector_mesh.points]
         new_key = self._model.add_new_detector_mask(mask)
-        QAppThreadCall(self._view.set_new_mask_key)(new_key)
+        self._view.set_new_mask_key(new_key)
 
     def on_add_mask_clicked(self) -> None:
         self._callback_queue.put((self._on_add_mask_clicked, ()))
 
     def _on_mask_item_selected(self) -> None:
-        self._model.apply_detector_masks(QAppThreadCall(self._view.selected_masks)())
+        self._model.apply_detector_masks(self._view.selected_masks())
         self.update_plotter()
-        self._update_line_plot_ws_and_draw(QAppThreadCall(self._view.current_selected_unit)())
+        self._update_line_plot_ws_and_draw(self._view.current_selected_unit())
         self._update_peak_buttons()
 
     def on_mask_item_selected(self) -> None:
@@ -321,7 +318,7 @@ class FullInstrumentViewPresenter:
         self._callback_queue.put((self._on_overwrite_mask_clicked, ()))
 
     def _on_clear_masks_clicked(self) -> None:
-        QAppThreadCall(self._view.clear_mask_list)()
+        self._view.clear_mask_list()
         self._model.clear_stored_masks()
         self._on_mask_item_selected()
 
@@ -329,7 +326,7 @@ class FullInstrumentViewPresenter:
         self._callback_queue.put((self._on_clear_masks_clicked, ()))
 
     def _reload_mask_workspaces(self) -> None:
-        QAppThreadCall(self._view.refresh_mask_ws_list)()
+        self._view.refresh_mask_ws_list()
         self.on_mask_item_selected()
 
     def mask_workspaces_in_ads(self) -> list[str]:
@@ -339,18 +336,18 @@ class FullInstrumentViewPresenter:
         return self._model.cached_masks_keys
 
     def _update_line_plot_ws_and_draw(self, unit: str) -> None:
-        self._model.extract_spectra_for_line_plot(unit, QAppThreadCall(self._view.sum_spectra_selected)())
-        QAppThreadCall(self._view.show_plot_for_detectors)(self._model.line_plot_workspace)
-        QAppThreadCall(self._view.set_selected_detector_info)(self._model.picked_detectors_info_text())
+        self._model.extract_spectra_for_line_plot(unit, self._view.sum_spectra_selected())
+        self._view.show_plot_for_detectors(self._model.line_plot_workspace)
+        self._view.set_selected_detector_info(self._model.picked_detectors_info_text())
         self._update_relative_detector_angle()
         self._update_peaks_workspaces()
         self.refresh_lineplot_peaks()
 
     def _update_relative_detector_angle(self) -> None:
         if len(self._model.picked_detector_ids) != 2:
-            QAppThreadCall(self._view.set_relative_detector_angle)(None)
+            self._view.set_relative_detector_angle(None)
         else:
-            QAppThreadCall(self._view.set_relative_detector_angle)(self._model.relative_detector_angle())
+            self._view.set_relative_detector_angle(self._model.relative_detector_angle())
 
     def on_clear_selected_detectors_clicked(self) -> None:
         self.update_picked_detectors(np.array([]))
@@ -370,12 +367,12 @@ class FullInstrumentViewPresenter:
         return rgba
 
     def _reload_peaks_workspaces(self):
-        QAppThreadCall(self._view.refresh_peaks_ws_list)()
+        self._view.refresh_peaks_ws_list()
         self.on_peaks_workspace_selected()
 
     def _delete_workspace_callback(self, ws_name):
         if self._model.workspace.name() == ws_name:
-            QAppThreadCall(self._view.close)()
+            self._view.close()
             logger.warning(f"Workspace {ws_name} deleted, closed Experimental Instrument View.")
         else:
             self._reload_peaks_workspaces()
@@ -397,7 +394,7 @@ class FullInstrumentViewPresenter:
         self._callback_queue.put((self._rename_workspace_callback, (ws_old_name, ws_new_name)))
 
     def clear_workspace_callback(self):
-        QAppThreadCall(self._view.close)()
+        self._view.close()
 
     def _replace_workspace_callback(self, ws_name, ws):
         if ws_name in self.peaks_workspaces_in_ads():
@@ -449,11 +446,11 @@ class FullInstrumentViewPresenter:
         self._peaks_grouped_by_ws = peaks_grouped_by_ws
 
     def on_peaks_workspace_selected(self) -> None:
-        self._model.set_peaks_workspaces(QAppThreadCall(self._view.selected_peaks_workspaces)())
-        QAppThreadCall(self._view.clear_overlay_meshes)()
+        self._model.set_peaks_workspaces(self._view.selected_peaks_workspaces())
+        self._view.clear_overlay_meshes()
         self._update_peaks_workspaces()
         self.refresh_lineplot_peaks()
-        QAppThreadCall(self._view.refresh_peaks_ws_list_colours)()
+        self._view.refresh_peaks_ws_list_colours()
         if len(self._peaks_grouped_by_ws) == 0:
             return
         # Keeping the points from each workspace separate so we can colour them differently
@@ -475,22 +472,22 @@ class FullInstrumentViewPresenter:
             # Plot the peaks and their labels on the projection
             if len(projected_points) > 0:
                 transformed_points = self._transform_vectors_with_matrix(projected_points, self._transform)
-                QAppThreadCall(self._view.plot_overlay_mesh)(transformed_points, labels, ws_peaks.colour)
+                self._view.plot_overlay_mesh(transformed_points, labels, ws_peaks.colour)
 
     def refresh_lineplot_peaks(self) -> None:
         # Plot vertical lines on the lineplot if the peak detector is selected
-        QAppThreadCall(self._view.clear_lineplot_overlays)()
+        self._view.clear_lineplot_overlays()
 
         for ws_peaks in self._peaks_grouped_by_ws:
             x_values = []
             labels = []
             for peak in ws_peaks.detector_peaks:
                 if peak.spectrum_no in self._model.picked_spectrum_nos:
-                    x_values += [p.location_in_unit(QAppThreadCall(self._view.current_selected_unit)()) for p in peak.peaks]
+                    x_values += [p.location_in_unit(self._view.current_selected_unit()) for p in peak.peaks]
                     labels += [p.label for p in peak.peaks]
             if len(x_values) > 0:
-                QAppThreadCall(self._view.plot_lineplot_overlay)(x_values, labels, ws_peaks.colour)
-        QAppThreadCall(self._view.redraw_lineplot)()
+                self._view.plot_lineplot_overlay(x_values, labels, ws_peaks.colour)
+        self._view.redraw_lineplot()
 
     def on_save_xml_mask_clicked(self):
         filename = open_a_file_dialog(
@@ -511,30 +508,30 @@ class FullInstrumentViewPresenter:
         x_in_workspace_unit = self._model.convert_units(self._view.current_selected_unit(), self._model.workspace_x_unit, 0, x)
         if self._peak_interaction_status == PeakInteractionStatus.Adding:
             peaks_ws = self._model.add_peak(x_in_workspace_unit, self._view.selected_peaks_workspaces())
-            QAppThreadCall(self._view.refresh_peaks_ws_list)()
-            QAppThreadCall(self._view.select_peaks_workspace)(peaks_ws)
+            self._view.refresh_peaks_ws_list()
+            self._view.select_peaks_workspace(peaks_ws)
         elif self._peak_interaction_status == PeakInteractionStatus.Deleting:
             self._model.delete_peak(x_in_workspace_unit)
         else:
             raise RuntimeError("Unknown peak operation")
         self._peak_interaction_status = PeakInteractionStatus.Disabled
-        QAppThreadCall(self._view.remove_peak_cursor_from_lineplot)()
+        self._view.remove_peak_cursor_from_lineplot()
         self._update_peak_buttons()
 
     def _update_peak_buttons(self) -> None:
-        QAppThreadCall(self._view.set_add_peak_button_enabled)(
+        self._view.set_add_peak_button_enabled(
             len(self._model.picked_detector_ids) == 1 and self._peak_interaction_status != PeakInteractionStatus.Adding
         )
-        QAppThreadCall(self._view.set_delete_peak_button_enabled)(
+        self._view.set_delete_peak_button_enabled(
             self._view.has_any_peak_overlays() and self._peak_interaction_status != PeakInteractionStatus.Adding
         )
-        QAppThreadCall(self._view.set_delete_all_selected_peaks_button_enabled)(
+        self._view.set_delete_all_selected_peaks_button_enabled(
             len(self._model.picked_detector_ids) > 0 and self._peak_interaction_status != PeakInteractionStatus.Adding
         )
 
     def _on_peak_clicked_in_lineplot(self, status: PeakInteractionStatus) -> None:
         self._peak_interaction_status = status
-        QAppThreadCall(self._view.add_peak_cursor_to_lineplot)()
+        self._view.add_peak_cursor_to_lineplot()
         self._update_peak_buttons()
 
     def on_delete_peak_clicked(self) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -47,6 +47,7 @@ from mantid.dataobjects import Workspace2D
 from mantid import UsageService, ConfigService
 from mantid.kernel import FeatureType
 from mantidqt.plotting.mantid_navigation_toolbar import MantidNavigationToolbar
+from mantidqt.utils.qt.qappthreadcall import run_on_qapp_thread
 
 from instrumentview.Detectors import DetectorInfo
 from instrumentview.InteractorStyles import CustomInteractorStyleZoomAndSelect, CustomInteractorStyleRubberBand3D
@@ -109,6 +110,7 @@ class WorkspaceListWidget(QListWidget):
         event.acceptProposedAction()
 
 
+@run_on_qapp_thread()
 class FullInstrumentViewWindow(QMainWindow):
     """View for the Instrument View window. Contains the 3D view, the projection view, boxes showing information about the selected
     detector, and a line plot of selected detector(s)"""

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -122,7 +122,6 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_ads_retrieve = MagicMock()
         mock_ads.retrieve.return_value = mock_ads_retrieve
         self._model.setup = MagicMock()
-        self._presenter.update_plotter = MagicMock()
         ws_name = self._model.workspace.name()
         mock_ads_retrieve.name.return_value = ws_name
         self._presenter._replace_workspace_callback(ws_name, None)
@@ -159,14 +158,14 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._mock_view.get_current_widget_implicit_function.return_value = mock_implicit_function
         self._mock_view.get_current_selected_tab.return_value = CurrentTab.Grouping
         self._model.add_new_detector_key = MagicMock(return_value="mock_key")
-        self._presenter.on_add_item_clicked()
+        self._presenter._on_add_item_clicked()
         np.testing.assert_allclose(self._model.add_new_detector_key.call_args.args[0], mock_implicit_return < 0)
         self._mock_view.set_new_item_key.assert_called_once_with(CurrentTab.Grouping, "mock_key")
 
     def test_on_save_mask_to_workspace_clicked(self):
         self._mock_view.get_current_tab.return_value = CurrentTab.Masking
         self._model.save_workspace_to_ads = MagicMock()
-        self._presenter.on_save_to_workspace_clicked()
+        self._presenter._on_save_to_workspace_clicked()
         self._model.save_workspace_to_ads.assert_called_once()
         self._mock_view.on_mask_item_selected.assert_not_called()
 

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -140,14 +140,22 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_has_unit.assert_called_once()
         self.assertEqual(self._presenter._UNIT_OPTIONS, units)
 
-    def test_model_refresh_on_correct_ws_replace(self):
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.AnalysisDataService")
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
+    def test_model_refresh_on_correct_ws_replace(self, mock_update_plotter, mock_ads):
+        mock_ads_retrieve = MagicMock()
+        mock_ads.retrieve.return_value = mock_ads_retrieve
         self._model.setup = MagicMock()
         ws_name = self._model.workspace.name()
-        self._presenter.replace_workspace_callback(ws_name, None)
+        mock_ads_retrieve.name.return_value = ws_name
+        self._presenter._replace_workspace_callback(ws_name, None)
         self._model.setup.assert_called_once()
+        mock_update_plotter.assert_called_once()
         self._mock_view.setup.reset_mock()
-        self._presenter.replace_workspace_callback("not_my_workspace", None)
+        mock_update_plotter.reset_mock()
+        self._presenter._replace_workspace_callback("not_my_workspace", None)
         self._mock_view.setup.assert_not_called()
+        mock_update_plotter.assert_not_called()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.on_peaks_workspace_selected")
     def test_reload_peaks_workspaces(self, mock_on_peaks_workspace_selected):

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -12,8 +12,8 @@ from vtkmodules.vtkInteractionWidgets import vtkBoxRepresentation
 import numpy as np
 
 from mantidqt.utils.qt.testing import start_qapplication
-from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
 from mantid.simpleapi import CreateSampleWorkspace
+from instrumentview.FullInstrumentViewWindow import FullInstrumentViewWindow
 
 
 @start_qapplication
@@ -28,7 +28,8 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
     @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
     @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
     def setUp(self, mock_plotter, mock_splitter_add_widget, mock_v_add_widget, mock_h_add_widget, mock_figure_canvas) -> None:
-        self._view = FullInstrumentViewWindow()
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            self._view = FullInstrumentViewWindow()
         self._mock_plotter = mock_plotter
         self._mock_splitter_add_widget = mock_splitter_add_widget
         self._mock_v_add_widget = mock_v_add_widget


### PR DESCRIPTION
This moves all callbacks to run on a separate worker thread. This is because some of the callbacks in the interface require the use of algorithms from `mantid`, but if a user runs an algorithm from Workbench then that algorithm will acquire the read lock on the workspace, then the ADS callback in the interface will be called before the original algorithm has released the read lock, resulting in a deadlock, (since the interface is waiting for the read lock to run an algorithm, but it's already inside an algorithm with the read lock). All calls that edit `Qt` components must be sent to the `Qt` thread using a `QAppThreadCall`, otherwise another hang.

Fixes #40682 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

Test all existing functionality in the new Instrument View, e.g. adding/removing peaks, adding/removing masks, writing peaks and masks to the ADS. 

Also try running e.g. `ConvertUnits` on the workspace open in the Instrument View. Before these changes that would hang.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
