### PR TITLE
Allow SplittersWorkspace to be created directly from python

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
@@ -31,6 +31,8 @@ class MANTID_DATAOBJECTS_DLL SplittersWorkspace : public DataObjects::TableWorks
 public:
   SplittersWorkspace();
 
+  const std::string id() const override { return "SplittersWorkspace"; }
+
   /// Returns a clone of the workspace
   std::unique_ptr<SplittersWorkspace> clone() const { return std::unique_ptr<SplittersWorkspace>(doClone()); }
 

--- a/Framework/DataObjects/src/SplittersWorkspace.cpp
+++ b/Framework/DataObjects/src/SplittersWorkspace.cpp
@@ -7,6 +7,7 @@
 #include "MantidDataObjects/SplittersWorkspace.h"
 #include "MantidAPI/Column.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/IPropertyManager.h"
 
 using namespace Mantid::Kernel;
@@ -17,6 +18,9 @@ namespace {
 /// static logger
 Kernel::Logger g_log("SplittersWorkspace");
 } // namespace
+
+DECLARE_WORKSPACE(SplittersWorkspace)
+
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/SplittersWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/SplittersWorkspace.cpp
@@ -5,11 +5,14 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataObjects/SplittersWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidPythonInterface/api/RegisterWorkspacePtrToPython.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include <boost/python/class.hpp>
+#include <boost/python/make_constructor.hpp>
 
 using Mantid::API::ISplittersWorkspace;
+using Mantid::API::WorkspaceFactory;
 using Mantid::DataObjects::SplittersWorkspace;
 using Mantid::DataObjects::TableWorkspace;
 using namespace Mantid::PythonInterface::Registry;
@@ -17,9 +20,16 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(SplittersWorkspace)
 
+namespace {
+Mantid::API::Workspace_sptr makeSplittersWorkspace() {
+  return WorkspaceFactory::Instance().createTable("SplittersWorkspace");
+}
+} // namespace
+
 void export_SplittersWorkspace() {
   class_<SplittersWorkspace, bases<TableWorkspace, ISplittersWorkspace>, boost::noncopyable>("SplittersWorkspace",
-                                                                                             no_init);
+                                                                                             no_init)
+      .def("__init__", make_constructor(&makeSplittersWorkspace));
 
   // register pointers
   RegisterWorkspacePtrToPython<SplittersWorkspace>();

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
@@ -1,7 +1,13 @@
 # mantid.dataobjects tests
 
-set(TEST_PY_FILES EventListTest.py GroupingWorkspaceTest.py SpecialWorkspace2DTest.py Workspace2DPickleTest.py
-                  PeakShapes.py WorkspaceValidatorsTest.py
+set(TEST_PY_FILES
+    EventListTest.py
+    GroupingWorkspaceTest.py
+    SpecialWorkspace2DTest.py
+    Workspace2DPickleTest.py
+    PeakShapes.py
+    WorkspaceValidatorsTest.py
+    SplittersWorkspaceTest.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/SplittersWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/SplittersWorkspaceTest.py
@@ -1,0 +1,45 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=invalid-name, too-many-public-methods
+import unittest
+
+from mantid.api import WorkspaceFactory, ISplittersWorkspace, ITableWorkspace
+from mantid.dataobjects import SplittersWorkspace, TableWorkspace
+
+
+class SplittersWorkspaceTest(unittest.TestCase):
+    def test_creation(self):
+        splitter_ws = SplittersWorkspace()
+        self.assertEqual(splitter_ws.id(), "SplittersWorkspace")
+        self.assertIsInstance(splitter_ws, ISplittersWorkspace)
+        self.assertIsInstance(splitter_ws, SplittersWorkspace)
+        self.assertIsInstance(splitter_ws, ITableWorkspace)
+        self.assertIsInstance(splitter_ws, TableWorkspace)
+
+    def test_WorkspaceFactory_creation(self):
+        splitter_ws = WorkspaceFactory.createTable("SplittersWorkspace")
+        self.assertEqual(splitter_ws.id(), "SplittersWorkspace")
+        self.assertIsInstance(splitter_ws, ISplittersWorkspace)
+        self.assertIsInstance(splitter_ws, SplittersWorkspace)
+        self.assertIsInstance(splitter_ws, ITableWorkspace)
+        self.assertIsInstance(splitter_ws, TableWorkspace)
+
+    def test_default_columns(self):
+        splitter_ws = SplittersWorkspace()
+        self.assertEqual(splitter_ws.getColumnNames(), ["start", "stop", "workspacegroup"])
+        self.assertEqual(splitter_ws.columnTypes(), ["long64", "long64", "int"])
+
+    def test_getNumberSplitters(self):
+        splitter_ws = SplittersWorkspace()
+        self.assertEqual(splitter_ws.getNumberSplitters(), 0)
+        splitter_ws.addRow([0, 10, 1])
+        splitter_ws.addRow([11, 20, 2])
+        self.assertEqual(splitter_ws.getNumberSplitters(), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/release/v6.16.0/Framework/Python/New_features/40719.rst
+++ b/docs/source/release/v6.16.0/Framework/Python/New_features/40719.rst
@@ -1,0 +1,1 @@
+- :py:obj:`SplittersWorkspaces <mantid.dataobjects.SplittersWorkspace>` can now be created directly from python.

--- a/qt/widgets/common/src/WorkspaceIcons.cpp
+++ b/qt/widgets/common/src/WorkspaceIcons.cpp
@@ -62,6 +62,7 @@ void WorkspaceIcons::initInternalLookup() {
 
   // Table workspace types
   m_idToPixmapName["TableWorkspace"] = "worksheet_xpm";
+  m_idToPixmapName["SplittersWorkspace"] = "worksheet_xpm";
   m_idToPixmapName["PeaksWorkspace"] = "worksheet_xpm";
   m_idToPixmapName["LeanElasticPeaksWorkspace"] = "worksheet_xpm";
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

This allows you to create a [SplittersWorkspace](https://docs.mantidproject.org/nightly/api/python/mantid/dataobjects/SplittersWorkspace.html) workspace directly from python.

Refs [14478: [mantid] WorkspaceFactory create empty SplittersWorkspace](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14478)

### To test:

```python
from mantid.api import WorkspaceFactory
from mantid.dataobjects import SplittersWorkspace

splitter_table = WorkspaceFactory.createTable("SplittersWorkspace")
# or
splitter_table2 = SplittersWorkspace()
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
