### PR TITLE
Eng Diff UI: Honor the GSAS-II timeout value

### DIFF
--- a/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/36748.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Engineering/Bugfixes/36748.rst
@@ -1,0 +1,1 @@
+- The :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` now honors the GSAS-II timeout value from the settings panel.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_settings.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_settings.py
@@ -25,6 +25,11 @@ def get_path_to_gsas2() -> str:
     return str(location) if location is not None else ""
 
 
+def get_timeout() -> int:
+    timeout = get_setting(INTERFACES_SETTINGS_GROUP, ENGINEERING_PREFIX, "timeout")
+    return int(timeout) if timeout else 100
+
+
 def get_texture_axes_transform():
     rd_str = get_setting(INTERFACES_SETTINGS_GROUP, ENGINEERING_PREFIX, "rd_dir")
     nd_str = get_setting(INTERFACES_SETTINGS_GROUP, ENGINEERING_PREFIX, "nd_dir")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -280,6 +280,7 @@ class GSAS2Model:
 
     def set_components_from_inputs(self, load_params: list, refinement_params: list, project: str, rb_number: Optional[str] = None) -> None:
         self.config.path_to_gsas2 = output_settings.get_path_to_gsas2()
+        self.config.timeout = output_settings.get_timeout()
         self.save_directories.project_name = project
         self.organize_save_directories(rb_number)
 


### PR DESCRIPTION
### Description of work

When running GSAS-II in the engineering diffraction UI, use the timeout value that has been set in the settings panel.

Most of the code was already there but not hooked up.

Closes #36748 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

You will need GSAS-II installed.

In the Eng Diff UI, set the GSAS-II `timeout interval` to 1 second

Follow the steps from the manual testing docs `Test 13`:
https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-13
At step 7, "click Refine in GSAS II" you should get a timeout error.

Go back to the settings and change the `timeout interval` to 100 seconds, now step 7 should succeed.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
