### PR TITLE
IntegratePeaksMD: better handles un-indexed peaks in HKL mode

### DIFF
--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -41,9 +41,10 @@ public:
   /** Create the (blank) MDEW */
   static void createMDEW() {
     // ---- Start with empty MDEW ----
-    FrameworkManager::Instance().exec("CreateMDWorkspace", 14, "Dimensions", "3", "Extents", "-10,10,-10,10,-10,10",
-                                      "Names", "h,k,l", "Units", "-,-,-", "SplitInto", "5", "MaxRecursionDepth", "2",
-                                      "OutputWorkspace", "PeakIntensityVsRadiusTest_MDEWS");
+    FrameworkManager::Instance().exec("CreateMDWorkspace", 16, "Dimensions", "3", "Extents", "-10,10,-10,10,-10,10",
+                                      "Names", "h,k,l", "Units", "r.l.u.,r.l.u.,r.l.u.", "Frames", "HKL,HKL,HKL",
+                                      "SplitInto", "5", "MaxRecursionDepth", "2", "OutputWorkspace",
+                                      "PeakIntensityVsRadiusTest_MDEWS");
   }
 
   //-------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -265,6 +265,7 @@ std::map<std::string, std::string> IntegratePeaksMD2::validateInputs() {
   std::vector<double> BackgroundOuterRadius = getProperty("BackgroundOuterRadius");
   bool ellipsoid = getProperty("Ellipsoid");
   bool cylinder = getProperty("Cylinder");
+  std::shared_ptr<IMDEventWorkspace> inputWS = getProperty("InputWorkspace");
 
   if (PeakRadius.size() != 1 && PeakRadius.size() != 3) {
     std::stringstream errmsg;
@@ -307,6 +308,10 @@ std::map<std::string, std::string> IntegratePeaksMD2::validateInputs() {
     errmsg << "Ellipsoid and Cylinder cannot both be true";
     result["Ellipsoid"] = errmsg.str();
     result["Cylinder"] = errmsg.str();
+  }
+
+  if (inputWS->getSpecialCoordinateSystem() == Mantid::Kernel::None) {
+    result["InputWorkspace"] = "Must have Special Coordinate System of QLab, QSample or HKL";
   }
 
   return result;
@@ -477,6 +482,8 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
       pos = p.getQSampleFrame();
     else if (CoordinatesToUse == Mantid::Kernel::HKL) //"HKL"
       pos = p.getHKL();
+    else
+      throw std::runtime_error("Workspace does not have a coordinate system set");
 
     // Do not integrate if sphere is off edge of detector
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -476,6 +476,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
     IPeak &p = peakWS->getPeak(i);
 
     // Get the peak center as a position in the dimensions of the workspace
+    bool missingIndex = false; // True if in HKL mode and pos is 0,0,0
     V3D pos;
     if (CoordinatesToUse == Mantid::Kernel::QLab) //"Q (lab frame)"
       pos = p.getQLabFrame();
@@ -485,6 +486,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
       pos = p.getHKL();
       if (pos.X() == 0 && pos.Y() == 0 && pos.Z() == 0) {
         ++zeroHKLCount;
+        missingIndex = true;
       }
     } else {
       throw std::runtime_error("Workspace does not have a coordinate system set");
@@ -565,7 +567,13 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
       }
       // if ellipsoid find covariance and centroid in spherical region
       // using one-pass algorithm from https://doi.org/10.1145/359146.359153
-      if (isEllipse) {
+      bool integrateAsEllipse = isEllipse;
+      if (isEllipse && missingIndex) {
+        integrateAsEllipse = false;
+        g_log.warning() << "Integrating un-indexed peak. Falling back to sphere peak shape to avoid numeric issues\n";
+      }
+
+      if (integrateAsEllipse) {
         // flat bg to subtract
         const auto bgDensity = bgSignal / (4 * M_PI * pow(PeakRadiusVector[i], 3) / 3);
         std::array<V3D, 3> eigenvects;

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -465,8 +465,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
   // Initialize progress reporting
   int nPeaks = peakWS->getNumberPeaks();
   Progress progress(this, 0., 1., nPeaks);
+  int zeroHKLCount = 0;
   bool doParallel = cylinderBool ? false : Kernel::threadSafe(*ws, *peakWS);
-  PARALLEL_FOR_IF(doParallel)
+  PARALLEL_SET_CONFIG_THREADS PRAGMA_OMP(parallel for if(doParallel) reduction(+:zeroHKLCount))
   for (int i = 0; i < nPeaks; ++i) {
     PARALLEL_START_INTERRUPT_REGION
     progress.report();
@@ -480,11 +481,14 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
       pos = p.getQLabFrame();
     else if (CoordinatesToUse == Mantid::Kernel::QSample) //"Q (sample frame)"
       pos = p.getQSampleFrame();
-    else if (CoordinatesToUse == Mantid::Kernel::HKL) //"HKL"
+    else if (CoordinatesToUse == Mantid::Kernel::HKL) { //"HKL"
       pos = p.getHKL();
-    else
+      if (pos.X() == 0 && pos.Y() == 0 && pos.Z() == 0) {
+        ++zeroHKLCount;
+      }
+    } else {
       throw std::runtime_error("Workspace does not have a coordinate system set");
-
+    }
     // Do not integrate if sphere is off edge of detector
 
     const double edgeDist = calculateDistanceToEdge(p.getQLabFrame());
@@ -892,6 +896,15 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
     PARALLEL_END_INTERRUPT_REGION
   }
   PARALLEL_CHECK_INTERRUPT_REGION
+
+  if (CoordinatesToUse == Kernel::HKL && zeroHKLCount > 0) {
+    if (zeroHKLCount == nPeaks) {
+      g_log.error() << "No peaks are indexed, integrated at HKL=0,0,0. You might need to run IndexPeaks.\n";
+    } else {
+      g_log.warning() << zeroHKLCount << " of " << nPeaks << " peaks are not indexed, integrated at HKL=0,0,0\n";
+    }
+  }
+
   // This flag is used by the PeaksWorkspace to evaluate whether it has
   // been integrated.
   peakWS->mutableRun().addProperty("PeaksIntegrated", 1, true);

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -637,7 +637,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Dimensions", "3"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Extents", "-0.5,0.5,-0.5,0.5,-0.5,0.5"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Names", "h,k,l"));
-    TS_ASSERT_THROWS_NOTHING(algC.setProperty("Units", "U,U,U"));
+    TS_ASSERT_THROWS_NOTHING(algC.setProperty("Units", "r.l.u.,r.l.u.,r.l.u."));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Frames", "HKL,HKL,HKL"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("SplitInto", "2"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("MaxRecursionDepth", "5"));

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -635,7 +635,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(algC.initialize())
     TS_ASSERT(algC.isInitialized())
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Dimensions", "3"));
-    TS_ASSERT_THROWS_NOTHING(algC.setProperty("Extents", "-0.5,0.5,-0.5,0.5,-0.5,0.5"));
+    TS_ASSERT_THROWS_NOTHING(algC.setProperty("Extents", "-0.5,0.5,-0.5,0.5,0.5,1.5"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Names", "h,k,l"));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Units", "r.l.u.,r.l.u.,r.l.u."));
     TS_ASSERT_THROWS_NOTHING(algC.setProperty("Frames", "HKL,HKL,HKL"));
@@ -647,7 +647,7 @@ public:
 
     // Test an ellipsoid against theoretical vol
     size_t numEvents = 200000;
-    V3D pos(0.0, 0.0, 0.0); // peak position
+    V3D pos(0.0, 0.0, 1.0); // peak position
 
     // Major axis along x
     double fail_val = 0.013;
@@ -655,7 +655,7 @@ public:
 
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
     PeaksWorkspace_sptr peakWS = std::make_shared<PeaksWorkspace>();
-    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5)});
+    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(0.5, 1.5)});
     peakWS->addPeak(Peak(inst, 1, 1.0, pos));
     AnalysisDataService::Instance().addOrReplace("IntegratePeaksMD2Test_peaks", peakWS);
 
@@ -675,13 +675,13 @@ public:
   void test_exec_EllipsoidRadii_NoBackground_SingleCount_Vol() {
     // Test an ellipsoid against theoretical vol
     size_t numEvents = 2000000;
-    V3D pos(0.0, 0.0, 0.0); // peak position
+    V3D pos(0.0, 1.0, 0.0); // peak position
 
     createMDEW();
 
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
     PeaksWorkspace_sptr peakWS = std::make_shared<PeaksWorkspace>();
-    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5)});
+    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(0.5, 1.5), std::make_pair(-0.5, 0.5)});
     peakWS->addPeak(Peak(inst, 1, 1.0, pos));
     AnalysisDataService::Instance().addOrReplace("IntegratePeaksMD2Test_peaks", peakWS);
 
@@ -724,13 +724,13 @@ public:
   void test_exec_EllipsoidRadii_WithBackground() {
     // Test an ellipsoid against theoretical vol
     size_t numEvents = 1000000;
-    V3D pos(0.0, 0.0, 0.0); // peak position
+    V3D pos(1.0, 0.0, 0.0); // peak position
 
     createMDEW();
 
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
     PeaksWorkspace_sptr peakWS = std::make_shared<PeaksWorkspace>();
-    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5)});
+    addUniform(numEvents, {std::make_pair(0.5, 1.5), std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5)});
     std::vector<std::vector<double>> eigenvects;
     eigenvects.push_back(std::vector<double>{1.0, 0.0, 0.0});
     eigenvects.push_back(std::vector<double>{0.0, 1.0, 0.0});
@@ -1172,14 +1172,17 @@ public:
   void test_exec_EllipsoidRadii_with_LeanElasticPeaks() {
     // Test an ellipsoid against theoretical vol
     const std::vector<double> radii{0.4, 0.3, 0.2};
-    const V3D pos(0.0, 0.0, 0.0); // peak position
+    const V3D pos(0.0, 0.0, 1.0); // peak position
     const int numEvents = 1000000;
 
     createMDEW();
-    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5)});
+    addUniform(numEvents, {std::make_pair(-0.5, 0.5), std::make_pair(-0.5, 0.5), std::make_pair(0.5, 1.5)});
 
     auto peakWS = std::make_shared<LeanElasticPeaksWorkspace>();
-    peakWS->addPeak(LeanElasticPeak(pos));
+    auto peak = LeanElasticPeak(pos);
+    peak.setHKL(pos);
+    peakWS->addPeak(peak);
+
     AnalysisDataService::Instance().addOrReplace("IntegratePeaksMD2Test_peaks", peakWS);
 
     doRun(radii, {0.0}, "IntegratePeaksMD2Test_Leanpeaks_out", {0.0}, true, false, "NoFit", 0.0, true, false);

--- a/docs/source/release/v6.16.0/Diffraction/Single_Crystal/Bugfixes/40175.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Single_Crystal/Bugfixes/40175.rst
@@ -1,0 +1,1 @@
+- Algorithm :ref:`algm-IntegratePeaksMD` better handles un-indexed peaks in HKL mode, warnings are given and numeric issues with ellipse finding are avoided by falling back to spherical integration.


### PR DESCRIPTION
### Description of work

Closes #40175 

- Ensure that InputWorkspace has coordinates
  - IntegratePeaksMD2 needs to use the peak position in the workspace MDEventWorkspace coordinate system, which causes problems if not set.
  - Update test that produces a workspace without coordinates set.
- IntegratePeaksMD2: Count un-indexed peaks in HKL mode
  - In HKL mode warn if there are peaks with pos 0,0,0 and give an error if they are all 0,0,0
- IntegratePeaksMD2. When integrating in HKL at 0,0,0 don't use ellipse
  -  The ellipse finding code fails with various numeric issues when run at HKL=0,0,0. In this case fall back to spherical integration.
  - This is can be hit when integrating peaks that have failed to index, or if indexing has now been done.
  - Change peak positions in some tests that integrate at HKL=0,0,0

An additional change would that could be done would be adding an option to integrate un-indexed peaks based in HKL space by using QSample and the UB matrix. This has not been implemented in this PR, because it is not clear if there is user demand.

### To test:

1) Run the following script
```
Load(Filename=r'SXD23767.raw', OutputWorkspace='SXD23767')
FindSXPeaksConvolve(InputWorkspace='SXD23767', PeaksWorkspace='SXD23767_peaks', ThresholdIoverSigma=10, NRows=3, NCols=3, GetNBinsFromBackToBackParams=True, NFWHM=3, ThresholdVarianceOverMean=1.5)
FindUBUsingFFT(PeaksWorkspace='SXD23767_peaks', MinD=1, MaxD=20)
CopySample(InputWorkspace='SXD23767_peaks', OutputWorkspace='SXD23767', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputWorkspace='SXD23767_HKL', OneEventPerBin=False, OutputDimensions='HKL')
IntegratePeaksMD(InputWorkspace='SXD23767_HKL', PeakRadius='0.15', BackgroundOuterRadius='0.19', PeaksWorkspace='SXD23767_peaks', OutputWorkspace='SXD23767_peaks_int', IntegrateIfOnEdge=False, AdaptiveQBackground=True, Ellipsoid=True, FixQAxis=True, UseCentroid=True)

peaks_int = mtd['SXD23767_peaks_int']
print(f"{peaks_int.getPeak(0).getPeakShape().toJSON()=}")
```

2) Open SXD23767_HKL in sliceviewer
3) Overlay SXD22767_peaks_int


On main the output after step 1 will have the `translation`s set to `null`:
```
peaks_int.getPeak(0).getPeakShape().toJSON()='{"algorithm_name":"IntegratePeaksMD","algorithm_version":2,"background_inner_radius0":0.14999999999999999,"background_inner_radius1":0.14999999999999999,"background_inner_radius2":0.14999999999999999,"background_outer_radius0":0.19,"background_outer_radius1":0.19,"background_outer_radius2":0.19,"direction0":"1 0 0","direction1":"0 1 0","direction2":"0 0 1","frame":3,"radius0":0.14999999999999999,"radius1":0.14999999999999999,"radius2":0.14999999999999999,"shape":"ellipsoid","translation0":null,"translation1":null,"translation2":null}'
```
When you overlay the peaks you will get an error.

With this PR. There will be no `null`s in the peak shape. Because it has fallen back to using spherical integration.

You will see an error `No peaks are indexed, integrated at HKL=0,0,0. You might need to run IndexPeaks`, because `IndexPeaks` has not been run in the script.

In slice viewer, overlay will not cause an error.



<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
