### PR TITLE
Fix weighted error propagation in `SumSpectra`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -15,13 +15,9 @@ namespace Mantid {
 
 namespace API { // forward declare
 class ISpectrum;
-}
+} // namespace API
 
 namespace Algorithms {
-
-namespace {
-struct WorkspaceLikeVector;
-}
 
 /** Takes a workspace as input and sums all of the spectra within it maintaining
    the existing bin structure and units.
@@ -67,6 +63,26 @@ public:
   std::map<std::string, std::string> validateInputs() override;
 
 private:
+  struct WorkspaceLikeVector : public std::vector<std::pair<std::vector<double>, std::vector<double>>> {
+    WorkspaceLikeVector(size_t yL, size_t numspec)
+        : std::vector<std::pair<std::vector<double>, std::vector<double>>>(yL) {
+      for (size_t j = 0; j < yL; j++) {
+        this->operator[](j).first.reserve(numspec);
+        this->operator[](j).second.reserve(numspec);
+      }
+      m_specNums.reserve(numspec);
+    }
+    std::vector<size_t> const &specNums() const { return m_specNums; }
+    std::vector<double> const &y(size_t j) const { return this->operator[](j).first; }
+    std::vector<double> const &e(size_t j) const { return this->operator[](j).second; }
+    void insertSpecNum(size_t specNum) { m_specNums.push_back(specNum); }
+    void insertY(size_t j, double const y) { this->operator[](j).first.push_back(y); }
+    void insertE(size_t j, double const e) { this->operator[](j).second.push_back(e); }
+
+  private:
+    std::vector<size_t> m_specNums;
+  };
+
   /// Handle logic for RebinnedOutput workspaces
   void doFractionalSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &, size_t &);
   void doFractionalWeightedSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &,

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -15,6 +15,7 @@ namespace Mantid {
 
 namespace API { // forward declare
 class ISpectrum;
+class SpectrumInfo;
 } // namespace API
 
 namespace DataObjects { // forward declare
@@ -72,51 +73,27 @@ public:
   std::map<std::string, std::string> validateInputs() override;
 
 private:
-  struct WorkspaceLikeVector : public std::vector<std::pair<std::vector<double>, std::vector<double>>> {
-    WorkspaceLikeVector(size_t yL, size_t numspec)
-        : std::vector<std::pair<std::vector<double>, std::vector<double>>>(yL) {
-      for (size_t j = 0; j < yL; j++) {
-        this->operator[](j).first.reserve(numspec);
-        this->operator[](j).second.reserve(numspec);
-      }
-      m_specNums.reserve(numspec);
-    }
-    std::vector<size_t> const &specNums() const { return m_specNums; }
-    std::vector<double> const &y(size_t j) const { return this->operator[](j).first; }
-    std::vector<double> const &e(size_t j) const { return this->operator[](j).second; }
-    void insertSpecNum(size_t specNum) { m_specNums.push_back(specNum); }
-    void insertY(size_t j, double const y) { this->operator[](j).first.push_back(y); }
-    void insertE(size_t j, double const e) { this->operator[](j).second.push_back(e); }
-
-  private:
-    std::vector<size_t> m_specNums;
-  };
-
   /// Handle logic for RebinnedOutput workspaces
-  void doFractionalSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &, WorkspaceLikeVector const &,
-                       API::Progress &, size_t &);
-  void doFractionalWeightedSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &,
-                               WorkspaceLikeVector const &, API::Progress &, size_t &);
+  void doFractionalSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &, API::Progress &, size_t &);
+  void doFractionalWeightedSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &, API::Progress &,
+                               size_t &);
   /// Handle logic for summing standard workspaces
-  void doSimpleSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
-  void doSimpleWeightedSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
+  void doSimpleSum(API::MatrixWorkspace_const_sptr const &, API::ISpectrum &, API::Progress &, size_t &);
+  void doSimpleWeightedSum(API::MatrixWorkspace_const_sptr const &, API::ISpectrum &, API::Progress &, size_t &);
 
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
-  void execEvent(const API::MatrixWorkspace_sptr &outputWorkspace, API::Progress &progress, size_t &numSpectra,
-                 size_t &numMasked, size_t &numZeros);
+  void execEvent(const API::MatrixWorkspace_sptr &outputWorkspace, API::Progress &progress, size_t &numZeros);
   specnum_t getOutputSpecNo(const API::MatrixWorkspace_const_sptr &localworkspace);
 
   API::MatrixWorkspace_sptr replaceSpecialValues();
-  void determineIndices(const size_t numberOfSpectra);
+  size_t determineIndices(API::SpectrumInfo const &, const size_t numberOfSpectra);
 
   /// The output spectrum number
   specnum_t m_outSpecNum{0};
   /// Set true to keep monitors
   bool m_keepMonitors{false};
-  /// Set true to remove special values before processing
-  bool m_replaceSpecialValues{false};
   /// numberOfSpectra in the input
   size_t m_numberOfSpectra{0};
   /// Blocksize of the input workspace

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -68,8 +68,9 @@ public:
 
 private:
   /// Handle logic for RebinnedOutput workspaces
-  void doFractionalSum(const API::MatrixWorkspace_sptr &outputWorkspace, API::Progress &progress, size_t &numSpectra,
-                       size_t &numMasked, size_t &numZeros);
+  void doFractionalSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &, size_t &);
+  void doFractionalWeightedSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &,
+                               size_t &);
   /// Handle logic for summing standard workspaces
   void doSimpleSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
   void doSimpleWeightedSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -17,7 +17,16 @@ namespace API { // forward declare
 class ISpectrum;
 } // namespace API
 
+namespace DataObjects { // forward declare
+class RebinnedOutput;
+using RebinnedOutput_sptr = std::shared_ptr<RebinnedOutput>;
+using RebinnedOutput_const_sptr = std::shared_ptr<const RebinnedOutput>;
+} // namespace DataObjects
+
 namespace Algorithms {
+
+using DataObjects::RebinnedOutput_const_sptr;
+using DataObjects::RebinnedOutput_sptr;
 
 /** Takes a workspace as input and sums all of the spectra within it maintaining
    the existing bin structure and units.
@@ -84,9 +93,10 @@ private:
   };
 
   /// Handle logic for RebinnedOutput workspaces
-  void doFractionalSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &, size_t &);
-  void doFractionalWeightedSum(API::MatrixWorkspace_sptr const &, WorkspaceLikeVector const &, API::Progress &,
-                               size_t &);
+  void doFractionalSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &, WorkspaceLikeVector const &,
+                       API::Progress &, size_t &);
+  void doFractionalWeightedSum(RebinnedOutput_const_sptr const &, RebinnedOutput_sptr const &,
+                               WorkspaceLikeVector const &, API::Progress &, size_t &);
   /// Handle logic for summing standard workspaces
   void doSimpleSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
   void doSimpleWeightedSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -12,7 +12,17 @@
 #include <set>
 
 namespace Mantid {
+
+namespace API { // forward declare
+class ISpectrum;
+}
+
 namespace Algorithms {
+
+namespace {
+struct WorkspaceLikeVector;
+}
+
 /** Takes a workspace as input and sums all of the spectra within it maintaining
    the existing bin structure and units.
     The result is stored as a new workspace containing a single spectra.
@@ -60,9 +70,9 @@ private:
   /// Handle logic for RebinnedOutput workspaces
   void doFractionalSum(const API::MatrixWorkspace_sptr &outputWorkspace, API::Progress &progress, size_t &numSpectra,
                        size_t &numMasked, size_t &numZeros);
-  /// Handle logic for Workspace2D workspaces
-  void doSimpleSum(const API::MatrixWorkspace_sptr &outputWorkspace, API::Progress &progress, size_t &numSpectra,
-                   size_t &numMasked, size_t &numZeros);
+  /// Handle logic for summing standard workspaces
+  void doSimpleSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
+  void doSimpleWeightedSum(API::ISpectrum &, WorkspaceLikeVector const &, API::Progress &, size_t &);
 
   // Overridden Algorithm methods
   void init() override;

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -560,9 +560,9 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
     const auto &e = summingWorkspace.e(j);
     for (size_t i = 0; i < e.size(); i++) {
       double fracVal = (isFinalized ? inWS->readF(specNum[i])[j] : 1.0);
-      double weight = 0.;
-      if (std::isnormal(e[i])) { // is non-zero, nan, or infinity
-        weight = 1. / (e[i] * e[i] * fracVal * fracVal);
+      double weight = e[i] * fracVal;
+      if (std::isnormal(weight)) { // is non-zero, nan, or infinity
+        weight = 1. / (weight * weight);
       } else {
         weight = 0.;
         nZeroes[j]++;

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -458,7 +458,8 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
 
 /**
  * This function handles the logic for summing RebinnedOutput workspaces.
- * @param outputWorkspace the workspace to hold the summed input
+ * @param inWS the input workspace containing the fractional area information
+ * @param outWS the workspace to hold the summed input
  * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
@@ -507,7 +508,8 @@ void SumSpectra::doFractionalSum(RebinnedOutput_const_sptr const &inWS, Rebinned
 
 /**
  * This function handles the logic for summing RebinnedOutput workspaces.
- * @param outputWorkspace the workspace to hold the summed input
+ * @param inWS the input workspace containing the fractional area information
+ * @param outWS the workspace to hold the summed input
  * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -376,7 +376,8 @@ API::MatrixWorkspace_sptr SumSpectra::replaceSpecialValues() {
 /**
  * Perform a simple sum of the spectra in the input workspace, where values for each bin are added together without
  * weighting. The error is propagated as sum-square error.
- * @param outputWorkspace the workspace to hold the summed input
+ * @param outSpec the workspace to hold the summed input
+ * @param summingWorkspace the workspace-like vector containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
@@ -402,11 +403,9 @@ void SumSpectra::doSimpleSum(ISpectrum &outSpec, WorkspaceLikeVector const &summ
 /**
  * Perform a weighted sum of the spectra in the input workspace, where values in each bin are weighted by inverse-square
  * error. Simple error propagation leads to error as the square root of the inverse of the sum of the weights.
- * @param outputWorkspace the workspace to hold the summed input
+ * @param outSpec the workspace to hold the summed input
+ * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
- * @param numSpectra The number of spectra contributed to the sum.
- * @param numMasked The spectra dropped from the summations because they are
- * masked.
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
@@ -458,10 +457,8 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
 /**
  * This function handles the logic for summing RebinnedOutput workspaces.
  * @param outputWorkspace the workspace to hold the summed input
+ * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
- * @param numSpectra The number of spectra contributed to the sum.
- * @param numMasked The spectra dropped from the summations because they are
- * masked.
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
@@ -517,10 +514,8 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
 /**
  * This function handles the logic for summing RebinnedOutput workspaces.
  * @param outputWorkspace the workspace to hold the summed input
+ * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
- * @param numSpectra The number of spectra contributed to the sum.
- * @param numMasked The spectra dropped from the summations because they are
- * masked.
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -205,12 +205,20 @@ bool useSpectrum(const SpectrumInfo &spectrumInfo, const size_t wsIndex, const b
 void SumSpectra::exec() {
   // Try and retrieve the optional properties
   m_keepMonitors = getProperty("IncludeMonitors");
-  m_replaceSpecialValues = getProperty("RemoveSpecialValues");
 
-  // Get the input workspace
+  // setup all of the outputs
+  MatrixWorkspace_sptr outputWorkspace = nullptr;
+  size_t numSpectra(0); // total number of processed spectra
+  size_t numMasked(0);  // total number of the masked and skipped spectra
+  size_t numZeros(0);   // number of spectra which have 0 value in the first column (used in special cases of evaluating
+                        // how good Poissonian statistics is)
+
+  // Get the input workspace -- ths may be a temporary workspace with the special values replaced
   MatrixWorkspace_const_sptr localworkspace = replaceSpecialValues();
+  auto spectrumInfo = localworkspace->spectrumInfo();
   m_numberOfSpectra = static_cast<int>(localworkspace->getNumberHistograms());
-  determineIndices(m_numberOfSpectra);
+  numMasked = determineIndices(spectrumInfo, m_numberOfSpectra);
+  numSpectra = m_indices.size();
   m_yLength = localworkspace->y(*(m_indices.begin())).size();
 
   // determine the output spectrum number
@@ -219,13 +227,6 @@ void SumSpectra::exec() {
 
   m_calculateWeightedSum = getProperty("WeightedSum");
   m_multiplyByNumSpec = getProperty("MultiplyBySpectra");
-
-  // setup all of the outputs
-  MatrixWorkspace_sptr outputWorkspace = nullptr;
-  size_t numSpectra(0); // total number of processed spectra
-  size_t numMasked(0);  // total number of the masked and skipped spectra
-  size_t numZeros(0);   // number of spectra which have 0 value in the first column (used in special cases of evaluating
-                        // how good Poissonian statistics is)
 
   Progress progress(this, 0.0, 1.0, m_indices.size());
   EventWorkspace_const_sptr eventW = std::dynamic_pointer_cast<const EventWorkspace>(localworkspace);
@@ -236,7 +237,7 @@ void SumSpectra::exec() {
     }
     outputWorkspace = create<EventWorkspace>(*eventW, 1, eventW->binEdges(0));
 
-    execEvent(outputWorkspace, progress, numSpectra, numMasked, numZeros);
+    execEvent(outputWorkspace, progress, numZeros);
   } else {
     //-------Workspace 2D mode -----
 
@@ -254,21 +255,8 @@ void SumSpectra::exec() {
     outSpec.setSpectrumNo(m_outSpecNum);
     outSpec.clearDetectorIDs();
 
-    // Create an intermediary workspace, one spectra per bin, each spectra has values from the spectra to be summed.
-    WorkspaceLikeVector pivot(m_yLength, m_indices.size());
-    // loop over spectra
-    auto spectrumInfo = localworkspace->spectrumInfo();
     for (size_t const i : m_indices) {
-      if (useSpectrum(spectrumInfo, i, m_keepMonitors, numMasked)) {
-        numSpectra++;
-        outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
-        pivot.insertSpecNum(i);
-        // loop over bins
-        for (size_t j = 0; j < m_yLength; j++) {
-          pivot.insertY(j, localworkspace->y(i)[j]);
-          pivot.insertE(j, localworkspace->e(i)[j]);
-        }
-      }
+      outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
     }
 
     if (localworkspace->id() == "RebinnedOutput") {
@@ -277,16 +265,16 @@ void SumSpectra::exec() {
       RebinnedOutput_const_sptr inWS = std::dynamic_pointer_cast<const RebinnedOutput>(localworkspace);
       RebinnedOutput_sptr outWS = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
       if (m_calculateWeightedSum) {
-        doFractionalWeightedSum(inWS, outWS, pivot, progress, numZeros);
+        doFractionalWeightedSum(inWS, outWS, progress, numZeros);
       } else {
-        doFractionalSum(inWS, outWS, pivot, progress, numZeros);
+        doFractionalSum(inWS, outWS, progress, numZeros);
       }
     } else {
       // for things where all the bins are lined up
       if (m_calculateWeightedSum) {
-        doSimpleWeightedSum(outSpec, pivot, progress, numZeros);
+        doSimpleWeightedSum(localworkspace, outSpec, progress, numZeros);
       } else {
-        doSimpleSum(outSpec, pivot, progress, numZeros);
+        doSimpleSum(localworkspace, outSpec, progress, numZeros);
       }
     }
   }
@@ -300,7 +288,7 @@ void SumSpectra::exec() {
   setProperty("OutputWorkspace", outputWorkspace);
 }
 
-void SumSpectra::determineIndices(const size_t numberOfSpectra) {
+size_t SumSpectra::determineIndices(SpectrumInfo const &spectrumInfo, const size_t numberOfSpectra) {
   // assume that m_numberOfSpectra has been set
   m_indices.clear();
 
@@ -318,10 +306,17 @@ void SumSpectra::determineIndices(const size_t numberOfSpectra) {
   }
 
   // create the indices in the range
+  size_t numMasked{0};
   if (!isEmpty(maxIndex)) {
-    for (int i = minIndex; i <= maxIndex; i++)
-      m_indices.insert(static_cast<size_t>(i));
+    for (int i = minIndex; i <= maxIndex; i++) {
+      // only include indices that are not masked and, if requested, are not monitors.
+      // the number of masked spectra is counted in numMasked.
+      if (useSpectrum(spectrumInfo, static_cast<size_t>(i), m_keepMonitors, numMasked)) {
+        m_indices.insert(static_cast<size_t>(i));
+      }
+    }
   }
+  return numMasked;
 }
 
 /**
@@ -357,46 +352,49 @@ specnum_t SumSpectra::getOutputSpecNo(const MatrixWorkspace_const_sptr &localwor
 API::MatrixWorkspace_sptr SumSpectra::replaceSpecialValues() {
   // Get a copy of the input workspace
   MatrixWorkspace_sptr wksp = getProperty("InputWorkspace");
-
-  if (!m_replaceSpecialValues) {
+  bool replaceSpecialValues = getProperty("RemoveSpecialValues");
+  if (replaceSpecialValues) {
+    auto alg = createChildAlgorithm("ReplaceSpecialValues");
+    alg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", wksp);
+    std::string outName = "_" + wksp->getName() + "_clean";
+    alg->setProperty("OutputWorkspace", outName);
+    alg->setProperty("NaNValue", 0.0);
+    alg->setProperty("NaNError", 0.0);
+    alg->setProperty("InfinityValue", 0.0);
+    alg->setProperty("InfinityError", 0.0);
+    alg->executeAsChildAlg();
+    return alg->getProperty("OutputWorkspace");
+  } else {
     // Skip any additional processing
     return wksp;
   }
-
-  auto alg = createChildAlgorithm("ReplaceSpecialValues");
-  alg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", wksp);
-  std::string outName = "_" + wksp->getName() + "_clean";
-  alg->setProperty("OutputWorkspace", outName);
-  alg->setProperty("NaNValue", 0.0);
-  alg->setProperty("NaNError", 0.0);
-  alg->setProperty("InfinityValue", 0.0);
-  alg->setProperty("InfinityError", 0.0);
-  alg->executeAsChildAlg();
-  return alg->getProperty("OutputWorkspace");
 }
 
 /**
  * Perform a simple sum of the spectra in the input workspace, where values for each bin are added together without
  * weighting. The error is propagated as sum-square error.
+ * @param inWS the input workspace containing the spectra to be summed
  * @param outSpec the workspace to hold the summed input
- * @param summingWorkspace the workspace-like vector containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doSimpleSum(ISpectrum &outSpec, WorkspaceLikeVector const &summingWorkspace, Progress &progress,
+void SumSpectra::doSimpleSum(MatrixWorkspace_const_sptr const &inWS, ISpectrum &outSpec, Progress &progress,
                              size_t &numZeros) {
   // Get references to the output workspaces's data vectors
   auto &YSum = outSpec.mutableY();
   auto &YErrorSum = outSpec.mutableE();
 
   // Loop over bins
-  for (size_t j = 0; j < m_yLength; j++) {
-    const auto &y = summingWorkspace.y(j);
-    const auto &e = summingWorkspace.e(j);
+  for (size_t jbin = 0; jbin < m_yLength; jbin++) {
+    YSum[jbin] = 0.;
+    YErrorSum[jbin] = 0.;
     // add the values for this bin together using simple summation
-    YSum[j] = std::accumulate(y.begin(), y.end(), 0.);
-    YErrorSum[j] = sqrt(std::accumulate(e.begin(), e.end(), 0., [](double etot, double e) { return etot + e * e; }));
+    for (size_t iwksp : m_indices) {
+      YSum[jbin] += inWS->y(iwksp)[jbin];
+      YErrorSum[jbin] += inWS->e(iwksp)[jbin] * inWS->e(iwksp)[jbin];
+    }
+    YErrorSum[jbin] = sqrt(YErrorSum[jbin]);
     progress.report();
   }
   numZeros = 0;
@@ -405,14 +403,14 @@ void SumSpectra::doSimpleSum(ISpectrum &outSpec, WorkspaceLikeVector const &summ
 /**
  * Perform a weighted sum of the spectra in the input workspace, where values in each bin are weighted by inverse-square
  * error. Simple error propagation leads to error as the square root of the inverse of the sum of the weights.
+ * @param inWS the input workspace containing the spectra to be summed
  * @param outSpec the workspace to hold the summed input
- * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector const &summingWorkspace,
-                                     Progress &progress, size_t &numZeros) {
+void SumSpectra::doSimpleWeightedSum(MatrixWorkspace_const_sptr const &inWS, ISpectrum &outSpec, Progress &progress,
+                                     size_t &numZeros) {
   // Get references to the output workspaces's data vectors
   auto &YSum = outSpec.mutableY();
   auto &YErrorSum = outSpec.mutableE();
@@ -420,35 +418,35 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
   std::vector<size_t> nZeroes(YSum.size(), 0);
 
   // Loop over bins
-  for (size_t j = 0; j < m_yLength; j++) {
-    const auto &y = summingWorkspace.y(j);
-    const auto &e = summingWorkspace.e(j);
-    // loop over spectra
+  for (size_t jbin = 0; jbin < m_yLength; jbin++) {
     double normalization = 0.;
-    YSum[j] = 0.;
-    YErrorSum[j] = 0.;
-    for (size_t i = 0; i < e.size(); i++) {
+    YSum[jbin] = 0.;
+    YErrorSum[jbin] = 0.;
+    // loop over spectra
+    for (size_t iwksp : m_indices) {
       double weight = 0.;
-      if (std::isnormal(e[i])) {
-        weight = 1. / (e[i] * e[i]);
+      double e = inWS->e(iwksp)[jbin];
+      double y = inWS->y(iwksp)[jbin];
+      if (std::isnormal(e)) {
+        weight = 1. / (e * e);
       } else {
         weight = 0.;
-        nZeroes[j]++;
+        nZeroes[jbin]++;
       }
       normalization += weight;
-      YSum[j] += weight * y[i];
+      YSum[jbin] += weight * y;
     }
     // apply the normalization factor
     if (normalization != 0.) {
       normalization = 1. / normalization;
-      YSum[j] *= normalization;
+      YSum[jbin] *= normalization;
       // NOTE: the total error ends up being the root of the normalization factor
-      YErrorSum[j] = sqrt(normalization);
+      YErrorSum[jbin] = sqrt(normalization);
     }
     if (m_multiplyByNumSpec) {
       // NOTE: do not include the zero-weighted values in the number of spectra
-      YSum[j] *= double(e.size() - nZeroes[j]);
-      YErrorSum[j] *= double(e.size() - nZeroes[j]);
+      YSum[jbin] *= double(m_indices.size() - nZeroes[jbin]);
+      YErrorSum[jbin] *= double(m_indices.size() - nZeroes[jbin]);
     }
     progress.report();
   }
@@ -460,13 +458,12 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
  * This function handles the logic for summing RebinnedOutput workspaces.
  * @param inWS the input workspace containing the fractional area information
  * @param outWS the workspace to hold the summed input
- * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
 void SumSpectra::doFractionalSum(RebinnedOutput_const_sptr const &inWS, RebinnedOutput_sptr const &outWS,
-                                 WorkspaceLikeVector const &summingWorkspace, Progress &progress, size_t &numZeros) {
+                                 Progress &progress, size_t &numZeros) {
   // Check finalize state prior to the sum process, at the completion
   // the output is unfinalized
   auto isFinalized = inWS->isFinalized();
@@ -478,22 +475,22 @@ void SumSpectra::doFractionalSum(RebinnedOutput_const_sptr const &inWS, Rebinned
   auto &FracSum = outWS->dataF(0);
 
   // loop over bins
-  const auto &specNum = summingWorkspace.specNums();
-  for (size_t j = 0; j < m_yLength; j++) {
-    YSum[j] = 0.;
-    YErrorSum[j] = 0.;
-    FracSum[j] = 0.;
+  for (size_t jbin = 0; jbin < m_yLength; jbin++) {
+    YSum[jbin] = 0.;
+    YErrorSum[jbin] = 0.;
+    FracSum[jbin] = 0.;
     // loop over spectra
-    const auto &y = summingWorkspace.y(j);
-    const auto &e = summingWorkspace.e(j);
-    for (size_t i = 0; i < e.size(); i++) {
-      // add the values for this bin together using simple summation
-      double fracVal = (isFinalized ? inWS->readF(specNum[i])[j] : 1.0);
-      YSum[j] += fracVal * y[i];
-      YErrorSum[j] += e[i] * e[i] * fracVal * fracVal;
-      FracSum[j] += inWS->readF(specNum[i])[j];
+    for (size_t iwksp : m_indices) {
+      // use the mappin y' --> y * fracVal and e' --> e * fracVal where fracVal is the fractional area for this bin
+      double fracVal = (isFinalized ? inWS->readF(iwksp)[jbin] : 1.0);
+      double y = inWS->y(iwksp)[jbin] * fracVal;
+      double e = inWS->e(iwksp)[jbin] * fracVal;
+      // no do simple sum of the mapped values
+      YSum[jbin] += y;
+      YErrorSum[jbin] += e * e;
+      FracSum[jbin] += inWS->readF(iwksp)[jbin];
     }
-    YErrorSum[j] = sqrt(YErrorSum[j]);
+    YErrorSum[jbin] = sqrt(YErrorSum[jbin]);
     progress.report();
   }
 
@@ -510,14 +507,12 @@ void SumSpectra::doFractionalSum(RebinnedOutput_const_sptr const &inWS, Rebinned
  * This function handles the logic for summing RebinnedOutput workspaces.
  * @param inWS the input workspace containing the fractional area information
  * @param outWS the workspace to hold the summed input
- * @param summingWorkspace the workspace containing the spectra to be summed
  * @param progress the progress indicator
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
 void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, RebinnedOutput_sptr const &outWS,
-                                         WorkspaceLikeVector const &summingWorkspace, Progress &progress,
-                                         size_t &numZeros) {
+                                         Progress &progress, size_t &numZeros) {
   // Check finalize state prior to the sum process, at the completion
   // the output is unfinalized
   auto isFinalized = inWS->isFinalized();
@@ -531,39 +526,40 @@ void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, 
   std::vector<size_t> nZeroes(YSum.size(), 0);
 
   // Loop over bins
-  const auto &specNum = summingWorkspace.specNums();
-  for (size_t j = 0; j < m_yLength; j++) {
-    YSum[j] = 0.;
-    YErrorSum[j] = 0.;
-    FracSum[j] = 0.;
+  for (size_t jbin = 0; jbin < m_yLength; jbin++) {
+    YSum[jbin] = 0.;
+    YErrorSum[jbin] = 0.;
+    FracSum[jbin] = 0.;
     double normalization = 0.;
     // loop over spectra
-    const auto &y = summingWorkspace.y(j);
-    const auto &e = summingWorkspace.e(j);
-    for (size_t i = 0; i < e.size(); i++) {
-      double fracVal = (isFinalized ? inWS->readF(specNum[i])[j] : 1.0);
-      double weight = e[i] * fracVal;
-      if (std::isnormal(weight)) { // is non-zero, nan, or infinity
-        weight = 1. / (weight * weight);
+    for (size_t iwksp : m_indices) {
+      // use the mappin y' --> y * fracVal and e' --> e * fracVal where fracVal is the fractional area for this bin
+      double fracVal = (isFinalized ? inWS->readF(iwksp)[jbin] : 1.0);
+      double y = inWS->y(iwksp)[jbin] * fracVal;
+      double e = inWS->e(iwksp)[jbin] * fracVal;
+      // now perform weghted sum of the mapped values
+      double weight = 0.;
+      if (std::isnormal(e)) { // is non-zero, nan, or infinity
+        weight = 1. / (e * e);
       } else {
         weight = 0.;
-        nZeroes[j]++;
+        nZeroes[jbin]++;
       }
       normalization += weight;
-      YSum[j] += weight * y[i] * fracVal;
-      FracSum[j] += inWS->readF(specNum[i])[j];
+      YSum[jbin] += weight * y;
+      FracSum[jbin] += inWS->readF(iwksp)[jbin];
     }
     // apply the normalization factor
     if (normalization != 0.) {
       normalization = 1. / normalization;
-      YSum[j] *= normalization;
+      YSum[jbin] *= normalization;
       // NOTE: the total error is the sqrt of the normalization factor
-      YErrorSum[j] = sqrt(normalization);
+      YErrorSum[jbin] = sqrt(normalization);
     }
     if (m_multiplyByNumSpec) {
       // NOTE: do not include the zero-weighted values in the number of spectra
-      YSum[j] *= double(e.size() - nZeroes[j]);
-      YErrorSum[j] *= double(e.size() - nZeroes[j]);
+      YSum[jbin] *= double(m_indices.size() - nZeroes[jbin]);
+      YErrorSum[jbin] *= double(m_indices.size() - nZeroes[jbin]);
     }
     progress.report();
   }
@@ -579,14 +575,10 @@ void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, 
 /** Executes the algorithm
  * @param outputWorkspace the workspace to hold the summed input
  * @param progress the progress indicator
- * @param numSpectra The number of spectra contributed to the sum.
- * @param numMasked The spectra dropped from the summations because they are
- * masked.
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::execEvent(const MatrixWorkspace_sptr &outputWorkspace, Progress &progress, size_t &numSpectra,
-                           size_t &numMasked, size_t &numZeros) {
+void SumSpectra::execEvent(const MatrixWorkspace_sptr &outputWorkspace, Progress &progress, size_t &numZeros) {
   MatrixWorkspace_const_sptr localworkspace = getProperty("InputWorkspace");
   EventWorkspace_const_sptr inputWorkspace = std::dynamic_pointer_cast<const EventWorkspace>(localworkspace);
 
@@ -596,20 +588,9 @@ void SumSpectra::execEvent(const MatrixWorkspace_sptr &outputWorkspace, Progress
   outputEL.setSpectrumNo(m_outSpecNum);
   outputEL.clearDetectorIDs();
 
-  const auto &spectrumInfo = inputWorkspace->spectrumInfo();
-
   // count number of events for the output
   std::size_t numOutputEvents{0};
   for (const auto i : m_indices) {
-    if (spectrumInfo.hasDetectors(i)) {
-      // Skip monitors, if the property is set to do so
-      if (!m_keepMonitors && spectrumInfo.isMonitor(i))
-        continue;
-      // Skip masked detectors
-      if (spectrumInfo.isMasked(i)) {
-        continue;
-      }
-    }
     numOutputEvents += inputWorkspace->getSpectrum(i).getNumberEvents();
   }
   outputEL.switchTo(inputWorkspace->getSpectrum(0).getEventType());
@@ -617,18 +598,6 @@ void SumSpectra::execEvent(const MatrixWorkspace_sptr &outputWorkspace, Progress
 
   // Loop over spectra
   for (const auto i : m_indices) {
-    if (spectrumInfo.hasDetectors(i)) {
-      // Skip monitors, if the property is set to do so
-      if (!m_keepMonitors && spectrumInfo.isMonitor(i))
-        continue;
-      // Skip masked detectors
-      if (spectrumInfo.isMasked(i)) {
-        numMasked++;
-        continue;
-      }
-    }
-    numSpectra++;
-
     // Add the event lists with the operator
     const EventList &inputEL = inputWorkspace->getSpectrum(i);
     if (inputEL.empty()) {

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -228,9 +228,9 @@ void SumSpectra::exec() {
   m_calculateWeightedSum = getProperty("WeightedSum");
   m_multiplyByNumSpec = getProperty("MultiplyBySpectra");
 
-  Progress progress(this, 0.0, 1.0, m_indices.size());
   EventWorkspace_const_sptr eventW = std::dynamic_pointer_cast<const EventWorkspace>(localworkspace);
   if (eventW) {
+    Progress progress(this, 0.0, 1.0, m_indices.size());
     if (m_calculateWeightedSum) {
       g_log.warning("Ignoring request for WeightedSum");
       m_calculateWeightedSum = false;
@@ -259,6 +259,7 @@ void SumSpectra::exec() {
       outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
     }
 
+    Progress progress(this, 0.0, 1.0, m_yLenth.size());
     if (localworkspace->id() == "RebinnedOutput") {
       // this version is for a special workspace that has fractional overlap information
       // Transform to real workspace types

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -259,7 +259,7 @@ void SumSpectra::exec() {
       outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
     }
 
-    Progress progress(this, 0.0, 1.0, m_yLenth.size());
+    Progress progress(this, 0.0, 1.0, m_yLength);
     if (localworkspace->id() == "RebinnedOutput") {
       // this version is for a special workspace that has fractional overlap information
       // Transform to real workspace types

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -182,38 +182,6 @@ std::map<std::string, std::string> SumSpectra::validateInputs() {
 }
 
 namespace { // anonymous namespace
-// small function that normalizes the accumulated weight in a consistent fashion
-// the weights are modified in the process
-size_t applyWeight(const size_t numSpectra, HistogramData::HistogramY &y, std::vector<double> &weights,
-                   const std::vector<size_t> &nZeros, const bool multiplyByNumSpec) {
-  // convert weight into proper normalization factor
-  if (multiplyByNumSpec) {
-    std::transform(weights.begin(), weights.end(), nZeros.begin(), weights.begin(),
-                   [numSpectra](const double weight, const size_t nzero) {
-                     if (numSpectra > nzero) {
-                       return static_cast<double>(numSpectra - nzero) / weight;
-                     } else {
-                       return 1.;
-                     }
-                   });
-  } else {
-    std::transform(weights.begin(), weights.end(), nZeros.begin(), weights.begin(),
-                   [numSpectra](const double weight, const size_t nzero) {
-                     if (numSpectra > nzero) {
-                       return 1. / weight;
-                     } else {
-                       return 1.;
-                     }
-                   });
-  }
-
-  // apply the normalization
-  y *= weights;
-
-  // the total number of bins with any zeros between all of the spectra used
-  return std::accumulate(nZeros.begin(), nZeros.end(), size_t(0));
-}
-
 // various checks on the workspace index to see if it should be included in the
 // sum if it is masked, the value of numMasked is incremented
 bool useSpectrum(const SpectrumInfo &spectrumInfo, const size_t wsIndex, const bool keepMonitors, size_t &numMasked) {
@@ -243,7 +211,6 @@ struct WorkspaceLikeVector : public std::vector<std::pair<std::vector<double>, s
   void insertY(size_t j, double const y) { this->operator[](j).first.push_back(y); }
   void insertE(size_t j, double const e) { this->operator[](j).second.push_back(e); }
 };
-
 } // anonymous namespace
 
 /** Executes the algorithm
@@ -318,10 +285,13 @@ void SumSpectra::exec() {
     }
 
     if (localworkspace->id() == "RebinnedOutput") {
-      // this version is for a special workspace that has fractional overlap
-      // information
-      size_t dummyNumSpec = 0, dummyNumMasked = 0;
-      doFractionalSum(outputWorkspace, progress, dummyNumSpec, dummyNumMasked, numZeros);
+      // this version is for a special workspace that has fractional overlap information
+      if (m_calculateWeightedSum) {
+        doFractionalWeightedSum(outputWorkspace, pivot, progress, numZeros);
+      } else {
+        doFractionalSum(outputWorkspace, pivot, progress, numZeros);
+      }
+
     } else {
       // for things where all the bins are lined up
       if (m_calculateWeightedSum) {
@@ -505,8 +475,8 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doFractionalSum(const MatrixWorkspace_sptr &outputWorkspace, Progress &progress, size_t &numSpectra,
-                                 size_t &numMasked, size_t &numZeros) {
+void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
+                                 WorkspaceLikeVector const &summingWorkspace, Progress &progress, size_t &numZeros) {
   // First, we need to clean the input workspace for nan's and inf's in order
   // to treat the data correctly later. This will create a new private
   // workspace that will be retrieved as mutable.
@@ -526,59 +496,102 @@ void SumSpectra::doFractionalSum(const MatrixWorkspace_sptr &outputWorkspace, Pr
   auto &YErrorSum = outSpec.mutableE();
   auto &FracSum = outWS->dataF(0);
 
-  std::vector<double> Weight;
-  std::vector<size_t> nZeros;
-  if (m_calculateWeightedSum) {
-    Weight.assign(YSum.size(), 0);
-    nZeros.assign(YSum.size(), 0);
-  }
-
-  const auto &spectrumInfo = localworkspace->spectrumInfo();
-  // Loop over spectra
-  for (const auto wsIndex : m_indices) {
-    if (!useSpectrum(spectrumInfo, wsIndex, m_keepMonitors, numMasked))
-      continue;
-    numSpectra++;
-
-    // Retrieve the spectrum into a vector
-    const auto &YValues = localworkspace->y(wsIndex);
-    const auto &YErrors = localworkspace->e(wsIndex);
-    const auto &FracArea = inWS->readF(wsIndex);
-
-    if (m_calculateWeightedSum) {
-      for (size_t yIndex = 0; yIndex < m_yLength; ++yIndex) {
-        const double yErrorsVal = YErrors[yIndex];
-        const double fracVal = (isFinalized ? FracArea[yIndex] : 1.0);
-        if (std::isnormal(yErrorsVal)) { // is non-zero, nan, or infinity
-          const double errsq = yErrorsVal * yErrorsVal * fracVal * fracVal;
-          YErrorSum[yIndex] += errsq;
-          Weight[yIndex] += 1. / errsq;
-          YSum[yIndex] += YValues[yIndex] * fracVal / errsq;
-        } else {
-          nZeros[yIndex]++;
-        }
-      }
-    } else {
-      for (size_t yIndex = 0; yIndex < m_yLength; ++yIndex) {
-        const double fracVal = (isFinalized ? FracArea[yIndex] : 1.0);
-        YSum[yIndex] += YValues[yIndex] * fracVal;
-        YErrorSum[yIndex] += YErrors[yIndex] * YErrors[yIndex] * fracVal * fracVal;
-      }
+  // loop over bins
+  for (size_t j = 0; j < m_yLength; j++) {
+    YSum[j] = 0.;
+    YErrorSum[j] = 0.;
+    FracSum[j] = 0.;
+    // loop over spectra
+    const auto &y = summingWorkspace.y(j);
+    const auto &e = summingWorkspace.e(j);
+    for (size_t i = 0; i < e.size(); i++) {
+      // add the values for this bin together using simple summation
+      double fracVal = (isFinalized ? inWS->readF(i)[j] : 1.0);
+      YSum[j] += fracVal * y[i];
+      YErrorSum[j] += e[i] * e[i] * fracVal * fracVal;
+      FracSum[j] += inWS->readF(i)[j];
     }
-    // accumulation of fractional weight is the same
-    std::transform(FracSum.begin(), FracSum.end(), FracArea.begin(), FracSum.begin(), std::plus<double>());
-
-    // Map all the detectors onto the spectrum of the output
-    outSpec.addDetectorIDs(localworkspace->getSpectrum(wsIndex).getDetectorIDs());
-
     progress.report();
   }
 
-  if (m_calculateWeightedSum) {
-    numZeros = applyWeight(numSpectra, YSum, Weight, nZeros, m_multiplyByNumSpec);
-  } else {
-    numZeros = 0;
+  numZeros = 0;
+
+  // Create the correct representation if using fractional area
+  auto useFractionalArea = getProperty("UseFractionalArea");
+  if (useFractionalArea) {
+    outWS->finalize();
   }
+}
+
+/**
+ * This function handles the logic for summing RebinnedOutput workspaces.
+ * @param outputWorkspace the workspace to hold the summed input
+ * @param progress the progress indicator
+ * @param numSpectra The number of spectra contributed to the sum.
+ * @param numMasked The spectra dropped from the summations because they are
+ * masked.
+ * @param numZeros The number of zero bins in histogram workspace or empty
+ * spectra for event workspace.
+ */
+void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorkspace,
+                                         WorkspaceLikeVector const &summingWorkspace, Progress &progress,
+                                         size_t &numZeros) {
+  // First, we need to clean the input workspace for nan's and inf's in order
+  // to treat the data correctly later. This will create a new private
+  // workspace that will be retrieved as mutable.
+  auto localworkspace = replaceSpecialValues();
+
+  // Transform to real workspace types
+  RebinnedOutput_sptr inWS = std::dynamic_pointer_cast<RebinnedOutput>(localworkspace);
+  RebinnedOutput_sptr outWS = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
+
+  // Check finalize state prior to the sum process, at the completion
+  // the output is unfinalized
+  auto isFinalized = inWS->isFinalized();
+
+  // Get references to the output workspaces's data vectors
+  auto &outSpec = outputWorkspace->getSpectrum(0);
+  auto &YSum = outSpec.mutableY();
+  auto &YErrorSum = outSpec.mutableE();
+  auto &FracSum = outWS->dataF(0);
+
+  std::vector<size_t> nZeroes(YSum.size(), 0);
+
+  // Loop over bins
+  for (size_t j = 0; j < m_yLength; j++) {
+    YSum[j] = 0.;
+    YErrorSum[j] = 0.;
+    FracSum[j] = 0.;
+    double normalization = 0.;
+    // loop over spectra
+    const auto &y = summingWorkspace.y(j);
+    const auto &e = summingWorkspace.e(j);
+    for (size_t i = 0; i < e.size(); i++) {
+      double fracVal = (isFinalized ? inWS->readF(i)[j] : 1.0);
+      double weight = 0.;
+      if (std::isnormal(e[i])) { // is non-zero, nan, or infinity
+        weight = 1. / (e[i] * e[i] * fracVal * fracVal);
+      } else {
+        weight = 0.;
+        nZeroes[j]++;
+      }
+      normalization += weight;
+      YSum[j] += weight * y[i] * fracVal;
+      FracSum[j] += inWS->readF(i)[j];
+    }
+    // apply the normalization factor
+    normalization = 1. / normalization;
+    YSum[j] *= normalization;
+    // NOTE: the total error ends up being the root of the normalization factor
+    YErrorSum[j] = sqrt(normalization);
+    if (m_multiplyByNumSpec) {
+      // NOTE: do not include the zero-weighted values in the number of spectra
+      YSum[j] *= double(e.size() - nZeroes[j]);
+      YErrorSum[j] *= double(e.size() - nZeroes[j]);
+    }
+    progress.report();
+  }
+  numZeros = std::accumulate(nZeroes.begin(), nZeroes.end(), size_t(0));
 
   // Create the correct representation if using fractional area
   auto useFractionalArea = getProperty("UseFractionalArea");

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -273,12 +273,14 @@ void SumSpectra::exec() {
 
     if (localworkspace->id() == "RebinnedOutput") {
       // this version is for a special workspace that has fractional overlap information
+      // Transform to real workspace types
+      RebinnedOutput_const_sptr inWS = std::dynamic_pointer_cast<const RebinnedOutput>(localworkspace);
+      RebinnedOutput_sptr outWS = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
       if (m_calculateWeightedSum) {
-        doFractionalWeightedSum(outputWorkspace, pivot, progress, numZeros);
+        doFractionalWeightedSum(inWS, outWS, pivot, progress, numZeros);
       } else {
-        doFractionalSum(outputWorkspace, pivot, progress, numZeros);
+        doFractionalSum(inWS, outWS, pivot, progress, numZeros);
       }
-
     } else {
       // for things where all the bins are lined up
       if (m_calculateWeightedSum) {
@@ -462,23 +464,14 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
+void SumSpectra::doFractionalSum(RebinnedOutput_const_sptr const &inWS, RebinnedOutput_sptr const &outWS,
                                  WorkspaceLikeVector const &summingWorkspace, Progress &progress, size_t &numZeros) {
-  // First, we need to clean the input workspace for nan's and inf's in order
-  // to treat the data correctly later. This will create a new private
-  // workspace that will be retrieved as mutable.
-  auto localworkspace = replaceSpecialValues();
-
-  // Transform to real workspace types
-  RebinnedOutput_sptr inWS = std::dynamic_pointer_cast<RebinnedOutput>(localworkspace);
-  RebinnedOutput_sptr outWS = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
-
   // Check finalize state prior to the sum process, at the completion
   // the output is unfinalized
   auto isFinalized = inWS->isFinalized();
 
   // Get references to the output workspaces's data vectors
-  auto &outSpec = outputWorkspace->getSpectrum(0);
+  auto &outSpec = outWS->getSpectrum(0);
   auto &YSum = outSpec.mutableY();
   auto &YErrorSum = outSpec.mutableE();
   auto &FracSum = outWS->dataF(0);
@@ -499,6 +492,7 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
       YErrorSum[j] += e[i] * e[i] * fracVal * fracVal;
       FracSum[j] += inWS->readF(specNum[i])[j];
     }
+    YErrorSum[j] = sqrt(YErrorSum[j]);
     progress.report();
   }
 
@@ -507,7 +501,7 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
   // Create the correct representation if using fractional area
   auto useFractionalArea = getProperty("UseFractionalArea");
   if (useFractionalArea) {
-    outWS->finalize();
+    outWS->finalize(/*hasSqrdErrs =*/false);
   }
 }
 
@@ -519,24 +513,15 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorkspace,
+void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, RebinnedOutput_sptr const &outWS,
                                          WorkspaceLikeVector const &summingWorkspace, Progress &progress,
                                          size_t &numZeros) {
-  // First, we need to clean the input workspace for nan's and inf's in order
-  // to treat the data correctly later. This will create a new private
-  // workspace that will be retrieved as mutable.
-  auto localworkspace = replaceSpecialValues();
-
-  // Transform to real workspace types
-  RebinnedOutput_sptr inWS = std::dynamic_pointer_cast<RebinnedOutput>(localworkspace);
-  RebinnedOutput_sptr outWS = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
-
   // Check finalize state prior to the sum process, at the completion
   // the output is unfinalized
   auto isFinalized = inWS->isFinalized();
 
   // Get references to the output workspaces's data vectors
-  auto &outSpec = outputWorkspace->getSpectrum(0);
+  auto &outSpec = outWS->getSpectrum(0);
   auto &YSum = outSpec.mutableY();
   auto &YErrorSum = outSpec.mutableE();
   auto &FracSum = outWS->dataF(0);
@@ -570,7 +555,7 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
     if (normalization != 0.) {
       normalization = 1. / normalization;
       YSum[j] *= normalization;
-      // NOTE: the total error ends up being the root of the normalization factor
+      // NOTE: the total error is the sqrt of the normalization factor
       YErrorSum[j] = sqrt(normalization);
     }
     if (m_multiplyByNumSpec) {
@@ -585,7 +570,7 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
   // Create the correct representation if using fractional area
   auto useFractionalArea = getProperty("UseFractionalArea");
   if (useFractionalArea) {
-    outWS->finalize();
+    outWS->finalize(/*hasSqrdErrs =*/false);
   }
 }
 

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -197,20 +197,6 @@ bool useSpectrum(const SpectrumInfo &spectrumInfo, const size_t wsIndex, const b
   }
   return true;
 }
-
-struct WorkspaceLikeVector : public std::vector<std::pair<std::vector<double>, std::vector<double>>> {
-  WorkspaceLikeVector(size_t yL, size_t numspec)
-      : std::vector<std::pair<std::vector<double>, std::vector<double>>>(yL) {
-    for (size_t j = 0; j < yL; j++) {
-      this->operator[](j).first.reserve(numspec);
-      this->operator[](j).second.reserve(numspec);
-    }
-  }
-  std::vector<double> const &y(size_t j) const { return this->operator[](j).first; }
-  std::vector<double> const &e(size_t j) const { return this->operator[](j).second; }
-  void insertY(size_t j, double const y) { this->operator[](j).first.push_back(y); }
-  void insertE(size_t j, double const e) { this->operator[](j).second.push_back(e); }
-};
 } // anonymous namespace
 
 /** Executes the algorithm
@@ -276,6 +262,7 @@ void SumSpectra::exec() {
       if (useSpectrum(spectrumInfo, i, m_keepMonitors, numMasked)) {
         numSpectra++;
         outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
+        pivot.insertSpecNum(i);
         // loop over bins
         for (size_t j = 0; j < m_yLength; j++) {
           pivot.insertY(j, localworkspace->y(i)[j]);
@@ -438,6 +425,7 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
     // loop over spectra
     double normalization = 0.;
     YSum[j] = 0.;
+    YErrorSum[j] = 0.;
     for (size_t i = 0; i < e.size(); i++) {
       double weight = 0.;
       if (std::isnormal(e[i])) {
@@ -450,10 +438,12 @@ void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector con
       YSum[j] += weight * y[i];
     }
     // apply the normalization factor
-    normalization = 1. / normalization;
-    YSum[j] *= normalization;
-    // NOTE: the total error ends up being the root of the normalization factor
-    YErrorSum[j] = sqrt(normalization);
+    if (normalization != 0.) {
+      normalization = 1. / normalization;
+      YSum[j] *= normalization;
+      // NOTE: the total error ends up being the root of the normalization factor
+      YErrorSum[j] = sqrt(normalization);
+    }
     if (m_multiplyByNumSpec) {
       // NOTE: do not include the zero-weighted values in the number of spectra
       YSum[j] *= double(e.size() - nZeroes[j]);
@@ -497,6 +487,7 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
   auto &FracSum = outWS->dataF(0);
 
   // loop over bins
+  const auto &specNum = summingWorkspace.specNums();
   for (size_t j = 0; j < m_yLength; j++) {
     YSum[j] = 0.;
     YErrorSum[j] = 0.;
@@ -506,10 +497,10 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr const &outputWorkspace,
     const auto &e = summingWorkspace.e(j);
     for (size_t i = 0; i < e.size(); i++) {
       // add the values for this bin together using simple summation
-      double fracVal = (isFinalized ? inWS->readF(i)[j] : 1.0);
+      double fracVal = (isFinalized ? inWS->readF(specNum[i])[j] : 1.0);
       YSum[j] += fracVal * y[i];
       YErrorSum[j] += e[i] * e[i] * fracVal * fracVal;
-      FracSum[j] += inWS->readF(i)[j];
+      FracSum[j] += inWS->readF(specNum[i])[j];
     }
     progress.report();
   }
@@ -558,6 +549,7 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
   std::vector<size_t> nZeroes(YSum.size(), 0);
 
   // Loop over bins
+  const auto &specNum = summingWorkspace.specNums();
   for (size_t j = 0; j < m_yLength; j++) {
     YSum[j] = 0.;
     YErrorSum[j] = 0.;
@@ -567,7 +559,7 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
     const auto &y = summingWorkspace.y(j);
     const auto &e = summingWorkspace.e(j);
     for (size_t i = 0; i < e.size(); i++) {
-      double fracVal = (isFinalized ? inWS->readF(i)[j] : 1.0);
+      double fracVal = (isFinalized ? inWS->readF(specNum[i])[j] : 1.0);
       double weight = 0.;
       if (std::isnormal(e[i])) { // is non-zero, nan, or infinity
         weight = 1. / (e[i] * e[i] * fracVal * fracVal);
@@ -577,13 +569,15 @@ void SumSpectra::doFractionalWeightedSum(MatrixWorkspace_sptr const &outputWorks
       }
       normalization += weight;
       YSum[j] += weight * y[i] * fracVal;
-      FracSum[j] += inWS->readF(i)[j];
+      FracSum[j] += inWS->readF(specNum[i])[j];
     }
     // apply the normalization factor
-    normalization = 1. / normalization;
-    YSum[j] *= normalization;
-    // NOTE: the total error ends up being the root of the normalization factor
-    YErrorSum[j] = sqrt(normalization);
+    if (normalization != 0.) {
+      normalization = 1. / normalization;
+      YSum[j] *= normalization;
+      // NOTE: the total error ends up being the root of the normalization factor
+      YErrorSum[j] = sqrt(normalization);
+    }
     if (m_multiplyByNumSpec) {
       // NOTE: do not include the zero-weighted values in the number of spectra
       YSum[j] *= double(e.size() - nZeroes[j]);

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -181,161 +181,6 @@ std::map<std::string, std::string> SumSpectra::validateInputs() {
   return validationOutput;
 }
 
-/** Executes the algorithm
- *
- */
-void SumSpectra::exec() {
-  // Try and retrieve the optional properties
-  m_keepMonitors = getProperty("IncludeMonitors");
-  m_replaceSpecialValues = getProperty("RemoveSpecialValues");
-
-  // Get the input workspace
-  MatrixWorkspace_const_sptr localworkspace = getProperty("InputWorkspace");
-  m_numberOfSpectra = static_cast<int>(localworkspace->getNumberHistograms());
-  determineIndices(m_numberOfSpectra);
-  m_yLength = localworkspace->y(*(m_indices.begin())).size();
-
-  // determine the output spectrum number
-  m_outSpecNum = getOutputSpecNo(localworkspace);
-  g_log.information() << "Spectra remapping gives single spectra with spectra number: " << m_outSpecNum << "\n";
-
-  m_calculateWeightedSum = getProperty("WeightedSum");
-  m_multiplyByNumSpec = getProperty("MultiplyBySpectra");
-
-  // setup all of the outputs
-  MatrixWorkspace_sptr outputWorkspace = nullptr;
-  size_t numSpectra(0); // total number of processed spectra
-  size_t numMasked(0);  // total number of the masked and skipped spectra
-  size_t numZeros(0);   // number of spectra which have 0 value in the first
-  // column (used in special cases of evaluating how good
-  // Poissonian statistics is)
-
-  Progress progress(this, 0.0, 1.0, m_indices.size());
-  EventWorkspace_const_sptr eventW = std::dynamic_pointer_cast<const EventWorkspace>(localworkspace);
-  if (eventW) {
-    if (m_calculateWeightedSum) {
-      g_log.warning("Ignoring request for WeightedSum");
-      m_calculateWeightedSum = false;
-    }
-    outputWorkspace = create<EventWorkspace>(*eventW, 1, eventW->binEdges(0));
-
-    execEvent(outputWorkspace, progress, numSpectra, numMasked, numZeros);
-  } else {
-    //-------Workspace 2D mode -----
-
-    // Create the 2D workspace for the output
-    outputWorkspace = API::WorkspaceFactory::Instance().create(
-        localworkspace, 1, localworkspace->x(*(m_indices.begin())).size(), m_yLength);
-
-    // This is the (only) output spectrum
-    auto &outSpec = outputWorkspace->getSpectrum(0);
-
-    // Copy over the bin boundaries
-    outSpec.setSharedX(localworkspace->sharedX(0));
-
-    // Build a new spectra map
-    outSpec.setSpectrumNo(m_outSpecNum);
-    outSpec.clearDetectorIDs();
-
-    if (localworkspace->id() == "RebinnedOutput") {
-      // this version is for a special workspace that has fractional overlap
-      // information
-      doFractionalSum(outputWorkspace, progress, numSpectra, numMasked, numZeros);
-    } else {
-      // for things where all the bins are lined up
-      doSimpleSum(outputWorkspace, progress, numSpectra, numMasked, numZeros);
-    }
-
-    // take the square root of all the accumulated squared errors - Assumes
-    // Gaussian errors
-    auto &YError = outSpec.mutableE();
-    std::transform(YError.begin(), YError.end(), YError.begin(), static_cast<double (*)(double)>(std::sqrt));
-  }
-
-  // set up the summing statistics
-  outputWorkspace->mutableRun().addProperty("NumAllSpectra", int(numSpectra), "", true);
-  outputWorkspace->mutableRun().addProperty("NumMaskSpectra", int(numMasked), "", true);
-  outputWorkspace->mutableRun().addProperty("NumZeroSpectra", int(numZeros), "", true);
-
-  // Assign it to the output workspace property
-  setProperty("OutputWorkspace", outputWorkspace);
-}
-
-void SumSpectra::determineIndices(const size_t numberOfSpectra) {
-  // assume that m_numberOfSpectra has been set
-  m_indices.clear();
-
-  // try the list form first
-  const std::vector<int> indices_list = getProperty("ListOfWorkspaceIndices");
-  m_indices.insert(indices_list.begin(), indices_list.end());
-
-  // add the range specified by the user
-  // this has been checked to be 0<= m_minWsInd <= maxIndex <=
-  // m_numberOfSpectra where maxIndex can be an EMPTY_INT
-  int minIndex = getProperty("StartWorkspaceIndex");
-  int maxIndex = getProperty("EndWorkspaceIndex");
-  if (isEmpty(maxIndex) && m_indices.empty()) {
-    maxIndex = static_cast<int>(numberOfSpectra - 1);
-  }
-
-  // create the indices in the range
-  if (!isEmpty(maxIndex)) {
-    for (int i = minIndex; i <= maxIndex; i++)
-      m_indices.insert(static_cast<size_t>(i));
-  }
-}
-
-/**
- * Determine the minimum spectrum No for summing. This requires that
- * SumSpectra::indices has aly been set.
- * @param localworkspace The workspace to use.
- * @return The minimum spectrum No for all the spectra being summed.
- */
-specnum_t SumSpectra::getOutputSpecNo(const MatrixWorkspace_const_sptr &localworkspace) {
-  // initial value - any included spectrum will do
-  specnum_t specId = localworkspace->getSpectrum(*(m_indices.begin())).getSpectrumNo();
-
-  // the total number of spectra
-  size_t totalSpec = localworkspace->getNumberHistograms();
-
-  specnum_t temp;
-  for (const auto index : m_indices) {
-    if (index < totalSpec) {
-      temp = localworkspace->getSpectrum(index).getSpectrumNo();
-      if (temp < specId)
-        specId = temp;
-    }
-  }
-
-  return specId;
-}
-
-/**
- * Calls an algorithm to replace special values within the workspace
- * such as NaN or Inf to 0.
- * @return The workspace with special floating point values set to 0
- */
-API::MatrixWorkspace_sptr SumSpectra::replaceSpecialValues() {
-  // Get a copy of the input workspace
-  MatrixWorkspace_sptr wksp = getProperty("InputWorkspace");
-
-  if (!m_replaceSpecialValues) {
-    // Skip any additional processing
-    return wksp;
-  }
-
-  auto alg = createChildAlgorithm("ReplaceSpecialValues");
-  alg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", wksp);
-  std::string outName = "_" + wksp->getName() + "_clean";
-  alg->setProperty("OutputWorkspace", outName);
-  alg->setProperty("NaNValue", 0.0);
-  alg->setProperty("NaNError", 0.0);
-  alg->setProperty("InfinityValue", 0.0);
-  alg->setProperty("InfinityError", 0.0);
-  alg->executeAsChildAlg();
-  return alg->getProperty("OutputWorkspace");
-}
-
 namespace { // anonymous namespace
 // small function that normalizes the accumulated weight in a consistent fashion
 // the weights are modified in the process
@@ -384,10 +229,222 @@ bool useSpectrum(const SpectrumInfo &spectrumInfo, const size_t wsIndex, const b
   }
   return true;
 }
+
+struct WorkspaceLikeVector : public std::vector<std::pair<std::vector<double>, std::vector<double>>> {
+  WorkspaceLikeVector(size_t yL, size_t numspec)
+      : std::vector<std::pair<std::vector<double>, std::vector<double>>>(yL) {
+    for (size_t j = 0; j < yL; j++) {
+      this->operator[](j).first.reserve(numspec);
+      this->operator[](j).second.reserve(numspec);
+    }
+  }
+  std::vector<double> const &y(size_t j) const { return this->operator[](j).first; }
+  std::vector<double> const &e(size_t j) const { return this->operator[](j).second; }
+  void insertY(size_t j, double const y) { this->operator[](j).first.push_back(y); }
+  void insertE(size_t j, double const e) { this->operator[](j).second.push_back(e); }
+};
+
 } // anonymous namespace
 
+/** Executes the algorithm
+ *
+ */
+void SumSpectra::exec() {
+  // Try and retrieve the optional properties
+  m_keepMonitors = getProperty("IncludeMonitors");
+  m_replaceSpecialValues = getProperty("RemoveSpecialValues");
+
+  // Get the input workspace
+  MatrixWorkspace_const_sptr localworkspace = replaceSpecialValues();
+  m_numberOfSpectra = static_cast<int>(localworkspace->getNumberHistograms());
+  determineIndices(m_numberOfSpectra);
+  m_yLength = localworkspace->y(*(m_indices.begin())).size();
+
+  // determine the output spectrum number
+  m_outSpecNum = getOutputSpecNo(localworkspace);
+  g_log.information() << "Spectra remapping gives single spectra with spectra number: " << m_outSpecNum << "\n";
+
+  m_calculateWeightedSum = getProperty("WeightedSum");
+  m_multiplyByNumSpec = getProperty("MultiplyBySpectra");
+
+  // setup all of the outputs
+  MatrixWorkspace_sptr outputWorkspace = nullptr;
+  size_t numSpectra(0); // total number of processed spectra
+  size_t numMasked(0);  // total number of the masked and skipped spectra
+  size_t numZeros(0);   // number of spectra which have 0 value in the first column (used in special cases of evaluating
+                        // how good Poissonian statistics is)
+
+  Progress progress(this, 0.0, 1.0, m_indices.size());
+  EventWorkspace_const_sptr eventW = std::dynamic_pointer_cast<const EventWorkspace>(localworkspace);
+  if (eventW) {
+    if (m_calculateWeightedSum) {
+      g_log.warning("Ignoring request for WeightedSum");
+      m_calculateWeightedSum = false;
+    }
+    outputWorkspace = create<EventWorkspace>(*eventW, 1, eventW->binEdges(0));
+
+    execEvent(outputWorkspace, progress, numSpectra, numMasked, numZeros);
+  } else {
+    //-------Workspace 2D mode -----
+
+    // Create the 2D workspace for the output
+    outputWorkspace = API::WorkspaceFactory::Instance().create(
+        localworkspace, 1, localworkspace->x(*(m_indices.begin())).size(), m_yLength);
+
+    // This is the (only) output spectrum
+    auto &outSpec = outputWorkspace->getSpectrum(0);
+
+    // Copy over the bin boundaries
+    outSpec.setSharedX(localworkspace->sharedX(0));
+
+    // Build a new spectra map
+    outSpec.setSpectrumNo(m_outSpecNum);
+    outSpec.clearDetectorIDs();
+
+    // Create an intermediary workspace, one spectra per bin, each spectra has values from the spectra to be summed.
+    WorkspaceLikeVector pivot(m_yLength, m_indices.size());
+    // loop over spectra
+    auto spectrumInfo = localworkspace->spectrumInfo();
+    for (size_t const i : m_indices) {
+      if (useSpectrum(spectrumInfo, i, m_keepMonitors, numMasked)) {
+        numSpectra++;
+        outSpec.addDetectorIDs(localworkspace->getSpectrum(i).getDetectorIDs());
+        // loop over bins
+        for (size_t j = 0; j < m_yLength; j++) {
+          pivot.insertY(j, localworkspace->y(i)[j]);
+          pivot.insertE(j, localworkspace->e(i)[j]);
+        }
+      }
+    }
+
+    if (localworkspace->id() == "RebinnedOutput") {
+      // this version is for a special workspace that has fractional overlap
+      // information
+      size_t dummyNumSpec = 0, dummyNumMasked = 0;
+      doFractionalSum(outputWorkspace, progress, dummyNumSpec, dummyNumMasked, numZeros);
+    } else {
+      // for things where all the bins are lined up
+      if (m_calculateWeightedSum) {
+        doSimpleWeightedSum(outSpec, pivot, progress, numZeros);
+      } else {
+        doSimpleSum(outSpec, pivot, progress, numZeros);
+      }
+    }
+  }
+
+  // set up the summing statistics
+  outputWorkspace->mutableRun().addProperty("NumAllSpectra", int(numSpectra), "", true);
+  outputWorkspace->mutableRun().addProperty("NumMaskSpectra", int(numMasked), "", true);
+  outputWorkspace->mutableRun().addProperty("NumZeroSpectra", int(numZeros), "", true);
+
+  // Assign it to the output workspace property
+  setProperty("OutputWorkspace", outputWorkspace);
+}
+
+void SumSpectra::determineIndices(const size_t numberOfSpectra) {
+  // assume that m_numberOfSpectra has been set
+  m_indices.clear();
+
+  // try the list form first
+  const std::vector<int> indices_list = getProperty("ListOfWorkspaceIndices");
+  m_indices.insert(indices_list.begin(), indices_list.end());
+
+  // add the range specified by the user
+  // this has been checked to be 0<= m_minWsInd <= maxIndex <=
+  // m_numberOfSpectra where maxIndex can be an EMPTY_INT
+  int minIndex = getProperty("StartWorkspaceIndex");
+  int maxIndex = getProperty("EndWorkspaceIndex");
+  if (isEmpty(maxIndex) && m_indices.empty()) {
+    maxIndex = static_cast<int>(numberOfSpectra - 1);
+  }
+
+  // create the indices in the range
+  if (!isEmpty(maxIndex)) {
+    for (int i = minIndex; i <= maxIndex; i++)
+      m_indices.insert(static_cast<size_t>(i));
+  }
+}
+
 /**
- * This function deals with the logic necessary for summing a Workspace2D.
+ * Determine the minimum spectrum No for summing. This requires that
+ * SumSpectra::indices has aly been set.
+ * @param localworkspace The workspace to use.
+ * @return The minimum spectrum No for all the spectra being summed.
+ */
+specnum_t SumSpectra::getOutputSpecNo(const MatrixWorkspace_const_sptr &localworkspace) {
+  // initial value - any included spectrum will do
+  specnum_t specId = localworkspace->getSpectrum(*m_indices.begin()).getSpectrumNo();
+
+  // the total number of spectra
+  size_t totalSpec = localworkspace->getNumberHistograms();
+
+  specnum_t temp;
+  for (const auto index : m_indices) {
+    if (index < totalSpec) {
+      temp = localworkspace->getSpectrum(index).getSpectrumNo();
+      if (temp < specId)
+        specId = temp;
+    }
+  }
+
+  return specId;
+}
+
+/**
+ * Calls an algorithm to replace special values within the workspace
+ * such as NaN or Inf to 0.
+ * @return The workspace with special floating point values set to 0
+ */
+API::MatrixWorkspace_sptr SumSpectra::replaceSpecialValues() {
+  // Get a copy of the input workspace
+  MatrixWorkspace_sptr wksp = getProperty("InputWorkspace");
+
+  if (!m_replaceSpecialValues) {
+    // Skip any additional processing
+    return wksp;
+  }
+
+  auto alg = createChildAlgorithm("ReplaceSpecialValues");
+  alg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", wksp);
+  std::string outName = "_" + wksp->getName() + "_clean";
+  alg->setProperty("OutputWorkspace", outName);
+  alg->setProperty("NaNValue", 0.0);
+  alg->setProperty("NaNError", 0.0);
+  alg->setProperty("InfinityValue", 0.0);
+  alg->setProperty("InfinityError", 0.0);
+  alg->executeAsChildAlg();
+  return alg->getProperty("OutputWorkspace");
+}
+
+/**
+ * Perform a simple sum of the spectra in the input workspace, where values for each bin are added together without
+ * weighting. The error is propagated as sum-square error.
+ * @param outputWorkspace the workspace to hold the summed input
+ * @param progress the progress indicator
+ * @param numZeros The number of zero bins in histogram workspace or empty
+ * spectra for event workspace.
+ */
+void SumSpectra::doSimpleSum(ISpectrum &outSpec, WorkspaceLikeVector const &summingWorkspace, Progress &progress,
+                             size_t &numZeros) {
+  // Get references to the output workspaces's data vectors
+  auto &YSum = outSpec.mutableY();
+  auto &YErrorSum = outSpec.mutableE();
+
+  // Loop over bins
+  for (size_t j = 0; j < m_yLength; j++) {
+    const auto &y = summingWorkspace.y(j);
+    const auto &e = summingWorkspace.e(j);
+    // add the values for this bin together using simple summation
+    YSum[j] = std::accumulate(y.begin(), y.end(), 0.);
+    YErrorSum[j] = sqrt(std::accumulate(e.begin(), e.end(), 0., [](double etot, double e) { return etot + e * e; }));
+    progress.report();
+  }
+  numZeros = 0;
+}
+
+/**
+ * Perform a weighted sum of the spectra in the input workspace, where values in each bin are weighted by inverse-square
+ * error. Simple error propagation leads to error as the square root of the inverse of the sum of the weights.
  * @param outputWorkspace the workspace to hold the summed input
  * @param progress the progress indicator
  * @param numSpectra The number of spectra contributed to the sum.
@@ -396,63 +453,46 @@ bool useSpectrum(const SpectrumInfo &spectrumInfo, const size_t wsIndex, const b
  * @param numZeros The number of zero bins in histogram workspace or empty
  * spectra for event workspace.
  */
-void SumSpectra::doSimpleSum(const MatrixWorkspace_sptr &outputWorkspace, Progress &progress, size_t &numSpectra,
-                             size_t &numMasked, size_t &numZeros) {
-  // Clean workspace of any NANs or Inf values
-  auto localworkspace = replaceSpecialValues();
-
+void SumSpectra::doSimpleWeightedSum(ISpectrum &outSpec, WorkspaceLikeVector const &summingWorkspace,
+                                     Progress &progress, size_t &numZeros) {
   // Get references to the output workspaces's data vectors
-  auto &outSpec = outputWorkspace->getSpectrum(0);
   auto &YSum = outSpec.mutableY();
   auto &YErrorSum = outSpec.mutableE();
 
-  std::vector<double> Weight;
-  std::vector<size_t> nZeros;
-  if (m_calculateWeightedSum) {
-    Weight.assign(YSum.size(), 0.);
-    nZeros.assign(YSum.size(), 0);
-  }
+  std::vector<size_t> nZeroes(YSum.size(), 0);
 
-  const auto &spectrumInfo = localworkspace->spectrumInfo();
-  // Loop over spectra
-  for (const auto wsIndex : m_indices) {
-    if (!useSpectrum(spectrumInfo, wsIndex, m_keepMonitors, numMasked))
-      continue;
-    numSpectra++;
-
-    const auto &YValues = localworkspace->y(wsIndex);
-    const auto &YErrors = localworkspace->e(wsIndex);
-
-    if (m_calculateWeightedSum) {
-      // Retrieve the spectrum into a vector
-      for (size_t yIndex = 0; yIndex < m_yLength; ++yIndex) {
-        const double yErrorsVal = YErrors[yIndex];
-        if (std::isnormal(yErrorsVal)) { // is non-zero, nan, or infinity
-          const double errsq = yErrorsVal * yErrorsVal;
-          YErrorSum[yIndex] += errsq;
-          Weight[yIndex] += 1. / errsq;
-          YSum[yIndex] += YValues[yIndex] / errsq;
-        } else {
-          nZeros[yIndex]++;
-        }
+  // Loop over bins
+  for (size_t j = 0; j < m_yLength; j++) {
+    const auto &y = summingWorkspace.y(j);
+    const auto &e = summingWorkspace.e(j);
+    // loop over spectra
+    double normalization = 0.;
+    YSum[j] = 0.;
+    for (size_t i = 0; i < e.size(); i++) {
+      double weight = 0.;
+      if (std::isnormal(e[i])) {
+        weight = 1. / (e[i] * e[i]);
+      } else {
+        weight = 0.;
+        nZeroes[j]++;
       }
-    } else {
-      YSum += YValues;
-      std::transform(YErrorSum.begin(), YErrorSum.end(), YErrors.begin(), YErrorSum.begin(),
-                     [](const double accum, const double yerrorSpec) { return accum + yerrorSpec * yerrorSpec; });
+      normalization += weight;
+      YSum[j] += weight * y[i];
     }
-
-    // Map all the detectors onto the spectrum of the output
-    outSpec.addDetectorIDs(localworkspace->getSpectrum(wsIndex).getDetectorIDs());
-
+    // apply the normalization factor
+    normalization = 1. / normalization;
+    YSum[j] *= normalization;
+    // NOTE: the total error ends up being the root of the normalization factor
+    YErrorSum[j] = sqrt(normalization);
+    if (m_multiplyByNumSpec) {
+      // NOTE: do not include the zero-weighted values in the number of spectra
+      YSum[j] *= double(e.size() - nZeroes[j]);
+      YErrorSum[j] *= double(e.size() - nZeroes[j]);
+    }
     progress.report();
   }
-
-  if (m_calculateWeightedSum) {
-    numZeros = applyWeight(numSpectra, YSum, Weight, nZeros, m_multiplyByNumSpec);
-  } else {
-    numZeros = 0;
-  }
+  // add up all zeros across the bins to get the total number of spectra that were dropped from the sum
+  numZeros = std::accumulate(nZeroes.begin(), nZeroes.end(), size_t(0));
 }
 
 /**

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -362,6 +362,7 @@ public:
     alg2.setPropertyValue("OutputWorkspace", outputSpace2);
     alg2.setProperty("IncludeMonitors", false);
     alg2.setProperty("WeightedSum", true);
+    // NOTE "MultiplyBySpectra" set to True by default
 
     TS_ASSERT_THROWS_NOTHING(alg2.execute());
     TS_ASSERT(alg2.isExecuted());
@@ -398,6 +399,8 @@ public:
     TS_ASSERT_DELTA(y[7], double(nSignals) * y0[7], 1.e-6);
     TS_ASSERT_DELTA(y[38], double(nSignals - 1) * y0[38], 1.e-6);
     TS_ASSERT_DELTA(y[72], double(nSignals) * y0[72], 1.e-6);
+    // NOTE: since all errors are the same and we are multiplying by num spectra, then
+    // error = Nspec * sqrt( 1. / sum( 1. / e0^2)) = Nspec * e0 / sqrt(Nspec) = sqrt(Nspec) * e0
     TS_ASSERT_DELTA(e[28], std::sqrt(double(nSignals)) * e0[28], 0.00001);
     TS_ASSERT_DELTA(e[38], std::sqrt(double(nSignals - 1)) * e0[38], 0.00001);
     TS_ASSERT_DELTA(e[47], std::sqrt(double(nSignals)) * e0[47], 0.00001);
@@ -467,10 +470,10 @@ public:
     TS_ASSERT_DELTA(y[7], y0[7], 1.e-6);
     TS_ASSERT_DELTA(y[38], y0[38], 1.e-6);
     TS_ASSERT_DELTA(y[72], y0[72], 1.e-6);
-    TS_ASSERT_DELTA(e[28], std::sqrt(double(nSignals)) * e0[28], 0.00001);
-    TS_ASSERT_DELTA(e[38], std::sqrt(double(nSignals - 1)) * e0[38], 0.00001);
-    TS_ASSERT_DELTA(e[47], std::sqrt(double(nSignals)) * e0[47], 0.00001);
-    TS_ASSERT_DELTA(e[99], std::sqrt(double(nSignals)) * e0[99], 0.00001);
+    TS_ASSERT_DELTA(e[28], e0[28] / std::sqrt(double(nSignals)), 0.00001);
+    TS_ASSERT_DELTA(e[38], e0[38] / std::sqrt(double(nSignals - 1)), 0.00001);
+    TS_ASSERT_DELTA(e[47], e0[47] / std::sqrt(double(nSignals)), 0.00001);
+    TS_ASSERT_DELTA(e[99], e0[99] / std::sqrt(double(nSignals)), 0.00001);
 
     // Check the detectors mapped to the single spectra
     const auto &spec = output2D->getSpectrum(0);

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -235,6 +235,41 @@ public:
     TS_ASSERT_EQUALS(boost::lexical_cast<std::string>(0), output2D->run().getLogData("NumZeroSpectra")->value())
   }
 
+  void testSumErrorIsNotWeightedSumError() {
+    if (!alg.isInitialized()) {
+      alg.initialize();
+      alg.setRethrows(true);
+    }
+
+    // Run once simply summing the workspaces
+    const std::string outputSpace1 = "SumSpectraOut1";
+    alg.setProperty("InputWorkspace", inputSpace);
+    alg.setPropertyValue("OutputWorkspace", outputSpace1);
+    alg.execute();
+    alg.isExecuted();
+
+    // Run again woth weighted sum
+    const std::string outputSpace2 = "SumSpectraOut2";
+    alg.setProperty("InputWorkspace", inputSpace);
+    alg.setPropertyValue("OutputWorkspace", outputSpace2);
+    alg.setProperty("WeightedSum", true);
+    alg.setProperty("MultiplyBySpectra", false);
+    alg.execute();
+    alg.isExecuted();
+
+    auto const wsSum =
+        std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(outputSpace1));
+    auto const wsWeightedSum =
+        std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(outputSpace2));
+
+    const auto &eSum = wsSum->e(0);
+    const auto &eWeightedSum = wsWeightedSum->e(0);
+    for (size_t j = 0; j < eSum.size(); ++j) {
+      TS_ASSERT_DIFFERS(eSum[j], eWeightedSum[j]);
+      TS_ASSERT_LESS_THAN(eWeightedSum[j], eSum[j]);
+    }
+  }
+
   void testExecEvent_inplace() { dotestExecEvent("testEvent", "testEvent", "5,10-15"); }
 
   void testExecEvent_copy() { dotestExecEvent("testEvent", "testEvent2", "5,10-15"); }

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -156,7 +156,7 @@ public:
 
     // Check the detectors mapped to the single spectra
     const auto &spec = output2D->getSpectrum(0);
-    TS_ASSERT_EQUALS(spec.getSpectrumNo(), 2);
+    TS_ASSERT_EQUALS(spec.getSpectrumNo(), 3);
     TS_ASSERT_EQUALS(spec.getDetectorIDs().size(), 2);
     TS_ASSERT(spec.hasDetectorID(3));
     TS_ASSERT(spec.hasDetectorID(4));

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -313,11 +313,11 @@ public:
       TS_ASSERT_EQUALS(output->blocksize(), 6);
       // Row with full acceptance
       TS_ASSERT_EQUALS(output->y(0)[1], 1.);
-      TS_ASSERT_DELTA(output->e(0)[1], 0.1666666666, 1.e-5);
+      TS_ASSERT_DELTA(output->e(0)[1], 0.40824829046386296, 1.e-5);
       TS_ASSERT_EQUALS(output->dataF(0)[1], 6.);
       // Row with limited, but non-zero acceptance, shouldn't have nans!
       TS_ASSERT_DELTA(output->y(0)[5], 0.66666, 1.e-5);
-      TS_ASSERT_DELTA(output->e(0)[5], 0.2222222222, 1.e-5);
+      TS_ASSERT_DELTA(output->e(0)[5], 0.47140452079103173, 1.e-5);
       TS_ASSERT_EQUALS(output->dataF(0)[5], 3.);
 
       TS_ASSERT(output->run().hasProperty("NumAllSpectra"))

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -313,11 +313,11 @@ public:
       TS_ASSERT_EQUALS(output->blocksize(), 6);
       // Row with full acceptance
       TS_ASSERT_EQUALS(output->y(0)[1], 1.);
-      TS_ASSERT_DELTA(output->e(0)[1], 0.40824829046386296, 1.e-5);
+      TS_ASSERT_DELTA(output->e(0)[1], 0.1666666666, 1.e-5);
       TS_ASSERT_EQUALS(output->dataF(0)[1], 6.);
       // Row with limited, but non-zero acceptance, shouldn't have nans!
       TS_ASSERT_DELTA(output->y(0)[5], 0.66666, 1.e-5);
-      TS_ASSERT_DELTA(output->e(0)[5], 0.47140452079103173, 1.e-5);
+      TS_ASSERT_DELTA(output->e(0)[5], 0.2222222222, 1.e-5);
       TS_ASSERT_EQUALS(output->dataF(0)[5], 3.);
 
       TS_ASSERT(output->run().hasProperty("NumAllSpectra"))
@@ -517,10 +517,9 @@ public:
       }
       sum += 1.;
       weightSum += 1 / testVal[i];
-      testSig += testVal[i];
     }
     testRez = nHist * sum / weightSum;
-    testSig = std::sqrt(testSig);
+    testSig = nHist * sqrt(1. / weightSum);
     // Set the properties
     alg2.setProperty("InputWorkspace", tws);
     alg2.setPropertyValue("OutputWorkspace", outName);

--- a/docs/source/algorithms/SumSpectra-v1.rst
+++ b/docs/source/algorithms/SumSpectra-v1.rst
@@ -16,29 +16,37 @@ spectra.
 
 If we define a the :math:`i^{th}` spectrum with bins :math:`j`. The unweighted sum is just (``WeightedSum=False``)
 
-.. math:: Signal[j] = \displaystyle\Sigma_{i \in spectra} Signal_i[j]
+.. math:: Signal[j] = \sum_{i \in spectra} Signal_i[j]
 
 and the corresponding error is correctly propagated as
 
-.. math:: Error[j] = \sqrt{\displaystyle\Sigma_{i \in spectra} Error_i^2[j]}.
+.. math:: Error[j] = \sqrt{\sum_{i \in spectra} Error_i^2[j]}.
 
 The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=False``, ignored for event workspaces)
 is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`),
 
-.. math:: Signal[j] = \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right) / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+.. math:: Signal[j] = \frac{
+        \sum_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right)
+    }{
+        \sum_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+    }
 
 and the error is correctly propagated as
 
-.. math:: Error[j] = \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)}.
+.. math:: Error[j] = \sqrt{\frac{1}{\sum_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)}}.
 
 The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=True``, ignored for event workspaces)
 is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`) as
 
-.. math:: Signal[j] = NSpectra \times \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right) / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+.. math:: Signal[j] = \frac{
+        NSpectra \times \sum_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right)
+    }{
+        \sum_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+    }
 
 and the error is correctly propagated as
 
-.. math:: Error[j] = NSpectra \times \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)},
+.. math:: Error[j] = NSpectra \times \sqrt{\frac{1}{\sum_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)}},
 
 where :math:`NSpectra` is the number of spectra contributing to that bin.
 If the weights contributing to the sum are equal, these result in the same value.
@@ -49,24 +57,38 @@ then multiplying by the number of spectra contributing to the bin is incorrect,
 use ``WeightedSum=True`` and ``MultiplyBySpectra=False``.
 
 If a workspace contains fractional bins, it is useful to consider an "effective" signal and error
-given by :math:`\tilde{Signal}_i[j] = Signal_i[j] fracVal_i[j]`
-and :math:`\tilde{Error}_i[j] = Error_i[j] fracVal_i[j]`,
+given by :math:`\overline{Signal}_i[j] = Signal_i[j] \timex fracVal_i[j]`
+and :math:`\overline{Error}_i[j] = Error_i[j] \times fracVal_i[j]`,
 where :math:`fracVal_i[j]` is the fractional value for the bin.
 Then the unweighted sum with fractional bins is defined as
 
-.. math:: Signal[j] = \sum_{i \in spectra} \tilde{Signal}_i[j] = \displaystyle\Sigma_{i \in spectra} Signal_i[j] fracVal_i[j],
+.. math:: Signal[j] = \sum_{i \in spectra} \overline{Signal}_i[j]
+    = \sum_{i \in spectra} Signal_i[j] \times fracVal_i[j],
 
 with error
 
-.. math:: Error[j] = \sqrt{\sum_{i \in spectra} \tilde{Error}_i[j]^2} = \sqrt{\displaystyle\Sigma_{i \in spectra} (Error_i[j] fracVal_i[j])^2}.
+.. math:: Error[j] = \sqrt{\sum_{i \in spectra} \overline{Error}_i[j]^2}
+    = \sqrt{\sum_{i \in spectra} (Error_i[j] \times fracVal_i[j])^2}.
 
 The weighted sum with fractional bins is defined as
 
-.. math:: Signal[j] = \frac{\sum_{i \in spectra} \frac{\tilde{Signal}_i[j]}{\tilde{Error}_i[j]^2}}{\sum_{i \in spectra} \frac{1}{\tilde{Error}_i[j]^2}} = \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j] fracVal_i[j]}{(Error_i[j] fracVal_i[j])^2}\right) / \Sigma_{i \in spectra}\left(\frac{1}{(Error_i[j] fracVal_i[j])^2}\right)
+.. math::
+  Signal[j] = \frac{
+    \sum_{i \in spectra} \frac{\overline{Signal}_i[j]}{\overline{Error}_i[j]^2}
+  }{
+    \sum_{i \in spectra} \frac{1}{\overline{Error}_i[j]^2}
+  }
+  = \frac{
+    \sum_{i \in spectra} \left(\frac{Signal_i[j] \times fracVal_i[j]}{(Error_i[j] \times fracVal_i[j])^2}\right)
+  }{
+    \sum_{i \in spectra} \left(\frac{1}{(Error_i[j] \times fracVal_i[j])^2}\right)
+  }
 
 with error
 
-.. math:: Error[j] = \sqrt{\frac{1}{\sum_{i \in spectra} \frac{1}{\tilde{Error}_i[j]^2}}} = \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{(Error_i[j] fracVal_i[j])^2}\right)}.
+.. math::
+  Error[j] = \sqrt{\frac{1}{\sum_{i \in spectra} \frac{1}{\overline{Error}_i[j]^2}}}
+  = \sqrt{\frac{1}{\sum_{i \in spectra}\left(\frac{1}{(Error_i[j] \times fracVal_i[j])^2}\right)}}.
 
 The algorithm adds to the ``OutputWorkspace`` three additional
 properties (Log values). The properties (Log) names are:

--- a/docs/source/algorithms/SumSpectra-v1.rst
+++ b/docs/source/algorithms/SumSpectra-v1.rst
@@ -18,20 +18,62 @@ If we define a the :math:`i^{th}` spectrum with bins :math:`j`. The unweighted s
 
 .. math:: Signal[j] = \displaystyle\Sigma_{i \in spectra} Signal_i[j]
 
-The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=True``, ignored for event workspaces), the sum is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`),
+and the corresponding error is correctly propagated as
+
+.. math:: Error[j] = \sqrt{\displaystyle\Sigma_{i \in spectra} Error_i^2[j]}.
+
+The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=False``, ignored for event workspaces)
+is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`),
+
+.. math:: Signal[j] = \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right) / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+
+and the error is correctly propagated as
+
+.. math:: Error[j] = \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)}.
+
+The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=True``, ignored for event workspaces)
+is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`) as
 
 .. math:: Signal[j] = NSpectra \times \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right) / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
 
-:math:`NSpectra` is the number of spectra contributing to that bin. If the weights contributing to the sum are equal, these result in the same value. This should be used for unnormalized (e.g. not divided by vanadium spectrum) data. If the data has been normalized (e.g. divided by vanadium spectrum for total scattering) then multiplying by the number of spectra contributing to the bin is incorrect, use ``WeightedSum=True`` and ``MultiplyBySpectra=False`` to sum as
+and the error is correctly propagated as
 
-.. math:: Signal[j] = \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right) / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)
+.. math:: Error[j] = NSpectra \times \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{Error_i^2[j]}\right)},
+
+where :math:`NSpectra` is the number of spectra contributing to that bin.
+If the weights contributing to the sum are equal, these result in the same value.
+This should be used for unnormalized (e.g. not divided by vanadium spectrum) data.
+
+If the data has been normalized (e.g. divided by vanadium spectrum for total scattering)
+then multiplying by the number of spectra contributing to the bin is incorrect,
+use ``WeightedSum=True`` and ``MultiplyBySpectra=False``.
+
+If a workspace contains fractional bins, it is useful to consider an "effective" signal and error
+given by :math:`\tilde{Signal}_i[j] = Signal_i[j] fracVal_i[j]`
+and :math:`\tilde{Error}_i[j] = Error_i[j] fracVal_i[j]`,
+where :math:`fracVal_i[j]` is the fractional value for the bin.
+Then the unweighted sum with fractional bins is defined as
+
+.. math:: Signal[j] = \sum_{i \in spectra} \tilde{Signal}_i[j] = \displaystyle\Sigma_{i \in spectra} Signal_i[j] fracVal_i[j],
+
+with error
+
+.. math:: Error[j] = \sqrt{\sum_{i \in spectra} \tilde{Error}_i[j]^2} = \sqrt{\displaystyle\Sigma_{i \in spectra} (Error_i[j] fracVal_i[j])^2}.
+
+The weighted sum with fractional bins is defined as
+
+.. math:: Signal[j] = \frac{\sum_{i \in spectra} \frac{\tilde{Signal}_i[j]}{\tilde{Error}_i[j]^2}}{\sum_{i \in spectra} \frac{1}{\tilde{Error}_i[j]^2}} = \displaystyle\Sigma_{i \in spectra} \left(\frac{Signal_i[j] fracVal_i[j]}{(Error_i[j] fracVal_i[j])^2}\right) / \Sigma_{i \in spectra}\left(\frac{1}{(Error_i[j] fracVal_i[j])^2}\right)
+
+with error
+
+.. math:: Error[j] = \sqrt{\frac{1}{\sum_{i \in spectra} \frac{1}{\tilde{Error}_i[j]^2}}} = \sqrt{1 / \Sigma_{i \in spectra}\left(\frac{1}{(Error_i[j] fracVal_i[j])^2}\right)}.
 
 The algorithm adds to the ``OutputWorkspace`` three additional
 properties (Log values). The properties (Log) names are:
 
 * ``NumAllSpectra`` is the number of spectra contributed to the sum
 
-* ``NumMaskSpectra`` is the spectra dropped from the summations because they are masked. Monitors are not included in this total if ``IncludeMonitors=False``.
+* ``NumMaskSpectra`` is the number of spectra dropped from the summations because they are masked. Monitors are not included in this total if ``IncludeMonitors=False``.
 
 * ``NumZeroSpectra`` is the number of zero bins in histogram workspace or empty spectra for event workspace. These spectra are dropped from the summation of histogram workspace when ``WeightedSum=True``.
 

--- a/docs/source/algorithms/SumSpectra-v1.rst
+++ b/docs/source/algorithms/SumSpectra-v1.rst
@@ -57,7 +57,7 @@ then multiplying by the number of spectra contributing to the bin is incorrect,
 use ``WeightedSum=True`` and ``MultiplyBySpectra=False``.
 
 If a workspace contains fractional bins, it is useful to consider an "effective" signal and error
-given by :math:`\overline{Signal}_i[j] = Signal_i[j] \timex fracVal_i[j]`
+given by :math:`\overline{Signal}_i[j] = Signal_i[j] \times fracVal_i[j]`
 and :math:`\overline{Error}_i[j] = Error_i[j] \times fracVal_i[j]`,
 where :math:`fracVal_i[j]` is the fractional value for the bin.
 Then the unweighted sum with fractional bins is defined as

--- a/docs/source/algorithms/SumSpectra-v1.rst
+++ b/docs/source/algorithms/SumSpectra-v1.rst
@@ -22,8 +22,9 @@ and the corresponding error is correctly propagated as
 
 .. math:: Error[j] = \sqrt{\sum_{i \in spectra} Error_i^2[j]}.
 
-The weighted sum (``WeightedSum=True`` and ``MultiplyBySpectra=False``, ignored for event workspaces)
-is defined (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`),
+In the case of using ``WeightedSum=True`` and ``MultiplyBySpectra=False`` (both ignored for event workspaces),
+what is calculated is the weighted mean of the spectra,
+defined as (skipping :math:`Signal_i[j]` when :math:`Error_i[j] == 0`),
 
 .. math:: Signal[j] = \frac{
         \sum_{i \in spectra} \left(\frac{Signal_i[j]}{Error_i^2[j]}\right)

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41039.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41039.rst
@@ -1,0 +1,1 @@
+- The :ref:`SumSpectra <algm-SumSpectra>` algorithm has been updated to correctly propagate errors for weighted sum calculations.


### PR DESCRIPTION
### Description of work

The `SumSpectra` algorithm allows for calculated error-weighted averages of spectra.  In this case, the new value at bin $j$ will be

$$Y[j] = \frac{\sum_i y_i[j] w_i[j] }{ \sum_i w_i[j]},$$

where $i$ is over all the spectra being summed, and $w_i[j] = 1/\sigma_i[j]^2$.  In this case, using standard, simple error propagation, the error associated with $Y[j]$ should be

$$\sigma_Y = \sqrt {\left(\sum_i \frac{\partial Y}{\partial y_i} \sigma_i\right)^2} = \sqrt{ \frac{1}{\sum_i w_i}},$$

or, written maybe more succinctly,

$$\frac{1}{\sigma_Y^2} = \sum_i \frac{1}{\sigma_i^2}.$$

See [here](https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Variance-defined_weights) for further detail.

However, `SumSpectra` was not written to return this value, and instead returned $\sigma_Y = \sqrt{\sum \sigma_i[j]^2},$ which greatly overestimates the error.

This PR updates to the correct equation.  It also makes the code more perspicuous.  The test values were changed to correspond to the new calculations.

Related to [EWM 15254](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15254)

### To test:

Build and run this script to check the errors:
```python
ws = CreateSampleWorkspace("Histogram", Random=True)
summed = SumSpectra(ws, WeightedSum=True)
print("Y", summed.extractY()[0][:5])
print("E", summed.extractE()[0][:5])
summed2 = SumSpectra(ws, WeightedSum=True, MultiplyBySpectra=False)
print("Y2", summed2.extractY()[0][:5])
print("E2", summed2.extractE()[0][:5])
```

Also check the new docs.
[SumSpectra-v1.html](https://github.com/user-attachments/files/25902798/SumSpectra-v1.html)

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
