### PR TITLE
Improve performance in MaskDetectors determining mask from MatrixWorkspace

### DIFF
--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40855.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40855.rst
@@ -1,0 +1,1 @@
+- Fix performance issue in :ref:`MaskDetectors <algm-MaskDetectors>` using a ``MatrixWorkspace`` as the source of the mask


### PR DESCRIPTION
When determining which spectra to mask using a MatrixWorkspace as the mask, the performance of `MaskDetectors` was unacceptably slow. This fixes the issue by replacing a `std::copy_if` with a hand written range based `for` loop with `std::vector::emplace_back`. I added a comment about the implementation because I was surprised by the speed difference.

There is no associated issue.

### To test:

The original bug report was (you'll need to find the files)
```py
from mantid.simpleapi import *

LoadNexusProcessed(Filename='/SNS/TOPAZ/shared/Vanadium/2025B_AG_4mm_sphere/solid_angle.nxs',
                   OutputWorkspace='sa')
LoadEventNexus(Filename='TOPAZ_46719.nxs.h5', OutputWorkspace='TOPAZ_46719')
MaskDetectors('TOPAZ_46719', MaskedWorkspace='sa')
```
Before this change, I killed the script after 40 minutes. With this change, it takes 9 seconds.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
