### PR TITLE
Add monitor count handling in LoadNexusProcessed and related tests

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1236,6 +1236,14 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
         mnp = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntMNP(mnp);
       }
+    } else if (str == "column_18") {
+      NXDouble nxDouble = nx_tw.openNXDouble(str);
+      nxDouble.load();
+
+      for (size_t r = 0; r < numberPeaks; r++) {
+        double val = nxDouble[r];
+        peakWS->getPeak(r).setMonitorCount(val);
+      }
     }
 
     // After all columns read set IntHKL if not set
@@ -1519,6 +1527,14 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       for (size_t r = 0; r < numberPeaks; ++r) {
         mnp = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntMNP(mnp);
+      }
+    } else if (str == "column_21") {
+      NXDouble nxDouble = nx_tw.openNXDouble(str);
+      nxDouble.load();
+
+      for (size_t r = 0; r < numberPeaks; r++) {
+        double val = nxDouble[r];
+        peakWS->getPeak(r).setMonitorCount(val);
       }
     }
   }

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -1225,46 +1225,42 @@ public:
   }
 
   void test_load_peaksWorkspace_monitor_count() {
-    // Create a PeaksWorkspace with known monitor counts
-    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular2(1, 10);
-    auto pw = std::make_shared<PeaksWorkspace>();
-    pw->setInstrument(inst);
-    Peak p1(inst, 1, 3.0);
-    Peak p2(inst, 10, 4.0);
-    p1.setMonitorCount(12345.0);
-    p2.setMonitorCount(54321.0);
-    pw->addPeak(p1);
-    pw->addPeak(p2);
+    auto peaksTestWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
+    // contains two peaks
+    const std::string filename = FileFinder::Instance().getFullPath("unit_testing/MINITOPAZ_Definition.xml").string();
+    InstrumentDefinitionParser parser(filename, "MINITOPAZ", Strings::loadFile(filename));
+    auto instrument = parser.parseXML(nullptr);
+    peaksTestWS->populateInstrumentParameters();
+    peaksTestWS->setInstrument(instrument);
+    peaksTestWS->getPeak(0).setMonitorCount(12345);
+    peaksTestWS->getPeak(1).setMonitorCount(54321);
+    TS_ASSERT_EQUALS(peaksTestWS->getNumberPeaks(), 2);
 
-    // Save to file
-    std::string filename = "testLoadPeaksWorkspaceMonitorCount.nxs";
     SaveNexusProcessed saveAlg;
+    saveAlg.setChild(true);
     saveAlg.initialize();
-    saveAlg.setProperty("InputWorkspace", std::dynamic_pointer_cast<Workspace>(pw));
-    saveAlg.setPropertyValue("Filename", filename);
+    saveAlg.setProperty("InputWorkspace", peaksTestWS);
+    saveAlg.setPropertyValue("Filename", "test_load_peaksWorkspace_monitor_count.nxs");
     saveAlg.execute();
-    TS_ASSERT(saveAlg.isExecuted());
-    filename = saveAlg.getPropertyValue("Filename");
+    std::string filePath = saveAlg.getPropertyValue("Filename");
 
-    // Load back
     LoadNexusProcessed loadAlg;
+    loadAlg.setChild(true);
     loadAlg.initialize();
-    loadAlg.setPropertyValue("Filename", filename);
-    loadAlg.setPropertyValue("OutputWorkspace", "loaded_peaks_monitor_count");
+    loadAlg.setPropertyValue("Filename", filePath);
+    loadAlg.setPropertyValue("OutputWorkspace", "dummy");
     loadAlg.execute();
-    TS_ASSERT(loadAlg.isExecuted());
 
-    auto loaded = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("loaded_peaks_monitor_count");
-    TS_ASSERT(loaded);
-    if (loaded) {
-      TS_ASSERT_EQUALS(loaded->getNumberPeaks(), 2);
-      TS_ASSERT_DELTA(loaded->getPeak(0).getMonitorCount(), 12345.0, 1e-5);
-      TS_ASSERT_DELTA(loaded->getPeak(1).getMonitorCount(), 54321.0, 1e-5);
+    Mantid::API::Workspace_sptr loadedWS = loadAlg.getProperty("OutputWorkspace");
+    auto loadedPeaksWS = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(loadedWS);
+    TS_ASSERT_EQUALS(loadedPeaksWS->getNumberPeaks(), 2);
+    TS_ASSERT_DELTA(loadedPeaksWS->getPeak(0).getMonitorCount(), 12345.0, 1e-5);
+    TS_ASSERT_DELTA(loadedPeaksWS->getPeak(1).getMonitorCount(), 54321.0, 1e-5);
+
+    AnalysisDataService::Instance().remove("dummy");
+    if (std::filesystem::exists(filePath)) {
+      std::filesystem::remove(filePath);
     }
-
-    AnalysisDataService::Instance().remove("loaded_peaks_monitor_count");
-    if (std::filesystem::exists(filename))
-      std::filesystem::remove(filename);
   }
 
   void test_ws_run_title_failover_to_title() {

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -38,6 +38,7 @@
 #include <filesystem>
 #include <string>
 
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::Geometry;
@@ -1173,6 +1174,10 @@ public:
     lpws->addPeak(pk1);
     lpws->addPeak(pk2);
 
+    // Set known monitor counts
+    lpws->getPeak(0).setMonitorCount(12345.0);
+    lpws->getPeak(1).setMonitorCount(54321.0);
+
     // save the lean elastic peak workspace to temp
     std::string filename = "testLoadLeanElasticPeaksWorkspace.nxs";
     SaveNexusProcessed save;
@@ -1211,7 +1216,53 @@ public:
     TS_ASSERT_DELTA(lpws->getPeak(1).getQLabFrame().X(), pk2.getQLabFrame().X(), 1e-5);
     TS_ASSERT_DELTA(lpws->getPeak(1).getQLabFrame().Y(), pk2.getQLabFrame().Y(), 1e-5);
     TS_ASSERT_DELTA(lpws->getPeak(1).getQLabFrame().Z(), pk2.getQLabFrame().Z(), 1e-5);
+    // --monitor counts
+    TS_ASSERT_DELTA(lpws_loaded->getPeak(0).getMonitorCount(), 12345.0, 1e-5);
+    TS_ASSERT_DELTA(lpws_loaded->getPeak(1).getMonitorCount(), 54321.0, 1e-5);
 
+    if (std::filesystem::exists(filename))
+      std::filesystem::remove(filename);
+  }
+
+  void test_load_peaksWorkspace_monitor_count() {
+    // Create a PeaksWorkspace with known monitor counts
+    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular2(1, 10);
+    auto pw = std::make_shared<PeaksWorkspace>();
+    pw->setInstrument(inst);
+    Peak p1(inst, 1, 3.0);
+    Peak p2(inst, 10, 4.0);
+    p1.setMonitorCount(12345.0);
+    p2.setMonitorCount(54321.0);
+    pw->addPeak(p1);
+    pw->addPeak(p2);
+
+    // Save to file
+    std::string filename = "testLoadPeaksWorkspaceMonitorCount.nxs";
+    SaveNexusProcessed saveAlg;
+    saveAlg.initialize();
+    saveAlg.setProperty("InputWorkspace", std::dynamic_pointer_cast<Workspace>(pw));
+    saveAlg.setPropertyValue("Filename", filename);
+    saveAlg.execute();
+    TS_ASSERT(saveAlg.isExecuted());
+    filename = saveAlg.getPropertyValue("Filename");
+
+    // Load back
+    LoadNexusProcessed loadAlg;
+    loadAlg.initialize();
+    loadAlg.setPropertyValue("Filename", filename);
+    loadAlg.setPropertyValue("OutputWorkspace", "loaded_peaks_monitor_count");
+    loadAlg.execute();
+    TS_ASSERT(loadAlg.isExecuted());
+
+    auto loaded = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("loaded_peaks_monitor_count");
+    TS_ASSERT(loaded);
+    if (loaded) {
+      TS_ASSERT_EQUALS(loaded->getNumberPeaks(), 2);
+      TS_ASSERT_DELTA(loaded->getPeak(0).getMonitorCount(), 12345.0, 1e-5);
+      TS_ASSERT_DELTA(loaded->getPeak(1).getMonitorCount(), 54321.0, 1e-5);
+    }
+
+    AnalysisDataService::Instance().remove("loaded_peaks_monitor_count");
     if (std::filesystem::exists(filename))
       std::filesystem::remove(filename);
   }

--- a/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
@@ -425,6 +425,7 @@ void LeanElasticPeaksWorkspace::saveNexus(Nexus::File *file) const {
   std::vector<double> goniometerMatrix(9 * np);
   std::vector<std::string> shapes(np);
   std::vector<double> qlabs(3 * np);
+  std::vector<double> monitorCount(np);
 
   // Populate column vectors
   size_t maxShapeJSONLength = 0;
@@ -472,6 +473,7 @@ void LeanElasticPeaksWorkspace::saveNexus(Nexus::File *file) const {
       qlabs[3 * i + 1] = p.getQLabFrame().Y();
       qlabs[3 * i + 2] = p.getQLabFrame().Z();
     }
+    monitorCount[i] = p.getMonitorCount();
   }
 
   // Start Peaks Workspace in Nexus File
@@ -642,6 +644,14 @@ void LeanElasticPeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->putAttr("name", "IntMNP");
   file->putAttr("interpret_as", "A vector of 3 doubles");
   file->putAttr("units", "r.l.u.");
+  file->closeData();
+
+  // Monitor Count column
+  file->writeData("column_18", monitorCount);
+  file->openData("column_18");
+  file->putAttr("name", "Monitor Count");
+  file->putAttr("interpret_as", specifyDouble);
+  file->putAttr("units", "Not known");
   file->closeData();
 
   file->closeGroup(); // end of peaks workpace

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -671,6 +671,7 @@ void PeaksWorkspace::saveNexus(Nexus::File *file) const {
   std::vector<double> intMNP(3 * np);
   std::vector<double> goniometerMatrix(9 * np);
   std::vector<std::string> shapes(np);
+  std::vector<double> monitorCount(np);
 
   // Populate column vectors from Peak Workspace
   size_t maxShapeJSONLength = 0;
@@ -717,6 +718,7 @@ void PeaksWorkspace::saveNexus(Nexus::File *file) const {
     if (shapeJSON.size() > maxShapeJSONLength) {
       maxShapeJSONLength = shapeJSON.size();
     }
+    monitorCount[i] = p.getMonitorCount();
   }
 
   // Start Peaks Workspace in Nexus File
@@ -878,6 +880,14 @@ void PeaksWorkspace::saveNexus(Nexus::File *file) const {
   file->putAttr("name", "IntMNP");
   file->putAttr("interpret_as", "A vector of 3 doubles");
   file->putAttr("units", "r.l.u.");
+  file->closeData();
+
+  // Monitor Count column
+  file->writeData("column_21", monitorCount);
+  file->openData("column_21");
+  file->putAttr("name", "Monitor Count");
+  file->putAttr("interpret_as", specifyDouble);
+  file->putAttr("units", "Not known");
   file->closeData();
 
   // Goniometer Matrix Column

--- a/Framework/DataObjects/test/LeanElasticPeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeaksWorkspaceTest.h
@@ -252,6 +252,11 @@ public:
     lpws->addPeak(p2);
     lpws->addPeak(p3);
 
+    // Set known monitor counts
+    lpws->getPeak(0).setMonitorCount(1000.0);
+    lpws->getPeak(1).setMonitorCount(2000.0);
+    lpws->getPeak(2).setMonitorCount(3000.0);
+
     // save to nexus
     NexusTestHelper nexusHelper(true);
     nexusHelper.createFile("testSaveLeanElasticPeaksWorkspace.nxs");
@@ -270,5 +275,20 @@ public:
     TS_ASSERT_DELTA(waveLengths[0], 3.0, 1e-5);
     TS_ASSERT_DELTA(waveLengths[1], 4.0, 1e-5);
     TS_ASSERT_DELTA(waveLengths[2], 5.0, 1e-5);
+
+    // Check monitor counts
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openData("column_18"));
+    std::string monitorColumnName;
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getAttr("name", monitorColumnName));
+    TS_ASSERT_EQUALS(monitorColumnName, "Monitor Count");
+    std::vector<double> monitorCounts;
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getData(monitorCounts));
+    nexusHelper.file->closeData();
+    TS_ASSERT_EQUALS(monitorCounts.size(), 3);
+    if (monitorCounts.size() >= 3) {
+      TS_ASSERT_DELTA(monitorCounts[0], 1000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[1], 2000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[2], 3000.0, 1e-5);
+    }
   }
 };

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -238,6 +238,23 @@ public:
       TS_ASSERT_DELTA(waveLengths[3], 3.0, 1e-5);
       TS_ASSERT_DELTA(waveLengths[4], 3.0, 1e-5);
     }
+
+    // Check monitor counts
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openData("column_21"));
+    std::string monitorColumnName;
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getAttr("name", monitorColumnName));
+    TS_ASSERT_EQUALS(monitorColumnName, "Monitor Count");
+    std::vector<double> monitorCounts;
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getData(monitorCounts));
+    nexusHelper.file->closeData();
+    TS_ASSERT_EQUALS(monitorCounts.size(), 5);
+    if (monitorCounts.size() >= 5) {
+      TS_ASSERT_DELTA(monitorCounts[0], 1000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[1], 2000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[2], 3000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[3], 4000.0, 1e-5);
+      TS_ASSERT_DELTA(monitorCounts[4], 5000.0, 1e-5);
+    }
   }
 
   void test_getSetLogAccess() {
@@ -646,6 +663,11 @@ private:
     pw->addPeak(p2);
     pw->addPeak(p3);
     pw->addPeak(p4);
+
+    // Set known monitor counts on all 5 peaks
+    for (size_t i = 0; i < pw->getNumberPeaks(); i++) {
+      pw->getPeak(i).setMonitorCount(1000.0 * static_cast<double>(i + 1));
+    }
 
     return pw;
   }

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -665,7 +665,7 @@ private:
     pw->addPeak(p4);
 
     // Set known monitor counts on all 5 peaks
-    for (size_t i = 0; i < pw->getNumberPeaks(); i++) {
+    for (size_t i = 0; i < static_cast<size_t>(pw->getNumberPeaks()); i++) {
       pw->getPeak(i).setMonitorCount(1000.0 * static_cast<double>(i + 1));
     }
 

--- a/Testing/SystemTests/tests/framework/SingleCrystalPeaksTest.py
+++ b/Testing/SystemTests/tests/framework/SingleCrystalPeaksTest.py
@@ -37,6 +37,7 @@ class SingleCrystalPeaksIntHKLIntMNPSaveLoadTest(systemtesting.MantidSystemTest)
         pk = pks.createPeak([3, 2, 1])
         pk.setIntHKL(V3D(1, 3, 2))
         pk.setIntMNP(V3D(3, 2, 1))
+        pk.setMonitorCount(54321.0)
         pks.addPeak(pk)
 
         file_name = os.path.join(self._test_dir, "peaks_workspace.nxs")
@@ -46,6 +47,7 @@ class SingleCrystalPeaksIntHKLIntMNPSaveLoadTest(systemtesting.MantidSystemTest)
 
         self.assertAlmostEqual(ref.getPeak(0).getIntHKL(), pks.getPeak(0).getIntHKL())
         self.assertAlmostEqual(ref.getPeak(0).getIntMNP(), pks.getPeak(0).getIntMNP())
+        self.assertAlmostEqual(ref.getPeak(0).getMonitorCount(), 54321.0)
 
         # lean peaks workspace
         pks = ConvertPeaksWorkspace(pks)
@@ -57,3 +59,4 @@ class SingleCrystalPeaksIntHKLIntMNPSaveLoadTest(systemtesting.MantidSystemTest)
 
         self.assertAlmostEqual(ref.getPeak(0).getIntHKL(), pks.getPeak(0).getIntHKL())
         self.assertAlmostEqual(ref.getPeak(0).getIntMNP(), pks.getPeak(0).getIntMNP())
+        self.assertAlmostEqual(ref.getPeak(0).getMonitorCount(), 54321.0)

--- a/docs/source/release/v6.16.0/Framework/Data_Objects/Bugfixes/41072.rst
+++ b/docs/source/release/v6.16.0/Framework/Data_Objects/Bugfixes/41072.rst
@@ -1,0 +1,2 @@
+- adds persistence and round-trip support for the MonitorCount field on peaks
+  when saving/loading Mantid “processed” NeXus peak workspaces.


### PR DESCRIPTION
### Description of work

Saving and loading monitor counts for the two types of peak workspaces.

**Changes:**
- Write `Monitor Count` as a new NeXus table column for `PeaksWorkspace` (`column_21`) and `LeanElasticPeaksWorkspace` (`column_18`).
- Load those columns in `LoadNexusProcessed` and apply them back onto each peak via `setMonitorCount`.
- Add/extend C++ unit tests and a Python system test to validate save/load round-tripping of monitor counts.

Companion to #41073  
Implements [EWM 15113](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15113)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
After building this branch, run script [EWM_15113_manual_test.py](https://github.com/user-attachments/files/26036648/EWM_15113_manual_test.py) in Workbench and verify all checks pass.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
