### PR TITLE
Fix Small Pole Figure Saving Bugs

### DIFF
--- a/scripts/Engineering/texture/polefigure/polefigure_model.py
+++ b/scripts/Engineering/texture/polefigure/polefigure_model.py
@@ -63,6 +63,7 @@ class TextureProjection:
         wss: Sequence[str], fit_params: Sequence[str], hkl: Optional[Sequence[int]], readout_column: str
     ) -> Tuple[str, str, str]:
         fws, lws = ADS.retrieve(wss[0]), ADS.retrieve(wss[-1])
+        readout_column = readout_column.replace("/", "_over_")
         try:
             run_range = f"{fws.getRun().getLogData('run_number').value}-{lws.getRun().getLogData('run_number').value}"
             instr = fws.getInstrument().getName()

--- a/scripts/Engineering/texture/polefigure/polefigure_model.py
+++ b/scripts/Engineering/texture/polefigure/polefigure_model.py
@@ -76,7 +76,11 @@ class TextureProjection:
             grouping = "GROUP"
         try:
             # try and get a peak reference either from hkl or from the X0 column of param
-            peak = "".join([str(ind) for ind in hkl]) if hkl else str(np.round(np.mean(ADS.retrieve(fit_params[0]).column("X0")), 2))
+            if hkl:
+                peak = "".join([str(ind) for ind in hkl])
+            else:
+                x0s = np.asarray(ADS.retrieve(fit_params[0]).column("X0"))
+                peak = str(np.round(np.mean(x0s[np.isfinite(x0s)]), 2))  # only use non nan x0s
             table_name = f"{peak}_{instr}_{run_range}_{grouping}_pf_table_{readout_column}"
             combined_wsname = f"{peak}_{instr}_{run_range}_{grouping}_spectra"
         except Exception:

--- a/scripts/Engineering/texture/polefigure/polefigure_model.py
+++ b/scripts/Engineering/texture/polefigure/polefigure_model.py
@@ -80,7 +80,7 @@ class TextureProjection:
                 peak = "".join([str(ind) for ind in hkl])
             else:
                 x0s = np.asarray(ADS.retrieve(fit_params[0]).column("X0"))
-                peak = str(np.round(np.mean(x0s[np.isfinite(x0s)]), 2))  # only use non nan x0s
+                peak = str(np.round(np.nanmean(x0s), 2))  # only use non nan x0s
             table_name = f"{peak}_{instr}_{run_range}_{grouping}_pf_table_{readout_column}"
             combined_wsname = f"{peak}_{instr}_{run_range}_{grouping}_spectra"
         except Exception:

--- a/scripts/Engineering/texture/polefigure/polefigure_model.py
+++ b/scripts/Engineering/texture/polefigure/polefigure_model.py
@@ -81,6 +81,7 @@ class TextureProjection:
             else:
                 x0s = np.asarray(ADS.retrieve(fit_params[0]).column("X0"))
                 peak = str(np.round(np.nanmean(x0s), 2))  # only use non nan x0s
+
             table_name = f"{peak}_{instr}_{run_range}_{grouping}_pf_table_{readout_column}"
             combined_wsname = f"{peak}_{instr}_{run_range}_{grouping}_spectra"
         except Exception:

--- a/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
+++ b/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
@@ -96,6 +96,21 @@ class TextureProjectionTest(unittest.TestCase):
         self.assertEqual("2.0_instrument_123456-123456_Texture20_pf_table_I", table_name)
         self.assertEqual("2.0_instrument_123456-123456_Texture20_spectra", spectra_ws)
 
+    @patch(correction_model_path + ".ADS")
+    def test_get_pf_table_name_with_no_hkl_and_params_all_x0_nan(self, mock_ads):
+        mock_param1, mock_param2 = MagicMock(), MagicMock()
+        mock_param1.column.return_value = np.array((np.nan, np.nan))  # nan should be ignored
+        mock_param2.column.return_value = np.array((np.nan, np.nan))
+        ads_wss = {"ws1": self.mock_ws, "ws2": self.mock_ws, "param_ws1": mock_param1, "param_ws2": mock_param2}
+
+        def get_ads_ws(key):
+            return ads_wss.get(key)
+
+        mock_ads.retrieve.side_effect = get_ads_ws
+        table_name, spectra_ws, grouping = self.model.get_pf_output_names(["ws1", "ws2"], ["param_ws1", "param_ws2"], None, "I")
+        self.assertEqual("nan_instrument_123456-123456_Texture20_pf_table_I", table_name)
+        self.assertEqual("nan_instrument_123456-123456_Texture20_spectra", spectra_ws)
+
     def test_parse_hkl_valid(self):
         hkl = self.model.parse_hkl("1", "2", "3")
         self.assertEqual(hkl, [1, 2, 3])

--- a/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
+++ b/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
@@ -84,8 +84,8 @@ class TextureProjectionTest(unittest.TestCase):
     @patch(correction_model_path + ".ADS")
     def test_get_pf_table_name_with_no_hkl_and_params(self, mock_ads):
         mock_param1, mock_param2 = MagicMock(), MagicMock()
-        mock_param1.column.return_value = np.array((1, 2, 3))
-        mock_param2.column.return_value = np.array((2, 2, 2))
+        mock_param1.column.return_value = np.array((1, 2, 3, np.nan))  # nan should be ignored
+        mock_param2.column.return_value = np.array((2, 2, 2, np.nan))
         ads_wss = {"ws1": self.mock_ws, "ws2": self.mock_ws, "param_ws1": mock_param1, "param_ws2": mock_param2}
 
         def get_ads_ws(key):


### PR DESCRIPTION
### Description of work
Two bugs I found pre-smoke-testing the texture analysis stuff for 6.15:

- The new column with eg. `I/I_err` doesn't save correctly as it makes the file path: `eg/path/Example_Workspace_Name_I/I_err.nxs` so saves `I_err.nxs` into a folder `Example_Workspace_Name_I` rather than `Example_Workspace_Name_I/I_err.nxs` into `path`
- Also when no crystal structure is provided the pf table name defaults to: `mean(X0)_etc_etc_pf_table` - this fails when some of the fits give `np.nan` for X0

### To test:
Run script and check that the output files appear in `root/TextureResults/GROUP/PoleFigureTables` and have sensible filenames
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from Engineering.texture.TextureUtils import (fit_all_peaks, 
                                                find_all_files, 
                                                mk, 
                                                _get_grouping_from_ws_log,
                                                create_pf_loop)
from mantid.simpleapi import AnalysisDataService as ADS

peaks = [1.16,1.22,1.43,2.03,2.34] # Al
i_over_sigma_thresh = 5.0
no_fit_value_dict = {"I": 0.0, "I_est": 0.0}
nan_replacement = None
readout_columns = ["I", "I/I_err"]
projection_method = "Azimuthal"
dir1 = np.array((1,0,0))
dir2 = np.array((0,0,1)) # projection axis
dir3 = np.array((0,1,0))
dir_names = ["RD", "ND", "TD"]
scatter = "both"
kernel = 6.0
include_scatt_power = False
chi2_thresh = 0.0   # max value of Chi^2 to be included as a point in the table
peak_thresh = 0.01   # max difference from either the HKL specified or the mean X0
scat_vol_pos = (0.0,0.0,0.0) # for now, can assume the gauge vol will be centred on origin

root = r"C:\Users\kcd17618\Documents\MantidScripts\add_i_over_sig"
focused_data_dir = os.path.join(root, "example_data")
fit_save_dir = os.path.join(root, "output")
focus_ws_paths = find_all_files(focused_data_dir)
focus_wss = [os.path.splitext(os.path.basename(fp))[0] for fp in focus_ws_paths]
for iws, ws in enumerate(focus_wss):
    Load(Filename = focus_ws_paths[iws], OutputWorkspace= ws)


fit_all_peaks(focus_wss, peaks, 0.05, fit_save_dir, i_over_sigma_thresh = i_over_sigma_thresh, nan_replacement = nan_replacement, no_fit_value_dict = no_fit_value_dict)  

eg_ws = ADS.retrieve(focus_wss[0])
group = _get_grouping_from_ws_log(eg_ws)

fit_load_dirs = [os.path.join(root, fit_save_dir, group, str(peak)) for peak in peaks]

fit_param_wss = []
for ifit, fit_dir in enumerate(fit_load_dirs):
    # get fit params
    fit_wss = find_all_files(fit_dir)
    param_wss = [os.path.splitext(os.path.basename(fp))[0] for fp in fit_wss]
    fit_param_wss.append(param_wss)
    for iparam, param in enumerate(param_wss):
        if not ADS.doesExist(param):
            Load(Filename=fit_wss[iparam], OutputWorkspace=param)
            
pf_root = os.path.join(root, "TextureResults")
pf_dir = os.path.join(pf_root, group)
mk(pf_root)
mk(pf_dir)

focus_wss = sorted(focus_wss, key = lambda x: int(x.split("_")[1]))
fit_param_wss = [sorted(param_wss, key = lambda x: int(x.split("_")[1])) for param_wss in fit_param_wss]

create_pf_loop(wss = focus_wss,
               param_wss = fit_param_wss,
               include_scatt_power = include_scatt_power, 
               xtal_input = None,
               xtal_args = None,
               readout_columns = readout_columns, 
               hkls = None,
               dir1 = dir1, 
               dir2 = dir2, 
               dir3 = dir3, 
               dir_names = dir_names, 
               scatter = scatter,
               kernel = kernel, 
               scat_vol_pos = scat_vol_pos,
               chi2_thresh = chi2_thresh, 
               peak_thresh = peak_thresh, 
               save_root = pf_dir, 
               exp_name = None, 
               projection_method = projection_method,
               create_combined_output = False,
               debug_info_level = 2,
               override_dir = True)   
```


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
