### PR TITLE
Ignore default pixi directory in git

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -120,9 +120,12 @@ if [[ $CLEAN_BUILD  == true ]]; then
     # git clean will delete most things in build but leave subrepositories such as build/_deps/span-src
     # so we need to remove the whole of build/ by hand
     rm -fr $BUILD_DIR
+    rm -fr "$WORKSPACE/.pixi/" # less logs with rm
 else
-    git_clean_excludes_extra="--exclude=build --exclude=miniforge"
+    git_clean_excludes_extra="--exclude=build --exclude=miniforge --exclude=.pixi"
 fi
+# -d is recurse into directories
+# -x ignores what is listed in the .gitignore
 git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
 
 # install pixi if not already installed


### PR DESCRIPTION
This is a version of #40807 into `ornl-next`