### PR TITLE
Enable plotting of bayes output params

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -213,10 +213,13 @@ class BayesStretch(PythonAlgorithm):
         self._create_workspace(fname + "_Beta", [xBet, yBet, eBet], nsam, Qaxis)
 
         group = fname + "_Sigma," + fname + "_Beta"
-        fit_ws = fname + "_Fit"
-        s_api.GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self.getPropertyValue("OutputWorkspaceFit"))
-        contour_ws = fname + "_Contour"
-        s_api.GroupWorkspaces(InputWorkspaces=groupZ, OutputWorkspace=self.getPropertyValue("OutputWorkspaceContour"))
+        fit_ws = fname + "_Fit" if self.getProperty("OutputWorkspaceFit").isDefault else self.getPropertyValue("OutputWorkspaceFit")
+        contour_ws = (
+            fname + "_Contour" if self.getProperty("OutputWorkspaceContour").isDefault else self.getPropertyValue("OutputWorkspaceContour")
+        )
+
+        s_api.GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=fit_ws)
+        s_api.GroupWorkspaces(InputWorkspaces=groupZ, OutputWorkspace=contour_ws)
 
         # Add some sample logs to the output workspaces
         log_prog = Progress(self, start=0.8, end=1.0, nreports=6)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -208,14 +208,15 @@ class BayesStretch(PythonAlgorithm):
 
         # create workspaces for sigma and beta
         workflow_prog.report("Creating OutputWorkspace")
+
         self._create_workspace(fname + "_Sigma", [xSig, ySig, eSig], nsam, Qaxis)
         self._create_workspace(fname + "_Beta", [xBet, yBet, eBet], nsam, Qaxis)
 
         group = fname + "_Sigma," + fname + "_Beta"
         fit_ws = fname + "_Fit"
-        s_api.GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=fit_ws)
+        s_api.GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self.getPropertyValue("OutputWorkspaceFit"))
         contour_ws = fname + "_Contour"
-        s_api.GroupWorkspaces(InputWorkspaces=groupZ, OutputWorkspace=contour_ws)
+        s_api.GroupWorkspaces(InputWorkspaces=groupZ, OutputWorkspace=self.getPropertyValue("OutputWorkspaceContour"))
 
         # Add some sample logs to the output workspaces
         log_prog = Progress(self, start=0.8, end=1.0, nreports=6)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch2.py
@@ -49,7 +49,7 @@ class BayesStretch2(QuickBayesTemplate):
             name="StartFWHM", defaultValue=0.01, doc="Start of FWHM values", validator=FloatBoundedValidator(lower=0.0, upper=1.0)
         )
         self.declareProperty(
-            name="EndFWHM", defaultValue=0.1, doc="End of FWHM values", validator=FloatBoundedValidator(lower=0.0, upper=1.0)
+            name="EndFWHM", defaultValue=0.2, doc="End of FWHM values", validator=FloatBoundedValidator(lower=0.0, upper=1.0)
         )
 
         super().PyInit()

--- a/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
@@ -111,7 +111,7 @@ class QuestTest(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-1
         self.disableChecking.append("SpectraMap")
-        return "irs26176_graphite002_Stretch_Fit", "ISISIndirectBayes_QuestTest.nxs"
+        return "fit_group", "ISISIndirectBayes_QuestTest.nxs"
 
     def cleanup(self):
         filenames = ["irs26176_graphite002_Qst.lpt", "irs26176_graphite002_Qss.ql2", "irs26176_graphite002_Qsb.ql1"]

--- a/docs/source/release/v6.15.0/Inelastic/New_features/40897.rst
+++ b/docs/source/release/v6.15.0/Inelastic/New_features/40897.rst
@@ -1,0 +1,2 @@
+- The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` will now plot result workspaces as a contour plot if the workspaces contain multiple spectra.
+- The ``BayesStretch`` algorithm now outputs contour and fit workspace groups with the name provided in the ``OutputWorkspaceContour`` and ``OutputWorkspaceFit`` input properties.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
@@ -5,11 +5,17 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
+#include <QString>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
 enum class BayesBackendType { QUASI_ELASTIC_BAYES, QUICK_BAYES };
+
+std::unordered_map<BayesBackendType, QString> const backendToQStr{
+    {BayesBackendType::QUASI_ELASTIC_BAYES, QString("quasielasticbayes")},
+    {BayesBackendType::QUICK_BAYES, QString("quickbayes")},
+};
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesBackendType.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include <QString>
+#include <unordered_map>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -22,6 +22,7 @@ BayesFitting::BayesFitting(QWidget *parent)
       m_backend(BayesBackendType::QUASI_ELASTIC_BAYES) {
   m_uiForm.setupUi(this);
   m_uiForm.pbSettings->setIcon(Settings::icon());
+  setBackend(backendToQStr.at(m_backend));
 
   // Connect Poco Notification Observer
   Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
@@ -120,13 +121,17 @@ std::string BayesFitting::documentationPage() const { return "Inelastic Bayes Fi
 
 void BayesFitting::setBackend(const QString &text) {
   BayesBackendType newBackend = m_backend;
-  if (text == "quasielasticbayes") {
+  if (text == backendToQStr.at(BayesBackendType::QUASI_ELASTIC_BAYES)) {
     newBackend = BayesBackendType::QUASI_ELASTIC_BAYES;
-    m_uiForm.warningLabel->setHidden(false);
+    m_uiForm.warningLabel->setText(
+        "Warning: quasielasticbayes (old Fortran library) is deprecated. This library will be\n"
+        "removed once confidence in quickbayes (new Python library) has been established.");
     m_uiForm.backendChoice->setToolTip("Old Fortran library");
-  } else if (text == "quickbayes") {
+  } else if (text == backendToQStr.at(BayesBackendType::QUICK_BAYES)) {
     newBackend = BayesBackendType::QUICK_BAYES;
-    m_uiForm.warningLabel->setHidden(true);
+    m_uiForm.warningLabel->setText(
+        "Warning: the process to establish confidence in quickbayes (new Python library)\n"
+        "is ongoing. Please feedback any issues you encounter to the Mantid development team.");
     m_uiForm.backendChoice->setToolTip("New Python library");
   }
   if (newBackend != m_backend) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
@@ -90,8 +90,6 @@
          <string notr="true">QLabel { color : red; }</string>
         </property>
         <property name="text">
-         <string>Warning: quasielasticbayes (old Fortran library) is deprecated
-and will be removed in a future release</string>
         </property>
         <property name="textFormat">
          <enum>Qt::AutoText</enum>
@@ -101,7 +99,6 @@ and will be removed in a future release</string>
       <item>
        <widget class="QComboBox" name="backendChoice">
         <property name="toolTip">
-         <string>Old Fortran library</string>
         </property>
         <property name="currentIndex">
          <number>0</number>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchData.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchData.h
@@ -19,7 +19,7 @@ struct StretchRunData {
   double startBeta{0.5};
   double endBeta{1.0};
   double startFWHM{0.01};
-  double endFWHM{0.1};
+  double endFWHM{0.2};
   const int beta{3};
   const int sigma{3};
   int sampleBinning{1};

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -132,14 +132,9 @@ void StretchPresenter::notifyPlotClicked() {
   for (auto it = fitWorkspace->begin(); it < fitWorkspace->end(); ++it) {
     auto const name = (*it)->getName();
     auto const specNum = std::static_pointer_cast<Mantid::API::MatrixWorkspace>(*it)->getNumberHistograms();
-    if (plotSigma &&
-        (name.substr(name.length() - 5) == PlotType::SIGMA || name.substr(name.length() - 4) == PlotType::FWHM)) {
-      if (specNum > 1) {
-        m_plotter->plotContour(name);
-      } else {
-        m_plotter->plotSpectra(name, "0", plotErrors);
-      }
-    } else if (plotBeta && name.substr(name.length() - 4) == PlotType::BETA) {
+    if ((plotSigma &&
+         (name.substr(name.length() - 5) == PlotType::SIGMA || name.substr(name.length() - 4) == PlotType::FWHM)) ||
+        (plotBeta && name.substr(name.length() - 4) == PlotType::BETA)) {
       if (specNum > 1) {
         m_plotter->plotContour(name);
       } else {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -130,14 +130,22 @@ void StretchPresenter::notifyPlotClicked() {
   auto const fitWorkspace = getADSWorkspace<WorkspaceGroup>(m_fitWorkspaceName);
   for (auto it = fitWorkspace->begin(); it < fitWorkspace->end(); ++it) {
     auto const name = (*it)->getName();
+    auto const specNum = std::static_pointer_cast<Mantid::API::MatrixWorkspace>(*it)->getNumberHistograms();
     if (plotSigma &&
         (name.substr(name.length() - 5) == PlotType::SIGMA || name.substr(name.length() - 4) == PlotType::FWHM)) {
-      m_plotter->plotSpectra(name, "0", plotErrors);
+      if (specNum > 1) {
+        m_plotter->plotContour(name);
+      } else {
+        m_plotter->plotSpectra(name, "0", plotErrors);
+      }
     } else if (plotBeta && name.substr(name.length() - 4) == PlotType::BETA) {
-      m_plotter->plotSpectra(name, "0", plotErrors);
+      if (specNum > 1) {
+        m_plotter->plotContour(name);
+      } else {
+        m_plotter->plotSpectra(name, "0", plotErrors);
+      }
     }
   }
-
   setPlotResultIsPlotting(false);
 }
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -51,8 +51,9 @@ void StretchPresenter::handleRun() {
 
   auto const cutIndex = algParams.sampleName.find_last_of("_");
   auto const baseName = algParams.sampleName.substr(0, cutIndex);
-  m_fitWorkspaceName = baseName + "_Stretch_Fit";
-  m_contourWorkspaceName = baseName + "_Stretch_Contour";
+  auto const fitSuffix = m_useQuickBayes ? "_QuickBayes" : "_QuasiElasticBayes";
+  m_fitWorkspaceName = baseName + "_Stretch_Fit" + fitSuffix;
+  m_contourWorkspaceName = baseName + "_Stretch_Contour" + fitSuffix;
 
   auto stretch = m_model->stretchAlgorithm(algParams, m_fitWorkspaceName, m_contourWorkspaceName, m_useQuickBayes);
   m_algorithmRunner->execute(stretch);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchPresenter.cpp
@@ -20,6 +20,7 @@ struct PlotType {
   inline static const std::string ALL = "All";
   inline static const std::string SIGMA = "Sigma";
   inline static const std::string BETA = "Beta";
+  inline static const std::string FWHM = "FWHM";
 };
 } // namespace
 
@@ -123,13 +124,14 @@ void StretchPresenter::notifyPlotClicked() {
 
   std::string const plotType = m_view->getPlotType();
   auto const plotErrors = SettingsHelper::externalPlotErrorBars();
-  auto const plotSigma = (plotType == PlotType::ALL || plotType == PlotType::SIGMA);
+  auto const plotSigma = (plotType == PlotType::ALL || (plotType == PlotType::SIGMA || plotType == PlotType::FWHM));
   auto const plotBeta = (plotType == PlotType::ALL || plotType == PlotType::BETA);
 
   auto const fitWorkspace = getADSWorkspace<WorkspaceGroup>(m_fitWorkspaceName);
   for (auto it = fitWorkspace->begin(); it < fitWorkspace->end(); ++it) {
     auto const name = (*it)->getName();
-    if (plotSigma && name.substr(name.length() - 5) == PlotType::SIGMA) {
+    if (plotSigma &&
+        (name.substr(name.length() - 5) == PlotType::SIGMA || name.substr(name.length() - 4) == PlotType::FWHM)) {
       m_plotter->plotSpectra(name, "0", plotErrors);
     } else if (plotBeta && name.substr(name.length() - 4) == PlotType::BETA) {
       m_plotter->plotSpectra(name, "0", plotErrors);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
@@ -147,7 +147,7 @@ void StretchView::setupPropertyBrowser(bool useQuickBayes) {
     addPropToTree<double>("startBeta", 0.5, NUM_DECIMALS, 0.5, 1.0);
     addPropToTree<double>("endBeta", 1.0, NUM_DECIMALS, 0.5, 1.001);
     addPropToTree<double>("startSigma(FWHM)", 0.01, NUM_DECIMALS, 0.0, 1.0);
-    addPropToTree<double>("endSigma(FWHM)", 0.1, NUM_DECIMALS, 0.0, 1.0);
+    addPropToTree<double>("endSigma(FWHM)", 0.2, NUM_DECIMALS, 0.0, 1.0);
   } else {
     addPropToTree<int>("SampleBinning", 1, INT_DECIMALS, 1);
   }

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -118,8 +118,8 @@ public:
 
     auto const cutIndex = runData.sampleName.find_last_of("_");
     auto const baseName = runData.sampleName.substr(0, cutIndex);
-    auto fitWorkspaceName = baseName + "_Stretch_Fit";
-    auto contourWorkspaceName = baseName + "_Stretch_Contour";
+    auto fitWorkspaceName = baseName + "_Stretch_Fit_QuasiElasticBayes";
+    auto contourWorkspaceName = baseName + "_Stretch_Contour_QuasiElasticBayes";
 
     ads.addOrReplace(fitWorkspaceName, m_workspace);
     ads.addOrReplace(contourWorkspaceName, m_workspace);


### PR DESCRIPTION
### Description of work

This PR:
- Enables the plotting on `quickBayes` output parameters from the `Stretch` tab
- Changes the default value of `EndSigma(FWHM)` to 0.2 as requested.
- Appends the backend to the group workspace output on the stretch tab, to enable differentiation between the two.
- If more than one spectra is present in a results workspace, `plot` outputs a contour/colourfill

Closes #40843

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Follow stretch tab instructions : https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html
- Try with block `quickbayes` and `QuasiElasticBayes` backends 
- To speed things up I recommend extracting 10 or so spectra from `rs26176_graphite002_red` and setting `beta` to `3`, as `quickbayes` is ironically slow.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
