### PR TITLE
Get sha for repository before moving into build directory

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -10,6 +10,8 @@ GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_MIRROR="$("${SCRIPT_DIR}/data_mirrors")"
 REPO_ROOT_DIR=$SCRIPT_DIR/../..
+SHA1=$(git rev-parse HEAD) # full sha for this source repository
+SHA1_SHORT=$(git rev-parse --short HEAD) # full sha for this source repository
 
 # source util functions
 . source/buildconfig/Jenkins/Conda/pixi-utils
@@ -47,9 +49,6 @@ echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/DocTest/' >> $WORKSPACE
 # Build the html docs
 export LC_ALL=C
 QT_QPA_PLATFORM=offscreen pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build cmake --build . --target docs-html
-
-SHA1=$(git rev-parse HEAD) # full sha for this source repository
-SHA1_SHORT=$(git rev-parse --short HEAD) # full sha for this source repository
 
 # Publish. Clone current docs to publish directory
 # and rsync between built html in html directory and current


### PR DESCRIPTION
The addition of git sha's in #40765 generated an error in [committing docs-nightly changes as seen here](https://builds.mantidproject.org/job/build_and_publish_docs/430/console). The end of the logs show
```
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in html.
++ git rev-parse HEAD
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+ SHA1=
Build step 'Invoke XShell command' marked build as failure
Finished: FAILURE
```
This is because the `git rev-parse` command was being run from the `build/` directory. 

This PR moves the commands for getting the git information to higher in the file before the `cd` happens.

### To test:

The best way to try it is to run the job.

*This does not require release notes* because it is fixing CI itself.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
