### PR TITLE
Replace pytz with stdlib zoneinfo across timezone

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/FacilityInfo.h
+++ b/Framework/Kernel/inc/MantidKernel/FacilityInfo.h
@@ -49,7 +49,7 @@ public:
   /// Returns the preferred file extension
   const std::string &preferredExtension() const { return m_extensions.front(); }
 
-  /// Returns the time zone designation compatible with pytz
+  /// Returns the time zone designation compatible with zoneinfo
   const std::string &timezone() const { return m_timezone; }
 
   /// Return the archive search interface names
@@ -86,7 +86,7 @@ private:
 
   CatalogInfo m_catalogs;                    ///< Gain access to the catalogInfo class.
   const std::string m_name;                  ///< facility name
-  std::string m_timezone;                    ///< Timezone designation in pytz
+  std::string m_timezone;                    ///< Timezone designation in zoneinfo
   int m_zeroPadding;                         ///< default zero padding for this facility
   std::string m_delimiter;                   ///< default delimiter between instrument name and run number
   std::vector<std::string> m_extensions;     ///< file extensions in order of preference

--- a/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/FacilityInfoTest.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from zoneinfo import ZoneInfo
 from mantid.kernel import FacilityInfo, InstrumentInfo, ConfigService
-import pytz
 
 
 class FacilityInfoTest(unittest.TestCase):
@@ -31,13 +31,13 @@ class FacilityInfoTest(unittest.TestCase):
         self.assertEqual(test_facility.timezone(), "Europe/London")
 
     def test_timezones(self):
-        # verify that all of the timezones can get converted by pytz
+        # verify that all of the timezones can get converted by zoneinfo
         for facility in ConfigService.getFacilities():
             if len(facility.timezone()) == 0:
                 continue  # don't test empty strings
-            tz = pytz.timezone(facility.timezone())
+            tz = ZoneInfo(facility.timezone())
             print(facility.name(), tz)
-            self.assertEqual(str(tz), facility.timezone())
+            self.assertEqual(tz.key, facility.timezone())
 
 
 if __name__ == "__main__":

--- a/docs/source/api/python/mantid/kernel/DateAndTime.rst
+++ b/docs/source/api/python/mantid/kernel/DateAndTime.rst
@@ -29,11 +29,11 @@ For converting `numpy.datetime64 <https://docs.scipy.org/doc/numpy/reference/arr
 
 .. code-block:: python
 
-   import pytz
-   tz = pytz.timezone(ConfigService.getFacility().timezone())
+   from zoneinfo import ZoneInfo
+   tz = ZoneInfo(ConfigService.getFacility().timezone())
    times = numpy.datetime_as_string(times, timezone=tz)
 
-This is how numpy internally converts `numpy.datetime64 <https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`_ to strings for printing, but the selection of timezone is explicit (using `pytz <https://pythonhosted.org/pytz/>`_) to allow for matching where the data was recorded rather than the system's timezone.
+This is how numpy internally converts `numpy.datetime64 <https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`_ to strings for printing, but the selection of timezone is explicit (using `zoneinfo <https://docs.python.org/3/library/zoneinfo.html>`_) to allow for matching where the data was recorded rather than the system's timezone.
 
 Converting strings to ``datetime64``
 ------------------------------------

--- a/docs/source/concepts/FacilitiesFile.rst
+++ b/docs/source/concepts/FacilitiesFile.rst
@@ -42,8 +42,8 @@ called *ABCDEF*. The facilities attributes have the following meanings:
 -  ``FileExtensions`` should list the extensions of the data files for
    the facility. The first is taken as the preferred extension.
 - ``timezone`` specifies what timezone the facility is in for use with
-  `pytz <https://pythonhosted.org/pytz/>`_. Valid timezones can be found
-  in python by looking at the list in ``pytz.all_timezones``
+  `zoneinfo <https://docs.python.org/3/library/zoneinfo.html>`_. Valid timezones can be found
+  in python by looking at the set returned by ``zoneinfo.available_timezones()``
 
 An instrument can have further attributes which define properties of the
 that instrument rather than the facility as a whole, e.g.

--- a/docs/source/release/v6.16.0/Framework/Dependencies/New_features/41017.rst
+++ b/docs/source/release/v6.16.0/Framework/Dependencies/New_features/41017.rst
@@ -1,0 +1,1 @@
+- Remove dependency ``pytz`` to prefer using python's built-in ``zoneinfo`` for time zone information


### PR DESCRIPTION
This is a version of #41017 into `ornl-next`