### PR TITLE
Pin Poco v1.14 to avoid newer version

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -92,8 +92,10 @@ orsopy:
   - '==1.2.1'
 
 # An API change to HTTPSClientSession was introduced in 1.14.0
+# v1.15 was introduced while release candidates were being produced
+# moving the pin will happen during the mantid v6.16 dev cycle
 poco:
-  - '>=1.14'
+  - '>=1.14,<1.15'
 
 psutil:
   - '>=5.8.0'

--- a/pixi.toml
+++ b/pixi.toml
@@ -86,7 +86,7 @@ numpy = "2.1.*"
 occt = { version = "7.*", build = "novtk*" }
 pillow = "<12.0.0"
 pip = ">=21.0.1"
-poco = ">=1.14"
+poco = ">=1.14,<1.15"
 psutil = ">=5.8.0"
 pydantic = ">=2.11.4,<3"
 pyqt = ">=5.15,<6"


### PR DESCRIPTION
Poco v1.15 (published to anaconda.org on 2026-02-17) introduces `std::atomic` into `NObserver`, which secretly prevents copying of any class with an `NObserver` object in it. You can only find this out when you go to build on Windows with MSVC and learn it is trying to create a default copy constructor, leading to an error. The temporary fix is to pin Poco.

This was discovered while making release candidates for mantid v6.15. The pin will be updated during the v6.16 development cycle.

There is no associated issue

### To test:

Windows package build will highlight the issue. It was demonstrated as broken in [this build](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/release-next_nightly/285/pipeline-overview/?start-byte=54527&selected-node=219#log-219-1517). It is working in [this build from the branch](https://builds.mantidproject.org/job/build_branch/1487/console).

**Bonus item:** adding a max-pin to poco in `conda/recipes/conda_build_config.yaml` and `pixi.toml` broke the `pixi-dependency-updater` pre-commit hook because the `pixi.lock` file is unchanged.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
