### PR TITLE
Guard against missing presenter on close

### DIFF
--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40727.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40727.rst
@@ -1,0 +1,1 @@
+- Fixed error on closing the new Instrument View due to a missing presenter.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -643,7 +643,8 @@ class FullInstrumentViewWindow(QMainWindow):
         self.main_plotter.close()
         if self._detector_spectrum_fig is not None:
             plt.close(self._detector_spectrum_fig.get_label())
-        self._presenter.handle_close()
+        if hasattr(self, "_presenter") and self._presenter is not None:
+            self._presenter.handle_close()
 
     def set_projection_combo_options(self, default_index: int, options: list[str]) -> None:
         self._projection_combo_box.addItems(options)

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -53,6 +53,12 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         self.assertEqual(2, mock_close_event.call_count)
         self._view.main_plotter.close.assert_called_once()
 
+    @mock.patch("qtpy.QtWidgets.QMainWindow.closeEvent")
+    def test_close_no_presenter(self, mock_close_event):
+        self._view._presenter = None
+        self._view.closeEvent(MagicMock())
+        self._view.main_plotter.close.assert_called_once()
+
     def test_add_simple_shape(self):
         self._view.main_plotter.reset_mock()
         mock_mesh = MagicMock()


### PR DESCRIPTION
Only try and close down the presenter if it actually exists. Unclear how one manages to achieve this state but we can protect against it anyway.

Fixes #40727

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

I couldn't reproduce the problem, so probably easiest to just look at the code and try opening/closing the new Instrument View.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
