### PR TITLE
Replace uses of `getChildren()` with `ComponentInfo`

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
+++ b/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
@@ -14,6 +14,10 @@
 #include "MantidDataObjects/EventWorkspace.h"
 
 namespace Mantid {
+namespace Geometry {
+class ComponentInfo;
+}
+
 namespace Crystal {
 
 // fit to ln(1/A*) = sum_{icoef=0}^{N=7} pc[7-icoef][ith]*(muR)^icoef

--- a/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
+++ b/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
@@ -125,8 +125,8 @@ private:
   double getEventWeight(const double lamda, const double two_theta, bool &muRTooLarge);
   void BuildLamdaWeights();
   double absor_sphere(const double twoth, const double wl, bool &muRTooLarge);
-  void scale_init(const Geometry::Instrument_const_sptr &inst, const double L2, const double depth, double &pathlength,
-                  const std::string &bankName);
+  void scale_init(const Geometry::Instrument_const_sptr &inst, const Geometry::ComponentInfo &componentInfo,
+                  const double L2, const double depth, double &pathlength, const std::string &bankName);
   double scale_exec(std::string &bankName, const double lambda, const double depth,
                     const Geometry::Instrument_const_sptr &inst, const double pathlength, double eventWeight);
 

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -46,12 +46,12 @@ private:
   int findPixelID(const std::string &bankName, int col, int row);
   void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace &peakWS);
   void sizeBanks(const std::string &bankName, int &nCols, int &nRows);
-  Geometry::Instrument_const_sptr inst;
+  Geometry::Instrument_const_sptr m_inst;
 
   /// Input 2D Workspace
-  API::MatrixWorkspace_sptr inWS;
-  DataObjects::EventWorkspace_const_sptr eventW;
-  Mantid::detid2index_map wi_to_detid_map;
+  API::MatrixWorkspace_sptr m_inWS;
+  DataObjects::EventWorkspace_const_sptr m_eventW;
+  Mantid::detid2index_map m_wi_to_detid_map;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -60,7 +60,7 @@ private:
   DataObjects::Peak readPeak(const DataObjects::PeaksWorkspace_sptr &outWS, std::string &lastStr, std::ifstream &in,
                              int &seqNum, const std::string &bankName, double qSign);
 
-  int findPixelID(const Geometry::Instrument_const_sptr &inst, const std::string &bankName, int col, int row);
+  int findPixelID(const DataObjects::PeaksWorkspace_sptr &ws, const std::string &bankName, int col, int row);
 
   /// Read the header of a peak block section, returns first word of next line
   std::string readPeakBlockHeader(std::string lastStr, std::ifstream &in, int &run, int &detName, double &chi,

--- a/Framework/Crystal/inc/MantidCrystal/SaveIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveIsawPeaks.h
@@ -8,11 +8,15 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidCrystal/DllConfig.h"
-#include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 
 namespace Mantid {
+
+namespace DataObjects {
+class PeaksWorkspace;
+using PeaksWorkspace_sptr = std::shared_ptr<PeaksWorkspace>;
+} // namespace DataObjects
 
 namespace Crystal {
 

--- a/Framework/Crystal/inc/MantidCrystal/SaveIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/SaveIsawPeaks.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidCrystal/DllConfig.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 
@@ -44,9 +45,10 @@ private:
   /// find position for rectangular and non-rectangular
   Kernel::V3D findPixelPos(const std::string &bankName, int col, int row);
   void sizeBanks(const std::string &bankName, int &NCOLS, int &NROWS, double &xsize, double &ysize);
-  bool bankMasked(const Geometry::IComponent_const_sptr &parent, const Geometry::DetectorInfo &detectorInfo);
+  bool bankMasked(size_t componentIndex, const Geometry::DetectorInfo &detectorInfo);
   void writeOffsets(std::ofstream &out, double qSign, const std::vector<double> &offset);
   Geometry::Instrument_const_sptr inst;
+  DataObjects::PeaksWorkspace_sptr m_ws;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -554,13 +554,13 @@ void AnvredCorrection::scale_init(const Instrument_const_sptr &inst, const Compo
                                   const double L2, const double depth, double &pathlength,
                                   const std::string &bankName) {
   // Distance to center of detector
-  std::shared_ptr<const IComponent> det0 = inst->getComponentByName(bankName);
+  const IComponent *det0 = inst->getComponentByName(bankName).get();
   if ("CORELLI" == inst->getName()) // for Corelli with sixteenpack under bank
   {
     const size_t bankIndex = componentInfo.indexOfAny(bankName);
     const auto children = componentInfo.children(bankIndex);
     if (!children.empty()) {
-      det0 = componentInfo.componentID(children[0])->shared_from_this();
+      det0 = componentInfo.componentID(children[0]);
     }
   }
   IComponent_const_sptr sample = inst->getSample();

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -13,6 +13,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/Fast_Exponential.h"
 #include "MantidKernel/Material.h"
@@ -214,8 +215,9 @@ void AnvredCorrection::exec() {
     std::string bankName;
     if (m_useScaleFactors) {
       const auto &det = spectrumInfo.detector(i);
+      const auto &componentInfo = m_inputWS->componentInfo();
       bankName = det.getParent()->getParent()->getName();
-      scale_init(inst, L2, depth, pathlength, bankName);
+      scale_init(inst, componentInfo, L2, depth, pathlength, bankName);
     }
 
     auto points = m_inputWS->points(i);
@@ -319,8 +321,9 @@ void AnvredCorrection::execEvent() {
     std::string bankName;
     if (m_useScaleFactors) {
       const auto &det = spectrumInfo.detector(i);
+      const auto &componentInfo = eventW->componentInfo();
       bankName = det.getParent()->getParent()->getName();
-      scale_init(inst, L2, depth, pathlength, bankName);
+      scale_init(inst, componentInfo, L2, depth, pathlength, bankName);
     }
 
     // multiplying an event list by a scalar value
@@ -547,16 +550,18 @@ void AnvredCorrection::BuildLamdaWeights() {
   }
 }
 
-void AnvredCorrection::scale_init(const Instrument_const_sptr &inst, const double L2, const double depth,
-                                  double &pathlength, const std::string &bankName) {
+void AnvredCorrection::scale_init(const Instrument_const_sptr &inst, const ComponentInfo &componentInfo,
+                                  const double L2, const double depth, double &pathlength,
+                                  const std::string &bankName) {
   // Distance to center of detector
   std::shared_ptr<const IComponent> det0 = inst->getComponentByName(bankName);
   if ("CORELLI" == inst->getName()) // for Corelli with sixteenpack under bank
   {
-    std::vector<Geometry::IComponent_const_sptr> children;
-    auto asmb = std::dynamic_pointer_cast<const Geometry::ICompAssembly>(inst->getComponentByName(bankName));
-    asmb->getChildren(children, false);
-    det0 = children[0];
+    const size_t bankIndex = componentInfo.indexOfAny(bankName);
+    const auto children = componentInfo.children(bankIndex);
+    if (!children.empty()) {
+      det0 = componentInfo.componentID(children[0])->shared_from_this();
+    }
   }
   IComponent_const_sptr sample = inst->getSample();
   double cosA = det0->getDistance(*sample) / L2;

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -188,6 +188,7 @@ void AnvredCorrection::exec() {
 
   // If sample not at origin, shift cached positions.
   const auto &spectrumInfo = m_inputWS->spectrumInfo();
+  const auto &componentInfo = m_inputWS->componentInfo();
   double L1 = spectrumInfo.l1();
 
   Progress prog(this, 0.0, 1.0, numHists);
@@ -215,7 +216,6 @@ void AnvredCorrection::exec() {
     std::string bankName;
     if (m_useScaleFactors) {
       const auto &det = spectrumInfo.detector(i);
-      const auto &componentInfo = m_inputWS->componentInfo();
       bankName = det.getParent()->getParent()->getName();
       scale_init(inst, componentInfo, L2, depth, pathlength, bankName);
     }
@@ -290,6 +290,7 @@ void AnvredCorrection::execEvent() {
   Instrument_const_sptr inst = m_inputWS->getInstrument();
 
   const auto &spectrumInfo = eventW->spectrumInfo();
+  const auto &componentInfo = eventW->componentInfo();
   double L1 = spectrumInfo.l1();
 
   Progress prog(this, 0.0, 1.0, numHists);
@@ -321,7 +322,6 @@ void AnvredCorrection::execEvent() {
     std::string bankName;
     if (m_useScaleFactors) {
       const auto &det = spectrumInfo.detector(i);
-      const auto &componentInfo = eventW->componentInfo();
       bankName = det.getParent()->getParent()->getName();
       scale_init(inst, componentInfo, L2, depth, pathlength, bankName);
     }

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -87,7 +87,7 @@ void CentroidPeaks::integrate() {
     }
   }
 
-  const auto inBlocksize = static_cast<int>(m_inWS->blocksize());
+  const auto inBlocksize = static_cast<int64_t>(m_inWS->blocksize());
   int Edge = getProperty("EdgePixels");
   Progress prog(this, MinPeaks, 1.0, MaxPeaks);
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inWS, *peakWS))

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -146,7 +146,7 @@ void CentroidPeaks::integrate() {
     col = (int)std::lround(colcentroid / intensity);
     boost::algorithm::clamp(col, 0, nCols - 1);
     chan = (int)std::lround(chancentroid / intensity);
-    boost::algorithm::clamp(chan, 0, inBlocksize);
+    boost::algorithm::clamp(chan, 0, static_cast<int>(inBlocksize));
 
     // Set wavelength to change tof for peak object
     if (!edgePixel(compInfo, bankName, col, row, Edge)) {

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -69,26 +69,26 @@ void CentroidPeaks::integrate() {
 
   int MinPeaks = -1;
   int MaxPeaks = -1;
-  size_t Numberwi = inWS->getNumberHistograms();
+  size_t Numberwi = m_inWS->getNumberHistograms();
   int NumberPeaks = peakWS->getNumberPeaks();
   for (int i = 0; i < NumberPeaks; ++i) {
     Peak const &peak = peakWS->getPeaks()[i];
     int pixelID = peak.getDetectorID();
 
     // Find the workspace index for this detector ID
-    if (wi_to_detid_map.find(pixelID) != wi_to_detid_map.end()) {
-      size_t wi = wi_to_detid_map[pixelID];
-      if (MinPeaks == -1 && peak.getRunNumber() == inWS->getRunNumber() && wi < Numberwi)
+    if (m_wi_to_detid_map.find(pixelID) != m_wi_to_detid_map.end()) {
+      size_t wi = m_wi_to_detid_map[pixelID];
+      if (MinPeaks == -1 && peak.getRunNumber() == m_inWS->getRunNumber() && wi < Numberwi)
         MinPeaks = i;
-      if (peak.getRunNumber() == inWS->getRunNumber() && wi < Numberwi)
+      if (peak.getRunNumber() == m_inWS->getRunNumber() && wi < Numberwi)
         MaxPeaks = i;
     }
   }
 
-  const auto inBlocksize = static_cast<int>(inWS->blocksize());
+  const auto inBlocksize = static_cast<int>(m_inWS->blocksize());
   int Edge = getProperty("EdgePixels");
   Progress prog(this, MinPeaks, 1.0, MaxPeaks);
-  PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *peakWS))
+  PARALLEL_FOR_IF(Kernel::threadSafe(*m_inWS, *peakWS))
   for (int i = MinPeaks; i <= MaxPeaks; ++i) {
     PARALLEL_START_INTERRUPT_REGION
     // Get a direct ref to that peak.
@@ -96,13 +96,13 @@ void CentroidPeaks::integrate() {
     int col = peak.getCol();
     int row = peak.getRow();
     int pixelID = peak.getDetectorID();
-    auto detidIterator = wi_to_detid_map.find(pixelID);
-    if (detidIterator == wi_to_detid_map.end()) {
+    auto detidIterator = m_wi_to_detid_map.find(pixelID);
+    if (detidIterator == m_wi_to_detid_map.end()) {
       continue;
     }
     size_t workspaceIndex = detidIterator->second;
     double TOFPeakd = peak.getTOF();
-    const auto &X = inWS->x(workspaceIndex);
+    const auto &X = m_inWS->x(workspaceIndex);
     int chan = Kernel::VectorHelper::getBinIndex(X.rawData(), TOFPeakd);
     std::string bankName = peak.getBankName();
     int nCols = 0, nRows = 0;
@@ -122,13 +122,13 @@ void CentroidPeaks::integrate() {
     for (int ichan = chanstart; ichan <= chanend; ++ichan) {
       for (int irow = rowstart; irow <= rowend; ++irow) {
         for (int icol = colstart; icol <= colend; ++icol) {
-          if (edgePixel(inst, bankName, icol, irow, Edge))
+          if (edgePixel(m_inst, bankName, icol, irow, Edge))
             continue;
-          const auto it = wi_to_detid_map.find(findPixelID(bankName, icol, irow));
-          if (it == wi_to_detid_map.end())
+          const auto it = m_wi_to_detid_map.find(findPixelID(bankName, icol, irow));
+          if (it == m_wi_to_detid_map.end())
             continue;
 
-          const auto &histogram = inWS->y(it->second);
+          const auto &histogram = m_inWS->y(it->second);
 
           intensity += histogram[ichan];
           rowcentroid += irow * histogram[ichan];
@@ -146,13 +146,13 @@ void CentroidPeaks::integrate() {
     boost::algorithm::clamp(chan, 0, inBlocksize);
 
     // Set wavelength to change tof for peak object
-    if (!edgePixel(inst, bankName, col, row, Edge)) {
+    if (!edgePixel(m_inst, bankName, col, row, Edge)) {
       peak.setDetectorID(findPixelID(bankName, col, row));
-      detidIterator = wi_to_detid_map.find(findPixelID(bankName, col, row));
+      detidIterator = m_wi_to_detid_map.find(findPixelID(bankName, col, row));
       workspaceIndex = (detidIterator->second);
       Mantid::Kernel::Units::Wavelength wl;
       std::vector<double> timeflight;
-      timeflight.emplace_back(inWS->x(workspaceIndex)[chan]);
+      timeflight.emplace_back(m_inWS->x(workspaceIndex)[chan]);
       double scattering = peak.getScattering();
       double L1 = peak.getL1();
       double L2 = peak.getL2();
@@ -161,7 +161,7 @@ void CentroidPeaks::integrate() {
       timeflight.clear();
 
       peak.setWavelength(lambda);
-      peak.setBinCount(inWS->y(workspaceIndex)[chan]);
+      peak.setBinCount(m_inWS->y(workspaceIndex)[chan]);
     }
     PARALLEL_END_INTERRUPT_REGION
   }
@@ -191,7 +191,7 @@ void CentroidPeaks::integrateEvent() {
 
   int MinPeaks = -1;
   int MaxPeaks = -1;
-  size_t Numberwi = inWS->getNumberHistograms();
+  size_t Numberwi = m_inWS->getNumberHistograms();
   int NumberPeaks = peakWS->getNumberPeaks();
 
   for (int i = 0; i < NumberPeaks; ++i) {
@@ -199,18 +199,18 @@ void CentroidPeaks::integrateEvent() {
     int pixelID = peak.getDetectorID();
 
     // Find the workspace index for this detector ID
-    if (wi_to_detid_map.find(pixelID) != wi_to_detid_map.end()) {
-      size_t wi = wi_to_detid_map[pixelID];
-      if (MinPeaks == -1 && peak.getRunNumber() == inWS->getRunNumber() && wi < Numberwi)
+    if (m_wi_to_detid_map.find(pixelID) != m_wi_to_detid_map.end()) {
+      size_t wi = m_wi_to_detid_map[pixelID];
+      if (MinPeaks == -1 && peak.getRunNumber() == m_inWS->getRunNumber() && wi < Numberwi)
         MinPeaks = i;
-      if (peak.getRunNumber() == inWS->getRunNumber() && wi < Numberwi)
+      if (peak.getRunNumber() == m_inWS->getRunNumber() && wi < Numberwi)
         MaxPeaks = i;
     }
   }
 
   int Edge = getProperty("EdgePixels");
   Progress prog(this, MinPeaks, 1.0, MaxPeaks);
-  PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *peakWS))
+  PARALLEL_FOR_IF(Kernel::threadSafe(*m_inWS, *peakWS))
   for (int i = MinPeaks; i <= MaxPeaks; ++i) {
     PARALLEL_START_INTERRUPT_REGION
     // Get a direct ref to that peak.
@@ -224,7 +224,7 @@ void CentroidPeaks::integrateEvent() {
 
     double intensity = 0.0;
     double tofcentroid = 0.0;
-    if (edgePixel(inst, bankName, col, row, Edge))
+    if (edgePixel(m_inst, bankName, col, row, Edge))
       continue;
 
     double tofstart = TOFPeakd * std::pow(1.004, -PeakRadius);
@@ -237,11 +237,11 @@ void CentroidPeaks::integrateEvent() {
     int colend = std::min(nCols - 1, col + PeakRadius);
     for (int irow = rowstart; irow <= rowend; ++irow) {
       for (int icol = colstart; icol <= colend; ++icol) {
-        if (edgePixel(inst, bankName, icol, irow, Edge))
+        if (edgePixel(m_inst, bankName, icol, irow, Edge))
           continue;
-        auto it1 = wi_to_detid_map.find(findPixelID(bankName, icol, irow));
+        auto it1 = m_wi_to_detid_map.find(findPixelID(bankName, icol, irow));
         size_t workspaceIndex = (it1->second);
-        EventList el = eventW->getSpectrum(workspaceIndex);
+        EventList el = m_eventW->getSpectrum(workspaceIndex);
         el.switchTo(WEIGHTED_NOTIME);
         std::vector<WeightedEventNoTime> events = el.getWeightedEventsNoTime();
 
@@ -263,7 +263,7 @@ void CentroidPeaks::integrateEvent() {
     boost::algorithm::clamp(row, 0, nRows - 1);
     col = int(colcentroid / intensity);
     boost::algorithm::clamp(col, 0, nCols - 1);
-    if (!edgePixel(inst, bankName, col, row, Edge)) {
+    if (!edgePixel(m_inst, bankName, col, row, Edge)) {
       peak.setDetectorID(findPixelID(bankName, col, row));
 
       // Set wavelength to change tof for peak object
@@ -294,14 +294,14 @@ void CentroidPeaks::integrateEvent() {
 /** Execute the algorithm.
  */
 void CentroidPeaks::exec() {
-  inWS = getProperty("InputWorkspace");
-  inst = inWS->getInstrument();
+  m_inWS = getProperty("InputWorkspace");
+  m_inst = m_inWS->getInstrument();
   // For quickly looking up workspace index from det id
-  wi_to_detid_map = inWS->getDetectorIDToWorkspaceIndexMap();
+  m_wi_to_detid_map = m_inWS->getDetectorIDToWorkspaceIndexMap();
 
-  eventW = std::dynamic_pointer_cast<const EventWorkspace>(inWS);
-  if (eventW) {
-    eventW->sortAll(TOF_SORT, nullptr);
+  m_eventW = std::dynamic_pointer_cast<const EventWorkspace>(m_inWS);
+  if (m_eventW) {
+    m_eventW->sortAll(TOF_SORT, nullptr);
     this->integrateEvent();
   } else {
     this->integrate();
@@ -309,7 +309,7 @@ void CentroidPeaks::exec() {
 }
 
 int CentroidPeaks::findPixelID(const std::string &bankName, int col, int row) {
-  std::shared_ptr<const IComponent> parent = inst->getComponentByName(bankName);
+  std::shared_ptr<const IComponent> parent = m_inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -320,9 +320,9 @@ int CentroidPeaks::findPixelID(const std::string &bankName, int col, int row) {
     // Only works for WISH
     bankName0.erase(0, 4);
     std::ostringstream pixelString;
-    pixelString << inst->getName() << "/" << bankName0 << "/" << bankName << "/tube" << std::setw(3)
+    pixelString << m_inst->getName() << "/" << bankName0 << "/" << bankName << "/tube" << std::setw(3)
                 << std::setfill('0') << col << "/pixel" << std::setw(4) << std::setfill('0') << row;
-    std::shared_ptr<const Geometry::IComponent> component = inst->getComponentByName(pixelString.str());
+    std::shared_ptr<const Geometry::IComponent> component = m_inst->getComponentByName(pixelString.str());
     std::shared_ptr<const Detector> pixel = std::dynamic_pointer_cast<const Detector>(component);
     return pixel->getID();
   }
@@ -339,7 +339,7 @@ void CentroidPeaks::removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace &peakWS)
     int row = peak.getRow();
     const std::string &bankName = peak.getBankName();
 
-    if (edgePixel(inst, bankName, col, row, Edge)) {
+    if (edgePixel(m_inst, bankName, col, row, Edge)) {
       badPeaks.emplace_back(i);
     }
   }
@@ -350,11 +350,11 @@ void CentroidPeaks::sizeBanks(const std::string &bankName, int &nCols, int &nRow
   if (bankName == "None")
     return;
   ExperimentInfo expInfo;
-  expInfo.setInstrument(inst);
+  expInfo.setInstrument(m_inst);
   const auto &compInfo = expInfo.componentInfo();
 
   // Get a single bank
-  auto bank = inst->getComponentByName(bankName);
+  auto bank = m_inst->getComponentByName(bankName);
   auto bankID = bank->getComponentID();
   auto allBankDetectorIndexes = compInfo.detectorsInSubtree(compInfo.indexOf(bankID));
 

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -14,6 +14,7 @@
 #include "MantidCrystal/CalibrationHelpers.h"
 #include "MantidCrystal/SCDCalibratePanels.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
@@ -204,10 +205,9 @@ std::string LoadIsawPeaks::readHeader(const PeaksWorkspace_sptr &outWS, std::ifs
   if (instr->getName() == "WISH")
     bankPart = "WISHpanel";
   // Get all children
-  std::vector<IComponent_const_sptr> comps;
-  instr->getChildren(comps, true);
-  for (auto &comp : comps) {
-    std::string bankName = comp->getName();
+  const auto &componentInfo = outWS->componentInfo();
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    std::string bankName = componentInfo.name(i);
     boost::trim(bankName);
     boost::erase_all(bankName, bankPart);
     int bank = 0;
@@ -329,7 +329,7 @@ DataObjects::Peak LoadIsawPeaks::readPeak(const PeaksWorkspace_sptr &outWS, std:
   if (!inst)
     throw std::runtime_error("No instrument in PeaksWorkspace!");
 
-  int pixelID = findPixelID(inst, bankName, static_cast<int>(col), static_cast<int>(row));
+  int pixelID = findPixelID(outWS, bankName, static_cast<int>(col), static_cast<int>(row));
 
   // Create the peak object
   Peak peak(outWS->getInstrument(), pixelID, wl);
@@ -345,7 +345,8 @@ DataObjects::Peak LoadIsawPeaks::readPeak(const PeaksWorkspace_sptr &outWS, std:
 }
 
 //----------------------------------------------------------------------------------------------
-int LoadIsawPeaks::findPixelID(const Instrument_const_sptr &inst, const std::string &bankName, int col, int row) {
+int LoadIsawPeaks::findPixelID(const PeaksWorkspace_sptr &ws, const std::string &bankName, int col, int row) {
+  const auto inst = ws->getInstrument();
   std::shared_ptr<const IComponent> parent = getCachedBankByName(bankName, inst);
 
   if (!parent)
@@ -357,25 +358,21 @@ int LoadIsawPeaks::findPixelID(const Instrument_const_sptr &inst, const std::str
     std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
     return pixel->getID();
   } else {
-    std::vector<Geometry::IComponent_const_sptr> children;
-    std::shared_ptr<const Geometry::ICompAssembly> asmb =
-        std::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
-    asmb->getChildren(children, false);
-    if (children[0]->getName() == "sixteenpack") {
-      asmb = std::dynamic_pointer_cast<const Geometry::ICompAssembly>(children[0]);
-      children.clear();
-      asmb->getChildren(children, false);
+    const auto &componentInfo = ws->componentInfo();
+    const size_t parentIndex = componentInfo.indexOfAny(bankName);
+    auto children = componentInfo.children(parentIndex);
+
+    if (!children.empty() && componentInfo.name(children[0]) == "sixteenpack") {
+      children = componentInfo.children(children[0]);
     }
     int col0 = col - 1;
     // WISH detectors are in bank in this order in instrument
     if (inst->getName() == "WISH")
       col0 = (col % 2 == 0 ? col / 2 + 75 : (col - 1) / 2);
-    std::shared_ptr<const Geometry::ICompAssembly> asmb2 =
-        std::dynamic_pointer_cast<const Geometry::ICompAssembly>(children[col0]);
-    std::vector<Geometry::IComponent_const_sptr> grandchildren;
-    asmb2->getChildren(grandchildren, false);
-    Geometry::IComponent_const_sptr first = grandchildren[row - 1];
-    Geometry::IDetector_const_sptr det = std::dynamic_pointer_cast<const Geometry::IDetector>(first);
+
+    auto grandchildren = componentInfo.children(children[col0]);
+    const auto *first = componentInfo.componentID(grandchildren[row - 1]);
+    const auto *det = dynamic_cast<const Geometry::IDetector *>(first);
     return det->getID();
   }
 }

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -81,10 +81,10 @@ void OptimizeLatticeForCellType::exec() {
   if (edge > 0)
     if (auto pw = std::dynamic_pointer_cast<PeaksWorkspace>(ws)) {
       std::vector<int> badPeaks;
-      Geometry::Instrument_const_sptr inst = ws->getInstrument();
+      Geometry::ComponentInfo const &compInfo = ws->componentInfo();
       for (int i = int(pw->getNumberPeaks()) - 1; i >= 0; --i) {
         const std::vector<Peak> &peaks = pw->getPeaks();
-        if (edgePixel(inst, peaks[i].getBankName(), peaks[i].getCol(), peaks[i].getRow(), edge)) {
+        if (edgePixel(compInfo, peaks[i].getBankName(), peaks[i].getCol(), peaks[i].getRow(), edge)) {
           badPeaks.emplace_back(i);
         }
       }

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -612,7 +612,7 @@ void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl, const DblMatrix &ori
     peak = std::make_unique<Peak>(m_inst, q, std::optional<double>(magnitude));
   }
 
-  if (m_edge > 0 && edgePixel(m_inst, peak->getBankName(), peak->getCol(), peak->getRow(), m_edge))
+  if (m_edge > 0 && edgePixel(m_pw->componentInfo(), peak->getBankName(), peak->getCol(), peak->getRow(), m_edge))
     return;
 
   // Only add peaks that hit the detector

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -23,6 +23,7 @@
 #include "MantidGeometry/Crystal/IndexingUtils.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ReducedCell.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -61,10 +62,11 @@ void SCDCalibratePanels::exec() {
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   Geometry::Instrument_const_sptr inst = peaksWs->getInstrument();
+  Geometry::ComponentInfo const &compInfo = peaksWs->componentInfo();
   if (edge > 0) {
     std::vector<Peak> &peaks = peaksWs->getPeaks();
-    auto it = std::remove_if(peaks.begin(), peaks.end(), [edge, inst](const Peak &pk) {
-      return edgePixel(inst, pk.getBankName(), pk.getCol(), pk.getRow(), edge);
+    auto it = std::remove_if(peaks.begin(), peaks.end(), [edge, &compInfo](const Peak &pk) {
+      return edgePixel(compInfo, pk.getBankName(), pk.getCol(), pk.getRow(), edge);
     });
     peaks.erase(it, peaks.end());
   }

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -231,13 +231,13 @@ void SaveIsawPeaks::exec() {
 
       std::string bankName = mess.str();
       // Retrieve it
-      const IComponent *det = inst->getComponentByName(bankName).get();
+      std::shared_ptr<const IComponent> det = inst->getComponentByName(bankName);
       if (inst->getName() == "CORELLI") // for Corelli with sixteenpack under bank
       {
         const size_t bankIndex = componentInfo.indexOfAny(bankName);
         const auto children = componentInfo.children(bankIndex);
         if (!children.empty()) {
-          det = componentInfo.componentID(children[0]);
+          det.reset(componentInfo.componentID(children[0]));
         }
       }
       if (det) {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -425,9 +425,9 @@ bool SaveIsawPeaks::bankMasked(size_t componentIndex, const Geometry::DetectorIn
     children = componentInfo.children(children[0]);
   }
 
-  for (const auto &colIndex : children) {
+  for (const auto &colIndex : children) { // cppcheck-suppress useStlAlgorithm
     auto grandchildren = componentInfo.children(colIndex);
-    for (const auto &rowIndex : grandchildren) {
+    for (const auto &rowIndex : grandchildren) { // cppcheck-suppress useStlAlgorithm
       if (componentInfo.isDetector(rowIndex)) {
         const auto detID = detectorInfo.detid(rowIndex);
         if (detID < 0)

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -87,18 +87,25 @@ void SaveIsawPeaks::exec() {
 
   // Get all children
   const auto &componentInfo = m_ws->componentInfo();
-  for (size_t i = 0; i < componentInfo.size(); ++i) {
-    std::string bankName = componentInfo.name(i);
-    boost::trim(bankName);
-    boost::erase_all(bankName, bankPart);
-    int bank = 0;
-    Strings::convert(bankName, bank);
-    if (bank == 0)
-      continue;
-    if (bankMasked(i, detectorInfo))
-      continue;
-    // Track unique bank numbers
-    uniqueBanks.insert(bank);
+  // iterate over the top level components, which contain the banks
+  size_t const rootIndex = componentInfo.root();
+  auto const topChildren = componentInfo.children(rootIndex);
+  for (size_t const i : topChildren) {
+    size_t bankParent = componentInfo.findBankParent(i, bankPart);
+    auto const children = componentInfo.children(bankParent);
+    for (size_t const child : children) {
+      std::string bankName = componentInfo.name(child);
+      boost::trim(bankName);
+      boost::erase_all(bankName, bankPart);
+      int bank = 0;
+      Strings::convert(bankName, bank);
+      if (bank == 0)
+        continue;
+      if (bankMasked(child, detectorInfo))
+        continue;
+      // Track unique bank numbers
+      uniqueBanks.insert(bank);
+    }
   }
   runMap_t runMap;
   for (size_t i = 0; i < peaks.size(); ++i) {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -237,7 +237,7 @@ void SaveIsawPeaks::exec() {
         const size_t bankIndex = componentInfo.indexOfAny(bankName);
         const auto children = componentInfo.children(bankIndex);
         if (!children.empty()) {
-          det.reset(componentInfo.componentID(children[0]));
+          det.reset(componentInfo.componentID(children[0]), NoDeleting());
         }
       }
       if (det) {
@@ -428,14 +428,14 @@ bool SaveIsawPeaks::bankMasked(size_t componentIndex, const Geometry::DetectorIn
   for (const auto &colIndex : children) {
     auto grandchildren = componentInfo.children(colIndex);
     for (const auto &rowIndex : grandchildren) {
-      auto *d = dynamic_cast<Detector *>(const_cast<IComponent *>(componentInfo.componentID(rowIndex)));
-      if (d) {
-        auto detID = d->getID();
+      if (componentInfo.isDetector(rowIndex)) {
+        const auto detID = detectorInfo.detid(rowIndex);
         if (detID < 0)
           continue;
-        const auto index = detectorInfo.indexOf(detID);
-        if (!detectorInfo.isMasked(index))
+        const auto detIndex = detectorInfo.indexOf(detID);
+        if (!detectorInfo.isMasked(detIndex)) {
           return false;
+        }
       }
     }
   }

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -8,6 +8,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/Sample.h"
 #include "MantidCrystal/AnvredCorrection.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -467,14 +468,10 @@ void SaveLauenorm::sizeBanks(const std::string &bankName, int &nCols, int &nRows
     nCols = RDet->xpixels();
     nRows = RDet->ypixels();
   } else {
-    std::vector<Geometry::IComponent_const_sptr> children;
-    std::shared_ptr<const Geometry::ICompAssembly> asmb =
-        std::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
-    asmb->getChildren(children, false);
-    std::shared_ptr<const Geometry::ICompAssembly> asmb2 =
-        std::dynamic_pointer_cast<const Geometry::ICompAssembly>(children[0]);
-    std::vector<Geometry::IComponent_const_sptr> grandchildren;
-    asmb2->getChildren(grandchildren, false);
+    const auto &componentInfo = ws->componentInfo();
+    const size_t parentIndex = componentInfo.indexOfAny(bankName);
+    auto children = componentInfo.children(parentIndex);
+    auto grandchildren = componentInfo.children(children[0]);
     nRows = static_cast<int>(grandchildren.size());
     nCols = static_cast<int>(children.size());
   }

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument_fwd.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
@@ -43,8 +43,9 @@ private:
   /// Run the algorithm
   void exec() override;
   /// find position for rectangular and non-rectangular
-  Kernel::V3D findPixelPos(const std::string &bankName, int col, int row);
-  void sizeBanks(const std::string &bankName, int &NCOLS, int &NROWS, double &xsize, double &ysize);
+  Kernel::V3D findPixelPos(const std::string &bankName, int col, int row, const Geometry::ComponentInfo &componentInfo);
+  void sizeBanks(const std::string &bankName, int &NCOLS, int &NROWS, double &xsize, double &ysize,
+                 const Geometry::ComponentInfo &componentInfo);
   Geometry::Instrument_const_sptr inst;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveIsawDetCal.h
@@ -8,10 +8,12 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataHandling/DllConfig.h"
-#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument_fwd.h"
 
 namespace Mantid {
+namespace Geometry {
+class ComponentInfo;
+}
 namespace Kernel {
 class V3D;
 }

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -221,7 +221,7 @@ void LoadDetectorsGroupingFile::setByComponents() {
 
       g_log.debug() << "Component Name = " << componentName
                     << "  Component ID = " << componentInfo.componentID(componentIndex)
-                    << "Number of Children = " << detectorIndices.size() << '\n';
+                    << "  Number of Children = " << detectorIndices.size() << '\n';
 
       for (const auto &detIndex : detectorIndices) {
         // c) get detector ID

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -219,7 +219,8 @@ void LoadDetectorsGroupingFile::setByComponents() {
       // b) get all detectors in the subtree of this component
       const auto detectorIndices = componentInfo.detectorsInSubtree(componentIndex);
 
-      g_log.debug() << "Component Name = " << componentName << "  Component ID = " << componentInfo.componentID(componentIndex)
+      g_log.debug() << "Component Name = " << componentName
+                    << "  Component ID = " << componentInfo.componentID(componentIndex)
                     << "Number of Children = " << detectorIndices.size() << '\n';
 
       for (const auto &detIndex : detectorIndices) {

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -15,6 +15,8 @@
 #include "MantidGeometry/ICompAssembly.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/OptionalBool.h"
 
@@ -202,6 +204,8 @@ void LoadDetectorsGroupingFile::setByComponents() {
 
   // 1. Prepare
   const detid2index_map indexmap = m_groupWS->getDetectorIDToWorkspaceIndexMap(true);
+  const auto &componentInfo = m_groupWS->componentInfo();
+  const auto &detectorInfo = m_groupWS->detectorInfo();
 
   // 2. Set
   for (auto &componentMap : m_groupComponentsMap) {
@@ -209,33 +213,25 @@ void LoadDetectorsGroupingFile::setByComponents() {
 
     for (auto &componentName : componentMap.second) {
 
-      // a) get component
-      Geometry::IComponent_const_sptr component = m_instrument->getComponentByName(componentName);
+      // a) get component by name and find its index
+      const size_t componentIndex = componentInfo.indexOfAny(componentName);
 
-      // b) component -> component assembly --> children (more than detectors)
-      std::shared_ptr<const Geometry::ICompAssembly> asmb =
-          std::dynamic_pointer_cast<const Geometry::ICompAssembly>(component);
-      std::vector<Geometry::IComponent_const_sptr> children;
-      asmb->getChildren(children, true);
+      // b) get all detectors in the subtree of this component
+      const auto detectorIndices = componentInfo.detectorsInSubtree(componentIndex);
 
-      g_log.debug() << "Component Name = " << componentName << "  Component ID = " << component->getComponentID()
-                    << "Number of Children = " << children.size() << '\n';
+      g_log.debug() << "Component Name = " << componentName << "  Component ID = " << componentInfo.componentID(componentIndex)
+                    << "Number of Children = " << detectorIndices.size() << '\n';
 
-      for (const auto &child : children) {
-        // c) convert component to detector
-        Geometry::IDetector_const_sptr det = std::dynamic_pointer_cast<const Geometry::IDetector>(child);
-
-        if (det) {
-          // Component is DETECTOR:
-          int32_t detid = det->getID();
-          auto itx = indexmap.find(detid);
-          if (itx != indexmap.end()) {
-            size_t wsindex = itx->second;
-            m_groupWS->mutableY(wsindex)[0] = componentMap.first;
-          } else {
-            g_log.error() << "Pixel w/ ID = " << detid << " Cannot Be Located\n";
-          }
-        } // ENDIF Detector
+      for (const auto &detIndex : detectorIndices) {
+        // c) get detector ID
+        const auto detid = detectorInfo.detectorIDs()[detIndex];
+        auto itx = indexmap.find(detid);
+        if (itx != indexmap.end()) {
+          size_t wsindex = itx->second;
+          m_groupWS->mutableY(wsindex)[0] = componentMap.first;
+        } else {
+          g_log.error() << "Pixel w/ ID = " << detid << " Cannot Be Located\n";
+        }
 
       } // ENDFOR (children of component)
     } // ENDFOR (component)

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1365,6 +1365,11 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
   }
   if (detList.empty())
     return;
+
+  // Get ComponentInfo from the first workspace in the collection
+  auto ws = workspace->getSingleHeldWorkspace();
+  const auto &componentInfo = ws->componentInfo();
+
   for (auto &det : detList) {
     bool keep = false;
     std::string det_name = det->getName();
@@ -1376,10 +1381,6 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
         break;
     }
     if (!keep) {
-      std::shared_ptr<const IComponent> parent = inst->getComponentByName(det_name);
-      // Get ComponentInfo from the first workspace in the collection
-      auto ws = workspace->getSingleHeldWorkspace();
-      const auto &componentInfo = ws->componentInfo();
       const size_t parentIndex = componentInfo.indexOfAny(det_name);
       const auto children = componentInfo.children(parentIndex);
       for (const auto &colIndex : children) {

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1377,7 +1377,9 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
     }
     if (!keep) {
       std::shared_ptr<const IComponent> parent = inst->getComponentByName(det_name);
-      const auto &componentInfo = workspace->componentInfo();
+      // Get ComponentInfo from the first workspace in the collection
+      auto ws = workspace->getSingleHeldWorkspace();
+      const auto &componentInfo = ws->componentInfo();
       const size_t parentIndex = componentInfo.indexOfAny(det_name);
       const auto children = componentInfo.children(parentIndex);
       for (const auto &colIndex : children) {

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -177,7 +177,7 @@ void LoadIsawDetCal::exec() {
     // Get all components using ComponentInfo
     auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
     const auto &componentInfo = expInfoWS->componentInfo();
-    
+
     for (size_t i = 0; i < componentInfo.size(); ++i) {
       std::string bankName = componentInfo.name(i);
       boost::trim(bankName);
@@ -309,7 +309,8 @@ void LoadIsawDetCal::exec() {
       const size_t bankIndex = componentInfo.indexOfAny(bankName);
       const auto children = componentInfo.children(bankIndex);
       if (!children.empty()) {
-        comp = componentInfo.componentID(children[0])->shared_from_this();
+        // Get the first child component by name
+        comp = inst->getComponentByName(componentInfo.name(children[0]));
       }
     }
     if (comp) {

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -178,16 +178,22 @@ void LoadIsawDetCal::exec() {
     auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
     const auto &componentInfo = expInfoWS->componentInfo();
 
-    for (size_t i = 0; i < componentInfo.size(); ++i) {
-      std::string bankName = componentInfo.name(i);
-      boost::trim(bankName);
-      boost::erase_all(bankName, bankPart);
+    // iterate over the top level components, which contain the banks
+    size_t const rootIndex = componentInfo.root();
+    auto const topChildren = componentInfo.children(rootIndex);
+    for (size_t const i : topChildren) {
       int bank = 0;
-      Strings::convert(bankName, bank);
-      if (bank == 0)
-        continue;
-      // Track unique bank numbers
-      uniqueBanks.insert(bank);
+      size_t bankParent = componentInfo.findBankParent(i, bankPart);
+      auto const children = componentInfo.children(bankParent);
+      for (size_t const child : children) {
+        std::string bankName = componentInfo.name(child);
+        boost::trim(bankName);
+        boost::erase_all(bankName, bankPart);
+        Strings::convert(bankName, bank);
+        if (bank != 0) {
+          uniqueBanks.insert(bank);
+        }
+      }
     }
   }
 

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -174,12 +174,12 @@ void LoadIsawDetCal::exec() {
   if (instname == "WISH")
     bankPart = "WISHpanel";
   if (detList.empty()) {
-    // Get all children
-    std::vector<IComponent_const_sptr> comps;
-    inst->getChildren(comps, true);
-
-    for (auto &comp : comps) {
-      std::string bankName = comp->getName();
+    // Get all components using ComponentInfo
+    auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+    const auto &componentInfo = expInfoWS->componentInfo();
+    
+    for (size_t i = 0; i < componentInfo.size(); ++i) {
+      std::string bankName = componentInfo.name(i);
       boost::trim(bankName);
       boost::erase_all(bankName, bankPart);
       int bank = 0;
@@ -306,11 +306,11 @@ void LoadIsawDetCal::exec() {
     auto comp = inst->getComponentByName(bankName);
     // for Corelli with sixteenpack under bank
     if (instname == "CORELLI") {
-      std::vector<Geometry::IComponent_const_sptr> children;
-      std::shared_ptr<const Geometry::ICompAssembly> asmb =
-          std::dynamic_pointer_cast<const Geometry::ICompAssembly>(inst->getComponentByName(bankName));
-      asmb->getChildren(children, false);
-      comp = children[0];
+      const size_t bankIndex = componentInfo.indexOfAny(bankName);
+      const auto children = componentInfo.children(bankIndex);
+      if (!children.empty()) {
+        comp = componentInfo.componentID(children[0])->shared_from_this();
+      }
     }
     if (comp) {
       // Omitted scaling tubes

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -309,8 +309,7 @@ void LoadIsawDetCal::exec() {
       const size_t bankIndex = componentInfo.indexOfAny(bankName);
       const auto children = componentInfo.children(bankIndex);
       if (!children.empty()) {
-        // Get the first child component by name
-        comp = inst->getComponentByName(componentInfo.name(children[0]));
+        comp = IComponent_const_sptr(componentInfo.componentID(children[0]), NoDeleting());
       }
     }
     if (comp) {

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -374,7 +374,6 @@ void LoadMask::processMaskOnDetectors(const detid2index_map &indexmap, bool toma
  *provided as input.
  */
 void LoadMask::componentToDetectors(const std::vector<std::string> &componentnames, std::vector<detid_t> &detectors) {
-  Geometry::Instrument_const_sptr minstrument = m_maskWS->getInstrument();
   const auto &componentInfo = m_maskWS->componentInfo();
   const auto &detectorInfo = m_maskWS->detectorInfo();
 
@@ -430,12 +429,12 @@ void LoadMask::bankToDetectors(const std::vector<std::string> &singlebanks, std:
   }
   g_log.debug(infoss.str());
 
-  Geometry::Instrument_const_sptr minstrument = m_maskWS->getInstrument();
+  Geometry::Instrument_const_sptr instrument = m_maskWS->getInstrument();
 
   for (auto &singlebank : singlebanks) {
     std::vector<Geometry::IDetector_const_sptr> idetectors;
 
-    minstrument->getDetectorsInBank(idetectors, singlebank);
+    instrument->getDetectorsInBank(idetectors, singlebank);
     g_log.debug() << "Bank: " << singlebank << " has " << idetectors.size() << " detectors\n";
 
     // a) get information

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -106,8 +106,6 @@ void SaveIsawDetCal::exec() {
       uniqueBanks.insert(bank);
     }
   }
-  if (!inst)
-    throw std::runtime_error("No instrument in PeaksWorkspace. Cannot save peaks file.");
 
   double l1;
   V3D beamline;

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ArrayProperty.h"
 
@@ -80,12 +81,10 @@ void SaveIsawDetCal::exec() {
 
   std::set<int> uniqueBanks;
   if (bankNames.empty()) {
-    // Get all children
-    std::vector<IComponent_const_sptr> comps;
-    inst->getChildren(comps, true);
-
-    for (auto &comp : comps) {
-      std::string bankName = comp->getName();
+    // Get all components using ComponentInfo
+    const auto &componentInfo = ws->componentInfo();
+    for (size_t i = 0; i < componentInfo.size(); ++i) {
+      std::string bankName = componentInfo.name(i);
       boost::trim(bankName);
       boost::erase_all(bankName, bankPart);
       int bank = 0;

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -163,7 +163,8 @@ void SaveIsawDetCal::exec() {
       const size_t bankIndex = componentInfo.indexOfAny(bankName);
       const auto children = componentInfo.children(bankIndex);
       if (!children.empty()) {
-        det = componentInfo.componentID(children[0])->shared_from_this();
+        // Get the first child component by name
+        det = inst->getComponentByName(componentInfo.name(children[0]));
       }
     }
     if (det) {
@@ -179,11 +180,13 @@ void SaveIsawDetCal::exec() {
       // Since WISH banks are curved use center and increment 2 for tubedown
       int midX = NCOLS / 2;
       int midY = NROWS / 2;
-      V3D base = findPixelPos(bankName, midX + 2, midY, componentInfo) - findPixelPos(bankName, midX, midY, componentInfo);
+      V3D base =
+          findPixelPos(bankName, midX + 2, midY, componentInfo) - findPixelPos(bankName, midX, midY, componentInfo);
       base.normalize();
 
       // Up unit vector (along the vertical, Y axis)
-      V3D up = findPixelPos(bankName, midX, midY + 1, componentInfo) - findPixelPos(bankName, midX, midY, componentInfo);
+      V3D up =
+          findPixelPos(bankName, midX, midY + 1, componentInfo) - findPixelPos(bankName, midX, midY, componentInfo);
       up.normalize();
 
       // Write the line

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -163,8 +163,7 @@ void SaveIsawDetCal::exec() {
       const size_t bankIndex = componentInfo.indexOfAny(bankName);
       const auto children = componentInfo.children(bankIndex);
       if (!children.empty()) {
-        // Get the first child component by name
-        det = inst->getComponentByName(componentInfo.name(children[0]));
+        det = IComponent_const_sptr(componentInfo.componentID(children[0]), NoDeleting());
       }
     }
     if (det) {

--- a/Framework/DataHandling/src/SaveNexusGeometry.cpp
+++ b/Framework/DataHandling/src/SaveNexusGeometry.cpp
@@ -18,7 +18,6 @@
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
-#include "MantidGeometry/Instrument/InstrumentVisitor.h"
 #include "MantidNexusGeometry/NexusGeometrySave.h"
 
 #include <memory>

--- a/Framework/DataHandling/test/LoadILLTest.h
+++ b/Framework/DataHandling/test/LoadILLTest.h
@@ -42,78 +42,127 @@ public:
     TS_ASSERT_EQUALS(alg.getPropertyValue("LoaderName"), resultLoader)
   }
 
-  void test_LoadSANS_D11() { checkLoader("ILL/D11/010560", "LoadILLSANS"); }
+  void test_LoadSANS_D11() {
+    std::cout << "Testing LoadSANS for D11" << std::endl;
+    checkLoader("ILL/D11/010560", "LoadILLSANS");
+  }
 
   void test_LoadSANS_D33() {
+    std::cout << "Testing LoadSANS for D33" << std::endl;
     checkLoader("ILL/D33/002294", "LoadILLSANS");
     checkLoader("ILL/D33/042610", "LoadILLSANS"); // D33 TOF
   }
 
-  void test_LoadSANS_D22() { checkLoader("ILL/D22/192068", "LoadILLSANS"); }
+  void test_LoadSANS_D22() {
+    std::cout << "Testing LoadSANS for D22" << std::endl;
+    checkLoader("ILL/D22/192068", "LoadILLSANS");
+  }
 
   void test_LoadSANS_D16() {
+    std::cout << "Testing LoadSANS for D16" << std::endl;
     checkLoader("ILL/D16/023583", "LoadILLSANS");
     checkLoader("ILL/D16/218356", "LoadILLSANS");
   }
 
-  void test_LoadSANS_D16B() { checkLoader("ILL/D16/066321", "LoadILLSANS"); }
+  void test_LoadSANS_D16B() {
+    std::cout << "Testing LoadSANS for D16B" << std::endl;
+    checkLoader("ILL/D16/066321", "LoadILLSANS");
+  }
 
-  void test_LoadDiffraction_D1B() { checkLoader("ILL/D1B/473432", "LoadILLDiffraction"); }
+  void test_LoadDiffraction_D1B() {
+    std::cout << "Testing LoadDiffraction for D1B" << std::endl;
+    checkLoader("ILL/D1B/473432", "LoadILLDiffraction");
+  }
 
-  void test_LoadDiffraction_D2B() { checkLoader("ILL/D2B/535401", "LoadILLDiffraction"); }
+  void test_LoadDiffraction_D2B() {
+    std::cout << "Testing LoadDiffraction for D2B" << std::endl;
+    checkLoader("ILL/D2B/535401", "LoadILLDiffraction");
+  }
 
-  void test_LoadDiffraction_D4() { checkLoader("ILL/D4/387230", "LoadILLDiffraction"); }
+  void test_LoadDiffraction_D4() {
+    std::cout << "Testing LoadDiffraction for D4" << std::endl;
+    checkLoader("ILL/D4/387230", "LoadILLDiffraction");
+  }
 
   void test_LoadDiffraction_D20() {
+    std::cout << "Testing LoadDiffraction for D20" << std::endl;
     checkLoader("ILL/D20/967076", "LoadILLDiffraction");
     checkLoader("ILL/D20/967087", "LoadILLDiffraction");
   }
 
-  void test_LoadPolarizedDiffraction_D7() { checkLoader("ILL/D7/394458", "LoadILLPolarizedDiffraction"); }
+  void test_LoadPolarizedDiffraction_D7() {
+    std::cout << "Testing LoadPolarizedDiffraction for D7" << std::endl;
+    checkLoader("ILL/D7/394458", "LoadILLPolarizedDiffraction");
+  }
 
   void test_loadIndirect_IN16B() {
+    std::cout << "Testing LoadIndirect for IN16B" << std::endl;
+    std::cout << "load one wing qens" << std::endl;
     checkLoader("ILL/IN16B/090661", "LoadILLIndirect"); // one wing qens
+    std::cout << "load one wing efws" << std::endl;
     checkLoader("ILL/IN16B/083072", "LoadILLIndirect"); // one wing efws
+    std::cout << "load one wing ifws" << std::endl;
     checkLoader("ILL/IN16B/083073", "LoadILLIndirect"); // one wing ifws
+    std::cout << "load two wing qens" << std::endl;
     checkLoader("ILL/IN16B/136558", "LoadILLIndirect"); // two wings qens
+    std::cout << "load two wing efws" << std::endl;
     checkLoader("ILL/IN16B/143720", "LoadILLIndirect"); // two wings efws
+    std::cout << "load two wing ifws" << std::endl;
     checkLoader("ILL/IN16B/170300", "LoadILLIndirect"); // two wings ifws
+    std::cout << "load bats" << std::endl;
     checkLoader("ILL/IN16B/215962", "LoadILLIndirect"); // bats
   }
 
-  void test_loadTOF_IN4() { checkLoader("ILL/IN4/084446", "LoadILLTOF"); }
+  void test_loadTOF_IN4() {
+    std::cout << "Testing LoadTOF for IN4" << std::endl;
+    checkLoader("ILL/IN4/084446", "LoadILLTOF");
+  }
 
   void test_loadTOF_IN5() {
+    std::cout << "Testing LoadTOF for IN5" << std::endl;
     checkLoader("ILL/IN5/104007", "LoadILLTOF");
     checkLoader("ILL/IN5/189171", "LoadILLTOF");
     checkLoader("ILL/IN5/199857", "LoadILLTOF"); // scan IN5
   }
 
   void test_loadTOF_IN6() {
+    std::cout << "Testing LoadTOF for IN6" << std::endl;
     checkLoader("ILL/IN6/164192", "LoadILLTOF");
     checkLoader("ILL/IN6/220010", "LoadILLTOF");
   }
 
   void test_loadTOF_PANTHER() {
+    std::cout << "Testing LoadTOF for PANTHER" << std::endl;
     checkLoader("ILL/PANTHER/001036", "LoadILLTOF"); // monochromatic PANTHER
     checkLoader("ILL/PANTHER/001723", "LoadILLTOF");
     checkLoader("ILL/PANTHER/010578", "LoadILLTOF"); // scan PANTHER
   }
 
   void test_loadTOF_SHARP() {
+    std::cout << "Testing LoadTOF for SHARP" << std::endl;
     checkLoader("ILL/SHARP/000102", "LoadILLTOF"); // single-channel
     checkLoader("ILL/SHARP/000103", "LoadILLTOF");
     checkLoader("ILL/SHARP/000104.nxs", "LoadILLTOF"); // scan SHARP
   }
 
-  void test_loadReflectometry_D17() { checkLoader("ILL/D17/317370", "LoadILLReflectometry"); }
+  void test_loadReflectometry_D17() {
+    std::cout << "Testing LoadReflectometry for D17" << std::endl;
+    checkLoader("ILL/D17/317370", "LoadILLReflectometry");
+  }
 
-  void test_loadReflectometry_FIGARO() { checkLoader("ILL/Figaro/000002", "LoadILLReflectometry"); }
+  void test_loadReflectometry_FIGARO() {
+    std::cout << "Testing LoadReflectometry for FIGARO" << std::endl;
+    checkLoader("ILL/Figaro/000002", "LoadILLReflectometry");
+  }
 
   void test_loadSALSA() {
+    std::cout << "Testing LoadSALSA" << std::endl;
     checkLoader("ILL/SALSA/046430", "LoadILLSALSA");
     checkLoader("ILL/SALSA/046508", "LoadILLSALSA");
   }
 
-  void test_loadLagrange() { checkLoader("ILL/LAGRANGE/014412", "LoadILLLagrange"); }
+  void test_loadLagrange() {
+    std::cout << "Testing LoadILLLagrange" << std::endl;
+    checkLoader("ILL/LAGRANGE/014412", "LoadILLLagrange");
+  }
 };

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/EdgePixel.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/EdgePixel.h
@@ -6,14 +6,17 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/DllConfig.h"
+#include <string>
 
 namespace Mantid {
 namespace Geometry {
 
+// forward declare
+class ComponentInfo;
+
 /// Function to find peaks near detector edge
-MANTID_GEOMETRY_DLL bool edgePixel(const Geometry::Instrument_const_sptr &inst, const std::string &bankName, int col,
-                                   int row, int Edge);
+MANTID_GEOMETRY_DLL bool edgePixel(ComponentInfo const &info, const std::string &bankName, int col, int row, int Edge);
 
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/IComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/IComponent.h
@@ -168,7 +168,8 @@ using IComponent_const_sptr = std::shared_ptr<const IComponent>;
 
 } // Namespace Geometry
 
-/// An object for constructing a shared_ptr that won't ever delete its pointee
+/// This functor is used as the deleter object of a shared_ptr to effectively erase ownership
+/// Raw pointers can be passed out as non-owning shared_ptrs that don't delete
 class NoDeleting {
 public:
   /// Does nothing

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -32,6 +32,7 @@ class DetectorInfo;
 class XMLInstrumentParameter;
 class ParameterMap;
 class ReferenceFrame;
+class InstrumentVisitor;
 /// Convenience typedef
 using InstrumentParameterCache =
     std::map<std::pair<std::string, const IComponent *>, std::shared_ptr<XMLInstrumentParameter>>;
@@ -220,6 +221,8 @@ public:
   void parseTreeAndCacheBeamline();
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
   makeBeamline(ParameterMap &pmap, const ParameterMap *source = nullptr) const;
+
+  friend InstrumentVisitor;
 
 private:
   /// Save information about a set of detectors to Nexus

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/CompAssembly.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/CompAssembly.h
@@ -64,8 +64,6 @@ public:
   //! Get a pointer to the ith component within the assembly. Easier to use than
   //[] when you have a pointer
   std::shared_ptr<IComponent> getChild(const int i) const override;
-  //! Returns a vector of all children contained.
-  void getChildren(std::vector<IComponent_const_sptr> &outVector, bool recursive) const override;
   //! Get a pointer to the ith component in the assembly
   std::shared_ptr<IComponent> operator[](int i) const override;
   /// Returns a pointer to the first component of assembly encountered with the
@@ -94,6 +92,8 @@ private:
   CompAssembly &operator=(const ICompAssembly &);
 
 protected:
+  //! Returns a vector of all children contained.
+  void getChildren(std::vector<IComponent_const_sptr> &outVector, bool recursive) const override;
   /// the group of child components
   std::vector<IComponent *> m_children;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -137,6 +137,8 @@ public:
   const ComponentInfoIterator<const ComponentInfo> cbegin();
   const ComponentInfoIterator<const ComponentInfo> cend();
 
+  size_t findBankParent(size_t index, const std::string &bankPart) const;
+
   friend class Instrument;
 };
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -150,6 +150,7 @@ private:
   void validateInput() const;
   /// Pointer to the base GridDetector, for parametrized instruments
   const GridDetector *m_gridBase;
+  bool isParametrized() const { return m_map && m_gridBase; }
   /// Private copy assignment operator
   GridDetector &operator=(const ICompAssembly &);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -150,7 +150,7 @@ private:
   void validateInput() const;
   /// Pointer to the base GridDetector, for parametrized instruments
   const GridDetector *m_gridBase;
-  bool isParametrized() const { return m_map && m_gridBase; }
+  bool isParametrized() const override { return m_map && m_gridBase; }
   /// Private copy assignment operator
   GridDetector &operator=(const ICompAssembly &);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -86,9 +86,9 @@ public:
 
   Kernel::V3D getRelativePosAtXYZ(int x, int y, int z) const;
   /// minimum detector id
-  detid_t minDetectorID();
+  detid_t minDetectorID() const;
   /// maximum detector id
-  detid_t maxDetectorID();
+  detid_t maxDetectorID() const;
   std::shared_ptr<const IComponent> getComponentByName(const std::string &cname, int nlevels = 0) const override;
 
   // This should inherit the getBoundingBox implementation from  CompAssembly

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ObjCompAssembly.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ObjCompAssembly.h
@@ -57,8 +57,6 @@ public:
   //! Get a pointer to the ith component within the assembly. Easier to use than
   //[] when you have a pointer
   std::shared_ptr<IComponent> getChild(const int i) const override { return (*this)[i]; }
-  //! Get all children
-  void getChildren(std::vector<IComponent_const_sptr> &outVector, bool recursive) const override;
   //! Returns a pointer to the first component of assembly encountered with the
   // given name
   std::shared_ptr<const IComponent> getComponentByName(const std::string &cname, int nlevels = 0) const override;
@@ -81,6 +79,10 @@ public:
                                     std::deque<IComponent_const_sptr> & /*searchQueue*/) const override;
 
   size_t registerContents(class Mantid::Geometry::ComponentVisitor &visitor) const override;
+
+protected:
+  //! Get all children
+  void getChildren(std::vector<IComponent_const_sptr> &outVector, bool recursive) const override;
 
 private:
   /// Private copy assignment operator

--- a/Framework/Geometry/src/Crystal/EdgePixel.cpp
+++ b/Framework/Geometry/src/Crystal/EdgePixel.cpp
@@ -14,38 +14,32 @@
 namespace Mantid::Geometry {
 
 /**
-  @param  inst         Instrument
+  @param  compInfo     ComponentInfo object containing instrument information
   @param  bankName     Name of detector bank
   @param  col          Column number containing peak
   @param  row          Row number containing peak
   @param  Edge         Number of edge points for each bank
   @return True if peak is on edge
 */
-bool edgePixel(const Mantid::Geometry::Instrument_const_sptr &inst, const std::string &bankName, int col, int row,
-               int Edge) {
-  if (bankName == "None")
+bool edgePixel(ComponentInfo const &compInfo, const std::string &bankName, int col, int row, int Edge) {
+  if (bankName == "None") {
     return false;
-  std::shared_ptr<const Geometry::IComponent> parent = inst->getComponentByName(bankName);
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const Geometry::RectangularDetector> RDet =
-        std::dynamic_pointer_cast<const Geometry::RectangularDetector>(parent);
+  }
+  size_t parentIndex = compInfo.indexOfAny(bankName);
+  if (compInfo.componentType(parentIndex) == Beamline::ComponentType::Rectangular) {
+    auto RDet = dynamic_cast<Geometry::RectangularDetector const *const>(compInfo.componentID(parentIndex));
 
     return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge || row >= (RDet->ypixels() - Edge);
   } else {
-    // get the component info
-    auto const &pmap = inst->getParameterMap();
-    auto const &wrappers = inst->makeBeamline(*pmap);
-    auto const &compInfo = wrappers.first;
 
     // get the children and grandchildren from the component info
-    size_t parentIndex = compInfo->indexOfAny(bankName);
-    auto children = compInfo->children(parentIndex);
+    auto children = compInfo.children(parentIndex);
     int startI = 1;
-    if (!children.empty() && compInfo->name(children[0]) == "sixteenpack") {
+    if (!children.empty() && compInfo.name(children[0]) == "sixteenpack") {
       startI = 0;
-      children = compInfo->children(children[0]);
+      children = compInfo.children(children[0]);
     }
-    auto grandchildren = compInfo->children(children[0]);
+    auto grandchildren = compInfo.children(children[0]);
 
     // calculate if the pixel is on the edge of the bank
     auto NROWS = static_cast<int>(grandchildren.size());

--- a/Framework/Geometry/src/Crystal/EdgePixel.cpp
+++ b/Framework/Geometry/src/Crystal/EdgePixel.cpp
@@ -48,6 +48,5 @@ bool edgePixel(ComponentInfo const &compInfo, const std::string &bankName, int c
     return col - startI < Edge || col - startI >= (NCOLS - Edge) || row - startI < Edge ||
            row - startI >= (NROWS - Edge);
   }
-  return false;
 }
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1233,9 +1233,8 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
     // Tolerance 1e-9 m as in Beamline::DetectorInfo::isEquivalent.
     if ((relPos - toVector3d(baseComponent->getRelativePos())).norm() >= 1e-9) {
       if (isDetFixedInBank) {
-        throw std::runtime_error("Cannot create legacy ParameterMap: Position "
-                                 "parameters for GridDetectorPixel are "
-                                 "not supported");
+        throw std::runtime_error(
+            "Cannot create legacy ParameterMap: Position parameters for GridDetectorPixel are not supported");
       }
       pmap->addV3D(componentId, ParameterMap::pos(), Kernel::toV3D(relPos));
     }
@@ -1255,9 +1254,8 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
  * instrument are loaded. */
 void Instrument::parseTreeAndCacheBeamline() {
   if (isParametrized())
-    throw std::logic_error("Instrument::parseTreeAndCacheBeamline must be "
-                           "called with the base instrument, not a "
-                           "parametrized instrument");
+    throw std::logic_error(
+        "Instrument::parseTreeAndCacheBeamline must be called with the base instrument, not a parametrized instrument");
   std::tie(m_componentInfo, m_detectorInfo) = InstrumentVisitor::makeWrappers(*this);
 }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -88,8 +88,7 @@ Instrument::Instrument(const Instrument &instr)
   getChildren(children, true);
   std::vector<IComponent_const_sptr>::const_iterator it;
   for (it = children.begin(); it != children.end(); ++it) {
-    // First check if the current component is a detector and add to cache if it
-    // is
+    // First check if the current component is a detector and add to cache if it is
     if (const IDetector *det = dynamic_cast<const Detector *>(it->get())) {
       if (instr.isMonitor(det->getID()))
         markAsMonitor(det);
@@ -98,8 +97,7 @@ Instrument::Instrument(const Instrument &instr)
       continue;
     }
     // Now check whether the current component is the source or sample.
-    // As the majority of components will be detectors, we will rarely get to
-    // here
+    // As the majority of components will be detectors, we will rarely get to here
     if (const auto *obj = dynamic_cast<const Component *>(it->get())) {
       const std::string objName = obj->getName();
       // This relies on the source and sample having a unique name.

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -449,4 +449,29 @@ const ComponentInfoConstIt ComponentInfo::cbegin() { return ComponentInfoConstIt
 
 const ComponentInfoConstIt ComponentInfo::cend() { return ComponentInfoConstIt(*this, size(), size()); }
 
+size_t ComponentInfo::findBankParent(size_t index, const std::string &bankPart) const {
+  constexpr size_t invalidIndex{0}; // index 0 will always be a dectector and never a bank
+  // if this component is a bank, return the parent
+  if (name(index).starts_with(bankPart)) {
+    return parent(index);
+  }
+  // check if the children components begin with bankPart
+  auto indexChildren = children(index);
+  if (indexChildren.empty()) {
+    return invalidIndex;
+  }
+  // if they do, we found the bank parent
+  if (name(indexChildren[0]).starts_with(bankPart)) {
+    return index;
+  }
+  // if not, check the grandchildren
+  for (size_t const child : indexChildren) {
+    size_t j = findBankParent(child, bankPart);
+    if (j != invalidIndex) {
+      return j;
+    }
+  }
+  return invalidIndex;
+}
+
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -141,6 +141,7 @@ detid_t getFillFirstX(const GridDetector *me, int x, int y, int z) {
   else
     return me->idstart() + x * me->idstep() + z * me->idstepbyrow() + y * (me->zpixels() * me->idstepbyrow());
 }
+} // end namespace
 
 //-------------------------------------------------------------------------------------------------
 /** Return the detector ID corresponding to the component in the assembly at the

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -160,9 +160,9 @@ detid_t GridDetector::getDetectorIDAtXYZ(const int x, const int y, const int z) 
   if (isParametrized())
     me = this->m_gridBase;
 
-  if (me->m_idFillOrder[0] == 'z')
+  if (me->idFillOrder()[0] == 'z')
     return getFillFirstZ(me, x, y, z);
-  else if (me->m_idFillOrder[0] == 'y')
+  else if (me->idFillOrder()[0] == 'y')
     return getFillFirstY(me, x, y, z);
   else
     return getFillFirstX(me, x, y, z);
@@ -799,9 +799,9 @@ void GridDetector::initDraw() const {
 /// Returns the shape of the Object
 const std::shared_ptr<const IObject> GridDetector::shape() const {
   // --- Create a cuboid shape for your pixels ----
-  double szX = m_xpixels;
-  double szY = m_ypixels;
-  double szZ = m_zpixels == 0 ? 0.5 : m_zpixels;
+  double szX = xpixels();
+  double szY = ypixels();
+  double szZ = zpixels() == 0 ? 0.5 : zpixels();
   std::ostringstream xmlShapeStream;
   xmlShapeStream << " <cuboid id=\"detector-shape\"> "
                  << "<left-front-bottom-point x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -155,7 +155,7 @@ detid_t getFillFirstX(const GridDetector *me, int x, int y, int z) {
  */
 detid_t GridDetector::getDetectorIDAtXYZ(const int x, const int y, const int z) const {
   const GridDetector *me = this;
-  if (m_map)
+  if (isParametrized())
     me = this->m_gridBase;
 
   if (me->m_idFillOrder[0] == 'z')
@@ -210,7 +210,7 @@ std::tuple<int, int, int> getXYZFillFirstX(const GridDetector *me, int col, int 
  */
 std::tuple<int, int, int> GridDetector::getXYZForDetectorID(const detid_t detectorID) const {
   const GridDetector *me = this;
-  if (m_map)
+  if (isParametrized())
     me = this->m_gridBase;
 
   int id = detectorID - me->m_idstart;
@@ -230,7 +230,7 @@ std::tuple<int, int, int> GridDetector::getXYZForDetectorID(const detid_t detect
 /// Returns the number of pixels in the X direction.
 /// @return number of X pixels
 int GridDetector::xpixels() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_xpixels;
   else
     return this->m_xpixels;
@@ -240,7 +240,7 @@ int GridDetector::xpixels() const {
 /// Returns the number of pixels in the Y direction.
 /// @return number of y pixels
 int GridDetector::ypixels() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_ypixels;
   else
     return this->m_ypixels;
@@ -250,7 +250,7 @@ int GridDetector::ypixels() const {
 /// Returns the number of pixels in the Z direction.
 /// @return number of z pixels
 int GridDetector::zpixels() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_zpixels;
   else
     return this->m_zpixels;
@@ -259,7 +259,7 @@ int GridDetector::zpixels() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the step size in the X direction
 double GridDetector::xstep() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
@@ -271,7 +271,7 @@ double GridDetector::xstep() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the step size in the Y direction
 double GridDetector::ystep() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
@@ -283,7 +283,7 @@ double GridDetector::ystep() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the step size in the Z direction
 double GridDetector::zstep() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
@@ -295,7 +295,7 @@ double GridDetector::zstep() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the start position in the X direction
 double GridDetector::xstart() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
@@ -307,7 +307,7 @@ double GridDetector::xstart() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the start position in the Y direction
 double GridDetector::ystart() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
@@ -319,7 +319,7 @@ double GridDetector::ystart() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the start position in the Z direction
 double GridDetector::zstart() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
@@ -331,7 +331,7 @@ double GridDetector::zstart() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the size in the X direction
 double GridDetector::xsize() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
@@ -343,7 +343,7 @@ double GridDetector::xsize() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the size in the Y direction
 double GridDetector::ysize() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
@@ -355,7 +355,7 @@ double GridDetector::ysize() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the size in the Z direction
 double GridDetector::zsize() const {
-  if (m_map) {
+  if (isParametrized()) {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
@@ -367,7 +367,7 @@ double GridDetector::zsize() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstart
 int GridDetector::idstart() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_idstart;
   else
     return this->m_idstart;
@@ -376,7 +376,7 @@ int GridDetector::idstart() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the idfillbyfirst_y
 bool GridDetector::idfillbyfirst_y() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_idfillbyfirst_y;
   else
     return this->m_idfillbyfirst_y;
@@ -384,7 +384,7 @@ bool GridDetector::idfillbyfirst_y() const {
 
 /// Returns the id fill order
 std::string GridDetector::idFillOrder() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_idFillOrder;
   else
     return this->m_idFillOrder;
@@ -393,7 +393,7 @@ std::string GridDetector::idFillOrder() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstepbyrow
 int GridDetector::idstepbyrow() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_idstepbyrow;
   else
     return this->m_idstepbyrow;
@@ -402,7 +402,7 @@ int GridDetector::idstepbyrow() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstep
 int GridDetector::idstep() const {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_idstep;
   else
     return this->m_idstep;
@@ -419,7 +419,7 @@ int GridDetector::idstep() const {
  * @return a V3D vector of the relative position
  */
 V3D GridDetector::getRelativePosAtXYZ(int x, int y, int z) const {
-  if (m_map) {
+  if (isParametrized()) {
     double scalex = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scalex = m_map->get(m_gridBase, "scalex")->value<double>();
@@ -563,7 +563,7 @@ void GridDetector::initialize(std::shared_ptr<IObject> shape, int xpixels, doubl
                               double ystart, double ystep, int zpixels, double zstart, double zstep, int idstart,
                               const std::string &idFillOrder, int idstepbyrow, int idstep) {
 
-  if (m_map)
+  if (isParametrized())
     throw std::runtime_error("GridDetector::initialize() called for a "
                              "parametrized GridDetector");
 
@@ -592,7 +592,7 @@ void GridDetector::initialize(std::shared_ptr<IObject> shape, int xpixels, doubl
  * @return minimum detector id
  */
 detid_t GridDetector::minDetectorID() {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_minDetId;
   return m_minDetId;
 }
@@ -602,7 +602,7 @@ detid_t GridDetector::minDetectorID() {
  * @return maximum detector id
  */
 detid_t GridDetector::maxDetectorID() {
-  if (m_map)
+  if (isParametrized())
     return m_gridBase->m_maxDetId;
   return m_maxDetId;
 }
@@ -745,7 +745,7 @@ int GridDetector::getPointInObject(V3D & /*point*/) const {
  * @param assemblyBox :: A BoundingBox object that will be overwritten
  */
 void GridDetector::getBoundingBox(BoundingBox &assemblyBox) const {
-  if (m_map) {
+  if (isParametrized()) {
     if (hasComponentInfo()) {
       assemblyBox = m_map->componentInfo().boundingBox(index(), &assemblyBox);
       return;

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -121,6 +121,7 @@ std::shared_ptr<Detector> GridDetector::getAtXYZ(const int x, const int y, const
   return std::dynamic_pointer_cast<Detector>(xCol->getChild(y));
 }
 
+namespace {
 detid_t getFillFirstZ(const GridDetector *me, int x, int y, int z) {
   if (me->idFillOrder()[1] == 'y')
     return me->idstart() + z * me->idstep() + y * me->idstepbyrow() + x * (me->ypixels() * me->idstepbyrow());
@@ -167,6 +168,7 @@ detid_t GridDetector::getDetectorIDAtXYZ(const int x, const int y, const int z) 
     return getFillFirstX(me, x, y, z);
 }
 
+namespace {
 std::tuple<int, int, int> getXYZFillFirstZ(const GridDetector *me, int col, int id) {
   if (me->idFillOrder()[1] == 'y') {
     int row = (id / me->idstepbyrow()) % me->ypixels();
@@ -202,6 +204,7 @@ std::tuple<int, int, int> getXYZFillFirstX(const GridDetector *me, int col, int 
     return std::tuple<int, int, int>(col, layer, row);
   }
 }
+} // end namespace
 
 //-------------------------------------------------------------------------------------------------
 /** Given a detector ID, return the X,Y,Z coords into the grid detector

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -235,7 +235,7 @@ std::tuple<int, int, int> GridDetector::getXYZForDetectorID(const detid_t detect
 /// @return number of X pixels
 int GridDetector::xpixels() const {
   if (isParametrized())
-    return m_gridBase->m_xpixels;
+    return m_gridBase->xpixels();
   else
     return this->m_xpixels;
 }
@@ -245,7 +245,7 @@ int GridDetector::xpixels() const {
 /// @return number of y pixels
 int GridDetector::ypixels() const {
   if (isParametrized())
-    return m_gridBase->m_ypixels;
+    return m_gridBase->ypixels();
   else
     return this->m_ypixels;
 }
@@ -255,7 +255,7 @@ int GridDetector::ypixels() const {
 /// @return number of z pixels
 int GridDetector::zpixels() const {
   if (isParametrized())
-    return m_gridBase->m_zpixels;
+    return m_gridBase->zpixels();
   else
     return this->m_zpixels;
 }
@@ -267,7 +267,7 @@ double GridDetector::xstep() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
-    return m_gridBase->m_xstep * scaling;
+    return m_gridBase->xstep() * scaling;
   } else
     return this->m_xstep;
 }
@@ -279,7 +279,7 @@ double GridDetector::ystep() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
-    return m_gridBase->m_ystep * scaling;
+    return m_gridBase->ystep() * scaling;
   } else
     return this->m_ystep;
 }
@@ -291,7 +291,7 @@ double GridDetector::zstep() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
-    return m_gridBase->m_zstep * scaling;
+    return m_gridBase->zstep() * scaling;
   } else
     return this->m_zstep;
 }
@@ -303,7 +303,7 @@ double GridDetector::xstart() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
-    return m_gridBase->m_xstart * scaling;
+    return m_gridBase->xstart() * scaling;
   } else
     return this->m_xstart;
 }
@@ -315,7 +315,7 @@ double GridDetector::ystart() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
-    return m_gridBase->m_ystart * scaling;
+    return m_gridBase->ystart() * scaling;
   } else
     return this->m_ystart;
 }
@@ -327,7 +327,7 @@ double GridDetector::zstart() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
-    return m_gridBase->m_zstart * scaling;
+    return m_gridBase->zstart() * scaling;
   } else
     return this->m_zstart;
 }
@@ -339,7 +339,7 @@ double GridDetector::xsize() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
       scaling = m_map->get(m_gridBase, "scalex")->value<double>();
-    return m_gridBase->m_xsize * scaling;
+    return m_gridBase->xsize() * scaling;
   } else
     return this->m_xsize;
 }
@@ -351,7 +351,7 @@ double GridDetector::ysize() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scaley"))
       scaling = m_map->get(m_gridBase, "scaley")->value<double>();
-    return m_gridBase->m_ysize * scaling;
+    return m_gridBase->ysize() * scaling;
   } else
     return this->m_ysize;
 }
@@ -363,7 +363,7 @@ double GridDetector::zsize() const {
     double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalez"))
       scaling = m_map->get(m_gridBase, "scalez")->value<double>();
-    return m_gridBase->m_zsize * scaling;
+    return m_gridBase->zsize() * scaling;
   } else
     return this->m_zsize;
 }
@@ -372,7 +372,7 @@ double GridDetector::zsize() const {
 /// Returns the idstart
 int GridDetector::idstart() const {
   if (isParametrized())
-    return m_gridBase->m_idstart;
+    return m_gridBase->idstart();
   else
     return this->m_idstart;
 }
@@ -381,7 +381,7 @@ int GridDetector::idstart() const {
 /// Returns the idfillbyfirst_y
 bool GridDetector::idfillbyfirst_y() const {
   if (isParametrized())
-    return m_gridBase->m_idfillbyfirst_y;
+    return m_gridBase->idfillbyfirst_y();
   else
     return this->m_idfillbyfirst_y;
 }
@@ -389,7 +389,7 @@ bool GridDetector::idfillbyfirst_y() const {
 /// Returns the id fill order
 std::string GridDetector::idFillOrder() const {
   if (isParametrized())
-    return m_gridBase->m_idFillOrder;
+    return m_gridBase->idFillOrder();
   else
     return this->m_idFillOrder;
 }
@@ -398,7 +398,7 @@ std::string GridDetector::idFillOrder() const {
 /// Returns the idstepbyrow
 int GridDetector::idstepbyrow() const {
   if (isParametrized())
-    return m_gridBase->m_idstepbyrow;
+    return m_gridBase->idstepbyrow();
   else
     return this->m_idstepbyrow;
 }
@@ -407,7 +407,7 @@ int GridDetector::idstepbyrow() const {
 /// Returns the idstep
 int GridDetector::idstep() const {
   if (isParametrized())
-    return m_gridBase->m_idstep;
+    return m_gridBase->idstep();
   else
     return this->m_idstep;
 }
@@ -487,10 +487,9 @@ bool checkValidOrderString(const std::string &order) {
 
 void GridDetector::validateInput() const {
   // Some safety checks
-  if (!checkValidOrderString(m_idFillOrder) || m_idFillOrder.size() != 3)
-    throw std::invalid_argument("GridDetector::initialize(): order string "
-                                "should only comprise exactly 3 letters x, y, "
-                                "and z in any order.");
+  if (!checkValidOrderString(m_idFillOrder))
+    throw std::invalid_argument(
+        "GridDetector::initialize(): order string should only comprise exactly 3 letters x, y, and z in any order.");
   if (m_xpixels <= 0)
     throw std::invalid_argument("GridDetector::initialize(): xpixels should be > 0");
   if (m_ypixels <= 0)
@@ -568,8 +567,7 @@ void GridDetector::initialize(std::shared_ptr<IObject> shape, int xpixels, doubl
                               const std::string &idFillOrder, int idstepbyrow, int idstep) {
 
   if (isParametrized())
-    throw std::runtime_error("GridDetector::initialize() called for a "
-                             "parametrized GridDetector");
+    throw std::runtime_error("GridDetector::initialize() called for a parametrized GridDetector");
 
   initializeValues(std::move(shape), xpixels, xstart, xstep, ypixels, ystart, ystep, zpixels, zstart, zstep, idstart,
                    idFillOrder, idstepbyrow, idstep);
@@ -595,9 +593,9 @@ void GridDetector::initialize(std::shared_ptr<IObject> shape, int xpixels, doubl
 /** Returns the minimum detector id
  * @return minimum detector id
  */
-detid_t GridDetector::minDetectorID() {
+detid_t GridDetector::minDetectorID() const {
   if (isParametrized())
-    return m_gridBase->m_minDetId;
+    return m_gridBase->minDetectorID();
   return m_minDetId;
 }
 
@@ -605,9 +603,9 @@ detid_t GridDetector::minDetectorID() {
 /** Returns the maximum detector id
  * @return maximum detector id
  */
-detid_t GridDetector::maxDetectorID() {
+detid_t GridDetector::maxDetectorID() const {
   if (isParametrized())
-    return m_gridBase->m_maxDetId;
+    return m_gridBase->maxDetectorID();
   return m_maxDetId;
 }
 
@@ -645,37 +643,32 @@ std::shared_ptr<const IComponent> GridDetector::getComponentByName(const std::st
 void GridDetector::testIntersectionWithChildren(Track &testRay,
                                                 std::deque<IComponent_const_sptr> & /*searchQueue*/) const {
   /// Base point (x,y,z) = position of pixel 0,0
-  V3D basePoint;
+  V3D const basePoint = getRelativePosAtXYZ(0, 0, 0);
 
   /// Vertical (y-axis) basis vector of the detector
-  V3D vertical;
+  V3D const vertical = getRelativePosAtXYZ(0, ypixels() - 1, 0) - basePoint;
 
   /// Horizontal (x-axis) basis vector of the detector
-  V3D horizontal;
-
-  basePoint = getAtXYZ(0, 0, 0)->getPos();
-  horizontal = getAtXYZ(xpixels() - 1, 0, 0)->getPos() - basePoint;
-  vertical = getAtXYZ(0, ypixels() - 1, 0)->getPos() - basePoint;
+  V3D horizontal = getRelativePosAtXYZ(xpixels() - 1, 0, 0) - basePoint;
 
   // The beam direction
-  V3D beam = testRay.direction();
+  V3D const beam = testRay.direction() * (-1.0);
 
   // From: http://en.wikipedia.org/wiki/Line-plane_intersection (taken on May 4,
   // 2011),
   // We build a matrix to solve the linear equation:
   Matrix<double> mat(3, 3);
-  mat.setColumn(0, beam * -1.0);
+  mat.setColumn(0, beam);
   mat.setColumn(1, horizontal);
   mat.setColumn(2, vertical);
   mat.Invert();
 
   // Multiply by the inverted matrix to find t,u,v
-  V3D tuv = mat * (testRay.startPoint() - basePoint);
+  V3D const tuv = mat * (testRay.startPoint() - basePoint);
   //  std::cout << tuv << "\n";
 
   // Intersection point
-  V3D intersec = beam;
-  intersec *= tuv[0];
+  V3D const intersec = beam * (tuv[0] * -1.0);
 
   // t = coordinate along the line
   // u,v = coordinates along horizontal, vertical

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -155,10 +155,9 @@ size_t InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembl
   const size_t componentStop = m_assemblySortedComponentIndices->size();
 
   m_detectorRanges->emplace_back(detectorStart, detectorStop);
-  m_componentRanges->emplace_back(std::make_pair(componentStart, componentStop));
+  m_componentRanges->emplace_back(componentStart, componentStop);
 
-  // Now that we know what the index of the parent is we can apply it to the
-  // children
+  // Now that we know what the index of the parent is we can apply it to the children
   for (const auto &child : children) {
     (*m_parentComponentIndices)[child] = componentIndex;
   }

--- a/Framework/Geometry/src/Instrument/ObjCompAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/ObjCompAssembly.cpp
@@ -27,13 +27,6 @@ using Kernel::DblMatrix;
 using Kernel::Quat;
 using Kernel::V3D;
 
-/// Void deleter for shared pointers
-class NoDeleting {
-public:
-  /// deleting operator. Does nothing
-  void operator()(void *p) { (void)p; }
-};
-
 /** Constructor for a parametrized ObjComponent
  * @param base: the base (un-parametrized) IComponent
  * @param map: pointer to the ParameterMap

--- a/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
+++ b/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
@@ -9,7 +9,6 @@
 //-------------------------------------------------------------
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
 #include "MantidGeometry/IComponent.h"
-#include "MantidGeometry/Instrument/InstrumentVisitor.h"
 #include "MantidGeometry/Objects/Track.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/V3D.h"

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/FindPeaksMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/FindPeaksMD.h
@@ -21,8 +21,9 @@
 
 namespace Mantid {
 namespace Geometry {
+class ComponentInfo;
 class InstrumentRayTracer;
-}
+} // namespace Geometry
 namespace MDAlgorithms {
 
 /** FindPeaksMD : TODO: DESCRIPTION
@@ -61,7 +62,8 @@ private:
   void determineOutputType(const std::string &peakType, const uint16_t numExperimentInfo);
 
   /// Adds a peak based on Q, bin count & a set of detector IDs
-  void addPeak(const Mantid::Kernel::V3D &Q, const double binCount, const Geometry::InstrumentRayTracer &tracer);
+  void addPeak(const Geometry::ComponentInfo &compInfo, const Mantid::Kernel::V3D &Q, const double binCount,
+               const Geometry::InstrumentRayTracer &tracer);
 
   /// Adds a peak based on Q, bin count
   void addLeanElasticPeak(const Mantid::Kernel::V3D &Q, const double binCount, const bool useGoniometer = false);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/FindPeaksMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/FindPeaksMD.h
@@ -108,7 +108,7 @@ private:
   enum eDimensionType { HKL, QLAB, QSAMPLE };
 
   /// Instrument
-  Mantid::Geometry::Instrument_const_sptr inst;
+  Mantid::Geometry::Instrument_const_sptr m_inst;
   /// Run number of the peaks
   int m_runNumber;
   /// Dimension type

--- a/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
@@ -128,11 +128,11 @@ std::map<int, RectangularDetector_const_sptr> ConvertToDetectorFaceMD::getBanks(
     // --- Find all rectangular detectors ----
     const auto &componentInfo = in_ws->componentInfo();
     for (size_t i = 0; i < componentInfo.size(); ++i) {
-      // Get the component and check if it's a RectangularDetector
-      const auto *comp = componentInfo.componentID(i);
-      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp->shared_from_this());
+      // Check if the component is a RectangularDetector by getting it by name
+      std::string name = componentInfo.name(i);
+      auto comp = inst->getComponentByName(name);
+      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp);
       if (det) {
-        std::string name = componentInfo.name(i);
         if (name.size() < 5)
           continue;
         std::string bank = name.substr(4, name.size() - 4);

--- a/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/MDEventFactory.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/ArrayLengthValidator.h"
@@ -125,15 +126,13 @@ std::map<int, RectangularDetector_const_sptr> ConvertToDetectorFaceMD::getBanks(
 
   if (bankNums.empty()) {
     // --- Find all rectangular detectors ----
-    // Get all children
-    std::vector<IComponent_const_sptr> comps;
-    inst->getChildren(comps, true);
-
-    for (auto &comp : comps) {
-      // Retrieve it
-      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp);
+    const auto &componentInfo = in_ws->componentInfo();
+    for (size_t i = 0; i < componentInfo.size(); ++i) {
+      // Get the component and check if it's a RectangularDetector
+      const auto *comp = componentInfo.componentID(i);
+      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp->shared_from_this());
       if (det) {
-        std::string name = det->getName();
+        std::string name = componentInfo.name(i);
         if (name.size() < 5)
           continue;
         std::string bank = name.substr(4, name.size() - 4);

--- a/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
@@ -128,11 +128,11 @@ std::map<int, RectangularDetector_const_sptr> ConvertToDetectorFaceMD::getBanks(
     // --- Find all rectangular detectors ----
     const auto &componentInfo = in_ws->componentInfo();
     for (size_t i = 0; i < componentInfo.size(); ++i) {
-      // Check if the component is a RectangularDetector by getting it by name
-      std::string name = componentInfo.name(i);
-      auto comp = inst->getComponentByName(name);
-      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp);
+      // Get the component and check if it's a RectangularDetector
+      auto det = RectangularDetector_const_sptr(dynamic_cast<const RectangularDetector *>(componentInfo.componentID(i)),
+                                                NoDeleting());
       if (det) {
+        std::string name = componentInfo.name(i);
         if (name.size() < 5)
           continue;
         std::string bank = name.substr(4, name.size() - 4);

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -107,7 +107,7 @@ const std::string FindPeaksMD::numberOfEventsNormalization = "NumberOfEventsNorm
  */
 FindPeaksMD::FindPeaksMD()
     : peakWS(), peakRadiusSquared(), DensityThresholdFactor(0.0), m_maxPeaks(0), m_addDetectors(true),
-      m_densityScaleFactor(1e-6), prog(nullptr), inst(), m_runNumber(-1), dimType(), m_goniometer() {}
+      m_densityScaleFactor(1e-6), prog(nullptr), m_inst(), m_runNumber(-1), dimType(), m_goniometer() {}
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
@@ -216,7 +216,7 @@ void FindPeaksMD::init() {
 /** Extract needed data from the workspace's experiment info */
 void FindPeaksMD::readExperimentInfo(const ExperimentInfo_sptr &ei) {
   // Instrument associated with workspace
-  inst = ei->getInstrument();
+  m_inst = ei->getInstrument();
   // Find the run number
   m_runNumber = ei->getRunNumber();
 
@@ -272,7 +272,7 @@ void FindPeaksMD::addPeak(const V3D &Q, const double binCount, const Geometry::I
   try {
     auto p = this->createPeak(Q, binCount, tracer);
     if (m_edge > 0) {
-      if (edgePixel(inst, p->getBankName(), p->getCol(), p->getRow(), m_edge))
+      if (edgePixel(m_inst, p->getBankName(), p->getCol(), p->getRow(), m_edge))
         return;
     }
     if (p->getDetectorID() != -1)
@@ -303,7 +303,7 @@ std::shared_ptr<DataObjects::Peak> FindPeaksMD::createPeak(const Mantid::Kernel:
   std::shared_ptr<DataObjects::Peak> p;
   if (dimType == QLAB) {
     // Build using the Q-lab-frame constructor
-    p = std::make_shared<Peak>(inst, Q);
+    p = std::make_shared<Peak>(m_inst, Q);
     // Save gonio matrix for later
     p->setGoniometerMatrix(m_goniometer);
   } else if (dimType == QSAMPLE) {
@@ -314,8 +314,8 @@ std::shared_ptr<DataObjects::Peak> FindPeaksMD::createPeak(const Mantid::Kernel:
       // Calculate Q lab from Q sample and wavelength
       double wavelength = getProperty("Wavelength");
       if (wavelength == DBL_MAX) {
-        if (inst->hasParameter("wavelength")) {
-          wavelength = inst->getNumberParameter("wavelength").at(0);
+        if (m_inst->hasParameter("wavelength")) {
+          wavelength = m_inst->getNumberParameter("wavelength").at(0);
         } else {
           throw std::runtime_error("Could not get wavelength, neither "
                                    "Wavelength algorithm property "
@@ -328,10 +328,10 @@ std::shared_ptr<DataObjects::Peak> FindPeaksMD::createPeak(const Mantid::Kernel:
       std::vector<double> angles = goniometer.getEulerAngles("YZY");
       g_log.information() << "Found goniometer rotation to be in YZY convention [" << angles[0] << ", " << angles[1]
                           << ". " << angles[2] << "] degrees for Q sample = " << Q << "\n";
-      p = std::make_shared<Peak>(inst, Q, goniometer.getR());
+      p = std::make_shared<Peak>(m_inst, Q, goniometer.getR());
 
     } else {
-      p = std::make_shared<Peak>(inst, Q, m_goniometer);
+      p = std::make_shared<Peak>(m_inst, Q, m_goniometer);
     }
   } else {
     throw std::invalid_argument("Cannot Integrate peaks unless the dimension is QLAB or QSAMPLE");
@@ -535,7 +535,7 @@ template <typename MDE, size_t nd> void FindPeaksMD::findPeaks(typename MDEventW
       ExperimentInfo_sptr ei = ws->getExperimentInfo(iexp);
       this->readExperimentInfo(ei);
 
-      Geometry::InstrumentRayTracer tracer(inst);
+      Geometry::InstrumentRayTracer tracer(m_inst);
       // Copy the instrument, sample, run to the peaks workspace.
       peakWS->copyExperimentInfoFrom(ei.get());
 
@@ -598,7 +598,7 @@ template <typename MDE, size_t nd> void FindPeaksMD::findPeaks(typename MDEventW
             }
             if (p->getDetectorID() != -1) {
               if (m_edge > 0) {
-                if (!edgePixel(inst, p->getBankName(), p->getCol(), p->getRow(), m_edge))
+                if (!edgePixel(m_inst, p->getBankName(), p->getCol(), p->getRow(), m_edge))
                   peakWS->addPeak(*p);
                 ;
               } else {
@@ -741,7 +741,7 @@ void FindPeaksMD::findPeaksHisto(const Mantid::DataObjects::MDHistoWorkspace_spt
     for (uint16_t iexp = 0; iexp < ws->getNumExperimentInfo(); iexp++) {
       ExperimentInfo_sptr ei = ws->getExperimentInfo(iexp);
       this->readExperimentInfo(ei);
-      Geometry::InstrumentRayTracer tracer(inst);
+      Geometry::InstrumentRayTracer tracer(m_inst);
 
       // Copy the instrument, sample, run to the peaks workspace.
       peakWS->copyExperimentInfoFrom(ei.get());

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -265,6 +265,7 @@ void FindPeaksMD::determineOutputType(const std::string &peakType, const uint16_
 //----------------------------------------------------------------------------------------------
 /** Create and add a Peak to the output workspace
  *
+ * @param compInfo :: ComponentInfo object to use for edge pixel checking
  * @param Q :: Q_lab or Q_sample, depending on workspace
  * @param binCount :: bin count to give to the peak.
  * @param tracer :: Ray tracer to use for detector finding

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -75,7 +75,7 @@ containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SampleCorrecti
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Crystal/inc/MantidCrystal/ClearUB.h:25
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Crystal/inc/MantidCrystal/PeaksIntersection.h:33
 variableScope:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IntegratePeakTimeSlices.cpp:239
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:606
+containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:608
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/Fit1D.cpp:379
 derefInvalidIteratorRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/ExcludeRangeFinder.cpp:77
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/BSpline.cpp:146

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -14,7 +14,7 @@ There are three layers to access instrument information, :py:obj:`~mantid.api.Sp
 
 A spectrum corresponds to (a group of) one or more detectors. Most algorithms work with spectra and thus :py:obj:`~mantid.api.SpectrumInfo` would be used. Some algorithms work on a lower level (with individual detectors) and thus :py:obj:`~mantid.geometry.DetectorInfo` would be used.
 
-The legacy :ref:`Instrument` largely consists of ``Detectors`` and ``Components`` - all detectors are also components. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` are the respective replacements for these. :py:obj:`~mantid.geometry.ComponentInfo` introduces a **component index** for access, and :py:obj:`~mantid.geometry:DetectorInfo` introduces a **detector index**, these will be discussed further below. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` share in-memory data. The difference between the two is best thought about in terms of their interfaces. The interface for :py:obj:`~mantid.geometry.DetectorInfo` is designed for working with detectors, and the interface for :py:obj:`~mantid.geometry.ComponentInfo` is designed for working with generic components.
+The legacy :ref:`Instrument` largely consists of ``Detectors`` and ``Components`` - all detectors are also components. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` are the respective replacements for these. :py:obj:`~mantid.geometry.ComponentInfo` introduces a **component index** for access, and :py:obj:`~mantid.geometry.DetectorInfo` introduces a **detector index**, these will be discussed further below. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` share in-memory data. The difference between the two is best thought about in terms of their interfaces. The interface for :py:obj:`~mantid.geometry.DetectorInfo` is designed for working with detectors, and the interface for :py:obj:`~mantid.geometry.ComponentInfo` is designed for working with generic components.
 
 In many cases direct access to legacy :ref:`Instrument` can be removed by using these layers. This will also help in moving to using indexes for enumeration, and only working with IDs for user-facing input.
 
@@ -82,6 +82,8 @@ The conversion is similar to that for ``DetectorInfo``, which is already largely
 * ``sourcePosition()``
 * ``samplePosition()``
 * ``l1()``
+
+Use of ``Instrument::getChildren()`` has been removed, and this method should not be used in any further.  Instead, use ``ComponentInfo::componentsInSubtree()`` to get the component indices for all components in a subtree, and then loop over these indices to perform the required operations.
 
 The following methods are useful helpers on ``ComponentInfo`` that allow the extraction of the **component index** for key components
 
@@ -185,11 +187,5 @@ ___________
 * ``ComponentInfo`` is widely forward declared. Ensure that you import - ``#include "MantidGeometry/Instrument/ComponentInfo.h"``
 * As explained above, a detector index is the same thing as a component index. No translation necessary. The fact that the first 0-n component indexes are for detectors is a feature that can be leveraged.
 * A bank always has a higher component index than any of its nested components. The root is the highest component index of all. This feature can be leveraged. Consider reverse iterating through component indexes when performing operations that involve higher-level components.
-
-Dealing with problems
----------------------
-
-Join #instrument-2_0 on Slack if you need help or have questions. Please also feel free to get in touch with Owen Arnold, Simon Heybrock or Lamar Moore directly for any questions about the ``ComponentInfo`` rollout.
-
 
 .. categories:: Concepts

--- a/tools/ArielToMantidXML/ArielToMantidXML/Component.cpp
+++ b/tools/ArielToMantidXML/ArielToMantidXML/Component.cpp
@@ -50,11 +50,6 @@ void Component::findChildren()
   }
 }
 
-std::vector<Component*> Component::getChildren() const
-{
-	return m_children;
-}
-
 void Component::setSpherical(const double &r, const double &theta, const double &phi)
 {
   m_r = r;

--- a/tools/ArielToMantidXML/ArielToMantidXML/Component.h
+++ b/tools/ArielToMantidXML/ArielToMantidXML/Component.h
@@ -35,13 +35,15 @@ public:
   const std::string printPos() const;
   // Returns the parent of this component
   const Component* const parent() const;
-  // Returns a vector of the children of this component
-  std::vector<Component*> getChildren() const;
   // Flag indicating whether this component has any children
   const bool hasChildren() const;
 
   // Static variable to count the total number of detectors found (just for checking)
   static int counter;
+
+protected:
+  // Returns a vector of the children of this component
+  std::vector<Component*> getChildren() const { return m_children; }
 
 private:
   Component(const Component&);


### PR DESCRIPTION
### Description of work

Megapixel instruments take up unmanageable amounts of memory in RAM.  Trying to reduce this requires limiting the instantiation of child pixels.  One step in that long process is to remove code that interacts with child elements, and have it go through the `ComponentInfo` layer instead.  This was supposed to be complete as part of [Instrument 2.0 rollout](https://docs.mantidproject.org/nightly/concepts/InstrumentAccessLayers.html), but some places were missed.

Takes over changes in PR #40871.  The bot was a good bot, and should get a treat.  The human (me) fixed a segfault, added a needed header, and used our `NoDeleting()` paradigm, which the bot wanted to implement with [`shared_from_this`](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this.html) (probably what we should be using instead, but may have not been standard in C++11).

I also cleaned up the remaining uses internal to Mantid::Geometry, which the bot was not able to touch.  Note that `Instrument` and `InstrumentVisitor` both need to be able to maintain the `getChildren()` method, as these are the parts that create the `ComponentInfo` layer.

This also makes a bunch of other cosmetic changes throughout DetectorGrid which I had lying around.  They should all seem pretty obvious.

Related to Issue #40839 
[EWM 15078](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15078)

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
