### PR TITLE
Explicitly delete copy constructors for classes with `Poco::NObserver`

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmFactoryObserver.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactoryObserver.h
@@ -35,6 +35,10 @@ public:
   AlgorithmFactoryObserver();
   virtual ~AlgorithmFactoryObserver();
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  AlgorithmFactoryObserver(const AlgorithmFactoryObserver &) = delete;
+  AlgorithmFactoryObserver &operator=(const AlgorithmFactoryObserver &) = delete;
+
   void observeUpdate(bool turnOn = true);
 
   virtual void updateHandle();

--- a/Framework/API/inc/MantidAPI/AlgorithmObserver.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmObserver.h
@@ -26,6 +26,10 @@ public:
   AlgorithmObserver(const IAlgorithm_const_sptr &alg);
   virtual ~AlgorithmObserver();
 
+  // must delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  AlgorithmObserver(const AlgorithmObserver &) = delete;
+  AlgorithmObserver &operator=(const AlgorithmObserver &) = delete;
+
   void observeAll(const IAlgorithm_const_sptr &alg);
   void observeProgress(const IAlgorithm_const_sptr &alg);
   void observeStarting();

--- a/Framework/API/inc/MantidAPI/AnalysisDataServiceObserver.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataServiceObserver.h
@@ -40,6 +40,10 @@ public:
   AnalysisDataServiceObserver();
   virtual ~AnalysisDataServiceObserver();
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  AnalysisDataServiceObserver(const AnalysisDataServiceObserver &) = delete;
+  AnalysisDataServiceObserver &operator=(const AnalysisDataServiceObserver &) = delete;
+
   void observeAll(bool turnOn = true);
   void observeAdd(bool turnOn = true);
   void observeReplace(bool turnOn = true);

--- a/Framework/API/src/MDGeometry.cpp
+++ b/Framework/API/src/MDGeometry.cpp
@@ -38,6 +38,10 @@ public:
     }
   }
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  MDGeometryNotificationHelper(const MDGeometryNotificationHelper &) = delete;
+  MDGeometryNotificationHelper &operator=(const MDGeometryNotificationHelper &) = delete;
+
   void watchForWorkspaceDeletions() {
     if (!m_observingDelete) {
       API::AnalysisDataService::Instance().notificationCenter.addObserver(m_delete_observer);

--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -30,6 +30,10 @@ public:
   static AsynchronousTest *createSuite() { return new AsynchronousTest(); }
   static void destroySuite(AsynchronousTest *suite) { delete suite; }
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  AsynchronousTest(const AsynchronousTest &) = delete;
+  AsynchronousTest &operator=(const AsynchronousTest &) = delete;
+
   class AsyncAlgorithm : public Algorithm {
   public:
     AsyncAlgorithm() : Algorithm(), result(0), throw_exception(false) {}

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -29,6 +29,10 @@ class WorkspaceGroupTest_WorkspaceGroupObserver {
   Poco::NObserver<WorkspaceGroupTest_WorkspaceGroupObserver, Mantid::API::GroupUpdatedNotification>
       m_workspaceGroupUpdateObserver;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  WorkspaceGroupTest_WorkspaceGroupObserver(const WorkspaceGroupTest_WorkspaceGroupObserver &) = delete;
+  WorkspaceGroupTest_WorkspaceGroupObserver &operator=(const WorkspaceGroupTest_WorkspaceGroupObserver &) = delete;
+
 public:
   bool received;
   WorkspaceGroupTest_WorkspaceGroupObserver()

--- a/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing.h
@@ -12,7 +12,6 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
-#include <Poco/NObserver.h>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Kernel/test/DynamicFactoryTest.h
+++ b/Framework/Kernel/test/DynamicFactoryTest.h
@@ -40,6 +40,10 @@ public:
 
   ~DynamicFactoryTest() override { factory.notificationCenter.removeObserver(m_notificationObserver); }
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  DynamicFactoryTest(const DynamicFactoryTest &) = delete;
+  DynamicFactoryTest &operator=(const DynamicFactoryTest &) = delete;
+
   void testCreate() {
     TS_ASSERT_THROWS(factory.create("testEntry"), const std::runtime_error &)
     factory.subscribe<int>("testEntry");

--- a/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
+++ b/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
@@ -74,6 +74,9 @@ class ProgressWatcher {
 public:
   /// Constructor
   ProgressWatcher() : m_loadedCount(0), m_foundCount(0), m_observer(*this, &ProgressWatcher::handleProgress) {}
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  ProgressWatcher(const ProgressWatcher &) = delete;
+  ProgressWatcher &operator=(const ProgressWatcher &) = delete;
   /// Add a notification to the count
   void handleProgress(const Poco::AutoPtr<Mantid::API::Algorithm::ProgressNotification> &notification) {
     const auto &message = notification->message;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -288,7 +288,7 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowse
 constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:526
 constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:531
 constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:553
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspaceSelector.cpp:302
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspaceSelector.cpp:301
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -90,11 +90,8 @@ occt:
 orsopy:
   - '==1.2.1'
 
-# An API change to HTTPSClientSession was introduced in 1.14.0
-# v1.15 was introduced while release candidates were being produced
-# moving the pin will happen during the mantid v6.16 dev cycle
 poco:
-  - '>=1.14,<1.15'
+  - '>=1.14'
 
 psutil:
   - '>=5.8.0'

--- a/pixi.toml
+++ b/pixi.toml
@@ -98,7 +98,7 @@ numpy = "2.1.*"
 occt = { version = "7.*", build = "novtk*" }
 pillow = "<12.0.0"
 pip = ">=21.0.1"
-poco = ">=1.14,<1.15"
+poco = ">=1.14"
 psutil = ">=5.8.0"
 pydantic = ">=2.11.4,<3"
 pyqt = ">=5.15,<6"

--- a/qt/scientific_interfaces/General/StepScan.h
+++ b/qt/scientific_interfaces/General/StepScan.h
@@ -30,6 +30,10 @@ public:
   explicit StepScan(QWidget *parent = nullptr);
   ~StepScan() override;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  StepScan(const StepScan &) = delete;
+  StepScan &operator=(const StepScan &) = delete;
+
 signals:
   void logsAvailable(const Mantid::API::MatrixWorkspace_const_sptr & /*_t1*/);
   void logsUpdated(const Mantid::API::MatrixWorkspace_const_sptr & /*_t1*/);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -62,9 +62,6 @@ public:
   ~RunsPresenter() override;
   RunsPresenter const &operator=(RunsPresenter const &) = delete;
 
-  RunsPresenter(RunsPresenter &&) = default;
-  RunsPresenter &operator=(RunsPresenter &&) = default;
-
   // IRunsPresenter overrides
   void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
   std::string initInstrumentList(const std::string &selectedInstrument = "") override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -85,14 +85,14 @@ public:
   void testInitInstrumentListUpdatesView() {
     auto presenter = makePresenter();
     expectInstrumentListUpdated();
-    presenter.initInstrumentList();
+    presenter->initInstrumentList();
   }
 
   void testInitInstrumentListUpdatesViewWithSelectedValue() {
     auto presenter = makePresenter();
     std::string const &selectedInstrument = m_instruments[2];
     expectInstrumentListUpdated(selectedInstrument);
-    TS_ASSERT_EQUALS(presenter.initInstrumentList(selectedInstrument), selectedInstrument);
+    TS_ASSERT_EQUALS(presenter->initInstrumentList(selectedInstrument), selectedInstrument);
   }
 
   void testCreatePresenterUpdatesView() {
@@ -103,13 +103,13 @@ public:
   void testSettingsChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, settingsChanged()).Times(1);
-    presenter.settingsChanged();
+    presenter->settingsChanged();
   }
 
   void testStartingSearchDoesNotClearPreviousResults() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_searcher, reset()).Times(0);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testStartingSearchClearsPreviousResultsIfSettingsChanged() {
@@ -117,7 +117,7 @@ public:
     expectSearchString(m_searchString);
     expectSearchSettingsChanged();
     EXPECT_CALL(*m_searcher, reset()).Times(AtLeast(1));
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testStartingSearchDoesNotClearPreviousResultsIfOverwritePrevented() {
@@ -126,7 +126,7 @@ public:
     expectSearchSettingsChanged();
     expectOverwriteSearchResultsPrevented();
     EXPECT_CALL(*m_searcher, reset()).Times(0);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testStartingSearchDisablesSearchInputs() {
@@ -136,7 +136,7 @@ public:
     EXPECT_CALL(m_view, setSearchButtonEnabled(false)).Times(1);
     EXPECT_CALL(m_view, setSearchResultsEnabled(false)).Times(1);
     EXPECT_CALL(m_view, setAutoreduceButtonEnabled(false)).Times(1);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testNotifySearchResultsEnablesSearchInputs() {
@@ -146,7 +146,7 @@ public:
     EXPECT_CALL(m_view, setSearchButtonEnabled(true)).Times(1);
     EXPECT_CALL(m_view, setSearchResultsEnabled(true)).Times(1);
     EXPECT_CALL(m_view, setAutoreduceButtonEnabled(true)).Times(1);
-    presenter.notifySearchComplete();
+    presenter->notifySearchComplete();
   }
 
   void testSearchUsesCorrectSearchProperties() {
@@ -158,7 +158,7 @@ public:
     expectSearchInstrument(instrument);
     expectSearchCycle(cycle);
     EXPECT_CALL(*m_searcher, startSearchAsync(SearchCriteria{instrument, cycle, searchString})).Times(1);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testSearchWithEmptyStringDoesNotStartSearch() {
@@ -166,7 +166,7 @@ public:
     auto searchString = std::string("");
     expectSearchString(searchString);
     EXPECT_CALL(*m_searcher, startSearchAsync(_)).Times(0);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testStartingSearchFails() {
@@ -176,7 +176,7 @@ public:
         .Times(1)
         .WillOnce(Return(false));
     EXPECT_CALL(m_messageHandler, giveUserCritical("Error starting search", "Error")).Times(1);
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testStartingSearchSucceeds() {
@@ -187,45 +187,45 @@ public:
         .WillOnce(Return(true));
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(0);
 
-    presenter.notifySearch();
+    presenter->notifySearch();
   }
 
   void testNotifyReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyResumeReductionRequested()).Times(AtLeast(1));
-    presenter.notifyResumeReductionRequested();
+    presenter->notifyResumeReductionRequested();
   }
 
   void testNotifyReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyPauseReductionRequested());
-    presenter.notifyPauseReductionRequested();
+    presenter->notifyPauseReductionRequested();
   }
 
   void testNotifyAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyResumeAutoreductionRequested());
-    presenter.notifyResumeAutoreductionRequested();
+    presenter->notifyResumeAutoreductionRequested();
   }
 
   void testNotifyAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyPauseAutoreductionRequested());
-    presenter.notifyPauseAutoreductionRequested();
+    presenter->notifyPauseAutoreductionRequested();
   }
 
   void testNoCheckOnOverwritingBatchOnAutoreductionResumed() {
     auto presenter = makePresenter();
     expectSearchString(m_searchString);
     EXPECT_CALL(m_mainPresenter, isOverwriteBatchPrevented()).Times(0);
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testNoCheckOnDiscardChangesOnAutoreductionResumed() {
     auto presenter = makePresenter();
     expectSearchString(m_searchString);
     EXPECT_CALL(m_mainPresenter, discardChanges(_)).Times(0);
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedSearchResults() {
@@ -236,30 +236,30 @@ public:
     EXPECT_CALL(m_mainPresenter, discardChanges("This will cause unsaved changes in the search results "
                                                 "to be lost. Continue?"))
         .Times(AtLeast(1));
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedTable() {
     auto presenter = makePresenter();
-    presenter.notifyTableChanged();
+    presenter->notifyTableChanged();
     expectSearchString(m_searchString);
     expectSearchSettingsChanged();
     EXPECT_CALL(m_mainPresenter, discardChanges("This will cause unsaved changes in the table "
                                                 "to be lost. Continue?"))
         .Times(AtLeast(1));
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedTableAndSearchResults() {
     auto presenter = makePresenter();
-    presenter.notifyTableChanged();
+    presenter->notifyTableChanged();
     expectSearchString(m_searchString);
     expectSearchSettingsChanged();
     expectUnsavedSearchResults();
     EXPECT_CALL(m_mainPresenter, discardChanges("This will cause unsaved changes in the search results "
                                                 "and main table to be lost. Continue?"))
         .Times(AtLeast(1));
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testDoNotStartAutoreductionWhenOverwritePreventedOnResumeAutoreductionWithNewSettings() {
@@ -268,27 +268,27 @@ public:
     expectSearchSettingsChanged();
     expectOverwriteSearchResultsPrevented();
     expectDoNotStartAutoreduction();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testTableClearedWhenStartAutoreductionForFirstTime() {
     auto presenter = makePresenter();
     expectSearchString(m_searchString);
     expectClearExistingTable();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testTableNotClearedWhenRestartAutoreduction() {
     auto presenter = makePresenter();
     // Set up first search and run autoreduction
     expectSearchString(m_searchString);
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
     verifyAndClear();
     // Resume autoreduction with same settings
     expectSearchString(m_searchString);
     expectSearchSettingsDefault();
     expectDoNotClearExistingTable();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testTableClearedWhenResumeAutoreductionWithNewSettings() {
@@ -296,7 +296,7 @@ public:
     expectSearchString(m_searchString);
     expectSearchSettingsChanged();
     expectClearExistingTable();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testTableNotClearedWhenOverwritePreventedOnResumeAutoreduction() {
@@ -305,21 +305,21 @@ public:
     expectSearchSettingsChanged();
     expectOverwriteSearchResultsPrevented();
     expectDoNotClearExistingTable();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testResumeAutoreductionCancelledIfSearchStringIsEmpty() {
     auto presenter = makePresenter();
     expectSearchString("");
     expectDoNotStartAutoreduction();
-    presenter.resumeAutoreduction();
+    presenter->resumeAutoreduction();
   }
 
   void testAutoreductionResumed() {
     auto presenter = makePresenter();
     expectWidgetsEnabledForAutoreducing();
     EXPECT_CALL(*m_runsTablePresenter, notifyAutoreductionResumed()).Times(1);
-    presenter.notifyAutoreductionResumed();
+    presenter->notifyAutoreductionResumed();
   }
 
   void testAutoreductionPaused() {
@@ -327,101 +327,101 @@ public:
     EXPECT_CALL(*m_runNotifier, stopPolling()).Times(1);
     EXPECT_CALL(*m_runsTablePresenter, notifyAutoreductionPaused()).Times(1);
     expectWidgetsEnabledForPaused();
-    presenter.notifyAutoreductionPaused();
+    presenter->notifyAutoreductionPaused();
   }
 
   void testAutoreductionCompleted() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runNotifier, startPolling()).Times(1);
     expectWidgetsEnabledForAutoreducing();
-    presenter.autoreductionCompleted();
+    presenter->autoreductionCompleted();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchReductionResumed()).Times(1);
-    presenter.notifyAnyBatchReductionResumed();
+    presenter->notifyAnyBatchReductionResumed();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchReductionPaused()).Times(1);
-    presenter.notifyAnyBatchReductionPaused();
+    presenter->notifyAnyBatchReductionPaused();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchAutoreductionResumed()).Times(1);
-    presenter.notifyAnyBatchAutoreductionResumed();
+    presenter->notifyAnyBatchAutoreductionResumed();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchAutoreductionPaused()).Times(1);
-    presenter.notifyAnyBatchAutoreductionPaused();
+    presenter->notifyAnyBatchAutoreductionPaused();
   }
 
   void testChangingInstrumentIsDisabledWhenAnotherBatchReducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsDisabledWhenAnotherBatchReducing();
-    presenter.notifyAnyBatchReductionResumed();
+    presenter->notifyAnyBatchReductionResumed();
   }
 
   void testChangingInstrumentIsEnabledWhenNoBatchesAreReducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsEnabledWhenNoBatchesAreReducing();
-    presenter.notifyAnyBatchReductionPaused();
+    presenter->notifyAnyBatchReductionPaused();
   }
 
   void testChangingInstrumentIsDisabledWhenAnotherBatchAutoreducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsDisabledWhenAnotherBatchAutoreducing();
-    presenter.notifyAnyBatchAutoreductionResumed();
+    presenter->notifyAnyBatchAutoreductionResumed();
   }
 
   void testChangingInstrumentIsEnabledWhenNoBatchesAreAutoreducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsEnabledWhenNoBatchesAreAutoreducing();
-    presenter.notifyAnyBatchAutoreductionPaused();
+    presenter->notifyAnyBatchAutoreductionPaused();
   }
 
   void testAutoreductionDisabledWhenAnotherBatchAutoreducing() {
     auto presenter = makePresenter();
     expectAutoreduceButtonDisabledWhenAnotherBatchAutoreducing();
-    presenter.notifyAnyBatchAutoreductionResumed();
+    presenter->notifyAnyBatchAutoreductionResumed();
   }
 
   void testAutoreductionEnabledWhenAnotherBatchNotAutoreducing() {
     auto presenter = makePresenter();
     expectAutoreduceButtonEnabledWhenNoBatchesAreAutoreducing();
-    presenter.notifyAnyBatchAutoreductionPaused();
+    presenter->notifyAnyBatchAutoreductionPaused();
   }
 
   void testNotifyCheckForNewRuns() {
     auto presenter = makePresenter();
     expectCheckForNewRuns();
-    presenter.notifyCheckForNewRuns();
+    presenter->notifyCheckForNewRuns();
   }
 
   void testNotifySearchResultsResizesColumnsWhenNotAutoreducing() {
     auto presenter = makePresenter();
     expectIsNotAutoreducing();
     EXPECT_CALL(m_view, resizeSearchResultsColumnsToContents()).Times(1);
-    presenter.notifySearchComplete();
+    presenter->notifySearchComplete();
   }
 
   void testNotifySearchResultsDoesNotResizeColumnsWhenAutoreducing() {
     auto presenter = makePresenter();
     expectIsAutoreducing();
     EXPECT_CALL(m_view, resizeSearchResultsColumnsToContents()).Times(0);
-    presenter.notifySearchComplete();
+    presenter->notifySearchComplete();
   }
 
   void testNotifySearchResultsResumesReductionWhenAutoreducing() {
     auto presenter = makePresenter();
     expectIsAutoreducing();
     EXPECT_CALL(m_mainPresenter, notifyResumeReductionRequested()).Times(AtLeast(1));
-    presenter.notifySearchComplete();
+    presenter->notifySearchComplete();
   }
 
   void testNotifySearchResultsTransfersRowsWhenAutoreducing() {
@@ -434,7 +434,7 @@ public:
     for (auto rowIndex : rowsToTransfer)
       EXPECT_CALL(*m_searcher, getSearchResult(rowIndex)).Times(1).WillOnce(ReturnRef(searchResult));
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(0);
-    presenter.notifySearchComplete();
+    presenter->notifySearchComplete();
   }
 
   void testTransferWithNoRowsSelected() {
@@ -443,7 +443,7 @@ public:
     EXPECT_CALL(m_view, getSelectedSearchRows()).Times(1).WillOnce(Return(selectedRows));
     EXPECT_CALL(m_messageHandler, giveUserCritical("Please select at least one run to transfer.", "No runs selected"))
         .Times(1);
-    presenter.notifyTransfer();
+    presenter->notifyTransfer();
   }
 
   void testTransferWithAutoreductionRunning() {
@@ -451,7 +451,7 @@ public:
     expectGetValidSearchRowSelection();
     expectIsAutoreducing();
     expectCreateEndlessProgressIndicator();
-    presenter.notifyTransfer();
+    presenter->notifyTransfer();
   }
 
   void testTransferWithAutoreductionStopped() {
@@ -459,21 +459,21 @@ public:
     expectGetValidSearchRowSelection();
     expectIsNotAutoreducing();
     expectCreatePercentageProgressIndicator();
-    presenter.notifyTransfer();
+    presenter->notifyTransfer();
   }
 
   void testTransferUpdatesTablePresenter() {
     auto presenter = makePresenter();
     auto expectedJobs = expectGetValidSearchResult();
     EXPECT_CALL(*m_runsTablePresenter, mergeAdditionalJobs(expectedJobs)).Times(1);
-    presenter.notifyTransfer();
+    presenter->notifyTransfer();
   }
 
   void testTransferUpdatesLookupIndexes() {
     auto presenter = makePresenter();
     auto expectedJobs = expectGetValidSearchResult();
     EXPECT_CALL(m_mainPresenter, notifyRunsTransferred()).Times(1);
-    presenter.notifyTransfer();
+    presenter->notifyTransfer();
   }
 
   void testChangeInstrumentOnViewNotifiesMainPresenter() {
@@ -482,7 +482,7 @@ public:
     expectPreviousInstrument("INTER");
     expectSearchInstrument(instrument);
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(AtLeast(1));
-    presenter.notifyChangeInstrumentRequested();
+    presenter->notifyChangeInstrumentRequested();
   }
 
   void testChangeInstrumentOnViewPromptsToDiscardChangesIfUnsaved() {
@@ -494,7 +494,7 @@ public:
     EXPECT_CALL(m_mainPresenter, discardChanges("This will cause unsaved changes in the search results to be "
                                                 "lost. Continue?"))
         .Times(1);
-    presenter.notifyChangeInstrumentRequested();
+    presenter->notifyChangeInstrumentRequested();
   }
 
   void testChangeInstrumentOnViewDoesNotPromptToDiscardChangesIfSaved() {
@@ -504,7 +504,7 @@ public:
     expectSearchInstrument(instrument);
     expectNoUnsavedSearchResults();
     EXPECT_CALL(m_mainPresenter, discardChanges(_)).Times(0);
-    presenter.notifyChangeInstrumentRequested();
+    presenter->notifyChangeInstrumentRequested();
   }
 
   void testChangeInstrumentOnViewDoesNotNotifyMainPresenterIfPrevented() {
@@ -514,7 +514,7 @@ public:
     expectSearchInstrument(instrument);
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(_)).Times(0);
-    presenter.notifyChangeInstrumentRequested();
+    presenter->notifyChangeInstrumentRequested();
   }
 
   void testChangeInstrumentOnViewRevertsChangeIfPrevented() {
@@ -524,7 +524,7 @@ public:
     expectSearchInstrument(instrument);
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_view, setSearchInstrument("INTER")).Times(1);
-    presenter.notifyChangeInstrumentRequested();
+    presenter->notifyChangeInstrumentRequested();
   }
 
   void testChangeInstrumentOnChildNotifiesMainPresenter() {
@@ -532,7 +532,7 @@ public:
     auto const instrument = std::string("TEST-instrumnet");
     expectPreviousInstrument("INTER");
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(AtLeast(1));
-    presenter.notifyChangeInstrumentRequested(instrument);
+    presenter->notifyChangeInstrumentRequested(instrument);
   }
 
   void testChangeInstrumentOnChildDoesNotNotifyMainPresenterIfPrevented() {
@@ -541,14 +541,14 @@ public:
     expectPreviousInstrument("INTER");
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(_)).Times(0);
-    presenter.notifyChangeInstrumentRequested(instrument);
+    presenter->notifyChangeInstrumentRequested(instrument);
   }
 
   void testChangeInstrumentOnChildReturnsTrueIfSuccess() {
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");
     expectPreviousInstrument("INTER");
-    auto success = presenter.notifyChangeInstrumentRequested(instrument);
+    auto success = presenter->notifyChangeInstrumentRequested(instrument);
     TS_ASSERT_EQUALS(success, true);
   }
 
@@ -557,7 +557,7 @@ public:
     auto const instrument = std::string("TEST-instrumnet");
     expectPreviousInstrument("INTER");
     expectChangeInstrumentPrevented();
-    auto success = presenter.notifyChangeInstrumentRequested(instrument);
+    auto success = presenter->notifyChangeInstrumentRequested(instrument);
     TS_ASSERT_EQUALS(success, false);
   }
 
@@ -565,78 +565,78 @@ public:
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(m_view, setSearchInstrument(instrument)).Times(1);
-    presenter.notifyInstrumentChanged(instrument);
+    presenter->notifyInstrumentChanged(instrument);
   }
 
   void testInstrumentChangedUpdatesChildPresenter() {
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(*m_runsTablePresenter, notifyInstrumentChanged(instrument)).Times(1);
-    presenter.notifyInstrumentChanged(instrument);
+    presenter->notifyInstrumentChanged(instrument);
   }
 
   void testInstrumentChangedClearsPreviousSearchResultsModel() {
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(*m_searcher, reset()).Times(1);
-    presenter.notifyInstrumentChanged(instrument);
+    presenter->notifyInstrumentChanged(instrument);
   }
 
   void testNotifyRowStateChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
-    presenter.notifyRowStateChanged();
+    presenter->notifyRowStateChanged();
   }
 
   void testNotifyRowStateChangedItem() {
     auto presenter = makePresenter();
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged(_)).Times(1);
-    presenter.notifyRowStateChanged(row);
+    presenter->notifyRowStateChanged(row);
   }
 
   void testRowStateChangedOnReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
-    presenter.notifyReductionResumed();
+    presenter->notifyReductionResumed();
   }
 
   void testRowStateChangedOnReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
-    presenter.notifyReductionPaused();
+    presenter->notifyReductionPaused();
   }
 
   void testRowStateChangedOnAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
-    presenter.notifyAutoreductionResumed();
+    presenter->notifyAutoreductionResumed();
   }
 
   void testRowStateChangedOnAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
-    presenter.notifyAutoreductionPaused();
+    presenter->notifyAutoreductionPaused();
   }
 
   void testNotifyRowModelChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged()).Times(1);
-    presenter.notifyRowModelChanged();
+    presenter->notifyRowModelChanged();
   }
 
   void testNotifyRowModelChangedItem() {
     auto presenter = makePresenter();
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged(_)).Times(1);
-    presenter.notifyRowModelChanged(row);
+    presenter->notifyRowModelChanged(row);
   }
 
   void testPercentCompleteIsRequestedFromMainPresenter() {
     auto presenter = makePresenter();
     auto progress = 33;
     EXPECT_CALL(m_mainPresenter, percentComplete()).Times(1).WillOnce(Return(progress));
-    TS_ASSERT_EQUALS(presenter.percentComplete(), progress);
+    TS_ASSERT_EQUALS(presenter->percentComplete(), progress);
   }
 
   void testStartMonitorStartsAlgorithmRunner() {
@@ -644,14 +644,14 @@ public:
     expectStartingLiveDataSucceeds();
     auto algRunner = expectGetAlgorithmRunner();
     EXPECT_CALL(*algRunner, startAlgorithmImpl(_)).Times(1);
-    presenter.notifyStartMonitor();
+    presenter->notifyStartMonitor();
   }
 
   void testStartMonitorUpdatesView() {
     auto presenter = makePresenter();
     expectStartingLiveDataSucceeds();
     expectUpdateViewWhenMonitorStarting();
-    presenter.notifyStartMonitor();
+    presenter->notifyStartMonitor();
   }
 
   void testStartMonitorSetsAlgorithmProperties() {
@@ -660,7 +660,7 @@ public:
     auto updateInterval = 20;
     expectGetLiveDataOptions(instrument, updateInterval);
     auto algRunner = expectGetAlgorithmRunner();
-    presenter.notifyStartMonitor();
+    presenter->notifyStartMonitor();
     auto expected = defaultLiveMonitorAlgorithmOptions(instrument, updateInterval);
     assertAlgorithmPropertiesContainOptions(*expected, algRunner);
   }
@@ -669,7 +669,7 @@ public:
     auto presenter = makePresenter();
     expectGetLiveDataOptions(defaultLiveMonitorReductionOptions());
     auto algRunner = expectGetAlgorithmRunner();
-    presenter.notifyStartMonitor();
+    presenter->notifyStartMonitor();
     auto expected = defaultLiveMonitorReductionOptions();
     assertPostProcessingPropertiesContainOptions(*expected, algRunner);
   }
@@ -682,16 +682,16 @@ public:
     expectGetLiveDataOptions(std::make_unique<Mantid::API::AlgorithmRuntimeProps>(
         dynamic_cast<const Mantid::API::AlgorithmRuntimeProps &>(*options)));
     auto algRunner = expectGetAlgorithmRunner();
-    presenter.notifyStartMonitor();
+    presenter->notifyStartMonitor();
     assertPostProcessingPropertiesContainOptions(*options, algRunner);
   }
 
   void testStopMonitorUpdatesView() {
     auto presenter = makePresenter();
-    presenter.m_monitorAlg = AlgorithmManager::Instance().createUnmanaged("MonitorLiveData");
+    presenter->m_monitorAlg = AlgorithmManager::Instance().createUnmanaged("MonitorLiveData");
     expectUpdateViewWhenMonitorStopped();
-    presenter.notifyStopMonitor();
-    TS_ASSERT_EQUALS(presenter.m_monitorAlg, nullptr);
+    presenter->notifyStopMonitor();
+    TS_ASSERT_EQUALS(presenter->m_monitorAlg, nullptr);
   }
 
   void testMonitorNotRunningAfterStartMonitorFails() {
@@ -704,46 +704,46 @@ public:
     startMonitorAlg->initialize();
     EXPECT_CALL(*algRunner, getAlgorithm()).Times(1).WillOnce(Return(startMonitorAlg));
     expectUpdateViewWhenMonitorStopped();
-    presenter.notifyStartMonitorComplete();
+    presenter->notifyStartMonitorComplete();
   }
 
   void testNotifyTableChangedSetsUnsavedFlag() {
     auto presenter = makePresenter();
-    presenter.notifyTableChanged();
-    TS_ASSERT_EQUALS(presenter.hasUnsavedChanges(), true);
+    presenter->notifyTableChanged();
+    TS_ASSERT_EQUALS(presenter->hasUnsavedChanges(), true);
   }
 
   void testNotifyChangsSavedClearsUnsavedFlag() {
     auto presenter = makePresenter();
-    presenter.notifyTableChanged();
-    presenter.notifyChangesSaved();
-    TS_ASSERT_EQUALS(presenter.hasUnsavedChanges(), false);
+    presenter->notifyTableChanged();
+    presenter->notifyChangesSaved();
+    TS_ASSERT_EQUALS(presenter->hasUnsavedChanges(), false);
   }
 
   void testNotifyChangsSavedUpdatesSearcher() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_searcher, setSaved()).Times(1);
-    presenter.notifyChangesSaved();
+    presenter->notifyChangesSaved();
   }
 
   void testNotifyBatchLoaded() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyBatchLoaded()).Times(1);
-    presenter.notifyBatchLoaded();
+    presenter->notifyBatchLoaded();
   }
 
   void testNotifyRowContentChanged() {
     auto presenter = makePresenter();
     auto row = makeRow(0.5);
     EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(row));
-    presenter.notifyRowContentChanged(row);
+    presenter->notifyRowContentChanged(row);
   }
 
   void testNotifyGroupNameChanged() {
     auto presenter = makePresenter();
     auto group = makeGroupWithOneRow();
     EXPECT_CALL(m_mainPresenter, notifyGroupNameChanged(group));
-    presenter.notifyGroupNameChanged(group);
+    presenter->notifyGroupNameChanged(group);
   }
 
   void testNotifyExportSearchResultsWhenNoResults() {
@@ -756,7 +756,7 @@ public:
                          "Error"))
         .Times(1);
 
-    presenter.notifyExportSearchResults();
+    presenter->notifyExportSearchResults();
   }
 
   void testNotifyExportSearchResultsWithResultsAndCSVFileExtension() {
@@ -770,7 +770,7 @@ public:
     EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)")).Times(1).WillOnce(Return(filename));
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(1);
 
-    presenter.notifyExportSearchResults();
+    presenter->notifyExportSearchResults();
   }
 
   void testNotifyExportSearchResultsWithResultsAndNoCSVFileExtension() {
@@ -787,7 +787,7 @@ public:
         .WillOnce(Return(filename_before_asking));
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename_after_asking, csv)).Times(1);
 
-    presenter.notifyExportSearchResults();
+    presenter->notifyExportSearchResults();
   }
 
   void testNotifyExportSearchResultsWhenSavingFails() {
@@ -803,7 +803,7 @@ public:
 
     EXPECT_CALL(m_messageHandler, giveUserCritical("Could not open file at: test.csv", "Error")).Times(1);
 
-    presenter.notifyExportSearchResults();
+    presenter->notifyExportSearchResults();
   }
 
   void testNotifyExportSearchResultsDoesNotSaveWhenFileCancelled() {
@@ -817,7 +817,7 @@ public:
     EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)")).Times(1).WillOnce(Return(filename));
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(0);
 
-    presenter.notifyExportSearchResults();
+    presenter->notifyExportSearchResults();
   }
 
 private:
@@ -833,20 +833,21 @@ private:
                         fileHandler) {}
   };
 
-  RunsPresenterFriend makePresenter() {
+  std::shared_ptr<RunsPresenterFriend> makePresenter() {
     Plotter plotter;
 
     auto makeRunsTablePresenter = RunsTablePresenterFactory(m_instruments, m_thetaTolerance, std::move(plotter));
-    auto presenter = RunsPresenterFriend(&m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
-                                         m_instruments, &m_messageHandler, &m_fileHandler);
+    auto presenter =
+        std::make_shared<RunsPresenterFriend>(&m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
+                                              m_instruments, &m_messageHandler, &m_fileHandler);
 
-    presenter.acceptMainPresenter(&m_mainPresenter);
-    presenter.m_tablePresenter.reset(new NiceMock<MockRunsTablePresenter>());
-    m_runsTablePresenter = dynamic_cast<NiceMock<MockRunsTablePresenter> *>(presenter.m_tablePresenter.get());
-    presenter.m_runNotifier.reset(new NiceMock<MockRunNotifier>());
-    m_runNotifier = dynamic_cast<NiceMock<MockRunNotifier> *>(presenter.m_runNotifier.get());
-    presenter.m_searcher.reset(new NiceMock<MockSearcher>());
-    m_searcher = dynamic_cast<NiceMock<MockSearcher> *>(presenter.m_searcher.get());
+    presenter->acceptMainPresenter(&m_mainPresenter);
+    presenter->m_tablePresenter.reset(new NiceMock<MockRunsTablePresenter>());
+    m_runsTablePresenter = dynamic_cast<NiceMock<MockRunsTablePresenter> *>(presenter->m_tablePresenter.get());
+    presenter->m_runNotifier.reset(new NiceMock<MockRunNotifier>());
+    m_runNotifier = dynamic_cast<NiceMock<MockRunNotifier> *>(presenter->m_runNotifier.get());
+    presenter->m_searcher.reset(new NiceMock<MockSearcher>());
+    m_searcher = dynamic_cast<NiceMock<MockSearcher> *>(presenter->m_searcher.get());
 
     // Return an empty table by default
     ON_CALL(*m_runsTablePresenter, runsTable()).WillByDefault(ReturnRef(m_runsTable));

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -57,6 +57,11 @@ public:
   explicit DataReduction(QWidget *parent = nullptr);
   /// Destructor
   ~DataReduction() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  DataReduction(const DataReduction &) = delete;
+  DataReduction &operator=(const DataReduction &) = delete;
+
   /// Interface name
   static std::string name() { return "Data Reduction"; }
   // This interface's categories.

--- a/qt/scientific_interfaces/Indirect/Simulation/Simulation.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/Simulation.h
@@ -37,6 +37,11 @@ public: // public constructor, destructor and functions
   Simulation(QWidget *parent = nullptr);
   /// Destructor
   ~Simulation() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  Simulation(const Simulation &) = delete;
+  Simulation &operator=(const Simulation &) = delete;
+
   /// Interface name
   static std::string name() { return "Simulation"; }
   /// This interface's categories.

--- a/qt/scientific_interfaces/Indirect/Tools/Tools.h
+++ b/qt/scientific_interfaces/Indirect/Tools/Tools.h
@@ -36,6 +36,11 @@ public: // public constructor, destructor and functions
   Tools(QWidget *parent = nullptr);
   /// Destructor
   ~Tools() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  Tools(const Tools &) = delete;
+  Tools &operator=(const Tools &) = delete;
+
   /// Interface name
   static std::string name() { return "Tools"; }
   // This interface's categories.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.h
@@ -39,6 +39,11 @@ public: // public constructor, destructor and functions
   BayesFitting(QWidget *parent = nullptr);
   /// Destructor
   ~BayesFitting() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  BayesFitting(const BayesFitting &) = delete;
+  BayesFitting &operator=(const BayesFitting &) = delete;
+
   /// Interface name
   static std::string name() { return "Bayes Fitting"; }
   // This interface's categories.

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.h
@@ -48,6 +48,10 @@ public:
   /// Default Constructor
   explicit Corrections(QWidget *parent = nullptr);
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  Corrections(const Corrections &) = delete;
+  Corrections &operator=(const Corrections &) = delete;
+
 private:
   /// Initialize the layout
   void initLayout() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmSelectorWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmSelectorWidget.h
@@ -61,6 +61,11 @@ class EXPORT_OPT_MANTIDQT_COMMON AlgorithmSelectorWidget : public QWidget {
 public:
   AlgorithmSelectorWidget(QWidget *parent);
   ~AlgorithmSelectorWidget() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  AlgorithmSelectorWidget(const AlgorithmSelectorWidget &) = delete;
+  AlgorithmSelectorWidget &operator=(const AlgorithmSelectorWidget &) = delete;
+
   SelectedAlgorithm getSelectedAlgorithm();
   void setSelectedAlgorithm(QString &algName);
   bool showExecuteButton() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
@@ -90,6 +90,10 @@ public:
   explicit BatchAlgorithmRunner(QObject *parent = nullptr);
   ~BatchAlgorithmRunner() override;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  BatchAlgorithmRunner(const BatchAlgorithmRunner &) = delete;
+  BatchAlgorithmRunner &operator=(const BatchAlgorithmRunner &) = delete;
+
   /// Adds an algorithm to the execution queue
   void addAlgorithm(const Mantid::API::IAlgorithm_sptr &algo);
   void addAlgorithm(const Mantid::API::IAlgorithm_sptr &algo,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -73,6 +73,11 @@ public:
   FitPropertyBrowser(QWidget *parent = nullptr, QObject *mantidui = nullptr);
   /// Destructor
   ~FitPropertyBrowser() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  FitPropertyBrowser(const FitPropertyBrowser &) = delete;
+  FitPropertyBrowser &operator=(const FitPropertyBrowser &) = delete;
+
   /// Get handler to the root composite function
   PropertyHandler *getHandler() const;
   /// Initialise layout

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
@@ -39,6 +39,11 @@ public:
   InstrumentSelector(QWidget *parent = nullptr, bool init = true);
   /// Destructor
   ~InstrumentSelector() override;
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  InstrumentSelector(const InstrumentSelector &) = delete;
+  InstrumentSelector &operator=(const InstrumentSelector &) = delete;
+
   /// Return the list of techniques
   const QStringList &getTechniques() const;
   /// Set the list of techniques

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtAlgorithmRunner.h
@@ -36,6 +36,10 @@ public:
   explicit QtAlgorithmRunner(QObject *parent = nullptr);
   ~QtAlgorithmRunner() override;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  QtAlgorithmRunner(const QtAlgorithmRunner &) = delete;
+  QtAlgorithmRunner &operator=(const QtAlgorithmRunner &) = delete;
+
   void cancelRunningAlgorithm();
 
   virtual void startAlgorithm(Mantid::API::IAlgorithm_sptr alg);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -46,6 +46,10 @@ public:
   /// Destructor
   ~WorkspaceMultiSelector() override;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  WorkspaceMultiSelector(const WorkspaceMultiSelector &) = delete;
+  WorkspaceMultiSelector &operator=(const WorkspaceMultiSelector &) = delete;
+
   void setupTable();
 
   void refresh();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceObserver.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceObserver.h
@@ -93,6 +93,11 @@ public:
   WorkspaceObserver();
   /// Destructor
   virtual ~WorkspaceObserver();
+
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  WorkspaceObserver(const WorkspaceObserver &) = delete;
+  WorkspaceObserver &operator=(const WorkspaceObserver &) = delete;
+
   /// Observe workspace deletes
   void observePreDelete(bool on = true);
   /// Observe workspace deletes

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/ADSAdapter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/ADSAdapter.h
@@ -23,6 +23,11 @@ class EXPORT_OPT_MANTIDQT_COMMON ADSAdapter : public WorkspaceProvider {
 public:
   explicit ADSAdapter();
   ~ADSAdapter() override;
+
+  // delete copy constructors and assignment operators -- Poco::NObserver is not copyable
+  ADSAdapter(const ADSAdapter &) = delete;
+  ADSAdapter &operator=(const ADSAdapter &) = delete;
+
   void registerPresenter(Presenter_wptr presenter) override;
   bool doesWorkspaceExist(const std::string &wsname) const override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceSelector.h
@@ -64,6 +64,10 @@ public:
   /// Destructor
   ~WorkspaceSelector() override;
 
+  // delete copy operations - Poco::NObserver contains std::atomic which is not copyable
+  WorkspaceSelector(const WorkspaceSelector &) = delete;
+  WorkspaceSelector &operator=(const WorkspaceSelector &) = delete;
+
   const QStringList &getWorkspaceTypes() const;
   void setWorkspaceTypes(const QStringList &types);
   bool showHiddenWorkspaces() const;

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -12,7 +12,6 @@
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 
 #include <Poco/AutoPtr.h>
-#include <Poco/NObserver.h>
 #include <Poco/Notification.h>
 #include <Poco/NotificationCenter.h>
 

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -10,7 +10,6 @@
 #include "MantidQtWidgets/Common/WorkspaceSelector.h"
 
 #include <Poco/AutoPtr.h>
-#include <Poco/NObserver.h>
 #include <Poco/Notification.h>
 #include <Poco/NotificationCenter.h>
 


### PR DESCRIPTION
### Description of work

Poco v1.15 (published to anaconda.org on 2026-02-17) introduces std::atomic into NObserver, which secretly prevents copying of any class with an NObserver object in it. You can only find this out when you go to build on Windows with MSVC and learn it is trying to create a default copy constructor, leading to an error.

This was discovered while making release candidates for mantid v6.15.  As pin as added in 6.15 to enable the package build in PR #40957.  

The problem is caused in classes with a `NObserver` member variable, but without an explicit copy constructor.    The MSVC compiler will attempt to create defaults, which is an error.  This work deletes the copy constructors in these classes, so that the defaults will not be constructed.

The pin is removed, so that the package can be built with Poco 1.15.

### To test:

This error only occurred on Windows.  Check the Windows conda package build.  It should be using Poco 1.15, and it should compile without error.
[Build 1496](https://builds.mantidproject.org/job/build_branch/1496/)
[![Build Status](https://builds.mantidproject.org/job/build_branch/1496/badge/icon)](https://builds.mantidproject.org/job/build_branch/1496/)
[Link to line with package Poco version](https://builds.mantidproject.org/job/build_branch/1496/pipeline-overview/?start-byte=0&selected-node=265#log-265-260)
NOTE: the build was kicked off from the commit just before HEAD, but the only difference is a cppcheck suppression

This does not require release notes because it explicitly removes unused compiler-made copy operators which will not impact a normal user.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
