### PR TITLE
Save Sample MeshObject to Nexus

### DIFF
--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -297,10 +297,7 @@ void Sample::saveNexus(Nexus::File *file, const std::string &group) const {
   file->putAttr("shape_xml", shapeXML);
 
   if (auto meshObject = std::dynamic_pointer_cast<Mantid::Geometry::MeshObject>(m_shape)) {
-    const int hasMesh = 1;
-    file->writeData("vertices", meshObject->getVertices());
-    file->writeData("faces", meshObject->getTriangles());
-    file->putAttr("shape_mesh", hasMesh);
+    meshObject->saveNexus(file, "shape_mesh");
   }
 
   m_shape->material().saveNexus(file, "material");
@@ -371,29 +368,8 @@ int Sample::loadNexus(Nexus::File *file, const std::string &group) {
     if (!shape_xml.empty()) {
       ShapeFactory shapeMaker;
       m_shape = shapeMaker.createShape(std::move(shape_xml), false /*Don't wrap with <type> tag*/);
-    } else {
-      int hasMesh = 0;
-      if (file->hasAttr("shape_mesh")) {
-        file->getAttr("shape_mesh", hasMesh);
-      }
-
-      if (hasMesh == 1) {
-        std::vector<double> flatVertices;
-        std::vector<uint32_t> faces;
-
-        file->readData("vertices", flatVertices);
-        file->readData("faces", faces);
-
-        const size_t nverts = flatVertices.size() / 3;
-        std::vector<Mantid::Kernel::V3D> vertices;
-        vertices.reserve(nverts);
-        for (size_t i = 0; i < nverts; ++i) {
-          vertices.emplace_back(flatVertices[3 * i + 0], flatVertices[3 * i + 1], flatVertices[3 * i + 2]);
-        }
-
-        m_shape =
-            std::make_shared<Mantid::Geometry::MeshObject>(std::move(faces), std::move(vertices), std::move(material));
-      }
+    } else if (file->hasGroup("shape_mesh", "NXoff_geometry")) {
+      m_shape = Mantid::Geometry::MeshObject::loadNexus(file, "shape_mesh", material);
     }
     // CSGObject expected, if so, set its material
     if (auto csgObj = std::dynamic_pointer_cast<Geometry::CSGObject>(m_shape)) {

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -391,7 +391,8 @@ int Sample::loadNexus(Nexus::File *file, const std::string &group) {
           vertices.emplace_back(flatVertices[3 * i + 0], flatVertices[3 * i + 1], flatVertices[3 * i + 2]);
         }
 
-        m_shape = std::make_shared<Mantid::Geometry::MeshObject>(faces, vertices, material);
+        m_shape =
+            std::make_shared<Mantid::Geometry::MeshObject>(std::move(faces), std::move(vertices), std::move(material));
       }
     }
     // CSGObject expected, if so, set its material

--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -331,9 +331,10 @@ public:
     NexusTestHelper th(true);
     th.createFile("SampleTestMesh.nxs");
 
-    // create single face mesh
-    const std::vector<V3D> vertices{V3D(0.0, 0.0, 0.0), V3D(1.0, 0.0, 0.0), V3D(0.0, 1.0, 0.0)};
-    const std::vector<uint32_t> faces{0, 1, 2};
+    // create tetrahedral mesh
+    const std::vector<V3D> vertices{V3D(0.0, 0.0, 0.0), V3D(1.0, 0.0, 0.0), V3D(0.0, 1.0, 0.0), V3D(0.0, 0.0, 1.0)};
+    // winding order should be CCW from outside the face
+    const std::vector<uint32_t> faces{0, 2, 1, 0, 1, 3, 1, 2, 3, 0, 3, 2};
 
     const Material material;
     IObject_sptr meshShape = std::make_shared<MeshObject>(faces, vertices, material);
@@ -355,6 +356,61 @@ public:
 
     TS_ASSERT_EQUALS(loadedMesh.getVertices(), originalMesh.getVertices());
     TS_ASSERT_EQUALS(loadedMesh.getTriangles(), originalMesh.getTriangles());
+  }
+
+  void test_load_nexus_with_square_faces() {
+    NexusTestHelper th(true);
+    th.createFile("SampleTestMesh.nxs");
+
+    Sample sample;
+    const Material material;
+
+    // create square-based pyramid, with a square face for the base and trangular faces for the others
+    const std::vector<V3D> vertices{V3D(0.0, 0.0, 0.0), V3D(2.0, 0.0, 0.0), V3D(0.0, 2.0, 0.0), V3D(2.0, 2.0, 0.0),
+                                    V3D(2.0, 2.0, 2.0)};
+    // winding order should be CCW from outside the face
+    const std::vector<uint32_t> winding{0, 2, 3, 1, 0, 1, 4, 1, 3, 4, 0, 4, 2, 2, 4, 3};
+    // face inds - where each face starts
+    const std::vector<uint32_t> faceInds{0, 4, 7, 10, 13};
+
+    // for validation this will be loaded as a triangular mesh, so triangulating the square base
+    const std::vector<uint32_t> validationWinding{0, 2, 3, 0, 3, 1, 0, 1, 4, 1, 3, 4, 0, 4, 2, 2, 4, 3};
+
+    const MeshObject validationMesh(validationWinding, vertices, material);
+
+    // to test - we won't set the shape because mantid doesn't support non triangular faces
+    // so we need to create the sample directly in nexus data which can be loaded
+
+    th.file->makeGroup("sample", "NXsample", true);
+    th.file->putAttr("name", "MeshSample");
+    th.file->putAttr("version", 1);
+    th.file->putAttr("shape_xml", std::string(""));
+    material.saveNexus(th.file.get(), "material");
+
+    th.file->makeGroup("shape_mesh", "NXoff_geometry", true);
+    th.file->writeData("vertices",
+                       validationMesh.getVertices()); // convert vector<V3D> into vector<double> for nexus saving
+    th.file->writeData("winding_order", winding);
+    th.file->writeData("faces", faceInds);
+    th.file->closeGroup();
+
+    th.file->writeData("num_other_samples", 0);
+    th.file->writeData("num_oriented_lattice", 0);
+    th.file->closeGroup(); // close sample
+
+    // validate
+
+    th.reopenFile();
+
+    Sample loaded;
+    loaded.loadNexus(th.file.get(), "sample");
+
+    TS_ASSERT_EQUALS(loaded.getName(), "MeshSample");
+
+    const auto &loadedMesh = dynamic_cast<const MeshObject &>(loaded.getShape());
+
+    TS_ASSERT_EQUALS(loadedMesh.getVertices(), validationMesh.getVertices());
+    TS_ASSERT_EQUALS(loadedMesh.getTriangles(), validationMesh.getTriangles());
   }
 
   void test_nexus_empty_name() {

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -500,7 +500,7 @@ set_property(TARGET Geometry PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   Geometry
   PUBLIC Mantid::Kernel Mantid::Beamline MuParser::MuParser
-  PRIVATE Mantid::Json
+  PRIVATE Mantid::Json Mantid::Nexus
 )
 
 if(ENABLE_OPENGL)

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -62,7 +62,7 @@ public:
   /// Assignment operator
   MeshObject &operator=(const MeshObject &) = delete;
   /// Destructor
-  virtual ~MeshObject() = default;
+  virtual ~MeshObject() = default; // cppcheck-suppress missingOverride
   /// Clone
   IObject *clone() const override { return new MeshObject(m_triangles, m_vertices, m_material); }
   IObject *cloneWithMaterial(const Kernel::Material &material) const override {

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -27,6 +27,9 @@ namespace Kernel {
 class PseudoRandomNumberGenerator;
 class V3D;
 } // namespace Kernel
+namespace Nexus {
+class File;
+} // namespace Nexus
 
 namespace Geometry {
 class CompGrp;
@@ -137,6 +140,12 @@ public:
   void multiply(const Kernel::Matrix<double> &);
   void scale(const double scaleFactor);
   void updateGeometryHandler();
+
+  /// Save mesh to an NXoff_geometry group in a NeXus file
+  void saveNexus(Nexus::File *file, const std::string &group) const;
+  /// Load mesh from an NXoff_geometry group in a NeXus file
+  static std::shared_ptr<MeshObject> loadNexus(Nexus::File *file, const std::string &group,
+                                               const Kernel::Material &material);
 
 private:
   void initialize();

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -62,7 +62,7 @@ public:
   /// Assignment operator
   MeshObject &operator=(const MeshObject &) = delete;
   /// Destructor
-  virtual ~MeshObject() = default; // cppcheck-suppress missingOverride
+  ~MeshObject() = default;
   /// Clone
   IObject *clone() const override { return new MeshObject(m_triangles, m_vertices, m_material); }
   IObject *cloneWithMaterial(const Kernel::Material &material) const override {

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -62,7 +62,7 @@ public:
   /// Assignment operator
   MeshObject &operator=(const MeshObject &) = delete;
   /// Destructor
-  ~MeshObject() = default;
+  ~MeshObject() override = default;
   /// Clone
   IObject *clone() const override { return new MeshObject(m_triangles, m_vertices, m_material); }
   IObject *cloneWithMaterial(const Kernel::Material &material) const override {

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
@@ -40,7 +40,7 @@ template <typename Adaptee> std::unique_ptr<Geometry::RenderingMesh> makeRenderi
     size_t numberOfTriangles() const override { return m_adaptee.numberOfTriangles(); }
     std::vector<double> getVertices() const override { return m_adaptee.getVertices(); }
     std::vector<uint32_t> getTriangles() const override { return m_adaptee.getTriangles(); }
-    ~Adapter() = default;
+    ~Adapter() override = default;
   };
   return std::make_unique<Adapter>(adaptee);
 }

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
@@ -40,7 +40,7 @@ template <typename Adaptee> std::unique_ptr<Geometry::RenderingMesh> makeRenderi
     size_t numberOfTriangles() const override { return m_adaptee.numberOfTriangles(); }
     std::vector<double> getVertices() const override { return m_adaptee.getVertices(); }
     std::vector<uint32_t> getTriangles() const override { return m_adaptee.getTriangles(); }
-    virtual ~Adapter() = default;
+    ~Adapter() = default;
   };
   return std::make_unique<Adapter>(adaptee);
 }

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -620,9 +620,9 @@ std::shared_ptr<MeshObject> MeshObject::loadNexus(Nexus::File *file, const std::
     const uint32_t nVertsInFace = end - start;
     // We assume that any polygon face is convex and that we can use a fan triangulation
     for (uint32_t v = 1; v + 1 < nVertsInFace; ++v) {
-      triangles.push_back(windingOrder[start]);
-      triangles.push_back(windingOrder[start + v]);
-      triangles.push_back(windingOrder[start + v + 1]);
+      triangles.push_back(windingOrder.at(start));
+      triangles.push_back(windingOrder.at(start + v));
+      triangles.push_back(windingOrder.at(start + v + 1));
     }
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -118,7 +118,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeom
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:112
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:128
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:169
-missingOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h:62
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h:43
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h:80
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h:75

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -118,7 +118,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeom
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:112
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:128
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h:169
-missingOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h:43
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h:80
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h:75
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Surfaces/Sphere.h:72

--- a/docs/source/release/v6.16.0/Framework/Data_Objects/New_features/40761.rst
+++ b/docs/source/release/v6.16.0/Framework/Data_Objects/New_features/40761.rst
@@ -1,0 +1,1 @@
+- Sample Shapes generated from ``.STL`` mesh files can now be saved and loaded from nexus files.


### PR DESCRIPTION
### Description of work

Currently the only sample/environment shape information that is saved to a nexus file is the sample shape if it is a CSG shape. I have extended it to now also handle mesh shapes.

This is discussed in #28581 but this does not close that issue as I haven't added handling for the environment.

I would have liked to use some more of the existing tools, specifically the NX_OFF and the `NexusGeometryParser` discussed in the issue, but they cannot be brought into API::Sample (at least, I couldn't do it).

The solution I gone with seems deceptively simple, just saving the vertices and face arrays directly. Upon loading I just reconstruct the MeshObject by reading these arrays. I do have some uncertainty about the scope and ownership of the newly created object, but my hope is that the `std::make_shared<Mantid::Geometry::MeshObject>` takes care of that. 

### To test:
run the following script
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# update the paths for the mantid build directory and some temporary directory to save a file to
build_dir = r"C:\Users\kcd17618\Documents\dev\mantid\build"
tmp_dir = r"C:\Users\kcd17618\Documents\TestingTMP"

# test by loading a file without a shape, adding mesh from stl, saving, loading and checking for shape mesh 
ws = Load(fr"{build_dir}\ExternalData\Testing\Data\SystemTest\Texture\ValidationFiles\Focus\ENGINX_364901_361838_Texture30_dSpacing.nxs")

ws = LoadSampleShape(ws, Filename = fr"{build_dir}\ExternalData\Testing\Data\UnitTest\cube.stl")

SaveNexus(ws, Filename = fr"{tmp_dir}\test_ws.nxs")

reload_ws = Load(Filename = fr"{tmp_dir}\test_ws.nxs")

print("ws mesh: ", ws.sample().getShape().getMesh(), " new_ws mesh: ",reload_ws.sample().getShape().getMesh())
```

#### If you have any other ideas of where this might break things please test/ let me know

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
