### PR TITLE
Add missing parameter in Stretch Tab of Bayes Fitting Interface

### DIFF
--- a/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
@@ -26,8 +26,16 @@ Settings
   Opens this help page.
 
 Backend selection box
-  This drop down selects whether to use the ``quasielasticbayes`` or ``quickbayes``
-  package as the underlying model for the Quasi and Stretch tabs.
+  This drop down selects whether to use the ``quasielasticbayes`` or ``quickbayes`` package as the underlying model for
+  the Quasi and Stretch tabs.
+
+  +------------------------+-----------------------------------------------------------------------------------+
+  | Backend selected       | Underlying algorithms                                                             |
+  +========================+===================================================================================+
+  | ``quasielasticbayes``  | :ref:`BayesQuasi <algm-BayesQuasi>`   & :ref:`BayesStretch <algm-BayesStretch>`   |
+  +------------------------+-----------------------------------------------------------------------------------+
+  | ``quickbayes``         | :ref:`BayesQuasi2 <algm-BayesQuasi2>` & :ref:`BayesStretch2 <algm-BayesStretch2>` |
+  +------------------------+-----------------------------------------------------------------------------------+
 
 Manage Directories
   Opens the Manage Directories dialog allowing you to change your search directories
@@ -55,30 +63,25 @@ algorithm.
 Options
 ~~~~~~~
 
-Vanadium File
-  Either a reduced file created using the Energy Transfer tab or an
-  :math:`S(Q, \omega)` file.
-
-Resolution File
-  A resolution file created using the Calibrtion tab.
-
-EMin & EMax
-  The energy range to perform fitting within.
-
-Preview Spectrum
-  Changes the spectrum displayed in the preview plot.
-
-Plot Current Preview
-  Plots the currently selected preview plot in a separate external window
-
-Run
-  Runs the processing configured on the current tab.
-
-Plot
-  Plots the selected parameter stored in the result workspaces.
-
-Save Result
-  Saves the result in the default save directory.
++----------------------+--------------------------------------------------------------------------------------------+
+| Parameter            | Description                                                                                |
++======================+============================================================================================+
+| Vanadium File        | Either a reduced file created using the Energy Transfer tab or a :math:`S(Q, \omega)` file |
++----------------------+--------------------------------------------------------------------------------------------+
+| Resolution File      | A resolution file created using the Calibration Tab                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot Current Preview | Plots the currently selected preview plot in a separate external window                    |
++----------------------+--------------------------------------------------------------------------------------------+
+| EMin & EMax          | The energy range to perform fitting within                                                 |
++----------------------+--------------------------------------------------------------------------------------------+
+| Preview Spectrum     | Changes the spectrum displayed in the preview plot                                         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Run                  | Runs the processing configured on the current tab                                          |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot                 | Plots the selected parameter stored in the result workspaces                               |
++----------------------+--------------------------------------------------------------------------------------------+
+| Save Result          | Saves the result in the default save directory                                             |
++----------------------+--------------------------------------------------------------------------------------------+
 
 Quasi
 -----
@@ -113,61 +116,49 @@ of spectra.
 Options
 ~~~~~~~
 
-Sample
-  Either a reduced file created using the Energy Transfer tab or an
-  :math:`S(Q, \omega)` file.
-
-Resolution
-  A resolution file created using the Calibration tab.
-
-Program
-  The curve fitting program to use.
-
-Background
-  The background fitting program to use.
-
-Elastic Peak
-  If an elastic peak should be used.
-
-Sequential Fit
-  Enables multiple fitting iterations.
-
-Fix Width
-  Allows selection of a width file.
-
-Use ResNorm
-  Allows selection of a ResNorm output file or workspace to use with fitting.
-
-EMin & EMax
-  The energy range to perform fitting within.
-
-Sample Binning
-  Sample binning to use.
-
-Resolution Binning
-  Resolution binning to use.
-
-Preview Spectrum
-  Changes the spectrum displayed in the preview plot.
-
-Plot Current Preview
-  Plots the currently selected preview plot in a separate external window
-
-Run
-  Runs the processing configured on the current tab.
-
-Plot
-  Plots the selected parameter stored in the result workspaces.
-
-Save Result
-  Saves the result in the default save directory.
++----------------------+--------------------------------------------------------------------------------------------+
+| Parameter            | Description                                                                                |
++======================+============================================================================================+
+| Sample               | Either a reduced file created using the Energy tab or a :math:`S(Q, \omega)` file.         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Resolution           | A resolution file created using the Calibration Tab                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Program              | The curve fitting program to use                                                           |
++----------------------+--------------------------------------------------------------------------------------------+
+| Background           | The background fitting program to use                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
+| Elastic Peak         | If an elastic peak should be used                                                          |
++----------------------+--------------------------------------------------------------------------------------------+
+| Sequential Fit       | Enabled multiple fitting iterations                                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot Current Preview | Plots the currently selected preview plot in a separate external window                    |
++----------------------+--------------------------------------------------------------------------------------------+
+| Fix Width            | Allows selection of a width file                                                           |
++----------------------+--------------------------------------------------------------------------------------------+
+| Use ResNorm          | Allows selection of a ResNorm output file or workspace to use with fitting                 |
++----------------------+--------------------------------------------------------------------------------------------+
+| EMin & EMax          | The energy range to perform fitting within                                                 |
++----------------------+--------------------------------------------------------------------------------------------+
+| Sample Binning       | Sample binning to use                                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
+| Resolution Binning   | Resolution binning to use                                                                  |
++----------------------+--------------------------------------------------------------------------------------------+
+| Preview Spectrum     | Changes the spectrum displayed in the preview plot                                         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Run                  | Runs the processing configured on the current tab                                          |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot                 | Plots the selected parameter stored in the result workspaces                               |
++----------------------+--------------------------------------------------------------------------------------------+
+| Save Result          | Saves the result in the default save directory                                             |
++----------------------+--------------------------------------------------------------------------------------------+
 
 Stretch
 -------
 
 This is a variation of the stretched exponential option of Quasi. For each
 spectrum, a fit is performed for a grid of β and σ values. The distribution of
-goodness of fit values is plotted.
+goodness of fit values is plotted. Some of the options change depending on the underlying
+model selected.
 
 .. interface:: Bayes Fitting
   :widget: Stretch
@@ -175,50 +166,58 @@ goodness of fit values is plotted.
 Options
 ~~~~~~~
 
-Sample
-  Either a reduced file created using the Energy Transfer tab or an
-  :math:`S(Q, \omega)` file.
+There are some parameters exclusive of either ``quasielasticbayes`` or ``quickbayes`` model that change automatically
+depending on the backend selection.
+For both models:
 
-Resolution
-  A resolution file created using the Calibration tab.
++----------------------+--------------------------------------------------------------------------------------------+
+| Parameter            | Description                                                                                |
++======================+============================================================================================+
+| Sample               | Either a reduced file created using the Energy tab or a :math:`S(Q, \omega)` file.         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Resolution           | A resolution file created using the Calibration Tab                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Background           | The background fitting program to use                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
+| Elastic Peak         | If an elastic peak should be used                                                          |
++----------------------+--------------------------------------------------------------------------------------------+
+| EMin & EMax          | The energy range to perform fitting within                                                 |
++----------------------+--------------------------------------------------------------------------------------------+
+| Sigma                | Number of Sigma(FWHM) values                                                               |
++----------------------+--------------------------------------------------------------------------------------------+
+| Beta                 | Number of Beta values                                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot Current Preview | Plots the currently selected preview plot in a separate external window                    |
++----------------------+--------------------------------------------------------------------------------------------+
+| Preview Spectrum     | Changes the spectrum displayed in the preview plot                                         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Run                  | Runs the processing configured on the current tab                                          |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot                 | Plots the selected parameter stored in the result workspaces                               |
++----------------------+--------------------------------------------------------------------------------------------+
+| Plot Contour         | Produces a contour plot of the selected workspaces                                         |
++----------------------+--------------------------------------------------------------------------------------------+
+| Save Result          | Saves the result in the default save directory                                             |
++----------------------+--------------------------------------------------------------------------------------------+
 
-Background
-  The background fitting program to use.
+For ``quasielastic`` model there are also the following parameters:
 
-Elastic Peak
-  If an elastic peak should be used.
++----------------------+--------------------------------------------------------------------------------------------+
+| Sequential Fit       | Enabled multiple fitting iterations                                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Sample Binning       | Sample binning to use                                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
 
-Sequential Fit
-  Enables multiple fitting iterations.
+While for ``quickbayes`` the additional parameters are:
 
-EMin & EMax
-  The energy range to perform fitting within.
-
-Sample Binning
-  Sample binning to use.
-
-Sigma
-  Value of Sigma to use.
-
-Beta
-  Value of Beta to use.
-
-Preview Spectrum
-  Changes the spectrum displayed in the preview plot.
-
-Plot Current Preview
-  Plots the currently selected preview plot in a separate external window
-
-Run
-  Runs the processing configured on the current tab.
-
-Plot
-  Plots the selected parameter stored in the result workspaces.
-
-Plot Contour
-  Produces a contour plot of the selected workspace.
-
-Save Result
-  Saves the result in the default save directory.
++----------------------+--------------------------------------------------------------------------------------------+
+| Start Beta           | Initial value of Beta                                                                      |
++----------------------+--------------------------------------------------------------------------------------------+
+| End Beta             | Final value of Beta                                                                        |
++----------------------+--------------------------------------------------------------------------------------------+
+| Start Sigma          | Initial value of Sigma(FWHM)                                                               |
++----------------------+--------------------------------------------------------------------------------------------+
+| End Sigma            | Final value of Sigma(FWHM)                                                                 |
++----------------------+--------------------------------------------------------------------------------------------+
 
 .. categories:: Interfaces Inelastic

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchData.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchData.h
@@ -14,18 +14,23 @@ struct StretchRunData {
   const std::string sampleName;
   const std::string resolutionName;
   const std::string backgroundName;
-  const double eMin;
-  const double eMax;
-  const int beta;
-  const bool elasticPeak;
-  const int sigma;
-  const int sampleBinning;
-  const bool sequentialFit;
+  const double eMin{-0.2};
+  const double eMax{0.2};
+  double startBeta{0.5};
+  double endBeta{1.0};
+  double startFWHM{0.01};
+  double endFWHM{0.1};
+  const int beta{3};
+  const int sigma{3};
+  int sampleBinning{1};
+  const bool elasticPeak{false};
+  bool sequentialFit{false};
 
-  StretchRunData(const std::string &sample, const std::string &resolution, double min, double max, int b, bool elastic,
-                 const std::string &bg, int sig, int binning, bool sequential)
-      : sampleName(sample), resolutionName(resolution), backgroundName(bg), eMin(min), eMax(max), beta(b),
-        elasticPeak(elastic), sigma(sig), sampleBinning(binning), sequentialFit(sequential) {}
+  StretchRunData() = default;
+  StretchRunData(const std::string &sample, const std::string &resolution, const std::string &bg, double min,
+                 double max, int beta, int sigma, bool elastic)
+      : sampleName(sample), resolutionName(resolution), backgroundName(bg), eMin(min), eMax(max), beta(beta),
+        sigma(sigma), elasticPeak(elastic) {}
 };
 
 struct CurrentPreviewData {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchModel.cpp
@@ -28,9 +28,16 @@ MantidQt::API::IConfiguredAlgorithm_sptr StretchModel::stretchAlgorithm(const St
   properties->setProperty("OutputWorkspaceFit", fitWorkspaceName);
   properties->setProperty("OutputWorkspaceContour", contourWorkspaceName);
   properties->setProperty("Background", algParams.backgroundName);
-  if (!useQuickBayes) {
-    properties->setProperty("SampleBins", algParams.sampleBinning);
+
+  if (useQuickBayes) {
+    properties->setProperty("NumberFWHM", algParams.sigma);
+    properties->setProperty("StartBeta", algParams.startBeta);
+    properties->setProperty("EndBeta", algParams.endBeta);
+    properties->setProperty("StartFWHM", algParams.startFWHM);
+    properties->setProperty("EndFWHM", algParams.endFWHM);
+  } else {
     properties->setProperty("NumberSigma", algParams.sigma);
+    properties->setProperty("SampleBins", algParams.sampleBinning);
     properties->setProperty("Loop", algParams.sequentialFit);
   }
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
@@ -128,48 +128,29 @@ void StretchView::setupPropertyBrowser(bool useQuickBayes) {
   auto const EMin = m_properties.contains("EMin") ? m_properties["EMin"]->valueText().toDouble() : 0.0;
   auto const EMax = m_properties.contains("EMax") ? m_properties["EMax"]->valueText().toDouble() : 0.0;
   auto const beta = m_properties.contains("Beta") ? m_properties["Beta"]->valueText().toInt() : 50;
+  auto const sigma = m_properties.contains("Sigma") ? m_properties["Sigma"]->valueText().toInt() : 3;
 
   m_properties.clear();
   m_dblManager->clear();
   m_propTree->clear();
 
   m_uiForm.treeSpace->addWidget(m_propTree);
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &StretchView::propertiesUpdated);
+  addPropToTree<double>("EMin", EMin);
+  addPropToTree<double>("EMax", EMax);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &StretchView::propertiesUpdated);
 
-  m_properties["EMin"] = m_dblManager->addProperty("EMin");
-  m_properties["EMax"] = m_dblManager->addProperty("EMax");
-  m_properties["Beta"] = m_dblManager->addProperty("Beta");
+  addPropToTree<int>("Beta", beta, INT_DECIMALS, 1, 200);
+  addPropToTree<int>("Sigma", sigma, INT_DECIMALS, 1, 200);
 
-  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
-  m_dblManager->setValue(m_properties["EMin"], EMin);
-  m_dblManager->setValue(m_properties["EMax"], EMax);
-
-  m_propTree->addProperty(m_properties["EMin"]);
-  m_propTree->addProperty(m_properties["EMax"]);
-  m_propTree->addProperty(m_properties["Beta"]);
-
-  m_dblManager->setValue(m_properties["Beta"], beta);
-  m_dblManager->setMinimum(m_properties["Beta"], 1);
-  m_dblManager->setMaximum(m_properties["Beta"], 200);
-
-  if (!useQuickBayes) {
-    m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
-    m_properties["Sigma"] = m_dblManager->addProperty("Sigma");
-
-    m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
-    m_dblManager->setDecimals(m_properties["Sigma"], INT_DECIMALS);
-
-    m_propTree->addProperty(m_properties["SampleBinning"]);
-    m_propTree->addProperty(m_properties["Sigma"]);
-
-    m_dblManager->setValue(m_properties["Sigma"], 50);
-    m_dblManager->setMinimum(m_properties["Sigma"], 1);
-    m_dblManager->setMaximum(m_properties["Sigma"], 200);
-    m_dblManager->setValue(m_properties["SampleBinning"], 1);
-    m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
+  if (useQuickBayes) {
+    addPropToTree<double>("startBeta", 0.5, NUM_DECIMALS, 0.5, 1.0);
+    addPropToTree<double>("endBeta", 1.0, NUM_DECIMALS, 0.5, 1.001);
+    addPropToTree<double>("startSigma(FWHM)", 0.01, NUM_DECIMALS, 0.0, 1.0);
+    addPropToTree<double>("endSigma(FWHM)", 0.1, NUM_DECIMALS, 0.0, 1.0);
+  } else {
+    addPropToTree<int>("SampleBinning", 1, INT_DECIMALS, 1);
   }
-
   formatTreeWidget(m_propTree, m_properties);
 }
 
@@ -261,25 +242,26 @@ void StretchView::validateUserInput(IUserInputValidator *validator) const {
 StretchRunData StretchView::getRunData(bool useQuickBayes) const {
   auto const sampleName = m_uiForm.dsSample->getCurrentDataName().toStdString();
   auto const resName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
-
   auto const background = m_uiForm.cbBackground->currentText().toStdString();
 
   auto const eMin = m_properties["EMin"]->valueText().toDouble();
   auto const eMax = m_properties["EMax"]->valueText().toDouble();
   auto const beta = m_properties["Beta"]->valueText().toInt();
-
+  auto const sigma = m_properties["Sigma"]->valueText().toInt();
   auto const elasticPeak = m_uiForm.chkElasticPeak->isChecked();
 
-  int sigma = 0;
-  int nBins = 0;
-  bool sequence = false;
-  if (!useQuickBayes) {
-    sigma = m_properties["Sigma"]->valueText().toInt();
-    nBins = m_properties["SampleBinning"]->valueText().toInt();
-    sequence = m_uiForm.chkSequentialFit->isChecked();
-  }
+  auto stretchData = StretchRunData(sampleName, resName, background, eMin, eMax, beta, sigma, elasticPeak);
 
-  return StretchRunData(sampleName, resName, eMin, eMax, beta, elasticPeak, background, sigma, nBins, sequence);
+  if (useQuickBayes) {
+    stretchData.startBeta = m_properties["startBeta"]->valueText().toDouble();
+    stretchData.endBeta = m_properties["endBeta"]->valueText().toDouble();
+    stretchData.startFWHM = m_properties["startSigma(FWHM)"]->valueText().toDouble();
+    stretchData.endFWHM = m_properties["endSigma(FWHM)"]->valueText().toDouble();
+  } else {
+    stretchData.sampleBinning = m_properties["SampleBinning"]->valueText().toInt();
+    stretchData.sequentialFit = m_uiForm.chkSequentialFit->isChecked();
+  }
+  return stretchData;
 }
 
 CurrentPreviewData StretchView::getCurrentPreviewData() const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
@@ -112,6 +112,21 @@ private slots:
   void plotCurrentPreviewClicked();
 
 private:
+  template <typename T>
+  void addPropToTree(const QString &propName, T initialValue, int precision = 6,
+                     std::optional<T> minValue = std::nullopt, std::optional<T> maxValue = std::nullopt) {
+    m_properties[propName] = m_dblManager->addProperty(propName);
+    const auto prop = m_properties[propName];
+    m_dblManager->setDecimals(prop, precision);
+    m_dblManager->setValue(prop, initialValue);
+    if (minValue.has_value()) {
+      m_dblManager->setMinimum(prop, *minValue);
+    }
+    if (maxValue.has_value()) {
+      m_dblManager->setMaximum(prop, *maxValue);
+    }
+    m_propTree->addProperty(prop);
+  }
   void formatTreeWidget(QtTreePropertyBrowser *treeWidget, QMap<QString, QtProperty *> const &properties) const;
 
   Ui::Stretch m_uiForm;

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -91,7 +91,7 @@ public:
     configSvc.setString("defaultsave.directory", "/test/test");
     ON_CALL(*m_view, displaySaveDirectoryMessage()).WillByDefault(Return(false));
 
-    StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
+    StretchRunData runData("sample_ws", "res_ws", "flat", -0.5, 0.5, 50, 30, true);
 
     ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
 
@@ -103,7 +103,7 @@ public:
   }
 
   void test_handleRun_with_valid_input_and_savedir() {
-    StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
+    StretchRunData runData("sample_ws", "res_ws", "flat", -0.5, 0.5, 50, 30, true);
 
     ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_view, setPlotADSEnabled(false)).Times(1);
@@ -114,7 +114,7 @@ public:
   }
 
   void test_notifySaveClicked_with_output_workspaces() {
-    StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
+    StretchRunData runData("sample_ws", "res_ws", "flat", -0.5, 0.5, 50, 30, true);
 
     auto const cutIndex = runData.sampleName.find_last_of("_");
     auto const baseName = runData.sampleName.substr(0, cutIndex);
@@ -151,7 +151,7 @@ public:
   }
 
   void test_notifyBackendChanged_changes_stretchAlgorithm_call() {
-    StretchRunData runData("sample_ws", "res_ws", -0.5, 0.5, 50, true, "flat", 30, 1, true);
+    StretchRunData runData("sample_ws", "res_ws", "flat", -0.5, 0.5, 50, 30, true);
 
     EXPECT_CALL(*m_view, getRunData(true)).Times(1);
     ON_CALL(*m_view, getRunData(true)).WillByDefault(Return(runData));


### PR DESCRIPTION
### Description of work
Fixes #40779  , related to #40730 found in Manual Testing. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40779. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Check that on switching backend from `quasielastic` to `quickbayes` on the `Stretch` tab of the `Bayes Fitting` interface, the property browser updates with appropriate parameters. 
---> For Quasielastic -> Emin, Emax, Beta, Sigma, Binning
---> For QuickBayes -> Emin, Emax, Beta, Sigma, Start Beta, End Beta, Start Sigma, End Sigma

Try to run the stretch algorithm in both backends with different parameters, test data is the same as manual testing: 
https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
