### PR TITLE
Added the checkbox to toggle the Y axis scale in the Reflectometry GUI

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -591,10 +591,20 @@ def _do_single_plot(ax, workspaces, errors, set_title, nums, kw, plot_kwargs, lo
 
 def _apply_scale_properties(ax_properties, scale_id, axis):
     mod_ax_properties = copy(ax_properties)
-    scale_properties = {"value": mod_ax_properties.pop(f"{scale_id}scale")}
+    scale_value = mod_ax_properties.pop(f"{scale_id}scale")
+    scale_properties = {"value": scale_value}
     add_prop_key = f"{scale_id}scale_opts"
     if add_prop_key in mod_ax_properties:
-        scale_properties.update(mod_ax_properties.pop(add_prop_key))
+        extra_props = mod_ax_properties.pop(add_prop_key)
+        if scale_value == "symlog":
+            allowed = {"linthresh", "linscale", "base", "subs"}
+        elif scale_value == "log":
+            allowed = {"base", "subs", "nonpositive"}
+        elif scale_value == "linear":
+            allowed = set()
+        else:
+            allowed = set(extra_props.keys())
+        scale_properties.update({k: v for k, v in extra_props.items() if k in allowed})
     getattr(axis, f"set_{scale_id}scale")(**scale_properties)
     return mod_ax_properties
 

--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -209,6 +209,7 @@ Preview tab
 #. Type ``INTER45455`` into the ``Run`` input. Set the ``Angle`` to ``1`` and click ``Load``. The instrument view plot should display the data on a detector with four banks. Note, with this dataset, we expect an error "Detector with ID..." to be thrown at this stage.
 #. Go to the drop-down underneath the color scale next to the second (slice viewer) plot and select ``SymmetricLog10``. This should allow you to see the counts on the slice viewer plot more clearly. You should see what appear as roughly four horizontal lines of data on the plot.
 #. Going back to the instrument view plot, click the rectangle-select button above it and draw a single region that selects all detector banks. The selected detector segments should be summed and the result plotted on the slice viewer, appearing as a single line of data.
+#. Check the ``Set Y-Axis Symlog`` checkbox and verify that the Y-axis of the plot updates. Input a value for ``Linthresh`` less than 2.0 and click ``Apply``. Verify that the plot updates accordingly.
 #. Reduce the size of your original region on the instrument view and check that multiple regions can be added to the plot. Check that when moving and resizing regions, the slice viewer plot is updated.
 #. Check that you can delete regions from the instrument view by selecting them and pressing the delete key on your keyboard.
 #. Make sure you have at least one region selected on the instrument view.

--- a/docs/source/release/v6.16.0/Reflectometry/New_features/40956.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/New_features/40956.rst
@@ -1,0 +1,1 @@
+- The :ref:`Reduction Preview <refl_preview>` tab in the ``ISIS Reflectometry`` interface now has a checkbox to toggle the Y-axis scale between log and symlog. A line edit has also been added to set the linthresh value.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -35,6 +35,7 @@ public:
 
   virtual void notifyEditROIModeRequested() = 0;
   virtual void notifyRectangularROIModeRequested() = 0;
+  virtual void notifySetYAxisSymlogChanged(bool checked) = 0;
 };
 
 class IPreviewDockedWidgets {
@@ -55,6 +56,7 @@ public:
   virtual void setInstViewSelectRectMode() = 0;
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
   virtual void setRegionSelectorEnabled(bool enable) = 0;
+  virtual void setYAxisSymlog(bool checked) = 0;
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
   virtual void setRectangularROIState(bool state) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -36,6 +36,7 @@ public:
   virtual void notifyEditROIModeRequested() = 0;
   virtual void notifyRectangularROIModeRequested() = 0;
   virtual void notifySetYAxisSymlogChanged(bool checked) = 0;
+  virtual void notifySetLinthreshChanged(double linthresh) = 0;
 };
 
 class IPreviewDockedWidgets {
@@ -56,7 +57,6 @@ public:
   virtual void setInstViewSelectRectMode() = 0;
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
   virtual void setRegionSelectorEnabled(bool enable) = 0;
-  virtual void setYAxisSymlog(bool checked) = 0;
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
   virtual void setRectangularROIState(bool state) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -60,6 +60,7 @@ public:
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
   virtual void setRectangularROIState(bool state) = 0;
+  virtual void setLinthreshold() const = 0;
 
   virtual std::vector<size_t> getSelectedDetectors() const = 0;
   virtual std::string getRegionType() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -35,8 +35,7 @@ public:
 
   virtual void notifyEditROIModeRequested() = 0;
   virtual void notifyRectangularROIModeRequested() = 0;
-  virtual void notifySetYAxisSymlogChanged(bool checked) = 0;
-  virtual void notifySetLinthreshChanged(double linthresh) = 0;
+  virtual void notifySetYAxisSymlogChanged() = 0;
 };
 
 class IPreviewDockedWidgets {
@@ -60,10 +59,11 @@ public:
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
   virtual void setRectangularROIState(bool state) = 0;
-  virtual void setLinthreshold() const = 0;
 
   virtual std::vector<size_t> getSelectedDetectors() const = 0;
   virtual std::string getRegionType() const = 0;
+  virtual double getLinthresh() const = 0;
+  virtual bool getSymlogEnabled() const = 0;
 
   virtual QLayout *getRegionSelectorLayout() const = 0;
   virtual MantidQt::MantidWidgets::IPlotView *getLinePlotView() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -157,6 +157,16 @@
            </property>
           </spacer>
          </item>
+         <item>
+            <widget class="QCheckBox" name="set_yaxis_symlog_checkbox">
+                <property name="text">
+                    <string>Set Y-Axis Symlog</string>
+                </property>
+                <property name="checked">
+                    <bool>false</bool>
+                </property>
+            </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -157,50 +157,6 @@
            </property>
           </spacer>
          </item>
-         <item>
-            <layout class="QVBoxLayout" name="symlog_controls_layout">
-                <item>
-                    <widget class="QCheckBox" name="set_yaxis_symlog_checkbox">
-                        <property name="text">
-                            <string>Set Y-Axis Symlog</string>
-                        </property>
-                        <property name="checked">
-                            <bool>false</bool>
-                        </property>
-                    </widget>
-                </item>
-                <item>
-                    <widget class="QWidget" name="linthresh_container">
-                        <property name="visible">
-                            <bool>false</bool>
-                        </property>
-                        <layout class="QHBoxLayout" name="linthresh_layout">
-                            <item>
-                                <widget class="QLabel" name="linthresh_label">
-                                    <property name="text">
-                                        <string>Linthresh:</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QLineEdit" name="linthresh_line_edit">
-                                    <property name="placeholderText">
-                                        <string>1e-4</string>
-                                    </property>
-                                </widget>
-                            </item>
-                            <item>
-                                <widget class="QPushButton" name="apply_button">
-                                    <property name="text">
-                                        <string>Apply</string>
-                                    </property>
-                                </widget>
-                            </item>
-                        </layout>
-                    </widget>
-                </item>
-            </layout>
-        </item>
         </layout>
        </item>
        <item>
@@ -251,6 +207,50 @@
          </property>
         </widget>
        </item>
+       <item>
+            <layout class="QVBoxLayout" name="symlog_controls_layout">
+                <item>
+                    <widget class="QCheckBox" name="set_yaxis_symlog_checkbox">
+                        <property name="text">
+                            <string>Set Y-Axis Symlog</string>
+                        </property>
+                        <property name="checked">
+                            <bool>false</bool>
+                        </property>
+                    </widget>
+                </item>
+                <item>
+                    <widget class="QWidget" name="linthresh_container">
+                        <property name="visible">
+                            <bool>false</bool>
+                        </property>
+                        <layout class="QHBoxLayout" name="linthresh_layout">
+                            <item>
+                                <widget class="QLabel" name="linthresh_label">
+                                    <property name="text">
+                                        <string>Linthresh:</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QLineEdit" name="linthresh_line_edit">
+                                    <property name="placeholderText">
+                                        <string>1e-4</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QPushButton" name="apply_button">
+                                    <property name="text">
+                                        <string>Apply</string>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </widget>
+                </item>
+            </layout>
+        </item>
       </layout>
      </item>
     </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -158,15 +158,49 @@
           </spacer>
          </item>
          <item>
-            <widget class="QCheckBox" name="set_yaxis_symlog_checkbox">
-                <property name="text">
-                    <string>Set Y-Axis Symlog</string>
-                </property>
-                <property name="checked">
-                    <bool>false</bool>
-                </property>
-            </widget>
-         </item>
+            <layout class="QVBoxLayout" name="symlog_controls_layout">
+                <item>
+                    <widget class="QCheckBox" name="set_yaxis_symlog_checkbox">
+                        <property name="text">
+                            <string>Set Y-Axis Symlog</string>
+                        </property>
+                        <property name="checked">
+                            <bool>false</bool>
+                        </property>
+                    </widget>
+                </item>
+                <item>
+                    <widget class="QWidget" name="linthresh_container">
+                        <property name="visible">
+                            <bool>false</bool>
+                        </property>
+                        <layout class="QHBoxLayout" name="linthresh_layout">
+                            <item>
+                                <widget class="QLabel" name="linthresh_label">
+                                    <property name="text">
+                                        <string>Linthresh:</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QLineEdit" name="linthresh_line_edit">
+                                    <property name="placeholderText">
+                                        <string>1e-4</string>
+                                    </property>
+                                </widget>
+                            </item>
+                            <item>
+                                <widget class="QPushButton" name="apply_button">
+                                    <property name="text">
+                                        <string>Apply</string>
+                                    </property>
+                                </widget>
+                            </item>
+                        </layout>
+                    </widget>
+                </item>
+            </layout>
+        </item>
         </layout>
        </item>
        <item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -61,7 +61,7 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_dockedWidgets->setInstViewToolbarEnabled(false);
   m_dockedWidgets->setRegionSelectorEnabled(false);
 
-  m_plotPresenter->setScaleSymLog(AxisID::YLeft, 1e-4);
+  m_plotPresenter->setScaleLog(AxisID::YLeft);
   m_plotPresenter->setAxisLimit(AxisID::YLeft, -1e-5, 2.0);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
   m_plotPresenter->setPlotErrorBars(true);
@@ -77,11 +77,21 @@ void PreviewPresenter::notifyAutoreductionResumed() { updateWidgetEnabledState()
 
 void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState(); }
 
+void PreviewPresenter::notifySetYAxisSymlogChanged(bool checked) { updatePlotAxes(checked); }
+
 void PreviewPresenter::updateWidgetEnabledState() {
   if (m_mainPresenter->isProcessing() || m_mainPresenter->isAutoreducing()) {
     m_view->disableMainWidget();
   } else {
     m_view->enableMainWidget();
+  }
+}
+
+void PreviewPresenter::updatePlotAxes(bool checked) {
+  if (checked) {
+    m_plotPresenter->setScaleSymLog(AxisID::YLeft, 1e-4);
+  } else {
+    m_plotPresenter->setScaleLog(AxisID::YLeft);
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -91,7 +91,7 @@ void PreviewPresenter::updateWidgetEnabledState() {
 
 void PreviewPresenter::updatePlotAxes(bool checked) {
   if (checked) {
-    m_plotPresenter->setScaleSymLog(AxisID::YLeft, 1e-4);
+    m_dockedWidgets->setLinthreshold();
   } else {
     m_plotPresenter->setScaleLog(AxisID::YLeft);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -76,9 +76,7 @@ void PreviewPresenter::notifyAutoreductionResumed() { updateWidgetEnabledState()
 
 void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState(); }
 
-void PreviewPresenter::notifySetYAxisSymlogChanged(bool checked) { updatePlotAxes(checked); }
-
-void PreviewPresenter::notifySetLinthreshChanged(double linthresh) { updateLinthresh(linthresh); }
+void PreviewPresenter::notifySetYAxisSymlogChanged() { updatePlotAxes(); }
 
 void PreviewPresenter::updateWidgetEnabledState() {
   if (m_mainPresenter->isProcessing() || m_mainPresenter->isAutoreducing()) {
@@ -88,18 +86,16 @@ void PreviewPresenter::updateWidgetEnabledState() {
   }
 }
 
-void PreviewPresenter::updatePlotAxes(bool checked) {
+void PreviewPresenter::updatePlotAxes() {
+  bool checked = m_dockedWidgets->getSymlogEnabled();
   if (checked) {
-    m_dockedWidgets->setLinthreshold();
+    double linthresh = m_dockedWidgets->getLinthresh();
+    m_plotPresenter->setScaleSymLog(AxisID::YLeft, linthresh);
     m_plotPresenter->setAxisLimit(AxisID::YLeft, -1e-5, 2.0);
   } else {
     m_plotPresenter->setScaleLog(AxisID::YLeft);
+    m_plotPresenter->setAxisLimit(AxisID::YLeft, 1e-5, 2.0);
   }
-  m_plotPresenter->plot();
-}
-
-void PreviewPresenter::updateLinthresh(double linthresh) {
-  m_plotPresenter->setScaleSymLog(AxisID::YLeft, linthresh);
   m_plotPresenter->plot();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -79,6 +79,8 @@ void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState();
 
 void PreviewPresenter::notifySetYAxisSymlogChanged(bool checked) { updatePlotAxes(checked); }
 
+void PreviewPresenter::notifySetLinthreshChanged(double linthresh) { updateLinthresh(linthresh); }
+
 void PreviewPresenter::updateWidgetEnabledState() {
   if (m_mainPresenter->isProcessing() || m_mainPresenter->isAutoreducing()) {
     m_view->disableMainWidget();
@@ -94,6 +96,8 @@ void PreviewPresenter::updatePlotAxes(bool checked) {
     m_plotPresenter->setScaleLog(AxisID::YLeft);
   }
 }
+
+void PreviewPresenter::updateLinthresh(double linthresh) { m_plotPresenter->setScaleSymLog(AxisID::YLeft, linthresh); }
 
 /** Notification received when the user has requested to load a workspace. If it already exists in the ADS
  * then we use that and continue to plot it; otherwise we start an async load.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -95,9 +95,13 @@ void PreviewPresenter::updatePlotAxes(bool checked) {
   } else {
     m_plotPresenter->setScaleLog(AxisID::YLeft);
   }
+  m_plotPresenter->plot();
 }
 
-void PreviewPresenter::updateLinthresh(double linthresh) { m_plotPresenter->setScaleSymLog(AxisID::YLeft, linthresh); }
+void PreviewPresenter::updateLinthresh(double linthresh) {
+  m_plotPresenter->setScaleSymLog(AxisID::YLeft, linthresh);
+  m_plotPresenter->plot();
+}
 
 /** Notification received when the user has requested to load a workspace. If it already exists in the ADS
  * then we use that and continue to plot it; otherwise we start an async load.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -62,7 +62,6 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_dockedWidgets->setRegionSelectorEnabled(false);
 
   m_plotPresenter->setScaleLog(AxisID::YLeft);
-  m_plotPresenter->setAxisLimit(AxisID::YLeft, -1e-5, 2.0);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
   m_plotPresenter->setPlotErrorBars(true);
 }
@@ -92,6 +91,7 @@ void PreviewPresenter::updateWidgetEnabledState() {
 void PreviewPresenter::updatePlotAxes(bool checked) {
   if (checked) {
     m_dockedWidgets->setLinthreshold();
+    m_plotPresenter->setAxisLimit(AxisID::YLeft, -1e-5, 2.0);
   } else {
     m_plotPresenter->setScaleLog(AxisID::YLeft);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -79,6 +79,7 @@ public:
 
   void notifyEditROIModeRequested() override;
   void notifyRectangularROIModeRequested() override;
+  void notifySetYAxisSymlogChanged(bool checked) override;
 
   void notifyApplyRequested() override;
 
@@ -122,5 +123,6 @@ private:
   void clearReductionPlot();
   bool isRegionSelectionChanged();
   bool isRegionChanged(ROIType type);
+  void updatePlotAxes(bool checked);
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -80,6 +80,7 @@ public:
   void notifyEditROIModeRequested() override;
   void notifyRectangularROIModeRequested() override;
   void notifySetYAxisSymlogChanged(bool checked) override;
+  void notifySetLinthreshChanged(double linthresh) override;
 
   void notifyApplyRequested() override;
 
@@ -124,5 +125,6 @@ private:
   bool isRegionSelectionChanged();
   bool isRegionChanged(ROIType type);
   void updatePlotAxes(bool checked);
+  void updateLinthresh(double linthresh);
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -79,8 +79,7 @@ public:
 
   void notifyEditROIModeRequested() override;
   void notifyRectangularROIModeRequested() override;
-  void notifySetYAxisSymlogChanged(bool checked) override;
-  void notifySetLinthreshChanged(double linthresh) override;
+  void notifySetYAxisSymlogChanged() override;
 
   void notifyApplyRequested() override;
 
@@ -124,7 +123,6 @@ private:
   void clearReductionPlot();
   bool isRegionSelectionChanged();
   bool isRegionChanged(ROIType type);
-  void updatePlotAxes(bool checked);
-  void updateLinthresh(double linthresh);
+  void updatePlotAxes();
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -82,6 +82,7 @@ void QtPreviewDockedWidgets::connectSignals() const {
   connect(m_ui.rs_edit_button, SIGNAL(clicked()), this, SLOT(onEditROIClicked()));
   // Line plot toolbar
   connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
+  connect(m_ui.set_yaxis_symlog_checkbox, SIGNAL(toggled(bool)), this, SLOT(setYAxisSymlog(bool)));
 }
 
 void QtPreviewDockedWidgets::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
@@ -94,6 +95,8 @@ void QtPreviewDockedWidgets::onRegionSelectorExportToAdsClicked() const {
 }
 
 void QtPreviewDockedWidgets::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequested(); }
+
+void QtPreviewDockedWidgets::setYAxisSymlog(bool checked) { m_notifyee->notifySetYAxisSymlogChanged(checked); }
 
 void QtPreviewDockedWidgets::onAddRectangularROIClicked(QAction *regionType) const {
   m_ui.rs_rect_select_button->setDefaultAction(regionType);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -82,7 +82,9 @@ void QtPreviewDockedWidgets::connectSignals() const {
   connect(m_ui.rs_edit_button, SIGNAL(clicked()), this, SLOT(onEditROIClicked()));
   // Line plot toolbar
   connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
-  connect(m_ui.set_yaxis_symlog_checkbox, SIGNAL(toggled(bool)), this, SLOT(setYAxisSymlog(bool)));
+  connect(m_ui.set_yaxis_symlog_checkbox, SIGNAL(toggled(bool)), this, SLOT(onYAxisSymlogToggled(bool)));
+  connect(m_ui.linthresh_line_edit, SIGNAL(textChanged(QString)), this, SLOT(onLineEditUpdated()));
+  connect(m_ui.apply_button, SIGNAL(clicked()), this, SLOT(onApplyButtonClicked()));
 }
 
 void QtPreviewDockedWidgets::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
@@ -96,7 +98,23 @@ void QtPreviewDockedWidgets::onRegionSelectorExportToAdsClicked() const {
 
 void QtPreviewDockedWidgets::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequested(); }
 
-void QtPreviewDockedWidgets::setYAxisSymlog(bool checked) { m_notifyee->notifySetYAxisSymlogChanged(checked); }
+void QtPreviewDockedWidgets::onYAxisSymlogToggled(bool checked) const {
+  m_ui.linthresh_container->setVisible(checked);
+  onLineEditUpdated();
+  m_notifyee->notifySetYAxisSymlogChanged(checked);
+}
+
+void QtPreviewDockedWidgets::onLineEditUpdated() const {
+  m_ui.apply_button->setEnabled(!m_ui.linthresh_line_edit->text().isEmpty());
+}
+
+void QtPreviewDockedWidgets::onApplyButtonClicked() const {
+  bool ok = false;
+  double linthresh = m_ui.linthresh_line_edit->text().toDouble(&ok);
+  if (ok && linthresh > 0.0) {
+    m_notifyee->notifySetLinthreshChanged(linthresh);
+  }
+}
 
 void QtPreviewDockedWidgets::onAddRectangularROIClicked(QAction *regionType) const {
   m_ui.rs_rect_select_button->setDefaultAction(regionType);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -107,12 +107,15 @@ void QtPreviewDockedWidgets::onYAxisSymlogToggled(bool checked) const {
 void QtPreviewDockedWidgets::onLineEditUpdated() const {
   m_ui.apply_button->setEnabled(!m_ui.linthresh_line_edit->text().isEmpty());
 }
+void QtPreviewDockedWidgets::setLinthreshold() const { onApplyButtonClicked(); }
 
 void QtPreviewDockedWidgets::onApplyButtonClicked() const {
   bool ok = false;
   double linthresh = m_ui.linthresh_line_edit->text().toDouble(&ok);
   if (ok && linthresh > 0.0) {
     m_notifyee->notifySetLinthreshChanged(linthresh);
+  } else {
+    m_notifyee->notifySetLinthreshChanged(1e-4);
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -101,23 +101,14 @@ void QtPreviewDockedWidgets::onEditROIClicked() const { m_notifyee->notifyEditRO
 void QtPreviewDockedWidgets::onYAxisSymlogToggled(bool checked) const {
   m_ui.linthresh_container->setVisible(checked);
   onLineEditUpdated();
-  m_notifyee->notifySetYAxisSymlogChanged(checked);
+  m_notifyee->notifySetYAxisSymlogChanged();
 }
 
 void QtPreviewDockedWidgets::onLineEditUpdated() const {
   m_ui.apply_button->setEnabled(!m_ui.linthresh_line_edit->text().isEmpty());
 }
-void QtPreviewDockedWidgets::setLinthreshold() const { onApplyButtonClicked(); }
 
-void QtPreviewDockedWidgets::onApplyButtonClicked() const {
-  bool ok = false;
-  double linthresh = m_ui.linthresh_line_edit->text().toDouble(&ok);
-  if (ok && linthresh > 0.0) {
-    m_notifyee->notifySetLinthreshChanged(linthresh);
-  } else {
-    m_notifyee->notifySetLinthreshChanged(1e-4);
-  }
-}
+void QtPreviewDockedWidgets::onApplyButtonClicked() const { m_notifyee->notifySetYAxisSymlogChanged(); }
 
 void QtPreviewDockedWidgets::onAddRectangularROIClicked(QAction *regionType) const {
   m_ui.rs_rect_select_button->setDefaultAction(regionType);
@@ -178,6 +169,18 @@ void QtPreviewDockedWidgets::setInstViewToolbarEnabled(bool enable) {
   m_ui.iv_zoom_button->setEnabled(enable);
   m_ui.iv_edit_button->setEnabled(enable);
   m_ui.iv_rect_select_button->setEnabled(enable);
+}
+
+bool QtPreviewDockedWidgets::getSymlogEnabled() const { return m_ui.set_yaxis_symlog_checkbox->isChecked(); }
+
+double QtPreviewDockedWidgets::getLinthresh() const {
+  bool ok = false;
+  double linthresh = m_ui.linthresh_line_edit->text().toDouble(&ok);
+  if (ok && linthresh > 0.0) {
+    return linthresh;
+  } else {
+    return 1e-4;
+  }
 }
 
 void QtPreviewDockedWidgets::setRegionSelectorEnabled(bool enable) { m_ui.rs_dock_content->setEnabled(enable); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -78,5 +78,6 @@ private slots:
   void onLinePlotExportToAdsClicked() const;
   void onEditROIClicked() const;
   void onAddRectangularROIClicked(QAction *regionType) const;
+  void setYAxisSymlog(bool checked) override;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -52,6 +52,7 @@ public:
   // Region selector toolbar
   void setEditROIState(bool state) override;
   void setRectangularROIState(bool state) override;
+  void setLinthreshold() const override;
 
   std::vector<size_t> getSelectedDetectors() const override;
   std::string getRegionType() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -78,6 +78,8 @@ private slots:
   void onLinePlotExportToAdsClicked() const;
   void onEditROIClicked() const;
   void onAddRectangularROIClicked(QAction *regionType) const;
-  void setYAxisSymlog(bool checked) override;
+  void onYAxisSymlogToggled(bool checked) const;
+  void onLineEditUpdated() const;
+  void onApplyButtonClicked() const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -52,10 +52,11 @@ public:
   // Region selector toolbar
   void setEditROIState(bool state) override;
   void setRectangularROIState(bool state) override;
-  void setLinthreshold() const override;
 
   std::vector<size_t> getSelectedDetectors() const override;
   std::string getRegionType() const override;
+  double getLinthresh() const override;
+  bool getSymlogEnabled() const override;
 
   QLayout *getRegionSelectorLayout() const override;
   MantidQt::MantidWidgets::IPlotView *getLinePlotView() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -34,6 +34,8 @@ public:
   MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(std::string, getRegionType, (), (const, override));
+  MOCK_METHOD(double, getLinthresh, (), (const, override));
+  MOCK_METHOD(bool, getSymlogEnabled, (), (const, override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
   MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -31,6 +31,7 @@ public:
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));
+  MOCK_METHOD(void, setLinthreshold, (), (const, override));
   MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(std::string, getRegionType, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -31,7 +31,6 @@ public:
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));
-  MOCK_METHOD(void, setLinthreshold, (), (const, override));
   MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(std::string, getRegionType, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -890,7 +890,6 @@ private:
     EXPECT_CALL(linePlot, setScaleLog(AxisID::YLeft)).Times(1);
     EXPECT_CALL(linePlot, setScaleLog(AxisID::XBottom)).Times(1);
     EXPECT_CALL(linePlot, setPlotErrorBars(true)).Times(1);
-    EXPECT_CALL(linePlot, setAxisLimit(AxisID::YLeft, -1e-5, 2.0)).Times(1);
   }
 
   void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewModel &mockModel,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -887,7 +887,7 @@ private:
 
   void expectPresenterConstructed(MockRegionSelector &regionSelector, MockPlotPresenter &linePlot) {
     EXPECT_CALL(regionSelector, subscribe(NotNull())).Times(1);
-    EXPECT_CALL(linePlot, setScaleSymLog(AxisID::YLeft, 1e-4)).Times(1);
+    EXPECT_CALL(linePlot, setScaleLog(AxisID::YLeft)).Times(1);
     EXPECT_CALL(linePlot, setScaleLog(AxisID::XBottom)).Times(1);
     EXPECT_CALL(linePlot, setPlotErrorBars(true)).Times(1);
     EXPECT_CALL(linePlot, setAxisLimit(AxisID::YLeft, -1e-5, 2.0)).Times(1);


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Closes #40956 . <!-- One line per closed issue. -->

Reverted the Y-axis plot scale in the Reflectivity GUI to log by default. The scale can optionally be made symlog using a checkbox. The linethresh parameter can also be provided.

<img width="269" height="61" alt="image" src="https://github.com/user-attachments/assets/21e97d82-6960-4886-b7ef-9de908653543" />


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

The steps come from the manual tests of the [Preview Tab](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#preview-tab)
1) Go to the **Reduction Preview** tab.
2) Type `INTER45455` into the Run input. Set the Angle to `1` and click **Load**.
3) 'Going back to the instrument view plot, click the rectangle-select button above it and draw a single region that selects all detector banks. The selected detector segments should be summed and the result plotted on the slice viewer, appearing as a single line of data.'
4) Check the `set Y-Axis Symlog` box and verify that the axis of the plot update.
<img width="337" height="264" alt="image" src="https://github.com/user-attachments/assets/3598a7e0-0295-4d37-8cfa-76d66480984a" />

5) Enter a different value in the line edit for **linthresh** and click apply and verify that the plot axis updates. The value provided must be less than **2**. 

**Note-**
There is some capping that is done in the code. It might originate from [here](https://github.com/mantidproject/mantid/blob/14d8aaa12d33b9788c22e60853f4bad23436bc31/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py#L37) where the last_valid_value is set to 2.0. I did not change the values/thresholds in this part of the code because it might effect other plotting functionality else where but can have a deeper look to see where to update the code so that **linthresh** can be set to a larger value as well.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
