### PR TITLE
Set system test threads default based on CPU count

### DIFF
--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -24,7 +24,9 @@ XVFB_SERVER_NUM=101
 if [[ -z "$BUILD_THREADS_SYSTEM_TESTS" ]]; then
     # Default to a 3/16 fraction of the build threads, e.g. 8 for a 32-core machine,
     # to allow enough RAM for concurrently running system tests.
-    BUILD_THREADS_SYSTEM_TESTS=$((BUILD_THREADS * 3 / 16))
+    BUILD_THREADS_SYSTEM_TESTS=$(( BUILD_THREADS * 3 / 16 ))
+    # Ensure at least 1 thread
+    (( BUILD_THREADS_SYSTEM_TESTS < 1 )) && BUILD_THREADS_SYSTEM_TESTS=1
 fi
 
 # Jenkins nodes may specify the maximum number of unit tests to run in parallel.

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -20,10 +20,11 @@ BUILD_THREADS=$6
 
 XVFB_SERVER_NUM=101
 
-# If this isn't specified for a Jenkins agent, revert to default value
+# If this isn't specified for a machine, revert to default value
 if [[ -z "$BUILD_THREADS_SYSTEM_TESTS" ]]; then
-    # Default to 3 system tests running in parallel, assuming builders have >= 32GB RAM
-    BUILD_THREADS_SYSTEM_TESTS=3
+    # Default to a 3/16 fraction of the build threads, e.g. 8 for a 32-core machine,
+    # to allow enough RAM for concurrently running system tests.
+    BUILD_THREADS_SYSTEM_TESTS=$((BUILD_THREADS * 3 / 16))
 fi
 
 # Jenkins nodes may specify the maximum number of unit tests to run in parallel.


### PR DESCRIPTION
### Description of work
In Jenkins, we set the value of `BUILD_THREADS_SYSTEM_TESTS` per machine to define how many system test to run in parallel. This adds logic to set a sensible default value of 3/16 multiplied by the core count.


### To test:
This is running on a github self-hosted runner here:
https://github.com/thomashampson/mantid_github_actions_test/pull/3
And here is the run with this change in it:
https://github.com/thomashampson/mantid_github_actions_test/actions/runs/21756642425/job/62768649276?pr=3
The runner has 32 cores, check that the number of system test threads is 6. This currently what we set it to for our Jenkins agents for 32-core machines.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
