### PR TITLE
Checkout release-next rather than main

### DIFF
--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -9,12 +9,18 @@ on:
   schedule:
     - cron: 0 6 * * *
 
+env:
+  # change this between main and release-next
+  UPDATE_BRANCH: release-next
+
 jobs:
   pixi-update-lockfile:
     if: ${{ github.repository_owner == 'mantidproject' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.UPDATE_BRANCH }}  # start from this branch
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
@@ -33,7 +39,7 @@ jobs:
           title: Update pixi lockfile
           body-path: diff.md
           branch: update-pixi
-          base: release-next
+          base:  ${{ env.UPDATE_BRANCH }}  # merge into this branch
           labels: |
             pixi
             Maintenance


### PR DESCRIPTION
When updating the branch for #40681, it was missed that the checkout action grabs the refspec for the job, which is the default branch of the repository, main. This changes the script to make the branch explicit in all places.

There is no associated issue

### To test:

See workflow run [here]https://github.com/mantidproject/mantid/actions/runs/21411273345) created #40741.

*This does not require release notes* because it fixes a bug in a maintenance CI job

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
