### PR TITLE
Replace np.xrange with range for compatibility with Python 3

### DIFF
--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -336,9 +336,9 @@ def getXTOF(box, peak):
     QX, QY, QZ = ICCFT.getQXQYQZ(box)
     origQS = peak.getQSampleFrame()
     tList = np.zeros_like(QX)
-    for i in np.xrange(QX.shape[0]):
-        for j in np.xrange(QX.shape[1]):
-            for k in np.xrange(QX.shape[2]):
+    for i in range(QX.shape[0]):
+        for j in range(QX.shape[1]):
+            for k in range(QX.shape[2]):
                 newQ = V3D(QX[i, j, k], QY[i, j, k], QZ[i, j, k])
                 peak.setQSampleFrame(newQ)
                 flightPath = peak.getL1() + peak.getL2()


### PR DESCRIPTION
### Description of work

Fixes a Python 3 compatibility issue in the SCD_Reduction module by replacing np.xrange with range

Closes #[40832](https://github.com/mantidproject/mantid/issues/40832) and [EWM 15004](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15004)
, Companion to PR #40967

No need for release notes, as this is a very minor fix not exposed to the public interface.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
