### PR TITLE
Instrument View - Fix crash when opening side by side

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/40949.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/40949.rst
@@ -1,0 +1,1 @@
+- New Instrument View no longer crashes when a `LOQ` workspace is open and side-by-side projection is selected.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -284,6 +284,10 @@ class FullInstrumentViewPresenter:
 
         window_width, window_height = plotter.window_size
 
+        # Safeguard against division by zero
+        mesh_width = mesh_width if mesh_width > 0 else window_width
+        mesh_height = mesh_height if mesh_height > 0 else window_height
+
         return self._scale_matrix_relative_to_centre((min_point + max_point) / 2, window_width / mesh_width, window_height / mesh_height)
 
     def _scale_matrix_relative_to_centre(self, centre, scale_x=1.0, scale_y=1.0) -> np.ndarray:


### PR DESCRIPTION
### Description of work

Fixes crash when selecting side-by-side projection with `LOQ` workspaces.

Closes #40949 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Load `LOQ74024` from the `loqdemo` in the `TrainingCourseData`.
2. Right-click the workspace and open the experimental instrument view.
3. Switch the projection to `Side by Side`.

You should see the projection without a crash.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
