### PR TITLE
Make instrument optional in LoadDiffCal

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadDiffCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadDiffCal.h
@@ -43,7 +43,7 @@ private:
 
   std::string m_filename;
   std::string m_workspaceName;
-  Geometry::Instrument_const_sptr m_instrument;
+  Geometry::Instrument_const_sptr m_instrument{nullptr};
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -164,22 +164,32 @@ void LoadDiffCal::getInstrument(H5File &file) {
 
   g_log.debug() << "IDF : " << idf << "\n"
                 << "NAME: " << instrumentName << "\n";
-
   API::Algorithm_sptr childAlg = this->createChildAlgorithm("LoadInstrument", 0.0, 0.1);
   MatrixWorkspace_sptr tempWS(new Workspace2D());
   childAlg->setProperty<MatrixWorkspace_sptr>("Workspace", tempWS);
-  if (idf.empty()) {
-    childAlg->setPropertyValue("InstrumentName", instrumentName);
-  } else {
-    childAlg->setPropertyValue("Filename", idf);
+  try {
+    if (idf.empty()) {
+      childAlg->setPropertyValue("InstrumentName", instrumentName);
+    } else {
+      childAlg->setPropertyValue("Filename", idf);
+    }
+    childAlg->setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
+    childAlg->executeAsChildAlg();
+    if (childAlg->isExecuted()) {
+      m_instrument = tempWS->getInstrument();
+
+      g_log.information() << "Loaded instrument \"" << m_instrument->getName() << "\" from \""
+                          << m_instrument->getFilename() << "\"\n";
+    } else {
+      g_log.debug("LoadInstrument child algorithm did not execute successfully. No instrument will be associated with "
+                  "the output workspaces.");
+      m_instrument = nullptr;
+    }
+  } catch (const std::exception &) {
+    g_log.debug("LoadInstrument child algorithm threw an exception. No instrument will be associated with the output "
+                "workspaces.");
+    m_instrument = nullptr;
   }
-  childAlg->setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
-  childAlg->executeAsChildAlg();
-
-  m_instrument = tempWS->getInstrument();
-
-  g_log.information() << "Loaded instrument \"" << m_instrument->getName() << "\" from \""
-                      << m_instrument->getFilename() << "\"\n";
 }
 
 void LoadDiffCal::makeGroupingWorkspace(const std::vector<int32_t> &detids, const std::vector<int32_t> &groups) {
@@ -198,7 +208,12 @@ void LoadDiffCal::makeGroupingWorkspace(const std::vector<int32_t> &detids, cons
   size_t numDet = detids.size();
   Progress progress(this, .4, .6, numDet);
 
-  GroupingWorkspace_sptr wksp = std::make_shared<DataObjects::GroupingWorkspace>(m_instrument);
+  GroupingWorkspace_sptr wksp{nullptr};
+  if (m_instrument) {
+    wksp = std::make_shared<DataObjects::GroupingWorkspace>(m_instrument);
+  } else {
+    wksp = std::make_shared<DataObjects::GroupingWorkspace>(detids);
+  }
   wksp->setTitle(m_filename);
   wksp->mutableRun().addProperty("Filename", m_filename);
 
@@ -221,7 +236,12 @@ void LoadDiffCal::makeMaskWorkspace(const std::vector<int32_t> &detids, const st
   size_t numDet = detids.size();
   Progress progress(this, .6, .8, numDet);
 
-  MaskWorkspace_sptr wksp = std::make_shared<DataObjects::MaskWorkspace>(m_instrument);
+  MaskWorkspace_sptr wksp{nullptr};
+  if (m_instrument) {
+    wksp = std::make_shared<DataObjects::MaskWorkspace>(m_instrument);
+  } else {
+    wksp = std::make_shared<DataObjects::MaskWorkspace>(detids);
+  }
   wksp->setTitle(m_filename);
   wksp->mutableRun().addProperty("Filename", m_filename);
 
@@ -465,6 +485,7 @@ void LoadDiffCal::exec() {
   } catch (FileIException &) {
     throw FileError("Failed to open file using HDF5", m_filename);
   }
+  // try to get the instrument - this can leave the instrument as nullptr if anything goes wrong
   getInstrument(file);
 
   Progress progress(this, 0.1, 0.4, 8);

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -9,6 +9,8 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataObjects/SpecialWorkspace2D.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/IDTypes.h"
+#include <vector>
 
 namespace Mantid {
 namespace DataObjects {
@@ -27,6 +29,7 @@ public:
   GroupingWorkspace(const Geometry::Instrument_const_sptr &inst);
   GroupingWorkspace() = default;
   GroupingWorkspace(size_t numvectors);
+  GroupingWorkspace(const std::vector<detid_t> &detids);
   GroupingWorkspace &operator=(const GroupingWorkspace &) = delete;
 
   /// Returns a clone of the workspace

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -29,7 +29,14 @@ public:
   GroupingWorkspace(const Geometry::Instrument_const_sptr &inst);
   GroupingWorkspace() = default;
   GroupingWorkspace(size_t numvectors);
-  GroupingWorkspace(const std::vector<detid_t> &detids);
+  /**
+   * Constructor, building from a list of detector IDs.
+   * Creates one spectrum per detector ID and associates each spectrum with its
+   * corresponding detector ID.
+   * @param detids :: vector of detector IDs, one per spectrum
+   */
+  inline GroupingWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) {}
+
   GroupingWorkspace &operator=(const GroupingWorkspace &) = delete;
 
   /// Returns a clone of the workspace

--- a/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
@@ -25,6 +25,7 @@ public:
   MaskWorkspace(std::size_t numvectors);
   MaskWorkspace(const Mantid::Geometry::Instrument_const_sptr &instrument, const bool includeMonitors = false);
   MaskWorkspace(const API::MatrixWorkspace_const_sptr &parent);
+  MaskWorkspace(const std::vector<detid_t> &detids);
 
   /// Returns a clone of the workspace
   std::unique_ptr<MaskWorkspace> clone() const { return std::unique_ptr<MaskWorkspace>(doClone()); }

--- a/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
@@ -25,7 +25,7 @@ public:
   MaskWorkspace(std::size_t numvectors);
   MaskWorkspace(const Mantid::Geometry::Instrument_const_sptr &instrument, const bool includeMonitors = false);
   MaskWorkspace(const API::MatrixWorkspace_const_sptr &parent);
-  MaskWorkspace(const std::vector<detid_t> &detids);
+  inline MaskWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) { this->clearMask(); }
 
   /// Returns a clone of the workspace
   std::unique_ptr<MaskWorkspace> clone() const { return std::unique_ptr<MaskWorkspace>(doClone()); }

--- a/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
@@ -33,6 +33,7 @@ public:
   SpecialWorkspace2D() = default;
   SpecialWorkspace2D(const Geometry::Instrument_const_sptr &inst, const bool includeMonitors = false);
   SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &parent);
+  SpecialWorkspace2D(const std::vector<detid_t> &detids);
 
   /// Returns a clone of the workspace
   std::unique_ptr<SpecialWorkspace2D> clone() const { return std::unique_ptr<SpecialWorkspace2D>(doClone()); }

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -28,6 +28,22 @@ DECLARE_WORKSPACE(GroupingWorkspace)
  */
 GroupingWorkspace::GroupingWorkspace(size_t numvectors) { this->init(numvectors, 1, 1); }
 
+/** Constructor, building from a list of detector IDs.
+ * Creates one spectrum per detector ID and associates each spectrum with its
+ * corresponding detector ID.
+ * @param detids :: vector of detector IDs, one per spectrum
+ */
+GroupingWorkspace::GroupingWorkspace(const std::vector<detid_t> &detids) {
+  this->init(detids.size(), 1, 1);
+  // set the detector ids
+  for (size_t wi = 0; wi < detids.size(); ++wi) {
+    this->getSpectrum(wi).setDetectorID(detids[wi]);
+  }
+  // set up the rest of the mapping information
+  this->MatrixWorkspace::rebuildSpectraMapping(false);
+  buildDetectorIDMapping();
+}
+
 //----------------------------------------------------------------------------------------------
 /** Constructor, building from an instrument
  *

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -28,21 +28,13 @@ DECLARE_WORKSPACE(GroupingWorkspace)
  */
 GroupingWorkspace::GroupingWorkspace(size_t numvectors) { this->init(numvectors, 1, 1); }
 
-/** Constructor, building from a list of detector IDs.
+/**
+ * Constructor, building from a list of detector IDs.
  * Creates one spectrum per detector ID and associates each spectrum with its
  * corresponding detector ID.
  * @param detids :: vector of detector IDs, one per spectrum
  */
-GroupingWorkspace::GroupingWorkspace(const std::vector<detid_t> &detids) {
-  this->init(detids.size(), 1, 1);
-  // set the detector ids
-  for (size_t wi = 0; wi < detids.size(); ++wi) {
-    this->getSpectrum(wi).setDetectorID(detids[wi]);
-  }
-  // set up the rest of the mapping information
-  this->MatrixWorkspace::rebuildSpectraMapping(false);
-  buildDetectorIDMapping();
-}
+GroupingWorkspace::GroupingWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) {}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor, building from an instrument

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -28,14 +28,6 @@ DECLARE_WORKSPACE(GroupingWorkspace)
  */
 GroupingWorkspace::GroupingWorkspace(size_t numvectors) { this->init(numvectors, 1, 1); }
 
-/**
- * Constructor, building from a list of detector IDs.
- * Creates one spectrum per detector ID and associates each spectrum with its
- * corresponding detector ID.
- * @param detids :: vector of detector IDs, one per spectrum
- */
-GroupingWorkspace::GroupingWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) {}
-
 //----------------------------------------------------------------------------------------------
 /** Constructor, building from an instrument
  *

--- a/Framework/DataObjects/src/MaskWorkspace.cpp
+++ b/Framework/DataObjects/src/MaskWorkspace.cpp
@@ -67,6 +67,8 @@ MaskWorkspace::MaskWorkspace(const API::MatrixWorkspace_const_sptr &parent) : Sp
   this->clearMask();
 }
 
+MaskWorkspace::MaskWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) { this->clearMask(); }
+
 //--------------------------------------------------------------------------
 
 void MaskWorkspace::clearMask() {

--- a/Framework/DataObjects/src/MaskWorkspace.cpp
+++ b/Framework/DataObjects/src/MaskWorkspace.cpp
@@ -67,8 +67,6 @@ MaskWorkspace::MaskWorkspace(const API::MatrixWorkspace_const_sptr &parent) : Sp
   this->clearMask();
 }
 
-MaskWorkspace::MaskWorkspace(const std::vector<detid_t> &detids) : SpecialWorkspace2D(detids) { this->clearMask(); }
-
 //--------------------------------------------------------------------------
 
 void MaskWorkspace::clearMask() {

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -56,6 +56,23 @@ SpecialWorkspace2D::SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &pa
   buildDetectorIDMapping();
 }
 
+/**
+ * Constructor, building from a list of detector IDs.
+ * Creates one spectrum per detector ID and associates each spectrum with its
+ * corresponding detector ID.
+ * @param detids :: vector of detector IDs, one per spectrum
+ */
+SpecialWorkspace2D::SpecialWorkspace2D(const std::vector<detid_t> &detids) {
+  this->init(detids.size(), 1, 1);
+  // set the detector ids
+  for (size_t wi = 0; wi < detids.size(); ++wi) {
+    this->getSpectrum(wi).setDetectorID(detids[wi]);
+  }
+  // set up the rest of the mapping information
+  this->MatrixWorkspace::rebuildSpectraMapping(false);
+  buildDetectorIDMapping();
+}
+
 //----------------------------------------------------------------------------------------------
 /** Sets the size of the workspace and initializes arrays to zero
  *  @param NVectors :: The number of vectors/histograms/detectors in the
@@ -68,6 +85,8 @@ void SpecialWorkspace2D::init(const size_t &NVectors, const size_t &XLength, con
     throw std::invalid_argument("SpecialWorkspace2D must have 'spectra' of length 1 only.");
   // Continue with standard initialization
   Workspace2D::init(NVectors, XLength, YLength);
+  // This method doesn't have an instrument to set the number of detectors, so set it here
+  this->setNumberOfDetectorGroups(NVectors);
 }
 
 void SpecialWorkspace2D::init(const HistogramData::Histogram &histogram) {

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -63,7 +63,10 @@ SpecialWorkspace2D::SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &pa
  * @param detids :: vector of detector IDs, one per spectrum
  */
 SpecialWorkspace2D::SpecialWorkspace2D(const std::vector<detid_t> &detids) {
-  this->initialize(detids.size(), 1, 1);
+  if (detids.empty()) // skip the full initialize method
+    this->init(0, 1, 1);
+  else
+    this->initialize(detids.size(), 1, 1);
   // set the detector ids
   for (size_t wi = 0; wi < detids.size(); ++wi) {
     this->getSpectrum(wi).setDetectorID(detids[wi]);

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -59,11 +59,11 @@ SpecialWorkspace2D::SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &pa
 /**
  * Constructor, building from a list of detector IDs.
  * Creates one spectrum per detector ID and associates each spectrum with its
- * corresponding detector ID.
+ * corresponding detector ID. This does not set an instrument.
  * @param detids :: vector of detector IDs, one per spectrum
  */
 SpecialWorkspace2D::SpecialWorkspace2D(const std::vector<detid_t> &detids) {
-  this->init(detids.size(), 1, 1);
+  this->initialize(detids.size(), 1, 1);
   // set the detector ids
   for (size_t wi = 0; wi < detids.size(); ++wi) {
     this->getSpectrum(wi).setDetectorID(detids[wi]);

--- a/Framework/DataObjects/test/GroupingWorkspaceTest.h
+++ b/Framework/DataObjects/test/GroupingWorkspaceTest.h
@@ -66,6 +66,29 @@ public:
     TS_ASSERT_EQUALS(map[45], 5);
   }
 
+  void test_constructor_from_detids() {
+    const std::vector<detid_t> detids = {10, 20, 30, 40, 50};
+    GroupingWorkspace_sptr ws(new GroupingWorkspace(detids));
+
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), detids.size());
+    TS_ASSERT_EQUALS(ws->blocksize(), 1);
+    for (size_t wi = 0; wi < detids.size(); ++wi) {
+      auto ids = ws->getSpectrum(wi).getDetectorIDs();
+      TS_ASSERT_EQUALS(ids.size(), 1);
+      TS_ASSERT_EQUALS(*ids.begin(), detids[wi]);
+    }
+
+    // Verify detID_to_WI mapping is populated via getValue (uses the map internally)
+    for (size_t wi = 0; wi < detids.size(); ++wi) {
+      TS_ASSERT_EQUALS(ws->getValue(detids[wi]), 0);
+    }
+  }
+
+  void test_constructor_from_detids_empty() {
+    GroupingWorkspace_sptr ws(new GroupingWorkspace(std::vector<detid_t>{}));
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 0);
+  }
+
   void testClone() {
     // As test_constructor_from_Instrument(), set on ws, get on clone.
     // Fake instrument with 5*9 pixels with ID starting at 1

--- a/Framework/DataObjects/test/SpecialWorkspace2DTest.h
+++ b/Framework/DataObjects/test/SpecialWorkspace2DTest.h
@@ -77,6 +77,29 @@ public:
     TS_ASSERT_DIFFERS(cloned->getValue(1), 1.1);
   }
 
+  void test_constructor_from_detids() {
+    const std::vector<detid_t> detids = {10, 20, 30, 40, 50};
+    SpecialWorkspace2D_sptr ws(new SpecialWorkspace2D(detids));
+
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), detids.size());
+    TS_ASSERT_EQUALS(ws->blocksize(), 1);
+    for (size_t wi = 0; wi < detids.size(); ++wi) {
+      auto ids = ws->getSpectrum(wi).getDetectorIDs();
+      TS_ASSERT_EQUALS(ids.size(), 1);
+      TS_ASSERT_EQUALS(*ids.begin(), detids[wi]);
+    }
+
+    // Verify detID_to_WI mapping is populated via getValue (uses the map internally)
+    for (size_t wi = 0; wi < detids.size(); ++wi) {
+      TS_ASSERT_EQUALS(ws->getValue(detids[wi]), 0);
+    }
+  }
+
+  void test_constructor_from_detids_empty() {
+    SpecialWorkspace2D_sptr ws(new SpecialWorkspace2D(std::vector<detid_t>{}));
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 0);
+  }
+
   void test_constructor_from_Instrument() {
     // Fake instrument with 5*9 pixels with ID starting at 1
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);

--- a/docs/source/algorithms/LoadDiffCal-v1.rst
+++ b/docs/source/algorithms/LoadDiffCal-v1.rst
@@ -22,6 +22,11 @@ This algorithm creates up to three workspaces from a hdf5 file:
 * ``GroupingWorkspace`` describes which pixels get added together by
   :ref:`algm-DiffractionFocussing`
 
+Specifying an Instrument
+------------------------
+If the instrument is supplied via ``InputWorkspace``, ``InstrumentName``, or ``InstrumentFilename``, it will be included in the :obj:`mantid.dataobjects.GroupingWorkspace` and :obj:`mantid.dataobjects.MaskWorkspace`.
+This is especially useful for debugging these in the instrument view.
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/release/v6.16.0/Diffraction/Powder/New_features/41070.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Powder/New_features/41070.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-LoadDiffCal` no longer requires the instrument to be resolvable. If the instrument definition file cannot be found or loaded, the grouping and mask workspaces are created directly from the detector IDs stored in the calibration file.


### PR DESCRIPTION
VULCAN added more detector banks and we are unable to process any of their data, including the previously existing banks, until a new IDF is created. This get past the issue in terms of loading the calibration file.

There is no associated issue, but this is related to [EWM15052](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15052).

### To test:

Pick your favorite diff-cal file and load it. The "data" can be viewed and the right-click menu item for showing the instrument is disabled.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
