### PR TITLE
Fix nightly docs publishing

### DIFF
--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -62,5 +62,5 @@ pixi run --manifest-path $REPO_ROOT_DIR/pixi.toml -e docs-build rsync --archive 
 git config user.name ${GIT_USER_NAME}
 git config user.email ${GIT_USER_EMAIL}
 git add .
-git commit -m "Publish nightly documentation from [${SHA1_SHORT}](https://github.com/mantidproject/mantid/commit/${SHA1})" || exit 0
+git commit -m "Publish nightly documentation from https://github.com/mantidproject/mantid/commit/${SHA1}" || exit 0
 git push https://${GITHUB_ACCESS_TOKEN}@github.com/mantidproject/docs-nightly main

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -11,7 +11,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_MIRROR="$("${SCRIPT_DIR}/data_mirrors")"
 REPO_ROOT_DIR=$SCRIPT_DIR/../..
 SHA1=$(git -C "$REPO_ROOT_DIR" rev-parse HEAD) # full sha for this source repository
-SHA1_SHORT=$(git -C "$REPO_ROOT_DIR" rev-parse --short HEAD) # full sha for this source repository
 
 # source util functions
 . source/buildconfig/Jenkins/Conda/pixi-utils

--- a/buildconfig/Jenkins/build_and_publish_docs.sh
+++ b/buildconfig/Jenkins/build_and_publish_docs.sh
@@ -10,8 +10,8 @@ GIT_USER_EMAIL="mantid-buildserver@mantidproject.org"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_MIRROR="$("${SCRIPT_DIR}/data_mirrors")"
 REPO_ROOT_DIR=$SCRIPT_DIR/../..
-SHA1=$(git rev-parse HEAD) # full sha for this source repository
-SHA1_SHORT=$(git rev-parse --short HEAD) # full sha for this source repository
+SHA1=$(git -C "$REPO_ROOT_DIR" rev-parse HEAD) # full sha for this source repository
+SHA1_SHORT=$(git -C "$REPO_ROOT_DIR" rev-parse --short HEAD) # full sha for this source repository
 
 # source util functions
 . source/buildconfig/Jenkins/Conda/pixi-utils


### PR DESCRIPTION
### Description of work
Nighlty docs publishing was broken because git commands were being run outside of a git repo. This fixes that by using the [-C option](https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt).

### To test:
A test build is running the script here:
https://builds.mantidproject.org/job/build_and_publish_docs/436/
When that job succeeds, verify that the commit is here and has a sensible commit message:
https://github.com/mantidproject/docs-nightly/commits/main/


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
