### PR TITLE
Update ruff hook from v0.14.13 to v0.14.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13
+    rev: v0.14.14
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff-check


### PR DESCRIPTION
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.14.13 → v0.14.14](https://github.com/astral-sh/ruff-pre-commit/compare/v0.14.13...v0.14.14)

This replaces #40716 and will get into `main` via the automerge CI job.