### PR TITLE
Ignore default pixi directory in git

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -120,9 +120,12 @@ if [[ $CLEAN_BUILD  == true ]]; then
     # git clean will delete most things in build but leave subrepositories such as build/_deps/span-src
     # so we need to remove the whole of build/ by hand
     rm -fr $BUILD_DIR
+    rm -fr "$WORKSPACE/.pixi/" # less logs with rm
 else
-    git_clean_excludes_extra="--exclude=build --exclude=miniforge"
+    git_clean_excludes_extra="--exclude=build --exclude=miniforge --exclude=.pixi"
 fi
+# -d is recurse into directories
+# -x ignores what is listed in the .gitignore
 git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
 
 # install pixi if not already installed


### PR DESCRIPTION
[conda-buildscript](https://github.com/mantidproject/mantid/blob/2b6d502021f65ea6f1dd04b82c693ebc4820b631/buildconfig/Jenkins/Conda/conda-buildscript#L126), runs
```sh
git clean -d -x --force --exclude=".Xauthority-*"
```
which deletes everything that isn't in the git gets deleted (`build/` and `miniforge/` are ignored for regular builds). Unfortunately, this deletes everything in `.pixi/` as well. 

This PR does not remove the `.pixi/` directory to save on network and disk writes since pixi will handle this correctly via its locking mechanism. Currently, we spend ~3 minutes of build time deleting this directory that will not be changed during the next build then another ~3 minutes installing all of the dependencies. As a side effect, the build logs will be significantly shorter because there will no longer be logs for deleting the files in `.pixi/`.

There is no associate issue, but this is related to #39497

### To test:

Look at the build logs to see that the section that normally starts with
```
05:10:28 + git clean -d -x --force '--exclude=.Xauthority-*' --exclude=build --exclude=miniforge
05:10:31 Removing .pixi/.condapackageignore
05:10:31 Removing .pixi/.gitignore
05:10:31 Removing .pixi/envs/default/bin/
05:10:31 Removing .pixi/envs/default/compiler_compat/
05:10:31 Removing .pixi/envs/default/conda-meta/
05:10:31 Removing .pixi/envs/default/doc/
05:10:31 Removing .pixi/envs/default/etc/
05:10:31 Removing .pixi/envs/default/fonts/
05:10:31 Removing .pixi/envs/default/hdf5/
```
skips the pixi directory tree

*This does not require release notes* because it is only changing build times.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
