### PR TITLE
Improve how pixi is installed on runners

### DIFF
--- a/buildconfig/Jenkins/Conda/pixi-utils
+++ b/buildconfig/Jenkins/Conda/pixi-utils
@@ -2,19 +2,27 @@
 
 # Download and install pixi (if it isn't installed)
 install_pixi() {
+  # configure the path to where pixi will end up
+  if [[ "$OSTYPE" != darwin* && -f ~/.bashrc ]]; then
+    source ~/.bashrc
+  else
+    export PATH="$PATH:$HOME/.pixi/bin"
+  fi
+
   # check if pixi is not installed
-  if ! command -v pixi >/dev/null 2>&1
-  then
+  if [ "$(command -v pixi)" ]; then
+      echo "updating previously installed pixi"
+      pixi self-update --no-progress --quiet
+  else
+    echo "install pixi"
+    set +x # don't care about details of pixi install
     curl -fsSL https://pixi.sh/install.sh | sh
+    set -x # turn logging back on
     # Verify pixi was installed successfully
-    if ! command -v $HOME/.pixi/bin/pixi >/dev/null 2>&1; then
+    if [ ! -f "$HOME/.pixi/bin/pixi" ]; then
       echo "ERROR: pixi installation failed"
       exit 1
     fi
-    if [[ "$OSTYPE" != darwin* && -f ~/.bashrc ]]; then
-      source ~/.bashrc
-    else
-      export PATH="$PATH:$HOME/.pixi/bin"
-    fi
   fi
+  echo "using $(pixi --version)"
 }


### PR DESCRIPTION
By default, pixi installs itself in `~/.pixi/` which is not normally in the PATH. Before this change, the check `command -v pixi` never found previously installed pixi because it was not in the path. Excerpt from [pull_requests-conda-linux/15982](https://builds.mantidproject.org/job/pull_requests-conda-linux/15982/consoleFull)
```
14:56:17 + install_pixi
14:56:17 + command -v pixi
14:56:17 + curl -fsSL https://pixi.sh/install.sh
14:56:17 + sh
14:56:17 This script will automatically download and install Pixi (latest) for you.
14:56:17 Getting it from this url: https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-unknown-linux-musl.tar.gz
14:56:19 The 'pixi' binary is installed into '/home/abc/.pixi/bin'
14:56:19 + command -v /home/abc/.pixi/bin/pixi
```
demonstrating that pixi is always installed (in less than a minute).

This change runs `pixi self-update` (with additional arguments) and prints out the version that is used before running the rest of the build script. Excerpt from [pull_requests-conda-linux/15983](https://builds.mantidproject.org/job/pull_requests-conda-linux/15983/consoleFull)
```
15:51:01 + install_pixi
15:51:01 + [[ linux-gnu != darwin* ]]
15:51:01 + [[ -f /home/abc/.bashrc ]]
15:51:01 + source /home/abc/.bashrc
...
15:51:01 ++ command -v pixi
15:51:01 + '[' /home/abc/.pixi/bin/pixi ']'
15:51:01 + echo 'updating previously installed pixi'
15:51:01 updating previously installed pixi
15:51:01 + pixi self-update --no-progress --quiet
15:51:01 ++ pixi --version
15:51:01 + echo 'using pixi 0.63.2'
15:51:01 using pixi 0.63.2
```
which also takes almost no time, but reduces network usage.

Refs #39497

This currently contains the changes from #40807 so do not merge before it.

### To test:

Look at the difference in the logs of this PR (any jenkins job) and the same job from any other PR. The first excerpt above can be seen elsewhere.

*This does not require release notes* because it is a devops change.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
