### PR TITLE
update PATH after inaugural pixi install

### DIFF
--- a/buildconfig/Jenkins/Conda/pixi-utils
+++ b/buildconfig/Jenkins/Conda/pixi-utils
@@ -3,8 +3,8 @@
 # Download and install pixi (if it isn't installed)
 install_pixi() {
   # configure the path to where pixi will end up
-  if [[ "$OSTYPE" != darwin* && -f ~/.bashrc ]]; then
-    . ~/.bashrc
+  if [[ "$OSTYPE" != darwin* && -f "$HOME/.bashrc" ]]; then
+    . "$HOME/.bashrc"
   else
     export PATH="$PATH:$HOME/.pixi/bin"
   fi
@@ -15,11 +15,11 @@ install_pixi() {
       pixi self-update --no-progress --quiet
   else
     echo "install pixi"
-    set +x # don't care about details of pixi install
+    set +x # disable xtrace - don't care about details of pixi install
     curl -fsSL https://pixi.sh/install.sh | sh
-    set -x # turn logging back on
+    set -x # turn logging back on (enable xtrace)
     # source bashrc for updated PATH
-    . ~/.bashrc
+    . "$HOME/.bashrc"
     # Verify pixi was installed successfully
     if [ ! -f "$HOME/.pixi/bin/pixi" ]; then
       echo "ERROR: pixi installation failed"

--- a/buildconfig/Jenkins/Conda/pixi-utils
+++ b/buildconfig/Jenkins/Conda/pixi-utils
@@ -4,7 +4,7 @@
 install_pixi() {
   # configure the path to where pixi will end up
   if [[ "$OSTYPE" != darwin* && -f ~/.bashrc ]]; then
-    source ~/.bashrc
+    . ~/.bashrc
   else
     export PATH="$PATH:$HOME/.pixi/bin"
   fi
@@ -18,11 +18,18 @@ install_pixi() {
     set +x # don't care about details of pixi install
     curl -fsSL https://pixi.sh/install.sh | sh
     set -x # turn logging back on
+    # source bashrc for updated PATH
+    . ~/.bashrc
     # Verify pixi was installed successfully
     if [ ! -f "$HOME/.pixi/bin/pixi" ]; then
       echo "ERROR: pixi installation failed"
       exit 1
     fi
   fi
-  echo "using $(pixi --version)"
+  if which pixi ; then
+    echo "using $(pixi --version)"
+  else
+    echo "ERROR: pixi command not found"
+    exit 1
+  fi
 }


### PR DESCRIPTION
### Description of work

Pixi is installed or verified at build time.  The installation script ([pixi-utils](https://github.com/mantidproject/mantid/blob/main/buildconfig/Jenkins/Conda/pixi-utils)) calls `curl -fsSL https://pixi.sh/install.sh | sh` which handles updating the user's bashrc.  When running a build in a new environment that doesn't already have pixi, it's necessary to source the user's bashrc so that the `~/.pixi/bin/pixi` binary is included in the PATH environment variable.

- 1st time test build with this change in a newly provisioned environment: https://github.com/idigs/mantid_github_actions_test/actions/runs/21997647335/job/63561755809
- 2nd time test build in existing environment w/ pixi: https://github.com/idigs/mantid_github_actions_test/actions/runs/21997550176/job/63561419923
______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
