### PR TITLE
Added the additional check to verify instance of list before accessing zeroth index

### DIFF
--- a/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
+++ b/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
@@ -1,0 +1,1 @@
+- Added additional checks in CurvesTabWidgetPresenter to verify the types before indexing the list to fix the error.

--- a/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
+++ b/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
@@ -1,1 +1,1 @@
-- Added additional checks in CurvesTabWidgetPresenter to verify the types before indexing the list to fix the error.
+- The Figure Options in the :ref:`Workbench Plot Window <WorkbenchPlotWindow>` should no longer throw an error due to missing list entries.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -121,12 +121,18 @@ class CurvesTabWidgetPresenter:
         if waterfall and ax.waterfall_has_fill() and datafunctions.waterfall_fill_is_line_colour(ax):
             check_line_colour = True
 
+        lines = ax.get_lines()
+        if not isinstance(lines, list):
+            return
         if isinstance(curve, Line2D):
-            curve_index = ax.get_lines().index(curve)
+            curve_index = lines.index(curve)
             errorbar = False
         elif isinstance(curve, ErrorbarContainer):
-            curve_index = ax.get_lines().index(curve[0])
-            errorbar = True
+            if isinstance(curve, tuple):
+                curve_index = lines.index(curve[0])
+                errorbar = True
+            else:
+                return
         else:
             return
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40494 . <!-- One line per closed issue. -->

The error originates from `curve_index = ax.get_lines().index(curve[0])`. 

The two things that can possibly cause an error are as follows:

1. `ax.get_lines()` returns an object that is not a list. Although the [code](https://github.com/matplotlib/matplotlib/blob/v3.10.8/lib/matplotlib/axes/_base.py#L2246-L2248) seems to suggest that it should always be a list. But just in case, I have added a check in `_replot_current_curve` to verify that it is a list so that **.index** does not throw an error.
2. **curve** is not indexable. The [code](https://matplotlib.org/stable/api/container_api.html#matplotlib.container.ErrorbarContainer) again seems to suggest that it should always be a tuple. But a check is added to verify that it is in fact a tuple so that the zeroth element can be indexed.

As it is difficult to recreate the error, the purpose of adding the checks is just to make sure that the mantid code is more robust and does not lead to a similar error from that particular line of code.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
It is not possible to test this because of lack of information about how to recreate the error. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
