### PR TITLE
Add flag to `FitPeaks` and `PDCalibration` to control the parameter inheritance from successful fits

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -273,6 +273,8 @@ private:
   bool m_fitPeaksFromRight;
   /// Fit iterations
   int m_fitIterations;
+  // Copy the peak parameters from the last successfully fit peak
+  bool m_copyLastGoodPeakParameters;
 
   //-------- Input param init values --------------------------------
   /// input starting parameters' indexes in peak function

--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -151,6 +151,7 @@ private:
   void fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_peak_centers,
                         const std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> &fit_result,
                         std::vector<std::vector<double>> &lastGoodPeakParameters,
+                        std::vector<size_t> &lastGoodPeakSpectra,
                         const std::shared_ptr<FitPeaksAlgorithm::PeakFitPreCheckResult> &pre_check_result);
 
   /// fit background

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -78,6 +78,7 @@ const std::string HIGH_BACKGROUND("HighBackground");
 const std::string POSITION_TOL("PositionTolerance");
 const std::string PEAK_MIN_HEIGHT("MinimumPeakHeight");
 const std::string CONSTRAIN_PEAK_POS("ConstrainPeakPositions");
+const std::string COPY_LAST_GOOD_PEAK_PARAMS("CopyLastGoodPeakParameters");
 const std::string OUTPUT_WKSP_MODEL("FittedPeaksWorkspace");
 const std::string OUTPUT_WKSP_PARAMS("OutputPeakParametersWorkspace");
 const std::string OUTPUT_WKSP_PARAM_ERRS("OutputParameterFitErrorsWorkspace");
@@ -400,6 +401,10 @@ void FitPeaks::init() {
                   "(highest Y value position) and "
                   "the peak width either estimted by observation or calculate.");
 
+  declareProperty(PropertyNames::COPY_LAST_GOOD_PEAK_PARAMS, true,
+                  "If true, initial peak parameters (with the exception of peak centre) "
+                  "will be copied from the last succesfully fit peak in the spectra.");
+
   // additional output for reviewing
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::OUTPUT_WKSP_MODEL, "",
                                                                        Direction::Output, PropertyMode::Optional),
@@ -585,6 +590,7 @@ void FitPeaks::processInputs() {
   m_fitPeaksFromRight = getProperty(PropertyNames::FIT_FROM_RIGHT);
   m_constrainPeaksPosition = getProperty(PropertyNames::CONSTRAIN_PEAK_POS);
   m_fitIterations = getProperty(PropertyNames::MAX_FIT_ITER);
+  m_copyLastGoodPeakParameters = getProperty(PropertyNames::COPY_LAST_GOOD_PEAK_PARAMS);
 
   // Peak centers, tolerance and fitting range
   processInputPeakCenters();
@@ -1252,8 +1258,8 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
       for (size_t i = 0; i < peakfunction->nParams(); ++i) {
         peakfunction->setParameter(i, lastGoodPeakParameters[peak_index][i]);
       }
-    } else if (neighborPeakSameSpectrum) {
-      // set the peak parameters from last good fit to that peak
+    } else if (neighborPeakSameSpectrum && m_copyLastGoodPeakParameters) {
+      // set the peak parameters from last good fit from ANY peak in the spectrum
       for (size_t i = 0; i < peakfunction->nParams(); ++i) {
         peakfunction->setParameter(i, lastGoodPeakParameters[prev_peak_index][i]);
       }

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1286,7 +1286,11 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
       // parameters will be used if present and the width will not be estimated
       // (note this will overwrite parameter values caluclated from
       // Parameters.xml)
-      auto useUserSpecifedIfGiven = !(samePeakCrossSpectrum || neighborPeakSameSpectrum);
+      // When CopyLastGoodPeakParameters is disabled, treat each peak as if it
+      // has no fitted neighbour so that user-specified initial values are
+      // re-applied as the baseline rather than falling back to function defaults.
+      auto useUserSpecifedIfGiven =
+          !(samePeakCrossSpectrum || (neighborPeakSameSpectrum && m_copyLastGoodPeakParameters));
       bool observe_peak_width = decideToEstimatePeakParams(useUserSpecifedIfGiven, peakfunction);
 
       if (observe_peak_width && m_peakWidthEstimateApproach == EstimatePeakWidth::NoEstimation) {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1227,8 +1227,8 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     // Check whether current spectrum's pixel (detector ID) is close to the
     // spectrum that last successfully fitted this peak.
     try {
-      size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
       if (wi > 0 && samePeakCrossSpectrum) {
+        size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
         std::shared_ptr<const Geometry::Detector> pdetector =
             std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
         std::shared_ptr<const Geometry::Detector> cdetector =

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1193,12 +1193,13 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
       bkgdfunction->setParameter(i, 0.);
 
     double expected_peak_pos = expected_peak_centers[peak_index];
+    std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
 
     // clone peak function for each peak (need to do this so can
     // set center and calc any parameters from xml)
     auto peakfunction = std::dynamic_pointer_cast<API::IPeakFunction>(m_peakFunction->clone());
     peakfunction->setCentre(expected_peak_pos);
-    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, 0.0, 0.0);
+    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
 
     std::map<size_t, double> keep_values;
     for (size_t ipar = 0; ipar < peakfunction->nParams(); ++ipar) {
@@ -1267,6 +1268,7 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
 
     // reset center though - don't know before hand which element this is
     peakfunction->setCentre(expected_peak_pos);
+
     // reset value of parameters that were fixed (but are now free to vary)
     for (const auto &[ipar, value] : keep_values) {
       peakfunction->setParameter(ipar, value);
@@ -1278,9 +1280,6 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
       peakfunction->setIntensity(0);
       number_of_out_of_range_peaks++;
     } else {
-      // find out the peak position to fit
-      std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
-
       // Decide whether to estimate peak width by observation
       // If no peaks fitted in the same or cross spectrum then the user supplied
       // parameters will be used if present and the width will not be estimated

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -403,7 +403,7 @@ void FitPeaks::init() {
 
   declareProperty(PropertyNames::COPY_LAST_GOOD_PEAK_PARAMS, true,
                   "If true, initial peak parameters (with the exception of peak centre) "
-                  "will be copied from the last successfully fit peak in the spectra.");
+                  "may be copied from the last successfully fit peak in the spectra.");
 
   // additional output for reviewing
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::OUTPUT_WKSP_MODEL, "",
@@ -1003,6 +1003,8 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
     // vector to store fit params for last good fit to each peak
     std::vector<std::vector<double>> lastGoodPeakParameters(m_numPeaksToFit,
                                                             std::vector<double>(m_peakFunction->nParams(), 0.0));
+    // track which spectrum index last successfully fitted each peak
+    std::vector<size_t> lastGoodPeakSpectra(m_numPeaksToFit, 0);
 
     for (auto wi = iws_begin; wi < iws_end; ++wi) {
       // peaks to fit
@@ -1017,7 +1019,7 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
           std::make_shared<FitPeaksAlgorithm::PeakFitPreCheckResult>();
 
       fitSpectrumPeaks(static_cast<size_t>(wi), expected_peak_centers, fit_result, lastGoodPeakParameters,
-                       spectrum_pre_check_result);
+                       lastGoodPeakSpectra, spectrum_pre_check_result);
 
       PARALLEL_CRITICAL(FindPeaks_WriteOutput) {
         writeFitResult(static_cast<size_t>(wi), expected_peak_centers, fit_result);
@@ -1145,6 +1147,7 @@ private:
 void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_peak_centers,
                                 const std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> &fit_result,
                                 std::vector<std::vector<double>> &lastGoodPeakParameters,
+                                std::vector<size_t> &lastGoodPeakSpectra,
                                 const std::shared_ptr<FitPeaksAlgorithm::PeakFitPreCheckResult> &pre_check_result) {
   assert(fit_result->getNumberPeaks() == m_numPeaksToFit);
   pre_check_result->setNumberOfSubmittedSpectrumPeaks(m_numPeaksToFit);
@@ -1221,14 +1224,13 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
                                                                     lastGoodPeakParameters[peak_index].end(),
                                                                     [&](auto const &val) { return val <= 1e-10; })));
 
-    // Check whether current spectrum's pixel (detector ID) is close to its
-    // previous spectrum's pixel (detector ID).
+    // Check whether current spectrum's pixel (detector ID) is close to the
+    // spectrum that last successfully fitted this peak.
     try {
+      size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
       if (wi > 0 && samePeakCrossSpectrum) {
-        // First spectrum or discontinuous detector ID: do not start from same
-        // peak of last spectrum
         std::shared_ptr<const Geometry::Detector> pdetector =
-            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi - 1));
+            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
         std::shared_ptr<const Geometry::Detector> cdetector =
             std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
 
@@ -1327,10 +1329,11 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
       // reset the flag such that there is at a peak fit in this spectrum
       neighborPeakSameSpectrum = true;
       prev_peak_index = peak_index;
-      // copy values
+      // copy values and record which spectrum they came from
       for (size_t i = 0; i < lastGoodPeakParameters[peak_index].size(); ++i) {
         lastGoodPeakParameters[peak_index][i] = peakfunction->getParameter(i);
       }
+      lastGoodPeakSpectra[peak_index] = wi;
     }
   }
 

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -403,7 +403,7 @@ void FitPeaks::init() {
 
   declareProperty(PropertyNames::COPY_LAST_GOOD_PEAK_PARAMS, true,
                   "If true, initial peak parameters (with the exception of peak centre) "
-                  "will be copied from the last succesfully fit peak in the spectra.");
+                  "will be copied from the last successfully fit peak in the spectra.");
 
   // additional output for reviewing
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::OUTPUT_WKSP_MODEL, "",

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -273,6 +273,11 @@ void PDCalibration::init() {
                   "Flag whether the input data has high background compared to peaks' heights. "
                   "This option is recommended for data with peak-to-background ratios under ~5.");
 
+  declareProperty(
+      "CopyLastGoodPeakParameters", true,
+      "If true, for a given peak in a spectrum the initial peak parameters (with the exception of peak centre) "
+      "will be copied from the last succesfully fit peak in that spectrum.");
+
   declareProperty("MinimumSignalToNoiseRatio", 0.,
                   "Used for validating peaks before fitting. If the signal-to-noise ratio is under this value, "
                   "the peak will be excluded from fitting and calibration. This check does not apply to peaks for "
@@ -344,6 +349,7 @@ void PDCalibration::init() {
   setPropertyGroup("HighBackground", fitPeaksGroup);
   setPropertyGroup("MaxChiSq", fitPeaksGroup);
   setPropertyGroup("ConstrainPeakPositions", fitPeaksGroup);
+  setPropertyGroup("CopyLastGoodPeakParameters", fitPeaksGroup);
 
   // make group for type of calibration
   std::string calGroup("Calibration Type");
@@ -496,6 +502,7 @@ void PDCalibration::exec() {
   const double minSignalToNoiseRatio = getProperty("MinimumSignalToNoiseRatio");
   const double minSignalToSigmaRatio = getProperty("MinimumSignalToSigmaRatio");
   const double maxChiSquared = getProperty("MaxChiSq");
+  const bool copyLastGoodPeakParameters = getProperty("CopyLastGoodPeakParameters");
 
   const std::string calParams = getPropertyValue("CalibrationParameters");
   if (calParams == std::string("DIFC"))
@@ -619,6 +626,10 @@ void PDCalibration::exec() {
   if (useChiSq) {
     algFitPeaks->setPropertyValue("OutputParameterFitErrorsWorkspace", diagnostic_prefix + "_fiterrors");
   }
+
+  // whether, for a given peak in each spectrum, the initial peak parameters (with the exception of peak centre)
+  // will be copied from the last succesfully fit peak in that spectrum.
+  algFitPeaks->setProperty("CopyLastGoodPeakParameters", copyLastGoodPeakParameters);
 
   // run and get the result
   algFitPeaks->executeAsChildAlg();

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -276,7 +276,7 @@ void PDCalibration::init() {
   declareProperty(
       "CopyLastGoodPeakParameters", true,
       "If true, for a given peak in a spectrum the initial peak parameters (with the exception of peak centre) "
-      "will be copied from the last succesfully fit peak in that spectrum.");
+      "will be copied from the last successfully fit peak in that spectrum.");
 
   declareProperty("MinimumSignalToNoiseRatio", 0.,
                   "Used for validating peaks before fitting. If the signal-to-noise ratio is under this value, "
@@ -628,7 +628,7 @@ void PDCalibration::exec() {
   }
 
   // whether, for a given peak in each spectrum, the initial peak parameters (with the exception of peak centre)
-  // will be copied from the last succesfully fit peak in that spectrum.
+  // will be copied from the last successfully fit peak in that spectrum.
   algFitPeaks->setProperty("CopyLastGoodPeakParameters", copyLastGoodPeakParameters);
 
   // run and get the result

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -276,7 +276,7 @@ void PDCalibration::init() {
   declareProperty(
       "CopyLastGoodPeakParameters", true,
       "If true, for a given peak in a spectrum the initial peak parameters (with the exception of peak centre) "
-      "will be copied from the last successfully fit peak in that spectrum.");
+      "may be copied from the last successfully fit peak in that spectrum.");
 
   declareProperty("MinimumSignalToNoiseRatio", 0.,
                   "Used for validating peaks before fitting. If the signal-to-noise ratio is under this value, "
@@ -628,7 +628,7 @@ void PDCalibration::exec() {
   }
 
   // whether, for a given peak in each spectrum, the initial peak parameters (with the exception of peak centre)
-  // will be copied from the last successfully fit peak in that spectrum.
+  // may be copied from the last successfully fit peak in that spectrum.
   algFitPeaks->setProperty("CopyLastGoodPeakParameters", copyLastGoodPeakParameters);
 
   // run and get the result

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1533,6 +1533,105 @@ public:
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
 
+  //----------------------------------------------------------------------------------------------
+  /** Test that CopyLastGoodPeakParameters property exists and defaults to true
+   */
+  void test_CopyLastGoodPeakParametersDefaultIsTrue() {
+    FitPeaks fitpeaks;
+    fitpeaks.initialize();
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    bool defaultVal = fitpeaks.getProperty("CopyLastGoodPeakParameters");
+    TS_ASSERT_EQUALS(defaultVal, true);
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Test that CopyLastGoodPeakParameters=false correctly fits multiple peaks
+   * without seeding initial parameters from the last successfully fitted neighbouring peak.
+   * With this option disabled, each peak must be independently initialized from
+   * data observation rather than inheriting potentially position-inappropriate
+   * parameters from a neighbour at a different d-spacing or TOF. Fitted positions
+   * must match those obtained with the default (true) setting.
+   */
+  void test_multiPeaksMultiSpectra_noCopyLastGoodPeakParameters() {
+    g_log.notice() << "TEST MULTIPLE PEAKS MULTI SPECTRA NO COPY LAST GOOD PEAK PARAMS";
+    // run serially so values don't depend on no. cores etc.
+    FrameworkManager::Instance().setNumOMPThreads(1);
+
+    // Generate input workspace with two Gaussian peaks of differing widths:
+    // ws=0: peak at x=5 (sigma=0.15) and peak at x=10 (sigma=0.1).
+    // With FitFromRight=true the narrower peak at x=10 is fitted first.
+    // When CopyLastGoodPeakParameters=false, the wider peak at x=5 cannot
+    // inherit sigma~0.1 from the right-hand neighbour; instead it must be
+    // estimated independently from the data.
+    generateTestDataGaussian(m_inputWorkspaceName);
+
+    FitPeaks fitpeaks;
+    fitpeaks.initialize();
+    fitpeaks.setRethrows(true);
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 2));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0, 10.0"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitWindowBoundaryList", "2.5, 6.5, 8.0, 12.0"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitFromRight", true));
+    // No PeakParameterNames/Values: each peak observes its own shape from data.
+    // This is the primary use case for CopyLastGoodPeakParameters=false, where
+    // each peak must be initialized independently without inheriting parameters
+    // from a potentially shape-incompatible neighbour.
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("CopyLastGoodPeakParameters", false));
+
+    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS_noCopy");
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS_noCopy");
+    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS_noCopy");
+    fitpeaks.setProperty("ConstrainPeakPositions", false);
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
+    TS_ASSERT(fitpeaks.isExecuted());
+    if (!fitpeaks.isExecuted())
+      return;
+
+    API::MatrixWorkspace_sptr main_out_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakPositionsWS_noCopy"));
+    TS_ASSERT(main_out_ws);
+    TS_ASSERT_EQUALS(main_out_ws->getNumberHistograms(), 3);
+
+    // Fitted peak positions must be correct regardless of how parameters are seeded.
+    const auto &fitted_positions_0 = main_out_ws->histogram(0).y();
+    TS_ASSERT_EQUALS(fitted_positions_0.size(), 2);
+    TS_ASSERT_DELTA(fitted_positions_0[0], 5.0, 1.E-6);
+    TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-6);
+
+    const auto &fitted_positions_2 = main_out_ws->histogram(2).y();
+    TS_ASSERT_EQUALS(fitted_positions_2.size(), 2);
+    TS_ASSERT_DELTA(fitted_positions_2[0], 5.03, 1.E-6);
+    TS_ASSERT_DELTA(fitted_positions_2[1], 10.02, 1.E-6);
+
+    // Verify each peak's fitted sigma is its own true width, not inherited from
+    // the neighbour. Peak at x=10 has sigma~0.1; peak at x=5 has sigma~0.15.
+    // Row order in param table: peak index within spectrum (right-to-left fit order
+    // means the table rows are still in peak-index order: row 0 = peak0/x=5,
+    // row 1 = peak1/x=10 for ws=0).
+    API::ITableWorkspace_sptr param_ws = std::dynamic_pointer_cast<API::ITableWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakParametersWS_noCopy"));
+    TS_ASSERT(param_ws);
+    // ws=0, peak0 (x=5, sigma~0.15): row 0, Sigma column = col 4 (Height, Sigma, PeakCentre + 2 index cols)
+    TS_ASSERT_DELTA(param_ws->cell<double>(0, 4), 0.15, 0.02);
+    // ws=0, peak1 (x=10, sigma~0.1): row 1
+    TS_ASSERT_DELTA(param_ws->cell<double>(1, 4), 0.1, 0.02);
+
+    // clean up
+    AnalysisDataService::Instance().remove(m_inputWorkspaceName);
+    AnalysisDataService::Instance().remove("PeakPositionsWS_noCopy");
+    AnalysisDataService::Instance().remove("FittedPeaksWS_noCopy");
+    AnalysisDataService::Instance().remove("PeakParametersWS_noCopy");
+
+    FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
+  }
+
   //--------------------------------------------------------------------------------------------------------------
   /** generate a peak-center workspace compatible with the workspace created by
    * generateTestDataGaussian(), which will have up to 3 spectra up to 2 peaks each

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -55,7 +55,11 @@ public:
   void setUp() override {
     // Needs other algorithms and functions to be registered
     FrameworkManager::Instance();
+    // Run serially so test values don't depend on number of cores
+    FrameworkManager::Instance().setNumOMPThreads(1);
   }
+
+  void tearDown() override { FrameworkManager::Instance().setNumOMPThreadsToConfigValue(); }
 
   void test_Init() {
     // Initialize FitPeak
@@ -214,8 +218,6 @@ public:
    */
   void test_multiPeaksMultiSpectra() {
     g_log.notice() << "TEST MULTIPLE PEAKS MULTI SPECTRA";
-    // run serially so values don't depend on no. cores etc.
-    FrameworkManager::Instance().setNumOMPThreads(1);
 
     // set up parameters with starting value
     std::vector<string> peakparnames;
@@ -305,8 +307,6 @@ public:
     AnalysisDataService::Instance().remove("PeakPositionsWS");
     AnalysisDataService::Instance().remove("FittedPeaksWS");
     AnalysisDataService::Instance().remove("PeakParametersWS");
-
-    FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   }
 
   //----------------------------------------------------------------------------------------------
@@ -315,8 +315,6 @@ public:
    */
   void test_effectivePeakParameters() {
     g_log.notice() << "TEST EFFECTIVE PEAK PARAMS";
-    // run serially so values don't depend on no. cores etc.
-    FrameworkManager::Instance().setNumOMPThreads(1);
 
     // set up parameters with starting value
     std::vector<string> peakparnames;
@@ -408,8 +406,6 @@ public:
     AnalysisDataService::Instance().remove("PeakPositionsWS");
     AnalysisDataService::Instance().remove("FittedPeaksWS");
     AnalysisDataService::Instance().remove("PeakParametersWS");
-
-    FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   }
 
   //----------------------------------------------------------------------------------------------
@@ -811,8 +807,6 @@ public:
    */
   void test_multiPeaksMultiSpectraBackToBackExp_with_Param_xml() {
     g_log.notice() << "TEST MULTI PEAKS SPECTRA BACK TO BACK WITH PARAM XML";
-    // run serially so values don't depend on no. cores etc.
-    FrameworkManager::Instance().setNumOMPThreads(1);
 
     // Generate input workspace
     std::string input_ws_name = generateTestDataBackToBackExponential();
@@ -913,8 +907,6 @@ public:
     AnalysisDataService::Instance().remove(peak_pos_ws_name);
     AnalysisDataService::Instance().remove(param_ws_name);
     AnalysisDataService::Instance().remove(model_ws_name);
-
-    FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
 
     return;
   }
@@ -1550,13 +1542,11 @@ public:
    * without seeding initial parameters from the last successfully fitted neighbouring peak.
    * With this option disabled, each peak must be independently initialized from
    * data observation rather than inheriting potentially position-inappropriate
-   * parameters from a neighbour at a different d-spacing or TOF. Fitted positions
-   * should still match those obtained with the default (true) setting.
+   * parameters from a neighbour at a different d-spacing or TOF. The test verifies
+   * that sensible, independently determined peak positions and widths are obtained.
    */
   void test_multiPeaksMultiSpectra_noCopyLastGoodPeakParameters() {
     g_log.notice() << "TEST MULTIPLE PEAKS MULTI SPECTRA NO COPY LAST GOOD PEAK PARAMS";
-    // run serially so values don't depend on no. cores etc.
-    FrameworkManager::Instance().setNumOMPThreads(1);
 
     // Generate input workspace with two Gaussian peaks of differing widths:
     // ws=0: peak at x=5 (sigma=0.15) and peak at x=10 (sigma=0.1).
@@ -1625,8 +1615,6 @@ public:
     AnalysisDataService::Instance().remove("PeakPositionsWS_noCopy");
     AnalysisDataService::Instance().remove("FittedPeaksWS_noCopy");
     AnalysisDataService::Instance().remove("PeakParametersWS_noCopy");
-
-    FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   }
 
   //--------------------------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1551,7 +1551,7 @@ public:
    * With this option disabled, each peak must be independently initialized from
    * data observation rather than inheriting potentially position-inappropriate
    * parameters from a neighbour at a different d-spacing or TOF. Fitted positions
-   * must match those obtained with the default (true) setting.
+   * should still match those obtained with the default (true) setting.
    */
   void test_multiPeaksMultiSpectra_noCopyLastGoodPeakParameters() {
     g_log.notice() << "TEST MULTIPLE PEAKS MULTI SPECTRA NO COPY LAST GOOD PEAK PARAMS";
@@ -1578,9 +1578,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitWindowBoundaryList", "2.5, 6.5, 8.0, 12.0"));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitFromRight", true));
     // No PeakParameterNames/Values: each peak observes its own shape from data.
-    // This is the primary use case for CopyLastGoodPeakParameters=false, where
-    // each peak must be initialized independently without inheriting parameters
-    // from a potentially shape-incompatible neighbour.
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("CopyLastGoodPeakParameters", false));
 

--- a/Framework/Algorithms/test/PDCalibrationTest.h
+++ b/Framework/Algorithms/test/PDCalibrationTest.h
@@ -398,6 +398,65 @@ public:
     Mantid::API::AnalysisDataService::Instance().remove(prefix + "_mask");
   }
 
+  void test_CopyLastGoodPeakParametersDefaultIsTrue() {
+    PDCalibration alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+
+    bool defaultVal = alg.getProperty("CopyLastGoodPeakParameters");
+    TS_ASSERT_EQUALS(defaultVal, true);
+  }
+
+  void test_exec_difc_noCopyLastGoodPeakParameters() {
+
+    // Test that PDCalibration produces correct DIFC calibration when
+    // CopyLastGoodPeakParameters=false, verifying that the property does
+    // not impact calibration accuracy for well-defined peaks.
+
+    std::vector<double> dValues = convertPosToD(DIFC_155);
+
+    const std::string prefix{"PDCalibration_difc_noCopyPeakParams"};
+
+    PDCalibration alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "PDCalibrationTest_WS"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("MaskWorkspace", prefix + "_mask"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("TofBinning", TOF_BINNING));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputCalibrationTable", prefix + "cal"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("DiagnosticWorkspaces", prefix + "diag"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PeakPositions", dValues));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CopyLastGoodPeakParameters", false));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    ITableWorkspace_sptr calTable = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(prefix + "cal");
+    TS_ASSERT(calTable);
+
+    Mantid::DataObjects::TableColumn_ptr<int> col0 = calTable->getColumn(0);
+    std::vector<int> detIDs = col0->data();
+
+    // DIFC values must match the default (CopyLastGoodPeakParameters=true) results.
+    size_t index = std::find(detIDs.begin(), detIDs.end(), 155) - detIDs.begin();
+    TS_ASSERT_EQUALS(calTable->cell<int>(index, 0), 155);
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), DIFC_155, .01); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);            // difa
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 3), 0);            // tzero
+
+    index = std::find(detIDs.begin(), detIDs.end(), 195) - detIDs.begin();
+    TS_ASSERT_EQUALS(calTable->cell<int>(index, 0), 195);
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), DIFC_155, .01); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);            // difa
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 3), 0);            // tzero
+
+    MatrixWorkspace_const_sptr mask = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(prefix + "_mask");
+    TS_ASSERT_EQUALS(mask->y(WKSPINDEX_155)[0], 0);
+    TS_ASSERT_EQUALS(mask->y(WKSPINDEX_195)[0], 0);
+
+    Mantid::API::AnalysisDataService::Instance().remove(prefix + "cal");
+    Mantid::API::AnalysisDataService::Instance().remove(prefix + "_mask");
+  }
+
   // Crop workspace so that final peak is evaluated over a range that includes
   // the last bin (stop regression out of range bug for histo workspaces)
   void test_exec_difc_histo() {

--- a/docs/source/algorithms/FitPeaks-v1.rst
+++ b/docs/source/algorithms/FitPeaks-v1.rst
@@ -62,6 +62,59 @@ user's input.
 The first peak will be fit with the starting value provided by the user.
 except background and peak center, which will be determiend by *observation*.
 
+Peak parameter initialisation order
+####################################
+
+Once at least one peak has been successfully fitted, the starting parameters for
+subsequent peaks are determined in the following priority order:
+
+1. **Same peak in a previous spectrum** — if the same peak was successfully
+   fitted in an earlier spectrum and the current spectrum has a consecutive
+   detector ID with the spectrum that produced that fit, those fitted
+   parameters are used as the starting point.
+
+2. **Last successfully fitted peak in the current spectrum** — if cross-spectrum
+   parameters are not available and ``CopyLastGoodPeakParameters`` is ``True``
+   (the default), the parameters from the most recently fitted peak *in the
+   same spectrum* are copied as starting values. This is generally a good
+   strategy because physically nearby peaks tend to have similar profile
+   parameters.
+
+3. **IDF / Parameter File defaults** — if neither of the above applies (e.g.
+   the very first peak in the first spectrum), the peak function retains the
+   default values from the Instrument Definition File (IDF). For peak functions
+   such as :ref:`func-BackToBackExponential`, the ``setMatrixWorkspace`` call
+   can calculate parameters (e.g. *A* and *B*) from formulae in the
+   ``INSTR_Parameter.xml`` file, which can provide physically meaningful
+   starting values.
+
+4. **Internal estimation routines** — peak centre, height and FWHM are always
+   estimated by *observation* of the data within the fit window (see
+   `Estimation of values of peak profiles`_ below). User-specified starting
+   values (``PeakParameterNames`` / ``PeakParameterValues``) are applied when
+   no parameter copying has occurred.
+
+Parameters marked as ``<fixed />`` in the Parameter File are applied as
+**ties** by ``setMatrixWorkspace()``. This means that regardless of which step
+above sets the starting values, these tied parameters are forced back to their
+IDF-calculated values during each iteration of the fit. In effect, they act as
+constraints that override any values copied from neighbouring peaks.
+
+CopyLastGoodPeakParameters
+==========================
+
+The ``CopyLastGoodPeakParameters`` property (default ``True``) controls whether
+step 2 above is used. Copying parameters from the last successfully fitted peak
+in the same spectrum is, in general, a good way of providing physically sensible
+starting values and has been retained as the default behaviour.
+
+However, in situations where peak parameters are highly wavelength-dependent but
+are *not* marked as fixed in the Parameter File, copying from a peak at a
+potentially very different wavelength can give a worse starting position than the
+default or data-driven estimation. Setting ``CopyLastGoodPeakParameters`` to
+``False`` disables step 2, so the algorithm falls through directly to the IDF
+defaults (step 3) and internal estimation (step 4) for each peak independently.
+
 Background
 ##########
 

--- a/docs/source/release/v6.16.0/Diffraction/Powder/New_features/41021.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Powder/New_features/41021.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-FitPeaks` and :ref:`algm-PDCalibration` now take a boolean flag to optionally disable inheriting initial peak-shape parameters from the most recently successful peak fit within the same spectrum.

--- a/instrument/ENGIN-X_Parameters.xml
+++ b/instrument/ENGIN-X_Parameters.xml
@@ -136,16 +136,6 @@ the create a distinct ENTITY for each bank-->
     <value val="0,1,0"/>
   </parameter>
 
-  <parameter name="BackToBackExponential:S" type="fitting">
-    <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
-  </parameter>
-  <parameter name="BackToBackExponential:A" type="fitting">
-    <formula eq="((&alpha_0;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>
-  <parameter name="BackToBackExponential:B" type="fitting">
-    <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
-  </parameter>
-
 </component-link>
 
 </parameter-file>

--- a/instrument/ENGIN-X_Parameters.xml
+++ b/instrument/ENGIN-X_Parameters.xml
@@ -136,6 +136,16 @@ the create a distinct ENTITY for each bank-->
     <value val="0,1,0"/>
   </parameter>
 
+  <parameter name="BackToBackExponential:S" type="fitting">
+    <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
+  </parameter>
+  <parameter name="BackToBackExponential:A" type="fitting">
+    <formula eq="((&alpha_0;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
+  <parameter name="BackToBackExponential:B" type="fitting">
+    <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+  </parameter>
+
 </component-link>
 
 </parameter-file>


### PR DESCRIPTION
### Description of work

Not sure if this is a bug or just a slightly misleading comment but previously the behaviour was: 

Peaks are fit sequentially (either left to right or right to left), with the peak parameters initially taken from 

1. The same peak in another spectrum
2. Or either: the algorithm's parameter estimation routines; or the defaults for that peak function (which have the ability to be good if there is an appropriate formula in the INSTR_Parameter.xml file).

(This PR is meant to address when the first check is unsuccessful, either when the fit is performed on the first spectrum of the workspace, or it just happens that the peak in question hasn't been successfully fit elsewhere.)

Once a peak in the given spectrum has been fit, however, the parameters are then taken in the order:

1. The same peak in another spectrum
2. The parameters of the last peak in this spectrum to be successfully fit (with any parameters marked as fixed in the Parameter File overwriting those copied from the nearest peak)
3. The defaults for that peak function if they exist on the IDF (which have the ability to be good if there is an appropriate formula in the INSTR_Parameter.xml file).
4. The algorithm's internal parameter estimation routines

This copying from the last peak in this spectrum, in general, a good way of setting starting parameters for new fits that are physically sensible and has been retained as the default behaviour. 

The new functionality is to optionally turn off this parameter copying behaviour in situations where the peak parameters are highly wavelength dependent but aren't marked as fixed in the Parameters File, and so copying the parameters from a peak at a potentially very different wavelength gives a worse starting position than the default/ data-driven estimation. (it essentially lets the user skip step 2 straight to step 3)

Specifically, this seems like it will be useful for setting up the calibration for IMAT (https://github.com/mantidproject/mantid/pull/40842)

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
