### PR TITLE
Update Jenkins example script for cleaning PR build folders

### DIFF
--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -200,30 +200,32 @@ It is advised to ensure nothing is running and pause the build queue.
       }
     }
 
-Remove directories from single node
-----------------------------------------
+Remove pull request build directories from specific nodes
+---------------------------------------------------------
 
-It is advised to take the target node offline.
+Take the target nodes offline and edit the list of agentNames.
 
 .. code-block:: groovy
 
     import hudson.model.*
 
-    // Example: "isis-ndw1597"
-    String agentName = <agent/node name>
+    // Example: ["isis-win-1", "isis-win-2", "isis-win-3", "isis-linux-1", "isis-linux-5", "isis-linux-9", "isis-ndw2996mac"]
+    agentNames = ["agent-name-1", "agent-name-2", ...]
 
-    // Example: "pull_requests-conda-windows" , "build_branch"
-    jobs = [<job 1 string> , <job 2 string>, ...]
+    JOB_PREFIX = "pull_requests-"
+    suffixes = ["conda-linux", "conda-osx", "conda-windows", "doc-tests"];
 
     nodes = Jenkins.instance.slaves
     for (node in nodes) {
-      if(node.toString() == "hudson.slaves.DumbSlave[$agentName]") {
-        for (job in jobs) {
-          FilePath fp = node.createPath(node.getRootPath().toString() + File.separator + "workspace" + File.separator + job)
-          if(fp!=null && fp.exists()) {
-            println(node.toString())
-            println(fp.toString())
-            fp.deleteRecursive()
+      for(agentName in agentNames) {
+        if(node.toString() == "hudson.slaves.DumbSlave[$agentName]") {
+          for (suffix in suffixes) {
+            FilePath fp = node.createPath(node.getRootPath().toString() + File.separator + "workspace" + File.separator + JOB_PREFIX + suffix + File.separator +  "build");
+            if(fp!=null && fp.exists()) {
+              println(node.toString())
+              println(fp.toString())
+              fp.deleteRecursive()
+            }
           }
         }
       }

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -215,16 +215,25 @@ Take the target nodes offline and edit the list of agentNames.
     JOB_PREFIX = "pull_requests-"
     suffixes = ["conda-linux", "conda-osx", "conda-windows", "doc-tests"];
 
+    DRY_RUN = true // set to false to actually delete
+
     nodes = Jenkins.instance.slaves
     for (node in nodes) {
-      for(agentName in agentNames) {
-        if(node.toString() == "hudson.slaves.DumbSlave[$agentName]") {
+      for (agentName in agentNames) {
+        if (node.name == agentName) {
           for (suffix in suffixes) {
             FilePath fp = node.createPath(node.getRootPath().toString() + File.separator + "workspace" + File.separator + JOB_PREFIX + suffix + File.separator +  "build");
-            if(fp!=null && fp.exists()) {
-              println(node.toString())
-              println(fp.toString())
-              fp.deleteRecursive()
+            if (fp != null && fp.exists()) {
+              println("Node: ${node.name}")
+              println("Path: ${fp}")
+              
+              if (DRY_RUN) {
+                println("DRY RUN: Would delete ${fp}\n")
+              }
+              else {
+                println("Deleting ${fp}\n")
+                fp.deleteRecursive()
+              }
             }
           }
         }

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -226,7 +226,7 @@ Take the target nodes offline and edit the list of agentNames.
             if (fp != null && fp.exists()) {
               println("Node: ${node.name}")
               println("Path: ${fp}")
-              
+
               if (DRY_RUN) {
                 println("DRY RUN: Would delete ${fp}\n")
               }


### PR DESCRIPTION
### Description of work
Makes the Jenkins script more useful for cleaning build folders across multiple nodes on all OS.

### To test:
Take a node offline, edit the list of `agentNames` so that it contains that node and run in the script console. It should print the node name and the folder that it deleted (assuming it existed).

*This does not require release notes* because it's a script for Jenkins maintenance.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
