### PR TITLE
Allow run_exports to work with X.Y.ZrcN version number builds

### DIFF
--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -98,11 +98,7 @@ requirements:
       then:
         - jemalloc ${{ jemalloc }}
   run_exports:
-    - if: "'rc' in version"
-      then:
-        - ${{ pin_subpackage('mantid', exact=True) }}
-      else:
-        - ${{ pin_subpackage('mantid', upper_bound='x.x.x') }}
+    - ${{ pin_subpackage('mantid', exact=True) }}
   run_constraints:
     - matplotlib-base ${{ matplotlib }}
     - pillow ${{ pillow }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -98,7 +98,11 @@ requirements:
       then:
         - jemalloc ${{ jemalloc }}
   run_exports:
-    - ${{ pin_subpackage('mantid', upper_bound='x.x.x') }}
+    - if: "'rc' in version"
+      then:
+        - mantid ${{ version }}
+      else:
+        - ${{ pin_subpackage('mantid', upper_bound='x.x.x') }}
   run_constraints:
     - matplotlib-base ${{ matplotlib }}
     - pillow ${{ pillow }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -100,7 +100,7 @@ requirements:
   run_exports:
     - if: "'rc' in version"
       then:
-        - mantid ${{ version }}
+        - ${{ pin_subpackage('mantid', exact=True) }}
       else:
         - ${{ pin_subpackage('mantid', upper_bound='x.x.x') }}
   run_constraints:

--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -62,7 +62,7 @@ requirements:
   run_exports:
     - if: "'rc' in version"
       then:
-        - mantidqt ${{ version }}
+        - ${{ pin_subpackage('mantidqt', exact=True) }}
       else:
         - ${{ pin_subpackage('mantidqt', upper_bound='x.x.x') }}
 

--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -60,11 +60,7 @@ requirements:
       then:
         - qt-gtk-platformtheme
   run_exports:
-    - if: "'rc' in version"
-      then:
-        - ${{ pin_subpackage('mantidqt', exact=True) }}
-      else:
-        - ${{ pin_subpackage('mantidqt', upper_bound='x.x.x') }}
+    - ${{ pin_subpackage('mantidqt', exact=True) }}
 
 tests:
   - python:

--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -60,7 +60,11 @@ requirements:
       then:
         - qt-gtk-platformtheme
   run_exports:
-    - ${{ pin_subpackage('mantidqt', upper_bound='x.x.x') }}
+    - if: "'rc' in version"
+      then:
+        - mantidqt ${{ version }}
+      else:
+        - ${{ pin_subpackage('mantidqt', upper_bound='x.x.x') }}
 
 tests:
   - python:


### PR DESCRIPTION
### Description of work
A `run_export` was added to the mantid and mantidqt recipes as part of the migration to rattler-build. The purpose of `run_exports` are to ensure that if package `X` uses package `Y` in its build or host environment, then package `Y` is also included in the run environment when someone installs package `X`. This is sensible for mantid and mantidqt: if some package is built using mantid, then it probably needs mantid to run.

In its current form, the run_exports pin mantid/mantidqt at the major.minor.patch level, so e.g. if someone builds package `X` with mantid 6.14.0, and we release 6.14.0.1, then any future installs of `X` will come with mantid 6.14.0.1, and not 6.14.0. For a lot of packages this would be a sensible strategy.

However, there appears to be a bug in rattler-build, where it thinks that `v6.15.0rc1` increments to `v6.15.0a2`, and it creates this inequality:

`mantid >=6.15.0rc1,<6.15.0a2`.

Nothing can exist between these two versions since `rc` always comes after `a` (see [PEP440](https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering)). It is like saying  `1 > x >= 4`, or "x is greater than or equal to 4 and less than 1" (unsolvable). This causes release candidate builds to fail, e.g.:
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/283/execution/node/249/log/

I think it's safer to just say "if you build against mantid, then you must ship with that exact version of mantid. That is what has been done in this PR.


### To test:

- Testing the new recipe with a `v6.15.0rc1` version number: https://builds.mantidproject.org/job/build_branch/1485/
- Testing the new recipe with a `v6.15.0` version number https://builds.mantidproject.org/job/build_branch/1486/
- PR packaging check will test the new recipe with a nightly version number.
- Other PR checks can be ignored since they use pixi and not rattler-build.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
