### PR TITLE
Run mdformat on more files

### DIFF
--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.md
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.md
@@ -6,7 +6,9 @@
 - On CentOS based systems (RHEL) install using yum with the following command: `sudo yum install git`
 
 ```{include} CloningMantid.md
-:heading-offset: 1
+---
+heading-offset: 1
+---
 ```
 
 ## Install [Miniforge](https://github.com/conda-forge/miniforge/releases)

--- a/dev-docs/source/GettingStarted/GettingStartedCondaOSX.md
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaOSX.md
@@ -5,7 +5,9 @@
 - On MacOS install using brew with the following command: `brew install git`
 
 ```{include} CloningMantid.md
-:heading-offset: 1
+---
+heading-offset: 1
+---
 ```
 
 ## Install [Miniforge](https://github.com/conda-forge/miniforge/releases)

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.md
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.md
@@ -24,7 +24,9 @@
 - Navigate to your Settings -> Manage App Execution Aliases, and turn off all Python Aliases.
 
 ```{include} CloningMantid.md
-:heading-offset: 1
+---
+heading-offset: 1
+---
 ```
 
 ## Install [Miniforge](https://github.com/conda-forge/miniforge/releases)

--- a/dev-docs/source/PyCharm.md
+++ b/dev-docs/source/PyCharm.md
@@ -174,7 +174,8 @@ This section assumes you have followed all previous instructions for debugging P
 
   ```python
   import pydevd_pycharm
-  pydevd_pycharm.settrace('localhost', port=8080, stdoutToServer=True, stderrToServer=True)
+
+  pydevd_pycharm.settrace("localhost", port=8080, stdoutToServer=True, stderrToServer=True)
   ```
 
 - Paste this code where you want to start debugging from, this will act like a breakpoint during normal debugging.
@@ -311,19 +312,22 @@ To test that the above instructions have worked, you can simply create a new Pyt
 ```python
 # Check that PyQt imports
 from qtpy import QtCore, QtGui, QtWidgets
+
 # Check that the Mantid Python API imports
 import mantid.simpleapi
 
-class DummyView(QtWidgets.QWidget):
 
+class DummyView(QtWidgets.QWidget):
     def __init__(self, name, parent=None):
         super(DummyView, self).__init__(parent)
         self.grid = QtWidgets.QGridLayout(self)
         btn = QtWidgets.QPushButton(name, self)
         self.grid.addWidget(btn)
 
+
 if __name__ == "__main__":
     import sys
+
     app = QtWidgets.QApplication(sys.argv)
     ui = DummyView("Hello")
     ui.show()

--- a/dev-docs/source/VSCode.md
+++ b/dev-docs/source/VSCode.md
@@ -372,7 +372,8 @@ python3 -m pip install --user debugpy
 
 ```python
 import debugpy
-debugpy.listen(('127.0.0.1', 5678))
+
+debugpy.listen(("127.0.0.1", 5678))
 debugpy.wait_for_client()
 debugpy.breakpoint()
 ```


### PR DESCRIPTION
#40822 added mdformat to pre-commit. #40737 converted some `.rst` files to `.md`. The pre-commit PR got merged and the doc migration wasn't rebased on it with formatting re-applied. This applies the formatting.

There is no associated issue

### To test:

*This does not require release notes* because it is reformatting files.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
