### PR TITLE
Fix error in SaveDiffCal algorithm

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
@@ -49,7 +49,7 @@ private:
   // GroupingWorkspace_histogram_count, MaskWorkspace_histogram_count)
   std::size_t m_numValues{0};
   API::ITableWorkspace_sptr m_calibrationWS;
-  std::map<detid_t, size_t> m_detidToIndex;
+  std::map<detid_t, std::vector<size_t>> m_detidToIndex;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -179,7 +179,7 @@ void SaveDiffCal::writeIntFieldFromSVWS(H5::Group &group, const std::string &nam
   std::vector<int32_t> values(m_numValues, 1);
 
   if (bool(ws)) {
-    for (size_t i = 0; i < m_numValues; ++i) {
+    for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       auto &ids = ws->getSpectrum(i).getDetectorIDs(); // set of detector ID's
       // check if the first detector ID in the set is in the calibration table
       auto found = m_detidToIndex.find(*(ids.begin())); // (detID, row_index)
@@ -192,7 +192,9 @@ void SaveDiffCal::writeIntFieldFromSVWS(H5::Group &group, const std::string &nam
           else
             value = 0;
         }
-        values[found->second] = value;
+        for (const auto &indexes : found->second) {
+          values[indexes] = value;
+        }
       }
     }
   }
@@ -208,7 +210,9 @@ void SaveDiffCal::generateDetidToIndex() {
 
   const size_t numDets = detids.size();
   for (size_t i = 0; i < numDets; ++i) {
-    m_detidToIndex[static_cast<detid_t>(detids[i])] = i;
+    if (i < m_numValues) {
+      m_detidToIndex[static_cast<detid_t>(detids[i])].push_back(i);
+    }
   }
 }
 
@@ -223,7 +227,7 @@ void SaveDiffCal::generateDetidToIndex(const DataObjects::SpecialWorkspace2D_con
   for (size_t i = 0; i < m_numValues; ++i) {
     const auto &detids = ws->getSpectrum(i).getDetectorIDs();
     for (const auto &detid : detids) {
-      m_detidToIndex[static_cast<detid_t>(detid)] = index;
+      m_detidToIndex[static_cast<detid_t>(detid)].push_back(index);
       index++;
     }
   }
@@ -249,22 +253,19 @@ void SaveDiffCal::exec() {
   // Get a starting number of values to work with that will be refined below
   // THE ORDER OF THE IF/ELSE TREE MATTERS
   m_numValues = std::numeric_limits<std::size_t>::max();
-  if (m_calibrationWS)
+  if (m_calibrationWS) {
     m_numValues = std::min(m_numValues, m_calibrationWS->rowCount());
-  if (groupingWS)
+    this->generateDetidToIndex();
+  } else if (groupingWS) {
     m_numValues = std::min(m_numValues, groupingWS->getNumberHistograms());
-  if (maskWS)
+    this->generateDetidToIndex(groupingWS);
+  } else if (maskWS) {
     m_numValues = std::min(m_numValues, maskWS->getNumberHistograms());
+    this->generateDetidToIndex(maskWS);
+  }
 
   // Initialize the mapping of detid to row number to make getting information
   // from the table faster. ORDER MATTERS
-  if (m_calibrationWS) {
-    this->generateDetidToIndex();
-  } else if (groupingWS) {
-    this->generateDetidToIndex(groupingWS);
-  } else if (maskWS) {
-    this->generateDetidToIndex(maskWS);
-  }
 
   if (groupingWS && groupingWS->isDetectorIDMappingEmpty())
     groupingWS->buildDetectorIDMapping();

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -210,9 +210,7 @@ void SaveDiffCal::generateDetidToIndex() {
 
   const size_t numDets = detids.size();
   for (size_t i = 0; i < numDets; ++i) {
-    if (i < m_numValues) {
-      m_detidToIndex[static_cast<detid_t>(detids[i])].push_back(i);
-    }
+    m_detidToIndex[static_cast<detid_t>(detids[i])].push_back(i);
   }
 }
 
@@ -252,20 +250,16 @@ void SaveDiffCal::exec() {
 
   // Get a starting number of values to work with that will be refined below
   // THE ORDER OF THE IF/ELSE TREE MATTERS
-  m_numValues = std::numeric_limits<std::size_t>::max();
   if (m_calibrationWS) {
-    m_numValues = std::min(m_numValues, m_calibrationWS->rowCount());
+    m_numValues = m_calibrationWS->rowCount();
     this->generateDetidToIndex();
   } else if (groupingWS) {
-    m_numValues = std::min(m_numValues, groupingWS->getNumberHistograms());
+    m_numValues = groupingWS->getNumberHistograms();
     this->generateDetidToIndex(groupingWS);
   } else if (maskWS) {
-    m_numValues = std::min(m_numValues, maskWS->getNumberHistograms());
+    m_numValues = maskWS->getNumberHistograms();
     this->generateDetidToIndex(maskWS);
   }
-
-  // Initialize the mapping of detid to row number to make getting information
-  // from the table faster. ORDER MATTERS
 
   if (groupingWS && groupingWS->isDetectorIDMappingEmpty())
     groupingWS->buildDetectorIDMapping();

--- a/Framework/DataHandling/test/SaveDiffCalTest.h
+++ b/Framework/DataHandling/test/SaveDiffCalTest.h
@@ -9,8 +9,10 @@
 #include <cxxtest/TestSuite.h>
 #include <filesystem>
 
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidDataHandling/LoadDiffCal.h"
 #include "MantidDataHandling/SaveDiffCal.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
@@ -26,6 +28,7 @@ using namespace Mantid::DataHandling;
 namespace {
 const size_t NUM_BANK = 5;
 const std::string FILENAME = "SaveDiffCalTest.h5";
+const double DIFC_OFFSET = 2000.0;
 } // namespace
 
 class SaveDiffCalTest : public CxxTest::TestSuite {
@@ -34,6 +37,13 @@ public:
   // This means the constructor isn't called when running other tests
   static SaveDiffCalTest *createSuite() { return new SaveDiffCalTest(); }
   static void destroySuite(SaveDiffCalTest *suite) { delete suite; }
+
+  void tearDown() override {
+    // cleanup
+    if (std::filesystem::exists(FILENAME)) {
+      std::filesystem::remove(FILENAME);
+    }
+  }
 
   void test_Init() {
     SaveDiffCal alg;
@@ -67,7 +77,7 @@ public:
     return maskWS;
   }
 
-  TableWorkspace_sptr createCalibration(const size_t numRows) {
+  TableWorkspace_sptr createCalibration(const size_t numRows, const bool repeatEntries = false) {
     TableWorkspace_sptr wksp = std::make_shared<TableWorkspace>();
     wksp->addColumn("int", "detid");
     wksp->addColumn("double", "difc");
@@ -75,14 +85,18 @@ public:
     wksp->addColumn("double", "tzero");
     wksp->addColumn("double", "tofmin");
 
-    for (size_t i = 0; i < numRows; ++i) {
-      TableRow row = wksp->appendRow();
+    const size_t tableSize = numRows * (1 + static_cast<int>(repeatEntries));
 
-      row << static_cast<int>(i) // detid
-          << 0.                  // difc
-          << 0.                  // difa
-          << 0.                  // tzero
-          << 0.;                 // tofmin
+    for (size_t i = 0; i < tableSize; ++i) {
+      TableRow row = wksp->appendRow();
+      // To compare other than zeros later
+      double difc = static_cast<double>(repeatEntries) * (DIFC_OFFSET + static_cast<double>(i % numRows));
+
+      row << static_cast<int>(i % numRows) // detid
+          << difc                          // difc
+          << 0.                            // difa
+          << 0.                            // tzero
+          << 0.;                           // tofmin
     }
     return wksp;
   }
@@ -102,22 +116,7 @@ public:
     GroupingWorkspace_sptr groupWS = createGrouping(inst);
     MaskWorkspace_sptr maskWS = createMasking(inst);
 
-    SaveDiffCal alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized());
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", maskWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
-    TS_ASSERT_THROWS_NOTHING(alg.execute());
-    TS_ASSERT(alg.isExecuted());
-
-    // confirm that it exists
-    std::string filename = alg.getPropertyValue("Filename");
-    TS_ASSERT(std::filesystem::exists(filename));
-
-    // cleanup
-    if (std::filesystem::exists(filename))
-      std::filesystem::remove(filename);
+    executeAndAssertAlgorithm(std::nullopt, groupWS, maskWS);
   }
 
   void test_empty_cal_wksp() {
@@ -140,73 +139,92 @@ public:
   void test_no_mask() {
     Instrument_sptr inst = createInstrument();
     GroupingWorkspace_sptr groupWS = createGrouping(inst);
-    MaskWorkspace_sptr maskWS = createMasking(inst);
     TableWorkspace_sptr calWS = createCalibration(NUM_BANK * 9); // nine components per bank
 
-    SaveDiffCal alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized());
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", calWS));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
-    TS_ASSERT(alg.isExecuted());
-
-    // confirm that it exists
-    std::string filename = alg.getPropertyValue("Filename");
-    TS_ASSERT(std::filesystem::exists(filename));
-
-    // cleanup
-    if (std::filesystem::exists(filename))
-      std::filesystem::remove(filename);
+    executeAndAssertAlgorithm(calWS, groupWS);
   }
 
   void test_no_grouping() {
     Instrument_sptr inst = createInstrument();
-    GroupingWorkspace_sptr groupWS = createGrouping(inst);
     MaskWorkspace_sptr maskWS = createMasking(inst);
     TableWorkspace_sptr calWS = createCalibration(NUM_BANK * 9); // nine components per bank
 
-    SaveDiffCal alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized());
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", maskWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", calWS));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
-    TS_ASSERT(alg.isExecuted());
-
-    // confirm that it exists
-    std::string filename = alg.getPropertyValue("Filename");
-    TS_ASSERT(std::filesystem::exists(filename));
-
-    // cleanup
-    if (std::filesystem::exists(filename))
-      std::filesystem::remove(filename);
+    executeAndAssertAlgorithm(calWS, std::nullopt, maskWS);
   }
 
-  void test_exec() {
+  void test_all_inputs() {
     Instrument_sptr inst = createInstrument();
     GroupingWorkspace_sptr groupWS = createGrouping(inst);
     MaskWorkspace_sptr maskWS = createMasking(inst);
     TableWorkspace_sptr calWS = createCalibration(NUM_BANK * 9); // nine components per bank
 
+    executeAndAssertAlgorithm(calWS, groupWS, maskWS);
+  }
+
+  void test_calibration_ws_repeated_entries() {
+    // Should be rare that this is the case, but it has happened: mantid #40853
+    Instrument_sptr inst = createInstrument();
+    GroupingWorkspace_sptr groupWS = createGrouping(inst, false);
+    MaskWorkspace_sptr maskWS = createMasking(inst);
+
+    TableWorkspace_sptr calWS = createCalibration(NUM_BANK * 9, true);
+
+    executeAndAssertAlgorithm(calWS, groupWS, maskWS);
+    checkLoadedDiffFileAgainstCalibrationTable(FILENAME, calWS);
+  }
+
+private:
+  void executeAndAssertAlgorithm(const std::optional<ITableWorkspace_sptr> &tableWS = std::nullopt,
+                                 const std::optional<GroupingWorkspace_sptr> &groupWS = std::nullopt,
+                                 const std::optional<MaskWorkspace_sptr> &maskWS = std::nullopt) {
+
     SaveDiffCal alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", maskWS));
+    if (tableWS.has_value()) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", *tableWS));
+    }
+    if (groupWS.has_value()) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", *groupWS));
+    }
+    if (maskWS.has_value()) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", *maskWS));
+    }
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", calWS));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
 
     // confirm that it exists
-    std::string filename = alg.getPropertyValue("Filename");
+    const std::string filename = alg.getPropertyValue("Filename");
     TS_ASSERT(std::filesystem::exists(filename));
+  }
+  void checkLoadedDiffFileAgainstCalibrationTable(const std::string &filename, const ITableWorkspace_sptr &calTable) {
+    LoadDiffCal alg;
 
-    // cleanup
-    if (std::filesystem::exists(filename))
-      std::filesystem::remove(filename);
+    alg.initialize();
+    alg.setProperty("Filename", filename);
+    alg.setProperty("WorkspaceName", "test");
+    alg.setProperty("MakeMaskWorkspace", false);
+    alg.setProperty("MakeGroupingWorkspace", false);
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    const auto &ads = AnalysisDataService::Instance();
+
+    TS_ASSERT(ads.doesExist("test_cal"));
+    const auto loadedCalTable = ads.retrieveWS<ITableWorkspace>("test_cal");
+
+    const auto difcCol = calTable->getColumn("difc");
+    const auto loadedDifcCol = loadedCalTable->getColumn("difc");
+    const auto difc = difcCol->numeric_fill<int32_t>();
+    const auto loadedDifc = loadedDifcCol->numeric_fill<int32_t>();
+    TS_ASSERT_EQUALS(difc, loadedDifc);
+
+    const auto detidCol = calTable->getColumn("detid");
+    const auto loadedDetidCol = loadedCalTable->getColumn("detid");
+    const auto detID = detidCol->numeric_fill<int32_t>();
+    const auto loadedDetID = loadedDetidCol->numeric_fill<int32_t>();
+    TS_ASSERT_EQUALS(detID, loadedDetID);
   }
 };

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40853.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/40853.rst
@@ -1,0 +1,1 @@
+- Fix crash in :ref:`SaveDiffCal <algm-SaveDiffCal>` produced by calibration tables with repeated entries.


### PR DESCRIPTION
### Description of work
Issue described in #40853 . In the h5 file, the array size for ``use`` or ``group`` groups is allotted by cross checking the detectors in the calibration table with those on the mask/grouping workspace. If the calibration table is larger (for example having repeated entries as in the case of the VESUVIO cal on #40853), the detector to index map allocates indexes that are outside the range of the array that's going to enter the h5 file (the array size is allocated looking at the size of mask ws or grouping ws if there's any). This causes the crash. 

To fix this, I was a bit more lenient with how the detector to index mapping allocates indexes, allowing to allocate multiple indexes per detector. This allows to reconstruct faithfully the calibration table in `LoadDiffCal` algorithm. Still, this is just the case when there are repeated entries in the calibration table, an talking to the user at vesuvio, this situation is actually quite rare, so it shouldn't affect current workflows. 
Additionally, I have added unittest and refactor a bit the test suite as there were quite a lot of redundant lines. 



<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40853 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Follow #40853 instructions.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
