### PR TITLE
Instrument View - Remove workaround that is no longer necessary

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -583,13 +583,7 @@ class FullInstrumentViewModel:
         SaveMask(ws_to_save, OutputFile=filename)
 
     def overwrite_mask_to_current_workspace(self) -> None:
-        ws_to_save = self.mask_ws
-        # TODO: Check if copies are expensive with big workspaces
-        temp_ws = CloneWorkspace(self._workspace.name(), StoreInADS=False)
-        temp_ws_name = f"__instrument_view_temp_{self._workspace.name()}"
-        AnalysisDataService.addOrReplace(temp_ws_name, temp_ws)
-        MaskDetectors(temp_ws_name, MaskedWorkspace=ws_to_save)
-        AnalysisDataService.addOrReplace(self._workspace.name(), AnalysisDataService.retrieve(temp_ws_name))
+        MaskDetectors(self._workspace.name(), MaskedWorkspace=self.mask_ws)
 
     def get_workspaces_in_ads_of_type(self, ws_type: MaskWorkspace | GroupingWorkspace | PeaksWorkspace):
         # TODO: Figure out how to avoid using a dictionary

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -511,11 +511,6 @@ class FullInstrumentViewPresenter:
         elif isinstance(ws, GroupingWorkspace):
             self._reload_grouping_workspaces()
         elif ws_name == self._model.workspace.name():
-            # This check is needed because observers are triggered
-            # before the RenameWorkspace is completed.
-            # Prevents strange behaviour from workspace not being fully replaced yet
-            if AnalysisDataService.retrieve(ws_name).name() != ws_name:
-                return
             self._model._workspace = AnalysisDataService.retrieve(ws_name)
             self._model.setup()
             self._setup_component_tree()


### PR DESCRIPTION
Because callbacks are put into a queue and executed in order, there is no longer the chance of Mantid hanging

### To test:

Overwrite a mask to a workspace, if Mantid does not hang, then all is well.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
