### PR TITLE
Remove deleting each individual pixel in `LoadEventNexus`

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1366,10 +1366,6 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
   if (detList.empty())
     return;
 
-  // Get ComponentInfo from the first workspace in the collection
-  auto ws = workspace->getSingleHeldWorkspace();
-  const auto &componentInfo = ws->componentInfo();
-
   for (auto &det : detList) {
     std::string det_name = det->getName() + "_events";
     bool keep =

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1371,27 +1371,10 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
   const auto &componentInfo = ws->componentInfo();
 
   for (auto &det : detList) {
-    bool keep = false;
-    std::string det_name = det->getName();
-    for (const auto &bankName : bankNames) {
-      size_t pos = bankName.find("_events");
-      if (det_name == bankName.substr(0, pos))
-        keep = true;
-      if (keep)
-        break;
-    }
+    std::string det_name = det->getName() + "_events";
+    bool keep =
+        std::any_of(bankNames.cbegin(), bankNames.cend(), [&det_name](std::string const &s) { return s == det_name; });
     if (!keep) {
-      const size_t parentIndex = componentInfo.indexOfAny(det_name);
-      const auto children = componentInfo.children(parentIndex);
-      for (const auto &colIndex : children) {
-        const auto grandchildren = componentInfo.children(colIndex);
-
-        for (const auto &rowIndex : grandchildren) {
-          auto *d = dynamic_cast<Detector *>(const_cast<IComponent *>(componentInfo.componentID(rowIndex)));
-          if (d)
-            inst->removeDetector(d);
-        }
-      }
       auto *comp = dynamic_cast<IComponent *>(det.get());
       inst->remove(comp);
     }


### PR DESCRIPTION
### Description of work

~In PR #40884 , instances using Instrument's `getChildren()` array were replaced with the methods in `ComponentInfo`.  However, this PR was apparently responsible for a performance regression discovered when trying to load a single bank for the `MANDI` instrument.~
I have checked, and this is not the source of the regression.  So I'm not sure how this problem hadn't been noticed before.

The replacement was inside the `deleteBanks()` method of `LoadEventNexus`.  If only a single bank is loaded, the code cycles through all of the pixels in the entire instrument which are not in the chosen bank, and deletes them.  This must have been a lot faster using the older Instrument methods, but it now takes such a long time that it users think the system has frozen.  In this particular case, the file being loaded had very few events, so that it paradoxically took less time to load the entire file, than it takes to load a single bank.

It is likely that the loop to remove all of the individual pixels isn't necessary.  Just removing the banks should be sufficient.

[EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15489)

### To test:

Build and run the following in workbench:
``` python
outws = LoadEventNexus("MANDI_13064", BankName="bank26")
```
Check the instrument; everything should be empty except for bank26.

There happen to be very few events in this run, but to ensure thee are events, look at spectrum `1710492`.

Please carefully explore the instrument and the workspace data to make sure that this behaves the way we expect a single-bank-loaded workspace to behave.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
