### PR TITLE
isis_powder generate_run_numbers() support plus signs in filename list

### DIFF
--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -215,6 +215,9 @@ def apply_placzek_correction_per_bank(
     sample_temp,
 ):
     raw_ws = mantid.Load(Filename="POLARIS" + str(run_number))
+    if raw_ws.isGroup():
+        raise ValueError("Placzek correction does not support group workspaces")
+
     sample_geometry_json = sample_details.generate_sample_geometry()
     sample_material_json = sample_details.generate_sample_material()
 

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -190,8 +190,9 @@ def extract_ws_spectra(ws_to_split):
 def generate_run_numbers(run_number_string):
     """
     Generates a list of run numbers as a list from the input. This input can be either a string or int type
-    and uses the same syntax that Mantid supports i.e. 1-10 generates 1,2,3...9,10 inclusive and commas can specify
-    breaks between runs
+    and uses the same syntax that Mantid supports i.e. 1-10 generates 1,2,3...9,10 inclusive and commas or plus signs
+    can specify breaks between runs (These are treated differently in Load, but this function just returns a list of
+    files that would be loaded).
     :param run_number_string: The string or int to convert into a list of run numbers
     :return: A list of run numbers generated from the string
     """
@@ -205,6 +206,7 @@ def generate_run_numbers(run_number_string):
 
     # If its a string we must parse it
     run_number_string = run_number_string.strip()
+    run_number_string = run_number_string.replace("+", ",")
     run_boundaries = run_number_string.replace("_", "-")  # Accept either _ or - delimiters
     run_list = _run_number_generator(processed_string=run_boundaries)
     return run_list
@@ -296,7 +298,6 @@ def get_first_run_number(run_number_string):
         raise RuntimeError("Attempted to load empty set of workspaces. Please input at least one valid run number")
 
     run_numbers = run_numbers[0]
-
     return run_numbers
 
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -267,6 +267,18 @@ class ISISPowderCommonTest(unittest.TestCase):
         returned_values = common.generate_run_numbers(run_number_string=input_string)
         self.assertEqual(expected_values, returned_values)
 
+        # Check plus operator
+        input_string = "40+45+50"
+        expected_values = [40, 45, 50]
+        returned_values = common.generate_run_numbers(run_number_string=input_string)
+        self.assertEqual(expected_values, returned_values)
+
+        # Check plus operator with range
+        input_string = "40+45-50"
+        expected_values = [40, 45, 46, 47, 48, 49, 50]
+        returned_values = common.generate_run_numbers(run_number_string=input_string)
+        self.assertEqual(expected_values, returned_values)
+
     def test_generate_spline_vanadium_name(self):
         reference_vanadium_name = "foo_123"
         sample_arg_one = "arg1"


### PR DESCRIPTION
For POLARIS total scattering it is sometimes useful to sum non consecutive runs, e.g. `146554+146603` or `146554+146603-146609`. This PR ensures that the POLARIS scripts can handle the plus operator to match `Load` behaviour.

### Description of work

In the ISIS powder POLARIS script, the focus method need to get a flat list of all the file included in a filename string. It does not need the full filename parsing that exists in Load, so it has its own simple implementation. For this comma and plus operators are equivalent.

Converts '+' to ',' so that the existing parsing in `IntArrayProperty` will work correctly.

Adds tests

Closes #40648 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Test script at:
https://github.com/mantidproject/mantid/issues/40648#issuecomment-3854161762
If it succeeds it will generate a workspace called test

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->
---

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?
<!--  GATEKEEPER: ...To HERE  -->
