### PR TITLE
AAFPSlim skip banks without calibration or instrument information#41031

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         - mdformat-ruff # ruff format code snippets
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.5
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff-check

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim/ProcessBankTask.cpp
@@ -49,20 +49,25 @@ void ProcessBankTask::operator()(const tbb::blocked_range<size_t> &range) const 
     const int64_t total_events = static_cast<size_t>(tof_SDS.getSpace().getSelectNpoints());
     if (total_events == 0) {
       m_progress->report();
+      g_log.debug() << bankName << " empty\n";
       continue;
     }
-
-    auto eventRanges = this->getEventIndexRanges(event_group, total_events);
-
-    // get handle to the data
-    auto detID_SDS = event_group.openDataSet(NxsFieldNames::DETID);
-    // auto tof_SDS = event_group.openDataSet(NxsFieldNames::TIME_OF_FLIGHT);
     // and the units
     std::string tof_unit;
     Nexus::H5Util::readStringAttribute(tof_SDS, "units", tof_unit);
     // now the calibration for the output group can be created
     // which detectors go into the current group - assumes ouput spectrum number is one more than workspace index
     const auto calibrations = this->getCalibrations(tof_unit, bank_index);
+    if (calibrations.empty()) {
+      m_progress->report();
+      g_log.debug() << "skipping " << bankName << " because calibration is empty\n";
+      continue;
+    }
+
+    auto eventRanges = this->getEventIndexRanges(event_group, total_events);
+
+    // get handle to the detector IDs
+    auto detID_SDS = event_group.openDataSet(NxsFieldNames::DETID);
 
     // declare arrays once so memory can be reused
     auto event_detid = std::make_unique<std::vector<uint32_t>>();       // uint32 for ORNL nexus file

--- a/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/41031.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/41031.rst
@@ -1,0 +1,1 @@
+- Fix bug where not having IDF for some of the pixels resulted in an exception. Now those events are skipped.


### PR DESCRIPTION
This brings the following into `ornl-next`
* #41031
* #41038