### PR TITLE
Patch memory leaks in two tests in `GeometryTest`

### DIFF
--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -164,6 +164,7 @@ public:
     TS_ASSERT_THROWS(i.markAsSamplePos(sss), const std::runtime_error &);
     delete s;
     delete ss;
+    delete sss;
   }
 
   void testBeamDirection() { TS_ASSERT_EQUALS(instrument.getBeamDirection(), V3D(0, 0, 1)); }

--- a/Framework/Geometry/test/XMLInstrumentParameterTest.h
+++ b/Framework/Geometry/test/XMLInstrumentParameterTest.h
@@ -109,6 +109,7 @@ public:
     // roi->addROI("2000-11-30T01:01:04", "2000-11-30T01:01:08");
     // const double secondFilteredValue = logFile->createParamValue(&series, secondRoi);
     // TSM_ASSERT_EQUALS("Filtering by Maximum is not performed correctly", secondExpectedValue, secondFilteredValue);
+    delete roi;
   }
 
   void test_filter_by_minimum_value() {
@@ -132,6 +133,7 @@ public:
     // roi->addROI("2000-11-30T01:01:02", "2000-11-30T01:01:08");
     // const double secondFilteredValue = logFile->createParamValue(&series, secondRoi);
     // TSM_ASSERT_EQUALS("Filtering by Minimum is not performed correctly", secondExpectedValue, secondFilteredValue);
+    delete roi;
   }
 
   void test_filter_by_mean_value() {
@@ -168,6 +170,7 @@ public:
     const double median = logFile->createParamValue(&series, roi);
     const double expected = 1.5; // middle of sequence 0, 1, 2, 4. Value 5 is excluded by the ROI
     TSM_ASSERT_DELTA("Filtering by Median is not performed correctly", median, expected, 0.1);
+    delete roi;
   }
 
   // This functionality will soon be legacy, since filtering by nth-position is


### PR DESCRIPTION
### Description of work

Mantid's use of memory for holding instruments causes some instruments (such as IMAGINE with 20million pixels) to be so large as to be unreadable except on supercomputers.

While investigating if a leak might be responsible, I built the `GeometryTest` target with the address sanitizers turned on to look for errors.  These two tests showed consistent memory leaks errors.  However, they were isolated to the tests, and adding the `delete`s fixes them.

Found during work on [EWM 14486](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14486).

### To test:

Build with the address sanitizer turned on.  See detailed [instructions here](https://developer.mantidproject.org/RunningSanitizers.html#command-line).

From command line:
``` bash
cmake . -DUSE_SANITIZER=Address -DCMAKE_BUILD_TYPE=RelWithDebInfo
echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
ninja GeometryTest && ctest -R GeometryTest
```

NOTE the middle command, which is necessary on Linux systems to turn off the memory address randomizer, which will conflict with the address sanitizer.

Run from `main`, you will get failures in two tests.  Run from this branch, there will be no failures.

When you are done, run
``` bash
echo 2 | sudo tee /proc/sys/kernel/randomize_va_space
cmake . --DUSE_SANITIZER=OFF
```
to reenable memory randomization.

*This does not require release notes* because it is inside of a unit test and invisible to users.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
