### PR TITLE
Generate random filenames in flaky tests

### DIFF
--- a/Framework/DataHandling/test/SaveNexusGeometryTest.h
+++ b/Framework/DataHandling/test/SaveNexusGeometryTest.h
@@ -36,7 +36,7 @@ public:
 
   void test_exec() {
 
-    FileResource fileResource("algorithm_test_file.hdf5");
+    FileResource fileResource("algorithm_test_file.hdf5", false, true);
     auto destinationFile = fileResource.fullPath();
     // Create test input
     Mantid::API::IEventWorkspace_sptr inputWS = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument2(1, 5);
@@ -58,7 +58,7 @@ public:
 
   void test_execution_successful_when_no_h5_root_provided_and_default_root_is_used() {
 
-    FileResource fileResource("algorithm_no_h5_root_file.hdf5");
+    FileResource fileResource("algorithm_no_h5_root_file.hdf5", false, true);
     auto destinationFile = fileResource.fullPath();
     // Create test input if necessary
     Mantid::API::IEventWorkspace_sptr inputWS = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument2(1, 5);
@@ -84,7 +84,7 @@ public:
     into the Input workspace property.
     */
 
-    FileResource fileResource("algorithm_no_instrument_in_workspace_provided_test_file.hdf5");
+    FileResource fileResource("algorithm_no_instrument_in_workspace_provided_test_file.hdf5", false, true);
     auto destinationFile = fileResource.fullPath();
     // Create test input if necessary
 
@@ -114,7 +114,7 @@ public:
     when invalid file extension is passed into fileName property.
     */
 
-    FileResource fileResource("algorithm_invalid_extension_provided_test_file.txt");
+    FileResource fileResource("algorithm_invalid_extension_provided_test_file.txt", false, true);
     auto destinationFile = fileResource.fullPath();
     // Create test workspace
     Mantid::API::IEventWorkspace_sptr inputWS = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument2(5, 5);
@@ -138,7 +138,7 @@ public:
 
   void test_eight_pack() {
 
-    FileResource fileResource("eight_pack.hdf5");
+    FileResource fileResource("eight_pack.hdf5", false, true);
     auto destinationFile = fileResource.fullPath();
 
     Mantid::DataHandling::LoadEmptyInstrument alg;
@@ -168,7 +168,7 @@ public:
     exception.
     */
 
-    FileResource fileResource("duplicate_names_test.hdf5");
+    FileResource fileResource("duplicate_names_test.hdf5", false, true);
     auto destinationFile = fileResource.fullPath();
 
     Mantid::DataHandling::LoadEmptyInstrument loader;

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
@@ -19,9 +19,10 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
     FIT_RESULTS_TABLE_NAME = "FitResults"
     LATTICE_PARAMS_TABLE_NAME = "LatticeParams"
     LATTICE_PARAMS = ["a", "b", "c", "alpha", "beta", "gamma", "volume"]
-    TEMP_FILE_NAME = os.path.join(tempfile.gettempdir(), "EnggSaveGSASIIFitResultsToHDF5Test.hdf5")
 
     def setUp(self):
+        self.TEMP_DIR = tempfile.TemporaryDirectory()
+        self.TEMP_FILE_NAME = os.path.join(self.TEMP_DIR.name, "EnggSaveGSASIIFitResultsToHDF5Test.hdf5")
         self.defaultAlgParams = {
             "LatticeParamWorkspaces": [self._create_lattice_params_table()],
             "BankIDs": [1],
@@ -30,10 +31,7 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
         }
 
     def tearDown(self):
-        try:
-            os.remove(self.TEMP_FILE_NAME)
-        except OSError:
-            pass
+        self.TEMP_DIR.cleanup()
 
     def test_saveLatticeParams(self):
         lattice_params = self._create_lattice_params_table()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveSinglePeakFitResultsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveSinglePeakFitResultsToHDF5Test.py
@@ -18,14 +18,13 @@ class EnggSaveSinglePeakFitResultsToHDF5Test(unittest.TestCase):
     ALG_NAME = "EnggSaveSinglePeakFitResultsToHDF5"
     FIT_PARAMS = ["dSpacing", "A0", "A0_Err", "A1", "A1_Err", "X0", "X0_Err", "A", "A_Err", "B", "B_Err", "S", "S_Err", "I", "I_Err", "Chi"]
     FIT_RESULTS_TABLE_NAME = "FitResults"
-    TEMP_FILE_NAME = os.path.join(tempfile.gettempdir(), "EnggSaveSinglePeakFitResultsToHDF5Test.hdf5")
+
+    def setUp(self):
+        self.TEMP_DIR = tempfile.TemporaryDirectory()
+        self.TEMP_FILE_NAME = os.path.join(self.TEMP_DIR.name, "EnggSaveSinglePeakFitResultsToHDF5Test.hdf5")
 
     def tearDown(self):
-        try:
-            os.remove(self.TEMP_FILE_NAME)
-
-        except OSError:
-            pass
+        self.TEMP_DIR.cleanup()
 
         if mantid.mtd.doesExist(self.FIT_RESULTS_TABLE_NAME):
             mantid.mtd.remove(self.FIT_RESULTS_TABLE_NAME)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToHDF5Test.py
@@ -24,14 +24,13 @@ from testhelpers import run_algorithm
 class ExportSampleLogsToHDF5Test(unittest.TestCase):
     ALG_NAME = "ExportSampleLogsToHDF5"
     TEST_WS_NAME = "SampleWorkspace"
-    TEMP_FILE_NAME = os.path.join(tempfile.gettempdir(), "ExportSampleLogsToHDF5Test.hdf5")
+
+    def setUp(self):
+        self.TEMP_DIR = tempfile.TemporaryDirectory()
+        self.TEMP_FILE_NAME = os.path.join(self.TEMP_DIR.name, "ExportSampleLogsToHDF5Test.hdf5")
 
     def tearDown(self):
-        try:
-            os.remove(self.TEMP_FILE_NAME)
-
-        except OSError:
-            pass
+        self.TEMP_DIR.cleanup()
 
         if mantid.mtd.doesExist(self.TEST_WS_NAME):
             mantid.mtd.remove(self.TEST_WS_NAME)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GenerateLogbookTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GenerateLogbookTest.py
@@ -8,7 +8,7 @@ import unittest
 from mantid.api import mtd, ITableWorkspace
 from mantid.simpleapi import config, GenerateLogbook
 import os
-from tempfile import gettempdir
+from tempfile import TemporaryDirectory
 
 
 class GenerateLogbookTest(unittest.TestCase):
@@ -26,10 +26,14 @@ class GenerateLogbookTest(unittest.TestCase):
         mtd.clear()
 
     @classmethod
+    def setUpClass(cls):
+        cls.TEMP_DIR = TemporaryDirectory()
+        cls.TEMP_FILE_NAME = os.path.join(cls.TEMP_DIR.name, "logbook.csv")
+
+    @classmethod
     def tearDownClass(cls):
         mtd.clear()
-        if os.path.exists(os.path.join(gettempdir(), "logbook.csv")):
-            os.remove(os.path.join(gettempdir(), "logbook.csv"))
+        cls.TEMP_DIR.cleanup()
 
     def test_instrument_does_not_exist(self):
         self.assertTrue(os.path.exists(self._data_directory))
@@ -88,9 +92,9 @@ class GenerateLogbookTest(unittest.TestCase):
             Facility="ILL",
             Instrument="D7",
             NumorRange="396990:396993",
-            OutputFile=os.path.join(gettempdir(), "logbook.csv"),
+            OutputFile=self.TEMP_FILE_NAME,
         )
-        self.assertTrue(os.path.join(gettempdir(), "logbook.csv"))
+        self.assertTrue(os.path.exists(self.TEMP_FILE_NAME))
 
     def _check_output(self, ws, numberEntries, numberColumns):
         self.assertTrue(mtd[ws])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibrationTest.py
@@ -9,7 +9,7 @@ from mantid.simpleapi import config, mtd, CloneWorkspace, D7YIGPositionCalibrati
 from mantid.api import ITableWorkspace, WorkspaceGroup
 import os.path
 from os import path
-import tempfile
+from tempfile import TemporaryDirectory
 
 
 class D7YIGPositionCalibrationTest(unittest.TestCase):
@@ -17,13 +17,13 @@ class D7YIGPositionCalibrationTest(unittest.TestCase):
     def setUpClass(cls):
         config.appendDataSearchSubDir("ILL/D7/")
         Load("402652_403041.nxs", OutputWorkspace="shortWavelengthScan")
+        cls.TEMP_DIR = TemporaryDirectory()
+        cls.TEMP_FILE_NAME = os.path.join(cls.TEMP_DIR.name, "D7YIGPositionCalibrationTest.xml")
 
     @classmethod
     def tearDownClass(cls):
         mtd.clear()
-        output_path = os.path.join(tempfile.gettempdir(), "test_shortWavelength.xml")
-        if path.exists(output_path):
-            os.remove(output_path)
+        cls.TEMP_DIR.cleanup()
 
     def test_algorithm_with_no_input_workspace_raises_exception(self):
         with self.assertRaisesRegex(
@@ -51,7 +51,7 @@ class D7YIGPositionCalibrationTest(unittest.TestCase):
         approximate_wavelength = "3.14"  # Angstrom
         self.assertTrue(mtd["shortWavelengthScan"])
         CloneWorkspace(InputWorkspace="shortWavelengthScan", OutputWorkspace="shortWavelengthScan_clone")
-        output_filename = os.path.join(tempfile.gettempdir(), "test_shortWavelength.xml")
+        output_filename = self.TEMP_FILE_NAME
         D7YIGPositionCalibration(
             InputWorkspace="shortWavelengthScan_clone",
             ApproximateWavelength=approximate_wavelength,

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
@@ -20,7 +20,7 @@
 class FileResource {
 
 public:
-  FileResource(const std::string &fileName, bool debugMode = false);
+  FileResource(const std::string &fileName, const bool debugMode = false, const bool randomize = false);
   void setDebugMode(bool mode);
   std::string fullPath() const;
   ~FileResource();

--- a/Framework/TestHelpers/src/FileResource.cpp
+++ b/Framework/TestHelpers/src/FileResource.cpp
@@ -5,15 +5,19 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidFrameworkTestHelpers/FileResource.h"
+#include "MantidKernel/Strings.h"
 #include <filesystem>
 #include <string>
 
-FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debugMode(debugMode) {
+FileResource::FileResource(const std::string &fileName, const bool debugMode, const bool randomize)
+    : m_debugMode(debugMode) {
 
   const auto temp_dir = std::filesystem::temp_directory_path();
   auto temp_full_path = temp_dir;
+
+  // add a random prefix to filename to avoid collision
   // append full path to temp directory to user input file name
-  temp_full_path /= fileName;
+  temp_full_path /= (randomize) ? (Mantid::Kernel::Strings::randomString(12) + "_" + fileName) : fileName;
 
   // Check proposed location and throw std::invalid argument if file does
   // not exist. otherwise set m_full_path to location.


### PR DESCRIPTION
### Description of work

See: https://github.com/mantidproject/mantid/issues/40658

There are currently flaky tests that error upon attempting to open a directory as a file (the directory should be a file).

This PR does not address the root cause, but it attempts to alleviate the issue by ensuring a random file name is used for each test, preventing file collisions between tests.

### To test:

Changes are limited to tests, so ensure that they pass.

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
