### PR TITLE
Edit framework release notes for v6.15.0

### DIFF
--- a/docs/source/api/python/mantid/api/Jacobian.rst
+++ b/docs/source/api/python/mantid/api/Jacobian.rst
@@ -1,3 +1,5 @@
+.. _func-Jacobian:
+
 ==========
  Jacobian
 ==========

--- a/docs/source/release/v6.15.0/framework.rst
+++ b/docs/source/release/v6.15.0/framework.rst
@@ -64,8 +64,8 @@ New features
 
 Bugfixes
 ########
-- (`#40029 <https://github.com/mantidproject/mantid/pull/40029>`_) ``MatrixWorkspace::getNumberBins()`` has been
-  replaced by ``MatrixWorkspace::blocksize()``, as the former is deprecated.
+- (`#40029 <https://github.com/mantidproject/mantid/pull/40029>`_) :py:meth:`mantid.api.MatrixWorkspace.getNumberBins()` has been
+  replaced by :py:meth:`mantid.api.MatrixWorkspace.blocksize()`, as the former is deprecated.
 - (`#40606 <https://github.com/mantidproject/mantid/pull/40606>`_) :ref:`algm-GenerateEventsFilter`
   will now be able to handle cases where there is no second pulse in the ROI.
 - (`#40336 <https://github.com/mantidproject/mantid/pull/40336>`_) :ref:`algm-CreateDetectorTable` will now return the

--- a/docs/source/release/v6.15.0/framework.rst
+++ b/docs/source/release/v6.15.0/framework.rst
@@ -121,7 +121,7 @@ Dependencies
 
 Bugfixes
 ############
-- (`#40246 <https://github.com/mantidproject/mantid/pull/40246>`_) Pin `occt` to 7.9.2 to avoid conda/rattler version
+- (`#40246 <https://github.com/mantidproject/mantid/pull/40246>`_) Pin ``occt`` to 7.9.2 to avoid conda/rattler version
   number parsing issue with 7.9.1 (See `here <https://github.com/conda-forge/occt-feedstock/pull/124>`_).
 
 Kernel

--- a/docs/source/release/v6.15.0/framework.rst
+++ b/docs/source/release/v6.15.0/framework.rst
@@ -10,107 +10,131 @@ Algorithms
 
 New features
 ############
-- (`#40367 <https://github.com/mantidproject/mantid/pull/40367>`_) `UnaryOperation <https://github.com/mantidproject/mantid/blob/main/Framework/Algorithms/src/UnaryOperation.cpp>`_ algorithms like :ref:`ReplaceSpecialValues <algm-ReplaceSpecialValues>`, :ref:`Logarithm <algm-Logarithm>` now support ragged workspaces.
-- (`#40063 <https://github.com/mantidproject/mantid/pull/40063>`_) Documenting flowchart diagram for :ref:`algm-LoadWANDSCD`.
-- (`#40067 <https://github.com/mantidproject/mantid/pull/40067>`_) :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` now has the parameter ``OutputSpectrumNumber`` for selecting to load only a single bank of data.
-- (`#40107 <https://github.com/mantidproject/mantid/pull/40107>`_) Created new algorithm :ref:`HFIRPowderReduction <algm-HFIRPowderReduction>`, just added UI for loading data to reduce
-- (`#40120 <https://github.com/mantidproject/mantid/pull/40120>`_) Documenting flowchart diagram for :ref:`algm-ConvertWANDSCDtoQ`.
-- (`#40122 <https://github.com/mantidproject/mantid/pull/40122>`_) Added a new implementation for splitting into multiple workspace to :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` that can be tested by setting ``ProcessBankSplitTask=True``.
-- (`#40128 <https://github.com/mantidproject/mantid/pull/40128>`_) :ref:`CreateDetectorTable <algm-CreateDetectorTable>` now supports option ``PickOneDetectorID`` for returning column of detector IDs as a column of integers containing only one detector ID per row.
-  By default this option is disabled, so by default the column of detector IDs will consist of strings of one or more detector ID per row.
-  This new option was introduced to be used in the background of the new instrument view interface, but might also be useful if the user wants a single detector ID per row.
-- (`#40213 <https://github.com/mantidproject/mantid/pull/40213>`_) Added UI elements for the reduction part of :ref:`HFIRPowderReduction <algm-HFIRPowderReduction>`
-- (`#40227 <https://github.com/mantidproject/mantid/pull/40227>`_) New algorithm, :ref:`CreateGroupingByComponent <algm-CreateGroupingByComponent>`, allows for creation of ``GroupingWorkspaces`` where the groups are formed by combining components, under a given parent component. Components which should be combined are identified by providing strings which their names should/should not contain. Each of these groups can be optionally subdivided into a further, ``GroupSubdivision``, number of groups.
-- (`#40234 <https://github.com/mantidproject/mantid/pull/40234>`_) Documenting flowchart diagram for :ref:`algm-ConvertHFIRSCDtoMDE`
-- (`#40327 <https://github.com/mantidproject/mantid/pull/40327>`_) New algorithm :ref:`ReorientUnitCell <algm-ReorientUnitCell>` to select the unit cell most aligned to goniometer axes.
-- (`#40332 <https://github.com/mantidproject/mantid/pull/40332>`_) New algorithm :ref:`AddLogSmoothed <algm-AddLogSmoothed>` for smoothing time series log data.
-- (`#40377 <https://github.com/mantidproject/mantid/pull/40377>`_) :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` can now can split events based on full time (pulsetime+TOF) with the parameter ``UseFullTime``.
-- (`#40420 <https://github.com/mantidproject/mantid/pull/40420>`_) Algorithm :ref:`LoadNGEM <algm-LoadNGEM>` has been extended to allow for data to be loaded directly into histograms, via the setting of the PreserveEvents property to ``False``. For workflows where preserving events is not necessary, this reduces load time and memory usage by a large factor.
--  Updated the :ref:`MaskDetectorsIf <algm-MaskDetectorsIf>` algorithm to allow the user to input the start and end index of the range to apply the mask on.
-- (`#40450 <https://github.com/mantidproject/mantid/pull/40450>`_) New algorithm :ref:`AddLogInterpolated <algm-AddLogInterpolated>` for interpolating time series sample logs.
-- (`#40493 <https://github.com/mantidproject/mantid/pull/40493>`_) :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` will now set the uncertainty values on the output workspace.
-- (`#40656 <https://github.com/mantidproject/mantid/pull/40656>`_) The :ref:`algm-Load` algorithm, and the file loader search process, now use a lazy file descriptor to check for the correct loading algorithm, further reducing time for :ref:`algm-Load`.
-- (`#40669 <https://github.com/mantidproject/mantid/pull/40669>`_) Updated default parameters ``ReadSizeFromDisk``, ``EventsPerThread``, and ``LogBlockList`` for :ref:`AlignAndFocusPowderSlim <algm-AlignAndFocusPowderSlim>` to give faster execution.
-- (`#40444 <https://github.com/mantidproject/mantid/pull/40444>`_) New property in :ref:`ApplyDetailedBalanceMD <algm-ApplyDetailedBalanceMD>` allows scaling data from one temperature to another.
+- (`#40367 <https://github.com/mantidproject/mantid/pull/40367>`_)
+  `UnaryOperation <https://github.com/mantidproject/mantid/blob/main/Framework/Algorithms/src/UnaryOperation.cpp>`_
+  algorithms like :ref:`ReplaceSpecialValues <algm-ReplaceSpecialValues>`, :ref:`Logarithm <algm-Logarithm>` now support
+  ragged workspaces.
+- Several algorithms have had flowcharts added to document their processing steps:
+
+  - (`#40063 <https://github.com/mantidproject/mantid/pull/40063>`_) :ref:`algm-LoadWANDSCD`
+  - (`#40120 <https://github.com/mantidproject/mantid/pull/40120>`_) :ref:`algm-ConvertWANDSCDtoQ`
+  - (`#40234 <https://github.com/mantidproject/mantid/pull/40234>`_) :ref:`algm-ConvertHFIRSCDtoMDE`
+
+- :ref:`algm-AlignAndFocusPowderSlim` has some new parameters:
+
+  - (`#40067 <https://github.com/mantidproject/mantid/pull/40067>`_)
+    ``OutputSpectrumNumber``, which allows a single bank of data to be loaded.
+  - (`#40122 <https://github.com/mantidproject/mantid/pull/40122>`_)
+    ``ProcessBankSplitTask``, which can split its output into multiple workspaces when set to ``True``.
+  - (`#40377 <https://github.com/mantidproject/mantid/pull/40377>`_)
+    ``UseFullTime``, which can split events based on full time (pulse time+TOF) when ``True``
+  - (`#40669 <https://github.com/mantidproject/mantid/pull/40669>`_)
+    ``ReadSizeFromDisk``, ``EventsPerThread``, and ``LogBlockList`` are existing parameters with new defaults to provide
+    faster execution.
+
+- (`#40493 <https://github.com/mantidproject/mantid/pull/40493>`_) :ref:`algm-AlignAndFocusPowderSlim` will now set the
+  uncertainty values on the output workspace.
+- (`#40107 <https://github.com/mantidproject/mantid/pull/40107>`_) :ref:`algm-HFIRPowderReduction` is a new algorithm,
+  which is currently just the UI elements for loading and reducing data.
+- (`#40128 <https://github.com/mantidproject/mantid/pull/40128>`_) :ref:`algm-CreateDetectorTable` now supports the
+  option ``PickOneDetectorID``. This returns a column of detector IDs as a column of integers containing only one
+  detector ID per row. By default this option is disabled, so by default the column of detector IDs will consist of
+  strings of one or more detector ID per row. This new option was introduced to be used in the background of the new
+  instrument view interface, but might also be useful if the user wants a single detector ID per row.
+- (`#40227 <https://github.com/mantidproject/mantid/pull/40227>`_) :ref:`algm-CreateGroupingByComponent` is a new
+  algorithm that allows for the creation of ``GroupingWorkspaces``, where the groups are formed by combining components
+  under a given parent component. Components which should be combined are identified by providing strings to indicate
+  what their names should/should not contain. Each of these groups can be optionally subdivided into a further,
+  ``GroupSubdivision``, number of groups.
+- (`#40327 <https://github.com/mantidproject/mantid/pull/40327>`_) :ref:`algm-ReorientUnitCell` is a new algorithm that
+  allows the selection of the unit cell most aligned to goniometer axes.
+- (`#40332 <https://github.com/mantidproject/mantid/pull/40332>`_) :ref:`algm-AddLogSmoothed` is also new, and allows
+  for the addition of smoothed time-series log data.
+- (`#40450 <https://github.com/mantidproject/mantid/pull/40450>`_) :ref:`algm-AddLogInterpolated` is new, and provides a
+  method for interpolating time series sample logs.
+- (`#40420 <https://github.com/mantidproject/mantid/pull/40420>`_) :ref:`algm-LoadNGEM` has been extended to allow for
+  data to be loaded directly into histograms, by setting the ``PreserveEvents`` property to ``False``. For workflows
+  where preserving events is not necessary, this significantly reduces load time and memory usage.
+- (`#40429 <https://github.com/mantidproject/mantid/pull/40429>`_) :ref:`algm-MaskDetectorsIf` now allows the user to
+  input the start and end index of the range to apply the mask on.
+- (`#40656 <https://github.com/mantidproject/mantid/pull/40656>`_) :ref:`algm-Load` and the file loader search process
+  now use a lazy file descriptor to check for the correct loading algorithm, further reducing the time taken to load files.
+- (`#40444 <https://github.com/mantidproject/mantid/pull/40444>`_) :ref:`algm-ApplyDetailedBalanceMD`
+  has a new parameter, ``RescaleToTemperature``, which allows the scaling of data from one temperature to another.
 
 Bugfixes
-############
-- (`#40029 <https://github.com/mantidproject/mantid/pull/40029>`_) Removed uses of ``MatrixWorkspace::getNumberBins()``, which is deprecated, and replaced those uses with ``MatrixWorkspace::blocksize()``.
-- (`#40606 <https://github.com/mantidproject/mantid/pull/40606>`_) :ref:`GenerateEventsFilter <algm-GenerateEventsFilter>` will now be able to handle cases where there is no second pulse in the ROI.
-- (`#40336 <https://github.com/mantidproject/mantid/pull/40336>`_) ``CreateDetectorTable`` will now return the workspace index as an integer, not a floating point number.
+########
+- (`#40029 <https://github.com/mantidproject/mantid/pull/40029>`_) ``MatrixWorkspace::getNumberBins()`` has been
+  replaced by ``MatrixWorkspace::blocksize()``, as the former is deprecated.
+- (`#40606 <https://github.com/mantidproject/mantid/pull/40606>`_) :ref:`algm-GenerateEventsFilter`
+  will now be able to handle cases where there is no second pulse in the ROI.
+- (`#40336 <https://github.com/mantidproject/mantid/pull/40336>`_) :ref:`algm-CreateDetectorTable` will now return the
+  workspace index as an integer, rather than a floating-point number.
 
 Deprecated
-############
-- (`#40380 <https://github.com/mantidproject/mantid/pull/40380>`_) :ref:`GetTimeSeriesLogInformation <algm-GetTimeSeriesLogInformation>` has been deprecated. Use ``workspace.run().getStatistics("log_name")`` instead to access time series log statistics directly.
-- (`#40625 <https://github.com/mantidproject/mantid/pull/40625>`_) :ref:`LoadMcStasNexus <algm-LoadMcStasNexus>` has been deprecated. Use :ref:`LoadMcStas <algm-LoadMcStas>` instead as it is more up to date.
-
-Removed
-############
+##########
+- (`#40380 <https://github.com/mantidproject/mantid/pull/40380>`_) :ref:`algm-GetTimeSeriesLogInformation` has been
+  deprecated. Use ``workspace.run().getStatistics("log_name")`` instead to access time series log statistics directly.
+- (`#40625 <https://github.com/mantidproject/mantid/pull/40625>`_) :ref:`algm-LoadMcStasNexus` has been deprecated.
+  Use :ref:`algm-LoadMcStas` instead - it is more up-to-date.
 
 Fit Functions
 -------------
 
-New features
-############
-
 Bugfixes
-############
-- (`#40267 <https://github.com/mantidproject/mantid/pull/40267>`_) Improve stabiltiy of :ref:`func-Gaussian` fits by change of internal 'active' parameter to ``1/sigma`` instead of ``1/sigma^2``.
-- (`#40267 <https://github.com/mantidproject/mantid/pull/40267>`_) Fix normalisation in histogram evaluation of :ref:`func-Gaussian` function and Jacobian such that they are now consistent with ``CentrePoint`` evaluation for small bin-widths.
-
-Deprecated
-############
-
-Removed
-############
-
+########
+- (`#40267 <https://github.com/mantidproject/mantid/pull/40267>`_) :ref:`func-Gaussian` has improved stability of fits
+  by changing the internal 'active' parameter to ``1/sigma`` instead of ``1/sigma^2``.
+- (`#40267 <https://github.com/mantidproject/mantid/pull/40267>`_) The normalisation in histogram evaluation of
+  :ref:`func-Gaussian` function and :ref:`func-Jacobian` has been fixed such that they are now consistent with
+  ``CentrePoint`` evaluation for small bin-widths.
 
 Data Objects
 ------------
 
 New features
 ############
-- (`#40054 <https://github.com/mantidproject/mantid/pull/40054>`_) :py:obj:`Table Workspaces <mantid.api.ITableWorkspace>` now support :py:meth:`mantid.api.ITableWorkspace.columnArray` for retrieving a column as a NumPy array.
-  For example, with ``import numpy as np``: ``table_ws.columnArray("Index")`` returns ``np.array([0, 1, 2, 3])``.
+- (`#40054 <https://github.com/mantidproject/mantid/pull/40054>`_) :ref:`Table Workspaces` now support
+  :py:meth:`mantid.api.ITableWorkspace.columnArray` for retrieving a column as a NumPy array. For example, with
+  ``import numpy as np``: ``table_ws.columnArray("Index")`` returns ``np.array([0, 1, 2, 3])``.
 
 Bugfixes
-############
-- (`#40551 <https://github.com/mantidproject/mantid/pull/40551>`_) Fix issue where ``MatrixWorkspace.getMemorySize()`` reported the wrong value for :ref:`ragged workspaces <Ragged_Workspace>`
-
+########
+- (`#40551 <https://github.com/mantidproject/mantid/pull/40551>`_) ``MatrixWorkspace.getMemorySize()`` now reports the
+  correct value for a :ref:`Ragged_Workspace`.
 
 Python
 ------
 
-New features
-############
-
 Bugfixes
-############
-- (`#40239 <https://github.com/mantidproject/mantid/pull/40239>`_) ``SampleShapePlot`` (from ``mantidqt/plotting/sample_shape``) no longer crashes upon being called from a script in workbench. Previously, this would crash as the plotting methods expected to be on the user interface thread.
-- (`#40545 <https://github.com/mantidproject/mantid/pull/40545>`_) ``jemalloc`` has been removed from the conda activation scripts because it was causing crashes with unrelated applications on Linux due to LD_PRELOAD being set globally.
-  Behaviour is now reverted to Mantid v6.13 where ``jemalloc`` is used only when launching ``mantidworkbench``.
+########
+- (`#40239 <https://github.com/mantidproject/mantid/pull/40239>`_) ``SampleShapePlot`` (from
+  ``mantidqt/plotting/sample_shape``) no longer crashes upon being called from a script in workbench. Previously, this
+  would crash as the plotting methods expected to be on the user interface thread.
+- (`#40545 <https://github.com/mantidproject/mantid/pull/40545>`_) ``jemalloc`` has been removed from the conda
+  activation scripts because it was causing crashes with unrelated applications on Linux due to ``LD_PRELOAD`` being set
+  globally. Behaviour is now reverted to Mantid v6.13 where ``jemalloc`` is used only when launching ``mantidworkbench``.
 
 
 Dependencies
-------------------
-
-New features
-############
-- (`#39957 <https://github.com/mantidproject/mantid/pull/39957>`_) Add the ability to select mirrors for test data in builds using the ``DATA_STORE_MIRROR`` cmake variable. See :doc:`data files for testing <mantid-dev:DataFilesForTesting>`
-- (`#40289 <https://github.com/mantidproject/mantid/pull/40289>`_) Add `AGENTS.md <https://github.com/mantidproject/mantid/blob/main/AGENTS.md>`_ which gives instructions to coding agents in a way consistent with the https://agents.md standard
+------------
 
 Bugfixes
 ############
-- (`#40246 <https://github.com/mantidproject/mantid/pull/40246>`_) Pin `occt` to 7.9.2 to avoid conda/rattler version number parsing issue with 7_9_1 (See: https://github.com/conda-forge/occt-feedstock/pull/124)
-
+- (`#40246 <https://github.com/mantidproject/mantid/pull/40246>`_) Pin `occt` to 7.9.2 to avoid conda/rattler version
+  number parsing issue with 7.9.1 (See `here <https://github.com/conda-forge/occt-feedstock/pull/124>`_).
 
 Kernel
 ------
 
 New features
 ############
-- (`#40343 <https://github.com/mantidproject/mantid/pull/40343>`_) Created function ``strmakef``, which allows developers to create ``std::string`` objects using C-style formatting strings.
-- (`#40487 <https://github.com/mantidproject/mantid/pull/40487>`_) :py:obj:`Property <mantid.kernel.Property>` and :py:obj:`IPropertyManager <mantid.kernel.IPropertyManager>` now support the application of multiple :py:obj:`IPropertySettings <mantid.kernel.IPropertySettings>` instances to a single property instance.  From Python, a property's ``getSettings`` method will now return a *vector* of ``IPropertySetting`` when appropriate.
+- (`#40343 <https://github.com/mantidproject/mantid/pull/40343>`_) Created function ``strmakef``, which allows
+  developers to create ``std::string`` objects using C-style formatting strings.
+- (`#40487 <https://github.com/mantidproject/mantid/pull/40487>`_) :py:obj:`Property <mantid.kernel.Property>` and
+  :py:obj:`IPropertyManager <mantid.kernel.IPropertyManager>` now support the application of multiple
+  :py:obj:`IPropertySettings <mantid.kernel.IPropertySettings>` instances to a single property instance. From Python, a
+  property's ``getSettings`` method will now return a *vector* of ``IPropertySetting`` when appropriate.
 
 
 MantidWorkbench


### PR DESCRIPTION


### Description of work

Edited Framework release notes for 6.15. 

Closes #40852

### To test:
1. Build `docs-html`.
2. Check grammar, links, formatting, etc.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
