### PR TITLE
Added additional logging to BayesQuasi2 to allow the user to see fitting updates per spectrum in the messages window

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
@@ -168,6 +168,7 @@ class BayesQuasi2(QuickBayesTemplate):
         # calculation
         for spec in range(N):
             report_progress.report(f"spectrum {spec}")
+            self.log().notice(f"Fitting spectrum {spec + 1} of {N}")
             sx = sample_ws.readX(spec)
             sy = sample_ws.readY(spec)
             se = sample_ws.readE(spec)

--- a/docs/source/release/v6.15.0/Framework/Python/Bugfixes/Used/40726.rst
+++ b/docs/source/release/v6.15.0/Framework/Python/Bugfixes/Used/40726.rst
@@ -1,0 +1,1 @@
+- Additional logging has been added to :ref:`BayesQuasi2 <algm-BayesQuasi2>` to inform users of the algorithm's progress.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40726. <!-- One line per closed issue. -->
The user will be able to see the logs and can be reassured that `BayesQuasi2` is making progress even tough it is taking a bit longer. 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Follow the instructions of the manual [test](https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html#quasi-tab).
2) Verify that additional logs are visible when using the `BayesQuasi2` algorithm.
<img width="446" height="179" alt="Screenshot 2026-02-03 at 2 36 46 pm" src="https://github.com/user-attachments/assets/abd07294-de62-4a9f-b1ea-8950b7b537b3" />


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
