### PR TITLE
Fix rendering of LaTeX for QtWebEngine

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,9 @@ extensions = [
 mathext = os.environ.get("MATH_EXT", "sphinx.ext.mathjax")
 extensions.append(mathext)
 
-# MathJax configuration to define Angstrom symbol macro
+# MathJax configuration to:
+# - define Angstrom symbol macro
+# - enable polyfill for hasOwn (needed for some older browsers)
 mathjax3_config = {"tex": {"macros": {"AA": r"\unicode{x212B}"}}, "startup": {"polyfillHasOwn": True}}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ mathext = os.environ.get("MATH_EXT", "sphinx.ext.mathjax")
 extensions.append(mathext)
 
 # MathJax configuration to define Angstrom symbol macro
-mathjax3_config = {"tex": {"macros": {"AA": r"\unicode{x212B}"}}}
+mathjax3_config = {"tex": {"macros": {"AA": r"\unicode{x212B}"}}, "startup": {"polyfillHasOwn": True}}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
### Description of work

We use mathjax 4.

This version introduced some compatibility issues with older versions of chromium, such as the one backing up `QtWebEngine`.


This PR implements the fix detailed in the compatibility section of this page:
https://github.com/mathjax/Mathjax-src/releases

Closes  #40744


### To test:

- Build the docs offline `ninja docs-html` in your `build` folder, or build the target in visual studio.
- Check that LaTeX renders (See doc for `MostLikelyMean` alg.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
