### PR TITLE
Fix constructing a filepath to get rid of erroneous warning message

### DIFF
--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -42,21 +42,19 @@ void LoadIDFFromNexus::init() {
                   "The name of the workspace in which to attach the imported instrument");
 
   const std::vector<std::string> exts{".nxs", ".nxs.h5"};
-  declareProperty(std::make_unique<FileProperty>("Filename", "", FileProperty::Load, exts),
-                  "The name (including its full or relative path) of the Nexus file to "
-                  "attempt to load the instrument from.");
+  declareProperty(
+      std::make_unique<FileProperty>("Filename", "", FileProperty::Load, exts),
+      "The name (including its full or relative path) of the Nexus file to attempt to load the instrument from.");
 
-  declareProperty("InstrumentParentPath", std::string(""),
-                  "Path name within the Nexus tree of the folder containing "
-                  "the instrument folder. "
-                  "For example it is 'raw_data_1' for an ISIS raw Nexus file "
-                  "and 'mantid_workspace_1' for a processed nexus file. "
-                  "Only a one level path is curently supported",
-                  Direction::Input);
+  declareProperty(
+      "InstrumentParentPath", std::string(""),
+      "Path name within the Nexus tree of the folder containing the instrument folder. "
+      "For example it is 'raw_data_1' for an ISIS raw Nexus file and 'mantid_workspace_1' for a processed nexus file. "
+      "Only a one level path is curently supported",
+      Direction::Input);
   declareProperty("ParameterCorrectionFilePath", std::string(""),
                   "Full path name of Parameter Correction file. "
-                  "This should only be used in a situation,"
-                  "where the default full file path is inconvenient.",
+                  "This should only be used in a situation,where the default full file path is inconvenient.",
                   Direction::Input);
 }
 
@@ -253,11 +251,11 @@ void LoadIDFFromNexus::LoadParameters(Nexus::File *nxfile, const MatrixWorkspace
     // No parameters have been found in Nexus file, so we look for them in a
     // parameter file.
     std::vector<std::string> directoryNames = ConfigService::Instance().getInstrumentDirectories();
-    const std::string instrumentName = localWorkspace->getInstrument()->getName();
+    const std::string instrParameterFileName = localWorkspace->getInstrument()->getName() + "_Parameters.xml";
     for (const auto &directoryName : directoryNames) {
-      // This will iterate around the directories from user ->etc ->install, and
-      // find the first appropriate file
-      const std::string paramFile = directoryName + instrumentName + "_Parameters.xml";
+      // This will iterate around the directories from user->etc->install, and find the first appropriate file
+      const std::filesystem::path direc(directoryName);
+      const std::string paramFile = (direc / instrParameterFileName).string();
 
       // Attempt to load specified file, if successful, use file and stop
       // search.
@@ -275,7 +273,6 @@ void LoadIDFFromNexus::LoadParameters(Nexus::File *nxfile, const MatrixWorkspace
 // Private function to load parameter file specified by a full path name into
 // given workspace, returning success.
 bool LoadIDFFromNexus::loadParameterFile(const std::string &fullPathName, const MatrixWorkspace_sptr &localWorkspace) {
-
   try {
     // load and also populate instrument parameters from this 'fallback'
     // parameter file


### PR DESCRIPTION
During the work to move from `Poco::Path` to `std::filesystem::path` a "bug" got in where the install version of the parameter file was not found and it was being logged at the information level. `LoadIDFFromNexus` was still behaving correctly, but this message was concerning users. 
```sh
LoadIDFFromNexus-[Information] File not found: /home/pf9/code/engineering-diffraction/.pixi/envs/default/instrument/instrumentVULCAN_Parameters.xml. Unable to parse File: in "/home/pf9/code/engineering-diffraction/.pixi/envs/default/bin/../instrument/instrumentVULCAN_Parameters.xml"
LoadParameterFile-[Information] Parsing from XML file: /home/pf9/code/engineering-diffraction/.pixi/envs/default/bin/../instrument/VULCAN_Parameters.xml
```
and now the "File not found:" message is gone. 

I also combined some strings so `clang-format` would break them with the "new" line length maximum. The significant change is near line 250.

There is no associated issue.

### To test:

`LoadEventNexus` with your favorite file that has an IDF in it. If you are logging at "information" level you'll see the message go away with this commit.

*This does not require release notes* because it fixes an issue introduced during the release cycle.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
