### PR TITLE
Fix crash on opening of file dialog

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41046.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41046.rst
@@ -1,1 +1,0 @@
-- The new Instrument View no longer hangs or crashes when saving an xml file.

--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41046.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41046.rst
@@ -1,0 +1,1 @@
+- The new Instrument View no longer hangs or crashes when saving an xml file.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -7,15 +7,13 @@
 import numpy as np
 import pyvista as pv
 from pyvista.plotting.opts import PickerType
-from qtpy.QtWidgets import QFileDialog
 from queue import Queue
 from typing import Optional
 from instrumentview.Globals import CurrentTab
 from threading import Thread
 from mantid import mtd
-from mantid.kernel import logger, ConfigService
+from mantid.kernel import logger
 from mantid.simpleapi import AnalysisDataService
-from mantidqt.io import open_a_file_dialog
 from mantid.dataobjects import MaskWorkspace, GroupingWorkspace, PeaksWorkspace
 
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
@@ -355,7 +353,7 @@ class FullInstrumentViewPresenter:
         self._callback_queue.put((self._on_clear_list_clicked, ()))
 
     def _on_save_mask_to_xml_clicked(self):
-        filename = self._get_filename_from_dialog()
+        filename = self._view.get_filename_from_dialog()
         if not filename:
             return
         self._model.save_mask_to_xml(filename)
@@ -370,22 +368,13 @@ class FullInstrumentViewPresenter:
         self._callback_queue.put((self._on_save_grouping_to_ads_clicked, ()))
 
     def _on_save_grouping_to_xml_clicked(self):
-        filename = self._get_filename_from_dialog()
+        filename = self._view.get_filename_from_dialog()
         if not filename:
             return
         self._model.save_grouping_to_xml(filename)
 
     def on_save_grouping_to_xml_clicked(self):
         self._callback_queue.put((self._on_save_grouping_to_xml_clicked, ()))
-
-    def _get_filename_from_dialog(self):
-        filename = open_a_file_dialog(
-            accept_mode=QFileDialog.AcceptSave,
-            file_mode=QFileDialog.AnyFile,
-            file_filter="XML files (*xml)",
-            directory=ConfigService["defaultsave.directory"],
-        )
-        return filename
 
     def _reload_mask_workspaces(self) -> None:
         self._view.refresh_workspaces_in_list(CurrentTab.Masking)

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -1084,10 +1084,9 @@ class FullInstrumentViewWindow(QMainWindow):
         Open file dialog for saving xml files.
         Needs to be in view to run in QThread.
         """
-        filename = open_a_file_dialog(
+        return open_a_file_dialog(
             accept_mode=QFileDialog.AcceptSave,
             file_mode=QFileDialog.AnyFile,
             file_filter="XML files (*xml)",
             directory=ConfigService["defaultsave.directory"],
         )
-        return filename

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -29,6 +29,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtGui import QDoubleValidator, QMovie, QDragEnterEvent, QDropEvent, QDragMoveEvent, QColor, QPalette
 from qtpy.QtCore import Qt, QEvent, QSize
+from qtpy.QtWidgets import QFileDialog
 from superqt import QDoubleRangeSlider
 from pyvistaqt import BackgroundPlotter
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -48,6 +49,7 @@ from mantid import UsageService, ConfigService
 from mantid.kernel import FeatureType
 from mantidqt.plotting.mantid_navigation_toolbar import MantidNavigationToolbar
 from mantidqt.utils.qt.qappthreadcall import run_on_qapp_thread
+from mantidqt.io import open_a_file_dialog
 
 from instrumentview.Detectors import DetectorInfo
 from instrumentview.InteractorStyles import CustomInteractorStyleZoomAndSelect, CustomInteractorStyleRubberBand3D
@@ -1076,3 +1078,16 @@ class FullInstrumentViewWindow(QMainWindow):
             self._lineplot_peak_cursor.linev.remove()
             self._lineplot_peak_cursor = None
             self._detector_figure_canvas.draw_idle()
+
+    def get_filename_from_dialog(self):
+        """
+        Open file dialog for saving xml files.
+        Needs to be in view to run in QThread.
+        """
+        filename = open_a_file_dialog(
+            accept_mode=QFileDialog.AcceptSave,
+            file_mode=QFileDialog.AnyFile,
+            file_filter="XML files (*xml)",
+            directory=ConfigService["defaultsave.directory"],
+        )
+        return filename


### PR DESCRIPTION

### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Fixes bug with opening the file dialog to save an xml file.

Closes #41046 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Save grouping and mask to xml file.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
