### PR TITLE
Update `Load` hook documentation

### DIFF
--- a/dev-docs/source/LoadAlgorithmHook.rst
+++ b/dev-docs/source/LoadAlgorithmHook.rst
@@ -7,45 +7,43 @@ Load Algorithm Hook
 
 The Load Algorithm
 ##################
-This page describes how to register a new file loading algorithm so that it can be used through
+This page describes how to register a new file loading algorithm so that it can be used by
 the general-purpose :ref:`Load <algm-Load>` algorithm.
-The :ref:`Load <algm-Load>` algorithm is a special algorithm that does very little loading itself.
+The :ref:`Load <algm-Load>` algorithm is a special algorithm that performs very little loading itself.
 It instead tries to search for the most suitable algorithm for a given file and then uses this
 algorithm as a child to load the file. An algorithm wishing to be included as part of the search
-must register itself slightly differently and not use ``DECLARE_ALGORITHM`` macro.
+must register itself slightly differently and not use the ``DECLARE_ALGORITHM`` macro.
 
-The process of searching for the correct loader needs to be fairly quick as it will be especially
-noticeable in the GUI if the process takes a long time. To speed up the process the loaders are
-currently split into 3 categories:
+The process of searching for the correct loader needs to be fairly quick as long load times will be especially
+noticeable in the GUI. To speed up the process the loaders are currently split into three categories:
 
 - Nexus (HDF5)
 - Legacy Nexus (HDF4/5 -- for ISIS muon scattering only)
 - Non-HDF
 
-A quick check is performed, using ``H5::H5File::isHdf5()``, to test whether the file looks like a
-`HDF5 <http://www.hdfgroup.org/>`__ file.
-If the check succeeds then only the HDF5 group of loaders are checked.
+A quick check is performed using ``H5::H5File::isHdf5()`` to test whether the file looks like a
+`HDF5 <http://www.hdfgroup.org/>`__ file.  If the check succeeds, then only the Nexus loaders are checked.
 Another quick check is performed to test whether the file has an HDF4 signature.  If this succeeds, then only the Legacy Nexus loaders are checked.
-If the file is neither HDF5 nor HDF4, then the non-HDF group of loaders are checked.
+If the file is neither HDF5 nor HDF4, then the non-HDF group of loaders is checked.
 
 Descriptors
 ###########
-To avoid the file being opened/closed by each ``confidence`` method, a ``Descriptor`` object is provided.
+To avoid opening and closing the file within each ``confidence`` method, a ``Descriptor`` object is provided.
 The actual ``Descriptor`` class depends on whether the file is an HDF5 file, an HDF4 file, or neither.
 
 Nexus
 -----
-To register an algorithm as a Nexus loader use the ``IFileLoader<NexusDescriptorLazy>`` interface as a base class for your algorithm.
-In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM``
+To register an algorithm as a Nexus loader, use the ``IFileLoader<NexusDescriptorLazy>`` interface as a base class for your algorithm.
+In your cpp file, include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM``
 macro *instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
 The interface requires that the method ``virtual int confidence(Nexus::NexusDescriptorLazy &descriptor) const = 0;``
-be overloaded in the inheriting class. It should use the provided descriptor to check whether the loader is
-able to load the wrapped file and return a confidence level as an integer.
+be overridden in the inheriting class. It should use the provided descriptor to check whether the loader is
+able to load the wrapped file, and return a confidence level as an integer.
 
 NexusDescriptorLazy
 ^^^^^^^^^^^^^^^^^^^
-The lazy Nexus descriptor perform a shallow preload of the file, and then only lazily checks for entries (without opening them)
+The lazy Nexus descriptor performs a shallow preload of the file, and then only lazily checks for entries (without opening them)
 as loaders query them.  It owns a handle to an HDF5 file.  This is also able to load string data, if necessary for determining file loader.
 Avoid calling the ``getAllEntries()`` method; doing so may lead to unexpected or inefficient results.
 
@@ -78,7 +76,7 @@ In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use t
 *instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
 The interface requires that the method ``virtual int confidence(Kernel::FileDescriptor & descriptor) const = 0;``
-be overloaded in the inheriting class. It should use the provided descriptor to check whether the loader is
+be overridden in the inheriting class. It should use the provided descriptor to check whether the loader is
 able to load the wrapped file and return a confidence level as an integer.
 
 FileDescriptor

--- a/dev-docs/source/LoadAlgorithmHook.rst
+++ b/dev-docs/source/LoadAlgorithmHook.rst
@@ -9,7 +9,7 @@ The Load Algorithm
 ##################
 This page describes how to register a new file loading algorithm so that it can be used through
 the general-purpose :ref:`Load <algm-Load>` algorithm.
-The :ref:`Load <algm-Load>` algorithm is a special algorithm as does very little work itself.
+The :ref:`Load <algm-Load>` algorithm is a special algorithm that does very little loading itself.
 It instead tries to search for the most suitable algorithm for a given file and then uses this
 algorithm as a child to load the file. An algorithm wishing to be included as part of the search
 must register itself slightly differently and not use ``DECLARE_ALGORITHM`` macro.
@@ -18,31 +18,63 @@ The process of searching for the correct loader needs to be fairly quick as it w
 noticeable in the GUI if the process takes a long time. To speed up the process the loaders are
 currently split into 2 categories:
 
-- HDF - Currently only HDF4/5
-- NonHDF - The rest
+- Nexus (HDF5)
+- Legacy Nexus (HDF4/5 -- for ISIS muon scattering only)
+- Non-HDF
 
-A quick check is performed, using ``HDFDescriptor::isHDF()``, to test whether the file looks like a
-`HDF <http://www.hdfgroup.org/>`__ file.
-If the check succeeds then only the HDF group of loaders are checked, otherwise only the NonHDF group are checked.
+A quick check is performed, using ``H5::H5File::isHdf5()``, to test whether the file looks like a
+`HDF5 <http://www.hdfgroup.org/>`__ file.
+If the check succeeds then only the HDF5 group of loaders are checked.
+Another quick check is performed to test whether the file has an HDF4 signature.  If this succeeds, then only the Legacy Nexus loaders are checked.
+If the file is neither HDF5 nor HDF4, then the non-HDF group of loaders are checked.
 
 Descriptors
 ###########
 To avoid the file being opened/closed by each ``confidence`` method, a ``Descriptor`` object is provided.
 The actual ``Descriptor`` class depends on whether the file is a HDF file or not.
 
-HDF
----
-To register an algorithm as a HDF loader use the IHDFLoader interface as a base class for your algorithm.
-In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_HDF_FILELOADER``
+Nexus
+-----
+To register an algorithm as a Nexus loader use the IFileLoader<NexusDescriptorLazy> interface as a base class for your algorithm.
+In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM``
 macro *instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
-The interface requires that the method ``virtual int confidence(Kernel::HDFDescriptor & descriptor) const = 0;``
+The interface requires that the method ``virtual int confidence(Nexus::NexusDescriptorLazy &descriptor) const = 0;``
 be overloaded in the inheriting class. It should use the provided descriptor to check whether the loader is
 able to load the wrapped file and return a confidence level as an integer.
 
-HDFDescriptor
-^^^^^^^^^^^^^
-This provides methods to query characteristics of the current file to avoid repeated accessing of the tree.
+NexusDescriptorLazy
+^^^^^^^^^^^^^^^^^^^
+The lazy Nexus descriptor perform a shallow preload of the file, and then only lazily checks for entries (without opening them)
+as loaders query them.  It owns a handle to an HDF5 file.  This is also able to load string data, if necessary for determining file loader.
+Avoid calling the ``getAllEntries()`` method; doing so may lead to unexpected or inefficient results.
+
+Do **NOT** open a ``Nexus::File`` object using the descriptor's filename; doing so defeats efficiency gains of using a shallow loader.
+
+All new algorithms for loading HDF5 data should use the lazy descriptor.
+
+NexusDescriptor
+^^^^^^^^^^^^^^^
+This Nexus descriptor should not be used for confidence checks in `Load`, as it performs an eager load of the entire filetree.
+Use the lazy descriptor instead.
+
+LegacyNexus
+-----------
+These loaders preserve the state of ``Mantid::Nexus`` prior to the Nexus refactor.  They still rely on ``napi`` for loading HDF4 files,
+and do not include many of the performance efficiency gains from the refactor.  This type of loader should only be used for algorithms
+meant to load ISIS muon files, many of which still use HDF4.
+
+No new loaders should be written to use the legacy Nexus subpackage.
+
+LegacyNexus
+-----------
+These loading algorithms are based on the old ``napi`` framework, and do not include improvements in efficiency and memory use made
+during the Nexus refactor.  They remain in this state only for use by muon scattering scientists at ISIS.  These are the only algorithms
+in Mantid capable of loading HDF4 files.  No new algorithms should be registered in this state.
+
+LegacyNexusDescriptor
+^^^^^^^^^^^^^^^^^^^^^
+This uses old ``napi`` behavior to load the entire filetree and store in a dictionary cache.  Parts of the tree may be queried using available methods.
 
 Non-HDF
 -------

--- a/dev-docs/source/LoadAlgorithmHook.rst
+++ b/dev-docs/source/LoadAlgorithmHook.rst
@@ -16,7 +16,7 @@ must register itself slightly differently and not use ``DECLARE_ALGORITHM`` macr
 
 The process of searching for the correct loader needs to be fairly quick as it will be especially
 noticeable in the GUI if the process takes a long time. To speed up the process the loaders are
-currently split into 2 categories:
+currently split into 3 categories:
 
 - Nexus (HDF5)
 - Legacy Nexus (HDF4/5 -- for ISIS muon scattering only)
@@ -31,11 +31,11 @@ If the file is neither HDF5 nor HDF4, then the non-HDF group of loaders are chec
 Descriptors
 ###########
 To avoid the file being opened/closed by each ``confidence`` method, a ``Descriptor`` object is provided.
-The actual ``Descriptor`` class depends on whether the file is a HDF file or not.
+The actual ``Descriptor`` class depends on whether the file is an HDF5 file, an HDF4 file, or neither.
 
 Nexus
 -----
-To register an algorithm as a Nexus loader use the IFileLoader<NexusDescriptorLazy> interface as a base class for your algorithm.
+To register an algorithm as a Nexus loader use the ``IFileLoader<NexusDescriptorLazy>`` interface as a base class for your algorithm.
 In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM``
 macro *instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
@@ -50,6 +50,7 @@ as loaders query them.  It owns a handle to an HDF5 file.  This is also able to 
 Avoid calling the ``getAllEntries()`` method; doing so may lead to unexpected or inefficient results.
 
 Do **NOT** open a ``Nexus::File`` object using the descriptor's filename; doing so defeats efficiency gains of using a shallow loader.
+If you need to check a data string, use ``NexusDescriptorLazy::getStrData()``, passing the absolute dataset address within the file (e.g. `/entry/instrument/definition`).
 
 All new algorithms for loading HDF5 data should use the lazy descriptor.
 
@@ -60,17 +61,11 @@ Use the lazy descriptor instead.
 
 LegacyNexus
 -----------
-These loaders preserve the state of ``Mantid::Nexus`` prior to the Nexus refactor.  They still rely on ``napi`` for loading HDF4 files,
-and do not include many of the performance efficiency gains from the refactor.  This type of loader should only be used for algorithms
-meant to load ISIS muon files, many of which still use HDF4.
+These loaders preserve the state of ``Mantid::Nexus`` prior to the Nexus refactor.  They still rely on ``napi`` for loading HDF files,
+and do not include many of the improvements in efficiency and memory use from the refactor.  This type of loader should only be used for algorithms
+meant to load ISIS muon files, many of which still use HDF4.  These are the only loaders in Mantid capable of loading HDF4 files.
 
-No new loaders should be written to use the legacy Nexus subpackage.
-
-LegacyNexus
------------
-These loading algorithms are based on the old ``napi`` framework, and do not include improvements in efficiency and memory use made
-during the Nexus refactor.  They remain in this state only for use by muon scattering scientists at ISIS.  These are the only algorithms
-in Mantid capable of loading HDF4 files.  No new algorithms should be registered in this state.
+LegacyNexus is deprecated.  No new loaders should be written to work in LegacyNexus.
 
 LegacyNexusDescriptor
 ^^^^^^^^^^^^^^^^^^^^^

--- a/dev-docs/source/LoadAlgorithmHook.rst
+++ b/dev-docs/source/LoadAlgorithmHook.rst
@@ -7,82 +7,119 @@ Load Algorithm Hook
 
 The Load Algorithm
 ##################
-This page describes how to register a new file loading algorithm so that it can be used by
-the general-purpose :ref:`Load <algm-Load>` algorithm.
-The :ref:`Load <algm-Load>` algorithm is a special algorithm that performs very little loading itself.
-It instead tries to search for the most suitable algorithm for a given file and then uses this
-algorithm as a child to load the file. An algorithm wishing to be included as part of the search
-must register itself slightly differently and not use the ``DECLARE_ALGORITHM`` macro.
+This page describes how to register a new file loading algorithm
+so that it can be used by the general-purpose :ref:`Load <algm-Load>` algorithm.
+The :ref:`Load <algm-Load>` algorithm is a special algorithm
+that performs very little loading itself.
+It instead tries to search for the most suitable algorithm for a given file
+and then uses this algorithm as a child to load the file.
+An algorithm wishing to be included as part of the search
+must register itself slightly differently
+and not use the ``DECLARE_ALGORITHM`` macro.
 
-The process of searching for the correct loader needs to be fairly quick as long load times will be especially
-noticeable in the GUI. To speed up the process the loaders are currently split into three categories:
+The process of searching for the correct loader needs to be fairly quick
+as long load times will be especially noticeable in the GUI.
+To speed up the process the loaders are currently split into three categories:
 
 - Nexus (HDF5)
 - Legacy Nexus (HDF4/5 -- for ISIS muon scattering only)
 - Non-HDF
 
 A quick check is performed using ``H5::H5File::isHdf5()`` to test whether the file looks like a
-`HDF5 <http://www.hdfgroup.org/>`__ file.  If the check succeeds, then only the Nexus loaders are checked.
-Another quick check is performed to test whether the file has an HDF4 signature.  If this succeeds, then only the Legacy Nexus loaders are checked.
+`HDF5 <http://www.hdfgroup.org/>`__ file.
+If the file is HDF5, then only the Nexus loaders are checked.
+If the file is not HDF5, then it is checked for the HDF4 signature.
+If the file is HDF5, then only the Legacy Nexus loaders are checked.
 If the file is neither HDF5 nor HDF4, then the non-HDF group of loaders is checked.
 
 Descriptors
 ###########
-To avoid opening and closing the file within each ``confidence`` method, a ``Descriptor`` object is provided.
-The actual ``Descriptor`` class depends on whether the file is an HDF5 file, an HDF4 file, or neither.
+To avoid opening and closing the file within each ``confidence`` method,
+a ``Descriptor`` object is provided.
+The actual ``Descriptor`` class depends on whether the file is
+an HDF5 file,
+an HDF4 file,
+or neither.
 
 Nexus
 -----
-To register an algorithm as a Nexus loader, use the ``IFileLoader<NexusDescriptorLazy>`` interface as a base class for your algorithm.
-In your cpp file, include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM``
-macro *instead* of the standard ``DECLARE_ALGORITHM`` macro.
+To register an algorithm as a Nexus loader,
+use the ``IFileLoader<NexusDescriptorLazy>`` interface
+as a base class for your algorithm.
+In your cpp file, include the ``MantidAPI/RegisterFileLoader.h`` header
+and use the ``DECLARE_NEXUS_FILELOADER_ALGORITHM`` macro
+*instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
-The interface requires that the method ``virtual int confidence(Nexus::NexusDescriptorLazy &descriptor) const = 0;``
-be overridden in the inheriting class. It should use the provided descriptor to check whether the loader is
-able to load the wrapped file, and return a confidence level as an integer.
+The interface requires that the method
+``virtual int confidence(Nexus::NexusDescriptorLazy &descriptor) const = 0;``
+be overridden in the inheriting class.
+It should use the provided descriptor to check
+whether the loader is able to load the wrapped file,
+and return a confidence level as an integer.
 
 NexusDescriptorLazy
 ^^^^^^^^^^^^^^^^^^^
-The lazy Nexus descriptor performs a shallow preload of the file, and then only lazily checks for entries (without opening them)
-as loaders query them.  It owns a handle to an HDF5 file.  This is also able to load string data, if necessary for determining file loader.
-Avoid calling the ``getAllEntries()`` method; doing so may lead to unexpected or inefficient results.
+The lazy Nexus descriptor performs a shallow preload of the file,
+and then only lazily checks for entries (without opening them) as loaders query them.
+It owns a handle to an HDF5 file.
+This is also able to load string data, if necessary for determining file loader.
+Avoid calling the ``getAllEntries()`` method;
+doing so may lead to unexpected or inefficient results.
 
-Do **NOT** open a ``Nexus::File`` object using the descriptor's filename; doing so defeats efficiency gains of using a shallow loader.
-If you need to check a data string, use ``NexusDescriptorLazy::getStrData()``, passing the absolute dataset address within the file (e.g. `/entry/instrument/definition`).
+.. warning::
+  Do **NOT** open a ``Nexus::File`` object using the descriptor's filename.
+  Doing so defeats efficiency gains of using a shallow loader.
+  If you need to check a data string,
+  use ``NexusDescriptorLazy::getStrData()``,
+  passing the absolute dataset address within the file (e.g. `/entry/instrument/definition`).
 
 All new algorithms for loading HDF5 data should use the lazy descriptor.
 
 NexusDescriptor
 ^^^^^^^^^^^^^^^
-This Nexus descriptor should not be used for confidence checks in `Load`, as it performs an eager load of the entire filetree.
+This Nexus descriptor should not be used for confidence checks in `Load`,
+as it performs an eager load of the entire filetree.
 Use the lazy descriptor instead.
 
 LegacyNexus
 -----------
-These loaders preserve the state of ``Mantid::Nexus`` prior to the Nexus refactor.  They still rely on ``napi`` for loading HDF files,
-and do not include many of the improvements in efficiency and memory use from the refactor.  This type of loader should only be used for algorithms
-meant to load ISIS muon files, many of which still use HDF4.  These are the only loaders in Mantid capable of loading HDF4 files.
+These loaders preserve the state of ``Mantid::Nexus`` prior to the Nexus refactor.
+They still rely on ``napi`` for loading HDF files,
+and do not include many of the improvements in efficiency and memory use from the refactor.
+This type of loader should only be used for algorithms meant to load ISIS muon files,
+many of which still use HDF4.
+These are the only loaders in Mantid capable of loading HDF4 files.
 
-LegacyNexus is deprecated.  No new loaders should be written to work in LegacyNexus.
+LegacyNexus is deprecated.
+No new loaders should be written to work in LegacyNexus.
 
 LegacyNexusDescriptor
 ^^^^^^^^^^^^^^^^^^^^^
-This uses old ``napi`` behavior to load the entire filetree and store in a dictionary cache.  Parts of the tree may be queried using available methods.
+This uses old ``napi`` behavior to load the entire filetree and store in a dictionary cache.
+Parts of the tree may be queried using available methods.
 
 Non-HDF
 -------
-To register an algorithm as a Non-HDF loader use the ``IFileLoader`` interface as a base class for your algorithm.
-In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header and use the ``DECLARE_FILELOADER`` macro
+To register an algorithm as a Non-HDF loader use the ``IFileLoader`` interface
+as a base class for your algorithm.
+In your cpp file include the ``MantidAPI/RegisterFileLoader.h`` header
+and use the ``DECLARE_FILELOADER`` macro
 *instead* of the standard ``DECLARE_ALGORITHM`` macro.
 
-The interface requires that the method ``virtual int confidence(Kernel::FileDescriptor & descriptor) const = 0;``
-be overridden in the inheriting class. It should use the provided descriptor to check whether the loader is
-able to load the wrapped file and return a confidence level as an integer.
+The interface requires that the method
+``virtual int confidence(Kernel::FileDescriptor & descriptor) const = 0;``
+be overridden in the inheriting class.
+It should use the provided descriptor to check
+whether the loader is able to load the wrapped file,
+and return a confidence level as an integer.
 
 FileDescriptor
 ^^^^^^^^^^^^^^
 
-This provides methods to query some characteristics of the current file and also access the open stream to avoid
-repeated opening/closing of the file. *Avoid* closing the stream. The code calling the ``confidence`` method ensures
-that the stream is back at the start of the file before checking the next loader so simply use the stream as
-necessary and leave it as it is.
+This provides methods to query some characteristics of the current file
+and also access the open stream to avoid repeated opening/closing of the file.
+
+.. warning::
+  *Avoid* closing the stream. The code calling the ``confidence`` method
+  ensures that the stream is back at the start of the file before checking the next loader
+  so simply use the stream as necessary and leave it as it is.


### PR DESCRIPTION
### Description of work

There is a [page of the documentation](https://developer.mantidproject.org/LoadAlgorithmHook.html) describing how to register algorithms with `Load`.

During work for the Nexus Refactor (Issue #38332), everything related to Nexus and HDF5 was rearranged, making the docs out of date.  Following work for Issue #37164, things drifted even more.  This PR updates the docs to reflect the current state of the `Load` algorithm, the `FileLoaderRegistry`, and the process for registering files as loadable by HDF5.

### To test:

Build docs, proof read.  Please view the entire document, and not just the change set.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
