### PR TITLE
Add link to sha that the docs come from

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -48,6 +48,9 @@ echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/DocTest/' >> $WORKSPACE
 export LC_ALL=C
 QT_QPA_PLATFORM=offscreen pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build cmake --build . --target docs-html
 
+SHA1=$(git rev-parse HEAD) # full sha for this source repository
+SHA1_SHORT=$(git rev-parse --short HEAD) # full sha for this source repository
+
 # Publish. Clone current docs to publish directory
 # and rsync between built html in html directory and current
 # docs in publish. This will ensure documents are deleted in the
@@ -60,5 +63,5 @@ pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build rsync --archive 
 git config user.name ${GIT_USER_NAME}
 git config user.email ${GIT_USER_EMAIL}
 git add .
-git commit -m "Publish nightly documentation" || exit 0
+git commit -m "Publish nightly documentation from [${SHA1_SHORT}](https://github.com/mantidproject/mantid/commit/${SHA1})" || exit 0
 git push https://${GITHUB_ACCESS_TOKEN}@github.com/mantidproject/docs-nightly main


### PR DESCRIPTION
While trying to track down an issue with the nightly docs (#40674), it was difficult to determine where the new docs came from since all of the commit messages in the documentation site repository are identically "Publish nightly documentation". This adds a link to the commit in the source repository.

There is no associated issue.

### To test:

The best test would be to see this run in a nightly build and look at the commit comment in https://github.com/mantidproject/docs-nightly/. However, you can look at the functionality/format by running the new lines in a terminal from bash (copy-pasted)
```sh
SHA1=$(git rev-parse HEAD) # full sha for this source repository
SHA1_SHORT=$(git rev-parse --short HEAD) # full sha for this source repository
echo "Publish nightly documentation from [${SHA1_SHORT}](https://github.com/mantidproject/mantid/commit/${SHA1})"
```
then navigate to the link that is printed. Also see that the commit message is formated in markdown.

*This does not require release notes* because it is annotating build results

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
