### PR TITLE
Handle spaces in multiple file property

### DIFF
--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -44,14 +44,14 @@ const std::string INVALID = R"(\+\+|,,|\+,|,\+)";
 static const boost::regex REGEX_INVALID(INVALID);
 
 // Regular expressions that represent the allowed instances of , operators
-const std::string NUM_COMMA_ALPHA(R"((?<=\d)\s*,\s*(?=\D))");
-const std::string ALPHA_COMMA_ALPHA(R"((?<=\D)\s*,\s*(?=\D))");
+const std::string NUM_COMMA_ALPHA(R"((?<=\d)\s*,\s*(?=[a-zA-Z]))");
+const std::string ALPHA_COMMA_ALPHA(R"((?<=\D)\s*,\s*(?=[a-zA-Z]))");
 const std::string COMMA_OPERATORS = NUM_COMMA_ALPHA + "|" + ALPHA_COMMA_ALPHA;
 static const boost::regex REGEX_COMMA_OPERATORS(COMMA_OPERATORS);
 
 // Regular expressions that represent the allowed instances of + operators
-const std::string NUM_PLUS_ALPHA(R"((?<=\d)\s*\+\s*(?=\D))");
-const std::string ALPHA_PLUS_ALPHA(R"((?<=\D)\s*\+\s*(?=\D))");
+const std::string NUM_PLUS_ALPHA(R"((?<=\d)\s*\+\s*(?=[a-zA-Z]))");
+const std::string ALPHA_PLUS_ALPHA(R"((?<=\D)\s*\+\s*(?=[a-zA-Z]))");
 const std::string PLUS_OPERATORS = NUM_PLUS_ALPHA + "|" + ALPHA_PLUS_ALPHA;
 static const boost::regex REGEX_PLUS_OPERATORS(PLUS_OPERATORS, boost::regex_constants::perl);
 

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -253,6 +253,7 @@ std::string MultipleFileProperty::setValueAsMultipleFiles(const std::string &pro
 
   for (; commaToken != end; ++commaToken) {
     const std::string commaTokenString = commaToken->str();
+    g_log.debug() << "1: commaTokenString: " << commaTokenString << "\n";
 
     // Tokenise on allowed plus operators.
     boost::sregex_token_iterator plusToken(commaTokenString.begin(), commaTokenString.end(), REGEX_PLUS_OPERATORS, -1);
@@ -267,6 +268,7 @@ std::string MultipleFileProperty::setValueAsMultipleFiles(const std::string &pro
 
     m_parser.setTrimWhiteSpaces(autoTrim()); // keep trimming whitespaces in parser consistent with this property
     for (auto &plusTokenString : plusTokenStrings) {
+      g_log.debug() << "2: plusTokenString: " << plusTokenString << "\n";
       try {
         m_parser.parse(plusTokenString);
       } catch (const std::range_error &re) {
@@ -278,6 +280,12 @@ std::string MultipleFileProperty::setValueAsMultipleFiles(const std::string &pro
       }
 
       std::vector<std::vector<std::string>> f = m_parser.fileNames();
+      for (const auto &f1 : f) {
+        for (const auto &f2 : f1) {
+          g_log.debug() << "f: " << f2 << "\n";
+        }
+        g_log.debug() << "f:\n";
+      }
 
       // If there are no files, then we should keep this token as it was passed
       // to the property, in its untampered form. This will enable us to deal
@@ -309,6 +317,13 @@ std::string MultipleFileProperty::setValueAsMultipleFiles(const std::string &pro
 
     fileNames.insert(fileNames.end(), std::make_move_iterator(temp.begin()), std::make_move_iterator(temp.end()));
   }
+
+  g_log.debug() << "2: filenames " << fileNames.size() << "\n";
+  for (const auto &fileName1 : fileNames) {
+    for (const auto &fileName : fileName1)
+      g_log.debug() << ">    " << fileName << "\n";
+    g_log.debug() << ">\n";
+  };
 
   std::vector<std::vector<std::string>> allUnresolvedFileNames = fileNames;
   std::vector<std::vector<std::string>> allFullFileNames;

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -184,6 +184,7 @@ public:
     p.setValue(dummyFile("TSC1.raw"));
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -192,6 +193,7 @@ public:
     p.setValue(dummyFile("1.raw"));
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -200,6 +202,7 @@ public:
     p.setValue(dummyFile("TSC1"));
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -208,6 +211,7 @@ public:
     p.setValue(dummyFile("1"));
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -216,6 +220,7 @@ public:
     p.setValue("TSC1.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -224,6 +229,7 @@ public:
     p.setValue("1.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -232,6 +238,7 @@ public:
     p.setValue("TSC1");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -240,6 +247,7 @@ public:
     p.setValue("1");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -248,6 +256,7 @@ public:
     p.setValue("TSC001.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -256,6 +265,7 @@ public:
     p.setValue("TSC000000000001.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
   }
 
@@ -264,6 +274,7 @@ public:
     p.setValue("TSC9999999.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC9999999.raw"));
   }
 
@@ -289,6 +300,7 @@ public:
     p.setValue("IRS10001-10005_graphite002_info.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("IRS10001-10005_graphite002_info.nxs"));
   }
 
@@ -297,6 +309,7 @@ public:
     p.setValue("bl6_flux_at_sample");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("bl6_flux_at_sample"));
   }
 
@@ -305,6 +318,7 @@ public:
     p.setValue("TSC1,2,3,4,5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -317,6 +331,7 @@ public:
     p.setValue("TSC1+2+3+4+5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -329,6 +344,7 @@ public:
     p.setValue("TSC1:5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -341,6 +357,7 @@ public:
     p.setValue("TSC1-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -353,6 +370,7 @@ public:
     p.setValue("TSC1:5:2.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 3);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00003.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00005.raw"));
@@ -363,6 +381,7 @@ public:
     p.setValue("TSC1-5:2.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00003.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00005.raw"));
@@ -373,6 +392,7 @@ public:
     p.setValue("TSC1,2:5,1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 7);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -391,6 +411,7 @@ public:
     p.setValue("TSC1-2+4-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00004.raw"));
@@ -402,6 +423,7 @@ public:
     p.setValue("TSC2+4-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00004.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00005.raw"));
@@ -412,6 +434,7 @@ public:
     p.setValue("TSC1-2+5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00005.raw"));
@@ -422,6 +445,7 @@ public:
     p.setValue("TSC1.raw,TSC2.raw,TSC3.raw,TSC4.raw,TSC5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -434,6 +458,7 @@ public:
     p.setValue("TSC1.raw+TSC2.raw+TSC3.raw+TSC4.raw+TSC5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -447,6 +472,7 @@ public:
                "IRS10003_graphite002_info.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 2);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("IRS10001_graphite002_info.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("IRS10002_graphite002_info.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("IRS10003_graphite002_info.nxs"));
@@ -457,6 +483,7 @@ public:
     p.setValue("TSC1,2.raw,TSC3,4,5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -469,6 +496,7 @@ public:
     p.setValue("TSC1,2.raw,TSC3:5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -485,6 +513,7 @@ public:
     p.setValue("TSC1-5:1.raw,IRS1-5:1.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 2);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -503,6 +532,7 @@ public:
     p.setValue("TSC1-5:1,IRS1-5:1");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 2);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -520,6 +550,7 @@ public:
     p.setValue("IRS1-5:1,TSC1-5:1.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 2);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("IRS00001.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("IRS00002.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("IRS00003.nxs"));
@@ -537,6 +568,7 @@ public:
     p.setValue("TSC1,2:5.raw,TSC1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 7);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -555,6 +587,7 @@ public:
     p.setValue("TSC1,2:5.raw,IRS10001_graphite002_info.nxs,TSC1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 8);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.raw"));
@@ -582,6 +615,7 @@ public:
     p.setValue("TSC1+2.raw+TSC3+4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.raw"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.raw"));
@@ -619,6 +653,7 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.nxs"));
@@ -632,6 +667,7 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.nxs"));
@@ -645,6 +681,7 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 5);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00002.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[2][0]), dummyFile("TSC00003.nxs"));
@@ -657,6 +694,7 @@ public:
     p.setValue("1-5, 3-4");
     std::vector<std::vector<std::string>> fileNames = p();
 
+    TS_ASSERT_EQUALS(fileNames.size(), 2);
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.nxs"));

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -339,6 +339,19 @@ public:
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][4]), dummyFile("TSC00005.raw"));
   }
 
+  void test_multipleFiles_shortForm_plusList_different_instrument_and_space() {
+    MultipleFileProperty p("Filename");
+    p.setValue("IRS1+2+3+4+ 5.raw");
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames.size(), 1);
+    TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("IRS00001.raw"));
+    TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("IRS00002.raw"));
+    TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("IRS00003.raw"));
+    TS_ASSERT_EQUALS(normalizePath(fileNames[0][3]), dummyFile("IRS00004.raw"));
+    TS_ASSERT_EQUALS(normalizePath(fileNames[0][4]), dummyFile("IRS00005.raw"));
+  }
+
   void test_multipleFiles_shortForm_range() {
     MultipleFileProperty p("Filename");
     p.setValue("TSC1:5.raw");
@@ -702,6 +715,26 @@ public:
     TS_ASSERT_EQUALS(normalizePath(fileNames[0][4]), dummyFile("TSC00005.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00003.nxs"));
     TS_ASSERT_EQUALS(normalizePath(fileNames[1][1]), dummyFile("TSC00004.nxs"));
+  }
+
+  void test_multipleFiles_ranges_instrument_consistent_with_spaces() {
+    g_config.setString("default.facility", "ISIS");
+    g_config.setString("default.instrument", "IRS");
+    for (auto &file_string : {"TSC1-3,3-4", "TSC1-3, 3-4"}) {
+      MultipleFileProperty p("Filename");
+      p.setValue(file_string);
+      std::vector<std::vector<std::string>> fileNames = p();
+
+      TS_ASSERT_EQUALS(fileNames.size(), 2);
+      TS_ASSERT_EQUALS(normalizePath(fileNames[0][0]), dummyFile("TSC00001.nxs"));
+      TS_ASSERT_EQUALS(normalizePath(fileNames[0][1]), dummyFile("TSC00002.nxs"));
+      TS_ASSERT_EQUALS(normalizePath(fileNames[0][2]), dummyFile("TSC00003.nxs"));
+      TS_ASSERT_EQUALS(normalizePath(fileNames[1][0]), dummyFile("TSC00003.nxs"));
+      TS_ASSERT_EQUALS(normalizePath(fileNames[1][1]), dummyFile("TSC00004.nxs"));
+    }
+
+    g_config.setString("default.facility", "ISIS");
+    g_config.setString("default.instrument", "TOSCA");
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description of work

DO NOT MERGE yet, still has debugging code

This changes the regular expression used to separate groups of filenames to be more robust against spaces after commas.

It results in `POLARIS146554, 146603-146609, 146616` being treated the same as `POLARIS146554,146603-146609,146616`. This is a change from the current behaviour which would treat it as `POLARIS146554, XXX146603-146609, XXX146616` where `XXX` is the current default instrument.

The previous regex used to find the commas that separate groups of files from separate instruments:
`NUM_COMMA_ALPHA(R"((?<=\d)\s*,\s*(?=\D))")`
uses a lookahead with `\D` to find a comma followed by something that did not start with a digit. E.g. this would match the comma in `,ALF123` but not `,123`. The bug is that it also matches `, 123` because the space is a non-digit character. Because we now have a group with a filename that starts with a number, the default instrument is assumed.

This fix replaces `\D` with `[a-zA-Z]` so that a new group is only started if there is a new instrument name.


Related to #40648
Closes #40793

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
