### PR TITLE
AAFPSlim skip banks without calibration or instrument information

### DIFF
--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -49,20 +49,25 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     const int64_t total_events = static_cast<size_t>(tof_SDS.getSpace().getSelectNpoints());
     if (total_events == 0) {
       m_progress->report();
+      g_log.debug() << bankName << " empty\n";
       continue;
     }
-
-    auto eventRanges = this->getEventIndexRanges(event_group, total_events);
-
-    // get handle to the data
-    auto detID_SDS = event_group.openDataSet(NxsFieldNames::DETID);
-    // auto tof_SDS = event_group.openDataSet(NxsFieldNames::TIME_OF_FLIGHT);
     // and the units
     std::string tof_unit;
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
     const auto calibrations = this->getCalibrations(tof_unit, bank_index);
+    if (calibrations.empty()) {
+      m_progress->report();
+      g_log.debug() << "skipping " << bankName << " because calibration is empty\n";
+      continue;
+    }
+
+    auto eventRanges = this->getEventIndexRanges(event_group, total_events);
+
+    // get handle to the detector IDs
+    auto detID_SDS = event_group.openDataSet(NxsFieldNames::DETID);
 
     // declare arrays once so memory can be reused
     auto event_detid = std::make_unique<std::vector<uint32_t>>();       // uint32 for ORNL nexus file

--- a/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/41031.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/41031.rst
@@ -1,0 +1,1 @@
+- Fix bug where not having IDF for some of the pixels resulted in an exception. Now those events are skipped.


### PR DESCRIPTION
In newer VULCAN files (like the one mentioned in the test instructions), there are additional banks that don't exist in the IDF yet. The lack of information to focus those pixels generated an uncaught exception. This change makes it a logged (at debug level) warning.

There is no associated issue, but this is related to [EWM15052](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15052).

### To test:

Reduce the troublesome 2.7GB file
```python
from mantid.simpleapi import *

AlignAndFocusPowderSlim(Filename='VULCAN_260112.nxs.h5', XMin='0.75', XMax='3', LogBlockList='', 
                        OutputWorkspace='VULCAN_217967', ReadSizeFromDisk=100000000, EventsPerThread=100000,
                        L1=43.755, L2='2.296', Polar='90', Azimuthal='180')
```
<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
