### PR TITLE
Fix crash in Stretch tab of bayes fitting interface

### DIFF
--- a/docs/source/release/v6.15.0/Inelastic/Bugfixes/40730.rst
+++ b/docs/source/release/v6.15.0/Inelastic/Bugfixes/40730.rst
@@ -1,1 +1,1 @@
-- Fix a bug in the `Stretch` tab of  :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` that caused Mantid to crash when trying to run the algorithm from the interface using the `quickbayes` option.
+- Fix a bug in the ``Stretch`` tab of  :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` that caused Mantid to crash when trying to run the algorithm from the interface using the ``quickbayes`` option.

--- a/docs/source/release/v6.15.0/Inelastic/Bugfixes/40730.rst
+++ b/docs/source/release/v6.15.0/Inelastic/Bugfixes/40730.rst
@@ -1,0 +1,1 @@
+- Fix a bug in the `Stretch` tab of  :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` that caused Mantid to crash when trying to run the algorithm from the interface using the `quickbayes` option.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
@@ -134,6 +134,9 @@ void QuasiView::setupFitOptions(bool useQuickBayes) {
 }
 
 void QuasiView::setupPropertyBrowser(bool useQuickBayes) {
+  auto const EMin = m_properties.contains("EMin") ? m_properties["EMin"]->valueText().toDouble() : 0.0;
+  auto const EMax = m_properties.contains("EMax") ? m_properties["EMax"]->valueText().toDouble() : 0.0;
+
   m_properties.clear();
   m_dblManager->clear();
   m_propTree->clear();
@@ -144,6 +147,8 @@ void QuasiView::setupPropertyBrowser(bool useQuickBayes) {
 
   m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
   m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
+  m_dblManager->setValue(m_properties["EMin"], EMin);
+  m_dblManager->setValue(m_properties["EMax"], EMax);
 
   m_propTree->addProperty(m_properties["EMin"]);
   m_propTree->addProperty(m_properties["EMax"]);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -46,7 +46,7 @@ void StretchPresenter::handleRun() {
 
   m_view->setPlotADSEnabled(false);
 
-  StretchRunData algParams = m_view->getRunData();
+  StretchRunData algParams = m_view->getRunData(m_useQuickBayes);
 
   auto const cutIndex = algParams.sampleName.find_last_of("_");
   auto const baseName = algParams.sampleName.substr(0, cutIndex);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
@@ -125,6 +125,10 @@ void StretchView::setupFitOptions(bool useQuickBayes) {
 }
 
 void StretchView::setupPropertyBrowser(bool useQuickBayes) {
+  auto const EMin = m_properties.contains("EMin") ? m_properties["EMin"]->valueText().toDouble() : 0.0;
+  auto const EMax = m_properties.contains("EMax") ? m_properties["EMax"]->valueText().toDouble() : 0.0;
+  auto const beta = m_properties.contains("Beta") ? m_properties["Beta"]->valueText().toInt() : 50;
+
   m_properties.clear();
   m_dblManager->clear();
   m_propTree->clear();
@@ -138,12 +142,14 @@ void StretchView::setupPropertyBrowser(bool useQuickBayes) {
   m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
   m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
   m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
+  m_dblManager->setValue(m_properties["EMin"], EMin);
+  m_dblManager->setValue(m_properties["EMax"], EMax);
 
   m_propTree->addProperty(m_properties["EMin"]);
   m_propTree->addProperty(m_properties["EMax"]);
   m_propTree->addProperty(m_properties["Beta"]);
 
-  m_dblManager->setValue(m_properties["Beta"], 50);
+  m_dblManager->setValue(m_properties["Beta"], beta);
   m_dblManager->setMinimum(m_properties["Beta"], 1);
   m_dblManager->setMaximum(m_properties["Beta"], 200);
 
@@ -252,9 +258,7 @@ void StretchView::validateUserInput(IUserInputValidator *validator) const {
   validator->checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 }
 
-StretchRunData StretchView::getRunData() const {
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-
+StretchRunData StretchView::getRunData(bool useQuickBayes) const {
   auto const sampleName = m_uiForm.dsSample->getCurrentDataName().toStdString();
   auto const resName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
 
@@ -266,9 +270,14 @@ StretchRunData StretchView::getRunData() const {
 
   auto const elasticPeak = m_uiForm.chkElasticPeak->isChecked();
 
-  auto const sigma = !useQuickBayes ? m_properties["Sigma"]->valueText().toInt() : 0;
-  auto const nBins = !useQuickBayes ? m_properties["SampleBinning"]->valueText().toInt() : 0;
-  auto const sequence = !useQuickBayes ? m_uiForm.chkSequentialFit->isChecked() : false;
+  int sigma = 0;
+  int nBins = 0;
+  bool sequence = false;
+  if (!useQuickBayes) {
+    sigma = m_properties["Sigma"]->valueText().toInt();
+    nBins = m_properties["SampleBinning"]->valueText().toInt();
+    sequence = m_uiForm.chkSequentialFit->isChecked();
+  }
 
   return StretchRunData(sampleName, resName, eMin, eMax, beta, elasticPeak, background, sigma, nBins, sequence);
 }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
@@ -37,7 +37,7 @@ public:
   virtual void applySettings(std::map<std::string, QVariant> const &settings) = 0;
   virtual void validateUserInput(IUserInputValidator *validator) const = 0;
 
-  virtual StretchRunData getRunData() const = 0;
+  virtual StretchRunData getRunData(bool useQuickBayes) const = 0;
   virtual CurrentPreviewData getCurrentPreviewData() const = 0;
   virtual std::string getPlotType() const = 0;
   virtual std::string getPlotContour() const = 0;
@@ -74,7 +74,7 @@ public:
   void applySettings(std::map<std::string, QVariant> const &settings) override;
   void validateUserInput(IUserInputValidator *validator) const override;
 
-  StretchRunData getRunData() const override;
+  StretchRunData getRunData(bool useQuickBayes) const override;
   CurrentPreviewData getCurrentPreviewData() const override;
   std::string getPlotType() const override;
   std::string getPlotContour() const override;

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/MockObjects.h
@@ -35,7 +35,7 @@ public:
   MOCK_METHOD(void, applySettings, ((std::map<std::string, QVariant> const &settings)), (override));
   MOCK_METHOD(void, validateUserInput, (IUserInputValidator * validator), (const, override));
 
-  MOCK_METHOD(StretchRunData, getRunData, (), (const, override));
+  MOCK_METHOD(StretchRunData, getRunData, (bool useQuickBayes), (const, override));
   MOCK_METHOD(CurrentPreviewData, getCurrentPreviewData, (), (const, override));
   MOCK_METHOD(std::string, getPlotType, (), (const, override));
   MOCK_METHOD(std::string, getPlotContour, (), (const, override));

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -93,7 +93,7 @@ public:
 
     StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
 
-    ON_CALL(*m_view, getRunData()).WillByDefault(Return(runData));
+    ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
 
     EXPECT_CALL(*m_view, setPlotADSEnabled(false)).Times(1);
 
@@ -105,7 +105,7 @@ public:
   void test_handleRun_with_valid_input_and_savedir() {
     StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
 
-    ON_CALL(*m_view, getRunData()).WillByDefault(Return(runData));
+    ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_view, setPlotADSEnabled(false)).Times(1);
 
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, _)).Times(1);
@@ -124,7 +124,7 @@ public:
     ads.addOrReplace(fitWorkspaceName, m_workspace);
     ads.addOrReplace(contourWorkspaceName, m_workspace);
 
-    ON_CALL(*m_view, getRunData()).WillByDefault(Return(runData));
+    ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_view, setPlotADSEnabled(false)).Times(1);
 
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, _)).Times(1);
@@ -153,13 +153,16 @@ public:
   void test_notifyBackendChanged_changes_stretchAlgorithm_call() {
     StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
 
-    ON_CALL(*m_view, getRunData()).WillByDefault(Return(runData));
+    EXPECT_CALL(*m_view, getRunData(true)).Times(1);
+    ON_CALL(*m_view, getRunData(true)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, true)).Times(1);
 
     m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
     m_presenter->handleRun();
 
+    EXPECT_CALL(*m_view, getRunData(false)).Times(1);
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, false)).Times(1);
+    ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
 
     m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
     m_presenter->handleRun();


### PR DESCRIPTION
Fix #40730 , found in manual testing. 
When running the bayes fitting on quickbayes, some deleted m_properties were trying to be accessed, causing the segfault. 
Additionally, the previously entered Emin and Emax properties on the fit property browser are remembered if you change from quasielastic to quickbayes, otherwise they reset to 0. 

Added release notes. 

### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40730. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Run stretch tab instructions : https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html  with quickbayes selected(try to change the beta parameter to a low value like 2, as quickbayes does a grid with beta values and it can take a very long time to finish)
- Reduction should not crash. 


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
