### PR TITLE
Migrate `LoadMuonNexusV2` to use `NexusDescriptorLazy`

### DIFF
--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -85,6 +85,21 @@ std::pair<IAlgorithm_sptr, int> searchForLoader(const std::string &filename,
 
   return {bestLoader, maxConfidence};
 }
+
+/// @brief Check if a file is HDF4 by examining its four signature bytes
+/// @param filename name of file to check
+/// @return true if it is HDF4 according to signature
+bool isHDF(std::string const &filename) {
+  // the HDF4 file signature, as per HDF's documentation
+  std::array<char, 4> constexpr hdf5_sig{0x0E, 0x03, 0x13, 0x01};
+  // read the signature in the first four bytes of this file
+  std::array<char, 4> signature;
+  std::ifstream file(filename, std::ios::binary);
+  if (!file.read(signature.data(), 4)) {
+    return false;
+  }
+  return signature == hdf5_sig;
+}
 } // namespace
 
 //----------------------------------------------------------------------------------------------
@@ -151,7 +166,8 @@ const std::shared_ptr<IAlgorithm> FileLoaderRegistryImpl::chooseLoader(const std
     } else {
       bestLoader = NexusLazyResult.first;
     }
-  } else {
+  } else if (isHDF(filename)) {
+    // If the file is HDF4, then it can only be loaded by the legacy nexus loaders
     try {
       bestLoader = searchForLoader<LegacyNexusDescriptor, IFileLoader<LegacyNexusDescriptor>>(
                        filename, m_names[LegacyNexus], m_log)

--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -91,14 +91,14 @@ std::pair<IAlgorithm_sptr, int> searchForLoader(const std::string &filename,
 /// @return true if it is HDF4 according to signature
 bool isHDF(std::string const &filename) {
   // the HDF4 file signature, as per HDF's documentation
-  std::array<char, 4> constexpr hdf5_sig{0x0E, 0x03, 0x13, 0x01};
+  std::array<char, 4> constexpr hdf4_sig{0x0E, 0x03, 0x13, 0x01};
   // read the signature in the first four bytes of this file
   std::array<char, 4> signature;
   std::ifstream file(filename, std::ios::binary);
   if (!file.read(signature.data(), 4)) {
     return false;
   }
-  return signature == hdf5_sig;
+  return signature == hdf4_sig;
 }
 } // namespace
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
@@ -5,11 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataHandling/LoadMuonStrategy.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -17,8 +18,8 @@ namespace DataHandling {
 
 Loads a file in the Nexus Muon format V2 and stores it in a 2D workspace
 (Workspace2D class). LoadMuonNexus is an algorithm that loads
-an HDF5 file and as such inherits from API::NexusFileLoader and
-the init() & execLoader() methods.
+an HDF5 file and as such inherits from API::IFileLoader<NexusDescriptorLazy> and
+the init() & exec() methods.
 Required Properties:
 <UL>
 <LI> Filename - The name of and path to the input NeXus file </LI>
@@ -35,7 +36,7 @@ OutputWorkspace_PeriodNo)
 @author Stephen Smith, ISIS
 */
 
-class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::NexusFileLoader {
+class MANTID_DATAHANDLING_DLL LoadMuonNexusV2 : public API::IFileLoader<Nexus::NexusDescriptorLazy> {
 public:
   // Default constructor
   LoadMuonNexusV2();
@@ -49,7 +50,7 @@ public:
            "given a NeXus file of this type.";
   }
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Nexus::NexusDescriptor &descriptor) const override;
+  int confidence(Nexus::NexusDescriptorLazy &descriptor) const override;
   // Version
   int version() const override { return 1; }
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
@@ -61,7 +61,7 @@ private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void execLoader() override;
+  void exec() override;
   // Determines whether entry contains multi period data
   void isEntryMultiPeriod();
   // Run child algorithm LoadISISNexus2

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -28,7 +28,7 @@
 
 namespace Mantid::DataHandling {
 
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMuonNexusV2)
+DECLARE_NEXUS_LAZY_FILELOADER_ALGORITHM(LoadMuonNexusV2)
 
 using namespace Kernel;
 using namespace API;
@@ -53,7 +53,7 @@ LoadMuonNexusV2::LoadMuonNexusV2()
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadMuonNexusV2::confidence(Nexus::NexusDescriptor &descriptor) const {
+int LoadMuonNexusV2::confidence(Nexus::NexusDescriptorLazy &descriptor) const {
   // Without this entry we cannot use LoadISISNexus
   if (!descriptor.isEntry(NeXusEntry::RAWDATA, "NXentry")) {
     return 0;
@@ -68,9 +68,7 @@ int LoadMuonNexusV2::confidence(Nexus::NexusDescriptor &descriptor) const {
   if (!descriptor.isEntry(NeXusEntry::DEFINITION))
     return 0;
 
-  Nexus::File file(descriptor.filename());
-  file.openAddress(NeXusEntry::DEFINITION);
-  std::string def = file.getStrData();
+  std::string def = descriptor.getStrData(NeXusEntry::DEFINITION);
   if (def == "muonTD" || def == "pulsedTD") {
     return 82; // have to return 82 to "beat" the LoadMuonNexus2 algorithm,
                // which returns 81 for this file as well
@@ -133,7 +131,7 @@ void LoadMuonNexusV2::init() {
                   "Table or a group of tables with information about the "
                   "detector grouping.");
 }
-void LoadMuonNexusV2::execLoader() {
+void LoadMuonNexusV2::exec() {
   // prepare nexus entry
   m_entrynumber = getProperty("EntryNumber");
   m_filename = getPropertyValue("Filename");

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -7,7 +7,7 @@
 #include "MantidMuon/LoadMuonNexus3.h"
 
 #include "MantidAPI/AlgorithmFactory.h"
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidKernel/Logger.h"
@@ -19,11 +19,11 @@ namespace {
 const int CONFIDENCE_THRESHOLD{80};
 
 int calculateConfidenceHDF5(const std::string &filePath, const std::shared_ptr<Mantid::API::Algorithm> &alg) {
-  const auto nexusLoader = std::dynamic_pointer_cast<Mantid::API::NexusFileLoader>(alg);
+  const auto nexusLoader = std::dynamic_pointer_cast<Mantid::API::IFileLoader<Nexus::NexusDescriptorLazy>>(alg);
   int confidence{0};
   if (H5::H5File::isHdf5(filePath)) {
     try {
-      Mantid::Nexus::NexusDescriptor descriptorHDF5(filePath);
+      Mantid::Nexus::NexusDescriptorLazy descriptorHDF5(filePath);
       confidence = nexusLoader->confidence(descriptorHDF5);
     } catch (std::exception const &e) {
       Mantid::Kernel::Logger("LoadMuonNexus3").debug()

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -19,7 +19,7 @@ namespace {
 const int CONFIDENCE_THRESHOLD{80};
 
 int calculateConfidenceHDF5(const std::string &filePath, const std::shared_ptr<Mantid::API::Algorithm> &alg) {
-  const auto nexusLoader = std::dynamic_pointer_cast<Mantid::API::IFileLoader<Nexus::NexusDescriptorLazy>>(alg);
+  const auto nexusLoader = std::dynamic_pointer_cast<Mantid::API::IFileLoader<Mantid::Nexus::NexusDescriptorLazy>>(alg);
   int confidence{0};
   if (H5::H5File::isHdf5(filePath)) {
     try {

--- a/Framework/Muon/test/LoadMuonNexus3Test.h
+++ b/Framework/Muon/test/LoadMuonNexus3Test.h
@@ -9,12 +9,13 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidMuon/LoadMuonNexus1.h"
 #include "MantidMuon/LoadMuonNexus2.h"
 #include "MantidMuon/LoadMuonNexus3.h"
+#include "MantidNexus/NexusDescriptorLazy.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -23,11 +24,11 @@ using namespace Mantid::DataObjects;
 
 namespace {
 // Mock class for LoadMuonNexusV2 which is in the DataHandling Library
-class LoadMuonNexusV2 : public NexusFileLoader {
+class LoadMuonNexusV2 : public IFileLoader<Nexus::NexusDescriptorLazy> {
   const std::string name() const override { return "LoadMuonNexusV2"; }
   int version() const override { return 1; }
-  int confidence(Mantid::Nexus::NexusDescriptor &) const override { return 100; }
-  void execLoader() override {}
+  int confidence(Mantid::Nexus::NexusDescriptorLazy &) const override { return 100; }
+  void exec() override {}
   const std::string summary() const override { return "mock class"; }
   void init() override {}
 };

--- a/Framework/Muon/test/LoadMuonNexus3Test.h
+++ b/Framework/Muon/test/LoadMuonNexus3Test.h
@@ -24,7 +24,7 @@ using namespace Mantid::DataObjects;
 
 namespace {
 // Mock class for LoadMuonNexusV2 which is in the DataHandling Library
-class LoadMuonNexusV2 : public IFileLoader<Nexus::NexusDescriptorLazy> {
+class LoadMuonNexusV2 : public IFileLoader<Mantid::Nexus::NexusDescriptorLazy> {
   const std::string name() const override { return "LoadMuonNexusV2"; }
   int version() const override { return 1; }
   int confidence(Mantid::Nexus::NexusDescriptorLazy &) const override { return 100; }


### PR DESCRIPTION
### Description of work

In PR #40570, a new file descriptor, `NexusDescriptorLazy`, was created for shallow and lazy checking of files as part of the `Load` algorithm's confidence check.

This is the only algorithm which has not yet been migrated to use this.  The switch was trivial, but required refactoring part of `LoadMuonNexus3` which checked for confidence among muon loaders.

To enhance performance, an additional check looks for HDF4 before trying to load anything with LegacyNexus; this allows the loader search to skip straight to non-HDF files without trying to open the file.

Follows on from Issue #37164 

### To test:

Run the system test, `LoadLotsOfFiles`:
``` bash
ninja Framework && ./systemtest -R LoadLotsOfFiles
```
Note that this runs on Jenkins.  In most recent, it took 277 seconds.

Note that `LoadLotsOfFiles` will try to load at least some muon files.

Build and run this script, to make sure muon nexus is loading:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

def wasLoadedMuon(ws):
    return ws.getHistory().getAlgorithmHistory(0).getPropertyValue("LoaderName") == "LoadMuonNexus"

for file in ["MUSR00015192", "MUSR00015189", "MUSR00022725"]:
    ret = Load(Filename=file, OutputWorkspace=f"ws_{file}")
    ws = mtd[f"ws_{file}"]
    if ws.isGroup():
        for i in range(ws.getNumberOfEntries()):
            assert wasLoadedMuon(ws.getItem(i))
    else:
      assert wasLoadedMuon(ws)
```
These files should exist in the unit test data.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
