### PR TITLE
Fix `LoadEmptyInstrument` for more generic Nexus file loading

### DIFF
--- a/Framework/DataHandling/src/LoadEmptyInstrument.cpp
+++ b/Framework/DataHandling/src/LoadEmptyInstrument.cpp
@@ -241,34 +241,18 @@ API::MatrixWorkspace_sptr LoadEmptyInstrument::runLoadInstrument(const std::stri
 // Call LoadIDFFromNexus as a child algorithm
 API::MatrixWorkspace_sptr LoadEmptyInstrument::runLoadIDFFromNexus(const std::string &filename) {
   const std::string instrumentEntryName{"/instrument/instrument_xml"};
-  // There are two possibilities for the parent of the instrument IDF entry
-  const std::string instrumentParentEntryName_1{"mantid_workspace_1"};
-  const std::string instrumentParentEntryName_2{"raw_data_1"};
-  std::string instrumentParentEntryName{instrumentParentEntryName_1};
-
-  // Test if instrument XML definition exists in the file
+  // get the top=level entry name
   bool foundIDF{false};
-  try {
+  std::string instrumentParentEntryName;
+  {
     Nexus::File nxsfile(filename);
-    nxsfile.openAddress("/" + instrumentParentEntryName + instrumentEntryName);
-    foundIDF = true;
-  } catch (Nexus::Exception const &) {
+    instrumentParentEntryName = nxsfile.getTopLevelEntryName();
+    foundIDF = nxsfile.hasAddress(instrumentParentEntryName + instrumentEntryName);
   }
 
   if (!foundIDF) {
-    instrumentParentEntryName = instrumentParentEntryName_2;
-    try {
-      Nexus::File nxsfile(filename);
-      nxsfile.openAddress("/" + instrumentParentEntryName + instrumentEntryName);
-      foundIDF = true;
-    } catch (Nexus::Exception const &) {
-    }
-  }
-
-  if (!foundIDF) {
-    throw std::runtime_error("No instrument XML definition found in " + filename + " at " +
-                             instrumentParentEntryName_1 + instrumentEntryName + " or at " +
-                             instrumentParentEntryName_2 + instrumentEntryName);
+    throw std::runtime_error("No instrument XML definition found in " + filename + " at " + instrumentParentEntryName +
+                             instrumentEntryName);
   }
 
   auto loadInst = createChildAlgorithm("LoadIDFFromNexus");

--- a/Framework/DataHandling/src/LoadEmptyInstrument.cpp
+++ b/Framework/DataHandling/src/LoadEmptyInstrument.cpp
@@ -18,9 +18,6 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/EnumeratedString.h"
 #include "MantidKernel/OptionalBool.h"
-#include "MantidNexus/NexusException.h"
-#include "MantidNexus/NexusFile.h"
-#include "MantidNexusGeometry/NexusGeometryParser.h"
 
 #include <filesystem>
 
@@ -245,9 +242,10 @@ API::MatrixWorkspace_sptr LoadEmptyInstrument::runLoadIDFFromNexus(const std::st
   bool foundIDF{false};
   std::string instrumentParentEntryName;
   {
-    Nexus::File nxsfile(filename);
-    instrumentParentEntryName = nxsfile.getTopLevelEntryName();
-    foundIDF = nxsfile.hasAddress(instrumentParentEntryName + instrumentEntryName);
+    // since we only need to evaluate if a single entry is present, use a lazy descriptor
+    Nexus::NexusDescriptorLazy nxsfile(filename);
+    instrumentParentEntryName = "/" + nxsfile.firstEntryNameType().first;
+    foundIDF = nxsfile.isEntry(instrumentParentEntryName + instrumentEntryName);
   }
 
   if (!foundIDF) {

--- a/Framework/DataHandling/src/LoadEmptyInstrument.cpp
+++ b/Framework/DataHandling/src/LoadEmptyInstrument.cpp
@@ -241,7 +241,7 @@ API::MatrixWorkspace_sptr LoadEmptyInstrument::runLoadInstrument(const std::stri
 // Call LoadIDFFromNexus as a child algorithm
 API::MatrixWorkspace_sptr LoadEmptyInstrument::runLoadIDFFromNexus(const std::string &filename) {
   const std::string instrumentEntryName{"/instrument/instrument_xml"};
-  // get the top=level entry name
+  // get the top-level entry name
   bool foundIDF{false};
   std::string instrumentParentEntryName;
   {

--- a/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
@@ -1210,9 +1210,11 @@ public:
     LoadEmptyInstrument alg;
     alg.initialize();
     alg.setChild(true);
+    alg.setRethrows(true);
     alg.setPropertyValue("Filename", filename1);
     alg.setPropertyValue("OutputWorkspace", "dummy");
     TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
   }
 
 private:

--- a/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
@@ -1204,6 +1204,17 @@ public:
     }
   }
 
+  void test_load_from_nxs() {
+    // this file has top-level name "entry" where instrument is stored
+    std::string const filename1 = "EQSANS_89157.nxs.h5";
+    LoadEmptyInstrument alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setPropertyValue("Filename", filename1);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+  }
+
 private:
   std::string inputFile;
   std::string wsName;

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40755.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40755.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadEmptyInstrument <algm-LoadEmptyInstrument>` will now load instruments from a wider class of NeXus files.


### PR DESCRIPTION
### Description of work

`LoadEmptyInstrument` is supposed to be able to open an instrument from inside a NeXus file.  However, the check was hard-coded to look only at instrument definitions off of "mantid_workspace_1" or "raw_data_1."  Many files instead use "entry", "entry0", or "entry1" as the top-level entry.

This uses functionality of `NexusDescriptorLazy` to retrieve the top-level entry's name, whatever it is, and check for the instrument off of that.  This enables loading more files.

Related to [EWM 14486](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14486)

### To test:

There is a new unit test.

Build and run this script:
``` python
from mantid.simpleapi import LoadEmptyInstrument

filename = "/SNS/SNAP/IPTS-24641/nexus/SNAP_46680.nxs.h5"
ws = LoadEmptyInstrument(filename)
```
Built on `main`, this script will fail, because the instrument XML is stored in "/entry/instrument/instrument_xml".  Built off of this branch, it will pass.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
