### PR TITLE
Improve phi slicing in sans gui

### DIFF
--- a/docs/source/release/v6.15.0/SANS/New_features/40831.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/40831.rst
@@ -1,0 +1,1 @@
+- Function ``PhiRanges`` in the :ref:`ISIS Command Interface<ScriptingSANSReductions>` uses the new TOML field for phi range in the reduction and accepts `use_mirror` as a keyword argument.

--- a/docs/source/release/v6.15.0/SANS/New_features/Used/39596.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/Used/39596.rst
@@ -1,2 +1,3 @@
 - New option for selecting a range of phi values in the masking tab of :ref:`ISIS SANS GUI <ISIS_Sans_interface_contents>` to generate multiple phi slices out of a single 1D reduction.
 - Add option in TOML :ref:`UserFiles<sans_toml_v1-ref>` to select a range of phi values to generate multiple phi slices in a single 1D reduction.
+- Function ``PhiRanges`` in the :ref:`ISIS Command Interface<ScriptingSANSReductions>` uses the new TOML field for phi range in the reduction and accepts `use_mirror` as a keyword argument.

--- a/docs/source/release/v6.15.0/SANS/New_features/Used/39596.rst
+++ b/docs/source/release/v6.15.0/SANS/New_features/Used/39596.rst
@@ -1,3 +1,2 @@
 - New option for selecting a range of phi values in the masking tab of :ref:`ISIS SANS GUI <ISIS_Sans_interface_contents>` to generate multiple phi slices out of a single 1D reduction.
 - Add option in TOML :ref:`UserFiles<sans_toml_v1-ref>` to select a range of phi values to generate multiple phi slices in a single 1D reduction.
-- Function ``PhiRanges`` in the :ref:`ISIS Command Interface<ScriptingSANSReductions>` uses the new TOML field for phi range in the reduction and accepts `use_mirror` as a keyword argument.

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -124,14 +124,17 @@ This is a required entry to specify the instrument name and `instrument.configur
 Phi Mask
 --------
 
-From Mantid 6.15, a new field for adding a range of phi slices is added to the phi mask. This is to automatize the process
-of reducing with different phi masks. A set of ranges as comma separated pairs can be input and there will be multiple reductions, each one with a different phi range.
-This settings overrides the phi start and stop angles, but is optional.
+From Mantid 6.15, a new field, ``range``, for adding a range of phi slices is added to the phi mask.
+This is to automatize the process of reducing with different phi masks. A range is input as a list of floats,
+which will produce multiple reductions, each one with a different phi mask.
+Note that the range has to contain an even number of values as the slices will be extracted as pairs from the list:
+:math:`[PhiMin_1,PhiMax_1,PhiMin_2,PhiMax_2] \to [PhiMin_1,PhiMax_1], [PhiMin_2,PhiMax_2]`.
+This field takes precedence over ``phi.start`` and ``phi.stop`` if both are set on the user file.
 
 ..  code-block:: yaml
 
   [mask.phi]
-    range = -15.0,15.0,45.0,90.0
+    range = [-15.0,15.0,45.0,90.0]
 
 
 Conversion From Legacy User Files

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -183,7 +183,7 @@ SetPhiLimit
     SetPhiLimit(phimin, phimax, use_mirror=True)
 
 Call this function to restrict the analysis to sectors of the detector.
-``Phimin`` and ``phimax`` define the limits of the sector where ``phi=0`` is the x-axis and ``phi=90`` is the y-axis.
+``phimin`` and ``phimax`` define the limits of the sector where ``phi=0`` is the x-axis and ``phi=90`` is the y-axis.
 Setting ``use_mirror`` to true causes the mirror sector to be included.
 
 .. _SANSScriptingWavRangeReduction:
@@ -267,5 +267,17 @@ The ``isOverlay`` flag determines if the times of the events and sample logs sho
 This is only applied if ``saveAsEvent`` was selected.
 The ``time_shifts`` variable is a list of additional time shifts which will be applied if ``isOverlay`` is selected.
 *Note that there has to be exactly one less time time shift than files to be added.*
+
+
+PhiRanges
+^^^^^^^^^
+
+.. code-block :: python
+
+    PhiRanges(phis, use_mirror=True, plot=False):
+
+Takes a list of phi ranges (``phis``) either as a list [a, b, c, d] or comma-separated string of number "a,b,c,d".
+It reduces in the phi ranges a-b and c-d. This is equivalent to combining ``setPhiLimit`` and then calling ``WavRangeReduction`` for
+multiple phi limits. ``use_mirror`` selects whether to use the mirror for each phi mask, and ``plot`` is not yet implemented.
 
 .. categories:: Techniques

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -276,8 +276,8 @@ PhiRanges
 
     PhiRanges(phis, use_mirror=True, plot=False):
 
-Takes a list of phi ranges (``phis``) either as a list [a, b, c, d] or comma-separated string of number "a,b,c,d".
-It reduces in the phi ranges a-b and c-d. This is equivalent to combining ``setPhiLimit`` and then calling ``WavRangeReduction`` for
-multiple phi limits. ``use_mirror`` selects whether to use the mirror for each phi mask, and ``plot`` is not yet implemented.
+Takes a list of phi ranges (``phis``) either as a list [a, b, c, d] or comma-separated string of numbers "a,b,c,d".
+It reduces in the phi ranges a-b and c-d. This is equivalent to combining ``SetPhiLimit`` and then calling ``WavRangeReduction`` for
+multiple phi limits. ``use_mirror`` selects whether to use the mirror for each phi mask. ``plot`` is not yet implemented.
 
 .. categories:: Techniques

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -1856,7 +1856,7 @@ QGroupBox::title {
                 </widget>
                </item>
                <item row="1" column="2">
-                <widget class="QComboBox" name="phi_range_step_type_combo_box">
+                <widget class="QComboBox" name="phi_limit_type_combo_box">
                  <property name="toolTip">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;PhiLimit type: if it is MinMax, the phi slice will be cut from a minimum (From) to a maximum (To). If pairs type is selected, the range can be input as pairs of numbers, each separated by comma (If input is: -15.0, 15.0, 45.0,90.0 two phi slices will be reduced: -15.0,15.0 and 45.0,90.0&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -743,7 +743,7 @@ def create_initial_reduction_packages(state, workspaces, monitors):
             monitors_for_package.update({workspace_type: workspace})
 
         # if we require multiple phi slicing
-        phi_range = state.mask.phi_range if state.mask.phi_range else [state.mask.phi_min, state.mask.phi_max]
+        phi_range = state.mask.phi_range if state.mask.use_phi_range and state.mask.phi_range else [state.mask.phi_min, state.mask.phi_max]
         if len(phi_range) > 2 and state.reduction.reduction_dimensionality is not ReductionDimensionality.ONE_DIM:
             # We select min and max of the whole range
             phi_range = [min(phi_range), max(phi_range)]

--- a/scripts/SANS/sans/command_interface/command_interface_state_director.py
+++ b/scripts/SANS/sans/command_interface/command_interface_state_director.py
@@ -535,7 +535,8 @@ class CommandInterfaceStateDirector(object):
         phi_min = command.values[0]
         phi_max = command.values[1]
         use_phi_mirror = command.values[2]
-        new_state_entries = {LimitsId.ANGLE: mask_angle_entry(min=phi_min, max=phi_max, use_mirror=use_phi_mirror)}
+        phi_range = command.values[3]
+        new_state_entries = {LimitsId.ANGLE: mask_angle_entry(min=phi_min, max=phi_max, use_mirror=use_phi_mirror, phi_range=phi_range)}
         self.add_to_processed_state_settings(new_state_entries)
 
     def _process_wavelength_correction_file(self, command):

--- a/scripts/SANS/sans/common/enums.py
+++ b/scripts/SANS/sans/common/enums.py
@@ -326,3 +326,14 @@ class BinningType(Enum):
     CUSTOM = "Custom"
     FROM_MONITORS = "FromMonitors"
     SAVE_AS_EVENT_DATA = "SaveAsEventData"
+
+
+class PhiLimitType(Enum):
+    """
+    Defines the limit type of slicing phi
+    MinMax: Traditional Minimum and Maximum (or start/stop) of a phi slice
+    Pairs: A range of Min,Max pairs for multiple phi slices.
+    """
+
+    MINMAX = "MinMax"
+    PAIRS = "Pairs"

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -689,7 +689,6 @@ class StateGuiModel(ModelCommon):
 
     @phi_limit_min.setter
     def phi_limit_min(self, value):
-        self._all_states.mask.phi_range = [value, self._all_states.mask.phi_max]
         self._all_states.mask.phi_min = value
 
     @property
@@ -699,8 +698,15 @@ class StateGuiModel(ModelCommon):
 
     @phi_limit_max.setter
     def phi_limit_max(self, value):
-        self._all_states.mask.phi_range = [self._all_states.mask.phi_min, value]
         self._all_states.mask.phi_max = value
+
+    @property
+    def phi_limit_use_range(self):
+        return self._all_states.mask.use_phi_range
+
+    @phi_limit_use_range.setter
+    def phi_limit_use_range(self, value):
+        self._all_states.mask.use_phi_range = value
 
     @property
     def phi_range(self):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -36,6 +36,7 @@ from sans.common.enums import (
     SANSInstrument,
     ReductionDimensionality,
     OutputMode,
+    PhiLimitType,
 )
 from sans.gui_logic.gui_common import (
     add_dir_to_datasearch,
@@ -286,8 +287,7 @@ class RunTabPresenter(PresenterCommon):
         sample_shape = ["Read from file", SampleShape.CYLINDER, SampleShape.FLAT_PLATE, SampleShape.DISC]
         self._view.sample_shape = sample_shape
 
-        phi_step_types = ["MinMax", "Pairs"]
-        self._view.phi_range_step_type = phi_step_types
+        self._view.phi_limit_use_range = [PhiLimitType.MINMAX, PhiLimitType.PAIRS]
 
         # Set the q range
         self._view.q_1d_step_type = [RangeStepType.LIN.value, RangeStepType.LOG.value]
@@ -1043,6 +1043,7 @@ class RunTabPresenter(PresenterCommon):
         self._set_on_view("phi_limit_min")
         self._set_on_view("phi_limit_max")
         self._set_on_view("phi_range")
+        self._set_on_view("phi_limit_use_range")
         self._set_on_view("phi_limit_use_mirror")
         self._set_on_view("radius_limit_min", self.DEFAULT_DECIMAL_PLACES_MM)
         self._set_on_view("radius_limit_max", self.DEFAULT_DECIMAL_PLACES_MM)
@@ -1158,7 +1159,15 @@ class RunTabPresenter(PresenterCommon):
                 "w_cut",
                 "q_1d",
             ],
-            "mask": ["phi_limit_min", "phi_limit_max", "phi_limit_use_mirror", "phi_range", "radius_limit_min", "radius_limit_max"],
+            "mask": [
+                "phi_limit_min",
+                "phi_limit_max",
+                "phi_limit_use_mirror",
+                "phi_range",
+                "phi_limit_use_range",
+                "radius_limit_min",
+                "radius_limit_max",
+            ],
             "user_file": ["user_file", "batch_file"],
             "beam_centre": ["rear_pos_1", "rear_pos_2", "front_pos_1", "front_pos_2"],
         }

--- a/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMaskDetectors.py
@@ -219,7 +219,8 @@ class StateMask(metaclass=JsonSerializable):
         self.phi_min = -90.0
         self.phi_max = 90.0
         self.use_mask_phi_mirror = True
-        self.phi_range: List[float] = []  # This attribute is not set from the user file, but from sans gui
+        self.phi_range: List[float] = []
+        self.use_phi_range = False
 
         # Beam stop
         self.beam_stop_arm_width: float = 0.0

--- a/scripts/SANS/sans/user_file/settings_tags.py
+++ b/scripts/SANS/sans/user_file/settings_tags.py
@@ -20,14 +20,13 @@ single_entry_with_detector = namedtuple("range_entry_with_detector", "entry, det
 back_single_monitor_entry = namedtuple("back_single_monitor_entry", "monitor, start, stop")
 
 # Limits
-mask_angle_entry = namedtuple("mask_angle_entry", "min, max, use_mirror")
+mask_angle_entry = namedtuple("mask_angle_entry", "min, max, use_mirror,phi_range", defaults=[-90.0, 90.0, True, []])
 simple_range = namedtuple("simple_range", "start, stop, step, step_type")
 q_xy_range = namedtuple("q_xy_range", "start, stop, step")
 complex_range = namedtuple("complex_steps", "start, step1, mid, step2, stop, step_type1, step_type2")
 rebin_string_values = namedtuple("rebin_string_values", "value")
 event_binning_string_values = namedtuple("event_binning_string_values", "value")
 q_rebin_values = namedtuple("q_rebin_values", "min, max, rebin_string")
-
 
 # Mask
 mask_line = namedtuple("mask_line", "width, angle, x, y")

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -518,6 +518,7 @@ class TomlV1ParserImpl(TomlParserImplBase):
                 self.mask.phi_max = phi_mask["stop"]
             if "range" in phi_mask:
                 self.mask.phi_range = phi_mask["range"]
+                self.mask.use_phi_range = True
 
     @staticmethod
     def _get_1d_min_max(one_d_binning: str):

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -603,6 +603,8 @@ class ParsedDictConverter(IStateParser):
             state_builder.set_phi_min(angle.min)
             state_builder.set_phi_max(angle.max)
             state_builder.set_use_mask_phi_mirror(angle.use_mirror)
+            state_builder.set_phi_range(angle.phi_range)
+            state_builder.set_use_phi_range(len(angle.phi_range) != 0)
 
         # ------------------------------------------------------------
         # 15. Maskfiles

--- a/scripts/test/SANS/command_interface/command_interface_state_director_test.py
+++ b/scripts/test/SANS/command_interface/command_interface_state_director_test.py
@@ -98,7 +98,7 @@ class CommandInterfaceStateDirectorTest(unittest.TestCase):
         self._assert_raises_nothing(command_interface.add_command, command)
 
         # Phi limits
-        command = NParameterCommand(command_id=NParameterCommandId.PHI_LIMIT, values=[12.5, 123.6, False])
+        command = NParameterCommand(command_id=NParameterCommandId.PHI_LIMIT, values=[12.5, 123.6, False, [11, 66, 33, 88]])
         self._assert_raises_nothing(command_interface.add_command, command)
 
         # Wavelength correction file
@@ -168,6 +168,7 @@ class CommandInterfaceStateDirectorTest(unittest.TestCase):
         self.assertEqual(state.mask.phi_min, 12.5)
         self.assertEqual(state.mask.phi_max, 123.6)
         self.assertFalse(state.mask.use_mask_phi_mirror)
+        self.assertEqual(state.mask.phi_range, [11, 66, 33, 88])
         self.assertTrue(
             state.adjustment.wavelength_and_pixel_adjustment.adjustment_files[DetectorType.HAB.value].wavelength_adjustment_file == "test"
         )

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -525,13 +525,14 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model.phi_range = "-15.0,15.0,75.0,90.0"
         self.assertEqual(state_gui_model.phi_range, "-15.0,15.0,75.0,90.0")
 
-    def test_that_phi_range_is_set_when_updating_phi_min_or_phi_max(self):
+    def test_use_phi_range_default_value(self):
         state_gui_model = StateGuiModel(AllStates())
-        state_gui_model.phi_limit_min = 12.0
+        self.assertFalse(state_gui_model.phi_limit_use_range)
 
-        self.assertEqual(state_gui_model.phi_range, "12.0,90.0")
-        state_gui_model.phi_limit_max = 30.0
-        self.assertEqual(state_gui_model.phi_range, "12.0,30.0")
+    def test_use_phi_range_setter(self):
+        state_gui_model = StateGuiModel(AllStates())
+        state_gui_model.phi_limit_use_range = True
+        self.assertTrue(state_gui_model.phi_limit_use_range)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Radius mask

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -665,6 +665,8 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual(False, masks.use_mask_phi_mirror)
         self.assertEqual(-50, masks.phi_min)
         self.assertEqual(50, masks.phi_max)
+        # By default phi range is not set
+        self.assertFalse(masks.phi_range)
 
         # TODO split below into own test
         transmission_state = parser_result.get_state_calculate_transmission()


### PR DESCRIPTION
### Description of work
This PR adds better control over the selection of phi slice from the sans GUI and the ISIS command interface. 
There is no associated issue but the feature was introduced on : #40585 . 
Gregory (from SANS) tried it on the 6.15 manual testing nightly release (so I consider found in beta) and gave me some feedback regarding the phi slicing. 
- There is a bug in the interface that when setting the phi mask on the `toml` user file (by setting the `mask.phi.range` field as a list) it's not easy to change back to the other mode (min max) on the interface -> I have improved this by adding a flag in the phi state. 
- Additionally, I added some support for phi slicing on the ISIS command interface. The way sans scientist change the phi mask from the command interface is by using the command `SetPhiLimit(MIN, MAX)` to change the phi mask state before the reduction. Additionally, there is the helper function `PhiRanges([min1,max1,...])`, which basically does a for loop applying `SetPhiLimit` before each reduction from the input list parameter. I have modified this function to use the new `mask.phi.range` field directly, this is slightly faster. 
 


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

The main change that is introduced is adding a state flag to control the selected phi mask from the interface. There is a combo box that selects the widget of the phi mask between two options (`MinMax` which selects one start and one stop value for the phi mask and `Pairs` which selects a series of phi masks from a list of values). The state flag controls which widget is selected to apply the appropriate reduction. 

No release notes as it is a correction to a feature introduced before release. 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

-> This example uses the LOQ demo from training user data. You will have to modify the `MaskFile.toml` and `MaskFile.txt` files. 

A. Testing on the SANS GUI. 

 - On the `MaskFile.toml`, modify the field: 
 ``` 
[mask.phi]
        mirror = true
        start = 45.0
        stop = 90.0
        range= [11.0,66.0, 33.0, 88.0] 
```
- Load this user file on the SANS GUI. The phi mask section should automatically be set to `Pairs` with the input range on the user file. 
<img width="786" height="166" alt="image" src="https://github.com/user-attachments/assets/76124d13-0b12-49e2-a213-1c5d1f39523b" />

- Run the reduction with the `batch_mode_reduction.csv` file from the LOQ demo (selecting only the first row)

The output should look something like : 
<img width="346" height="189" alt="image" src="https://github.com/user-attachments/assets/f7c68367-498d-4f34-89fb-840b52298262" />

- Change the `PhiLimit type` combo box to` MinMax` and run the reduction again. 
   You should have a two new output workspaces ending in `..Phi45.0_90.0`

B. Testing on the command interface. 

- On the `MaskFile.txt` (legacy format) modify the following field : 
```
L/PHI 45 78 
```

Then run the following python script in Mantid (it assumes you have the path to the loqdemo files on the directories): 

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

#import Command Interface from sans library
from sans.command_interface.ISISCommandInterface import *


Clean()

LOQ()
MaskFile('MaskFile.txt')

AssignSample('LOQ74044.nxs')
TransmissionSample('LOQ74024.nxs', 'LOQ74014.nxs')
AssignCan('LOQ74019.nxs')
TransmissionCan('LOQ74020.nxs', 'LOQ74014.nxs')

WavRangeReduction(2.2, 10) # Phi extracted from legacy file
PhiRanges([23,33,35,42]) # Using phi ranges
SetPhiLimit(11.0,23.0) # Using phi min and max
WavRangeReduction(2.2,10)
PhiRanges([11.0,66.0]) # Using phi ranges again
```
The output should be: 
<img width="345" height="334" alt="image" src="https://github.com/user-attachments/assets/b6f59f7d-4b8c-478a-a024-2673ab9ec035" />




<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
