### PR TITLE
Fix FileFinder instrument matching

### DIFF
--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -46,15 +46,18 @@ public:
   bool getCaseSensitive() const;
   static std::vector<IArchiveSearch_sptr> getArchiveSearch(const Kernel::FacilityInfo &facility);
   const API::Result<std::string> findRun(const std::string &hintstr, const std::vector<std::string> &exts = {},
-                                         const bool useExtsOnly = false) const;
+                                         const bool useExtsOnly = false,
+                                         const std::string &defaultInstrument = "") const;
   std::vector<std::string> findRuns(const std::string &hintstr, const std::vector<std::string> &exts = {},
                                     const bool useExtsOnly = false) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
-  const Kernel::InstrumentInfo getInstrument(const std::string &hint, const bool returnDefaultIfNotFound = true) const;
+  const Kernel::InstrumentInfo getInstrument(const std::string &hint, const bool returnDefaultIfNotFound = true,
+                                             const std::string &defaultInstrument = "") const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   std::string getExtension(const std::string &filename, const std::vector<std::string> &exts) const;
   void getUniqueExtensions(const std::vector<std::string> &extensionsToAdd, std::vector<std::string> &uniqueExts) const;
-  std::pair<std::string, std::string> toInstrumentAndNumber(const std::string &hint) const;
+  std::pair<std::string, std::string> toInstrumentAndNumber(const std::string &hint,
+                                                            const std::string &defaultInstrument = "") const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FileFinderImpl>;

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -48,6 +48,9 @@ public:
   const API::Result<std::string> findRun(const std::string &hintstr, const std::vector<std::string> &exts = {},
                                          const bool useExtsOnly = false,
                                          const std::string &defaultInstrument = "") const;
+  const API::Result<std::string> findRun(const std::string &hintstr, const Kernel::InstrumentInfo &instrument,
+                                         const std::vector<std::string> &exts = {},
+                                         const bool useExtsOnly = false) const;
   std::vector<std::string> findRuns(const std::string &hintstr, const std::vector<std::string> &exts = {},
                                     const bool useExtsOnly = false) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
@@ -58,6 +61,8 @@ public:
   void getUniqueExtensions(const std::vector<std::string> &extensionsToAdd, std::vector<std::string> &uniqueExts) const;
   std::pair<std::string, std::string> toInstrumentAndNumber(const std::string &hint,
                                                             const std::string &defaultInstrument = "") const;
+  std::pair<std::string, std::string> toInstrumentAndNumber(const std::string &hint,
+                                                            const Kernel::InstrumentInfo &instrument) const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FileFinderImpl>;

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -144,25 +144,7 @@ const Kernel::InstrumentInfo FileFinderImpl::getInstrument(const string &hint, c
     std::string filename = toUpper(std::filesystem::path(hint).filename().string());
 
     try {
-      std::string instrName;
-
-      // try full name first
-      {
-        const auto &names = Kernel::ConfigService::Instance().getInstrumentNames();
-        auto it = std::find_if(names.begin(), names.end(),
-                               [&](const std::string &name) { return filename.starts_with(name); });
-        if (it != names.end())
-          instrName = *it;
-      }
-
-      // try short name next
-      if (instrName.empty()) {
-        const auto &shortNames = Kernel::ConfigService::Instance().getInstrumentShortNames();
-        auto it = std::find_if(shortNames.begin(), shortNames.end(),
-                               [&](const std::string &shortName) { return filename.starts_with(shortName); });
-        if (it != shortNames.end())
-          instrName = *it;
-      }
+      std::string instrName = Kernel::ConfigService::Instance().findLongestInstrumentPrefix(filename);
 
       // if still empty, throw not found
       if (instrName.empty()) {

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -147,21 +147,21 @@ const Kernel::InstrumentInfo FileFinderImpl::getInstrument(const string &hint, c
       std::string instrName;
 
       // try short name first
-      for (const auto &shortName : Kernel::ConfigService::Instance().getInstrumentShortNames()) {
-        if (filename.starts_with(shortName)) {
-          instrName = shortName;
-          break;
-        }
+      {
+        const auto &shortNames = Kernel::ConfigService::Instance().getInstrumentShortNames();
+        auto it = std::find_if(shortNames.begin(), shortNames.end(),
+                               [&](const std::string &shortName) { return filename.starts_with(shortName); });
+        if (it != shortNames.end())
+          instrName = *it;
       }
 
       // try full name next
       if (instrName.empty()) {
-        for (const auto &shortName : Kernel::ConfigService::Instance().getInstrumentNames()) {
-          if (filename.starts_with(shortName)) {
-            instrName = shortName;
-            break;
-          }
-        }
+        const auto &names = Kernel::ConfigService::Instance().getInstrumentNames();
+        auto it = std::find_if(names.begin(), names.end(),
+                               [&](const std::string &name) { return filename.starts_with(name); });
+        if (it != names.end())
+          instrName = *it;
       }
 
       // if still empty, throw not found

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -558,9 +558,7 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr,
       throw std::invalid_argument("Malformed range of runs: " + *h);
     } else if ((range.count() == 2) && (!fileSuspected)) {
       std::pair<std::string, std::string> p1 = toInstrumentAndNumber(range[0]);
-      if (boost::algorithm::istarts_with(hint, "PG3")) {
-        instrSName = "PG3";
-      }
+
       std::string run = p1.second;
       size_t nZero = run.size(); // zero padding
       if (range[1].size() > nZero) {
@@ -603,12 +601,7 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr,
           }
         }
 
-        std::string path;
-        if (boost::algorithm::istarts_with(hint, "PG3")) {
-          path = findRun(instrSName + run, extensionsProvided, useOnlyExtensionsProvided).result();
-        } else {
-          path = findRun(p1.first + run, extensionsProvided, useOnlyExtensionsProvided).result();
-        }
+        std::string path = findRun(p1.first + run, extensionsProvided, useOnlyExtensionsProvided).result();
 
         if (!path.empty()) {
           // Cache successfully found path and extension
@@ -622,18 +615,8 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr,
         }
       }
     } else {
-      std::string path;
-      // Special check for "PG3", to cope with situation like '48314,48316'.
-      if (boost::algorithm::istarts_with(hint, "PG3")) {
-        if (h == hints.begin()) {
-          instrSName = "PG3";
-          path = findRun(*h, extensionsProvided, useOnlyExtensionsProvided).result();
-        } else {
-          path = findRun(instrSName + *h, extensionsProvided, useOnlyExtensionsProvided).result();
-        }
-      } else {
-        path = findRun(*h, extensionsProvided, useOnlyExtensionsProvided).result();
-      }
+      std::string path = findRun(*h, extensionsProvided, useOnlyExtensionsProvided).result();
+
       if (!path.empty()) {
         res.emplace_back(path);
       } else {

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -141,7 +141,7 @@ const Kernel::InstrumentInfo FileFinderImpl::getInstrument(const string &hint, c
                                                            const std::string &defaultInstrument) const {
   if ((!hint.empty()) && (!isdigit(hint[0]))) {
     // If hint contains path components, use only the filename part for instrument detection
-    std::string filename = toUpper(std::filesystem::path(hint).filename());
+    std::string filename = toUpper(std::filesystem::path(hint).filename().string());
 
     try {
       std::string instrName;
@@ -183,6 +183,8 @@ const Kernel::InstrumentInfo FileFinderImpl::getInstrument(const string &hint, c
 /**
  * Extracts the instrument name and run number from a hint
  * @param hint :: The name hint
+ * @param defaultInstrument :: The default instrument to use if the hint does not contain an instrument name. If empty,
+ * the system default is used.
  * @return A pair of instrument name and run number
  */
 std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const std::string &hint,

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -185,7 +185,6 @@ std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const 
                                                                           const Kernel::InstrumentInfo &instr) const {
   g_log.debug() << "toInstrumentAndNumber(" << hint << ")\n";
   std::string runPart;
-  std::string instrPart = instr.shortName();
 
   if (hint.empty()) {
     throw std::invalid_argument("Malformed hint: empty hint");
@@ -194,6 +193,15 @@ std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const 
   if (isdigit(hint[0])) {
     runPart = hint;
   } else {
+    const auto hintUpper = toUpper(hint);
+    std::string instrPart = instr.name();
+    if (!hintUpper.starts_with(instrPart)) {
+      instrPart = instr.shortName();
+      if (!hintUpper.starts_with(instrPart)) {
+        throw std::invalid_argument("Malformed hint: does not start with instrument name or short name");
+      }
+    }
+
     // need to advance to the first digit after the instrument name to handle underscores, etc.
     size_t nChars = instrPart.length();
     while (nChars < hint.size() && !std::isdigit(static_cast<unsigned char>(hint[nChars])))
@@ -221,9 +229,7 @@ std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const 
     throw std::invalid_argument("Run number does not match instrument's zero padding");
   }
 
-  instrPart = instr.filePrefix(irunPart);
-
-  return std::make_pair(instrPart, runPart);
+  return std::make_pair(instr.filePrefix(irunPart), runPart);
 }
 
 /**

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -146,21 +146,21 @@ const Kernel::InstrumentInfo FileFinderImpl::getInstrument(const string &hint, c
     try {
       std::string instrName;
 
-      // try short name first
+      // try full name first
       {
-        const auto &shortNames = Kernel::ConfigService::Instance().getInstrumentShortNames();
-        auto it = std::find_if(shortNames.begin(), shortNames.end(),
-                               [&](const std::string &shortName) { return filename.starts_with(shortName); });
-        if (it != shortNames.end())
-          instrName = *it;
-      }
-
-      // try full name next
-      if (instrName.empty()) {
         const auto &names = Kernel::ConfigService::Instance().getInstrumentNames();
         auto it = std::find_if(names.begin(), names.end(),
                                [&](const std::string &name) { return filename.starts_with(name); });
         if (it != names.end())
+          instrName = *it;
+      }
+
+      // try short name next
+      if (instrName.empty()) {
+        const auto &shortNames = Kernel::ConfigService::Instance().getInstrumentShortNames();
+        auto it = std::find_if(shortNames.begin(), shortNames.end(),
+                               [&](const std::string &shortName) { return filename.starts_with(shortName); });
+        if (it != shortNames.end())
           instrName = *it;
       }
 
@@ -234,7 +234,6 @@ std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const 
  * name is absent the default one is used.
  * @param hint :: The name hint
  * @param instrument :: The current instrument object
- * @param defaultInstrument :: The default instrument to use if not found. If empty, the system default is used.
  * @return The file name
  * @throw NotFoundError if a required default is not set
  * @throw std::invalid_argument if the argument is malformed or run number is

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -205,6 +205,10 @@ std::pair<std::string, std::string> FileFinderImpl::toInstrumentAndNumber(const 
   std::string runPart;
   std::string instrPart = instr.shortName();
 
+  if (hint.empty()) {
+    throw std::invalid_argument("Malformed hint: empty hint");
+  }
+
   if (isdigit(hint[0])) {
     runPart = hint;
   } else {
@@ -265,7 +269,11 @@ std::string FileFinderImpl::makeFileName(const std::string &hint, const Kernel::
       if (hintUpper.rfind(shortName, 0) != 0 && hintUpper.rfind(name, 0) != 0) {
         instrToUse = getInstrument(hint, false);
       }
+    } catch (const std::exception &ex) {
+      g_log.debug() << "Failed to resolve instrument from hint '" << hint << "' in makeFileName: " << ex.what();
     } catch (...) {
+      g_log.debug() << "Failed to resolve instrument from hint '" << hint
+                    << "' in makeFileName due to an unknown exception.";
     }
   }
 
@@ -673,7 +681,7 @@ std::vector<std::string> FileFinderImpl::findRuns(const std::string &hintstr,
       }
     } else {
       Kernel::InstrumentInfo instr = this->getInstrument(*h, true, instrSName);
-      // udpate instrument short name for later use
+      // update instrument short name for later use
       instrSName = instr.shortName();
 
       std::string path = findRun(*h, instr, extensionsProvided, useOnlyExtensionsProvided).result();

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -87,6 +87,15 @@ public:
                                "      <technique>Reflectometer</technique>"
                                "    </instrument>"
                                "  </facility>"
+                               "  <facility name=\"HFIR\" delimiter=\"_\" "
+                               "FileExtensions=\"_event.nxs,.nxs,.dat\">"
+                               "    <archive>"
+                               "      <archiveSearch plugin=\"ORNLDataSearch\" />"
+                               "    </archive>"
+                               "    <instrument name=\"GPSANS\" shortname=\"CG2\">"
+                               "      <technique>Small Angle Scattering</technique>"
+                               "    </instrument>"
+                               "  </facility>"
                                "  <facility name=\"ILL\" delimiter=\"_\" FileExtensions=\".nxs,.dat\">"
                                "    <instrument name=\"IN5\" shortname=\"IN5\">"
                                "      <technique>Inelastic Spectroscopy</technique>"
@@ -232,6 +241,9 @@ public:
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("PG3_").name(), "POWGEN");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("LOQ").name(), "LOQ");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("SANS2D").name(), "SANS2D");
+    TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("CG2").name(), "GPSANS");
+    TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("CG21234").name(), "GPSANS");
+    TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("CG2_1234").name(), "GPSANS");
   }
 
   void testGetExtension() {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -299,7 +299,7 @@ public:
     TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns("MUSR15189n-15193"), const std::invalid_argument &);
     TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns("MUSR15189-15193n"), const std::invalid_argument &);
     TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns("MUSR15189-151n93"), const std::invalid_argument &);
-    TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns("MUSR15n189-151n93"), const Exception::NotFoundError &);
+    TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns("MUSR15n189-151n93"), const std::invalid_argument &);
     TS_ASSERT_THROWS_NOTHING(files = FileFinder::Instance().findRuns("MUSR15189-15193"));
     TS_ASSERT_EQUALS(files.size(), 5);
     std::vector<std::string>::iterator it = files.begin();

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -229,12 +229,14 @@ public:
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("PG31234").name(), "POWGEN");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("PG3_1234").name(), "POWGEN");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("PG3_1234_event.nxs").name(), "POWGEN");
+    TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("pg3_1234_event.nxs").name(), "POWGEN");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("/home/user123/CNCS_234_neutron_event.dat").name(), "CNCS");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("REF_L1234").name(), "REF_L");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("REF_L_1234").name(), "REF_L");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("REF_L_1234.nxs.h5").name(), "REF_L");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("LOQ16613.n001").name(), "LOQ");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("LOQ16613.s01").name(), "LOQ");
+    TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("loq16613.n001").name(), "LOQ");
     TS_ASSERT_EQUALS(FileFinder::Instance().getInstrument("SANS2D00032676.nxs").name(), "SANS2D");
     TS_ASSERT_THROWS(FileFinder::Instance().getInstrument("BADINSTR12354.nxs", false),
                      const Mantid::Kernel::Exception::NotFoundError &);

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -299,6 +299,13 @@ private:
   Kernel::ProxyInfo m_proxyInfo;
   /// whether the proxy has been populated yet
   bool m_isProxySet;
+
+  /// Cache for instrument names
+  mutable std::vector<std::string> m_instrumentNamesCache;
+  mutable bool m_isInstrumentNamesCached = false;
+  /// Cache for instrument short names
+  mutable std::vector<std::string> m_instrumentShortNamesCache;
+  mutable bool m_isInstrumentShortNamesCached = false;
 };
 
 EXTERN_MANTID_KERNEL template class MANTID_KERNEL_DLL Mantid::Kernel::SingletonHolder<ConfigServiceImpl>;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -213,6 +213,9 @@ public:
   /// Look for an instrument
   const InstrumentInfo &getInstrument(const std::string &instrumentName = "") const;
 
+  const std::vector<std::string> getInstrumentNames() const;
+  const std::vector<std::string> getInstrumentShortNames() const;
+
   /// Add an observer for a notification
   void addObserver(const Poco::AbstractObserver &observer) const;
 

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -213,8 +213,8 @@ public:
   /// Look for an instrument
   const InstrumentInfo &getInstrument(const std::string &instrumentName = "") const;
 
-  const std::vector<std::string> getInstrumentNames() const;
-  const std::vector<std::string> getInstrumentShortNames() const;
+  // Find the longest matching instrument prefix for the given hint.
+  const std::string findLongestInstrumentPrefix(const std::string &hint) const;
 
   /// Add an observer for a notification
   void addObserver(const Poco::AbstractObserver &observer) const;
@@ -300,12 +300,9 @@ private:
   /// whether the proxy has been populated yet
   bool m_isProxySet = false;
 
-  /// Cache for instrument names
-  mutable std::vector<std::string> m_instrumentNamesCache;
-  mutable bool m_isInstrumentNamesCached = false;
-  /// Cache for instrument short names
-  mutable std::vector<std::string> m_instrumentShortNamesCache;
-  mutable bool m_isInstrumentShortNamesCached = false;
+  // cache for longest matching instrument prefix
+  mutable std::vector<std::string> m_instrumentPrefixesCache;
+  mutable bool m_isInstrumentPrefixesCached = false;
 };
 
 EXTERN_MANTID_KERNEL template class MANTID_KERNEL_DLL Mantid::Kernel::SingletonHolder<ConfigServiceImpl>;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -298,7 +298,7 @@ private:
   /// local cache of proxy details
   Kernel::ProxyInfo m_proxyInfo;
   /// whether the proxy has been populated yet
-  bool m_isProxySet;
+  bool m_isProxySet = false;
 
   /// Cache for instrument names
   mutable std::vector<std::string> m_instrumentNamesCache;

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -125,8 +125,7 @@ const std::string LOG_LEVEL_KEY("logging.loggers.root.level");
 ConfigServiceImpl::ConfigServiceImpl()
     : m_pConf(nullptr), m_pSysConfig(new Poco::Util::SystemConfiguration()), m_changed_keys(), m_strBaseDir(""),
       m_propertyString(""), m_properties_file_name("Mantid.properties"),
-      m_user_properties_file_name("Mantid.user.properties"), m_dataSearchDirs(), m_instrumentDirs(), m_proxyInfo(),
-      m_isProxySet(false) {
+      m_user_properties_file_name("Mantid.user.properties"), m_dataSearchDirs(), m_instrumentDirs(), m_proxyInfo() {
   // Register StdChannel with Poco
   Poco::LoggingFactory::defaultFactory().registerChannelClass(
       "StdoutChannel", new Poco::Instantiator<Poco::StdoutChannel, Poco::Channel>);

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1798,6 +1798,10 @@ void ConfigServiceImpl::clearFacilities() {
     delete facility;
   }
   m_facilities.clear();
+  m_instrumentNamesCache.clear();
+  m_isInstrumentNamesCached = false;
+  m_instrumentShortNamesCache.clear();
+  m_isInstrumentShortNamesCached = false;
 }
 
 /**
@@ -1838,16 +1842,24 @@ const InstrumentInfo &ConfigServiceImpl::getInstrument(const std::string &instru
 }
 
 const std::vector<std::string> ConfigServiceImpl::getInstrumentNames() const {
+  if (m_isInstrumentNamesCached) {
+    return m_instrumentNamesCache;
+  }
   std::vector<std::string> names;
   for (const auto &facility : m_facilities) {
     const auto &insts = facility->instruments();
     std::transform(insts.cbegin(), insts.cend(), std::back_inserter(names),
                    [](const auto &inst) { return inst.name(); });
   }
-  return names;
+  m_instrumentNamesCache = names;
+  m_isInstrumentNamesCached = true;
+  return m_instrumentNamesCache;
 }
 
 const std::vector<std::string> ConfigServiceImpl::getInstrumentShortNames() const {
+  if (m_isInstrumentShortNamesCached) {
+    return m_instrumentShortNamesCache;
+  }
   std::vector<std::string> names;
   for (const auto &facility : m_facilities) {
     const auto &insts = facility->instruments();
@@ -1855,7 +1867,9 @@ const std::vector<std::string> ConfigServiceImpl::getInstrumentShortNames() cons
                    [](const auto &inst) { return inst.shortName(); });
   }
 
-  return names;
+  m_instrumentShortNamesCache = names;
+  m_isInstrumentShortNamesCached = true;
+  return m_instrumentShortNamesCache;
 }
 
 /** Gets a vector of the facility Information objects

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1837,6 +1837,30 @@ const InstrumentInfo &ConfigServiceImpl::getInstrument(const std::string &instru
   throw Exception::NotFoundError(errMsg, instrumentName);
 }
 
+const std::vector<std::string> ConfigServiceImpl::getInstrumentNames() const {
+  std::vector<std::string> names;
+  for (const auto &facility : m_facilities) {
+    const auto &insts = facility->instruments();
+    for (const auto &inst : insts) {
+      names.emplace_back(inst.name());
+    }
+  }
+
+  return names;
+}
+
+const std::vector<std::string> ConfigServiceImpl::getInstrumentShortNames() const {
+  std::vector<std::string> names;
+  for (const auto &facility : m_facilities) {
+    const auto &insts = facility->instruments();
+    for (const auto &inst : insts) {
+      names.emplace_back(inst.shortName());
+    }
+  }
+
+  return names;
+}
+
 /** Gets a vector of the facility Information objects
  * @return A vector of FacilityInfo objects
  */

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1841,11 +1841,9 @@ const std::vector<std::string> ConfigServiceImpl::getInstrumentNames() const {
   std::vector<std::string> names;
   for (const auto &facility : m_facilities) {
     const auto &insts = facility->instruments();
-    for (const auto &inst : insts) {
-      names.emplace_back(inst.name());
-    }
+    std::transform(insts.cbegin(), insts.cend(), std::back_inserter(names),
+                   [](const auto &inst) { return inst.name(); });
   }
-
   return names;
 }
 
@@ -1853,9 +1851,8 @@ const std::vector<std::string> ConfigServiceImpl::getInstrumentShortNames() cons
   std::vector<std::string> names;
   for (const auto &facility : m_facilities) {
     const auto &insts = facility->instruments();
-    for (const auto &inst : insts) {
-      names.emplace_back(inst.shortName());
-    }
+    std::transform(insts.cbegin(), insts.cend(), std::back_inserter(names),
+                   [](const auto &inst) { return inst.shortName(); });
   }
 
   return names;

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -201,6 +201,28 @@ public:
     TS_ASSERT_EQUALS(ConfigService::Instance().getInstrument().name(), "OSIRIS");
   }
 
+  void testFindLongestInstrumentPrefix() {
+    // Set a default facility
+    ConfigService::Instance().setFacility("SNS");
+
+    // Check that we can find the longest matching prefix for some hints
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("BASIS"), "BASIS");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("BASIS123"), "BASIS");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("BSS"), "BSS");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("BSS123"), "BSS");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("MAR"), "MAR");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("MAR123"), "MAR");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("PG3"), "PG3");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("PG3123"), "PG3");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("OSI"), "OSI");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("OSI123"), "OSI");
+
+    // Check that we return an empty string if there is no match
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("BS"), "");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("AAA"), "");
+    TS_ASSERT_EQUALS(ConfigService::Instance().findLongestInstrumentPrefix("XYZ"), "");
+  }
+
   void testSystemValues() {
     // we cannot test the return values here as they will differ based on the
     // environment.

--- a/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
@@ -39,6 +39,16 @@ class FileFinderTest(unittest.TestCase):
             self.assertEqual(len(runs), 1)
             self.assertTrue(os.path.exists(runs[0]))
 
+    def test_multiple_different_runs(self):
+        runs = FileFinder.findRuns("HB2C_7000-7001,475936")
+        self.assertEqual(len(runs), 3)
+        for run in runs:
+            self.assertTrue(os.path.exists(run))
+
+        self.assertEqual(os.path.basename(runs[0]), "HB2C_7000.nxs.h5")
+        self.assertEqual(os.path.basename(runs[1]), "HB2C_7001.nxs.h5")
+        self.assertEqual(os.path.basename(runs[2]), "HB2C_475936.nxs.h5")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40817.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40817.rst
@@ -1,0 +1,1 @@
+- :ref:`FileFinder <mantid.api.FileFinderImpl>` has been update to more reliably determine the instrument from the hint particularly when the instrument name contains digits.


### PR DESCRIPTION
### Description of work

This fixes how the instrument is extracted from the hints.

The examples for `FileFinder.findRuns`  from #40542 should now all work.


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

This only addresses part of #40542 There will need to be much bigger changes to fix everything.

Refs [EWM14890](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14890)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Using test data you should now be able to do things like

```python
FileFinder.findRuns('HB2C_7000-7001,475936')
FileFinder.findRuns('REF_L_179926-179927,183110-183112')
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
