### PR TITLE
fix windows systest targ

### DIFF
--- a/buildconfig/CMake/WindowsSetup.cmake
+++ b/buildconfig/CMake/WindowsSetup.cmake
@@ -166,9 +166,9 @@ if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
   set_target_properties(
     SystemTests
     PROPERTIES VS_DEBUGGER_COMMAND "${Python_EXECUTABLE}"
-               VS_DEBUGGER_COMMAND_ARGUMENTS VS_DEBUGGER_ENVIRONMENT
+               VS_DEBUGGER_COMMAND_ARGUMENTS
                "${CMAKE_SOURCE_DIR}/Testing/SystemTests/scripts/runSystemTests.py --executable python3"
-               "${MSVC_IDE_ENV}"
+               VS_DEBUGGER_ENVIRONMENT "${MSVC_IDE_ENV}"
   )
 endif()
 

--- a/buildconfig/CMake/WindowsSetup.cmake
+++ b/buildconfig/CMake/WindowsSetup.cmake
@@ -163,8 +163,16 @@ if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
   add_custom_target(SystemTests)
   add_dependencies(SystemTests Framework)
   add_dependencies(SystemTests StandardTestData SystemTestData)
+
+  # create a launchable VS project purely for Debugging properties
+  set(_stub "${CMAKE_CURRENT_BINARY_DIR}/systemtests_stub.cpp")
+  file(WRITE "${_stub}" "int main(){return 0;}\n")
+
+  add_executable(SystemTestsDebug EXCLUDE_FROM_ALL "${_stub}")
+  add_dependencies(SystemTestsDebug SystemTests)
+
   set_target_properties(
-    SystemTests
+    SystemTestsDebug
     PROPERTIES VS_DEBUGGER_COMMAND "${Python_EXECUTABLE}"
                VS_DEBUGGER_COMMAND_ARGUMENTS
                "${CMAKE_SOURCE_DIR}/Testing/SystemTests/scripts/runSystemTests.py --executable python3"

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -217,12 +217,12 @@ fixed when running CMake, e.g.
 Selecting Tests to Run From IDE
 -------------------------------
 
-System tests can be run from the MSVC IDE using the ``SystemTests`` target,
+System tests can be run from the MSVC IDE using the ``SystemTestsDebug`` target,
 which behaves in a similar way to unit test targets. One key advantage is
 that it allows you to start Mantid in a debug environment rather than attach
 to one midway through.
 
-To select an individual test, or range of tests, go to the ``SystemTests``
+To select an individual test, or range of tests, go to the ``SystemTestsDebug``
 properties, go to ```Command Arguments``` and append flags as appropriate.
 
 For example, adding ``-R ISIS`` will run any tests which match the regular


### PR DESCRIPTION
### Description of work

According to the docs, it should be possible to run system tests through Visual Studio using the `SystemTests` target. This should allow a developer to run specific system test and automatically attach a debugger to it to break in c++.

This currently doesn't work due to the way `VS_DEBUGGER_COMMAND_ARGUMENTS` interacts with custom targets, as opposed to executables, and according to chatgpt possible never worked (though the original PR seems to contradict this). I can't find anything of relevance in actual docs.

Regardless, this PR adds an executable target, `SystemTestsDebug`, that does allow a user to run and debug system tests from Visual Studio.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Follow the instructions in the modified docs.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
