### PR TITLE
Correctly call and import `get_gauge_vol_str` method from `texture_helper.py`

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/show_sample_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/show_sample_presenter.py
@@ -7,6 +7,7 @@
 #
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.show_sample.show_sample_model import ShowSampleModel
+from Engineering.texture.texture_helper import get_gauge_vol_str
 
 
 class ShowSamplePresenter(object):
@@ -32,6 +33,4 @@ class ShowSamplePresenter(object):
 
     def _set_gauge_vol_str(self):
         if self.include_gauge_volume:
-            self.sample_model.set_gauge_vol_str(
-                self.tab_model.get_gauge_vol_str(self.view.get_shape_method(), self.view.get_custom_shape())
-            )
+            self.sample_model.set_gauge_vol_str(get_gauge_vol_str(self.view.get_shape_method(), self.view.get_custom_shape()))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/test/test_show_sample_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/test/test_show_sample_presenter.py
@@ -22,20 +22,20 @@ class TestShowSamplePresenter(unittest.TestCase):
     def test_init_connects_signal(self):
         self.view.set_on_view_shape_requested.assert_called_once_with(self.presenter._on_view_shape_clicked)
 
-    @patch(dir_path + ".ShowSamplePresenter._view_shape")
+    @patch(dir_path + ".ShowSamplePresenter._view_shape", autospec=True)
     def test_on_view_shape_clicked(self, mock_view_shape):
         ws_name = "test"
         self.presenter._on_view_shape_clicked(ws_name)
-        mock_view_shape.assert_called_with(ws_name, True)
+        mock_view_shape.assert_called_with(self.presenter, ws_name, True)
 
-    @patch(dir_path + ".ShowSamplePresenter._view_shape")
+    @patch(dir_path + ".ShowSamplePresenter._view_shape", autospec=True)
     def test_on_view_reference_shape_clicked(self, mock_view_shape):
         self.model.get_reference_ws.return_value = "ref_ws"
         self.presenter.on_view_reference_shape_clicked()
-        mock_view_shape.assert_called_with("ref_ws", False)
+        mock_view_shape.assert_called_with(self.presenter, "ref_ws", False)
 
-    @patch(dir_path + ".output_settings")
-    @patch(dir_path + ".ShowSamplePresenter._set_gauge_vol_str")
+    @patch(dir_path + ".output_settings", autospec=True)
+    @patch(dir_path + ".ShowSamplePresenter._set_gauge_vol_str", autospec=True)
     def test_view_shape(self, mock_set_gv, mock_settings):
         ws_name, fix_axes = "ws", True
         mock_settings.get_texture_axes_transform.return_value = None, ("a", "b", "c")
@@ -47,7 +47,7 @@ class TestShowSamplePresenter(unittest.TestCase):
         mock_set_gv.assert_called_once()
         self.presenter.sample_model.show_shape_plot.assert_called_with(None, ("a", "b", "c"))
 
-    @patch(dir_path + ".get_gauge_vol_str")
+    @patch(dir_path + ".get_gauge_vol_str", autospec=True)
     def test_set_gauge_vol_str(self, mock_get_gv_str):
         self.presenter.include_gauge_volume = True
         gv_string = "gv"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/test/test_show_sample_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/test/test_show_sample_presenter.py
@@ -47,7 +47,8 @@ class TestShowSamplePresenter(unittest.TestCase):
         mock_set_gv.assert_called_once()
         self.presenter.sample_model.show_shape_plot.assert_called_with(None, ("a", "b", "c"))
 
-    def test_set_gauge_vol_str(self):
+    @patch(dir_path + ".get_gauge_vol_str")
+    def test_set_gauge_vol_str(self, mock_get_gv_str):
         self.presenter.include_gauge_volume = True
         gv_string = "gv"
         # set up mocks
@@ -55,12 +56,12 @@ class TestShowSamplePresenter(unittest.TestCase):
         shape_method, custom_shape = MagicMock(), MagicMock()
         self.view.get_shape_method.return_value = shape_method
         self.view.get_custom_shape.return_value = custom_shape
-        self.model.get_gauge_vol_str.return_value = gv_string
+        mock_get_gv_str.return_value = gv_string
 
         # run
         self.presenter._set_gauge_vol_str()
 
-        self.model.get_gauge_vol_str.assert_called_with(shape_method, custom_shape)
+        mock_get_gv_str.assert_called_with(shape_method, custom_shape)
         self.presenter.sample_model.set_gauge_vol_str.assert_called_with(gv_string)
 
 


### PR DESCRIPTION
### Description of work

As per title and issue, fixes bug found in manual testing.

I've also added `autospec = True` to the patches to try and defend against this sort of bug in future

Closes #40751

### To test:

Follow absorption correction test (test 4 at time of writing but I know the instructions have been updated) in https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html.

Check no error

*This does not require release notes* because fixes a bug in a feature which wasn't in previous release

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
