### PR TITLE
Write full component name if SCDCalibratePanels2 output XML files

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -1260,14 +1260,12 @@ void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
 
   // configure and add each bank
   for (auto bankName : AllBankNames) {
+    // Prepare data for node
+    if (instrument->getName().compare("CORELLI") == 0)
+      bankName.append("/sixteenpack");
+
     std::shared_ptr<const IComponent> bank = instrument->getComponentByName(bankName);
     auto bankFullName = bank->getFullName();
-
-    // Prepare data for node
-    if (instrument->getName().compare("CORELLI") == 0) {
-      bankName.append("/sixteenpack");
-      bankFullName.append("/sixteenpack");
-    }
 
     Quat relRot = bank->getRelativeRot();
     std::vector<double> relRotAngles = relRot.getEulerAngles("XYZ");

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -1260,11 +1260,14 @@ void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
 
   // configure and add each bank
   for (auto bankName : AllBankNames) {
-    // Prepare data for node
-    if (instrument->getName().compare("CORELLI") == 0)
-      bankName.append("/sixteenpack");
-
     std::shared_ptr<const IComponent> bank = instrument->getComponentByName(bankName);
+    auto bankFullName = bank->getFullName();
+
+    // Prepare data for node
+    if (instrument->getName().compare("CORELLI") == 0) {
+      bankName.append("/sixteenpack");
+      bankFullName.append("/sixteenpack");
+    }
 
     Quat relRot = bank->getRelativeRot();
     std::vector<double> relRotAngles = relRot.getEulerAngles("XYZ");
@@ -1300,7 +1303,7 @@ void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
     bank_sx.put("<xmlattr>.name", "scalex");
     bank_sy.put("<xmlattr>.name", "scaley");
 
-    bank_root.put("<xmlattr>.name", bankName);
+    bank_root.put("<xmlattr>.name", bankFullName); // avoid future expensive search in the instrument's tree
 
     // configure structure
     bank_dx.add_child("value", bank_dx_val);

--- a/Framework/DataHandling/src/LoadParameterFile.cpp
+++ b/Framework/DataHandling/src/LoadParameterFile.cpp
@@ -85,6 +85,8 @@ void LoadParameterFile::exec() {
   Progress prog(this, 0.0, 1.0, 100);
 
   prog.report("Parsing XML");
+
+  const auto parseStartTime = std::chrono::high_resolution_clock::now();
   // If we've been given an XML string parse that instead
   if (!parameterXMLProperty->isDefault()) {
     try {
@@ -113,6 +115,7 @@ void LoadParameterFile::exec() {
       throw Kernel::Exception::FileError("Unable to parse File:", filename);
     }
   }
+  addTimer("xmlParsing", parseStartTime, std::chrono::high_resolution_clock::now());
 
   // Get pointer to root element
   Element *pRootElem = pDoc->documentElement();
@@ -120,13 +123,17 @@ void LoadParameterFile::exec() {
     throw Kernel::Exception::InstrumentDefinitionError("No root element in XML Parameter file", filename);
   }
 
-  // Set all parameters that specified in all component-link elements of
-  // pRootElem
+  // Set all parameters that specified in all component-link elements of pRootElem
+  const auto linkStartTime = std::chrono::high_resolution_clock::now();
   InstrumentDefinitionParser loadInstr;
   loadInstr.setComponentLinks(instrument, pRootElem, &prog, localWorkspace->getWorkspaceStartDate());
+  addTimer("setComponentLinks", linkStartTime, std::chrono::high_resolution_clock::now());
 
   // populate parameter map of workspace
+  const auto populateStartTime = std::chrono::high_resolution_clock::now();
   localWorkspace->populateInstrumentParameters();
+  addTimer("populateInstrumentParameters", populateStartTime, std::chrono::high_resolution_clock::now());
+
   if (!filename.empty()) {
     localWorkspace->instrumentParameters().addParameterFilename(filename);
   }

--- a/Framework/DataHandling/src/LoadParameterFile.cpp
+++ b/Framework/DataHandling/src/LoadParameterFile.cpp
@@ -20,7 +20,9 @@
 #include <Poco/DOM/NodeFilter.h>
 #include <Poco/DOM/NodeIterator.h>
 #include <Poco/DOM/NodeList.h>
+#include <chrono>
 #include <filesystem>
+
 using Mantid::Geometry::InstrumentDefinitionParser;
 using Poco::XML::AutoPtr;
 using Poco::XML::Document;

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2375,9 +2375,7 @@ void InstrumentDefinitionParser::setLogfile(const Geometry::IComponent *comp, co
 
 //-----------------------------------------------------------------------------------------------------------------------
 /** Apply parameters that may be specified in \<component-link\> XML elements.
- *  Input variable pRootElem may e.g. be the root element of an XML parameter
- *file or
- *  the root element of a IDF
+ *  Input variable pRootElem may e.g. be the root element of an XML parameter file or the root element of a IDF
  *
  *  @param instrument :: Instrument
  *  @param pRootElem ::  Associated Poco::XML element that may contain
@@ -2439,9 +2437,7 @@ void InstrumentDefinitionParser::setComponentLinks(std::shared_ptr<Geometry::Ins
 
         sharedIComp.emplace_back(detector);
 
-        // If the user also supplied a name, make sure it's consistent with
-        // the
-        // detector id.
+        // If the user also supplied a name, make sure it's consistent with the detector id.
         if (name.length() > 0) {
           auto comp = std::dynamic_pointer_cast<const IComponent>(detector);
           if (comp) {
@@ -2456,10 +2452,7 @@ void InstrumentDefinitionParser::setComponentLinks(std::shared_ptr<Geometry::Ins
         }
       } else {
         // No detector id given, fall back to using the name
-
-        if (name.find('/', 0) == std::string::npos) { // Simple name, look for
-          // all components of that
-          // name.
+        if (name.find('/', 0) == std::string::npos) { // Simple name, look for all components of that name.
           sharedIComp = instrument->getAllComponentsWithName(name);
         } else { // Pathname given. Assume it is unique.
           std::shared_ptr<const Geometry::IComponent> shared = instrument->getComponentByName(name);
@@ -2470,8 +2463,7 @@ void InstrumentDefinitionParser::setComponentLinks(std::shared_ptr<Geometry::Ins
       for (auto &ptr : sharedIComp) {
         std::shared_ptr<const Geometry::Component> sharedComp =
             std::dynamic_pointer_cast<const Geometry::Component>(ptr);
-        if (sharedComp) {
-          // Not empty Component
+        if (sharedComp) { // Not empty Component
           if (sharedComp->isParametrized()) {
             setLogfile(sharedComp->base(), curElem, instrument->getLogfileCache(), requestedDate);
           } else {

--- a/docs/source/algorithms/SCDCalibratePanels-v2.rst
+++ b/docs/source/algorithms/SCDCalibratePanels-v2.rst
@@ -136,7 +136,7 @@ Usage
         Workspace='cws',
         ComponentName='moderator',
         X=0, Y=0, Z=dL1,
-        RelativePosition=true,
+        RelativePosition=True,
     )
 
     # Generate predicted peak workspace
@@ -147,7 +147,7 @@ Usage
     CreatePeaksWorkspace(OutputWorkspace='pws')
     omegas = range(0, 180, 3)
 
-    for omega in tqdm(omegas):
+    for omega in omegas:
         SetGoniometer(
             Workspace="cws",
             Axis0=f"{omega},0,1,0,1",
@@ -176,7 +176,7 @@ Usage
         Workspace='pws',
         ComponentName='moderator',
         X=0, Y=0, Z=-dL1,
-        RelativePosition=true,
+        RelativePosition=True,
     )
 
     # run the calibration on pws

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40714.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40714.rst
@@ -1,1 +1,1 @@
-- :ref:`SCDCalibratePanels2 <algm-SCDCalibratePanels2>` now writes the full name for bank components.
+- :ref:`algm-SCDCalibratePanels-v2` now writes the full name for bank components.

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40714.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40714.rst
@@ -1,0 +1,1 @@
+- :ref:`SCDCalibratePanels2 <algm-SCDCalibratePanels2>` now writes the full name for bank components.


### PR DESCRIPTION
### Description of work
This pull request aims to add performance timing instrumentation to the LoadParameterFile algorithm by measuring the duration of XML parsing, component link setting, and instrument parameter population operations. Additionally, it includes  an optimization in SCDCalibratePanels2 to use full component names to avoid expensive tree searches.

Companion to 40715
EWM [14642](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14642)

### To test:
Run the following script in the workbench to generate calibration file `/tmp/test_2.xml`:

```
# necessary import
import numpy as np
from collections import namedtuple
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure

# generate synthetic testing data
def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

# lattice constant for Si
# data from Mantid web documentation
lc_silicon = {
    "a": 5.431,  # A
    "b": 5.431,  # A
    "c": 5.431,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}
silicon = convert(lc_silicon)
cs_silicon = CrystalStructure(
    f"{silicon.a} {silicon.b} {silicon.c}",
    "F d -3 m",
    "Si 0 0 0 1.0 0.05",
)

# Generate simulated workspace for TOPAZ
CreateSimulationWorkspace(
    Instrument='TOPAZ',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)
cws = mtd['cws']

# Set the UB matrix for the sample
# u, v is the critical part, we can start with the
# ideal position
SetUB(
    Workspace="cws",
    u='1,0,0',  # vector along k_i, when goniometer is at 0
    v='0,1,0',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_silicon,
)

# set the crystal structure for virtual workspace
cws.sample().setCrystalStructure(cs_silicon)

# tweak L1
dL1 = 1.414e-2  # 1.414cm
MoveInstrumentComponent(
    Workspace='cws',
    ComponentName='moderator',
    X=0, Y=0, Z=dL1,
    RelativePosition=True,
)

# Generate predicted peak workspace
dspacings = convert({'min': 1.0, 'max': 10.0})
wavelengths = convert({'min': 0.8, 'max': 2.9})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(OutputWorkspace='pws')
omegas = range(0, 180, 3)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        WavelengthMin=wavelengths.min,
        wavelengthMax=wavelengths.max,
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

pws = mtd['pws']

# move the source back to make PWS forget the answer
MoveInstrumentComponent(
    Workspace='pws',
    ComponentName='moderator',
    X=0, Y=0, Z=-dL1,
    RelativePosition=True,
)

# run the calibration on pws
# similar to actual calibration, where
#   1. the peaks in side pws knows the correct L1, but info is embedded in Qsamples
#   2. the recorded L1 in instrument Info is the default engineering value
SCDCalibratePanels(
    PeakWorkspace="pws",
    a=silicon.a,
    b=silicon.b,
    c=silicon.c,
    alpha=silicon.alpha,
    beta=silicon.beta,
    gamma=silicon.gamma,
    CalibrateL1=True,
    CalibrateBanks=False,
    CalibrateT0=True,
    TuneSamplePosition=True,
    OutputWorkspace="testCaliTable",
    XmlFilename="/tmp/test_2.xml",
)
```

After that, generate calibration file `/tmp/test_1.xml` where bank names have relative names:

```/bin/cp /tmp/test_2.xml /tmp/test_1.xml; sed -i 's/name="TOPAZ\/bank/name="bank/g' /tmp/test_1.xml```

In the workbench, compare the time it takes `LoadParameterFile` to load each file:

```
from mantid.simpleapi import LoadEmptyInstrument, LoadParameterFile
ws = LoadEmptyInstrument(InstrumentName="TOPAZ", MakeEventWorkspace=False)
LoadParameterFile(ws, Filename="/tmp/test_1.xml")
LoadParameterFile(ws, Filename="/tmp/test_2.xml")
```

Look in the logging window for statements such as:
```
LoadParameterFile successful, Duration 12.68 seconds
LoadParameterFile successful, Duration 1.89 seconds
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
