### PR TITLE
Add link to 6.16 release notes

### DIFF
--- a/docs/source/concepts/MPI.rst
+++ b/docs/source/concepts/MPI.rst
@@ -363,6 +363,6 @@ Additional Resources
 
 - MPI Tutorial: https://mpitutorial.com/
 - mpi4py Documentation: https://mpi4py.readthedocs.io/
-- Mantid MPI Algorithms: See :ref:`BroadcastWorkspace <algm-broadcastworkspace>` and :ref:`GatherWorkspaces <algm-gatherworkspaces>`
+- Mantid MPI Algorithms: See :ref:`BroadcastWorkspace <algm-BroadcastWorkspace>` and :ref:`GatherWorkspaces <algm-GatherWorkspaces>`
 
 .. categories:: Concepts

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -16,7 +16,7 @@ Release Notes
 * v6.16.0 - in progress - :doc:`release notes <v6.16.0/index>`
 * v6.15.0 - 2026-02-23 - :doc:`release notes <v6.15.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.15.0>`__
 * v6.14.0 - 2025-10-23 - :doc:`release notes <v6.14.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.14.0>`__
-* v6.14.0 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`__
+* v6.13.1 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`__
 * v6.13.0 - 2025-07-07 - :doc:`release notes <v6.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.0>`__
 * v6.12.0 - 2025-02-26 - :doc:`release notes <v6.12.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.12.0>`__
 * v6.11.0 - 2024-10-24 - :doc:`release notes <v6.11.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.11.0>`__

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -13,7 +13,8 @@ Release Notes
 
 .. plot:: release/versions.py
 
-* v6.15.0 - in progress - :doc:`release notes <v6.15.0/index>`
+* v6.16.0 - in progress - :doc:`release notes <v6.16.0/index>`
+* v6.15.0 - 2026-02-23 - :doc:`release notes <v6.15.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.15.0>`__
 * v6.14.0 - 2025-10-23 - :doc:`release notes <v6.14.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.14.0>`__
 * v6.14.0 - 2025-07-24 - :doc:`release notes <v6.13.1/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.1>`__
 * v6.13.0 - 2025-07-07 - :doc:`release notes <v6.13.0/index>` - `github tag <https://github.com/mantidproject/mantid/releases/tag/v6.13.0>`__

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40952.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/40952.rst
@@ -1,1 +1,1 @@
-- MPI Algorithms :ref:`BroadcastWorkspace <algm-broadcastworkspace>` and :ref:`GatherWorkspaces <algm-gatherworkspaces>` have been added to mantid to allow for MPI processing that is workspace friendly. These are available on linux in the ``mantidmpi`` package.
+- MPI Algorithms :ref:`BroadcastWorkspace <algm-BroadcastWorkspace>` and :ref:`GatherWorkspaces <algm-GatherWorkspaces>` have been added to mantid to allow for MPI processing that is workspace friendly. These are available on linux in the ``mantidmpi`` package.


### PR DESCRIPTION
@AndreiSavici discovered that the release notes index page was missing v6.16. This adds it back and fixes up another mistake with v6.13.1

There is no associated issue

### To test:

```sh
ninja docs-html
```
and look at the release notes index page

This does not need release notes because it is cleaning up a documentation page.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
