### PR TITLE
Move some variables out of loops in IDF parsing

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
@@ -104,7 +104,7 @@ public:
 
   //! Translate the IComponent (x,y,z form). This is relative to parent if
   // present.
-  void translate(double, double, double) override;
+  void translate(const double, const double, const double) override;
 
   //! Rotate the IComponent. This is relative to parent.
   void rotate(const Kernel::Quat &) override;

--- a/Framework/Geometry/src/Instrument/CompAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/CompAssembly.cpp
@@ -101,7 +101,7 @@ int CompAssembly::add(IComponent *comp) {
 
   if (comp) {
     comp->setParent(this);
-    m_children.emplace_back(comp);
+    m_children.emplace_back(std::move(comp));
   }
   return static_cast<int>(m_children.size());
 }

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -239,7 +239,7 @@ void Component::setRot(const Quat &q) {
  *   @param y :: translation on the y-axis
  *  @param z :: translation on the z-axis
  */
-void Component::translate(double x, double y, double z) {
+void Component::translate(const double x, const double y, const double z) {
   if (!m_map) {
     m_pos[0] += x;
     m_pos[1] += y;


### PR DESCRIPTION
While looking into why there is so much memory used while loading the IMAGINE instrument, I found that there were temporary variables that were being created inside of tight loops that could easily pulled out. This makes almost no difference for performance.

There is no associated issue.

### To test:

The code should compile and the tests still pass.

*This does not require release notes* because this moves around some variables. 

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
