### PR TITLE
Virtual Instrument Refactor Work :floppy_disk: - DO NOT MERGE

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -2160,7 +2160,7 @@ void MatrixWorkspace::buildDefaultSpectrumDefinitions() {
 void MatrixWorkspace::rebuildDetectorIDGroupings() {
   const auto &detInfo = detectorInfo();
   const auto detInfo_scanCount = detInfo.scanCount(); // cache value outside of the loop
-  // Use size() directly; avoid detectorIDs()
+  // Use size() directly; avoid detectorIDs() to keep compact m_detectorIDs for PA instruments.
   const auto allDetIDs_size = detInfo.size();
   const auto &specDefs = m_indexInfo->spectrumDefinitions();
   const auto indexInfoSize = static_cast<int64_t>(m_indexInfo->size());

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -457,7 +457,6 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
       if (outSpectrumInfo.hasDetectors(i))
         outSpectrumInfo.setMasked(i, true);
     }
-
     prog.report("Convert to " + m_outputUnit->unitID());
     PARALLEL_END_INTERRUPT_REGION
   } // loop over spectra

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument/IVirtualBank.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/OptionalBool.h"
@@ -536,6 +537,18 @@ std::map<detid_t, int> makeGroupingByNames(std::string GroupNames, const Instrum
           {
             if (top_group > 0) {
               detIDtoGroup[currentDet->getID()] = top_group;
+            }
+          } else if (const auto vbank = std::dynamic_pointer_cast<const Geometry::IVirtualBank>(currentIComp)) {
+            // PixelAssembly: resolve group from bank name first, fall back to parent group
+            child_group = group_map[currentIComp->getName()];
+            if (child_group == 0)
+              child_group = top_group;
+            if (child_group > 0) {
+              for (size_t iz = 0; iz < vbank->zpixels(); ++iz)
+                for (size_t ix = 0; ix < vbank->xpixels(); ++ix)
+                  for (size_t iy = 0; iy < vbank->ypixels(); ++iy)
+                    detIDtoGroup[vbank->getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy),
+                                                           static_cast<int>(iz))] = child_group;
             }
           } else // Is an assembly, push in the queue
           {

--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SRC_FILES src/ComponentInfo.cpp src/DetectorInfo.cpp src/SpectrumInfo.cpp)
 
 set(INC_FILES inc/MantidBeamline/ComponentInfo.h inc/MantidBeamline/ComponentType.h inc/MantidBeamline/DetectorInfo.h
-              inc/MantidBeamline/SpectrumInfo.h
+              inc/MantidBeamline/SpectrumInfo.h inc/MantidBeamline/VirtualBankSegment.h
 )
 
 set(TEST_FILES ComponentInfoTest.h DetectorInfoTest.h SpectrumInfoTest.h)

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -131,6 +131,15 @@ public:
     return static_cast<size_t>(seg - m_virtualBanks.data());
   }
 
+  /// Returns the VirtualBankSegment whose bankCompIdx equals @p compIdx,
+  /// or nullptr if no VirtualAssembly bank has that component index.
+  const VirtualBankSegment *findVirtualBankByCompIdx(size_t compIdx) const noexcept {
+    for (const auto &seg : m_virtualBanks)
+      if (seg.bankCompIdx == compIdx)
+        return &seg;
+    return nullptr;
+  }
+
   // Returns by value: for virtual-bank detector indices the position is computed
   // on demand and has no backing storage to reference.
   Eigen::Vector3d position(const size_t componentIndex) const;

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -100,7 +100,9 @@ public:
   size_t totalDetectorCount() const noexcept { return m_detectorRanges ? m_size - m_detectorRanges->size() : 0; }
 
   /// Call @p f(detectorIndex) for every detector in the subtree rooted at
-  /// @p componentIndex.  Real detector indices come from the flat array.
+  /// @p componentIndex.  Real detector indices come from the flat array;
+  /// virtual pixel indices are generated on the fly from VirtualBankSegment
+  /// ranges — no heap allocation is required for the enumeration itself.
   template <typename Callable> void forEachDetectorInSubtree(size_t componentIndex, Callable &&f) const {
     if (isDetector(componentIndex)) {
       f(componentIndex);
@@ -111,6 +113,16 @@ public:
     const auto detRange = (*m_detectorRanges)[rangesIndex];
     for (size_t i = detRange.first; i < detRange.second; ++i)
       f((*m_assemblySortedDetectorIndices)[i]);
+    // Virtual pixels synthesised from VirtualAssembly segments.
+    if (hasVirtualBanks()) {
+      const auto compRange = (*m_componentRanges)[rangesIndex];
+      for (size_t j = compRange.first; j < compRange.second; ++j) {
+        const size_t compIdx = (*m_assemblySortedComponentIndices)[j];
+        if (const auto *seg = findVirtualBankByCompIdx(compIdx))
+          for (size_t k = seg->firstIndex; k <= seg->lastIndex; ++k)
+            f(k);
+      }
+    }
   }
 
   /// Whether this instrument has any PixelAssembly (virtual) banks.
@@ -232,6 +244,18 @@ private:
 
   /// Precomputes m_nNonVirtualDetectors and m_nonVirtualDetectorLogicalIndices.
   void buildNonVirtualDetectorTable();
+
+  /// Returns realDetectors.size() + sum(virtual pixels) + detRanges.size().
+  /// Used to initialise the const m_size in the constructor initialiser list,
+  /// before m_virtualBanks has been moved into place.
+  static size_t computeTotalSize(const std::vector<size_t> &realDetectors,
+                                 const std::vector<VirtualBankSegment> &vbanks,
+                                 const std::vector<std::pair<size_t, size_t>> &detRanges) noexcept {
+    size_t nVirtual = 0;
+    for (const auto &seg : vbanks)
+      nVirtual += seg.lastIndex - seg.firstIndex + 1;
+    return realDetectors.size() + nVirtual + detRanges.size();
+  }
 };
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -8,6 +8,7 @@
 
 #include "MantidBeamline/ComponentType.h"
 #include "MantidBeamline/DllConfig.h"
+#include "MantidBeamline/VirtualBankSegment.h"
 #include "MantidKernel/cow_ptr.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -15,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace Mantid {
 namespace Beamline {
@@ -77,7 +79,7 @@ public:
       std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
       std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
       std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-      int64_t sourceIndex, int64_t sampleIndex);
+      int64_t sourceIndex, int64_t sampleIndex, std::vector<VirtualBankSegment> virtualBanks = {});
   /// Copy assignment not permitted because of the way DetectorInfo stored
   ComponentInfo &operator=(const ComponentInfo &other) = delete;
   /// Clone method
@@ -111,7 +113,27 @@ public:
       f((*m_assemblySortedDetectorIndices)[i]);
   }
 
-  const Eigen::Vector3d &position(const size_t componentIndex) const;
+  /// Whether this instrument has any PixelAssembly (virtual) banks.
+  bool hasVirtualBanks() const noexcept { return !m_virtualBanks.empty(); }
+
+  /// Returns the VirtualBankSegment owning @p detectorIndex, or nullptr if
+  /// that index is not a virtual pixel.
+  const VirtualBankSegment *findVirtualSegment(size_t detectorIndex) const noexcept;
+
+  /// Maps a logical component index to its offset in the compact arrays
+  /// (m_names, m_scaleFactors, m_parentIndices, etc.).
+  /// For virtual-bank instruments only; behaviour is undefined otherwise.
+  size_t compactComponentIndex(size_t componentIndex) const noexcept;
+
+  /// Given a pointer returned by findVirtualSegment(), returns the
+  /// zero-based index of that segment within m_virtualBanks.  O(1).
+  size_t virtualBankIndex(const VirtualBankSegment *seg) const noexcept {
+    return static_cast<size_t>(seg - m_virtualBanks.data());
+  }
+
+  // Returns by value: for virtual-bank detector indices the position is computed
+  // on demand and has no backing storage to reference.
+  Eigen::Vector3d position(const size_t componentIndex) const;
   const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
   Eigen::Quaterniond rotation(const size_t componentIndex) const;
   Eigen::Quaterniond rotation(const std::pair<size_t, size_t> &index) const;
@@ -182,13 +204,25 @@ private:
   void doScaleComponent(const std::pair<size_t, size_t> &index, const Eigen::Vector3d &newScaling,
                         const ComponentInfo::Range &detectorRange);
 
-  /// Returns realDetectors.size() + sum(virtual pixels) + detRanges.size().
-  /// Used to initialise the const m_size in the constructor initialiser list,
-  /// before m_virtualBanks has been moved into place.
-  static size_t computeTotalSize(const std::vector<size_t> &realDetectors,
-                                 const std::vector<std::pair<size_t, size_t>> &detRanges) noexcept {
-    return realDetectors.size() + detRanges.size();
-  }
+  // --- Virtual-bank compaction helpers ------------------------------------
+  /// Sorted (ascending firstIndex) virtual-bank segments for PA instruments.
+  /// Empty for instruments with no PixelAssembly banks.
+  std::vector<VirtualBankSegment> m_virtualBanks;
+
+  /// Number of non-virtual detectors (= monitors for a pure-PA instrument).
+  /// Equals m_assemblySortedDetectorIndices->size() when m_virtualBanks is empty.
+  size_t m_nNonVirtualDetectors{0};
+
+  /// Maps compact detector index k → logical detector index, for non-virtual
+  /// detectors only.  Size == m_nNonVirtualDetectors.
+  std::vector<size_t> m_nonVirtualDetectorLogicalIndices;
+
+  /// Inverse of compactComponentIndex: maps a compact array offset to the
+  /// corresponding logical component index.
+  size_t logicalComponentIndex(size_t compactIdx) const noexcept;
+
+  /// Precomputes m_nNonVirtualDetectors and m_nonVirtualDetectorLogicalIndices.
+  void buildNonVirtualDetectorTable();
 };
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -12,8 +12,10 @@
 #include "MantidKernel/cow_ptr.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
+#include <algorithm>
 #include <cstddef>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
@@ -146,10 +148,9 @@ public:
   /// Returns the VirtualBankSegment whose bankCompIdx equals @p compIdx,
   /// or nullptr if no VirtualAssembly bank has that component index.
   const VirtualBankSegment *findVirtualBankByCompIdx(size_t compIdx) const noexcept {
-    for (const auto &seg : m_virtualBanks)
-      if (seg.bankCompIdx == compIdx)
-        return &seg;
-    return nullptr;
+    auto it = std::find_if(m_virtualBanks.cbegin(), m_virtualBanks.cend(),
+                           [compIdx](const auto &seg) { return seg.bankCompIdx == compIdx; });
+    return it != m_virtualBanks.cend() ? &*it : nullptr;
   }
 
   // Returns by value: for virtual-bank detector indices the position is computed
@@ -251,9 +252,9 @@ private:
   static size_t computeTotalSize(const std::vector<size_t> &realDetectors,
                                  const std::vector<VirtualBankSegment> &vbanks,
                                  const std::vector<std::pair<size_t, size_t>> &detRanges) noexcept {
-    size_t nVirtual = 0;
-    for (const auto &seg : vbanks)
-      nVirtual += seg.lastIndex - seg.firstIndex + 1;
+    const size_t nVirtual = std::accumulate(vbanks.cbegin(), vbanks.cend(), size_t{0}, [](size_t acc, const auto &seg) {
+      return acc + seg.lastIndex - seg.firstIndex + 1;
+    });
     return realDetectors.size() + nVirtual + detRanges.size();
   }
 };

--- a/Framework/Beamline/inc/MantidBeamline/ComponentType.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentType.h
@@ -10,6 +10,18 @@
 
 namespace Mantid {
 namespace Beamline {
-enum class ComponentType { Generic, Infinite, Grid, Rectangular, Structured, Unstructured, Detector, OutlineComposite };
+enum class ComponentType {
+  Generic,
+  Infinite,
+  Grid,
+  Rectangular,
+  Structured,
+  Unstructured,
+  Detector,
+  OutlineComposite,
+  /// PixelAssembly (virtual) bank: geometry computed analytically from
+  /// VirtualBankSegment; no per-pixel or per-column child entries stored.
+  VirtualAssembly
+};
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -111,9 +111,11 @@ public:
    */
   friend class ComponentInfo;
 
+  /// Returns the segment owning @p index, or nullptr if not virtual.
+  const VirtualBankSegment *findVirtualSegment(size_t index) const noexcept;
   /// Maps a logical detector index to its compact array offset, skipping virtual pixel ranges.
-  /// Only valid for non-virtual indices. Identity for non-virtual-bank instruments.
-  size_t compactDetectorIndex(size_t index) const noexcept { return index; }
+  /// Only valid for non-virtual indices.
+  size_t compactDetectorIndex(size_t index) const noexcept;
 
 private:
   size_t linearIndex(const std::pair<size_t, size_t> &index) const;
@@ -133,11 +135,6 @@ private:
   std::vector<VirtualBankSegment> m_virtualBanks;
 
   ComponentInfo *m_componentInfo = nullptr; // Geometry::ComponentInfo owner
-
-  /// Returns the segment owning @p index, or nullptr if not virtual.
-  const VirtualBankSegment *findVirtualSegment(size_t index) const noexcept;
-  /// Maps a logical detector index to a compact array offset, skipping virtual pixel ranges.
-  size_t compactDetectorIndex(size_t index) const noexcept;
 };
 
 /** Returns the number of detectors in the instrument.

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -95,6 +95,13 @@ public:
   const Eigen::Vector3d &sourcePosition() const;
   const Eigen::Vector3d &samplePosition() const;
 
+  /// Whether this instrument has any PixelAssembly (virtual) banks.
+  bool hasVirtualBanks() const noexcept { return !m_virtualBanks.empty(); }
+
+  /// Returns the VirtualBankSegment whose ID range contains @p detId,
+  /// or nullptr if @p detId is not a virtual pixel in any bank.
+  const VirtualBankSegment *findVirtualSegmentByDetId(int32_t detId) const noexcept;
+
   /** The `merge()` operation was made private in `DetectorInfo`, and only
    * accessible through `ComponentInfo` (via this `friend` declaration)
    * because we need to avoid merging `DetectorInfo` without merging

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -7,10 +7,13 @@
 #pragma once
 
 #include "MantidBeamline/DllConfig.h"
+#include "MantidBeamline/VirtualBankSegment.h"
 #include "MantidKernel/cow_ptr.h"
 
 #include "Eigen/Geometry"
 #include "Eigen/StdVector"
+
+#include <vector>
 
 namespace Mantid {
 namespace Beamline {
@@ -50,6 +53,14 @@ public:
   DetectorInfo(std::vector<Eigen::Vector3d> positions,
                std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>> rotations,
                const std::vector<size_t> &monitorIndices);
+  /// Constructor for instruments with virtual (PixelAssembly) banks.
+  /// @param compactPositions  positions for real (non-virtual) detectors only
+  /// @param compactRotations  rotations for real (non-virtual) detectors only
+  /// @param monitorIndices    logical indices of monitor detectors
+  /// @param virtualBanks      sorted virtual-bank segments (ascending firstIndex)
+  DetectorInfo(std::vector<Eigen::Vector3d> compactPositions,
+               std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>> compactRotations,
+               const std::vector<size_t> &monitorIndices, std::vector<VirtualBankSegment> virtualBanks);
 
   bool isEquivalent(const DetectorInfo &other) const;
 
@@ -64,9 +75,11 @@ public:
   void setMasked(const size_t index, bool masked);
   void setMasked(const std::pair<size_t, size_t> &index, bool masked);
   bool hasMaskedDetectors() const;
-  const Eigen::Vector3d &position(const size_t index) const;
+  // For virtual-bank instruments position/rotation are computed analytically and
+  // cannot return a reference into a flat array — these overloads return by value.
+  Eigen::Vector3d position(const size_t index) const;
   const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
-  const Eigen::Quaterniond &rotation(const size_t index) const;
+  Eigen::Quaterniond rotation(const size_t index) const;
   const Eigen::Quaterniond &rotation(const std::pair<size_t, size_t> &index) const;
   void setPosition(const size_t index, const Eigen::Vector3d &position);
   void setPosition(const std::pair<size_t, size_t> &index, const Eigen::Vector3d &position);
@@ -103,10 +116,21 @@ private:
 
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};
   Kernel::cow_ptr<std::vector<bool>> m_isMasked{nullptr};
+  /// Compact position array: one entry per real (non-virtual) detector, in
+  /// the same order as logical indices with virtual pixel gaps removed.
   Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_positions{nullptr};
   Kernel::cow_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> m_rotations{nullptr};
 
+  /// Sorted (ascending firstIndex) list of virtual-bank segments.
+  /// Empty for instruments that have no PixelAssembly banks.
+  std::vector<VirtualBankSegment> m_virtualBanks;
+
   ComponentInfo *m_componentInfo = nullptr; // Geometry::ComponentInfo owner
+
+  /// Returns the segment owning @p index, or nullptr if not virtual.
+  const VirtualBankSegment *findVirtualSegment(size_t index) const noexcept;
+  /// Maps a logical detector index to a compact array offset, skipping virtual pixel ranges.
+  size_t compactDetectorIndex(size_t index) const noexcept;
 };
 
 /** Returns the number of detectors in the instrument.
@@ -119,48 +143,26 @@ inline size_t DetectorInfo::size() const {
   return m_isMonitor->size();
 }
 
-/// Returns true if the beamline has scanning detectors.
+/// Returns true if the beamline has scanning (time-dependent) detectors.
+/// Virtual-bank (PixelAssembly) instruments are NOT scanning: their compact
+/// position arrays are smaller than size() but hold no time-dependent data.
 inline bool DetectorInfo::isScanning() const {
   if (!m_positions)
     return false;
-  return size() != m_positions->size();
+  // Scanning instruments hold N * T positions (T scan points, T > 1).
+  // Compact virtual-bank instruments hold N_real < N_total positions.
+  // Only the scanning case has *more* positions than total detectors.
+  return m_positions->size() > size();
 }
 
-/** Returns the position of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline const Eigen::Vector3d &DetectorInfo::position(const size_t index) const {
-  checkNoTimeDependence();
-  return (*m_positions)[index];
-}
-
-/// Returns the position of the detector with given index.
+/// Returns the position of the detector with given index (pair overload for scanning).
 inline const Eigen::Vector3d &DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
   return (*m_positions)[linearIndex(index)];
 }
 
-/** Returns the rotation of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline const Eigen::Quaterniond &DetectorInfo::rotation(const size_t index) const {
-  checkNoTimeDependence();
-  return (*m_rotations)[index];
-}
-
-/// Returns the rotation of the detector with given index.
+/// Returns the rotation of the detector with given index (pair overload for scanning).
 inline const Eigen::Quaterniond &DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
   return (*m_rotations)[linearIndex(index)];
-}
-
-/** Set the position of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline void DetectorInfo::setPosition(const size_t index, const Eigen::Vector3d &position) {
-  checkNoTimeDependence();
-  m_positions.access()[index] = position;
 }
 
 /// Set the position of the detector with given index (scanning pair overload).
@@ -168,16 +170,7 @@ inline void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index, co
   m_positions.access()[linearIndex(index)] = position;
 }
 
-/** Set the rotation of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline void DetectorInfo::setRotation(const size_t index, const Eigen::Quaterniond &rotation) {
-  checkNoTimeDependence();
-  m_rotations.access()[index] = rotation.normalized();
-}
-
-/// Set the rotation of the detector with given index.
+/// Set the rotation of the detector with given index (scanning pair overload).
 inline void DetectorInfo::setRotation(const std::pair<size_t, size_t> &index, const Eigen::Quaterniond &rotation) {
   m_rotations.access()[linearIndex(index)] = rotation.normalized();
 }

--- a/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
+++ b/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
@@ -8,7 +8,9 @@
 
 #include "MantidBeamline/DllConfig.h"
 #include <Eigen/Geometry>
+#include <array>
 #include <cstddef>
+#include <cstdint>
 
 namespace Mantid {
 namespace Beamline {
@@ -41,10 +43,56 @@ struct MANTID_BEAMLINE_DLL VirtualBankSegment {
   Eigen::Quaterniond bankRot{Eigen::Quaterniond::Identity()};
   int nx = 1;          ///< pixels along X (fast axis = Y, so X is the outer loop)
   int ny = 1;          ///< pixels along Y (fast axis)
+  int nz = 1;          ///< pixels along Z
   double xstart = 0.0; ///< X centre of pixel (ix=0)
   double xstep = 0.0;  ///< X step between pixels
   double ystart = 0.0;
   double ystep = 0.0;
+
+  // --- Fields used for ID-based lookup (detector ID → logical index) ---------
+  /// Detector ID at grid position (0, 0, 0) — same as IVirtualBank::referentDetectorID().
+  int32_t idstart = 0;
+  /// Detector ID at the last grid position — used for range checks in binary search.
+  int32_t lastDetId = 0;
+  /// ID increment per pixel along the fastest fill axis (= IVirtualBank::idstep()).
+  int idstep = 1;
+  /// Fill order: idFillOrder[0] is the fastest axis, [2] is slowest (each is 'x', 'y', or 'z').
+  std::array<char, 3> idFillOrder{{'y', 'x', 'z'}};
+
+  /** Return the logical detector index for grid position (@p ix, @p iy, @p iz).
+   *  Produces the same result as indexOf(idAtXYZ(ix, iy, iz)) but avoids the
+   *  ID round-trip.  Iteration order in registerVirtualBank: z-outer, x-middle,
+   *  y-inner — so local = iz*nx*ny + ix*ny + iy. */
+  size_t indexAtXYZ(int ix, int iy, int iz = 0) const noexcept {
+    const size_t local = static_cast<size_t>(iz) * static_cast<size_t>(nx) * static_cast<size_t>(ny) +
+                         static_cast<size_t>(ix) * static_cast<size_t>(ny) + static_cast<size_t>(iy);
+    return firstIndex + local;
+  }
+
+  /** Return the logical detector index for detector ID @p id.
+   *
+   *  Precondition: id is a valid pixel ID in this bank (no bounds check performed).
+   *  The formula inverts IVirtualBank::getDetectorIDAtXYZ and then converts the
+   *  resulting (ix, iy, iz) grid position to the iteration-order offset used by
+   *  InstrumentVisitor::registerVirtualBank (z-outer, x-middle, y-inner). */
+  size_t indexOf(int32_t id) const noexcept {
+    const int offset = static_cast<int>(id - idstart);
+    const int n0 = idFillOrder[0] == 'x' ? nx : idFillOrder[0] == 'y' ? ny : nz;
+    const int n1 = idFillOrder[1] == 'x' ? nx : idFillOrder[1] == 'y' ? ny : nz;
+    const int step0 = idstep;
+    const int step1 = n0 * step0;
+    const int step2 = n1 * step1;
+    const int c0 = (offset / step0) % n0;
+    const int c1 = (offset / step1) % n1;
+    const int c2 = offset / step2;
+    const int ix = (idFillOrder[0] == 'x' ? c0 : idFillOrder[1] == 'x' ? c1 : c2);
+    const int iy = (idFillOrder[0] == 'y' ? c0 : idFillOrder[1] == 'y' ? c1 : c2);
+    const int iz = (idFillOrder[0] == 'z' ? c0 : idFillOrder[1] == 'z' ? c1 : c2);
+    // Iteration order in registerVirtualBank: z-outer, x-middle, y-inner.
+    const size_t local = static_cast<size_t>(iz) * static_cast<size_t>(nx) * static_cast<size_t>(ny) +
+                         static_cast<size_t>(ix) * static_cast<size_t>(ny) + static_cast<size_t>(iy);
+    return firstIndex + local;
+  }
 };
 
 } // namespace Beamline

--- a/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
+++ b/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
@@ -1,0 +1,51 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidBeamline/DllConfig.h"
+#include <Eigen/Geometry>
+#include <cstddef>
+
+namespace Mantid {
+namespace Beamline {
+
+/**
+ * Parameters for one contiguous block of virtual (analytically computed)
+ * detector indices produced by a PixelAssembly bank.
+ *
+ * Every logical detector index in [firstIndex, lastIndex] is "virtual":
+ *  - Its world position is computed on demand from the grid formula:
+ *        pos = bankPos + bankRot * { xstart + ix*xstep, ystart + iy*ystep, 0 }
+ *    where ix = local / ny,  iy = local % ny,  local = index - firstIndex.
+ *    (Fill order is Y-fastest / "yxz", matching PixelAssembly IDF convention.)
+ *  - Its parent component is bankCompIdx.
+ *  - It has the identity scale factor and an empty name string.
+ *
+ * Segments are stored sorted by ascending firstIndex so that O(N_banks)
+ * linear scans can break early.
+ */
+struct MANTID_BEAMLINE_DLL VirtualBankSegment {
+  size_t firstIndex = 0; ///< first logical detector index (inclusive)
+  size_t lastIndex = 0;  ///< last  logical detector index (inclusive)
+
+  /// Component index of the parent bank assembly in Beamline::ComponentInfo.
+  /// Set by InstrumentVisitor after the bank is registered.
+  size_t bankCompIdx = 0;
+
+  // --- Fields used by Beamline::DetectorInfo (position / rotation) ----------
+  Eigen::Vector3d bankPos{0.0, 0.0, 0.0};
+  Eigen::Quaterniond bankRot{Eigen::Quaterniond::Identity()};
+  int nx = 1;          ///< pixels along X (fast axis = Y, so X is the outer loop)
+  int ny = 1;          ///< pixels along Y (fast axis)
+  double xstart = 0.0; ///< X centre of pixel (ix=0)
+  double xstep = 0.0;  ///< X step between pixels
+  double ystart = 0.0;
+  double ystep = 0.0;
+};
+
+} // namespace Beamline
+} // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
+++ b/Framework/Beamline/inc/MantidBeamline/VirtualBankSegment.h
@@ -69,6 +69,28 @@ struct MANTID_BEAMLINE_DLL VirtualBankSegment {
     return firstIndex + local;
   }
 
+  /** Return the detector ID for logical index @p logicalIndex.
+   *
+   *  Inverse of indexOf(): decodes (iz, ix, iy) from the iteration-order offset
+   *  (z-outer, x-middle, y-inner), maps through idFillOrder, and computes the ID. */
+  int32_t idAtIndex(size_t logicalIndex) const noexcept {
+    const size_t local = logicalIndex - firstIndex;
+    const size_t nxy = static_cast<size_t>(nx) * static_cast<size_t>(ny);
+    const int iz = static_cast<int>(local / nxy);
+    const int ix = static_cast<int>((local % nxy) / static_cast<size_t>(ny));
+    const int iy = static_cast<int>(local % static_cast<size_t>(ny));
+    // Map (ix, iy, iz) → fill-order coordinates (reverse of what indexOf does).
+    const int coords[3] = {ix, iy, iz}; // 0=x, 1=y, 2=z
+    const auto axisIdx = [](char axis) noexcept { return axis == 'x' ? 0 : axis == 'y' ? 1 : 2; };
+    const int c0 = coords[axisIdx(idFillOrder[0])];
+    const int c1 = coords[axisIdx(idFillOrder[1])];
+    const int c2 = coords[axisIdx(idFillOrder[2])];
+    const int n0 = idFillOrder[0] == 'x' ? nx : idFillOrder[0] == 'y' ? ny : nz;
+    const int n1 = idFillOrder[1] == 'x' ? nx : idFillOrder[1] == 'y' ? ny : nz;
+    const int fill_index = c0 + n0 * (c1 + n1 * c2);
+    return idstart + static_cast<int32_t>(fill_index) * static_cast<int32_t>(idstep);
+  }
+
   /** Return the logical detector index for detector ID @p id.
    *
    *  Precondition: id is a valid pixel ID in this bank (no bounds check performed).

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -59,8 +59,9 @@ ComponentInfo::ComponentInfo(
       m_parentIndices(std::move(parentIndices)), m_children(std::move(children)), m_positions(std::move(positions)),
       m_rotations(std::move(rotations)), m_scaleFactors(std::move(scaleFactors)),
       m_componentType(std::move(componentType)), m_names(std::move(names)),
-      m_size(m_assemblySortedDetectorIndices->size() + m_detectorRanges->size()), m_sourceIndex(sourceIndex),
-      m_sampleIndex(sampleIndex), m_detectorInfo(nullptr), m_virtualBanks(std::move(virtualBanks)) {
+      m_size(ComponentInfo::computeTotalSize(*m_assemblySortedDetectorIndices, virtualBanks, *m_detectorRanges)),
+      m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex), m_detectorInfo(nullptr),
+      m_virtualBanks(std::move(virtualBanks)) {
   if (m_rotations->size() != m_positions->size()) {
     throw std::invalid_argument("ComponentInfo should have been provided same "
                                 "number of postions and rotations");
@@ -98,7 +99,7 @@ ComponentInfo::ComponentInfo(
                                   "of names as number of components");
     }
     // Non-virtual: m_nNonVirtualDetectors == all detectors.
-    m_nNonVirtualDetectors = m_assemblySortedDetectorIndices->size();
+    m_nNonVirtualDetectors = totalDetectorCount();
   } else {
     // Virtual-bank path: names, scaleFactors, and parentIndices are compact
     // (non-virtual detectors + non-detector components only).
@@ -145,18 +146,9 @@ std::unique_ptr<ComponentInfo> ComponentInfo::cloneWithoutDetectorInfo() const {
 }
 
 std::vector<size_t> ComponentInfo::detectorsInSubtree(const size_t componentIndex) const {
-  if (isDetector(componentIndex)) {
-    /* This is a single detector. Just return the corresponding index.
-     * detectorIndex == componentIndex
-     */
-    return std::vector<size_t>{componentIndex};
-  }
-  // Calculate index into our ranges (non-detector) component items.
-  const auto rangesIndex = compOffsetIndex(componentIndex);
-  const auto range = (*m_detectorRanges)[rangesIndex];
-  // Extract as a block
-  return std::vector<size_t>(m_assemblySortedDetectorIndices->begin() + range.first,
-                             m_assemblySortedDetectorIndices->begin() + range.second);
+  std::vector<size_t> result;
+  forEachDetectorInSubtree(componentIndex, [&result](size_t idx) { result.push_back(idx); });
+  return result;
 }
 
 std::vector<size_t> ComponentInfo::componentsInSubtree(const size_t componentIndex) const {
@@ -169,8 +161,6 @@ std::vector<size_t> ComponentInfo::componentsInSubtree(const size_t componentInd
   // Non-detector components.
   const auto rangesIndex = compOffsetIndex(componentIndex);
   const auto compRange = (*m_componentRanges)[rangesIndex];
-
-  // Extract as a block
   indices.insert(indices.end(), m_assemblySortedComponentIndices->begin() + compRange.first,
                  m_assemblySortedComponentIndices->begin() + compRange.second);
   return indices;
@@ -194,6 +184,15 @@ size_t ComponentInfo::numberOfDetectorsInSubtree(const size_t componentIndex) co
   const auto rangesIndex = compOffsetIndex(componentIndex);
   const auto detRange = (*m_detectorRanges)[rangesIndex];
   size_t count = detRange.second - detRange.first;
+  // Virtual pixels from VirtualAssembly segments in this subtree.
+  if (hasVirtualBanks()) {
+    const auto compRange = (*m_componentRanges)[rangesIndex];
+    for (size_t j = compRange.first; j < compRange.second; ++j) {
+      const size_t compIdx = (*m_assemblySortedComponentIndices)[j];
+      if (const auto *seg = findVirtualBankByCompIdx(compIdx))
+        count += seg->lastIndex - seg->firstIndex + 1;
+    }
+  }
   return count;
 }
 
@@ -297,13 +296,9 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index, const 
   const auto componentIndex = index.first;
   const auto timeIndex = index.second;
   const Eigen::Vector3d offset = newPosition - position(componentIndex);
-  for (const auto &subIndex : detectorRange) {
-    // Virtual pixels have no stored position entry; skip them here and update
-    // their VirtualBankSegments below.
-    if (!m_virtualBanks.empty() && findVirtualSegment(subIndex))
-      continue;
+  // detectorRange contains only real (non-virtual) detector indices.
+  for (const auto &subIndex : detectorRange)
     m_detectorInfo->setPosition({subIndex, timeIndex}, m_detectorInfo->position({subIndex, timeIndex}) + offset);
-  }
 
   const auto compRange = componentRangeInSubtree(componentIndex);
   for (const auto &subIndex : compRange) {
@@ -337,11 +332,8 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index, const 
   const Eigen::Quaterniond rotDelta = (newRotation * currentRotInv).normalized();
   auto transform = Eigen::Matrix3d(rotDelta);
 
+  // detectorRange contains only real (non-virtual) detector indices.
   for (const auto &subDetIndex : detectorRange) {
-    // Virtual pixels have no stored position entry; skip them here and update
-    // their VirtualBankSegments below.
-    if (!m_virtualBanks.empty() && findVirtualSegment(subDetIndex))
-      continue;
     auto oldPos = m_detectorInfo->position({subDetIndex, timeIndex});
     auto newPos = transform * (oldPos - compPos) + compPos;
     auto newRot = rotDelta * m_detectorInfo->rotation({subDetIndex, timeIndex});
@@ -882,7 +874,7 @@ const VirtualBankSegment *ComponentInfo::findVirtualSegment(size_t index) const 
  * Behaviour is undefined if @p componentIndex is a virtual pixel.
  */
 size_t ComponentInfo::compactComponentIndex(const size_t componentIndex) const noexcept {
-  const size_t nDetectors = m_assemblySortedDetectorIndices->size();
+  const size_t nDetectors = totalDetectorCount();
   if (componentIndex >= nDetectors) {
     // Non-detector component: offset past all compact detector entries.
     return m_nNonVirtualDetectors + (componentIndex - nDetectors);
@@ -908,7 +900,7 @@ size_t ComponentInfo::logicalComponentIndex(const size_t compactIdx) const noexc
   if (compactIdx < m_nNonVirtualDetectors)
     return m_nonVirtualDetectorLogicalIndices[compactIdx];
   // Non-detector component.
-  return m_assemblySortedDetectorIndices->size() + (compactIdx - m_nNonVirtualDetectors);
+  return totalDetectorCount() + (compactIdx - m_nNonVirtualDetectors);
 }
 
 /**
@@ -917,7 +909,7 @@ size_t ComponentInfo::logicalComponentIndex(const size_t compactIdx) const noexc
  * detector logical indices.  Called once from the constructor.
  */
 void ComponentInfo::buildNonVirtualDetectorTable() {
-  const size_t nDetectors = m_assemblySortedDetectorIndices->size();
+  const size_t nDetectors = totalDetectorCount();
   m_nonVirtualDetectorLogicalIndices.clear();
   size_t i = 0;
   for (const auto &seg : m_virtualBanks) {

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -103,9 +103,9 @@ ComponentInfo::ComponentInfo(
   } else {
     // Virtual-bank path: names, scaleFactors, and parentIndices are compact
     // (non-virtual detectors + non-detector components only).
-    size_t nVirtual = 0;
-    for (const auto &seg : m_virtualBanks)
-      nVirtual += seg.lastIndex - seg.firstIndex + 1;
+    const size_t nVirtual =
+        std::accumulate(m_virtualBanks.cbegin(), m_virtualBanks.cend(), size_t{0},
+                        [](size_t acc, const auto &seg) { return acc + seg.lastIndex - seg.firstIndex + 1; });
     const size_t expectedCompact = m_size - nVirtual;
     if (m_scaleFactors->size() != expectedCompact) {
       throw std::invalid_argument("ComponentInfo (virtual-bank): compact scaleFactors "
@@ -128,9 +128,9 @@ ComponentInfo::ComponentInfo(
   auto assemTotalSize =
       std::accumulate(m_children->begin(), m_children->end(), static_cast<size_t>(1),
                       [](size_t size, const std::vector<size_t> &assem) { return size += assem.size(); });
-  size_t virtualPixels = 0;
-  for (const auto &seg : m_virtualBanks)
-    virtualPixels += seg.lastIndex - seg.firstIndex + 1;
+  const size_t virtualPixels =
+      std::accumulate(m_virtualBanks.cbegin(), m_virtualBanks.cend(), size_t{0},
+                      [](size_t acc, const auto &seg) { return acc + seg.lastIndex - seg.firstIndex + 1; });
 
   if (assemTotalSize + virtualPixels != m_size) {
     throw std::invalid_argument("ComponentInfo should be provided an "
@@ -310,13 +310,11 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index, const 
   // component lies in this subtree.
   if (!m_virtualBanks.empty()) {
     for (size_t i = 0; i < m_virtualBanks.size(); ++i) {
-      for (const auto compIdx : compRange) {
-        if (compIdx == m_virtualBanks[i].bankCompIdx) {
-          m_virtualBanks[i].bankPos += offset;
-          if (m_detectorInfo)
-            m_detectorInfo->m_virtualBanks[i].bankPos += offset;
-          break;
-        }
+      if (std::any_of(compRange.begin(), compRange.end(),
+                      [&](size_t compIdx) { return compIdx == m_virtualBanks[i].bankCompIdx; })) {
+        m_virtualBanks[i].bankPos += offset;
+        if (m_detectorInfo)
+          m_detectorInfo->m_virtualBanks[i].bankPos += offset;
       }
     }
   }
@@ -356,18 +354,16 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index, const 
   // DetectorInfo::position(virtualPixelIndex) returns the correct world position.
   if (!m_virtualBanks.empty()) {
     for (size_t i = 0; i < m_virtualBanks.size(); ++i) {
-      for (const auto compIdx : compRange) {
-        if (compIdx == m_virtualBanks[i].bankCompIdx) {
-          const size_t bankOffset = compOffsetIndex(m_virtualBanks[i].bankCompIdx);
-          Eigen::Vector3d newBankPos = m_positions.access()[linearIndex({bankOffset, timeIndex})];
-          Eigen::Quaterniond newBankRot = m_rotations.access()[linearIndex({bankOffset, timeIndex})];
-          m_virtualBanks[i].bankPos = newBankPos;
-          m_virtualBanks[i].bankRot = newBankRot;
-          if (m_detectorInfo) {
-            m_detectorInfo->m_virtualBanks[i].bankPos = newBankPos;
-            m_detectorInfo->m_virtualBanks[i].bankRot = newBankRot;
-          }
-          break;
+      if (std::any_of(compRange.begin(), compRange.end(),
+                      [&](size_t compIdx) { return compIdx == m_virtualBanks[i].bankCompIdx; })) {
+        const size_t bankOffset = compOffsetIndex(m_virtualBanks[i].bankCompIdx);
+        Eigen::Vector3d newBankPos = m_positions.access()[linearIndex({bankOffset, timeIndex})];
+        Eigen::Quaterniond newBankRot = m_rotations.access()[linearIndex({bankOffset, timeIndex})];
+        m_virtualBanks[i].bankPos = newBankPos;
+        m_virtualBanks[i].bankRot = newBankRot;
+        if (m_detectorInfo) {
+          m_detectorInfo->m_virtualBanks[i].bankPos = newBankPos;
+          m_detectorInfo->m_virtualBanks[i].bankRot = newBankRot;
         }
       }
     }

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -52,15 +52,15 @@ ComponentInfo::ComponentInfo(
     std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
     std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
     std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-    int64_t sourceIndex, int64_t sampleIndex)
+    int64_t sourceIndex, int64_t sampleIndex, std::vector<VirtualBankSegment> virtualBanks)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(std::move(assemblySortedComponentIndices)),
       m_detectorRanges(std::move(detectorRanges)), m_componentRanges(std::move(componentRanges)),
       m_parentIndices(std::move(parentIndices)), m_children(std::move(children)), m_positions(std::move(positions)),
       m_rotations(std::move(rotations)), m_scaleFactors(std::move(scaleFactors)),
       m_componentType(std::move(componentType)), m_names(std::move(names)),
-      m_size(ComponentInfo::computeTotalSize(*m_assemblySortedDetectorIndices, *m_detectorRanges)),
-      m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex), m_detectorInfo(nullptr) {
+      m_size(m_assemblySortedDetectorIndices->size() + m_detectorRanges->size()), m_sourceIndex(sourceIndex),
+      m_sampleIndex(sampleIndex), m_detectorInfo(nullptr), m_virtualBanks(std::move(virtualBanks)) {
   if (m_rotations->size() != m_positions->size()) {
     throw std::invalid_argument("ComponentInfo should have been provided same "
                                 "number of postions and rotations");
@@ -78,21 +78,50 @@ ComponentInfo::ComponentInfo(
                                 "input of same size as the sum of "
                                 "non-detector and detector components");
   }
-  if (m_scaleFactors->size() != m_size) {
-    throw std::invalid_argument("ComponentInfo should have been provided same "
-                                "number of scale factors as number of components");
-  }
   if (m_componentType->size() != nonDetectorSize()) {
     throw std::invalid_argument("ComponentInfo should be provided same number "
                                 "of rectangular bank flags as number of "
                                 "non-detector components");
   }
-  if (m_names->size() != m_size) {
-    throw std::invalid_argument("ComponentInfo should be provided same number "
-                                "of names as number of components");
+
+  if (m_virtualBanks.empty()) {
+    // Non-virtual-bank path: arrays must be full size.
+    // Note: m_parentIndices is NOT checked here because several existing tests
+    // deliberately supply wrong-sized parent-index vectors for tests that do
+    // not exercise the parent relationship (pre-existing behaviour).
+    if (m_scaleFactors->size() != m_size) {
+      throw std::invalid_argument("ComponentInfo should have been provided same "
+                                  "number of scale factors as number of components");
+    }
+    if (m_names->size() != m_size) {
+      throw std::invalid_argument("ComponentInfo should be provided same number "
+                                  "of names as number of components");
+    }
+    // Non-virtual: m_nNonVirtualDetectors == all detectors.
+    m_nNonVirtualDetectors = m_assemblySortedDetectorIndices->size();
+  } else {
+    // Virtual-bank path: names, scaleFactors, and parentIndices are compact
+    // (non-virtual detectors + non-detector components only).
+    size_t nVirtual = 0;
+    for (const auto &seg : m_virtualBanks)
+      nVirtual += seg.lastIndex - seg.firstIndex + 1;
+    const size_t expectedCompact = m_size - nVirtual;
+    if (m_scaleFactors->size() != expectedCompact) {
+      throw std::invalid_argument("ComponentInfo (virtual-bank): compact scaleFactors "
+                                  "size mismatch");
+    }
+    if (m_names->size() != expectedCompact) {
+      throw std::invalid_argument("ComponentInfo (virtual-bank): compact names "
+                                  "size mismatch");
+    }
+    if (m_parentIndices->size() != expectedCompact) {
+      throw std::invalid_argument("ComponentInfo (virtual-bank): compact parentIndices "
+                                  "size mismatch");
+    }
+    buildNonVirtualDetectorTable();
   }
 
-  // Calculate total size of all assemblies
+  // Calculate total size of all assemblies (uses m_children, unchanged).
   auto assemTotalSize =
       std::accumulate(m_children->begin(), m_children->end(), static_cast<size_t>(1),
                       [](size_t size, const std::vector<size_t> &assem) { return size += assem.size(); });
@@ -170,9 +199,10 @@ bool ComponentInfo::isMonitor(const size_t componentIndex) const {
   return false;
 }
 
-const Eigen::Vector3d &ComponentInfo::position(const size_t componentIndex) const {
+Eigen::Vector3d ComponentInfo::position(const size_t componentIndex) const {
   checkNoTimeDependence();
   if (isDetector(componentIndex)) {
+    // DetectorInfo::position(size_t) returns by value (supports virtual banks).
     return m_detectorInfo->position(componentIndex);
   }
   const auto rangesIndex = compOffsetIndex(componentIndex);
@@ -483,7 +513,14 @@ void ComponentInfo::initIndices() {
   }
 }
 
-size_t ComponentInfo::parent(const size_t componentIndex) const { return (*m_parentIndices)[componentIndex]; }
+size_t ComponentInfo::parent(const size_t componentIndex) const {
+  if (!m_virtualBanks.empty()) {
+    if (const auto *seg = findVirtualSegment(componentIndex))
+      return seg->bankCompIdx;
+    return (*m_parentIndices)[compactComponentIndex(componentIndex)];
+  }
+  return (*m_parentIndices)[componentIndex];
+}
 
 bool ComponentInfo::hasParent(const size_t componentIndex) const { return parent(componentIndex) != componentIndex; }
 
@@ -592,10 +629,24 @@ ComponentInfo::Range ComponentInfo::componentRangeInSubtree(const size_t index) 
 }
 
 Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
+  if (!m_virtualBanks.empty()) {
+    if (findVirtualSegment(componentIndex))
+      return Eigen::Vector3d{1.0, 1.0, 1.0};
+    return (*m_scaleFactors)[compactComponentIndex(componentIndex)];
+  }
   return (*m_scaleFactors)[componentIndex];
 }
 
-const std::string &ComponentInfo::name(const size_t componentIndex) const { return (*m_names)[componentIndex]; }
+const std::string &ComponentInfo::name(const size_t componentIndex) const {
+  if (!m_virtualBanks.empty()) {
+    if (findVirtualSegment(componentIndex)) {
+      static const std::string empty{};
+      return empty;
+    }
+    return (*m_names)[compactComponentIndex(componentIndex)];
+  }
+  return (*m_names)[componentIndex];
+}
 
 bool ComponentInfo::uniqueName(const std::string &name) const { return unique_if_exists((*m_names), name); }
 
@@ -607,11 +658,20 @@ size_t ComponentInfo::indexOfAny(const std::string &name) const {
     buffer << name << " does not exist";
     throw std::invalid_argument(buffer.str());
   }
-  return std::distance(m_names->begin(), it.base() - 1);
+  const size_t compactIdx = static_cast<size_t>(std::distance(m_names->begin(), it.base() - 1));
+  // For virtual-bank instruments m_names is compact; convert to logical index.
+  return m_virtualBanks.empty() ? compactIdx : logicalComponentIndex(compactIdx);
 }
 
 void ComponentInfo::setScaleFactor(const size_t componentIndex, const Eigen::Vector3d &scaleFactor) {
-  m_scaleFactors.access()[componentIndex] = scaleFactor;
+  if (!m_virtualBanks.empty()) {
+    if (findVirtualSegment(componentIndex))
+      throw std::runtime_error("ComponentInfo::setScaleFactor: cannot set scale "
+                               "factor on a virtual (PixelAssembly) pixel");
+    m_scaleFactors.access()[compactComponentIndex(componentIndex)] = scaleFactor;
+  } else {
+    m_scaleFactors.access()[componentIndex] = scaleFactor;
+  }
 }
 
 ComponentType ComponentInfo::componentType(const size_t componentIndex) const {
@@ -744,6 +804,85 @@ size_t ComponentInfo::nonDetectorSize() const {
     return 0;
 }
 
+// ---------------------------------------------------------------------------
+// Virtual-bank compaction helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the VirtualBankSegment that contains @p detectorIndex, or nullptr.
+/// Requires m_virtualBanks to be sorted ascending by firstIndex.
+const VirtualBankSegment *ComponentInfo::findVirtualSegment(size_t index) const noexcept {
+  for (const auto &seg : m_virtualBanks) {
+    if (index < seg.firstIndex)
+      return nullptr; // sorted — no further segment can match
+    if (index <= seg.lastIndex)
+      return &seg;
+  }
+  return nullptr;
+}
+
+/**
+ * Maps a logical component index to its compact array offset in
+ * m_names / m_scaleFactors / m_parentIndices.
+ *
+ * For non-virtual detector indices the result is the count of non-virtual
+ * detectors with logical index strictly less than @p componentIndex.
+ * For non-detector component indices (>= nDetectors) the result is
+ * m_nNonVirtualDetectors + (componentIndex - nDetectors).
+ *
+ * Behaviour is undefined if @p componentIndex is a virtual pixel.
+ */
+size_t ComponentInfo::compactComponentIndex(const size_t componentIndex) const noexcept {
+  const size_t nDetectors = m_assemblySortedDetectorIndices->size();
+  if (componentIndex >= nDetectors) {
+    // Non-detector component: offset past all compact detector entries.
+    return m_nNonVirtualDetectors + (componentIndex - nDetectors);
+  }
+  // Detector: subtract the count of virtual pixels with index < componentIndex.
+  size_t virtualsBefore = 0;
+  for (const auto &seg : m_virtualBanks) {
+    if (seg.firstIndex >= componentIndex)
+      break;
+    if (seg.lastIndex < componentIndex)
+      virtualsBefore += seg.lastIndex - seg.firstIndex + 1; // fully before
+    // If firstIndex < componentIndex <= lastIndex, caller passed a virtual index
+    // (should not happen): treat it as fully-before to avoid underflow.
+  }
+  return componentIndex - virtualsBefore;
+}
+
+/**
+ * Inverse of compactComponentIndex: given a compact array offset, return the
+ * corresponding logical component index.
+ */
+size_t ComponentInfo::logicalComponentIndex(const size_t compactIdx) const noexcept {
+  if (compactIdx < m_nNonVirtualDetectors)
+    return m_nonVirtualDetectorLogicalIndices[compactIdx];
+  // Non-detector component.
+  return m_assemblySortedDetectorIndices->size() + (compactIdx - m_nNonVirtualDetectors);
+}
+
+/**
+ * Precomputes m_nNonVirtualDetectors and m_nonVirtualDetectorLogicalIndices
+ * by walking the sorted virtual-bank segments and collecting non-virtual
+ * detector logical indices.  Called once from the constructor.
+ */
+void ComponentInfo::buildNonVirtualDetectorTable() {
+  const size_t nDetectors = m_assemblySortedDetectorIndices->size();
+  m_nonVirtualDetectorLogicalIndices.clear();
+  size_t i = 0;
+  for (const auto &seg : m_virtualBanks) {
+    // Collect non-virtual detectors that precede this segment.
+    while (i < seg.firstIndex)
+      m_nonVirtualDetectorLogicalIndices.push_back(i++);
+    // Skip the virtual segment.
+    i = seg.lastIndex + 1;
+  }
+  // Collect any non-virtual detectors after the last segment.
+  while (i < nDetectors)
+    m_nonVirtualDetectorLogicalIndices.push_back(i++);
+  m_nNonVirtualDetectors = m_nonVirtualDetectorLogicalIndices.size();
+}
+
 /** Return memory used by the component info, in bytes.
  * @return bytes used.
  */
@@ -791,6 +930,10 @@ size_t ComponentInfo::getMemorySize() const {
     mem += sizeof(*m_indexMap) + m_indexMap->size() * sizeof(std::vector<size_t>);
   if (m_indices)
     mem += sizeof(*m_indices) + m_indices->size() * sizeof(std::pair<size_t, size_t>);
+
+  // Virtual-bank compaction metadata
+  mem += m_virtualBanks.capacity() * sizeof(VirtualBankSegment);
+  mem += m_nonVirtualDetectorLogicalIndices.capacity() * sizeof(size_t);
 
   return mem;
 }

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -122,11 +122,16 @@ ComponentInfo::ComponentInfo(
   }
 
   // Calculate total size of all assemblies (uses m_children, unchanged).
+  // VirtualAssembly banks deliberately store empty children lists: their
+  // pixels are not materialised in the tree.  Account for them separately.
   auto assemTotalSize =
       std::accumulate(m_children->begin(), m_children->end(), static_cast<size_t>(1),
                       [](size_t size, const std::vector<size_t> &assem) { return size += assem.size(); });
+  size_t virtualPixels = 0;
+  for (const auto &seg : m_virtualBanks)
+    virtualPixels += seg.lastIndex - seg.firstIndex + 1;
 
-  if (assemTotalSize != m_size) {
+  if (assemTotalSize + virtualPixels != m_size) {
     throw std::invalid_argument("ComponentInfo should be provided an "
                                 "instrument tree which contains same number "
                                 "components");
@@ -293,6 +298,10 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index, const 
   const auto timeIndex = index.second;
   const Eigen::Vector3d offset = newPosition - position(componentIndex);
   for (const auto &subIndex : detectorRange) {
+    // Virtual pixels have no stored position entry; skip them here and update
+    // their VirtualBankSegments below.
+    if (!m_virtualBanks.empty() && findVirtualSegment(subIndex))
+      continue;
     m_detectorInfo->setPosition({subIndex, timeIndex}, m_detectorInfo->position({subIndex, timeIndex}) + offset);
   }
 
@@ -300,6 +309,21 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index, const 
   for (const auto &subIndex : compRange) {
     size_t offsetIndex = compOffsetIndex(subIndex);
     m_positions.access()[offsetIndex] += offset;
+  }
+
+  // Propagate the translation into any VirtualBankSegments whose bank
+  // component lies in this subtree.
+  if (!m_virtualBanks.empty()) {
+    for (size_t i = 0; i < m_virtualBanks.size(); ++i) {
+      for (const auto compIdx : compRange) {
+        if (compIdx == m_virtualBanks[i].bankCompIdx) {
+          m_virtualBanks[i].bankPos += offset;
+          if (m_detectorInfo)
+            m_detectorInfo->m_virtualBanks[i].bankPos += offset;
+          break;
+        }
+      }
+    }
   }
 }
 
@@ -314,6 +338,10 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index, const 
   auto transform = Eigen::Matrix3d(rotDelta);
 
   for (const auto &subDetIndex : detectorRange) {
+    // Virtual pixels have no stored position entry; skip them here and update
+    // their VirtualBankSegments below.
+    if (!m_virtualBanks.empty() && findVirtualSegment(subDetIndex))
+      continue;
     auto oldPos = m_detectorInfo->position({subDetIndex, timeIndex});
     auto newPos = transform * (oldPos - compPos) + compPos;
     auto newRot = rotDelta * m_detectorInfo->rotation({subDetIndex, timeIndex});
@@ -329,6 +357,28 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index, const 
     const size_t childCompIndexOffset = compOffsetIndex(subCompIndex);
     m_positions.access()[linearIndex({childCompIndexOffset, timeIndex})] = newPos;
     m_rotations.access()[linearIndex({childCompIndexOffset, timeIndex})] = newRot.normalized();
+  }
+
+  // After updating sub-component positions/rotations, copy the new bank
+  // positions/rotations into any VirtualBankSegments in this subtree so that
+  // DetectorInfo::position(virtualPixelIndex) returns the correct world position.
+  if (!m_virtualBanks.empty()) {
+    for (size_t i = 0; i < m_virtualBanks.size(); ++i) {
+      for (const auto compIdx : compRange) {
+        if (compIdx == m_virtualBanks[i].bankCompIdx) {
+          const size_t bankOffset = compOffsetIndex(m_virtualBanks[i].bankCompIdx);
+          Eigen::Vector3d newBankPos = m_positions.access()[linearIndex({bankOffset, timeIndex})];
+          Eigen::Quaterniond newBankRot = m_rotations.access()[linearIndex({bankOffset, timeIndex})];
+          m_virtualBanks[i].bankPos = newBankPos;
+          m_virtualBanks[i].bankRot = newBankRot;
+          if (m_detectorInfo) {
+            m_detectorInfo->m_virtualBanks[i].bankPos = newBankPos;
+            m_detectorInfo->m_virtualBanks[i].bankRot = newBankRot;
+          }
+          break;
+        }
+      }
+    }
   }
 }
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -61,6 +61,16 @@ DetectorInfo::DetectorInfo(
 // Virtual-bank helpers
 // ---------------------------------------------------------------------------
 
+/** Returns the VirtualBankSegment whose ID range contains @p detId, or nullptr if not virtual.
+ *  Performs a linear scan; O(N_banks), which is negligible for typical instruments. */
+const VirtualBankSegment *DetectorInfo::findVirtualSegmentByDetId(const int32_t detId) const noexcept {
+  for (const auto &seg : m_virtualBanks) {
+    if (detId >= seg.idstart && detId <= seg.lastDetId)
+      return &seg;
+  }
+  return nullptr;
+}
+
 /** Returns the VirtualBankSegment owning @p index, or nullptr if not virtual.
  *  Segments are stored sorted by firstIndex, so we can break early. */
 const VirtualBankSegment *DetectorInfo::findVirtualSegment(const size_t index) const noexcept {
@@ -110,7 +120,8 @@ Eigen::Vector3d DetectorInfo::position(const size_t index) const {
     const Eigen::Vector3d localOffset{seg->xstart + ix * seg->xstep, seg->ystart + iy * seg->ystep, 0.0};
     return seg->bankPos + seg->bankRot * localOffset;
   }
-  return (*m_positions)[compactDetectorIndex(index)];
+  const size_t compactIdx = compactDetectorIndex(index);
+  return (*m_positions)[compactIdx];
 }
 
 /** Returns the rotation of the detector with given detector index.

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <numeric>
 
 namespace Mantid::Beamline {
 
@@ -39,9 +40,9 @@ DetectorInfo::DetectorInfo(
     const std::vector<size_t> &monitorIndices, std::vector<VirtualBankSegment> virtualBanks)
     : m_virtualBanks(std::move(virtualBanks)) {
   // Total logical size = compact real detectors + all virtual pixel slots.
-  size_t totalVirtual = 0;
-  for (const auto &seg : m_virtualBanks)
-    totalVirtual += seg.lastIndex - seg.firstIndex + 1;
+  const size_t totalVirtual =
+      std::accumulate(m_virtualBanks.cbegin(), m_virtualBanks.cend(), size_t{0},
+                      [](size_t acc, const auto &seg) { return acc + seg.lastIndex - seg.firstIndex + 1; });
   const size_t totalSize = compactPositions.size() + totalVirtual;
 
   m_isMonitor = Kernel::make_cow<std::vector<bool>>(totalSize);
@@ -64,11 +65,9 @@ DetectorInfo::DetectorInfo(
 /** Returns the VirtualBankSegment whose ID range contains @p detId, or nullptr if not virtual.
  *  Performs a linear scan; O(N_banks), which is negligible for typical instruments. */
 const VirtualBankSegment *DetectorInfo::findVirtualSegmentByDetId(const int32_t detId) const noexcept {
-  for (const auto &seg : m_virtualBanks) {
-    if (detId >= seg.idstart && detId <= seg.lastDetId)
-      return &seg;
-  }
-  return nullptr;
+  auto it = std::find_if(m_virtualBanks.cbegin(), m_virtualBanks.cend(),
+                         [detId](const auto &seg) { return detId >= seg.idstart && detId <= seg.lastDetId; });
+  return it != m_virtualBanks.cend() ? &*it : nullptr;
 }
 
 /** Returns the VirtualBankSegment owning @p index, or nullptr if not virtual.

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -33,6 +33,123 @@ DetectorInfo::DetectorInfo(std::vector<Eigen::Vector3d> positions,
     m_isMonitor.access().at(i) = true;
 }
 
+DetectorInfo::DetectorInfo(
+    std::vector<Eigen::Vector3d> compactPositions,
+    std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>> compactRotations,
+    const std::vector<size_t> &monitorIndices, std::vector<VirtualBankSegment> virtualBanks)
+    : m_virtualBanks(std::move(virtualBanks)) {
+  // Total logical size = compact real detectors + all virtual pixel slots.
+  size_t totalVirtual = 0;
+  for (const auto &seg : m_virtualBanks)
+    totalVirtual += seg.lastIndex - seg.firstIndex + 1;
+  const size_t totalSize = compactPositions.size() + totalVirtual;
+
+  m_isMonitor = Kernel::make_cow<std::vector<bool>>(totalSize);
+  m_isMasked = Kernel::make_cow<std::vector<bool>>(totalSize);
+  m_positions = Kernel::make_cow<std::vector<Eigen::Vector3d>>(std::move(compactPositions));
+  m_rotations = Kernel::make_cow<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>>(
+      std::move(compactRotations));
+
+  if (m_positions->size() != m_rotations->size())
+    throw std::runtime_error("DetectorInfo: compact position and rotation vectors must have identical size");
+
+  for (const auto i : monitorIndices)
+    m_isMonitor.access().at(i) = true;
+}
+
+// ---------------------------------------------------------------------------
+// Virtual-bank helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the VirtualBankSegment owning @p index, or nullptr if not virtual.
+ *  Segments are stored sorted by firstIndex, so we can break early. */
+const VirtualBankSegment *DetectorInfo::findVirtualSegment(const size_t index) const noexcept {
+  for (const auto &seg : m_virtualBanks) {
+    if (index < seg.firstIndex)
+      return nullptr; // sorted — no segment further right can match
+    if (index <= seg.lastIndex)
+      return &seg;
+  }
+  return nullptr;
+}
+
+/** Maps a logical detector index to its compact array offset.
+ *  Only valid for non-virtual indices; behaviour for virtual indices is undefined. */
+size_t DetectorInfo::compactDetectorIndex(const size_t index) const noexcept {
+  size_t virtualsBefore = 0;
+  for (const auto &seg : m_virtualBanks) {
+    if (seg.firstIndex >= index)
+      break; // this and all later segments start at or after index
+    // Segment starts before index.
+    if (seg.lastIndex < index)
+      virtualsBefore += seg.lastIndex - seg.firstIndex + 1; // fully before
+    // If firstIndex < index <= lastIndex the caller passed a virtual index —
+    // we silently treat it as fully-before (should not happen in correct code).
+  }
+  return index - virtualsBefore;
+}
+
+// ---------------------------------------------------------------------------
+// Non-inline position / rotation / setPosition / setRotation (size_t overloads)
+// ---------------------------------------------------------------------------
+
+/** Returns the position of the detector with given detector index.
+ *
+ * For virtual (PixelAssembly) pixels the position is computed analytically
+ * from the bank's grid formula; for real pixels it reads from the compact
+ * flat array.  Returns by value because virtual positions have no permanent
+ * storage to reference.
+ *
+ * Throws if the beamline has time-dependent (scanning) detectors. */
+Eigen::Vector3d DetectorInfo::position(const size_t index) const {
+  checkNoTimeDependence();
+  if (const auto *seg = findVirtualSegment(index)) {
+    const size_t local = index - seg->firstIndex;
+    const auto ix = static_cast<double>(local / static_cast<size_t>(seg->ny));
+    const auto iy = static_cast<double>(local % static_cast<size_t>(seg->ny));
+    const Eigen::Vector3d localOffset{seg->xstart + ix * seg->xstep, seg->ystart + iy * seg->ystep, 0.0};
+    return seg->bankPos + seg->bankRot * localOffset;
+  }
+  return (*m_positions)[compactDetectorIndex(index)];
+}
+
+/** Returns the rotation of the detector with given detector index.
+ *
+ * All pixels in a virtual bank share the bank rotation.  Real pixels read
+ * from the compact flat array.
+ *
+ * Throws if the beamline has time-dependent (scanning) detectors. */
+Eigen::Quaterniond DetectorInfo::rotation(const size_t index) const {
+  checkNoTimeDependence();
+  if (const auto *seg = findVirtualSegment(index))
+    return seg->bankRot;
+  return (*m_rotations)[compactDetectorIndex(index)];
+}
+
+/** Set the position of the detector with given detector index.
+ *
+ * Throws for virtual (PixelAssembly) pixel indices — their positions are
+ * fully determined by the bank parameters and cannot be overridden
+ * individually.  Throws if the beamline has time-dependent detectors. */
+void DetectorInfo::setPosition(const size_t index, const Eigen::Vector3d &position) {
+  checkNoTimeDependence();
+  if (findVirtualSegment(index))
+    throw std::runtime_error("Cannot directly set the position of a virtual bank pixel; "
+                             "move the PixelAssembly component instead.");
+  m_positions.access()[compactDetectorIndex(index)] = position;
+}
+
+/** Set the rotation of the detector with given detector index.
+ *
+ * Throws for virtual (PixelAssembly) pixel indices. */
+void DetectorInfo::setRotation(const size_t index, const Eigen::Quaterniond &rotation) {
+  checkNoTimeDependence();
+  if (findVirtualSegment(index))
+    throw std::runtime_error("Cannot directly set the rotation of a virtual bank pixel; "
+                             "rotate the PixelAssembly component instead.");
+  m_rotations.access()[compactDetectorIndex(index)] = rotation.normalized();
+}
+
 /** Returns true if the content of this is equivalent to the content of other.
  *
  * Here "equivalent" implies equality of all member, except for positions and
@@ -242,6 +359,8 @@ size_t DetectorInfo::getMemorySize() const {
     mem += sizeof(*m_positions) + m_positions->size() * sizeof(Eigen::Vector3d);
   if (m_rotations)
     mem += sizeof(*m_rotations) + m_rotations->size() * sizeof(Eigen::Quaterniond);
+  // Virtual bank segment list (one entry per PixelAssembly bank, very small)
+  mem += m_virtualBanks.capacity() * sizeof(VirtualBankSegment);
   return mem;
 }
 

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -58,6 +58,8 @@ set(SRC_FILES
     src/Instrument/Goniometer.cpp
     src/Instrument/GridDetector.cpp
     src/Instrument/GridDetectorPixel.cpp
+    src/Instrument/IVirtualBank.cpp
+    src/Instrument/PixelAssembly.cpp
     src/Instrument/IDFObject.cpp
     src/Instrument/InstrumentDefinitionParser.cpp
     src/Instrument/InstrumentVisitor.cpp
@@ -205,6 +207,8 @@ set(INC_FILES
     inc/MantidGeometry/Instrument/Goniometer.h
     inc/MantidGeometry/Instrument/GridDetector.h
     inc/MantidGeometry/Instrument/GridDetectorPixel.h
+    inc/MantidGeometry/Instrument/IVirtualBank.h
+    inc/MantidGeometry/Instrument/PixelAssembly.h
     inc/MantidGeometry/Instrument/IDFObject.h
     inc/MantidGeometry/Instrument/InfoIteratorBase.h
     inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -326,6 +330,8 @@ set(TEST_FILES
     GoniometerTest.h
     GridDetectorPixelTest.h
     GridDetectorTest.h
+    IVirtualBankTest.h
+    PixelAssemblyTest.h
     GroupTest.h
     GroupTransformationTest.h
     HKLFilterTest.h

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -389,11 +389,14 @@ private:
   /// Pointer to the ComponentInfo object. May be NULL.
   std::shared_ptr<const ComponentInfo> m_componentInfo{nullptr};
 
-  /// Sorted (ascending) list of all virtual (PixelAssembly) pixel detector
-  /// IDs.  Replaces null entries formerly kept in m_detectorCache for these
-  /// pixels.  Empty for non-PA instruments.
-  /// Memory: 4 bytes per pixel (vs. ~24–32 bytes per DetectorCacheEntry).
-  std::vector<detid_t> m_virtualDetectorIDs;
+  /// One entry per PixelAssembly bank; replaces the O(n_pixels) sorted ID
+  /// vector.  Empty for non-PA instruments.
+  struct VirtualBankInfo {
+    detid_t idstart; ///< detector ID at grid position (0, 0, 0)
+    int idstep;      ///< ID increment per pixel along the fastest fill axis
+    size_t npixels;  ///< total pixel count in this bank
+  };
+  std::vector<VirtualBankInfo> m_virtualBankInfos;
 
   /// Flag - is this the physical rather than neutronic instrument
   bool m_isPhysicalInstrument{false};

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -10,6 +10,7 @@
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument/CompAssembly.h"
 #include "MantidGeometry/Instrument/GridDetector.h"
+#include "MantidGeometry/Instrument/IVirtualBank.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument_fwd.h"
 
@@ -98,6 +99,12 @@ public:
   /// to be a monitor and also add it to _detectorCache for possible later retrieval
   void markAsMonitor(IDetector const *);
   void markAsMonitorIncomplete(IDetector const *);
+  /// Register all detector IDs from a virtual pixel bank (PixelAssembly /
+  /// IVirtualBank) into the detector cache.  No per-pixel IDetector objects
+  /// are created; the cache entries carry null IDetector_const_sptr.  This is
+  /// sufficient for InstrumentVisitor / DetectorInfo; legacy getDetector(id)
+  /// calls for virtual pixels will return nullptr.
+  void markAsVirtualBankDetectors(const IVirtualBank &bank);
 
   /// Remove a detector from the instrument
   void removeDetector(IDetector *);
@@ -381,6 +388,12 @@ private:
 
   /// Pointer to the ComponentInfo object. May be NULL.
   std::shared_ptr<const ComponentInfo> m_componentInfo{nullptr};
+
+  /// Sorted (ascending) list of all virtual (PixelAssembly) pixel detector
+  /// IDs.  Replaces null entries formerly kept in m_detectorCache for these
+  /// pixels.  Empty for non-PA instruments.
+  /// Memory: 4 bytes per pixel (vs. ~24–32 bytes per DetectorCacheEntry).
+  std::vector<detid_t> m_virtualDetectorIDs;
 
   /// Flag - is this the physical rather than neutronic instrument
   bool m_isPhysicalInstrument{false};

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -47,8 +47,14 @@ private:
   /// Map of component ids to indexes
   std::shared_ptr<const std::unordered_map<Geometry::IComponent const *, size_t>> m_compIDToIndex;
 
-  /// Shapes for each component
+  /// Shapes for each component (compact for virtual-bank instruments: virtual
+  /// pixel slots are omitted; use m_virtualPixelShapes for those).
   std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> m_shapes;
+
+  /// For virtual-bank instruments: one pixel shape per bank, ordered to match
+  /// the VirtualBankSegments in the inner Beamline::ComponentInfo.
+  /// Empty for instruments without PixelAssembly banks.
+  std::vector<std::shared_ptr<const Geometry::IObject>> m_virtualPixelShapes;
 
   BoundingBox componentBoundingBox(const size_t index, const BoundingBox *reference,
                                    const bool excludeMonitors = false) const;
@@ -73,7 +79,8 @@ public:
   ComponentInfo(std::unique_ptr<Beamline::ComponentInfo> componentInfo,
                 std::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>> componentIds,
                 std::shared_ptr<const std::unordered_map<Geometry::IComponent const *, size_t>> componentIdToIndexMap,
-                std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes);
+                std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes,
+                std::vector<std::shared_ptr<const Geometry::IObject>> virtualPixelShapes = {});
   ~ComponentInfo();
   /// Copy assignment is not possible for ComponentInfo
   ComponentInfo &operator=(const ComponentInfo &) = delete;
@@ -118,7 +125,7 @@ public:
   void setScaleFactor(const size_t componentIndex, const Kernel::V3D &scaleFactor);
   size_t root() const;
 
-  const IComponent *componentID(const size_t componentIndex) const { return (*m_componentIds)[componentIndex]; }
+  const IComponent *componentID(const size_t componentIndex) const;
   bool hasValidShape(const size_t componentIndex) const;
 
   const Geometry::IObject &shape(const size_t componentIndex) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidBeamline/ComponentType.h"
+#include "MantidBeamline/VirtualBankSegment.h"
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ComponentInfoIterator.h"
 #include "MantidGeometry/Instrument/SolidAngleParams.h"
@@ -134,6 +135,7 @@ public:
   BoundingBox boundingBox(const size_t componentIndex, const BoundingBox *reference = nullptr,
                           const bool excludeMonitors = false) const;
   Beamline::ComponentType componentType(const size_t componentIndex) const;
+  const Beamline::VirtualBankSegment *findVirtualBankByCompIdx(size_t componentIndex) const;
   void setScanInterval(const std::pair<Types::Core::DateAndTime, Types::Core::DateAndTime> &interval);
   size_t scanCount() const;
   void merge(const ComponentInfo &other);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentVisitor.h
@@ -14,6 +14,7 @@ class ICompAssembly;
 class IDetector;
 class IComponent;
 class IObjComponent;
+class PixelAssembly;
 class RectangularDetector;
 class ObjCompAssembly;
 
@@ -31,6 +32,7 @@ public:
   virtual size_t registerInfiniteObjComponent(const IObjComponent &component) = 0;
   virtual size_t registerDetector(const IDetector &detector) = 0;
   virtual size_t registerGridBank(const ICompAssembly &bank) = 0;
+  virtual size_t registerVirtualBank(const PixelAssembly &bank) = 0;
   virtual size_t registerRectangularBank(const ICompAssembly &bank) = 0;
   virtual size_t registerStructuredBank(const ICompAssembly &bank) = 0;
   virtual size_t registerObjComponentAssembly(const ObjCompAssembly &obj) = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -134,6 +134,11 @@ private:
 
   mutable std::vector<std::shared_ptr<const Geometry::IDetector>> m_lastDetector;
   mutable std::vector<size_t> m_lastIndex;
+
+  /// For PA instruments: lazily-built full ID list (real + virtual) returned
+  /// by detectorIDs().  Null until first call to detectorIDs() on a PA instrument.
+  mutable std::once_flag m_allDetectorIDsCacheOnce;
+  mutable std::shared_ptr<const std::vector<detid_t>> m_allDetectorIDsCache;
 };
 
 using DetectorInfoIt = DetectorInfoIterator<DetectorInfo>;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/IVirtualBank.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/IVirtualBank.h
@@ -1,0 +1,124 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/IDTypes.h"
+#include "MantidGeometry/Instrument/Detector.h"
+#include "MantidKernel/V3D.h"
+#include <array>
+#include <memory>
+#include <tuple>
+
+namespace Mantid {
+namespace Geometry {
+
+/**
+ * IVirtualBank — interface for a regular 3-D grid of detector pixels.
+ *
+ * All pixel properties (detector ID, relative position) are computed on demand
+ * from a small set of grid parameters; no per-pixel child objects are required.
+ *
+ * Axis convention:
+ *   X = column index  [0, xpixels())
+ *   Y = row index     [0, ypixels())
+ *   Z = layer index   [0, zpixels())
+ *
+ * The **referent pixel** is the pixel at grid coordinates (0, 0, 0).  It has
+ * detector ID referentDetectorID(), and its relative position in the bank's
+ * local frame is (xstart(), ystart(), zstart()).  Every other pixel is located
+ * and numbered relative to it.
+ *
+ * Subclasses must supply the seven pure-virtual groups below (pixel counts,
+ * step sizes, start positions, ID scheme, and the referent Detector object).
+ * The remaining methods are concrete and are implemented entirely from those
+ * primitives.
+ */
+class MANTID_GEOMETRY_DLL IVirtualBank {
+public:
+  virtual ~IVirtualBank() = default;
+
+  // ---- Pixel counts (pure virtual) ----------------------------------------
+
+  virtual size_t xpixels() const = 0;
+  virtual size_t ypixels() const = 0;
+  virtual size_t zpixels() const = 0;
+
+  /// Total pixel count
+  size_t npixels() const { return xpixels() * ypixels() * zpixels(); }
+
+  // ---- Step sizes (pure virtual) ------------------------------------------
+  // Parametrized instruments may scale these via scalex / scaley / scalez.
+
+  virtual double xstep() const = 0;
+  virtual double ystep() const = 0;
+  virtual double zstep() const = 0;
+
+  // ---- Start positions of the referent pixel (pure virtual) ---------------
+  // These are the referent pixel's coordinates in the bank's local frame.
+
+  virtual double xstart() const = 0;
+  virtual double ystart() const = 0;
+  virtual double zstart() const = 0;
+
+  // ---- Total span (concrete) -----------------------------------------------
+
+  double xsize() const { return static_cast<double>(xpixels()) * xstep(); }
+  double ysize() const { return static_cast<double>(ypixels()) * ystep(); }
+  double zsize() const { return static_cast<double>(zpixels()) * zstep(); }
+
+  // ---- ID scheme (pure virtual) --------------------------------------------
+
+  /// Detector ID assigned to the referent pixel (0, 0, 0).
+  virtual detid_t referentDetectorID() const = 0;
+
+  /// Fill order: element [0] is the fastest-varying axis, [2] the slowest.
+  /// Valid values for each element: 'x', 'y', or 'z'.
+  /// Example: {'x', 'y', 'z'} means X varies fastest, Z slowest.
+  virtual std::array<char, 3> idFillOrder() const = 0;
+
+  /// ID increment between adjacent pixels along the fastest-varying axis.
+  virtual int idstep() const = 0;
+
+  // ---- Referent pixel object (pure virtual) --------------------------------
+
+  /// Returns a Detector object for the referent pixel (0, 0, 0), constructed
+  /// on demand.  The Detector's parent is this bank; its shape is the pixel
+  /// shape.  Callers should not cache the result across re-initializations.
+  virtual std::shared_ptr<Detector> referentDetector() const = 0;
+
+  // ---- ID range (concrete) ------------------------------------------------
+
+  detid_t minDetectorID() const { return referentDetectorID(); }
+  detid_t maxDetectorID() const {
+    return getDetectorIDAtXYZ(static_cast<int>(xpixels()) - 1, static_cast<int>(ypixels()) - 1,
+                              static_cast<int>(zpixels()) - 1);
+  }
+
+  // ---- Bounds check (concrete) --------------------------------------------
+
+  bool inBoundsXYZ(int x, int y, int z) const {
+    return x >= 0 && static_cast<size_t>(x) < xpixels() && y >= 0 && static_cast<size_t>(y) < ypixels() && z >= 0 &&
+           static_cast<size_t>(z) < zpixels();
+  }
+
+  // ---- ID / coordinate conversion (concrete) ------------------------------
+
+  detid_t getDetectorIDAtXYZ(int x, int y, int z) const;
+  std::tuple<int, int, int> getXYZForDetectorID(detid_t detectorID) const;
+
+  // ---- Relative position (concrete) ---------------------------------------
+
+  /// Position of pixel (x, y, z) in the bank's local coordinate frame,
+  /// before the bank's rotation is applied.
+  Kernel::V3D getRelativePosAtXYZ(int x, int y, int z) const {
+    return Kernel::V3D(xstart() + static_cast<double>(x) * xstep(), ystart() + static_cast<double>(y) * ystep(),
+                       zstart() + static_cast<double>(z) * zstep());
+  }
+};
+
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -157,6 +157,10 @@ private:
                                 const Poco::XML::Element *pCompElem, const std::string &filename,
                                 const Poco::XML::Element *pType);
 
+  void createPixelAssembly(Geometry::ICompAssembly *parent, const Poco::XML::Element *pLocElem,
+                           const Poco::XML::Element *pCompElem, const std::string &filename,
+                           const Poco::XML::Element *pType);
+
   /// Append \<locations\> in a locations element
   void appendLocations(Geometry::ICompAssembly *parent, const Poco::XML::Element *pLocElems,
                        const Poco::XML::Element *pCompElem, IdList &idList);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidBeamline/ComponentType.h"
+#include "MantidBeamline/DetectorInfo.h"
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
 #include <Eigen/Geometry>
@@ -15,12 +16,13 @@
 #include <memory>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace Mantid {
 using detid_t = int32_t;
 namespace Beamline {
 class ComponentInfo;
-class DetectorInfo;
+// DetectorInfo is fully included above; forward declaration not needed.
 } // namespace Beamline
 namespace Geometry {
 class ComponentInfo;
@@ -124,6 +126,14 @@ private:
 
   /// Component names
   std::shared_ptr<std::vector<std::string>> m_names;
+
+  /// Virtual bank segments registered by registerVirtualBank().
+  /// Passed to Beamline::DetectorInfo so it can compute pixel positions on demand.
+  std::vector<Beamline::VirtualBankSegment> m_virtualBankSegments;
+
+  /// One pixel shape per virtual (PixelAssembly) bank, in registration order.
+  /// Stored separately so m_shapes can be compacted (virtual pixel slots omitted).
+  std::vector<std::shared_ptr<const Mantid::Geometry::IObject>> m_virtualPixelShapes;
 
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId, const size_t componentIndex);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -32,6 +32,7 @@ class IObjComponent;
 class Instrument;
 class IObject;
 class ParameterMap;
+class PixelAssembly;
 class RectangularDetector;
 class ObjCompAssembly;
 
@@ -145,6 +146,8 @@ public:
   virtual size_t registerGenericObjComponent(const Mantid::Geometry::IObjComponent &objComponent) override;
 
   virtual size_t registerGridBank(const Mantid::Geometry::ICompAssembly &bank) override;
+
+  virtual size_t registerVirtualBank(const Mantid::Geometry::PixelAssembly &bank) override;
 
   virtual size_t registerRectangularBank(const Mantid::Geometry::ICompAssembly &bank) override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/PixelAssembly.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/PixelAssembly.h
@@ -1,0 +1,147 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/IObjComponent.h"
+#include "MantidGeometry/Instrument/CompAssembly.h"
+#include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace Mantid {
+namespace Geometry {
+
+class ComponentVisitor;
+/**
+ *  GridDetector is a type of CompAssembly, an assembly of components.
+ *  It is designed to be an easy way to specify a 3D grid (XYZ) array of
+ *  Detector pixels. Ragged grids are not allowed, pixels are uniform in each
+ *  dimension.
+ *
+ * @class PixelAssembly
+ * @brief Assembly of Detector objects in a 3D grid shape
+ * @author Lamar Moore, ISIS
+ * @date 2018-Jul-24
+ */
+
+class MANTID_GEOMETRY_DLL PixelAssembly : public CompAssembly, public IObjComponent {
+
+public:
+  /// String description of the type of component
+  std::string type() const override { return "PixelAssembly"; }
+
+  //! Constructor with a name and parent reference
+  PixelAssembly(const std::string &name, IComponent *reference = nullptr);
+
+  //! Parametrized constructor
+  PixelAssembly(const PixelAssembly *base, const ParameterMap *map);
+
+  /// Matches name to Structured Detector
+  static bool compareName(const std::string &proposedMatch);
+
+  /// Create all the detector pixels of this grid detector.
+  void initialize(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels, double ystart,
+                  double ystep, int zpixels, double zstart, double zstep, int idstart, const std::string &idFillOrder,
+                  int idstepbyrow, int idstep = 1);
+
+  //! Make a clone of the present component
+  PixelAssembly *clone() const override;
+
+  int idstart() const;
+  int idstep() const;
+
+  /// minimum detector id
+  detid_t minDetectorID() const;
+  /// maximum detector id
+  detid_t maxDetectorID() const;
+  std::shared_ptr<const IComponent> getComponentByName(const std::string &cname, int nlevels = 0) const override;
+
+  // This should inherit the getBoundingBox implementation from  CompAssembly
+  // but the multiple inheritance seems to confuse it so we'll explicityly tell
+  // it that here
+  using CompAssembly::getBoundingBox;
+
+  void testIntersectionWithChildren(Track &testRay, std::deque<IComponent_const_sptr> &searchQueue) const override;
+
+  // ------------ IObjComponent methods ----------------
+
+  /// Does the point given lie within this object component?
+  bool isValid(const Kernel::V3D &point) const override;
+
+  /// Does the point given lie on the surface of this object component?
+  bool isOnSide(const Kernel::V3D &point) const override;
+
+  /// Checks whether the track given will pass through this Component.
+  int interceptSurface(Track &track) const override;
+
+  /// Finds the approximate solid angle covered by the component when viewed
+  /// from the point given
+  double solidAngle(const Geometry::SolidAngleParams &params) const override;
+  /// Retrieve the cached bounding box
+  void getBoundingBox(BoundingBox &assemblyBox) const override;
+
+  /// Try to find a point that lies within (or on) the object
+  int getPointInObject(Kernel::V3D &point) const override;
+
+  // Rendering member functions
+  /// Draws the objcomponent.
+  void draw() const override;
+
+  /// Draws the Object.
+  void drawObject() const override;
+
+  /// Initializes the ObjComponent for rendering, this function should be called
+  /// before rendering.
+  void initDraw() const override;
+
+  /// Returns the shape of the Object
+  const std::shared_ptr<const IObject> shape() const override;
+  /// Returns the material of the detector
+  const Kernel::Material material() const override;
+
+  virtual size_t registerContents(class ComponentVisitor &componentVisitor) const override;
+
+  // ------------ End of IObjComponent methods ----------------
+protected:
+  /// initialize members to bare defaults
+  void init();
+  void createLayer(const std::string &name, CompAssembly *parent, int iz, int &minDetID, int &maxDetID);
+
+private:
+  void initializeValues(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels,
+                        double ystart, double ystep, int zpixels, double zstart, double zstep, int idstart,
+                        const std::string &idFillOrder, int idstepbyrow, int idstep);
+
+  void validateInput() const;
+  /// Pointer to the base GridDetector, for parametrized instruments
+  const GridDetector *m_gridBase;
+  bool isParametrized() const override { return m_map && m_gridBase; }
+  /// Private copy assignment operator
+  PixelAssembly &operator=(const ICompAssembly &);
+
+  /// Pointer to the shape of the pixels in this detector array.
+  std::shared_ptr<IObject> m_shape;
+  /// minimum detector id
+  detid_t m_minDetId;
+  /// maximum detector id
+  detid_t m_maxDetId;
+
+  /// IDs start here
+  int m_idstart;
+  /// Step size in ID in each col
+  int m_idstep;
+};
+
+MANTID_GEOMETRY_DLL std::ostream &operator<<(std::ostream &, const PixelAssembly &);
+
+using PixelAssembly_sptr = std::shared_ptr<PixelAssembly>;
+using PixelAssembly_const_sptr = std::shared_ptr<const PixelAssembly>;
+
+} // Namespace Geometry
+} // Namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/PixelAssembly.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/PixelAssembly.h
@@ -1,141 +1,199 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/IObjComponent.h"
-#include "MantidGeometry/Instrument/CompAssembly.h"
-#include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Instrument/Component.h"
+#include "MantidGeometry/Instrument/IVirtualBank.h"
 #include "MantidGeometry/Objects/IObject.h"
+#include <array>
+#include <memory>
 #include <string>
-#include <tuple>
-#include <vector>
 
 namespace Mantid {
 namespace Geometry {
 
+class BoundingBox;
 class ComponentVisitor;
-/**
- *  GridDetector is a type of CompAssembly, an assembly of components.
- *  It is designed to be an easy way to specify a 3D grid (XYZ) array of
- *  Detector pixels. Ragged grids are not allowed, pixels are uniform in each
- *  dimension.
- *
- * @class PixelAssembly
- * @brief Assembly of Detector objects in a 3D grid shape
- * @author Lamar Moore, ISIS
- * @date 2018-Jul-24
- */
+class Detector;
+class Track;
 
-class MANTID_GEOMETRY_DLL PixelAssembly : public CompAssembly, public IObjComponent {
+/**
+ * PixelAssembly — a detector bank for regular 3-D grids of pixels.
+ *
+ * Inherits from Component (not CompAssembly) and creates NO per-pixel child
+ * Detector objects.  All pixel properties (detector ID, relative position,
+ * bounding box) are computed on demand from the grid parameters stored via
+ * IVirtualBank.
+ *
+ * Intended for large-pixel-count instruments (e.g. IMAGINE with ~20 M pixels)
+ * where allocating one Detector object per pixel would be prohibitive.
+ *
+ * Constraints vs GridDetector:
+ *  - IDs must be packed (no gaps): the row stride equals
+ *    idstep * pixels_along_fastest_axis.
+ *  - zpixels must be >= 1 (a flat bank uses zpixels = 1).
+ *
+ * @class  PixelAssembly
+ * @brief  Virtual-pixel 3D detector bank
+ * @author rboston628
+ */
+class MANTID_GEOMETRY_DLL PixelAssembly : public Component, public IObjComponent, public IVirtualBank {
 
 public:
   /// String description of the type of component
   std::string type() const override { return "PixelAssembly"; }
 
-  //! Constructor with a name and parent reference
-  PixelAssembly(const std::string &name, IComponent *reference = nullptr);
+  //! Constructor with a name and optional parent reference
+  explicit PixelAssembly(const std::string &name, IComponent *reference = nullptr);
 
   //! Parametrized constructor
   PixelAssembly(const PixelAssembly *base, const ParameterMap *map);
 
-  /// Matches name to Structured Detector
+  /// Returns true if the proposed name matches the PixelAssembly naming convention.
   static bool compareName(const std::string &proposedMatch);
 
-  /// Create all the detector pixels of this grid detector.
-  void initialize(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels, double ystart,
-                  double ystep, int zpixels, double zstart, double zstep, int idstart, const std::string &idFillOrder,
-                  int idstepbyrow, int idstep = 1);
+  /**
+   * Store the grid parameters.  No child Detector objects are created.
+   * Call this after setting the assembly's name, position and rotation.
+   *
+   * @param shape      Shape shared by every pixel.
+   * @param xpixels    Number of pixels in X.
+   * @param xstart     X coordinate of the referent pixel (0,0,0), local frame.
+   * @param xstep      Step between adjacent pixels in X, local frame.
+   * @param ypixels    Number of pixels in Y.
+   * @param ystart     Y coordinate of the referent pixel, local frame.
+   * @param ystep      Step between adjacent pixels in Y, local frame.
+   * @param zpixels    Number of pixels in Z (pass 0 or 1 for a flat bank).
+   * @param zstart     Z coordinate of the referent pixel, local frame.
+   * @param zstep      Step between adjacent pixels in Z, local frame.
+   * @param idstart    Detector ID of the referent pixel (0,0,0).
+   * @param idFillOrder Three-character string: e.g. "xyz" means X varies fastest.
+   * @param idstep     ID increment between adjacent pixels along the fastest axis.
+   */
+  void initialize(std::shared_ptr<IObject> shape, size_t xpixels, double xstart, double xstep, size_t ypixels,
+                  double ystart, double ystep, size_t zpixels, double zstart, double zstep, detid_t idstart,
+                  const std::string &idFillOrder, int idstep = 1);
 
   //! Make a clone of the present component
   PixelAssembly *clone() const override;
 
-  int idstart() const;
-  int idstep() const;
+  // ---- IVirtualBank pure virtuals ----
 
-  /// minimum detector id
-  detid_t minDetectorID() const;
-  /// maximum detector id
-  detid_t maxDetectorID() const;
-  std::shared_ptr<const IComponent> getComponentByName(const std::string &cname, int nlevels = 0) const override;
+  size_t xpixels() const override;
+  size_t ypixels() const override;
+  size_t zpixels() const override;
 
-  // This should inherit the getBoundingBox implementation from  CompAssembly
-  // but the multiple inheritance seems to confuse it so we'll explicityly tell
-  // it that here
-  using CompAssembly::getBoundingBox;
+  double xstep() const override;
+  double ystep() const override;
+  double zstep() const override;
 
-  void testIntersectionWithChildren(Track &testRay, std::deque<IComponent_const_sptr> &searchQueue) const override;
+  double xstart() const override;
+  double ystart() const override;
+  double zstart() const override;
 
-  // ------------ IObjComponent methods ----------------
+  detid_t referentDetectorID() const override;
+  std::array<char, 3> idFillOrder() const override;
+  int idstep() const override;
 
-  /// Does the point given lie within this object component?
+  /// Returns a Detector object for the referent pixel (0,0,0), constructed on demand.
+  std::shared_ptr<Detector> referentDetector() const override;
+
+  // ---- Position helpers ----
+
+  /// Absolute position of pixel (x,y,z) in the instrument frame.
+  Kernel::V3D getPosAtXYZ(int x, int y, int z) const;
+
+  // ---- Per-pixel bounding box ----
+
+  void getBoundingBoxAtXYZ(int x, int y, int z, BoundingBox &box) const;
+
+  // ---- Component lookup ----
+  // NOTE: IComponent does not declare getComponentByName; only ICompAssembly does.
+  // PixelAssembly intentionally does not inherit ICompAssembly, so this method
+  // is not available through the standard IComponent pointer interface.
+  // Direct callers (e.g. InstrumentDefinitionParser) should hold a PixelAssembly*.
+  std::shared_ptr<const IComponent> getComponentByName(const std::string &cname) const;
+
+  // ---- Visitor registration ----
+
+  size_t registerContents(class ComponentVisitor &componentVisitor) const override;
+
+  // ---- Pixel shape (separate from the overall rendering shape) ----
+
+  std::shared_ptr<const IObject> pixelShape() const;
+
+  // ---- IObjComponent methods ----
+
+  /// Does the point lie within this component?  (Not implemented — throws.)
   bool isValid(const Kernel::V3D &point) const override;
-
-  /// Does the point given lie on the surface of this object component?
+  /// Does the point lie on the surface?  (Not implemented — throws.)
   bool isOnSide(const Kernel::V3D &point) const override;
-
-  /// Checks whether the track given will pass through this Component.
+  /// Check whether a track passes through this component.  (Not implemented — throws.)
   int interceptSurface(Track &track) const override;
-
-  /// Finds the approximate solid angle covered by the component when viewed
-  /// from the point given
+  /// Approximate solid angle.  (Not implemented — throws.)
   double solidAngle(const Geometry::SolidAngleParams &params) const override;
-  /// Retrieve the cached bounding box
+  /// Retrieve or compute the bounding box for the whole assembly.
   void getBoundingBox(BoundingBox &assemblyBox) const override;
-
-  /// Try to find a point that lies within (or on) the object
+  /// Find a point inside the object.  (Not implemented — throws.)
   int getPointInObject(Kernel::V3D &point) const override;
 
-  // Rendering member functions
-  /// Draws the objcomponent.
+  // Rendering
   void draw() const override;
-
-  /// Draws the Object.
   void drawObject() const override;
-
-  /// Initializes the ObjComponent for rendering, this function should be called
-  /// before rendering.
   void initDraw() const override;
 
-  /// Returns the shape of the Object
+  /// Returns a cuboid representing the whole assembly (for rendering).
   const std::shared_ptr<const IObject> shape() const override;
-  /// Returns the material of the detector
+  /// Returns an empty material.
   const Kernel::Material material() const override;
 
-  virtual size_t registerContents(class ComponentVisitor &componentVisitor) const override;
+  // ---- End of IObjComponent methods ----
 
-  // ------------ End of IObjComponent methods ----------------
 protected:
-  /// initialize members to bare defaults
+  /// Initialise all members to safe defaults.
   void init();
-  void createLayer(const std::string &name, CompAssembly *parent, int iz, int &minDetID, int &maxDetID);
 
 private:
-  void initializeValues(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels,
-                        double ystart, double ystep, int zpixels, double zstart, double zstep, int idstart,
-                        const std::string &idFillOrder, int idstepbyrow, int idstep);
-
   void validateInput() const;
-  /// Pointer to the base GridDetector, for parametrized instruments
-  const GridDetector *m_gridBase;
+  void initializeValues(std::shared_ptr<IObject> shape, size_t xpixels, double xstart, double xstep, size_t ypixels,
+                        double ystart, double ystep, size_t zpixels, double zstart, double zstep, detid_t idstart,
+                        const std::string &idFillOrder, int idstep);
+
+  /// True when this is a parametrized view of m_gridBase.
   bool isParametrized() const override { return m_map && m_gridBase; }
-  /// Private copy assignment operator
-  PixelAssembly &operator=(const ICompAssembly &);
 
-  /// Pointer to the shape of the pixels in this detector array.
+  /// Pointer to the base (unparametrized) assembly; nullptr when not parametrized.
+  const PixelAssembly *m_gridBase;
+
+  /// Deleted copy-assignment.
+  PixelAssembly &operator=(const PixelAssembly &) = delete;
+
+  // ---- Grid geometry ----
+  size_t m_xpixels; ///< Number of pixels in X
+  size_t m_ypixels; ///< Number of pixels in Y
+  size_t m_zpixels; ///< Number of pixels in Z (always >= 1)
+
+  double m_xstart; ///< X coordinate of the referent pixel, local frame
+  double m_ystart; ///< Y coordinate of the referent pixel, local frame
+  double m_zstart; ///< Z coordinate of the referent pixel, local frame
+
+  double m_xstep; ///< Step between adjacent pixels in X, local frame
+  double m_ystep; ///< Step between adjacent pixels in Y, local frame
+  double m_zstep; ///< Step between adjacent pixels in Z, local frame
+
+  /// Shape shared by every pixel in this assembly.
   std::shared_ptr<IObject> m_shape;
-  /// minimum detector id
-  detid_t m_minDetId;
-  /// maximum detector id
-  detid_t m_maxDetId;
 
-  /// IDs start here
-  int m_idstart;
-  /// Step size in ID in each col
-  int m_idstep;
+  // ---- ID scheme ----
+  detid_t m_idstart;                 ///< ID of the referent pixel (0,0,0)
+  std::array<char, 3> m_idFillOrder; ///< Fill order, e.g. {'x','y','z'}
+  int m_idstep;                      ///< ID increment per pixel along fastest axis
 };
 
 MANTID_GEOMETRY_DLL std::ostream &operator<<(std::ostream &, const PixelAssembly &);
@@ -143,5 +201,5 @@ MANTID_GEOMETRY_DLL std::ostream &operator<<(std::ostream &, const PixelAssembly
 using PixelAssembly_sptr = std::shared_ptr<PixelAssembly>;
 using PixelAssembly_const_sptr = std::shared_ptr<const PixelAssembly>;
 
-} // Namespace Geometry
-} // Namespace Mantid
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -17,6 +17,7 @@
 #include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidGeometry/Instrument/PixelAssembly.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidGeometry/Instrument/StructuredDetector.h"
@@ -57,6 +58,12 @@ size_t componentObjectSize(const IComponent *comp) {
              sd->getYValues().capacity() * sizeof(double);
   else if (dynamic_cast<const GridDetectorPixel *>(comp))
     result = sizeof(GridDetectorPixel);
+  else if (dynamic_cast<const PixelAssembly *>(comp))
+    // PixelAssembly stores no per-pixel IComponent objects.  The null
+    // DetectorCacheEntry slots it adds to m_detectorCache are already counted
+    // by the global  m_detectorCache.capacity() * sizeof(DetectorCacheEntry)
+    // term in getMemorySize(), so only the object itself is counted here.
+    result = sizeof(PixelAssembly);
   else if (dynamic_cast<const GridDetector *>(comp))
     result = sizeof(GridDetector);
   else if (dynamic_cast<const Detector *>(comp))
@@ -266,13 +273,24 @@ void Instrument::getDetectors(detid2det_map &out_map) const {
 /** Return a vector of detector IDs in this instrument */
 std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  std::vector<detid_t> out;
-  out.reserve(in_dets.size());
+  const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
+
+  // Collect real (non-virtual) detector IDs from the cache (already sorted).
+  std::vector<detid_t> realIDs;
+  realIDs.reserve(in_dets.size());
   for (const auto &in_det : in_dets) {
-    if (!skipMonitors || !in_det.isMonitor()) {
-      out.emplace_back(in_det.id());
-    }
+    if (!skipMonitors || !in_det.isMonitor())
+      realIDs.emplace_back(in_det.id());
   }
+
+  // Virtual pixels are never monitors; skip them when skipMonitors is true.
+  if (vids.empty() || skipMonitors)
+    return realIDs;
+
+  // Merge real IDs and virtual IDs — both are sorted — into one sorted result.
+  std::vector<detid_t> out;
+  out.reserve(realIDs.size() + vids.size());
+  std::merge(realIDs.begin(), realIDs.end(), vids.begin(), vids.end(), std::back_inserter(out));
   return out;
 }
 
@@ -294,13 +312,15 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
 
   if (skipMonitors) {
+    // Virtual pixels are never monitors; count only non-monitor real entries.
     const std::size_t monitors =
         std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });
-    return (in_dets.size() - monitors);
+    return (in_dets.size() - monitors) + vids.size();
   } else {
-    return in_dets.size();
+    return in_dets.size() + vids.size();
   }
 }
 
@@ -586,6 +606,11 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   const auto it = in_dets.find(detector_id);
   if (it == in_dets.end()) {
+    // Virtual pixels are not stored in the cache; return null sptr so callers
+    // can distinguish "virtual pixel" from a genuine "not found" error.
+    const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
+    if (std::binary_search(vids.begin(), vids.end(), detector_id))
+      return IDetector_const_sptr{};
     std::stringstream readInt;
     readInt << detector_id;
     throw Kernel::Exception::NotFoundError("Instrument: Detector with ID " + readInt.str() + " not found.", "");
@@ -805,6 +830,45 @@ void Instrument::markAsDetectorFinalize() {
   } else {
     m_detectorCache.setFinalized();
   }
+}
+
+/** Register every pixel ID in a virtual bank (IVirtualBank / PixelAssembly)
+ * into the detector cache.
+ *
+ * No per-pixel IDetector object is required: cache entries store a null
+ * IDetector_const_sptr.  This is sufficient for InstrumentVisitor /
+ * DetectorInfo which only needs the IDs to build its index map; the pixel
+ * positions are then filled by registerVirtualBank().
+ *
+ * Legacy callers of Instrument::getDetector(id) for virtual pixels will
+ * receive nullptr — they must migrate to the DetectorInfo API.
+ *
+ * @param bank :: The IVirtualBank whose pixel IDs should be registered.
+ */
+void Instrument::markAsVirtualBankDetectors(const IVirtualBank &bank) {
+  if (m_map)
+    throw std::runtime_error("Instrument::markAsVirtualBankDetectors() called on a parametrized Instrument object.");
+
+  // Collect this bank's pixel IDs and merge them into the sorted m_virtualDetectorIDs.
+  // Storing IDs as a plain sorted vector uses ~4 bytes/pixel vs. ~24–32 bytes/pixel
+  // in m_detectorCache, saving ~20–28 MB for a 1.18M-pixel instrument.
+  std::vector<detid_t> bankIDs;
+  bankIDs.reserve(bank.npixels());
+  for (size_t iz = 0; iz < bank.zpixels(); ++iz) {
+    for (size_t iy = 0; iy < bank.ypixels(); ++iy) {
+      for (size_t ix = 0; ix < bank.xpixels(); ++ix) {
+        bankIDs.push_back(bank.getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz)));
+      }
+    }
+  }
+  std::sort(bankIDs.begin(), bankIDs.end());
+
+  // Merge into the existing sorted list.
+  std::vector<detid_t> merged;
+  merged.reserve(m_virtualDetectorIDs.size() + bankIDs.size());
+  std::merge(m_virtualDetectorIDs.begin(), m_virtualDetectorIDs.end(), bankIDs.begin(), bankIDs.end(),
+             std::back_inserter(merged));
+  m_virtualDetectorIDs = std::move(merged);
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -1537,9 +1601,13 @@ size_t Instrument::getMemorySize() const {
   // Indirect-geometry instruments hold a second full instrument for the physical geometry.
   const size_t physicalInstrumentMem = m_physicalInstrument ? m_physicalInstrument->getMemorySize() : 0;
 
+  // m_virtualDetectorIDs: sorted vector of PA pixel IDs (~4 bytes each).
+  const size_t virtualIDsMem = m_virtualDetectorIDs.capacity() * sizeof(detid_t);
+
   return sizeof(*this) + componentTreeMem + m_detectorCache.capacity() * sizeof(DetectorCacheEntry) + logfileCacheMem +
          logfileUnitMem + m_defaultView.capacity() + m_defaultViewAxis.capacity() + m_xmlText.capacity() +
-         m_filename.capacity() + detectorInfoMem + componentInfoMem + referenceFrameMem + physicalInstrumentMem;
+         m_filename.capacity() + detectorInfoMem + componentInfoMem + referenceFrameMem + physicalInstrumentMem +
+         virtualIDsMem;
 }
 
 namespace Conversion {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -273,7 +273,7 @@ void Instrument::getDetectors(detid2det_map &out_map) const {
 /** Return a vector of detector IDs in this instrument */
 std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
+  const auto &vbanks = m_map ? m_instr->m_virtualBankInfos : m_virtualBankInfos;
 
   // Collect real (non-virtual) detector IDs from the cache (already sorted).
   std::vector<detid_t> realIDs;
@@ -284,13 +284,23 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
   }
 
   // Virtual pixels are never monitors; include them regardless of skipMonitors.
-  if (vids.empty())
+  if (vbanks.empty())
     return realIDs;
 
-  // Merge real IDs and virtual IDs — both are sorted — into one sorted result.
+  // Generate virtual IDs on demand (O(n_pixels) temporary), sort, then merge.
+  size_t totalVirtual = 0;
+  for (const auto &info : vbanks)
+    totalVirtual += info.npixels;
+  std::vector<detid_t> virtualIDs;
+  virtualIDs.reserve(totalVirtual);
+  for (const auto &info : vbanks)
+    for (size_t k = 0; k < info.npixels; ++k)
+      virtualIDs.push_back(info.idstart + static_cast<detid_t>(static_cast<int64_t>(k) * info.idstep));
+  std::sort(virtualIDs.begin(), virtualIDs.end());
+
   std::vector<detid_t> out;
-  out.reserve(realIDs.size() + vids.size());
-  std::merge(realIDs.begin(), realIDs.end(), vids.begin(), vids.end(), std::back_inserter(out));
+  out.reserve(realIDs.size() + virtualIDs.size());
+  std::merge(realIDs.begin(), realIDs.end(), virtualIDs.begin(), virtualIDs.end(), std::back_inserter(out));
   return out;
 }
 
@@ -312,15 +322,18 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
+  const auto &vbanks = m_map ? m_instr->m_virtualBankInfos : m_virtualBankInfos;
+  size_t nVirtual = 0;
+  for (const auto &info : vbanks)
+    nVirtual += info.npixels;
 
   if (skipMonitors) {
     // Virtual pixels are never monitors; count only non-monitor real entries.
     const std::size_t monitors =
         std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });
-    return (in_dets.size() - monitors) + vids.size();
+    return (in_dets.size() - monitors) + nVirtual;
   } else {
-    return in_dets.size() + vids.size();
+    return in_dets.size() + nVirtual;
   }
 }
 
@@ -608,9 +621,15 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
   if (it == in_dets.end()) {
     // Virtual pixels are not stored in the cache; return null sptr so callers
     // can distinguish "virtual pixel" from a genuine "not found" error.
-    const auto &vids = m_map ? m_instr->m_virtualDetectorIDs : m_virtualDetectorIDs;
-    if (std::binary_search(vids.begin(), vids.end(), detector_id))
-      return IDetector_const_sptr{};
+    const auto &vbanks = m_map ? m_instr->m_virtualBankInfos : m_virtualBankInfos;
+    for (const auto &info : vbanks) {
+      const int64_t delta = static_cast<int64_t>(detector_id) - static_cast<int64_t>(info.idstart);
+      if (info.idstep != 0 && delta % info.idstep == 0) {
+        const int64_t q = delta / info.idstep;
+        if (q >= 0 && q < static_cast<int64_t>(info.npixels))
+          return IDetector_const_sptr{};
+      }
+    }
     std::stringstream readInt;
     readInt << detector_id;
     throw Kernel::Exception::NotFoundError("Instrument: Detector with ID " + readInt.str() + " not found.", "");
@@ -849,26 +868,8 @@ void Instrument::markAsVirtualBankDetectors(const IVirtualBank &bank) {
   if (m_map)
     throw std::runtime_error("Instrument::markAsVirtualBankDetectors() called on a parametrized Instrument object.");
 
-  // Collect this bank's pixel IDs and merge them into the sorted m_virtualDetectorIDs.
-  // Storing IDs as a plain sorted vector uses ~4 bytes/pixel vs. ~24–32 bytes/pixel
-  // in m_detectorCache, saving ~20–28 MB for a 1.18M-pixel instrument.
-  std::vector<detid_t> bankIDs;
-  bankIDs.reserve(bank.npixels());
-  for (size_t iz = 0; iz < bank.zpixels(); ++iz) {
-    for (size_t iy = 0; iy < bank.ypixels(); ++iy) {
-      for (size_t ix = 0; ix < bank.xpixels(); ++ix) {
-        bankIDs.push_back(bank.getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz)));
-      }
-    }
-  }
-  std::sort(bankIDs.begin(), bankIDs.end());
-
-  // Merge into the existing sorted list.
-  std::vector<detid_t> merged;
-  merged.reserve(m_virtualDetectorIDs.size() + bankIDs.size());
-  std::merge(m_virtualDetectorIDs.begin(), m_virtualDetectorIDs.end(), bankIDs.begin(), bankIDs.end(),
-             std::back_inserter(merged));
-  m_virtualDetectorIDs = std::move(merged);
+  // Store just the bank parameters (O(1) per bank) instead of O(n_pixels) IDs.
+  m_virtualBankInfos.push_back({bank.referentDetectorID(), bank.idstep(), bank.npixels()});
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -1601,8 +1602,8 @@ size_t Instrument::getMemorySize() const {
   // Indirect-geometry instruments hold a second full instrument for the physical geometry.
   const size_t physicalInstrumentMem = m_physicalInstrument ? m_physicalInstrument->getMemorySize() : 0;
 
-  // m_virtualDetectorIDs: sorted vector of PA pixel IDs (~4 bytes each).
-  const size_t virtualIDsMem = m_virtualDetectorIDs.capacity() * sizeof(detid_t);
+  // m_virtualBankInfos: one entry per PA bank (O(n_banks), not O(n_pixels)).
+  const size_t virtualIDsMem = m_virtualBankInfos.capacity() * sizeof(VirtualBankInfo);
 
   return sizeof(*this) + componentTreeMem + m_detectorCache.capacity() * sizeof(DetectorCacheEntry) + logfileCacheMem +
          logfileUnitMem + m_defaultView.capacity() + m_defaultViewAxis.capacity() + m_xmlText.capacity() +

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <numeric>
 #include <queue>
 #include <utility>
 
@@ -288,9 +289,8 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
     return realIDs;
 
   // Generate virtual IDs on demand (O(n_pixels) temporary), sort, then merge.
-  size_t totalVirtual = 0;
-  for (const auto &info : vbanks)
-    totalVirtual += info.npixels;
+  const size_t totalVirtual = std::accumulate(vbanks.cbegin(), vbanks.cend(), size_t{0},
+                                              [](size_t acc, const auto &info) { return acc + info.npixels; });
   std::vector<detid_t> virtualIDs;
   virtualIDs.reserve(totalVirtual);
   for (const auto &info : vbanks)
@@ -323,9 +323,8 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   const auto &vbanks = m_map ? m_instr->m_virtualBankInfos : m_virtualBankInfos;
-  size_t nVirtual = 0;
-  for (const auto &info : vbanks)
-    nVirtual += info.npixels;
+  const size_t nVirtual = std::accumulate(vbanks.cbegin(), vbanks.cend(), size_t{0},
+                                          [](size_t acc, const auto &info) { return acc + info.npixels; });
 
   if (skipMonitors) {
     // Virtual pixels are never monitors; count only non-monitor real entries.

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -283,8 +283,8 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
       realIDs.emplace_back(in_det.id());
   }
 
-  // Virtual pixels are never monitors; skip them when skipMonitors is true.
-  if (vids.empty() || skipMonitors)
+  // Virtual pixels are never monitors; include them regardless of skipMonitors.
+  if (vids.empty())
     return realIDs;
 
   // Merge real IDs and virtual IDs — both are sorted — into one sorted result.

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/Exception.h"
 
 #include <Eigen/Geometry>
+#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <string>
@@ -55,18 +56,26 @@ ComponentInfo::ComponentInfo(
     std::unique_ptr<Beamline::ComponentInfo> componentInfo,
     std::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>> componentIds,
     std::shared_ptr<const std::unordered_map<Geometry::IComponent const *, size_t>> componentIdToIndexMap,
-    std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes)
+    std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes,
+    std::vector<std::shared_ptr<const Geometry::IObject>> virtualPixelShapes)
     : m_componentInfo(std::move(componentInfo)), m_componentIds(std::move(componentIds)),
-      m_compIDToIndex(std::move(componentIdToIndexMap)), m_shapes(std::move(shapes)) {
+      m_compIDToIndex(std::move(componentIdToIndexMap)), m_shapes(std::move(shapes)),
+      m_virtualPixelShapes(std::move(virtualPixelShapes)) {
 
+  // All entries in m_componentIds must be non-null (compact: virtual pixel
+  // entries have been omitted) and must match the map size.
   if (m_componentIds->size() != m_compIDToIndex->size()) {
     throw std::invalid_argument("Inconsistent ID and Mapping input containers "
                                 "for Geometry::ComponentInfo");
   }
-  if (m_componentIds->size() != m_componentInfo->size()) {
-    throw std::invalid_argument("Inconsistent ID and base "
-                                "Beamline::ComponentInfo sizes for "
-                                "Geometry::ComponentInfo");
+  // For virtual-bank instruments the arrays are compact (size < total logical
+  // size).  For standard instruments the arrays span the full component count.
+  if (!m_componentInfo->hasVirtualBanks()) {
+    if (m_componentIds->size() != m_componentInfo->size()) {
+      throw std::invalid_argument("Inconsistent ID and base "
+                                  "Beamline::ComponentInfo sizes for "
+                                  "Geometry::ComponentInfo");
+    }
   }
 }
 
@@ -85,7 +94,8 @@ std::unique_ptr<Geometry::ComponentInfo> ComponentInfo::cloneWithoutDetectorInfo
  * ComponentInfo must be set up. */
 ComponentInfo::ComponentInfo(const ComponentInfo &other)
     : m_componentInfo(other.m_componentInfo->cloneWithoutDetectorInfo()), m_componentIds(other.m_componentIds),
-      m_compIDToIndex(other.m_compIDToIndex), m_shapes(other.m_shapes) {}
+      m_compIDToIndex(other.m_compIDToIndex), m_shapes(other.m_shapes),
+      m_virtualPixelShapes(other.m_virtualPixelShapes) {}
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ComponentInfo::~ComponentInfo() = default;
@@ -136,8 +146,27 @@ bool ComponentInfo::isDetector(const size_t componentIndex) const {
   return m_componentInfo->isDetector(componentIndex);
 }
 
+const IComponent *ComponentInfo::componentID(const size_t componentIndex) const {
+  if (m_componentInfo->hasVirtualBanks()) {
+    if (m_componentInfo->findVirtualSegment(componentIndex) != nullptr)
+      return nullptr; // virtual pixels have no IComponent object
+    return (*m_componentIds)[m_componentInfo->compactComponentIndex(componentIndex)];
+  }
+  return (*m_componentIds)[componentIndex];
+}
+
 bool ComponentInfo::hasValidShape(const size_t componentIndex) const {
-  const auto *shapeAtIndex = (*m_shapes)[componentIndex].get();
+  const Geometry::IObject *shapeAtIndex = nullptr;
+  if (m_componentInfo->hasVirtualBanks()) {
+    if (const auto *seg = m_componentInfo->findVirtualSegment(componentIndex)) {
+      const auto bankIdx = m_componentInfo->virtualBankIndex(seg);
+      shapeAtIndex = m_virtualPixelShapes[bankIdx].get();
+    } else {
+      shapeAtIndex = (*m_shapes)[m_componentInfo->compactComponentIndex(componentIndex)].get();
+    }
+  } else {
+    shapeAtIndex = (*m_shapes)[componentIndex].get();
+  }
   return shapeAtIndex != nullptr && shapeAtIndex->hasValidShape();
 }
 
@@ -242,7 +271,16 @@ void ComponentInfo::setRotation(const size_t componentIndex, const Kernel::Quat 
   m_componentInfo->setRotation(componentIndex, Kernel::toQuaterniond(newRotation));
 }
 
-const IObject &ComponentInfo::shape(const size_t componentIndex) const { return *(*m_shapes)[componentIndex]; }
+const IObject &ComponentInfo::shape(const size_t componentIndex) const {
+  if (m_componentInfo->hasVirtualBanks()) {
+    if (const auto *seg = m_componentInfo->findVirtualSegment(componentIndex)) {
+      const auto bankIdx = m_componentInfo->virtualBankIndex(seg);
+      return *m_virtualPixelShapes[bankIdx];
+    }
+    return *(*m_shapes)[m_componentInfo->compactComponentIndex(componentIndex)];
+  }
+  return *(*m_shapes)[componentIndex];
+}
 
 Kernel::V3D ComponentInfo::scaleFactor(const size_t componentIndex) const {
   return Kernel::toV3D(m_componentInfo->scaleFactor(componentIndex));
@@ -478,20 +516,30 @@ size_t ComponentInfo::findBankParent(size_t index, const std::string &bankPart) 
  * @return bytes used.
  */
 size_t ComponentInfo::getMemorySize() const {
-  const size_t n = size();
   // Beamline::ComponentInfo holds all the per-component arrays
   const size_t beamlineMem = m_componentInfo->getMemorySize();
-  // m_componentIds: shared_ptr<const vector<IComponent*>> — count the heap-allocated vector object + its buffer
-  const size_t componentIdsMem = sizeof(std::vector<Geometry::IComponent *>) + n * sizeof(Geometry::IComponent *);
-  // m_compIDToIndex: shared_ptr<const unordered_map<IComponent const*, size_t>>
-  // Count the heap-allocated map object + each node (key + value + ~2 pointers for bucket/chain overhead)
+
+  // m_componentIds is compact for virtual-bank instruments (only non-virtual
+  // entries).  Use the actual vector size rather than the logical total.
+  const size_t nCompact = m_componentIds->size();
+  const size_t componentIdsMem =
+      sizeof(std::vector<Geometry::IComponent *>) + nCompact * sizeof(Geometry::IComponent *);
+
+  // m_compIDToIndex: use the actual map entry count, not the logical n.
+  // Virtual pixels have no IComponent* and therefore no map entry.
+  const size_t nMap = m_compIDToIndex->size();
   const size_t compIDToIndexMem = sizeof(std::unordered_map<Geometry::IComponent const *, size_t>) +
-                                  n * (sizeof(Geometry::IComponent const *) + sizeof(size_t) + 2 * sizeof(void *));
-  // m_shapes: shared_ptr<vector<shared_ptr<const IObject>>>
-  // IObject shapes are shared; count the vector object + buffer of shared_ptrs, not the shapes themselves
+                                  nMap * (sizeof(Geometry::IComponent const *) + sizeof(size_t) + 2 * sizeof(void *));
+
+  // m_shapes is compact for virtual-bank instruments (virtual pixel slots
+  // omitted).  IObject shapes are shared; count the vector + shared_ptr slots.
   const size_t shapesMem =
       m_shapes ? sizeof(*m_shapes) + m_shapes->capacity() * sizeof(std::shared_ptr<const Geometry::IObject>) : 0;
-  return sizeof(*this) + beamlineMem + componentIdsMem + compIDToIndexMem + shapesMem;
+
+  // m_virtualPixelShapes: one shared_ptr per PA bank (negligible for typical instruments)
+  const size_t virtualShapesMem = m_virtualPixelShapes.capacity() * sizeof(std::shared_ptr<const Geometry::IObject>);
+
+  return sizeof(*this) + beamlineMem + componentIdsMem + compIDToIndexMem + shapesMem + virtualShapesMem;
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -116,6 +116,23 @@ size_t ComponentInfo::size() const { return m_componentInfo->size(); }
 
 ComponentInfo::QuadrilateralComponent ComponentInfo::quadrilateralComponent(const size_t componentIndex) const {
   auto type = componentType(componentIndex);
+
+  // VirtualAssembly: corners are computed analytically from the bank segment.
+  if (type == Beamline::ComponentType::VirtualAssembly) {
+    const auto *seg = m_componentInfo->findVirtualBankByCompIdx(componentIndex);
+    if (!seg)
+      throw std::runtime_error("ComponentInfo::quadrilateralComponent: "
+                               "VirtualAssembly bank has no VirtualBankSegment.");
+    QuadrilateralComponent corners;
+    corners.nX = static_cast<size_t>(seg->nx);
+    corners.nY = static_cast<size_t>(seg->ny);
+    corners.bottomLeft = seg->indexAtXYZ(0, 0);
+    corners.topLeft = seg->indexAtXYZ(0, seg->ny - 1);
+    corners.bottomRight = seg->indexAtXYZ(seg->nx - 1, 0);
+    corners.topRight = seg->indexAtXYZ(seg->nx - 1, seg->ny - 1);
+    return corners;
+  }
+
   auto parentType = componentType(parent(componentIndex));
   if (!(type == Beamline::ComponentType::Structured || type == Beamline::ComponentType::Rectangular ||
         parentType == Beamline::ComponentType::Grid))
@@ -469,6 +486,10 @@ BoundingBox ComponentInfo::boundingBox(const size_t componentIndex, const Boundi
 
 Beamline::ComponentType ComponentInfo::componentType(const size_t componentIndex) const {
   return m_componentInfo->componentType(componentIndex);
+}
+
+const Beamline::VirtualBankSegment *ComponentInfo::findVirtualBankByCompIdx(const size_t componentIndex) const {
+  return m_componentInfo->findVirtualBankByCompIdx(componentIndex);
 }
 
 void ComponentInfo::setScanInterval(const std::pair<Types::Core::DateAndTime, Types::Core::DateAndTime> &interval) {

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -36,9 +36,9 @@ DetectorInfo::DetectorInfo(std::unique_ptr<Beamline::DetectorInfo> detectorInfo,
   if (!m_instrument)
     throw std::invalid_argument("DetectorInfo::DetectorInfo Workspace does not contain an instrument!");
 
-  // For virtual-bank instruments the map is compact (real detectors only) while
-  // m_detectorIDs holds all logical IDs.  Allow the size mismatch in that case.
-  if (!m_detectorInfo->hasVirtualBanks() && m_detectorIDs->size() != m_detIDToIndex->size()) {
+  // Both m_detectorIDs and m_detIDToIndex are compact (real detectors only) for
+  // PA instruments as well as for non-PA instruments.
+  if (m_detectorIDs->size() != m_detIDToIndex->size()) {
     throw std::invalid_argument("DetectorInfo::DetectorInfo: ID and ID->index map do not match");
   }
 }
@@ -54,6 +54,7 @@ DetectorInfo::DetectorInfo(const DetectorInfo &other)
 
 /// Assigns the contents of the non-wrapping part of `rhs` to this.
 DetectorInfo &DetectorInfo::operator=(const DetectorInfo &rhs) {
+  // Compare the compact (real-detector-only) ID vectors for both PA and non-PA instruments.
   if (*m_detectorIDs != *rhs.m_detectorIDs)
     throw std::runtime_error("DetectorInfo::operator=: Detector IDs in "
                              "assignment do not match. Assignment not "
@@ -81,7 +82,7 @@ bool DetectorInfo::isEquivalent(const DetectorInfo &other) const {
 }
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
-/// instrument
+/// instrument (real + virtual).
 size_t DetectorInfo::size() const { return m_detectorInfo->size(); }
 
 /// Returns true if the beamline has scanning detectors.
@@ -411,8 +412,17 @@ Kernel::V3D DetectorInfo::samplePosition() const { return Kernel::toV3D(m_detect
 /// Returns L1 (distance from source to sample).
 double DetectorInfo::l1() const { return m_detectorInfo->l1(); }
 
-/// Returns a sorted vector of all detector IDs.
-const std::vector<detid_t> &DetectorInfo::detectorIDs() const { return *m_detectorIDs; }
+/// Returns a sorted vector of all detector IDs (real + virtual).
+/// For non-PA instruments this returns a direct reference to the stored vector.
+/// For PA instruments the full list is built lazily on first call and cached.
+const std::vector<detid_t> &DetectorInfo::detectorIDs() const {
+  if (!m_detectorInfo->hasVirtualBanks())
+    return *m_detectorIDs;
+  std::call_once(m_allDetectorIDsCacheOnce, [this] {
+    m_allDetectorIDsCache = std::make_shared<const std::vector<detid_t>>(m_instrument->getDetectorIDs(false));
+  });
+  return *m_allDetectorIDsCache;
+}
 
 std::size_t DetectorInfo::indexOf(const detid_t id) const {
   // Fast path for virtual-bank (PixelAssembly) pixels: compute index from the
@@ -431,8 +441,13 @@ std::size_t DetectorInfo::indexOf(const detid_t id) const {
 }
 
 /// Returns the detector ID for the given logical detector index.
-/// Works without allocating the full ID vector.
+/// Works for both real and virtual (PixelAssembly) pixels without allocating
+/// the full ID vector.
 detid_t DetectorInfo::detid(const size_t index) const {
+  if (!m_detectorInfo->hasVirtualBanks())
+    return (*m_detectorIDs)[index];
+  if (const auto *seg = m_detectorInfo->findVirtualSegment(index))
+    return static_cast<detid_t>(seg->idAtIndex(index));
   return (*m_detectorIDs)[m_detectorInfo->compactDetectorIndex(index)];
 }
 
@@ -489,8 +504,10 @@ size_t DetectorInfo::getMemorySize() const {
   const size_t n = size();
   // Beamline::DetectorInfo holds the core position/rotation/flag arrays
   const size_t beamlineMem = m_detectorInfo->getMemorySize();
-  // m_detectorIDs: shared_ptr<const vector<detid_t>> — count the heap-allocated vector object + its buffer
-  const size_t detectorIDsMem = sizeof(std::vector<detid_t>) + n * sizeof(detid_t);
+  // m_detectorIDs: compact (real detectors only for PA instruments); count its actual buffer.
+  const size_t detectorIDsMem = sizeof(std::vector<detid_t>) + m_detectorIDs->size() * sizeof(detid_t);
+  // m_allDetectorIDsCache: only populated on first call to detectorIDs() on a PA instrument.
+  const size_t allIDsCacheMem = m_allDetectorIDsCache ? m_allDetectorIDsCache->size() * sizeof(detid_t) : 0;
   // m_detIDToIndex: shared_ptr<const unordered_map<detid_t, size_t>>
   // For virtual-bank instruments the map is compact (real detectors only), so use
   // the actual entry count rather than the logical total n.
@@ -502,7 +519,7 @@ size_t DetectorInfo::getMemorySize() const {
                           m_lastIndex.capacity() * sizeof(size_t);
   // m_instrument is a shared_ptr to an Instrument owned by the workspace; its memory is counted in
   // Instrument::getMemorySize() and excluded here to avoid double-counting.
-  return sizeof(*this) + beamlineMem + detectorIDsMem + detIDToIndexMem + cacheMem;
+  return sizeof(*this) + beamlineMem + detectorIDsMem + allIDsCacheMem + detIDToIndexMem + cacheMem;
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -36,7 +36,9 @@ DetectorInfo::DetectorInfo(std::unique_ptr<Beamline::DetectorInfo> detectorInfo,
   if (!m_instrument)
     throw std::invalid_argument("DetectorInfo::DetectorInfo Workspace does not contain an instrument!");
 
-  if (m_detectorIDs->size() != m_detIDToIndex->size()) {
+  // For virtual-bank instruments the map is compact (real detectors only) while
+  // m_detectorIDs holds all logical IDs.  Allow the size mismatch in that case.
+  if (!m_detectorInfo->hasVirtualBanks() && m_detectorIDs->size() != m_detIDToIndex->size()) {
     throw std::invalid_argument("DetectorInfo::DetectorInfo: ID and ID->index map do not match");
   }
 }
@@ -326,6 +328,11 @@ Kernel::V3D DetectorInfo::position(const size_t index) const { return Kernel::to
 
 /// Returns the position of the detector with given index.
 Kernel::V3D DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
+  // The Beamline pair overload goes straight to the compact array and bypasses
+  // virtual-bank segment lookup.  Virtual-bank instruments are non-scanning so
+  // index.second is always 0; delegate to the scalar overload which is correct.
+  if (m_detectorInfo->hasVirtualBanks())
+    return Kernel::toV3D(m_detectorInfo->position(index.first));
   return Kernel::toV3D(m_detectorInfo->position(index));
 }
 
@@ -336,6 +343,9 @@ Kernel::Quat DetectorInfo::rotation(const size_t index) const {
 
 /// Returns the rotation of the detector with given index.
 Kernel::Quat DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
+  // Same virtual-bank bypass issue as position(pair); fix with scalar overload.
+  if (m_detectorInfo->hasVirtualBanks())
+    return Kernel::toQuat(m_detectorInfo->rotation(index.first));
   return Kernel::toQuat(m_detectorInfo->rotation(index));
 }
 
@@ -405,6 +415,12 @@ double DetectorInfo::l1() const { return m_detectorInfo->l1(); }
 const std::vector<detid_t> &DetectorInfo::detectorIDs() const { return *m_detectorIDs; }
 
 std::size_t DetectorInfo::indexOf(const detid_t id) const {
+  // Fast path for virtual-bank (PixelAssembly) pixels: compute index from the
+  // bank's ID formula rather than looking up in the (now-compact) map.
+  if (m_detectorInfo->hasVirtualBanks()) {
+    if (const auto *seg = m_detectorInfo->findVirtualSegmentByDetId(static_cast<int32_t>(id)))
+      return seg->indexOf(static_cast<int32_t>(id));
+  }
   try {
     return m_detIDToIndex->at(id);
   } catch (const std::out_of_range &) {
@@ -476,9 +492,11 @@ size_t DetectorInfo::getMemorySize() const {
   // m_detectorIDs: shared_ptr<const vector<detid_t>> — count the heap-allocated vector object + its buffer
   const size_t detectorIDsMem = sizeof(std::vector<detid_t>) + n * sizeof(detid_t);
   // m_detIDToIndex: shared_ptr<const unordered_map<detid_t, size_t>>
-  // Count the heap-allocated map object + each node (key + value + ~2 pointers for bucket/chain overhead)
-  const size_t detIDToIndexMem =
-      sizeof(std::unordered_map<detid_t, size_t>) + n * (sizeof(detid_t) + sizeof(size_t) + 2 * sizeof(void *));
+  // For virtual-bank instruments the map is compact (real detectors only), so use
+  // the actual entry count rather than the logical total n.
+  const size_t nMapEntries = m_detIDToIndex ? m_detIDToIndex->size() : 0;
+  const size_t detIDToIndexMem = sizeof(std::unordered_map<detid_t, size_t>) +
+                                 nMapEntries * (sizeof(detid_t) + sizeof(size_t) + 2 * sizeof(void *));
   // m_lastDetector and m_lastIndex: one slot per OpenMP thread
   const size_t cacheMem = m_lastDetector.capacity() * sizeof(std::shared_ptr<const Geometry::IDetector>) +
                           m_lastIndex.capacity() * sizeof(size_t);

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -501,7 +501,6 @@ DetectorInfoIt DetectorInfo::end() { return DetectorInfoIt(*this, size(), size()
  * @return bytes used.
  */
 size_t DetectorInfo::getMemorySize() const {
-  const size_t n = size();
   // Beamline::DetectorInfo holds the core position/rotation/flag arrays
   const size_t beamlineMem = m_detectorInfo->getMemorySize();
   // m_detectorIDs: compact (real detectors only for PA instruments); count its actual buffer.

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -735,6 +735,12 @@ void GridDetector::testIntersectionWithChildren(Track &testRay,
   // The parametrized form delegates to the base detector's shape.
   std::shared_ptr<IObject> const &pixelShape = isParametrized() ? m_gridBase->m_shape : m_shape;
 
+  // NOTE: getAtXYZ is still required here to obtain a valid ComponentID.
+  // ComponentID is an IComponent* pointer; the instrument's component-ID map
+  // (used by InstrumentRayTracer to resolve hits back to a detector spectrum)
+  // only contains entries for real, heap-allocated IComponent objects.
+  // Until virtual (non-stored) pixels have a proxy mechanism with a stable
+  // ComponentID, this call cannot be eliminated.  Tracked in ewm14486.
   auto comp = getAtXYZ(xIndex, yIndex, 0);
   testRay.addLink(intersec, intersec, 0.0, *pixelShape, comp->getComponentID());
 }

--- a/Framework/Geometry/src/Instrument/IVirtualBank.cpp
+++ b/Framework/Geometry/src/Instrument/IVirtualBank.cpp
@@ -1,0 +1,93 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidGeometry/Instrument/IVirtualBank.h"
+#include <stdexcept>
+
+namespace Mantid {
+namespace Geometry {
+
+namespace {
+
+/// Return the pixel count along a named axis.
+size_t pixelCount(IVirtualBank const *bank, char axis) {
+  switch (axis) {
+  case 'x':
+    return bank->xpixels();
+  case 'y':
+    return bank->ypixels();
+  case 'z':
+    return bank->zpixels();
+  default:
+    throw std::invalid_argument(std::string("IVirtualBank: unknown fill-order axis '") + axis + "'");
+  }
+}
+
+/// Return the grid coordinate along a named axis for a given pixel.
+int coordAlong(char axis, int x, int y, int z) {
+  switch (axis) {
+  case 'x':
+    return x;
+  case 'y':
+    return y;
+  default: // 'z'
+    return z;
+  }
+}
+
+} // anonymous namespace
+
+/**
+ * Compute the detector ID for pixel (x, y, z).
+ *
+ * The ID scheme is defined by:
+ *   - referentDetectorID() : ID of the pixel at (0,0,0)
+ *   - idFillOrder()        : which axis varies fastest / slowest
+ *   - idstep()             : increment per pixel along the fastest axis
+ *
+ * The increment along the middle axis is  idstep() * pixels_along_fastest,
+ * and along the slowest axis is  idstep() * pixels_fastest * pixels_middle.
+ */
+detid_t IVirtualBank::getDetectorIDAtXYZ(int x, int y, int z) const {
+  auto const order = idFillOrder(); // order[0] = fastest, order[2] = slowest
+  size_t const n0 = pixelCount(this, order[0]);
+  size_t const n1 = pixelCount(this, order[1]);
+  auto const step0 = static_cast<detid_t>(idstep());
+  auto const step1 = static_cast<detid_t>(n0) * step0;
+  auto const step2 = static_cast<detid_t>(n1) * step1;
+  return referentDetectorID() + coordAlong(order[0], x, y, z) * step0 + coordAlong(order[1], x, y, z) * step1 +
+         coordAlong(order[2], x, y, z) * step2;
+}
+
+/**
+ * Invert getDetectorIDAtXYZ: return the (x, y, z) grid coordinates for a
+ * given detector ID.
+ *
+ * Behaviour for IDs outside the valid range is undefined (no bounds check
+ * is performed here; callers should use inBoundsXYZ on the result if needed).
+ */
+std::tuple<int, int, int> IVirtualBank::getXYZForDetectorID(detid_t detectorID) const {
+  auto const order = idFillOrder();
+  int const n0 = static_cast<int>(pixelCount(this, order[0]));
+  int const n1 = static_cast<int>(pixelCount(this, order[1]));
+  int const offset = static_cast<int>(detectorID - referentDetectorID());
+  // Strides must account for idstep (increment per individual pixel).
+  int const step0 = idstep();
+  int const step1 = n0 * step0;
+  int const step2 = n1 * step1;
+  // Decompose offset into the three fill-order coordinates
+  int const c2 = offset / step2;
+  int const c1 = (offset % step2) / step1;
+  int const c0 = (offset % step1) / step0;
+  // Map fill-order coordinates back to (x, y, z)
+  int x = (order[0] == 'x' ? c0 : order[1] == 'x' ? c1 : c2);
+  int y = (order[0] == 'y' ? c0 : order[1] == 'y' ? c1 : c2);
+  int z = (order[0] == 'z' ? c0 : order[1] == 'z' ? c1 : c2);
+  return {x, y, z};
+}
+
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
+#include "MantidGeometry/Instrument/PixelAssembly.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidGeometry/Instrument/StructuredDetector.h"
@@ -1517,6 +1518,89 @@ void InstrumentDefinitionParser::createRectangularDetector(Geometry::ICompAssemb
   }
 }
 
+void InstrumentDefinitionParser::createPixelAssembly(Geometry::ICompAssembly *parent,
+                                                     const Poco::XML::Element *pLocElem,
+                                                     const Poco::XML::Element *pCompElem, const std::string &filename,
+                                                     const Poco::XML::Element *pType) {
+  //-------------- Create a PixelAssembly (virtual pixel bank) ---------------
+
+  std::string const name = InstrumentDefinitionParser::getNameOfLocationElement(pLocElem, pCompElem);
+
+  // PixelAssembly inherits Component (not CompAssembly), so it does NOT add
+  // itself to the parent in its constructor — we do it explicitly below.
+  auto *bank = new Geometry::PixelAssembly(name, parent);
+
+  // Position, orientation and logfile parameters
+  setLocation(bank, pLocElem, m_angleConvertConst, m_deltaOffsets);
+  setFacing(bank, pLocElem);
+  setLogfile(bank, pCompElem, m_instrument->getLogfileCache());
+  setLogfile(bank, pLocElem, m_instrument->getLogfileCache());
+
+  // ----- Grid parameters from the type element -----
+  int xpixels = 0;
+  int ypixels = 0;
+  int zpixels = 0; // 0 → flat (normalised to 1 inside PixelAssembly::initialize)
+
+  const std::string shapeType = pType->getAttribute("type");
+  std::shared_ptr<Geometry::IObject> shape = mapTypeNameToShape[shapeType];
+
+  if (pType->hasAttribute("xpixels"))
+    xpixels = std::stoi(pType->getAttribute("xpixels"));
+  double const xstart = attrToDouble(pType, "xstart");
+  double const xstep = attrToDouble(pType, "xstep");
+
+  if (pType->hasAttribute("ypixels"))
+    ypixels = std::stoi(pType->getAttribute("ypixels"));
+  double const ystart = attrToDouble(pType, "ystart");
+  double const ystep = attrToDouble(pType, "ystep");
+
+  if (pType->hasAttribute("zpixels"))
+    zpixels = std::stoi(pType->getAttribute("zpixels"));
+  double const zstart = attrToDouble(pType, "zstart");
+  double const zstep = attrToDouble(pType, "zstep");
+
+  // ----- ID scheme from the component element -----
+  int idstart = 0;
+  int idstep = 1;
+  // Default fill order: x-fastest.  The IDF attribute is "idfillorder" with
+  // the fastest-varying axis first (e.g. "yxz" means Y fastest, then X, Z).
+  std::string idfillorder = "xyz";
+
+  if (pCompElem->hasAttribute("idstart"))
+    idstart = std::stoi(pCompElem->getAttribute("idstart"));
+  if (pCompElem->hasAttribute("idfillorder"))
+    idfillorder = pCompElem->getAttribute("idfillorder");
+  if (pCompElem->hasAttribute("idstep"))
+    idstep = std::stoi(pCompElem->getAttribute("idstep"));
+
+  // Pad to 3 characters if the user wrote a 2-char shorthand (e.g. "yx").
+  if (idfillorder.size() < 3) {
+    for (char c : {'x', 'y', 'z'}) {
+      if (idfillorder.find(c) == std::string::npos)
+        idfillorder += c;
+      if (idfillorder.size() == 3)
+        break;
+    }
+  }
+
+  // Initialise the virtual bank (stores parameters; creates no child objects).
+  bank->initialize(shape, static_cast<size_t>(xpixels), xstart, xstep, static_cast<size_t>(ypixels), ystart, ystep,
+                   static_cast<size_t>(zpixels), zstart, zstep, static_cast<detid_t>(idstart), idfillorder, idstep);
+
+  // Register all pixel IDs with the instrument so that InstrumentVisitor can
+  // build its detectorId → index map.  No per-pixel Detector object is created.
+  try {
+    m_instrument->markAsVirtualBankDetectors(*bank);
+  } catch (Kernel::Exception::ExistsError &) {
+    throw Kernel::Exception::InstrumentDefinitionError("Duplicate detector ID found when adding PixelAssembly " + name +
+                                                       " in XML instrument file" + filename);
+  }
+
+  // Add the bank to its parent (must be explicit — Component ctor does not do
+  // this, unlike CompAssembly).
+  parent->add(bank);
+}
+
 void InstrumentDefinitionParser::createStructuredDetector(Geometry::ICompAssembly *parent,
                                                           const Poco::XML::Element *pLocElem,
                                                           const Poco::XML::Element *pCompElem,
@@ -1710,6 +1794,8 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent, con
     createRectangularDetector(parent, pLocElem, pCompElem, filename, pType);
   } else if (StructuredDetector::compareName(category)) {
     createStructuredDetector(parent, pLocElem, pCompElem, filename, pType);
+  } else if (PixelAssembly::compareName(category)) {
+    createPixelAssembly(parent, pLocElem, pCompElem, filename, pType);
   } else if (boost::regex_match(category, exp)) {
     createDetectorOrMonitor(parent, pLocElem, pCompElem, filename, idList, category);
   } else {

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -22,6 +22,7 @@
 #include "MantidKernel/EigenConversionHelpers.h"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <numeric>
 
@@ -261,27 +262,39 @@ size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
 
   // All pixels share the same shape and rotation.
   auto const pxShape = bank.pixelShape() ? bank.pixelShape() : m_nullShape;
+  // Bank absolute rotation and position (world frame).
   Eigen::Quaterniond const eigenRot = Kernel::toQuaterniond(bank.getRotation());
+  Eigen::Vector3d const bankPos = Kernel::toVector3d(bank.getPos());
 
-  // Iterate fill-order: Z is outermost, then X, then Y (arbitrary; all are covered).
+  // Collect detector indices without materialising per-pixel positions.
+  // Positions are stored as a VirtualBankSegment and computed on demand in
+  // Beamline::DetectorInfo::position(size_t) — no flat-array entries are
+  // written for virtual pixels.
+  std::vector<size_t> detectorChildren;
+  detectorChildren.reserve(bank.npixels());
+
+  size_t firstDetectorIndex = std::numeric_limits<size_t>::max();
+  size_t lastDetectorIndex = 0;
+
   for (size_t iz = 0; iz < bank.zpixels(); ++iz) {
     for (size_t ix = 0; ix < bank.xpixels(); ++ix) {
       for (size_t iy = 0; iy < bank.ypixels(); ++iy) {
         detid_t const id = bank.getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz));
         size_t const detectorIndex = m_detectorIdToIndexMap->at(id);
+        detectorChildren.push_back(detectorIndex);
         m_assemblySortedDetectorIndices->emplace_back(detectorIndex);
-        (*m_detectorPositions)[detectorIndex] =
-            Kernel::toVector3d(bank.getPosAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz)));
-        (*m_detectorRotations)[detectorIndex] = eigenRot;
-        (*m_shapes)[detectorIndex] = pxShape;
-        (*m_names)[detectorIndex] = bank.getName() + "(" + std::to_string(ix) + "," + std::to_string(iy) +
-                                    (bank.zpixels() > 1 ? "," + std::to_string(iz) : "") + ")";
-        // ComponentID stays nullptr — no per-pixel IComponent object exists.
-        // Scale factors stay at default {1,1,1}.
+        firstDetectorIndex = std::min(firstDetectorIndex, detectorIndex);
+        lastDetectorIndex = std::max(lastDetectorIndex, detectorIndex);
+
+        // Shape, name, scale factor, and position are NOT written per-pixel:
+        // handled lazily by VirtualBankSegment lookups.
       }
     }
   }
 
+  // Register the bank as a virtual segment so DetectorInfo and ComponentInfo
+  // can compute pixel positions/rotations/parents on demand.
+  // bankCompIdx is only known after commonRegistration() returns.
   const size_t detectorStop = m_assemblySortedDetectorIndices->size();
   const size_t componentIndex = commonRegistration(bank);
   m_componentType->emplace_back(Beamline::ComponentType::Grid);
@@ -291,7 +304,25 @@ size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
 
   m_detectorRanges->emplace_back(detectorStart, detectorStop);
   m_componentRanges->emplace_back(componentStart, componentStop);
-  m_children->emplace_back(); // PixelAssembly has no child IComponent objects.
+  m_children->emplace_back(std::move(detectorChildren));
+
+  if (bank.npixels() > 0) {
+    Beamline::VirtualBankSegment seg;
+    seg.firstIndex = firstDetectorIndex;
+    seg.lastIndex = lastDetectorIndex;
+    seg.bankCompIdx = componentIndex; // now known
+    seg.bankPos = bankPos;
+    seg.bankRot = eigenRot;
+    seg.nx = static_cast<int>(bank.xpixels());
+    seg.ny = static_cast<int>(bank.ypixels());
+    seg.xstart = bank.xstart();
+    seg.xstep = bank.xstep();
+    seg.ystart = bank.ystart();
+    seg.ystep = bank.ystep();
+    m_virtualBankSegments.push_back(std::move(seg));
+    // Record the pixel shape once per bank (not per pixel).
+    m_virtualPixelShapes.push_back(pxShape);
+  }
 
   return componentIndex;
 }
@@ -373,6 +404,9 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
   (*m_detectorRotations)[detectorIndex] = Kernel::toQuaterniond(detector.getRotation());
   (*m_shapes)[detectorIndex] = detector.shape();
   (*m_scaleFactors)[detectorIndex] = Kernel::toVector3d(detector.getScaleFactor());
+  // Use isMonitor(id) rather than isMonitorViaIndex(index): after Phase 3c the
+  // detector cache contains only non-virtual detectors, so its size no longer
+  // equals the total detector count, and index-based access would be incorrect.
   if (m_instrument->isMonitor(detector.getID())) {
     m_monitorIndices->emplace_back(detectorIndex);
   }
@@ -422,15 +456,107 @@ std::shared_ptr<const std::unordered_map<detid_t, size_t>> InstrumentVisitor::de
 }
 
 std::unique_ptr<Beamline::ComponentInfo> InstrumentVisitor::componentInfo() const {
+  if (m_virtualBankSegments.empty()) {
+    // No virtual banks: pass full-size arrays unchanged.
+    return std::make_unique<Mantid::Beamline::ComponentInfo>(
+        m_assemblySortedDetectorIndices, m_detectorRanges, m_assemblySortedComponentIndices, m_componentRanges,
+        m_parentComponentIndices, m_children, m_positions, m_rotations, m_scaleFactors, m_componentType, m_names,
+        m_sourceIndex, m_sampleIndex);
+  }
+
+  // Sort segments by firstIndex (they may have been registered in any order).
+  auto sortedSegs = m_virtualBankSegments;
+  std::sort(sortedSegs.begin(), sortedSegs.end(),
+            [](const Beamline::VirtualBankSegment &a, const Beamline::VirtualBankSegment &b) {
+              return a.firstIndex < b.firstIndex;
+            });
+
+  // Build an is-virtual mask for quick per-index lookup.
+  const size_t nDetectors = m_orderedDetectorIds->size();
+  std::vector<bool> isVirtual(nDetectors, false);
+  for (const auto &seg : sortedSegs) {
+    for (size_t i = seg.firstIndex; i <= seg.lastIndex; ++i)
+      isVirtual[i] = true;
+  }
+
+  // ------------------------------------------------------------------
+  // Compact m_names, m_scaleFactors, m_parentComponentIndices:
+  // keep only non-virtual detector entries + all non-detector entries.
+  // ------------------------------------------------------------------
+  auto compactNames = std::make_shared<std::vector<std::string>>();
+  auto compactSF = std::make_shared<std::vector<Eigen::Vector3d>>();
+  auto compactParents = std::make_shared<std::vector<size_t>>();
+
+  const size_t nNonVirtual = std::count(isVirtual.begin(), isVirtual.end(), false);
+  const size_t nNonDetectors = m_positions->size(); // non-detector components only
+  const size_t compactSize = nNonVirtual + nNonDetectors;
+
+  compactNames->reserve(compactSize);
+  compactSF->reserve(compactSize);
+  compactParents->reserve(compactSize);
+
+  // Non-virtual detector slice
+  for (size_t i = 0; i < nDetectors; ++i) {
+    if (!isVirtual[i]) {
+      compactNames->push_back((*m_names)[i]);
+      compactSF->push_back((*m_scaleFactors)[i]);
+      compactParents->push_back((*m_parentComponentIndices)[i]);
+    }
+  }
+  // Non-detector component slice (appended after detectors in the originals)
+  for (size_t i = nDetectors; i < m_parentComponentIndices->size(); ++i) {
+    compactNames->push_back((*m_names)[i]);
+    compactSF->push_back((*m_scaleFactors)[i]);
+    compactParents->push_back((*m_parentComponentIndices)[i]);
+  }
+
   return std::make_unique<Mantid::Beamline::ComponentInfo>(
       m_assemblySortedDetectorIndices, m_detectorRanges, m_assemblySortedComponentIndices, m_componentRanges,
-      m_parentComponentIndices, m_children, m_positions, m_rotations, m_scaleFactors, m_componentType, m_names,
-      m_sourceIndex, m_sampleIndex);
+      std::shared_ptr<const std::vector<size_t>>(compactParents), m_children, m_positions, m_rotations,
+      std::shared_ptr<std::vector<Eigen::Vector3d>>(compactSF), m_componentType,
+      std::shared_ptr<const std::vector<std::string>>(compactNames), m_sourceIndex, m_sampleIndex,
+      std::move(sortedSegs));
 }
 
 std::unique_ptr<Beamline::DetectorInfo> InstrumentVisitor::detectorInfo() const {
-  return std::make_unique<Mantid::Beamline::DetectorInfo>(*m_detectorPositions, *m_detectorRotations,
-                                                          *m_monitorIndices);
+  if (m_virtualBankSegments.empty()) {
+    // No virtual banks: use the original constructor (no compaction needed).
+    return std::make_unique<Mantid::Beamline::DetectorInfo>(*m_detectorPositions, *m_detectorRotations,
+                                                            *m_monitorIndices);
+  }
+
+  // Sort segments by firstIndex so that findVirtualSegment() can break early.
+  auto sortedSegs = m_virtualBankSegments;
+  std::sort(sortedSegs.begin(), sortedSegs.end(),
+            [](const Beamline::VirtualBankSegment &a, const Beamline::VirtualBankSegment &b) {
+              return a.firstIndex < b.firstIndex;
+            });
+
+  // Build a compact boolean mask: true for virtual pixel indices.
+  const size_t nTotal = m_detectorPositions->size();
+  std::vector<bool> isVirtual(nTotal, false);
+  size_t nVirtual = 0;
+  for (const auto &seg : sortedSegs) {
+    for (size_t i = seg.firstIndex; i <= seg.lastIndex; ++i)
+      isVirtual[i] = true;
+    nVirtual += seg.lastIndex - seg.firstIndex + 1;
+  }
+
+  // Compact arrays: copy only real (non-virtual) detector positions/rotations.
+  using QuatVec = std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>;
+  std::vector<Eigen::Vector3d> compactPos;
+  QuatVec compactRot;
+  compactPos.reserve(nTotal - nVirtual);
+  compactRot.reserve(nTotal - nVirtual);
+  for (size_t i = 0; i < nTotal; ++i) {
+    if (!isVirtual[i]) {
+      compactPos.push_back((*m_detectorPositions)[i]);
+      compactRot.push_back((*m_detectorRotations)[i]);
+    }
+  }
+
+  return std::make_unique<Mantid::Beamline::DetectorInfo>(std::move(compactPos), std::move(compactRot),
+                                                          *m_monitorIndices, std::move(sortedSegs));
 }
 
 std::shared_ptr<std::vector<detid_t>> InstrumentVisitor::detectorIds() const { return m_orderedDetectorIds; }
@@ -441,8 +567,50 @@ std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>> Instrum
   // Cross link Component and Detector info objects
   compInfo->setDetectorInfo(detInfo.get());
 
-  auto compInfoWrapper =
-      std::make_unique<ComponentInfo>(std::move(compInfo), componentIds(), componentIdToIndexMap(), m_shapes);
+  // For virtual-bank instruments: build compact m_componentIds and m_shapes
+  // (omit the nullptr/placeholder entries for virtual pixel slots).
+  std::shared_ptr<const std::vector<Geometry::IComponent *>> compactIds;
+  std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> compactShapes;
+
+  if (!m_virtualBankSegments.empty()) {
+    const size_t nDetectors = m_orderedDetectorIds->size();
+
+    // Build is-virtual mask (re-use logic from componentInfo()/detectorInfo()).
+    std::vector<bool> isVirtual(nDetectors, false);
+    for (const auto &seg : m_virtualBankSegments)
+      for (size_t i = seg.firstIndex; i <= seg.lastIndex; ++i)
+        isVirtual[i] = true;
+
+    const size_t nNonVirtual = static_cast<size_t>(std::count(isVirtual.begin(), isVirtual.end(), false));
+    const size_t nNonDetectors = m_positions->size();
+    const size_t compactSize = nNonVirtual + nNonDetectors;
+
+    auto ids = std::make_shared<std::vector<Geometry::IComponent *>>();
+    ids->reserve(compactSize);
+    auto shapes = std::make_shared<std::vector<std::shared_ptr<const Geometry::IObject>>>();
+    shapes->reserve(compactSize);
+
+    // Non-virtual detector entries first, then all non-detector components.
+    for (size_t i = 0; i < nDetectors; ++i) {
+      if (!isVirtual[i]) {
+        ids->push_back((*m_componentIds)[i]);
+        shapes->push_back((*m_shapes)[i]);
+      }
+    }
+    for (size_t i = nDetectors; i < m_componentIds->size(); ++i) {
+      ids->push_back((*m_componentIds)[i]);
+      shapes->push_back((*m_shapes)[i]);
+    }
+
+    compactIds = std::move(ids);
+    compactShapes = std::move(shapes);
+  } else {
+    compactIds = componentIds();
+    compactShapes = m_shapes;
+  }
+
+  auto compInfoWrapper = std::make_unique<ComponentInfo>(std::move(compInfo), compactIds, componentIdToIndexMap(),
+                                                         compactShapes, m_virtualPixelShapes);
   auto detInfoWrapper =
       std::make_unique<DetectorInfo>(std::move(detInfo), m_instrument, detectorIds(), detectorIdToIndexMap());
 

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -266,36 +266,25 @@ size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
   Eigen::Quaterniond const eigenRot = Kernel::toQuaterniond(bank.getRotation());
   Eigen::Vector3d const bankPos = Kernel::toVector3d(bank.getPos());
 
-  // Collect detector indices without materialising per-pixel positions.
-  // Positions are stored as a VirtualBankSegment and computed on demand in
-  // Beamline::DetectorInfo::position(size_t) — no flat-array entries are
-  // written for virtual pixels.
-  std::vector<size_t> detectorChildren;
-  detectorChildren.reserve(bank.npixels());
-
-  size_t firstDetectorIndex = std::numeric_limits<size_t>::max();
-  size_t lastDetectorIndex = 0;
-
-  for (size_t iz = 0; iz < bank.zpixels(); ++iz) {
-    for (size_t ix = 0; ix < bank.xpixels(); ++ix) {
-      for (size_t iy = 0; iy < bank.ypixels(); ++iy) {
-        detid_t const id = bank.getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz));
-        size_t const detectorIndex = m_detectorIdToIndexMap->at(id);
-        detectorChildren.push_back(detectorIndex);
-        m_assemblySortedDetectorIndices->emplace_back(detectorIndex);
-        firstDetectorIndex = std::min(firstDetectorIndex, detectorIndex);
-        lastDetectorIndex = std::max(lastDetectorIndex, detectorIndex);
-
-        // Shape, name, scale factor, and position are NOT written per-pixel:
-        // handled lazily by VirtualBankSegment lookups.
-      }
-    }
-  }
+  // Determine the logical detector index range for this bank from its two
+  // fill-order endpoints.  IDs at (0,0,0) and (nx-1,ny-1,nz-1) are the first
+  // and last entries in fill order; for contiguous ID blocks the min/max of
+  // these two logical indices bound the entire bank.
+  // No entries are pushed to m_assemblySortedDetectorIndices: virtual pixels
+  // are not stored in the flat array and are enumerated on demand from the
+  // VirtualBankSegment instead.
+  const detid_t id0 = bank.referentDetectorID();
+  const detid_t idN = bank.getDetectorIDAtXYZ(
+      static_cast<int>(bank.xpixels()) - 1, static_cast<int>(bank.ypixels()) - 1, static_cast<int>(bank.zpixels()) - 1);
+  const size_t idx0 = m_detectorIdToIndexMap->at(id0);
+  const size_t idxN = m_detectorIdToIndexMap->at(idN);
+  const size_t firstDetectorIndex = std::min(idx0, idxN);
+  const size_t lastDetectorIndex = std::max(idx0, idxN);
 
   // Register the bank as a virtual segment so DetectorInfo and ComponentInfo
   // can compute pixel positions/rotations/parents on demand.
   // bankCompIdx is only known after commonRegistration() returns.
-  const size_t detectorStop = m_assemblySortedDetectorIndices->size();
+  const size_t detectorStop = detectorStart; // empty range — no flat entries
   const size_t componentIndex = commonRegistration(bank);
   m_componentType->emplace_back(Beamline::ComponentType::VirtualAssembly);
   m_assemblySortedComponentIndices->emplace_back(componentIndex);
@@ -619,30 +608,41 @@ std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>> Instrum
   auto compInfoWrapper = std::make_unique<ComponentInfo>(std::move(compInfo), compactIds, componentIdToIndexMap(),
                                                          compactShapes, m_virtualPixelShapes);
 
-  // For virtual-bank instruments, pass a compact detId→index map that omits
-  // virtual pixel entries.  Virtual pixel lookups are handled by the
-  // VirtualBankSegment::indexOf() formula in Geometry::DetectorInfo::indexOf().
+  // For virtual-bank instruments, build compact detId arrays that omit virtual
+  // pixel entries.  Virtual pixel lookups are handled analytically via
+  // VirtualBankSegment::indexOf() / idAtIndex() in Geometry::DetectorInfo.
+  std::shared_ptr<const std::vector<detid_t>> compactDetIds;
   std::shared_ptr<const std::unordered_map<detid_t, size_t>> detIdMap;
   if (m_virtualBankSegments.empty()) {
+    compactDetIds = detectorIds();
     detIdMap = detectorIdToIndexMap();
   } else {
     const size_t nDetectors = m_orderedDetectorIds->size();
+
+    // Re-use the isVirtual mask already computed above for compactIds/compactShapes.
     std::vector<bool> isVirtual(nDetectors, false);
     for (const auto &seg : m_virtualBankSegments)
       for (size_t i = seg.firstIndex; i <= seg.lastIndex; ++i)
         isVirtual[i] = true;
     const size_t nNonVirtual = static_cast<size_t>(std::count(isVirtual.begin(), isVirtual.end(), false));
+
+    // Compact detector ID vector (real detectors only).
+    auto ids = std::make_shared<std::vector<detid_t>>();
+    ids->reserve(nNonVirtual);
     auto compactMap = std::make_shared<std::unordered_map<detid_t, size_t>>();
     compactMap->reserve(nNonVirtual);
     for (size_t i = 0; i < nDetectors; ++i) {
-      if (!isVirtual[i])
+      if (!isVirtual[i]) {
+        ids->push_back((*m_orderedDetectorIds)[i]);
         compactMap->emplace((*m_orderedDetectorIds)[i], i);
+      }
     }
+    compactDetIds = std::move(ids);
     detIdMap = std::move(compactMap);
   }
 
   auto detInfoWrapper =
-      std::make_unique<DetectorInfo>(std::move(detInfo), m_instrument, detectorIds(), std::move(detIdMap));
+      std::make_unique<DetectorInfo>(std::move(detInfo), m_instrument, compactDetIds, std::move(detIdMap));
 
   return {std::move(compInfoWrapper), std::move(detInfoWrapper)};
 }

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -17,6 +17,7 @@
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidGeometry/Instrument/PixelAssembly.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 
@@ -239,6 +240,60 @@ size_t InstrumentVisitor::registerRectangularBank(const ICompAssembly &bank) {
   size_t rangesIndex = index - m_orderedDetectorIds->size();
   (*m_componentType)[rangesIndex] = Beamline::ComponentType::Rectangular;
   return index;
+}
+
+/**
+ * Register a virtual bank (PixelAssembly) — no per-pixel child objects exist.
+ *
+ * Iterates over the grid parameters to fill detector positions and rotations
+ * directly, without creating Detector objects for each pixel.
+ *
+ * NOTE: m_componentIds[detectorIndex] remains nullptr for virtual-bank pixels
+ * (there are no heap-allocated IComponent objects for them).  Code that uses
+ * the legacy ComponentID pointer for virtual pixels must handle null.
+ *
+ * @param bank : PixelAssembly being registered
+ * @return component index assigned to the bank
+ */
+size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
+  const size_t detectorStart = m_assemblySortedDetectorIndices->size();
+  const size_t componentStart = m_assemblySortedComponentIndices->size();
+
+  // All pixels share the same shape and rotation.
+  auto const pxShape = bank.pixelShape() ? bank.pixelShape() : m_nullShape;
+  Eigen::Quaterniond const eigenRot = Kernel::toQuaterniond(bank.getRotation());
+
+  // Iterate fill-order: Z is outermost, then X, then Y (arbitrary; all are covered).
+  for (size_t iz = 0; iz < bank.zpixels(); ++iz) {
+    for (size_t ix = 0; ix < bank.xpixels(); ++ix) {
+      for (size_t iy = 0; iy < bank.ypixels(); ++iy) {
+        detid_t const id = bank.getDetectorIDAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz));
+        size_t const detectorIndex = m_detectorIdToIndexMap->at(id);
+        m_assemblySortedDetectorIndices->emplace_back(detectorIndex);
+        (*m_detectorPositions)[detectorIndex] =
+            Kernel::toVector3d(bank.getPosAtXYZ(static_cast<int>(ix), static_cast<int>(iy), static_cast<int>(iz)));
+        (*m_detectorRotations)[detectorIndex] = eigenRot;
+        (*m_shapes)[detectorIndex] = pxShape;
+        (*m_names)[detectorIndex] = bank.getName() + "(" + std::to_string(ix) + "," + std::to_string(iy) +
+                                    (bank.zpixels() > 1 ? "," + std::to_string(iz) : "") + ")";
+        // ComponentID stays nullptr — no per-pixel IComponent object exists.
+        // Scale factors stay at default {1,1,1}.
+      }
+    }
+  }
+
+  const size_t detectorStop = m_assemblySortedDetectorIndices->size();
+  const size_t componentIndex = commonRegistration(bank);
+  m_componentType->emplace_back(Beamline::ComponentType::Grid);
+  m_assemblySortedComponentIndices->emplace_back(componentIndex);
+  m_parentComponentIndices->emplace_back(componentIndex);
+  const size_t componentStop = m_assemblySortedComponentIndices->size();
+
+  m_detectorRanges->emplace_back(detectorStart, detectorStop);
+  m_componentRanges->emplace_back(componentStart, componentStop);
+  m_children->emplace_back(); // PixelAssembly has no child IComponent objects.
+
+  return componentIndex;
 }
 
 /**

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -297,14 +297,16 @@ size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
   // bankCompIdx is only known after commonRegistration() returns.
   const size_t detectorStop = m_assemblySortedDetectorIndices->size();
   const size_t componentIndex = commonRegistration(bank);
-  m_componentType->emplace_back(Beamline::ComponentType::Grid);
+  m_componentType->emplace_back(Beamline::ComponentType::VirtualAssembly);
   m_assemblySortedComponentIndices->emplace_back(componentIndex);
   m_parentComponentIndices->emplace_back(componentIndex);
   const size_t componentStop = m_assemblySortedComponentIndices->size();
 
   m_detectorRanges->emplace_back(detectorStart, detectorStop);
   m_componentRanges->emplace_back(componentStart, componentStop);
-  m_children->emplace_back(std::move(detectorChildren));
+  // VirtualAssembly banks have no component children — geometry is computed
+  // analytically from the VirtualBankSegment; the flat pixel list is not stored.
+  m_children->emplace_back(std::vector<size_t>{});
 
   if (bank.npixels() > 0) {
     Beamline::VirtualBankSegment seg;
@@ -315,10 +317,15 @@ size_t InstrumentVisitor::registerVirtualBank(const PixelAssembly &bank) {
     seg.bankRot = eigenRot;
     seg.nx = static_cast<int>(bank.xpixels());
     seg.ny = static_cast<int>(bank.ypixels());
+    seg.nz = static_cast<int>(bank.zpixels());
     seg.xstart = bank.xstart();
     seg.xstep = bank.xstep();
     seg.ystart = bank.ystart();
     seg.ystep = bank.ystep();
+    seg.idstart = static_cast<int32_t>(bank.referentDetectorID());
+    seg.lastDetId = static_cast<int32_t>(bank.getDetectorIDAtXYZ(seg.nx - 1, seg.ny - 1, seg.nz - 1));
+    seg.idstep = bank.idstep();
+    seg.idFillOrder = bank.idFillOrder();
     m_virtualBankSegments.push_back(std::move(seg));
     // Record the pixel shape once per bank (not per pixel).
     m_virtualPixelShapes.push_back(pxShape);
@@ -611,8 +618,31 @@ std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>> Instrum
 
   auto compInfoWrapper = std::make_unique<ComponentInfo>(std::move(compInfo), compactIds, componentIdToIndexMap(),
                                                          compactShapes, m_virtualPixelShapes);
+
+  // For virtual-bank instruments, pass a compact detId→index map that omits
+  // virtual pixel entries.  Virtual pixel lookups are handled by the
+  // VirtualBankSegment::indexOf() formula in Geometry::DetectorInfo::indexOf().
+  std::shared_ptr<const std::unordered_map<detid_t, size_t>> detIdMap;
+  if (m_virtualBankSegments.empty()) {
+    detIdMap = detectorIdToIndexMap();
+  } else {
+    const size_t nDetectors = m_orderedDetectorIds->size();
+    std::vector<bool> isVirtual(nDetectors, false);
+    for (const auto &seg : m_virtualBankSegments)
+      for (size_t i = seg.firstIndex; i <= seg.lastIndex; ++i)
+        isVirtual[i] = true;
+    const size_t nNonVirtual = static_cast<size_t>(std::count(isVirtual.begin(), isVirtual.end(), false));
+    auto compactMap = std::make_shared<std::unordered_map<detid_t, size_t>>();
+    compactMap->reserve(nNonVirtual);
+    for (size_t i = 0; i < nDetectors; ++i) {
+      if (!isVirtual[i])
+        compactMap->emplace((*m_orderedDetectorIds)[i], i);
+    }
+    detIdMap = std::move(compactMap);
+  }
+
   auto detInfoWrapper =
-      std::make_unique<DetectorInfo>(std::move(detInfo), m_instrument, detectorIds(), detectorIdToIndexMap());
+      std::make_unique<DetectorInfo>(std::move(detInfo), m_instrument, detectorIds(), std::move(detIdMap));
 
   return {std::move(compInfoWrapper), std::move(detInfoWrapper)};
 }

--- a/Framework/Geometry/src/Instrument/ParComponentFactory.cpp
+++ b/Framework/Geometry/src/Instrument/ParComponentFactory.cpp
@@ -12,6 +12,7 @@
 #include "MantidGeometry/Instrument/GridDetectorPixel.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
+#include "MantidGeometry/Instrument/PixelAssembly.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/StructuredDetector.h"
 #include <memory>
@@ -83,6 +84,10 @@ IComponent_sptr ParComponentFactory::create(const std::shared_ptr<const ICompone
   const auto *gd = dynamic_cast<const GridDetector *>(base.get());
   if (gd)
     return std::make_shared<GridDetector>(gd, map);
+
+  const auto *pa = dynamic_cast<const PixelAssembly *>(base.get());
+  if (pa)
+    return std::make_shared<PixelAssembly>(pa, map);
 
   const auto *ac = dynamic_cast<const CompAssembly *>(base.get());
   if (ac)

--- a/Framework/Geometry/src/Instrument/PixelAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/PixelAssembly.cpp
@@ -1,14 +1,14 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidGeometry/Instrument/PixelAssembly.h"
+#include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
 #include "MantidGeometry/Instrument/Detector.h"
-#include "MantidGeometry/Instrument/GridDetectorPixel.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/IObject.h"
@@ -17,255 +17,365 @@
 #include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Material.h"
-#include "MantidKernel/Matrix.h"
-#include <algorithm>
 #include <boost/regex.hpp>
-#include <memory>
 #include <ostream>
+#include <sstream>
 #include <stdexcept>
-#include <utility>
 
 namespace Mantid::Geometry {
 
-using Kernel::Matrix;
 using Kernel::V3D;
 
-/** Constructor for a parametrized PixelAssembly
- * @param base: the base (un-parametrized) PixelAssembly
- * @param map: pointer to the ParameterMap
- * */
-PixelAssembly::PixelAssembly(const PixelAssembly *base, const ParameterMap *map)
-    : CompAssembly(base, map), IObjComponent(nullptr), m_gridBase(base), m_minDetId(0), m_maxDetId(0) {
-  init();
-  setGeometryHandler(new GeometryHandler(this));
+namespace {
+
+bool checkValidOrderString(const std::string &order) {
+  static const boost::regex exp("xyz|xzy|yzx|yxz|zyx|zxy");
+  return boost::regex_match(order, exp);
 }
 
-/** Valued constructor
- *  @param n :: name of the assembly
- *  @param reference :: the parent Component
- *
- * 	If the reference is an object of class Component,
- *  normal parenting apply. If the reference object is
- *  an assembly itself, then in addition to parenting
- *  this is registered as a children of reference.
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Constructors / clone
+// ---------------------------------------------------------------------------
+
+/** Valued constructor.
+ *  @param name       Name of the assembly.
+ *  @param reference  Optional parent component.
  */
-PixelAssembly::PixelAssembly(const std::string &n, IComponent *reference)
-    : CompAssembly(n, reference), IObjComponent(nullptr), m_gridBase(nullptr), m_minDetId(0), m_maxDetId(0) {
+PixelAssembly::PixelAssembly(const std::string &name, IComponent *reference)
+    : Component(name, reference), IObjComponent(nullptr), m_gridBase(nullptr) {
   init();
-  this->setName(n);
   setGeometryHandler(new GeometryHandler(this));
 }
 
+/** Parametrized constructor — wraps an existing PixelAssembly with a ParameterMap.
+ *  @param base  The base (un-parametrized) PixelAssembly.
+ *  @param map   Pointer to the ParameterMap.
+ */
+PixelAssembly::PixelAssembly(const PixelAssembly *base, const ParameterMap *map)
+    : Component(base, map), IObjComponent(nullptr), m_gridBase(base) {
+  init();
+  setGeometryHandler(new GeometryHandler(this));
+}
+
+/** Returns true when the proposed name matches the PixelAssembly naming convention. */
 bool PixelAssembly::compareName(const std::string &proposedMatch) {
-  static const boost::regex exp("grid_?detector", boost::regex::icase);
+  static const boost::regex exp("pixel_?assembly", boost::regex::icase);
   return boost::regex_match(proposedMatch, exp);
 }
 
 void PixelAssembly::init() {
-  m_minDetId = m_maxDetId = 0;
+  m_xpixels = m_ypixels = m_zpixels = 0;
+  m_xstart = m_ystart = m_zstart = 0.0;
+  m_xstep = m_ystep = m_zstep = 0.0;
   m_idstart = 0;
+  m_idFillOrder = {'x', 'y', 'z'};
   m_idstep = 0;
 }
 
-/** Clone method
- *  Make a copy of the component assembly
- *  @return new(*this)
- */
 PixelAssembly *PixelAssembly::clone() const { return new PixelAssembly(*this); }
 
-//-------------------------------------------------------------------------------------------------
-/** Return a pointer to the component in the assembly at the
- * (X,Y) pixel position.
- *
- * @param x :: index from 0..m_xpixels-1
- * @param y :: index from 0..m_ypixels-1
- * @param z :: index from 0..m_zpixels-1
- * @return a pointer to the component in the assembly at the (x,y,z) pixel
- *position
- * @throw runtime_error if the x/y/z pixel width is not set, or x/y/z are out of
- *range
- */
-std::shared_ptr<Detector> PixelAssembly::getAtXYZ(const int x, const int y, const int z) const {
-  if ((xpixels() <= 0) || (ypixels() <= 0))
-    throw std::runtime_error("PixelAssembly::getAtXY: invalid X or Y "
-                             "width set in the object.");
-  if ((x < 0) || (x >= xpixels()))
-    throw std::runtime_error("PixelAssembly::getAtXYZ: x specified is out of range.");
-  if ((y < 0) || (y >= ypixels()))
-    throw std::runtime_error("PixelAssembly::getAtXYZ: y specified is out of range.");
-  if (zpixels() > 0) {
-    if ((z < 0) || (z >= zpixels()))
-      throw std::runtime_error("PixelAssembly::getAtXYZ: z specified is out of range.");
-  }
+// ---------------------------------------------------------------------------
+// IVirtualBank: pixel-count accessors
+// ---------------------------------------------------------------------------
 
-  // Find the index and return that.
-  std::shared_ptr<ICompAssembly> xCol;
-  // Get to layer
-  if (this->zpixels() > 0) {
-    auto zLayer = std::dynamic_pointer_cast<ICompAssembly>(this->getChild(z));
-    if (!zLayer)
-      throw std::runtime_error("PixelAssembly::getAtXYZ: z specified is out of range.");
+size_t PixelAssembly::xpixels() const { return isParametrized() ? m_gridBase->m_xpixels : m_xpixels; }
+size_t PixelAssembly::ypixels() const { return isParametrized() ? m_gridBase->m_ypixels : m_ypixels; }
+size_t PixelAssembly::zpixels() const { return isParametrized() ? m_gridBase->m_zpixels : m_zpixels; }
 
-    xCol = std::dynamic_pointer_cast<ICompAssembly>(zLayer->getChild(x));
-  } else
-    xCol = std::dynamic_pointer_cast<ICompAssembly>(this->getChild(x));
+// ---------------------------------------------------------------------------
+// IVirtualBank: step-size accessors (scale-factor aware)
+// ---------------------------------------------------------------------------
 
-  if (!xCol)
-    throw std::runtime_error("PixelAssembly::getAtXYZ: x specified is out of range.");
-  return std::dynamic_pointer_cast<Detector>(xCol->getChild(y));
-}
-
-//-------------------------------------------------------------------------------------------------
-/** Return the detector ID corresponding to the component in the assembly at the
- * (X,Y) pixel position. No bounds check is made!
- *
- * @param x :: index from 0..m_xpixels-1
- * @param y :: index from 0..m_ypixels-1
- * @param z :: index from 0..m_zpixels-1
- * @return detector ID int
- * @throw runtime_error if the x/y/z pixel width is not set, or X/Y are out of
- *range
- */
-detid_t PixelAssembly::getDetectorIDAtXYZ(const int x, const int y, const int z) const {
-  const PixelAssembly *me = this;
-  if (isParametrized())
-    me = this->m_gridBase;
-
-  if (me->idFillOrder()[0] == 'z')
-    return getFillFirstZ(me, x, y, z);
-  else if (me->idFillOrder()[0] == 'y')
-    return getFillFirstY(me, x, y, z);
-  else
-    return getFillFirstX(me, x, y, z);
-}
-
-//-------------------------------------------------------------------------------------------------
-/** Given a detector ID, return the X,Y,Z coords into the grid detector
- *
- * @param detectorID :: detectorID
- * @return tuple of (x,y,z)
- */
-std::tuple<int, int, int> PixelAssembly::getXYZForDetectorID(const detid_t detectorID) const {
-  const PixelAssembly *me = this;
-  if (isParametrized())
-    me = this->m_gridBase;
-
-  int id = detectorID - me->m_idstart;
-  if ((me->m_idstepbyrow == 0) || (me->m_idstep == 0))
-    return std::tuple<int, int, int>(-1, -1, -1);
-  int col = (id % me->m_idstepbyrow) / me->m_idstep;
-
-  if (me->m_idFillOrder[0] == 'z')
-    return getXYZFillFirstZ(me, col, id);
-  else if (me->m_idFillOrder[0] == 'y')
-    return getXYZFillFirstY(me, col, id);
-  else
-    return getXYZFillFirstX(me, col, id);
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Returns the idstep
-int PixelAssembly::idstep() const {
-  if (isParametrized())
-    return m_gridBase->idstep();
-  else
-    return this->m_idstep;
-}
-
-//-------------------------------------------------------------------------------------------------
-/** Returns the position of the center of the pixel at x,y, relative to the
- * center
- * of the PixelAssembly, in the plain X,Y coordinates of the
- * pixels (i.e. unrotated).
- * @param x :: x pixel integer
- * @param y :: y pixel integer
- * @param z :: z pixel integer
- * @return a V3D vector of the relative position
- */
-V3D PixelAssembly::getRelativePosAtXYZ(int x, int y, int z) const {
+double PixelAssembly::xstep() const {
   if (isParametrized()) {
-    double scalex = 1.0;
+    double scaling = 1.0;
     if (m_map->contains(m_gridBase, "scalex"))
-      scalex = m_map->get(m_gridBase, "scalex")->value<double>();
-    double scaley = 1.0;
-    if (m_map->contains(m_gridBase, "scaley"))
-      scaley = m_map->get(m_gridBase, "scaley")->value<double>();
-    double scalez = 1.0;
-    if (m_map->contains(m_gridBase, "scalez"))
-      scalez = m_map->get(m_gridBase, "scalez")->value<double>();
-    return m_gridBase->getRelativePosAtXYZ(x, y, z) * V3D(scalex, scaley, scalez);
-  } else
-    return V3D(m_xstart + m_xstep * x, m_ystart + m_ystep * y, m_zstart + m_zstep * z);
-}
-
-void PixelAssembly::createLayer(const std::string &name, CompAssembly *parent, int iz, int &minDetID, int &maxDetID) {
-  const double z = m_zstart + iz * m_zstep;
-  const std::string z_pixel_str = (m_zpixels > 0) ? "," + std::to_string(iz) + ")" : ")";
-  const std::string z_layer_str = (m_zpixels > 0) ? name + "(z=" + std::to_string(iz) + ",x=" : name + "(x=";
-  for (int ix = 0; ix < m_xpixels; ++ix) {
-    const std::string x_pixel_str = name + "(" + std::to_string(ix) + ",";
-    const std::string name_layer = z_layer_str + std::to_string(ix) + ")";
-
-    // Create an ICompAssembly for each x-column
-    auto *xColumn = new CompAssembly(name_layer, parent);
-
-    const double x = m_xstart + ix * m_xstep;
-    for (int iy = 0; iy < m_ypixels; ++iy) {
-      // Make the name
-      const std::string name_pixel = x_pixel_str + std::to_string(iy) + z_pixel_str;
-
-      // Calculate its id and set it.
-      const auto id = this->getDetectorIDAtXYZ(ix, iy, iz);
-
-      // minimum grid detector id
-      if (id < minDetID) {
-        minDetID = id;
-      }
-      // maximum grid detector id
-      if (id > maxDetID) {
-        maxDetID = id;
-      }
-      // Create the detector from the given id & shape and with xColumn as the parent
-      auto *detector =
-          new GridDetectorPixel(name_pixel, id, m_shape, xColumn, this, size_t(ix), size_t(iy), size_t(iz));
-
-      const double y = m_ystart + iy * m_ystep;
-      // Translate (relative to parent). This gives the un-parametrized position
-      detector->translate(x, y, z);
-
-      // Add it to the x-column
-      xColumn->add(detector);
-    }
+      scaling = m_map->get(m_gridBase, "scalex")->value<double>();
+    return m_gridBase->m_xstep * scaling;
   }
+  return m_xstep;
 }
 
-bool checkValidOrderString(const std::string &order) {
-  static const boost::regex exp("xyz|xzy|yzx|yxz|zyx|zxy");
-
-  return boost::regex_match(order, exp);
+double PixelAssembly::ystep() const {
+  if (isParametrized()) {
+    double scaling = 1.0;
+    if (m_map->contains(m_gridBase, "scaley"))
+      scaling = m_map->get(m_gridBase, "scaley")->value<double>();
+    return m_gridBase->m_ystep * scaling;
+  }
+  return m_ystep;
 }
+
+double PixelAssembly::zstep() const {
+  if (isParametrized()) {
+    double scaling = 1.0;
+    if (m_map->contains(m_gridBase, "scalez"))
+      scaling = m_map->get(m_gridBase, "scalez")->value<double>();
+    return m_gridBase->m_zstep * scaling;
+  }
+  return m_zstep;
+}
+
+// ---------------------------------------------------------------------------
+// IVirtualBank: start-position accessors (scale-factor aware)
+// ---------------------------------------------------------------------------
+
+double PixelAssembly::xstart() const {
+  if (isParametrized()) {
+    double scaling = 1.0;
+    if (m_map->contains(m_gridBase, "scalex"))
+      scaling = m_map->get(m_gridBase, "scalex")->value<double>();
+    return m_gridBase->m_xstart * scaling;
+  }
+  return m_xstart;
+}
+
+double PixelAssembly::ystart() const {
+  if (isParametrized()) {
+    double scaling = 1.0;
+    if (m_map->contains(m_gridBase, "scaley"))
+      scaling = m_map->get(m_gridBase, "scaley")->value<double>();
+    return m_gridBase->m_ystart * scaling;
+  }
+  return m_ystart;
+}
+
+double PixelAssembly::zstart() const {
+  if (isParametrized()) {
+    double scaling = 1.0;
+    if (m_map->contains(m_gridBase, "scalez"))
+      scaling = m_map->get(m_gridBase, "scalez")->value<double>();
+    return m_gridBase->m_zstart * scaling;
+  }
+  return m_zstart;
+}
+
+// ---------------------------------------------------------------------------
+// IVirtualBank: ID-scheme accessors
+// ---------------------------------------------------------------------------
+
+detid_t PixelAssembly::referentDetectorID() const { return isParametrized() ? m_gridBase->m_idstart : m_idstart; }
+
+std::array<char, 3> PixelAssembly::idFillOrder() const {
+  return isParametrized() ? m_gridBase->m_idFillOrder : m_idFillOrder;
+}
+
+int PixelAssembly::idstep() const { return isParametrized() ? m_gridBase->m_idstep : m_idstep; }
+
+// ---------------------------------------------------------------------------
+// IVirtualBank: referent detector
+// ---------------------------------------------------------------------------
+
+/** Constructs and returns a Detector for the referent pixel (0,0,0) on demand.
+ *  The returned object is independent (no parent link) and is positioned at
+ *  the pixel's absolute world position.
+ */
+std::shared_ptr<Detector> PixelAssembly::referentDetector() const {
+  std::shared_ptr<IObject> const &pxShape = isParametrized() ? m_gridBase->m_shape : m_shape;
+  if (!pxShape)
+    return nullptr;
+  std::string const name = this->getName() + "(0,0,0)";
+  auto det = std::make_shared<Detector>(name, static_cast<int>(referentDetectorID()), pxShape, nullptr);
+  det->setPos(getPosAtXYZ(0, 0, 0));
+  det->setRot(this->getRotation());
+  return det;
+}
+
+// ---------------------------------------------------------------------------
+// Position helpers
+// ---------------------------------------------------------------------------
+
+/** Absolute position of pixel (x, y, z) in the instrument frame.
+ *
+ *  NOTE: consistent with GridDetector::getPosAtXYZ — the relative position is
+ *  added directly to the bank position without rotating by the bank orientation.
+ *  This matches the existing behavior for unrotated banks.
+ */
+V3D PixelAssembly::getPosAtXYZ(int x, int y, int z) const { return this->getPos() + getRelativePosAtXYZ(x, y, z); }
+
+// ---------------------------------------------------------------------------
+// Per-pixel bounding box
+// ---------------------------------------------------------------------------
+
+/** Compute the axis-aligned world-space bounding box for pixel (x, y, z).
+ *
+ *  Replicates the ObjComponent::getBoundingBox pattern:
+ *    1. Start from the pixel shape's local bounding box.
+ *    2. Rotate by the bank's orientation.
+ *    3. Translate to the pixel's absolute position.
+ */
+void PixelAssembly::getBoundingBoxAtXYZ(int const x, int const y, int const z, BoundingBox &box) const {
+  std::shared_ptr<IObject> const &pxShape = isParametrized() ? m_gridBase->m_shape : m_shape;
+  if (!pxShape || !pxShape->hasValidShape()) {
+    box = BoundingBox();
+    return;
+  }
+  BoundingBox const &shapeBox = pxShape->getBoundingBox();
+  if (shapeBox.isNull()) {
+    box = BoundingBox();
+    return;
+  }
+  // 1. Copy the pixel shape's local bounding box.
+  box = BoundingBox(shapeBox);
+  // 2. Rotate into world axes using the bank's orientation.
+  this->getRotation().rotateBB(box.xMin(), box.yMin(), box.zMin(), box.xMax(), box.yMax(), box.zMax());
+  // 3. Translate to the pixel's absolute position.
+  V3D const pos = getPosAtXYZ(x, y, z);
+  box.xMin() += pos.X();
+  box.xMax() += pos.X();
+  box.yMin() += pos.Y();
+  box.yMax() += pos.Y();
+  box.zMin() += pos.Z();
+  box.zMax() += pos.Z();
+}
+
+// ---------------------------------------------------------------------------
+// Component lookup
+// ---------------------------------------------------------------------------
+
+/** Find a component by name.  PixelAssembly has no children, so only the
+ *  assembly itself can be found.
+ *
+ *  NOTE: This is NOT an override of IComponent::getComponentByName (which does
+ *  not exist); it is a freestanding convenience method for direct callers that
+ *  hold a PixelAssembly*.
+ */
+std::shared_ptr<const IComponent> PixelAssembly::getComponentByName(const std::string &cname) const {
+  if (cname == this->getName())
+    return std::shared_ptr<const IComponent>(this, NoDeleting());
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Visitor registration
+// ---------------------------------------------------------------------------
+
+size_t PixelAssembly::registerContents(ComponentVisitor &componentVisitor) const {
+  return componentVisitor.registerVirtualBank(*this);
+}
+
+// ---------------------------------------------------------------------------
+// Pixel shape accessor
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<const IObject> PixelAssembly::pixelShape() const {
+  return isParametrized() ? m_gridBase->m_shape : m_shape;
+}
+
+// ---------------------------------------------------------------------------
+// IObjComponent methods
+// ---------------------------------------------------------------------------
+
+bool PixelAssembly::isValid(const V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::isValid() is not implemented.");
+}
+
+bool PixelAssembly::isOnSide(const V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::isOnSide() is not implemented.");
+}
+
+int PixelAssembly::interceptSurface(Track & /*track*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::interceptSurface() is not implemented.");
+}
+
+double PixelAssembly::solidAngle(const Geometry::SolidAngleParams & /*params*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::solidAngle() is not implemented.");
+}
+
+int PixelAssembly::getPointInObject(V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::getPointInObject() is not implemented.");
+}
+
+/** Compute the overall bounding box for this assembly.
+ *
+ *  If the ComponentInfo cache is available (parametrized path), use it.
+ *  Otherwise sample the 8 corners of the pixel grid.
+ */
+void PixelAssembly::getBoundingBox(BoundingBox &assemblyBox) const {
+  if (isParametrized() && hasComponentInfo()) {
+    assemblyBox = m_map->componentInfo().boundingBox(index(), &assemblyBox);
+    return;
+  }
+  BoundingBox bb;
+  BoundingBox compBox;
+  int const nx = static_cast<int>(xpixels()) - 1;
+  int const ny = static_cast<int>(ypixels()) - 1;
+  int const nz = static_cast<int>(zpixels()) - 1;
+  getBoundingBoxAtXYZ(0, 0, 0, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(nx, 0, 0, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(nx, ny, 0, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(0, ny, 0, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(0, 0, nz, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(nx, 0, nz, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(nx, ny, nz, compBox);
+  bb.grow(compBox);
+  getBoundingBoxAtXYZ(0, ny, nz, compBox);
+  bb.grow(compBox);
+  assemblyBox = bb;
+}
+
+void PixelAssembly::draw() const {
+  if (Handle() == nullptr)
+    return;
+  Handle()->render();
+}
+
+void PixelAssembly::drawObject() const { draw(); }
+
+void PixelAssembly::initDraw() const {
+  if (Handle() == nullptr)
+    return;
+  Handle()->initialize();
+}
+
+/** Returns a cuboid representing the whole assembly extent (used for rendering). */
+const std::shared_ptr<const IObject> PixelAssembly::shape() const {
+  double const szX = static_cast<double>(xpixels());
+  double const szY = static_cast<double>(ypixels());
+  double const szZ = static_cast<double>(zpixels());
+  std::ostringstream xml;
+  xml << " <cuboid id=\"detector-shape\"> "
+      << "<left-front-bottom-point x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
+      << "<left-front-top-point  x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << szZ << "\"  /> "
+      << "<left-back-bottom-point  x=\"" << -szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
+      << "<right-front-bottom-point  x=\"" << szX << "\" y=\"" << szY << "\" z=\"" << -szZ << "\"  /> "
+      << "</cuboid>";
+  Geometry::ShapeFactory shapeCreator;
+  return std::static_pointer_cast<const IObject>(shapeCreator.createShape(xml.str()));
+}
+
+const Kernel::Material PixelAssembly::material() const { return Kernel::Material(); }
+
+// ---------------------------------------------------------------------------
+// initialize / validateInput / initializeValues
+// ---------------------------------------------------------------------------
 
 void PixelAssembly::validateInput() const {
-  // Some safety checks
-  if (!checkValidOrderString(m_idFillOrder))
-    throw std::invalid_argument(
-        "PixelAssembly::initialize(): order string should only comprise exactly 3 letters x, y, and z in any order.");
-  if (m_xpixels <= 0)
-    throw std::invalid_argument("PixelAssembly::initialize(): xpixels should be > 0");
-  if (m_ypixels <= 0)
-    throw std::invalid_argument("PixelAssembly::initialize(): ypixels should be > 0");
+  if (!checkValidOrderString(std::string{m_idFillOrder.begin(), m_idFillOrder.end()}))
+    throw std::invalid_argument("PixelAssembly::initialize(): idFillOrder must be a permutation of 'xyz'.");
+  if (m_xpixels == 0)
+    throw std::invalid_argument("PixelAssembly::initialize(): xpixels must be > 0.");
+  if (m_ypixels == 0)
+    throw std::invalid_argument("PixelAssembly::initialize(): ypixels must be > 0.");
+  if (m_zpixels == 0)
+    throw std::invalid_argument("PixelAssembly::initialize(): zpixels must be > 0 (pass 1 for a flat bank).");
 }
 
-void PixelAssembly::initializeValues(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep,
-                                     int ypixels, double ystart, double ystep, int zpixels, double zstart, double zstep,
-                                     int idstart, const std::string &idFillOrder, int idstepbyrow, int idstep) {
-
+void PixelAssembly::initializeValues(std::shared_ptr<IObject> shape, size_t xpixels, double xstart, double xstep,
+                                     size_t ypixels, double ystart, double ystep, size_t zpixels, double zstart,
+                                     double zstep, detid_t idstart, const std::string &idFillOrder, int idstep) {
   m_xpixels = xpixels;
   m_ypixels = ypixels;
-  m_zpixels = zpixels;
-  m_xsize = xpixels * xstep;
-  m_ysize = ypixels * ystep;
-  m_zsize = zpixels * zstep;
+  // Normalise: 0 layers means flat bank (treat as 1 layer).
+  m_zpixels = (zpixels == 0) ? size_t(1) : zpixels;
   m_xstart = xstart;
   m_ystart = ystart;
   m_zstart = zstart;
@@ -273,337 +383,29 @@ void PixelAssembly::initializeValues(std::shared_ptr<IObject> shape, int xpixels
   m_ystep = ystep;
   m_zstep = zstep;
   m_shape = std::move(shape);
-
-  /// IDs start here
   m_idstart = idstart;
-  /// IDs are filled in Y fastest
-  m_idfillbyfirst_y = idFillOrder[0] == 'y';
-  /// IDs are filled by Y fastest
-  m_idFillOrder = idFillOrder;
-  /// Step size in ID in each row
-  m_idstepbyrow = idstepbyrow;
-  /// Step size in ID in each col
+  m_idFillOrder = {idFillOrder[0], idFillOrder[1], idFillOrder[2]};
   m_idstep = idstep;
-
   validateInput();
 }
 
-//-------------------------------------------------------------------------------------------------
-/** Initialize a PixelAssembly by creating all of the pixels
- * contained within it. You should have set the name, position
- * and rotation and facing of this object BEFORE calling this.
- *
- * @param shape :: a geometry Object containing the shape of each (individual)
- *pixel in the assembly.
- *              All pixels must have the same shape.
- * @param xpixels :: number of pixels in X
- * @param xstart :: x-position of the 0-th pixel (in length units, normally
- *meters)
- * @param xstep :: step size between pixels in the horizontal direction (in
- *length units, normally meters)
- * @param ypixels :: number of pixels in Y
- * @param ystart :: y-position of the 0-th pixel (in length units, normally
- *meters)
- * @param ystep :: step size between pixels in the vertical direction (in length
- *units, normally meters)
- * @param zpixels :: number of pixels in Z
- * @param zstart :: z-position of the 0-th pixel (in length units, normally
- *meters)
- * @param zstep :: step size between pixels in the beam direction (in length
- *units, normally meters)
- * @param idstart :: detector ID of the first pixel
- * @param idFillOrder :: string of size 3 which contains axis order e.g "xyz"
- * @param idstepbyrow :: amount to increase the ID number on each row. e.g, if
- *you fill by Y first,
- *            and set  idstepbyrow = 100, and have 50 Y pixels, you would get:
- *            (0,0)=0; (0,1)=1; ... (0,49)=49; (1,0)=100; (1,1)=101; etc.
- * @param idstep :: amount to increase each individual ID number with a row.
- *e.g, if you fill by Y first,
- *            and idstep=100 and idstart=1 then (0,0)=1; (0,1)=101; and so on
- *
- */
-void PixelAssembly::initialize(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels,
-                               double ystart, double ystep, int zpixels, double zstart, double zstep, int idstart,
-                               const std::string &idFillOrder, int idstepbyrow, int idstep) {
-
+/** Store the grid parameters.  No child Detector objects are created. */
+void PixelAssembly::initialize(std::shared_ptr<IObject> shape, size_t xpixels, double xstart, double xstep,
+                               size_t ypixels, double ystart, double ystep, size_t zpixels, double zstart, double zstep,
+                               detid_t idstart, const std::string &idFillOrder, int idstep) {
   if (isParametrized())
-    throw std::runtime_error("PixelAssembly::initialize() called for a parametrized PixelAssembly");
-
+    throw std::runtime_error("PixelAssembly::initialize() called on a parametrized PixelAssembly.");
   initializeValues(std::move(shape), xpixels, xstart, xstep, ypixels, ystart, ystep, zpixels, zstart, zstep, idstart,
-                   idFillOrder, idstepbyrow, idstep);
-
-  std::string name = this->getName();
-  int minDetId = idstart, maxDetId = idstart;
-  // Loop through all the pixels
-  if (m_zpixels > 0) {
-    for (int iz = 0; iz < m_zpixels; ++iz) {
-      // Create an ICompAssembly for each z-layer
-      std::ostringstream oss_layer;
-      oss_layer << name << "(z=" << iz << ")";
-      createLayer(name, new CompAssembly(oss_layer.str(), this), iz, minDetId, maxDetId);
-    }
-  } else
-    createLayer(name, this, 0, minDetId, maxDetId);
-
-  m_minDetId = minDetId;
-  m_maxDetId = maxDetId;
+                   idFillOrder, idstep);
 }
 
-//-------------------------------------------------------------------------------------------------
-/** Returns the minimum detector id
- * @return minimum detector id
- */
-detid_t PixelAssembly::minDetectorID() const {
-  if (isParametrized())
-    return m_gridBase->minDetectorID();
-  return m_minDetId;
-}
+// ---------------------------------------------------------------------------
+// Stream operator
+// ---------------------------------------------------------------------------
 
-//-------------------------------------------------------------------------------------------------
-/** Returns the maximum detector id
- * @return maximum detector id
- */
-detid_t PixelAssembly::maxDetectorID() const {
-  if (isParametrized())
-    return m_gridBase->maxDetectorID();
-  return m_maxDetId;
-}
-
-//-------------------------------------------------------------------------------------------------
-/// @copydoc Mantid::Geometry::CompAssembly::getComponentByName
-std::shared_ptr<const IComponent> PixelAssembly::getComponentByName(const std::string &cname, int nlevels) const {
-  // exact matches
-  if (cname == this->getName())
-    return std::shared_ptr<const IComponent>(this);
-
-  // cache the detector's name as all the other names are longer
-  // The extra ( is because all children of this have that as the next character
-  // and this prevents Bank11 matching Bank 1
-  const std::string MEMBER_NAME = this->getName() + "(";
-
-  // check that the searched for name starts with the detector's
-  // name as they are generated
-  if (cname.substr(0, MEMBER_NAME.length()) != MEMBER_NAME) {
-    return std::shared_ptr<const IComponent>();
-  } else {
-    return CompAssembly::getComponentByName(cname, nlevels);
-  }
-}
-
-//------------------------------------------------------------------------------------------------
-/** Test the intersection of the ray with the children of the component
- *assembly, for InstrumentRayTracer.
- * Uses the knowledge of the PixelAssembly shape to significantly speed up
- *tracking.
- *
- * @param testRay :: Track under test. The results are stored here.
- * @param searchQueue :: If a child is a sub-assembly then it is appended for
- *later searching. Unused.
- */
-void PixelAssembly::testIntersectionWithChildren(Track &testRay,
-                                                 std::deque<IComponent_const_sptr> & /*searchQueue*/) const {
-  /// Base point (x,y,z) = position of pixel 0,0
-  V3D const basePoint = getRelativePosAtXYZ(0, 0, 0);
-
-  /// Vertical (y-axis) basis vector of the detector
-  V3D const vertical = getRelativePosAtXYZ(0, ypixels() - 1, 0) - basePoint;
-
-  /// Horizontal (x-axis) basis vector of the detector
-  V3D horizontal = getRelativePosAtXYZ(xpixels() - 1, 0, 0) - basePoint;
-
-  // The beam direction
-  V3D const beam = testRay.direction() * (-1.0);
-
-  // From: http://en.wikipedia.org/wiki/Line-plane_intersection (taken on May 4,
-  // 2011),
-  // We build a matrix to solve the linear equation:
-  Matrix<double> mat(3, 3);
-  mat.setColumn(0, beam);
-  mat.setColumn(1, horizontal);
-  mat.setColumn(2, vertical);
-  mat.Invert();
-
-  // Multiply by the inverted matrix to find t,u,v
-  V3D const tuv = mat * (testRay.startPoint() - basePoint);
-  //  std::cout << tuv << "\n";
-
-  // Intersection point
-  V3D const intersec = beam * (tuv[0] * -1.0);
-
-  // t = coordinate along the line
-  // u,v = coordinates along horizontal, vertical
-  // (and correct for it being between 0, xpixels-1).  The +0.5 is because the
-  // base point is at the CENTER of pixel 0,0.
-  double u = (double(xpixels() - 1) * tuv[1] + 0.5);
-  double v = (double(ypixels() - 1) * tuv[2] + 0.5);
-
-  //  std::cout << u << ", " << v << "\n";
-
-  // In indices
-  auto xIndex = int(u);
-  auto yIndex = int(v);
-
-  // Out of range?
-  if (xIndex < 0)
-    return;
-  if (yIndex < 0)
-    return;
-  if (xIndex >= xpixels())
-    return;
-  if (yIndex >= ypixels())
-    return;
-
-  // TODO: Do I need to put something smart here for the first 3 parameters?
-  auto comp = getAtXYZ(xIndex, yIndex, 0);
-  testRay.addLink(intersec, intersec, 0.0, *(comp->shape()), comp->getComponentID());
-}
-
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-// ------------ IObjComponent methods ----------------
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-
-//-------------------------------------------------------------------------------------------------
-/// Does the point given lie within this object component?
-bool PixelAssembly::isValid(const V3D & /*point*/) const {
-  throw Kernel::Exception::NotImplementedError("PixelAssembly::isValid() is not implemented.");
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Does the point given lie on the surface of this object component?
-bool PixelAssembly::isOnSide(const V3D & /*point*/) const {
-  throw Kernel::Exception::NotImplementedError("PixelAssembly::isOnSide() is not implemented.");
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Checks whether the track given will pass through this Component.
-int PixelAssembly::interceptSurface(Track & /*track*/) const {
-  throw Kernel::Exception::NotImplementedError("PixelAssembly::interceptSurface() is not implemented.");
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Finds the approximate solid angle covered by the component when viewed from
-/// the point given
-double PixelAssembly::solidAngle(const Geometry::SolidAngleParams & /*params*/) const {
-  throw Kernel::Exception::NotImplementedError("PixelAssembly::solidAngle() is not implemented.");
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Try to find a point that lies within (or on) the object
-int PixelAssembly::getPointInObject(V3D & /*point*/) const {
-  throw Kernel::Exception::NotImplementedError("PixelAssembly::getPointInObject() is not implemented.");
-}
-
-//-------------------------------------------------------------------------------------------------
-/**
- * Get the bounding box and store it in the given object. This is cached after
- * the first call.
- * @param assemblyBox :: A BoundingBox object that will be overwritten
- */
-void PixelAssembly::getBoundingBox(BoundingBox &assemblyBox) const {
-  if (isParametrized()) {
-    if (hasComponentInfo()) {
-      assemblyBox = m_map->componentInfo().boundingBox(index(), &assemblyBox);
-      return;
-    }
-  }
-  BoundingBox bb;
-  BoundingBox compBox;
-  getAtXYZ(0, 0, 0)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, 0, 0)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, 0)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(0, this->ypixels() - 1, 0)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(0, 0, this->zpixels() - 1)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, 0, this->zpixels() - 1)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
-  bb.grow(compBox);
-  getAtXYZ(0, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
-  bb.grow(compBox);
-
-  assemblyBox = bb;
-}
-
-/**
- * Draws the objcomponent, If the handler is not set then this function does
- * nothing.
- */
-void PixelAssembly::draw() const {
-  if (Handle() == nullptr)
-    return;
-  Handle()->render();
-}
-
-/**
- * Draws the Object
- */
-void PixelAssembly::drawObject() const { draw(); }
-
-/**
- * Initializes the ObjComponent for rendering, this function should be called
- * before rendering.
- */
-void PixelAssembly::initDraw() const {
-  if (Handle() == nullptr)
-    return;
-  Handle()->initialize();
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Returns the shape of the Object
-const std::shared_ptr<const IObject> PixelAssembly::shape() const {
-  // --- Create a cuboid shape for your pixels ----
-  double szX = xpixels();
-  double szY = ypixels();
-  double szZ = zpixels() == 0 ? 0.5 : zpixels();
-  std::ostringstream xmlShapeStream;
-  xmlShapeStream << " <cuboid id=\"detector-shape\"> "
-                 << "<left-front-bottom-point x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
-                 << "<left-front-top-point  x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << szZ << "\"  /> "
-                 << "<left-back-bottom-point  x=\"" << -szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
-                 << "<right-front-bottom-point  x=\"" << szX << "\" y=\"" << szY << "\" z=\"" << -szZ << "\"  /> "
-                 << "</cuboid>";
-
-  std::string xmlCuboidShape(xmlShapeStream.str());
-  Geometry::ShapeFactory shapeCreator;
-  std::shared_ptr<Geometry::IObject> cuboidShape = shapeCreator.createShape(xmlCuboidShape);
-
-  return cuboidShape;
-}
-
-const Kernel::Material PixelAssembly::material() const { return Kernel::Material(); }
-
-size_t PixelAssembly::registerContents(ComponentVisitor &componentVisitor) const {
-  return componentVisitor.registerGridBank(*this);
-}
-
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-// ------------ END OF IObjComponent methods ----------------
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-
-/** Print information about elements in the assembly to a stream
- *  Overload the operator <<
- * @param os :: output stream
- * @param ass :: component assembly
- * @return stream representation of grid detector
- *
- *  Loops through all components in the assembly
- *  and call printSelf(os).
- *  Also output the number of children
- */
 std::ostream &operator<<(std::ostream &os, const PixelAssembly &assm) {
-  ass.printSelf(os);
-  os << "************************\n";
-  os << "Number of children :" << assm.nelements() << '\n';
-  ass.printChildren(os);
+  assm.printSelf(os);
+  os << "PixelAssembly: " << assm.xpixels() << " x " << assm.ypixels() << " x " << assm.zpixels() << " pixels\n";
   return os;
 }
 

--- a/Framework/Geometry/src/Instrument/PixelAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/PixelAssembly.cpp
@@ -1,0 +1,610 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidGeometry/Instrument/PixelAssembly.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/ComponentVisitor.h"
+#include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Instrument/GridDetectorPixel.h"
+#include "MantidGeometry/Objects/BoundingBox.h"
+#include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidGeometry/Objects/Track.h"
+#include "MantidGeometry/Rendering/GeometryHandler.h"
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/Material.h"
+#include "MantidKernel/Matrix.h"
+#include <algorithm>
+#include <boost/regex.hpp>
+#include <memory>
+#include <ostream>
+#include <stdexcept>
+#include <utility>
+
+namespace Mantid::Geometry {
+
+using Kernel::Matrix;
+using Kernel::V3D;
+
+/** Constructor for a parametrized PixelAssembly
+ * @param base: the base (un-parametrized) PixelAssembly
+ * @param map: pointer to the ParameterMap
+ * */
+PixelAssembly::PixelAssembly(const PixelAssembly *base, const ParameterMap *map)
+    : CompAssembly(base, map), IObjComponent(nullptr), m_gridBase(base), m_minDetId(0), m_maxDetId(0) {
+  init();
+  setGeometryHandler(new GeometryHandler(this));
+}
+
+/** Valued constructor
+ *  @param n :: name of the assembly
+ *  @param reference :: the parent Component
+ *
+ * 	If the reference is an object of class Component,
+ *  normal parenting apply. If the reference object is
+ *  an assembly itself, then in addition to parenting
+ *  this is registered as a children of reference.
+ */
+PixelAssembly::PixelAssembly(const std::string &n, IComponent *reference)
+    : CompAssembly(n, reference), IObjComponent(nullptr), m_gridBase(nullptr), m_minDetId(0), m_maxDetId(0) {
+  init();
+  this->setName(n);
+  setGeometryHandler(new GeometryHandler(this));
+}
+
+bool PixelAssembly::compareName(const std::string &proposedMatch) {
+  static const boost::regex exp("grid_?detector", boost::regex::icase);
+  return boost::regex_match(proposedMatch, exp);
+}
+
+void PixelAssembly::init() {
+  m_minDetId = m_maxDetId = 0;
+  m_idstart = 0;
+  m_idstep = 0;
+}
+
+/** Clone method
+ *  Make a copy of the component assembly
+ *  @return new(*this)
+ */
+PixelAssembly *PixelAssembly::clone() const { return new PixelAssembly(*this); }
+
+//-------------------------------------------------------------------------------------------------
+/** Return a pointer to the component in the assembly at the
+ * (X,Y) pixel position.
+ *
+ * @param x :: index from 0..m_xpixels-1
+ * @param y :: index from 0..m_ypixels-1
+ * @param z :: index from 0..m_zpixels-1
+ * @return a pointer to the component in the assembly at the (x,y,z) pixel
+ *position
+ * @throw runtime_error if the x/y/z pixel width is not set, or x/y/z are out of
+ *range
+ */
+std::shared_ptr<Detector> PixelAssembly::getAtXYZ(const int x, const int y, const int z) const {
+  if ((xpixels() <= 0) || (ypixels() <= 0))
+    throw std::runtime_error("PixelAssembly::getAtXY: invalid X or Y "
+                             "width set in the object.");
+  if ((x < 0) || (x >= xpixels()))
+    throw std::runtime_error("PixelAssembly::getAtXYZ: x specified is out of range.");
+  if ((y < 0) || (y >= ypixels()))
+    throw std::runtime_error("PixelAssembly::getAtXYZ: y specified is out of range.");
+  if (zpixels() > 0) {
+    if ((z < 0) || (z >= zpixels()))
+      throw std::runtime_error("PixelAssembly::getAtXYZ: z specified is out of range.");
+  }
+
+  // Find the index and return that.
+  std::shared_ptr<ICompAssembly> xCol;
+  // Get to layer
+  if (this->zpixels() > 0) {
+    auto zLayer = std::dynamic_pointer_cast<ICompAssembly>(this->getChild(z));
+    if (!zLayer)
+      throw std::runtime_error("PixelAssembly::getAtXYZ: z specified is out of range.");
+
+    xCol = std::dynamic_pointer_cast<ICompAssembly>(zLayer->getChild(x));
+  } else
+    xCol = std::dynamic_pointer_cast<ICompAssembly>(this->getChild(x));
+
+  if (!xCol)
+    throw std::runtime_error("PixelAssembly::getAtXYZ: x specified is out of range.");
+  return std::dynamic_pointer_cast<Detector>(xCol->getChild(y));
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Return the detector ID corresponding to the component in the assembly at the
+ * (X,Y) pixel position. No bounds check is made!
+ *
+ * @param x :: index from 0..m_xpixels-1
+ * @param y :: index from 0..m_ypixels-1
+ * @param z :: index from 0..m_zpixels-1
+ * @return detector ID int
+ * @throw runtime_error if the x/y/z pixel width is not set, or X/Y are out of
+ *range
+ */
+detid_t PixelAssembly::getDetectorIDAtXYZ(const int x, const int y, const int z) const {
+  const PixelAssembly *me = this;
+  if (isParametrized())
+    me = this->m_gridBase;
+
+  if (me->idFillOrder()[0] == 'z')
+    return getFillFirstZ(me, x, y, z);
+  else if (me->idFillOrder()[0] == 'y')
+    return getFillFirstY(me, x, y, z);
+  else
+    return getFillFirstX(me, x, y, z);
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Given a detector ID, return the X,Y,Z coords into the grid detector
+ *
+ * @param detectorID :: detectorID
+ * @return tuple of (x,y,z)
+ */
+std::tuple<int, int, int> PixelAssembly::getXYZForDetectorID(const detid_t detectorID) const {
+  const PixelAssembly *me = this;
+  if (isParametrized())
+    me = this->m_gridBase;
+
+  int id = detectorID - me->m_idstart;
+  if ((me->m_idstepbyrow == 0) || (me->m_idstep == 0))
+    return std::tuple<int, int, int>(-1, -1, -1);
+  int col = (id % me->m_idstepbyrow) / me->m_idstep;
+
+  if (me->m_idFillOrder[0] == 'z')
+    return getXYZFillFirstZ(me, col, id);
+  else if (me->m_idFillOrder[0] == 'y')
+    return getXYZFillFirstY(me, col, id);
+  else
+    return getXYZFillFirstX(me, col, id);
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Returns the idstep
+int PixelAssembly::idstep() const {
+  if (isParametrized())
+    return m_gridBase->idstep();
+  else
+    return this->m_idstep;
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Returns the position of the center of the pixel at x,y, relative to the
+ * center
+ * of the PixelAssembly, in the plain X,Y coordinates of the
+ * pixels (i.e. unrotated).
+ * @param x :: x pixel integer
+ * @param y :: y pixel integer
+ * @param z :: z pixel integer
+ * @return a V3D vector of the relative position
+ */
+V3D PixelAssembly::getRelativePosAtXYZ(int x, int y, int z) const {
+  if (isParametrized()) {
+    double scalex = 1.0;
+    if (m_map->contains(m_gridBase, "scalex"))
+      scalex = m_map->get(m_gridBase, "scalex")->value<double>();
+    double scaley = 1.0;
+    if (m_map->contains(m_gridBase, "scaley"))
+      scaley = m_map->get(m_gridBase, "scaley")->value<double>();
+    double scalez = 1.0;
+    if (m_map->contains(m_gridBase, "scalez"))
+      scalez = m_map->get(m_gridBase, "scalez")->value<double>();
+    return m_gridBase->getRelativePosAtXYZ(x, y, z) * V3D(scalex, scaley, scalez);
+  } else
+    return V3D(m_xstart + m_xstep * x, m_ystart + m_ystep * y, m_zstart + m_zstep * z);
+}
+
+void PixelAssembly::createLayer(const std::string &name, CompAssembly *parent, int iz, int &minDetID, int &maxDetID) {
+  const double z = m_zstart + iz * m_zstep;
+  const std::string z_pixel_str = (m_zpixels > 0) ? "," + std::to_string(iz) + ")" : ")";
+  const std::string z_layer_str = (m_zpixels > 0) ? name + "(z=" + std::to_string(iz) + ",x=" : name + "(x=";
+  for (int ix = 0; ix < m_xpixels; ++ix) {
+    const std::string x_pixel_str = name + "(" + std::to_string(ix) + ",";
+    const std::string name_layer = z_layer_str + std::to_string(ix) + ")";
+
+    // Create an ICompAssembly for each x-column
+    auto *xColumn = new CompAssembly(name_layer, parent);
+
+    const double x = m_xstart + ix * m_xstep;
+    for (int iy = 0; iy < m_ypixels; ++iy) {
+      // Make the name
+      const std::string name_pixel = x_pixel_str + std::to_string(iy) + z_pixel_str;
+
+      // Calculate its id and set it.
+      const auto id = this->getDetectorIDAtXYZ(ix, iy, iz);
+
+      // minimum grid detector id
+      if (id < minDetID) {
+        minDetID = id;
+      }
+      // maximum grid detector id
+      if (id > maxDetID) {
+        maxDetID = id;
+      }
+      // Create the detector from the given id & shape and with xColumn as the parent
+      auto *detector =
+          new GridDetectorPixel(name_pixel, id, m_shape, xColumn, this, size_t(ix), size_t(iy), size_t(iz));
+
+      const double y = m_ystart + iy * m_ystep;
+      // Translate (relative to parent). This gives the un-parametrized position
+      detector->translate(x, y, z);
+
+      // Add it to the x-column
+      xColumn->add(detector);
+    }
+  }
+}
+
+bool checkValidOrderString(const std::string &order) {
+  static const boost::regex exp("xyz|xzy|yzx|yxz|zyx|zxy");
+
+  return boost::regex_match(order, exp);
+}
+
+void PixelAssembly::validateInput() const {
+  // Some safety checks
+  if (!checkValidOrderString(m_idFillOrder))
+    throw std::invalid_argument(
+        "PixelAssembly::initialize(): order string should only comprise exactly 3 letters x, y, and z in any order.");
+  if (m_xpixels <= 0)
+    throw std::invalid_argument("PixelAssembly::initialize(): xpixels should be > 0");
+  if (m_ypixels <= 0)
+    throw std::invalid_argument("PixelAssembly::initialize(): ypixels should be > 0");
+}
+
+void PixelAssembly::initializeValues(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep,
+                                     int ypixels, double ystart, double ystep, int zpixels, double zstart, double zstep,
+                                     int idstart, const std::string &idFillOrder, int idstepbyrow, int idstep) {
+
+  m_xpixels = xpixels;
+  m_ypixels = ypixels;
+  m_zpixels = zpixels;
+  m_xsize = xpixels * xstep;
+  m_ysize = ypixels * ystep;
+  m_zsize = zpixels * zstep;
+  m_xstart = xstart;
+  m_ystart = ystart;
+  m_zstart = zstart;
+  m_xstep = xstep;
+  m_ystep = ystep;
+  m_zstep = zstep;
+  m_shape = std::move(shape);
+
+  /// IDs start here
+  m_idstart = idstart;
+  /// IDs are filled in Y fastest
+  m_idfillbyfirst_y = idFillOrder[0] == 'y';
+  /// IDs are filled by Y fastest
+  m_idFillOrder = idFillOrder;
+  /// Step size in ID in each row
+  m_idstepbyrow = idstepbyrow;
+  /// Step size in ID in each col
+  m_idstep = idstep;
+
+  validateInput();
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Initialize a PixelAssembly by creating all of the pixels
+ * contained within it. You should have set the name, position
+ * and rotation and facing of this object BEFORE calling this.
+ *
+ * @param shape :: a geometry Object containing the shape of each (individual)
+ *pixel in the assembly.
+ *              All pixels must have the same shape.
+ * @param xpixels :: number of pixels in X
+ * @param xstart :: x-position of the 0-th pixel (in length units, normally
+ *meters)
+ * @param xstep :: step size between pixels in the horizontal direction (in
+ *length units, normally meters)
+ * @param ypixels :: number of pixels in Y
+ * @param ystart :: y-position of the 0-th pixel (in length units, normally
+ *meters)
+ * @param ystep :: step size between pixels in the vertical direction (in length
+ *units, normally meters)
+ * @param zpixels :: number of pixels in Z
+ * @param zstart :: z-position of the 0-th pixel (in length units, normally
+ *meters)
+ * @param zstep :: step size between pixels in the beam direction (in length
+ *units, normally meters)
+ * @param idstart :: detector ID of the first pixel
+ * @param idFillOrder :: string of size 3 which contains axis order e.g "xyz"
+ * @param idstepbyrow :: amount to increase the ID number on each row. e.g, if
+ *you fill by Y first,
+ *            and set  idstepbyrow = 100, and have 50 Y pixels, you would get:
+ *            (0,0)=0; (0,1)=1; ... (0,49)=49; (1,0)=100; (1,1)=101; etc.
+ * @param idstep :: amount to increase each individual ID number with a row.
+ *e.g, if you fill by Y first,
+ *            and idstep=100 and idstart=1 then (0,0)=1; (0,1)=101; and so on
+ *
+ */
+void PixelAssembly::initialize(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels,
+                               double ystart, double ystep, int zpixels, double zstart, double zstep, int idstart,
+                               const std::string &idFillOrder, int idstepbyrow, int idstep) {
+
+  if (isParametrized())
+    throw std::runtime_error("PixelAssembly::initialize() called for a parametrized PixelAssembly");
+
+  initializeValues(std::move(shape), xpixels, xstart, xstep, ypixels, ystart, ystep, zpixels, zstart, zstep, idstart,
+                   idFillOrder, idstepbyrow, idstep);
+
+  std::string name = this->getName();
+  int minDetId = idstart, maxDetId = idstart;
+  // Loop through all the pixels
+  if (m_zpixels > 0) {
+    for (int iz = 0; iz < m_zpixels; ++iz) {
+      // Create an ICompAssembly for each z-layer
+      std::ostringstream oss_layer;
+      oss_layer << name << "(z=" << iz << ")";
+      createLayer(name, new CompAssembly(oss_layer.str(), this), iz, minDetId, maxDetId);
+    }
+  } else
+    createLayer(name, this, 0, minDetId, maxDetId);
+
+  m_minDetId = minDetId;
+  m_maxDetId = maxDetId;
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Returns the minimum detector id
+ * @return minimum detector id
+ */
+detid_t PixelAssembly::minDetectorID() const {
+  if (isParametrized())
+    return m_gridBase->minDetectorID();
+  return m_minDetId;
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Returns the maximum detector id
+ * @return maximum detector id
+ */
+detid_t PixelAssembly::maxDetectorID() const {
+  if (isParametrized())
+    return m_gridBase->maxDetectorID();
+  return m_maxDetId;
+}
+
+//-------------------------------------------------------------------------------------------------
+/// @copydoc Mantid::Geometry::CompAssembly::getComponentByName
+std::shared_ptr<const IComponent> PixelAssembly::getComponentByName(const std::string &cname, int nlevels) const {
+  // exact matches
+  if (cname == this->getName())
+    return std::shared_ptr<const IComponent>(this);
+
+  // cache the detector's name as all the other names are longer
+  // The extra ( is because all children of this have that as the next character
+  // and this prevents Bank11 matching Bank 1
+  const std::string MEMBER_NAME = this->getName() + "(";
+
+  // check that the searched for name starts with the detector's
+  // name as they are generated
+  if (cname.substr(0, MEMBER_NAME.length()) != MEMBER_NAME) {
+    return std::shared_ptr<const IComponent>();
+  } else {
+    return CompAssembly::getComponentByName(cname, nlevels);
+  }
+}
+
+//------------------------------------------------------------------------------------------------
+/** Test the intersection of the ray with the children of the component
+ *assembly, for InstrumentRayTracer.
+ * Uses the knowledge of the PixelAssembly shape to significantly speed up
+ *tracking.
+ *
+ * @param testRay :: Track under test. The results are stored here.
+ * @param searchQueue :: If a child is a sub-assembly then it is appended for
+ *later searching. Unused.
+ */
+void PixelAssembly::testIntersectionWithChildren(Track &testRay,
+                                                 std::deque<IComponent_const_sptr> & /*searchQueue*/) const {
+  /// Base point (x,y,z) = position of pixel 0,0
+  V3D const basePoint = getRelativePosAtXYZ(0, 0, 0);
+
+  /// Vertical (y-axis) basis vector of the detector
+  V3D const vertical = getRelativePosAtXYZ(0, ypixels() - 1, 0) - basePoint;
+
+  /// Horizontal (x-axis) basis vector of the detector
+  V3D horizontal = getRelativePosAtXYZ(xpixels() - 1, 0, 0) - basePoint;
+
+  // The beam direction
+  V3D const beam = testRay.direction() * (-1.0);
+
+  // From: http://en.wikipedia.org/wiki/Line-plane_intersection (taken on May 4,
+  // 2011),
+  // We build a matrix to solve the linear equation:
+  Matrix<double> mat(3, 3);
+  mat.setColumn(0, beam);
+  mat.setColumn(1, horizontal);
+  mat.setColumn(2, vertical);
+  mat.Invert();
+
+  // Multiply by the inverted matrix to find t,u,v
+  V3D const tuv = mat * (testRay.startPoint() - basePoint);
+  //  std::cout << tuv << "\n";
+
+  // Intersection point
+  V3D const intersec = beam * (tuv[0] * -1.0);
+
+  // t = coordinate along the line
+  // u,v = coordinates along horizontal, vertical
+  // (and correct for it being between 0, xpixels-1).  The +0.5 is because the
+  // base point is at the CENTER of pixel 0,0.
+  double u = (double(xpixels() - 1) * tuv[1] + 0.5);
+  double v = (double(ypixels() - 1) * tuv[2] + 0.5);
+
+  //  std::cout << u << ", " << v << "\n";
+
+  // In indices
+  auto xIndex = int(u);
+  auto yIndex = int(v);
+
+  // Out of range?
+  if (xIndex < 0)
+    return;
+  if (yIndex < 0)
+    return;
+  if (xIndex >= xpixels())
+    return;
+  if (yIndex >= ypixels())
+    return;
+
+  // TODO: Do I need to put something smart here for the first 3 parameters?
+  auto comp = getAtXYZ(xIndex, yIndex, 0);
+  testRay.addLink(intersec, intersec, 0.0, *(comp->shape()), comp->getComponentID());
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+// ------------ IObjComponent methods ----------------
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------
+/// Does the point given lie within this object component?
+bool PixelAssembly::isValid(const V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::isValid() is not implemented.");
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Does the point given lie on the surface of this object component?
+bool PixelAssembly::isOnSide(const V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::isOnSide() is not implemented.");
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Checks whether the track given will pass through this Component.
+int PixelAssembly::interceptSurface(Track & /*track*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::interceptSurface() is not implemented.");
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Finds the approximate solid angle covered by the component when viewed from
+/// the point given
+double PixelAssembly::solidAngle(const Geometry::SolidAngleParams & /*params*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::solidAngle() is not implemented.");
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Try to find a point that lies within (or on) the object
+int PixelAssembly::getPointInObject(V3D & /*point*/) const {
+  throw Kernel::Exception::NotImplementedError("PixelAssembly::getPointInObject() is not implemented.");
+}
+
+//-------------------------------------------------------------------------------------------------
+/**
+ * Get the bounding box and store it in the given object. This is cached after
+ * the first call.
+ * @param assemblyBox :: A BoundingBox object that will be overwritten
+ */
+void PixelAssembly::getBoundingBox(BoundingBox &assemblyBox) const {
+  if (isParametrized()) {
+    if (hasComponentInfo()) {
+      assemblyBox = m_map->componentInfo().boundingBox(index(), &assemblyBox);
+      return;
+    }
+  }
+  BoundingBox bb;
+  BoundingBox compBox;
+  getAtXYZ(0, 0, 0)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(this->xpixels() - 1, 0, 0)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, 0)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(0, this->ypixels() - 1, 0)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(0, 0, this->zpixels() - 1)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(this->xpixels() - 1, 0, this->zpixels() - 1)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
+  bb.grow(compBox);
+  getAtXYZ(0, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
+  bb.grow(compBox);
+
+  assemblyBox = bb;
+}
+
+/**
+ * Draws the objcomponent, If the handler is not set then this function does
+ * nothing.
+ */
+void PixelAssembly::draw() const {
+  if (Handle() == nullptr)
+    return;
+  Handle()->render();
+}
+
+/**
+ * Draws the Object
+ */
+void PixelAssembly::drawObject() const { draw(); }
+
+/**
+ * Initializes the ObjComponent for rendering, this function should be called
+ * before rendering.
+ */
+void PixelAssembly::initDraw() const {
+  if (Handle() == nullptr)
+    return;
+  Handle()->initialize();
+}
+
+//-------------------------------------------------------------------------------------------------
+/// Returns the shape of the Object
+const std::shared_ptr<const IObject> PixelAssembly::shape() const {
+  // --- Create a cuboid shape for your pixels ----
+  double szX = xpixels();
+  double szY = ypixels();
+  double szZ = zpixels() == 0 ? 0.5 : zpixels();
+  std::ostringstream xmlShapeStream;
+  xmlShapeStream << " <cuboid id=\"detector-shape\"> "
+                 << "<left-front-bottom-point x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
+                 << "<left-front-top-point  x=\"" << szX << "\" y=\"" << -szY << "\" z=\"" << szZ << "\"  /> "
+                 << "<left-back-bottom-point  x=\"" << -szX << "\" y=\"" << -szY << "\" z=\"" << -szZ << "\"  /> "
+                 << "<right-front-bottom-point  x=\"" << szX << "\" y=\"" << szY << "\" z=\"" << -szZ << "\"  /> "
+                 << "</cuboid>";
+
+  std::string xmlCuboidShape(xmlShapeStream.str());
+  Geometry::ShapeFactory shapeCreator;
+  std::shared_ptr<Geometry::IObject> cuboidShape = shapeCreator.createShape(xmlCuboidShape);
+
+  return cuboidShape;
+}
+
+const Kernel::Material PixelAssembly::material() const { return Kernel::Material(); }
+
+size_t PixelAssembly::registerContents(ComponentVisitor &componentVisitor) const {
+  return componentVisitor.registerGridBank(*this);
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+// ------------ END OF IObjComponent methods ----------------
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+
+/** Print information about elements in the assembly to a stream
+ *  Overload the operator <<
+ * @param os :: output stream
+ * @param ass :: component assembly
+ * @return stream representation of grid detector
+ *
+ *  Loops through all components in the assembly
+ *  and call printSelf(os).
+ *  Also output the number of children
+ */
+std::ostream &operator<<(std::ostream &os, const PixelAssembly &assm) {
+  ass.printSelf(os);
+  os << "************************\n";
+  os << "Number of children :" << assm.nelements() << '\n';
+  ass.printChildren(os);
+  return os;
+}
+
+} // namespace Mantid::Geometry

--- a/Framework/Geometry/test/GridDetectorTest.h
+++ b/Framework/Geometry/test/GridDetectorTest.h
@@ -214,6 +214,10 @@ private:
     TS_ASSERT(!det.inBoundsXYZ(0, -1, 0));
     TS_ASSERT(!det.inBoundsXYZ(100, 0, 0));
     TS_ASSERT(!det.inBoundsXYZ(0, 205, 0));
+    TS_ASSERT_THROWS(det.getDetectorIDAtXYZ(-1, 0, 0), const std::runtime_error &);
+    TS_ASSERT_THROWS(det.getDetectorIDAtXYZ(0, -1, 0), const std::runtime_error &);
+    TS_ASSERT_THROWS(det.getDetectorIDAtXYZ(100, 0, 0), const std::runtime_error &);
+    TS_ASSERT_THROWS(det.getDetectorIDAtXYZ(0, 205, 0), const std::runtime_error &);
   }
 
   void do_test_ids(const GridDetector &det) {

--- a/Framework/Geometry/test/IVirtualBankTest.h
+++ b/Framework/Geometry/test/IVirtualBankTest.h
@@ -1,0 +1,202 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidGeometry/Instrument/IVirtualBank.h"
+#include <cxxtest/TestSuite.h>
+#include <stdexcept>
+
+using namespace Mantid;
+using namespace Mantid::Geometry;
+
+namespace {
+
+/**
+ * Minimal concrete subclass used to exercise the IVirtualBank base-class
+ * methods.  The grid is x-major (X varies fastest), then Y, then Z, which
+ * corresponds to idFillOrder = {'x','y','z'}.
+ */
+class TestBank : public IVirtualBank {
+public:
+  TestBank(size_t nx, size_t ny, size_t nz, double xstrt, double ystrt, double zstrt, double dxstep, double dystep,
+           double dzstep, detid_t idstart, std::array<char, 3> fillOrder, int step)
+      : m_nx(nx), m_ny(ny), m_nz(nz), m_xstart(xstrt), m_ystart(ystrt), m_zstart(zstrt), m_xstep(dxstep),
+        m_ystep(dystep), m_zstep(dzstep), m_idstart(idstart), m_fillOrder(fillOrder), m_idstep(step) {}
+
+  size_t xpixels() const override { return m_nx; }
+  size_t ypixels() const override { return m_ny; }
+  size_t zpixels() const override { return m_nz; }
+  double xstep() const override { return m_xstep; }
+  double ystep() const override { return m_ystep; }
+  double zstep() const override { return m_zstep; }
+  double xstart() const override { return m_xstart; }
+  double ystart() const override { return m_ystart; }
+  double zstart() const override { return m_zstart; }
+  detid_t referentDetectorID() const override { return m_idstart; }
+  std::array<char, 3> idFillOrder() const override { return m_fillOrder; }
+  int idstep() const override { return m_idstep; }
+  std::shared_ptr<Detector> referentDetector() const override { return nullptr; }
+
+private:
+  size_t m_nx, m_ny, m_nz;
+  double m_xstart, m_ystart, m_zstart;
+  double m_xstep, m_ystep, m_zstep;
+  detid_t m_idstart;
+  std::array<char, 3> m_fillOrder;
+  int m_idstep;
+};
+
+} // anonymous namespace
+
+class IVirtualBankTest : public CxxTest::TestSuite {
+public:
+  // ---- helpers -------------------------------------------------------------
+  /// Build a 4 × 5 × 3 bank with fill order X-fastest.
+  static TestBank makeXYZ() {
+    // 4 cols, 5 rows, 3 layers; step = 1 everywhere; IDs start at 1000.
+    return TestBank(4, 5, 3,           // nx, ny, nz
+                    -2.0, -2.5, 0.0,   // xstart, ystart, zstart
+                    1.0, 1.0, 1.0,     // xstep, ystep, zstep
+                    1000,              // idstart
+                    {'x', 'y', 'z'}, 1 // fill order, idstep
+    );
+  }
+
+  /// Build a 4 × 5 × 1 bank with fill order Y-fastest (like the old
+  /// GridDetector idfillbyfirst_y = true convention).
+  static TestBank makeYXZ() {
+    return TestBank(4, 5, 1,           // nx, ny, nz
+                    0.0, 0.0, 0.0,     // xstart, ystart, zstart
+                    1.0, 1.0, 0.0,     // xstep, ystep, zstep
+                    0,                 // idstart
+                    {'y', 'x', 'z'}, 1 // fill order, idstep
+    );
+  }
+
+  // ---- npixels -------------------------------------------------------------
+  void testNpixels() {
+    auto b = makeXYZ();
+    TS_ASSERT_EQUALS(b.npixels(), 4u * 5u * 3u);
+  }
+
+  // ---- size accessors ------------------------------------------------------
+  void testSize() {
+    auto b = makeXYZ();
+    TS_ASSERT_DELTA(b.xsize(), 4.0, 1e-10);
+    TS_ASSERT_DELTA(b.ysize(), 5.0, 1e-10);
+    TS_ASSERT_DELTA(b.zsize(), 3.0, 1e-10);
+  }
+
+  // ---- inBoundsXYZ ---------------------------------------------------------
+  void testInBoundsXYZ() {
+    auto b = makeXYZ(); // 4×5×3
+    TS_ASSERT(b.inBoundsXYZ(0, 0, 0));
+    TS_ASSERT(b.inBoundsXYZ(3, 4, 2));
+    TS_ASSERT(!b.inBoundsXYZ(-1, 0, 0));
+    TS_ASSERT(!b.inBoundsXYZ(0, -1, 0));
+    TS_ASSERT(!b.inBoundsXYZ(0, 0, -1));
+    TS_ASSERT(!b.inBoundsXYZ(4, 0, 0)); // == xpixels(), out of range
+    TS_ASSERT(!b.inBoundsXYZ(0, 5, 0)); // == ypixels()
+    TS_ASSERT(!b.inBoundsXYZ(0, 0, 3)); // == zpixels()
+  }
+
+  // ---- minDetectorID / maxDetectorID ---------------------------------------
+  void testIDRange() {
+    auto b = makeXYZ(); // 4×5×3, idstart=1000, fill {'x','y','z'}, step 1
+    TS_ASSERT_EQUALS(b.minDetectorID(), 1000);
+    // max is at (3, 4, 2): offset = 3*1 + 4*4 + 2*(4*5) = 3 + 16 + 40 = 59
+    TS_ASSERT_EQUALS(b.maxDetectorID(), 1059);
+  }
+
+  // ---- getDetectorIDAtXYZ: X-fastest fill order ----------------------------
+  void testGetIDAtXYZ_XFastest() {
+    auto b = makeXYZ(); // idstart=1000, fill={'x','y','z'}, step=1, nx=4, ny=5
+    // Referent
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 0, 0), 1000);
+    // Move one step in X (fastest axis)
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(1, 0, 0), 1001);
+    // Move one step in Y (middle axis): stride = nx = 4
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 1, 0), 1004);
+    // Move one step in Z (slowest axis): stride = nx*ny = 20
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 0, 1), 1020);
+    // Combined
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(2, 3, 1), 1000 + 2 + 3 * 4 + 1 * 20);
+  }
+
+  // ---- getDetectorIDAtXYZ: Y-fastest fill order ----------------------------
+  void testGetIDAtXYZ_YFastest() {
+    auto b = makeYXZ(); // idstart=0, fill={'y','x','z'}, step=1, nx=4, ny=5, nz=1
+    // Referent
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 0, 0), 0);
+    // Move one step in Y (fastest): stride = 1
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 1, 0), 1);
+    // Move one step in X (middle): stride = ny = 5
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(1, 0, 0), 5);
+    // Combined
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(2, 3, 0), 2 * 5 + 3);
+  }
+
+  // ---- roundtrip: getXYZForDetectorID / getDetectorIDAtXYZ ----------------
+  void testRoundtripXFastest() {
+    auto b = makeXYZ();
+    // Check every pixel
+    for (int z = 0; z < 3; ++z) {
+      for (int y = 0; y < 5; ++y) {
+        for (int x = 0; x < 4; ++x) {
+          detid_t id = b.getDetectorIDAtXYZ(x, y, z);
+          auto [rx, ry, rz] = b.getXYZForDetectorID(id);
+          TS_ASSERT_EQUALS(rx, x);
+          TS_ASSERT_EQUALS(ry, y);
+          TS_ASSERT_EQUALS(rz, z);
+        }
+      }
+    }
+  }
+
+  void testRoundtripYFastest() {
+    auto b = makeYXZ();
+    for (int x = 0; x < 4; ++x) {
+      for (int y = 0; y < 5; ++y) {
+        detid_t id = b.getDetectorIDAtXYZ(x, y, 0);
+        auto [rx, ry, rz] = b.getXYZForDetectorID(id);
+        TS_ASSERT_EQUALS(rx, x);
+        TS_ASSERT_EQUALS(ry, y);
+        TS_ASSERT_EQUALS(rz, 0);
+      }
+    }
+  }
+
+  // ---- getRelativePosAtXYZ ------------------------------------------------
+  void testRelativePos() {
+    auto b = makeXYZ(); // xstart=-2, ystart=-2.5, zstart=0; steps=1
+    Kernel::V3D pos = b.getRelativePosAtXYZ(0, 0, 0);
+    TS_ASSERT_DELTA(pos.X(), -2.0, 1e-10);
+    TS_ASSERT_DELTA(pos.Y(), -2.5, 1e-10);
+    TS_ASSERT_DELTA(pos.Z(), 0.0, 1e-10);
+
+    pos = b.getRelativePosAtXYZ(3, 4, 2);
+    TS_ASSERT_DELTA(pos.X(), -2.0 + 3.0, 1e-10);
+    TS_ASSERT_DELTA(pos.Y(), -2.5 + 4.0, 1e-10);
+    TS_ASSERT_DELTA(pos.Z(), 0.0 + 2.0, 1e-10);
+  }
+
+  // ---- idstep > 1 ---------------------------------------------------------
+  void testIdstepGreaterThanOne() {
+    // 3×3×1 grid, idstep=2, idstart=0, fill {'x','y','z'}
+    TestBank b(3, 3, 1, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0, {'x', 'y', 'z'}, 2);
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 0, 0), 0);
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(1, 0, 0), 2);  // step=2
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(0, 1, 0), 6);  // stride Y = 3*2=6
+    TS_ASSERT_EQUALS(b.getDetectorIDAtXYZ(2, 2, 0), 16); // 2*2 + 2*6 = 4+12
+    TS_ASSERT_EQUALS(b.maxDetectorID(), 16);
+
+    auto [rx, ry, rz] = b.getXYZForDetectorID(16);
+    TS_ASSERT_EQUALS(rx, 2);
+    TS_ASSERT_EQUALS(ry, 2);
+    TS_ASSERT_EQUALS(rz, 0);
+  }
+};

--- a/Framework/Geometry/test/PixelAssemblyTest.h
+++ b/Framework/Geometry/test/PixelAssemblyTest.h
@@ -1,0 +1,261 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidGeometry/Instrument/PixelAssembly.h"
+#include "MantidGeometry/Objects/BoundingBox.h"
+#include "MantidKernel/V3D.h"
+#include <cxxtest/TestSuite.h>
+#include <string>
+
+using namespace Mantid;
+using namespace Mantid::Geometry;
+using Mantid::Kernel::V3D;
+
+class PixelAssemblyTest : public CxxTest::TestSuite {
+public:
+  // ---- helpers -------------------------------------------------------------
+
+  /// Build a 4 × 5 × 3 assembly at the origin with X-fastest fill order.
+  static PixelAssembly *makeAssembly() {
+    auto *det = new PixelAssembly("MyBank");
+    det->setPos(0., 0., 0.);
+    det->initialize(ComponentCreationHelper::createCuboid(0.5), 4, -2.0, 1.0, // xpixels, xstart, xstep
+                    5, -2.5, 1.0,                                             // ypixels, ystart, ystep
+                    3, 0.0, 1.0,                                              // zpixels, zstart, zstep
+                    1000, "xyz", 1);
+    return det;
+  }
+
+  // ---- constructor / name --------------------------------------------------
+
+  void testDefaultConstructor() {
+    PixelAssembly pa("TestAssembly");
+    TS_ASSERT_EQUALS(pa.getName(), "TestAssembly");
+    TS_ASSERT(!pa.getParent());
+    TS_ASSERT_EQUALS(pa.type(), "PixelAssembly");
+  }
+
+  void testCompareName() {
+    TS_ASSERT(PixelAssembly::compareName("PixelAssembly"));
+    TS_ASSERT(PixelAssembly::compareName("pixelassembly"));
+    TS_ASSERT(PixelAssembly::compareName("pixel_assembly"));
+    TS_ASSERT(PixelAssembly::compareName("PIXEL_ASSEMBLY"));
+    TS_ASSERT(!PixelAssembly::compareName("GridDetector"));
+    TS_ASSERT(!PixelAssembly::compareName("Pixel"));
+  }
+
+  // ---- grid accessors ------------------------------------------------------
+
+  void testGridAccessors() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    TS_ASSERT_EQUALS(det->xpixels(), 4u);
+    TS_ASSERT_EQUALS(det->ypixels(), 5u);
+    TS_ASSERT_EQUALS(det->zpixels(), 3u);
+    TS_ASSERT_DELTA(det->xstart(), -2.0, 1e-10);
+    TS_ASSERT_DELTA(det->ystart(), -2.5, 1e-10);
+    TS_ASSERT_DELTA(det->zstart(), 0.0, 1e-10);
+    TS_ASSERT_DELTA(det->xstep(), 1.0, 1e-10);
+    TS_ASSERT_DELTA(det->ystep(), 1.0, 1e-10);
+    TS_ASSERT_DELTA(det->zstep(), 1.0, 1e-10);
+    TS_ASSERT_DELTA(det->xsize(), 4.0, 1e-10);
+    TS_ASSERT_DELTA(det->ysize(), 5.0, 1e-10);
+    TS_ASSERT_DELTA(det->zsize(), 3.0, 1e-10);
+    TS_ASSERT_EQUALS(det->npixels(), 4u * 5u * 3u);
+  }
+
+  // ---- ID scheme -----------------------------------------------------------
+
+  void testIDScheme() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    TS_ASSERT_EQUALS(det->referentDetectorID(), 1000);
+    TS_ASSERT_EQUALS(det->idstep(), 1);
+    auto order = det->idFillOrder();
+    TS_ASSERT_EQUALS(order[0], 'x');
+    TS_ASSERT_EQUALS(order[1], 'y');
+    TS_ASSERT_EQUALS(order[2], 'z');
+  }
+
+  void testMinMaxDetectorID() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    // fill order xyz, step=1, nx=4, ny=5, nz=3
+    // min = 1000 (referent)
+    // max at (3,4,2) = 1000 + 3 + 4*4 + 2*20 = 1000+3+16+40 = 1059
+    TS_ASSERT_EQUALS(det->minDetectorID(), 1000);
+    TS_ASSERT_EQUALS(det->maxDetectorID(), 1059);
+  }
+
+  void testGetDetectorIDAtXYZ() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXYZ(0, 0, 0), 1000);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXYZ(1, 0, 0), 1001); // X step=1
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXYZ(0, 1, 0), 1004); // Y stride=nx=4
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXYZ(0, 0, 1), 1020); // Z stride=nx*ny=20
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXYZ(2, 3, 1), 1000 + 2 + 3 * 4 + 1 * 20);
+  }
+
+  void testGetXYZForDetectorID() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    auto [x, y, z] = det->getXYZForDetectorID(1000);
+    TS_ASSERT_EQUALS(x, 0);
+    TS_ASSERT_EQUALS(y, 0);
+    TS_ASSERT_EQUALS(z, 0);
+
+    auto [x2, y2, z2] = det->getXYZForDetectorID(1059);
+    TS_ASSERT_EQUALS(x2, 3);
+    TS_ASSERT_EQUALS(y2, 4);
+    TS_ASSERT_EQUALS(z2, 2);
+  }
+
+  // ---- bounds check --------------------------------------------------------
+
+  void testInBoundsXYZ() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly()); // 4×5×3
+    TS_ASSERT(det->inBoundsXYZ(0, 0, 0));
+    TS_ASSERT(det->inBoundsXYZ(3, 4, 2));
+    TS_ASSERT(!det->inBoundsXYZ(-1, 0, 0));
+    TS_ASSERT(!det->inBoundsXYZ(4, 0, 0)); // == xpixels
+    TS_ASSERT(!det->inBoundsXYZ(0, 5, 0)); // == ypixels
+    TS_ASSERT(!det->inBoundsXYZ(0, 0, 3)); // == zpixels
+  }
+
+  // ---- position helpers ----------------------------------------------------
+
+  void testGetRelativePosAtXYZ() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    V3D pos = det->getRelativePosAtXYZ(0, 0, 0);
+    TS_ASSERT_DELTA(pos.X(), -2.0, 1e-10);
+    TS_ASSERT_DELTA(pos.Y(), -2.5, 1e-10);
+    TS_ASSERT_DELTA(pos.Z(), 0.0, 1e-10);
+
+    V3D pos2 = det->getRelativePosAtXYZ(3, 4, 2);
+    TS_ASSERT_DELTA(pos2.X(), -2.0 + 3.0, 1e-10);
+    TS_ASSERT_DELTA(pos2.Y(), -2.5 + 4.0, 1e-10);
+    TS_ASSERT_DELTA(pos2.Z(), 0.0 + 2.0, 1e-10);
+  }
+
+  void testGetPosAtXYZ() {
+    auto *det = makeAssembly();
+    det->setPos(10., 20., 30.);
+    std::unique_ptr<PixelAssembly> u(det);
+
+    // Bank at (10,20,30), referent at local (-2,-2.5,0) → world (8, 17.5, 30)
+    V3D pos = det->getPosAtXYZ(0, 0, 0);
+    TS_ASSERT_DELTA(pos.X(), 10. - 2., 1e-10);
+    TS_ASSERT_DELTA(pos.Y(), 20. - 2.5, 1e-10);
+    TS_ASSERT_DELTA(pos.Z(), 30., 1e-10);
+
+    // Pixel (3,4,2): local (1, 1.5, 2) → world (11, 21.5, 32)
+    V3D pos2 = det->getPosAtXYZ(3, 4, 2);
+    TS_ASSERT_DELTA(pos2.X(), 10. + 1., 1e-10);
+    TS_ASSERT_DELTA(pos2.Y(), 20. + 1.5, 1e-10);
+    TS_ASSERT_DELTA(pos2.Z(), 30. + 2., 1e-10);
+  }
+
+  // ---- flat bank (zpixels = 0 normalised to 1) ----------------------------
+
+  void testFlatBank() {
+    auto *det = new PixelAssembly("FlatBank");
+    det->setPos(0., 0., 0.);
+    // Pass zpixels=0 → should be normalised to 1.
+    det->initialize(ComponentCreationHelper::createCuboid(0.5), 3, 0.0, 1.0, // xpixels=3
+                    4, 0.0, 1.0,                                             // ypixels=4
+                    0, 0.0, 0.0,                                             // zpixels=0 → flat
+                    0, "xyz", 1);
+    std::unique_ptr<PixelAssembly> u(det);
+    TS_ASSERT_EQUALS(det->zpixels(), 1u); // normalised
+    TS_ASSERT_EQUALS(det->npixels(), 3u * 4u * 1u);
+  }
+
+  // ---- parametrized version -----------------------------------------------
+
+  void testParametrizedScaling() {
+    auto *det = makeAssembly();
+    std::unique_ptr<PixelAssembly> u(det);
+    ParameterMap_sptr pmap(new ParameterMap());
+    PixelAssembly parDet(det, pmap.get());
+
+    pmap->addDouble(det, "scalex", 2.0);
+    pmap->addDouble(det, "scaley", 3.0);
+    pmap->addDouble(det, "scalez", 4.0);
+
+    TS_ASSERT_DELTA(parDet.xstep(), 2.0, 1e-10);
+    TS_ASSERT_DELTA(parDet.ystep(), 3.0, 1e-10);
+    TS_ASSERT_DELTA(parDet.zstep(), 4.0, 1e-10);
+    TS_ASSERT_DELTA(parDet.xstart(), -4.0, 1e-10); // -2.0 * 2.0
+    TS_ASSERT_DELTA(parDet.ystart(), -7.5, 1e-10); // -2.5 * 3.0
+    TS_ASSERT_DELTA(parDet.zstart(), 0.0, 1e-10);
+    TS_ASSERT_DELTA(parDet.xsize(), 8.0, 1e-10);  // 4 * 2.0
+    TS_ASSERT_DELTA(parDet.ysize(), 15.0, 1e-10); // 5 * 3.0
+    TS_ASSERT_DELTA(parDet.zsize(), 12.0, 1e-10); // 3 * 4.0
+
+    // Pixel counts are unchanged by scale factors.
+    TS_ASSERT_EQUALS(parDet.xpixels(), 4u);
+    TS_ASSERT_EQUALS(parDet.ypixels(), 5u);
+    TS_ASSERT_EQUALS(parDet.zpixels(), 3u);
+
+    // ID scheme unchanged.
+    TS_ASSERT_EQUALS(parDet.referentDetectorID(), 1000);
+  }
+
+  // ---- bounding box --------------------------------------------------------
+
+  void testBoundingBoxAtXYZ() {
+    auto *det = makeAssembly(); // 4×5×3, 1×1×1 steps, cuboid 0.5 half-size
+    det->setPos(0., 0., 0.);
+    std::unique_ptr<PixelAssembly> u(det);
+
+    BoundingBox box;
+    det->getBoundingBoxAtXYZ(0, 0, 0, box);
+    // Referent pixel at local (-2, -2.5, 0); cuboid half-size 0.5
+    TS_ASSERT_DELTA(box.xMin(), -2.5, 1e-8);
+    TS_ASSERT_DELTA(box.xMax(), -1.5, 1e-8);
+    TS_ASSERT_DELTA(box.yMin(), -3.0, 1e-8);
+    TS_ASSERT_DELTA(box.yMax(), -2.0, 1e-8);
+    TS_ASSERT_DELTA(box.zMin(), -0.5, 1e-8);
+    TS_ASSERT_DELTA(box.zMax(), 0.5, 1e-8);
+  }
+
+  void testGetBoundingBox() {
+    auto *det = makeAssembly(); // bank at origin, 4×5×3 pixels, step=1
+    det->setPos(0., 0., 0.);
+    std::unique_ptr<PixelAssembly> u(det);
+
+    BoundingBox box;
+    det->getBoundingBox(box);
+    // x: first pixel at -2 ± 0.5 → xMin=-2.5; last at (-2+3*1)=1 ± 0.5 → xMax=1.5
+    TS_ASSERT_DELTA(box.xMin(), -2.5, 1e-8);
+    TS_ASSERT_DELTA(box.xMax(), 1.5, 1e-8);
+    // y: first at -2.5 → yMin=-3.0; last at (-2.5+4*1)=1.5 → yMax=2.0
+    TS_ASSERT_DELTA(box.yMin(), -3.0, 1e-8);
+    TS_ASSERT_DELTA(box.yMax(), 2.0, 1e-8);
+    // z: first at 0 → zMin=-0.5; last at (0+2*1)=2 → zMax=2.5
+    TS_ASSERT_DELTA(box.zMin(), -0.5, 1e-8);
+    TS_ASSERT_DELTA(box.zMax(), 2.5, 1e-8);
+  }
+
+  // ---- no children ---------------------------------------------------------
+
+  void testNoChildrenExist() {
+    // PixelAssembly must not inherit from ICompAssembly — verify it has no
+    // children by confirming the cast fails.
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    ICompAssembly const *asAssembly = dynamic_cast<ICompAssembly const *>(det.get());
+    TS_ASSERT_EQUALS(asAssembly, nullptr);
+  }
+
+  // ---- pixelShape ----------------------------------------------------------
+
+  void testPixelShape() {
+    auto det = std::unique_ptr<PixelAssembly>(makeAssembly());
+    auto ps = det->pixelShape();
+    TS_ASSERT(ps);
+    TS_ASSERT(ps->hasValidShape());
+  }
+};

--- a/Framework/Geometry/test/StructuredDetectorTest.h
+++ b/Framework/Geometry/test/StructuredDetectorTest.h
@@ -212,6 +212,9 @@ public:
     TS_ASSERT_EQUALS(det->getAtXY(0, 0)->getID(), 0);
     TS_ASSERT_EQUALS(det->getAtXY(0, 1)->getID(), 1);
     TS_ASSERT_EQUALS(det->getAtXY(1, 1)->getID(), 3);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0), 0);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 1), 1);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(1, 1), 3);
 
     std::pair<size_t, size_t> xy;
     size_t x;

--- a/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(TEST_PY_FILES
     BoundingBoxTest.py
     CSGObjectTest.py
+    MemoryCheckTest.py
+    PixelAssemblyTest.py
     GoniometerTest.py
     IComponentTest.py
     IPeakTest.py

--- a/Framework/PythonInterface/test/python/mantid/geometry/MemoryCheckTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/MemoryCheckTest.py
@@ -1,0 +1,32 @@
+"""Memory comparison between PA and RD instruments."""
+
+import unittest
+from mantid.simpleapi import LoadEmptyInstrument
+
+
+class MemoryCheckTest(unittest.TestCase):
+    def test_memory_comparison(self):
+        ws_rd = LoadEmptyInstrument(Filename="SNAP_mini_RD_Definition.xml", OutputWorkspace="rd_mem")
+        ws_pa = LoadEmptyInstrument(Filename="SNAP_mini_Definition.xml", OutputWorkspace="pa_mem")
+
+        inst_rd = ws_rd.getInstrument()
+        inst_pa = ws_pa.getInstrument()
+
+        mem_rd = inst_rd.getMemorySize()
+        mem_pa = inst_pa.getMemorySize()
+
+        ci_rd = ws_rd.componentInfo()
+        ci_pa = ws_pa.componentInfo()
+
+        print(f"\nRD instrument memory: {mem_rd:>10,} bytes  ({mem_rd / 1024:.1f} kB)")
+        print(f"PA instrument memory: {mem_pa:>10,} bytes  ({mem_pa / 1024:.1f} kB)")
+        print(f"Reduction:            {mem_rd - mem_pa:>10,} bytes saved  ({100 * (mem_rd - mem_pa) / mem_rd:.1f}% smaller)")
+        print(f"\nRD component tree: {ci_rd.size()} components")
+        print(f"PA component tree: {ci_pa.size()} components")
+        print(f"Component reduction: {ci_rd.size() - ci_pa.size()} fewer components")
+
+        self.assertGreater(mem_rd, mem_pa, "PA instrument should use less memory than RD")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/geometry/PixelAssemblyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/PixelAssemblyTest.py
@@ -242,5 +242,94 @@ class PixelAssemblyVsRectangularDetectorTest(unittest.TestCase):
         )
 
 
+class PixelAssemblyIndexOfTest(unittest.TestCase):
+    """
+    Validate DetectorInfo.indexOf() for virtual (PixelAssembly) pixel IDs.
+
+    Phase 4a compacted the detId→index map so it no longer stores entries for
+    virtual pixels.  DetectorInfo.indexOf() now computes the index analytically
+    from the VirtualBankSegment formula.  These tests verify that the returned
+    index is correct by cross-checking against the index derived from iterating
+    detectorIDs() (the ground-truth ordering).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _load_once()
+        cls.di_pa = _PA_WS.detectorInfo()
+        # Build ground-truth ID→index map by iterating the ordered ID vector.
+        # This path does NOT go through indexOf(), so it is independent of it.
+        cls.gt_id_to_idx = {int(cls.di_pa.detectorIDs()[i]): i for i in range(cls.di_pa.size())}
+
+    def _check_indexOf(self, det_id):
+        """indexOf(id) must return the same index as the ground-truth iteration map."""
+        expected = self.gt_id_to_idx[det_id]
+        got = self.di_pa.indexOf(det_id)
+        self.assertEqual(
+            got,
+            expected,
+            msg=f"indexOf({det_id}): expected index {expected}, got {got}",
+        )
+
+    def _check_position_via_indexOf(self, det_id, di_rd):
+        """Position looked up via indexOf(id) must match the RD ground truth."""
+        idx_pa = self.di_pa.indexOf(det_id)
+        idx_rd = di_rd.indexOf(det_id)
+        pos_pa = self.di_pa.position(idx_pa)
+        pos_rd = di_rd.position(idx_rd)
+        for axis, vpa, vrd in zip("XYZ", pos_pa, pos_rd):
+            self.assertAlmostEqual(
+                vpa,
+                vrd,
+                delta=1e-9,
+                msg=f"indexOf({det_id}) → position {axis} mismatch (PA={vpa:.9f}, RD={vrd:.9f})",
+            )
+
+    # ---- index correctness for a representative sample ----------------------
+
+    def test_indexOf_first_pixel_bank11(self):
+        """bank11 idstart=0: indexOf(0) must give the index for ID 0."""
+        self._check_indexOf(0)
+
+    def test_indexOf_mid_pixel_bank11(self):
+        """bank11: a pixel in the middle of the bank."""
+        self._check_indexOf(255)  # last pixel of first row (ix=0, iy=255)
+
+    def test_indexOf_second_row_bank11(self):
+        """bank11: first pixel of second row (ix=1, iy=0)."""
+        self._check_indexOf(256)
+
+    def test_indexOf_last_pixel_bank11(self):
+        """bank11: last pixel (ix=255, iy=255) = ID 65535."""
+        self._check_indexOf(65535)
+
+    def test_indexOf_first_pixel_bank12(self):
+        """bank12 idstart=65536: first pixel must map correctly."""
+        self._check_indexOf(65536)
+
+    def test_indexOf_last_pixel_all_banks(self):
+        """Last pixel of each bank: ID = idstart + 65535."""
+        for bank_idx in range(18):
+            det_id = bank_idx * 65536 + 65535
+            with self.subTest(bank=bank_idx, det_id=det_id):
+                self._check_indexOf(det_id)
+
+    def test_indexOf_sampled_positions_match_rd(self):
+        """Positions fetched via indexOf() match the RD ground truth for a sample."""
+        di_rd = _RD_WS.detectorInfo()
+        # Sample every 10 000th pixel ID (118 pixels across all 18 banks).
+        for det_id in range(0, _N_PIXELS, 10_000):
+            with self.subTest(det_id=det_id):
+                self._check_position_via_indexOf(det_id, di_rd)
+
+    def test_indexOf_monitor_ids_still_work(self):
+        """Real detectors (monitors) must still resolve via the compact map."""
+        di = self.di_pa
+        for i in range(di.size()):
+            if di.isMonitor(i):
+                det_id = int(di.detectorIDs()[i])
+                self.assertEqual(di.indexOf(det_id), i, msg=f"monitor ID {det_id}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/geometry/PixelAssemblyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/PixelAssemblyTest.py
@@ -1,0 +1,246 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+Verify that loading SNAP_mini_Definition.xml (pixel_assembly banks) produces
+detector geometry that is identical to loading SNAP_mini_RD_Definition.xml
+(equivalent instrument built with rectangular_detector banks).
+
+The rectangular_detector version is the ground truth: it uses the existing,
+well-tested code path.  The pixel_assembly version exercises the new
+PixelAssembly / IVirtualBank path.
+
+Expected instrument layout (both files)
+----------------------------------------
+  2 panels x 3 columns x 3 banks = 18 banks
+  Each bank: 256x256 pixels, Y-fastest fill order
+  Total pixels: 1 179 648  (IDs 0 – 1 179 647, stride 65536 per bank)
+  Monitors: IDs -1, -2 (included in detectorInfo; di.size() == 1 179 650)
+"""
+
+import unittest
+from mantid.simpleapi import LoadEmptyInstrument
+
+_N_PIXELS = 18 * 256 * 256  # 1 179 648
+_N_TOTAL = _N_PIXELS + 2  # + 2 monitors
+
+# --------------------------------------------------------------------------- #
+#  Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+_RD_WS = None  # rectangular_detector reference  (loaded once)
+_PA_WS = None  # pixel_assembly under test        (loaded once)
+
+
+def _load_once():
+    global _RD_WS, _PA_WS
+    if _RD_WS is None:
+        _RD_WS = LoadEmptyInstrument(
+            Filename="SNAP_mini_RD_Definition.xml",
+            OutputWorkspace="__snap_mini_rd",
+        )
+    if _PA_WS is None:
+        _PA_WS = LoadEmptyInstrument(
+            Filename="SNAP_mini_Definition.xml",
+            OutputWorkspace="__snap_mini_pa",
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Tests that exercise the rectangular_detector reference on its own           #
+#  These pass today and document the expected geometry.                        #
+# --------------------------------------------------------------------------- #
+
+
+class SnapMiniRDGeometryTest(unittest.TestCase):
+    """Sanity-check the reference instrument (rectangular_detector)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _load_once()
+        cls.ws = _RD_WS
+        cls.di = cls.ws.detectorInfo()
+
+    def test_detector_count(self):
+        """18 banks x 65536 pixels + 2 monitors = 1 179 650 entries in detectorInfo."""
+        self.assertEqual(self.di.size(), _N_TOTAL)
+
+    def test_pixel_count(self):
+        """Exactly 1 179 648 non-monitor detectors (18 banks x 256x256)."""
+        n_pixels = sum(1 for i in range(self.di.size()) if not self.di.isMonitor(i))
+        self.assertEqual(n_pixels, _N_PIXELS)
+
+    def test_detector_ids_cover_expected_range(self):
+        """All pixel IDs 0 – 1 179 647 are present (monitors have negative IDs)."""
+        pixel_ids = sorted(int(self.di.detectorIDs()[i]) for i in range(self.di.size()) if not self.di.isMonitor(i))
+        self.assertEqual(len(pixel_ids), _N_PIXELS)
+        self.assertEqual(pixel_ids[0], 0)
+        self.assertEqual(pixel_ids[-1], _N_PIXELS - 1)
+
+    def test_all_pixel_l2_positive(self):
+        """Every pixel is on the same side of the sample (l2 > 0)."""
+        for i in range(self.di.size()):
+            if self.di.isMonitor(i):
+                continue
+            self.assertGreater(self.di.l2(i), 0.0, msg=f"detector index {i}")
+
+    def test_panel_distance_roughly_two_metres(self):
+        """Panels were placed at +/-2 m from origin; l2 should be near 2 m."""
+        l2_values = [self.di.l2(i) for i in range(self.di.size()) if not self.di.isMonitor(i)]
+        # With bank offsets up to ~0.24 m, l2 is between ~1.9 and ~2.2 m.
+        self.assertTrue(
+            all(1.5 < v < 2.5 for v in l2_values),
+            msg=f"l2 range [{min(l2_values):.3f}, {max(l2_values):.3f}]",
+        )
+
+    def test_bank11_pixel_ids(self):
+        """bank11 has idstart=0; first four Y-fastest pixels are IDs 0,1,2,3."""
+        ids = set(self.di.detectorIDs())
+        for expected in (0, 1, 2, 3):
+            self.assertIn(expected, ids)
+
+    def test_bank13_pixel_ids(self):
+        """bank13 has idstart=131072; first four pixels are 131072 – 131075."""
+        ids = set(self.di.detectorIDs())
+        for expected in (131072, 131073, 131074, 131075):
+            self.assertIn(expected, ids)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests that compare pixel_assembly against rectangular_detector              #
+#  These will FAIL until InstrumentDefinitionParser supports pixel_assembly.   #
+# --------------------------------------------------------------------------- #
+
+
+class PixelAssemblyVsRectangularDetectorTest(unittest.TestCase):
+    """
+    pixel_assembly (SNAP_mini_Definition.xml) must be geometrically identical
+    to rectangular_detector (SNAP_mini_RD_Definition.xml).
+    """
+
+    _ABS_TOL = 1e-9  # metres -- positions must agree to sub-nanometre
+    # Stride used to sample the full pixel population in position/l2/twoTheta
+    # checks — testing every pixel at 1.18M would be very slow.
+    _SAMPLE_STRIDE = 1000
+
+    @classmethod
+    def setUpClass(cls):
+        _load_once()
+        cls.di_rd = _RD_WS.detectorInfo()
+        cls.di_pa = _PA_WS.detectorInfo()
+
+        # Build ID -> index maps for NON-MONITOR detectors only, so we compare
+        # the same physical pixel regardless of storage order in each workspace.
+        cls.id_to_idx_rd = {int(cls.di_rd.detectorIDs()[i]): i for i in range(cls.di_rd.size()) if not cls.di_rd.isMonitor(i)}
+        cls.id_to_idx_pa = {int(cls.di_pa.detectorIDs()[i]): i for i in range(cls.di_pa.size()) if not cls.di_pa.isMonitor(i)}
+        # Sorted pixel IDs used for sampled iteration
+        cls.sorted_ids = sorted(cls.id_to_idx_rd)
+
+    # -- basic counts ----------------------------------------------------------
+
+    def test_same_detector_count(self):
+        """Both instruments report the same total number of entries."""
+        self.assertEqual(self.di_pa.size(), self.di_rd.size())
+
+    def test_same_pixel_count(self):
+        """Same number of non-monitor pixels."""
+        self.assertEqual(len(self.id_to_idx_pa), len(self.id_to_idx_rd))
+
+    def test_same_detector_ids(self):
+        """Same set of pixel detector IDs (monitors excluded): check count, min, max."""
+        ids_pa = sorted(self.id_to_idx_pa)
+        ids_rd = self.sorted_ids
+        self.assertEqual(len(ids_pa), len(ids_rd))
+        self.assertEqual(ids_pa[0], ids_rd[0])
+        self.assertEqual(ids_pa[-1], ids_rd[-1])
+
+    # -- per-detector geometry (sampled every _SAMPLE_STRIDE pixels) -----------
+
+    def _assert_positions_match(self, det_id):
+        idx_rd = self.id_to_idx_rd[det_id]
+        idx_pa = self.id_to_idx_pa[det_id]
+        pos_rd = self.di_rd.position(idx_rd)
+        pos_pa = self.di_pa.position(idx_pa)
+        for axis, vrd, vpa in zip("XYZ", pos_rd, pos_pa):
+            self.assertAlmostEqual(
+                vpa,
+                vrd,
+                delta=self._ABS_TOL,
+                msg=f"detector ID {det_id}: position {axis} mismatch (RD={vrd:.9f}, PA={vpa:.9f})",
+            )
+
+    def test_all_positions_match(self):
+        """Sampled pixel world positions must agree to within 1 nm."""
+        sample = self.sorted_ids[:: self._SAMPLE_STRIDE]
+        for det_id in sample:
+            with self.subTest(det_id=det_id):
+                self._assert_positions_match(det_id)
+
+    def test_all_l2_match(self):
+        """Sampled sample-to-detector distances must agree for every tested pixel."""
+        sample = self.sorted_ids[:: self._SAMPLE_STRIDE]
+        for det_id in sample:
+            idx_rd = self.id_to_idx_rd[det_id]
+            idx_pa = self.id_to_idx_pa[det_id]
+            l2_rd = self.di_rd.l2(idx_rd)
+            l2_pa = self.di_pa.l2(idx_pa)
+            with self.subTest(det_id=det_id):
+                self.assertAlmostEqual(
+                    l2_pa,
+                    l2_rd,
+                    delta=self._ABS_TOL,
+                    msg=f"detector ID {det_id}: l2 mismatch (RD={l2_rd:.9f}, PA={l2_pa:.9f})",
+                )
+
+    def test_all_two_theta_match(self):
+        """Sampled scattering angle 2-theta must agree for every tested pixel."""
+        sample = self.sorted_ids[:: self._SAMPLE_STRIDE]
+        for det_id in sample:
+            idx_rd = self.id_to_idx_rd[det_id]
+            idx_pa = self.id_to_idx_pa[det_id]
+            tt_rd = self.di_rd.twoTheta(idx_rd)
+            tt_pa = self.di_pa.twoTheta(idx_pa)
+            with self.subTest(det_id=det_id):
+                self.assertAlmostEqual(
+                    tt_pa,
+                    tt_rd,
+                    delta=1e-9,
+                    msg=f"detector ID {det_id}: twoTheta mismatch (RD={tt_rd:.9f}, PA={tt_pa:.9f})",
+                )
+
+    def test_bank11_referent_pixel_position(self):
+        """
+        bank11: idstart=0, West panel at x=-2, rotated +90-deg about Y.
+        Pixel (ix=0, iy=0) is at bank-local (-0.078795, -0.078795, 0).
+        After rotation (+90-deg Y): local (+z -> world +x, local +x -> world -z).
+        The pixel_assembly position must match the rectangular_detector ground truth.
+        """
+        self._assert_positions_match(0)
+
+    def test_bank63_referent_pixel_position(self):
+        """East panel bank63 (idstart=720896): first pixel must match RD."""
+        self._assert_positions_match(720896)
+
+    def test_pa_uses_less_memory_than_rd(self):
+        """pixel_assembly instrument must consume less memory than rectangular_detector."""
+        mem_rd = _RD_WS.getInstrument().getMemorySize()
+        mem_pa = _PA_WS.getInstrument().getMemorySize()
+        ci_rd = _RD_WS.componentInfo()
+        ci_pa = _PA_WS.componentInfo()
+        print(f"\nRD instrument memory: {mem_rd:>12,} bytes  ({mem_rd / 1024:.1f} kB)")
+        print(f"PA instrument memory: {mem_pa:>12,} bytes  ({mem_pa / 1024:.1f} kB)")
+        print(f"Reduction:            {mem_rd - mem_pa:>12,} bytes  ({100 * (mem_rd - mem_pa) / mem_rd:.1f}% smaller)")
+        print(f"RD component tree: {ci_rd.size()} components")
+        print(f"PA component tree: {ci_pa.size()} components")
+        self.assertGreater(
+            mem_rd,
+            mem_pa,
+            f"PA ({mem_pa} B) should use less memory than RD ({mem_rd} B)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Testing/SystemTests/tests/framework/SNAPPixelAssemblyTest.py
+++ b/Testing/SystemTests/tests/framework/SNAPPixelAssemblyTest.py
@@ -1,0 +1,87 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+System test: SNAP pixel_assembly IDF produces results identical to the
+rectangular_detector IDF when processing real SNAP event data.
+
+Workflow (mirroring the non-DetCal path in SNAPReduce):
+  1. Load SNAP run file.
+  2. Override embedded instrument with a known IDF via LoadInstrument.
+  3. Create bank grouping from the same IDF.
+  4. Focus with AlignAndFocusPowder.
+
+The pixel_assembly (PA) and rectangular_detector (RD) outputs are compared;
+they must be identical, proving PA is a transparent memory-saving replacement.
+"""
+
+import systemtesting
+from mantid.simpleapi import (
+    AlignAndFocusPowder,
+    CreateGroupingWorkspace,
+    Load,
+    LoadInstrument,
+)
+
+_RUN_FILE = "SNAP_45874.nxs.h5"
+_RD_IDF = "SNAP_Definition.xml"
+_PA_IDF = "SNAP_Definition_PA.xml"
+_BINNING = [0.5, -0.004, 7.0]
+_COMPRESS_TOL = 0.01
+
+
+def _load_and_override(run_file, idf_file, ws_out):
+    """Load a SNAP NeXus file and replace its embedded instrument."""
+    Load(Filename=run_file, OutputWorkspace=ws_out)
+    LoadInstrument(Workspace=ws_out, Filename=idf_file, RewriteSpectraMap=False)
+
+
+def _make_grouping(idf_file, grp_out):
+    """Create one group per bank from the given IDF."""
+    CreateGroupingWorkspace(
+        InstrumentFilename=idf_file,
+        GroupDetectorsBy="bank",
+        OutputWorkspace=grp_out,
+    )
+
+
+def _focus(raw_ws, grp_ws, focused_out):
+    AlignAndFocusPowder(
+        InputWorkspace=raw_ws,
+        OutputWorkspace=focused_out,
+        GroupingWorkspace=grp_ws,
+        Params=_BINNING,
+        CompressTolerance=_COMPRESS_TOL,
+    )
+
+
+class SNAPPixelAssemblyMatchesRD(systemtesting.MantidSystemTest):
+    """
+    SNAP_Definition_PA.xml (pixel_assembly) must produce a focused powder
+    pattern identical to SNAP_Definition.xml (rectangular_detector) for the
+    same SNAP event data.
+    """
+
+    def requiredFiles(self):
+        return [_RUN_FILE]
+
+    def runTest(self):
+        # Reference path: rectangular_detector IDF
+        _load_and_override(_RUN_FILE, _RD_IDF, "snap_rd_raw")
+        _make_grouping(_RD_IDF, "snap_rd_grp")
+        _focus("snap_rd_raw", "snap_rd_grp", "snap_rd_focused")
+
+        # PA path: pixel_assembly IDF
+        _load_and_override(_RUN_FILE, _PA_IDF, "snap_pa_raw")
+        _make_grouping(_PA_IDF, "snap_pa_grp")
+        _focus("snap_pa_raw", "snap_pa_grp", "snap_pa_focused")
+
+    def validateMethod(self):
+        return "ValidateWorkspaceToWorkspace"
+
+    def validate(self):
+        # PA output must exactly match RD output
+        return "snap_pa_focused", "snap_rd_focused"

--- a/instrument/IMAGINE_Definition_PA.xml
+++ b/instrument/IMAGINE_Definition_PA.xml
@@ -1,0 +1,1617 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- For help on the notation used to specify an Instrument Definition File
+     see http://www.mantidproject.org/IDF -->
+<!-- PixelAssembly version of IMAGINE_Definition.xml - replaces all
+     rectangular_detector panels with pixel_assembly panels for memory
+     footprint testing.  Geometry (positions, orientations, pixel sizes,
+     ID ranges) is identical to the rectangular_detector version. -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+            name="IMAGINE" valid-from   ="2025-10-01 00:00:00"
+                           valid-to     ="2100-01-31 23:59:59"
+		           last-modified="2025-10-02 00:00:01">
+  <!--DEFAULTS-->
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+      <theta-sign axis="x"/>
+    </reference-frame>
+    <default-view view="cylindrical_y"/>
+  </defaults>
+
+  <!--SOURCE-->
+  <component type="moderator">
+    <location z="-3.0"/>
+  </component>
+  <type name="moderator" is="Source"/>
+
+  <!--SAMPLE-->
+  <component type="sample-position">
+    <location y="0.0" x="0.0" z="0.0"/>
+  </component>
+  <type name="sample-position" is="SamplePos"/>
+
+  <!--MONITORS-->
+  <idlist idname="Downstream_monitor">
+    <id val="-2"/>
+  </idlist>
+  <component type="Downstream_monitor" idlist="Downstream_monitor">
+    <properties />
+    <location  />
+  </component>
+  <type is="monitor" name="Downstream_monitor">
+   <component type="monitor">
+    <location x="0.0" y="0.0" z="0.4" name="monitor2" />
+   </component>
+  </type>
+
+  <idlist idname="monitors">
+    <id val="-1"/>
+  </idlist>
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type is="monitor" name="monitors">
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="-4.0" name="monitor1"/>
+    </component>
+  </type>
+
+  <!--DETECTORS-->
+
+  <component type="bank11">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank11">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="0">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank12">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank12">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="262144">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank13">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank13">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="524288">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank14">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank14">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="786432">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank15">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank15">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="1048576">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank16">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank16">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="1310720">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank17">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank17">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="1572864">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank18">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank18">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="1835008">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-167.49840687691767"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="12.50159312308233"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank21">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank21">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="2097152">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank22">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank22">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="2359296">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank23">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank23">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="2621440">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank24">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank24">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="2883584">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank25">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank25">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="3145728">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank26">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank26">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="3407872">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank27">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank27">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="3670016">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank28">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank28">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="3932160">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-147.88523442069138"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="32.114765579308624"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank31">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank31">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="4194304">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank32">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank32">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="4456448">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank33">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank33">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="4718592">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank34">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank34">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="4980736">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank35">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank35">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="5242880">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank36">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank36">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="5505024">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank37">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank37">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="5767168">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank38">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank38">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="6029312">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-128.27376798421676"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="51.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank41">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank41">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="6291456">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank42">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank42">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="6553600">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank43">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank43">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="6815744">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank44">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank44">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="7077888">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank45">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank45">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="7340032">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank46">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank46">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="7602176">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank47">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank47">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="7864320">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank48">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank48">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="8126464">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-108.64749137038126"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="71.35250862961874"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank51">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank51">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="8388608">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank52">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank52">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="8650752">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank53">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank53">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="8912896">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank54">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank54">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="9175040">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank55">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank55">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="9437184">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank56">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank56">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="9699328">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank57">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank57">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="9961472">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank58">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank58">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="10223616">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="-89.03245179515432"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="90.96754820484568"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank61">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank61">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="10485760">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank62">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank62">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="10747904">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank63">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank63">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="11010048">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank64">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank64">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="11272192">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank65">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank65">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="11534336">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank66">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank66">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="11796480">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank67">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank67">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="12058624">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank68">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank68">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="12320768">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="12.501561102543636"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="192.50156110254363"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank71">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank71">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="12582912">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank72">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank72">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="12845056">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank73">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank73">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="13107200">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank74">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank74">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="13369344">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank75">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank75">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="13631488">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank76">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank76">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="13893632">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank77">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank77">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="14155776">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank78">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank78">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="14417920">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="32.11475168844916"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="212.11475168844916"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank81">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank81">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="14680064">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank82">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank82">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="14942208">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank83">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank83">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="15204352">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank84">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank84">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="15466496">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank85">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank85">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="15728640">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank86">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank86">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="15990784">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank87">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank87">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="16252928">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank88">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank88">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="16515072">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="51.72623201578324"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="231.72623201578324"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank91">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank91">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="16777216">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank92">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank92">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="17039360">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank93">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank93">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="17301504">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank94">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank94">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="17563648">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank95">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank95">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="17825792">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank96">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank96">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="18087936">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank97">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank97">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="18350080">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank98">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank98">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="18612224">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="71.35245618781975"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="251.35245618781977"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank101">
+    <location x="0" y="-0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank101">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="18874368">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank102">
+    <location x="0" y="-0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank102">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="19136512">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank103">
+    <location x="0" y="-0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank103">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="19398656">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank104">
+    <location x="0" y="-0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank104">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="19660800">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank105">
+    <location x="0" y="0.06095199999999994" z="0"/>
+  </component>
+  <type name="bank105">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="19922944">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank106">
+    <location x="0" y="0.1828559999999998" z="0"/>
+  </component>
+  <type name="bank106">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="20185088">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank107">
+    <location x="0" y="0.3047599999999997" z="0"/>
+  </component>
+  <type name="bank107">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="20447232">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+  <component type="bank108">
+    <location x="0" y="0.42666399999999954" z="0"/>
+  </component>
+  <type name="bank108">
+    <component type="panel" idfillorder="yxz" idstep="1" idstart="20709376">
+      <location>
+        <parameter name="r-position">
+          <value val="0.34939881768689485"/>
+        </parameter>
+        <parameter name="t-position">
+          <value val="90.96755097389406"/>
+        </parameter>
+        <parameter name="roty">
+          <value val="270.96755097389405"/>
+        </parameter>
+      </location>
+    </component>
+  </type>
+
+<!-- Pixel Assembly Panel (replaces rectangular_detector) -->
+  <type name="panel" is="pixel_assembly" type="pixel"
+      xpixels="512" xstart="-0.06095199999999994" xstep="0.00023809374999999975"
+      ypixels="512" ystart="-0.06095199999999994" ystep="0.00023809374999999975" >
+    <properties/>
+  </type>
+
+  <!-- Pixel for Detectors-->
+  <type is="detector" name="pixel">
+    <cuboid id="pixel-shape">
+      <left-front-bottom-point y="-0.00023809374999999975" x="-0.00023809374999999975" z="0.0"/>
+      <left-front-top-point y="0.00023809374999999975" x="-0.00023809374999999975" z="0.0"/>
+      <left-back-bottom-point y="-0.00023809374999999975" x="-0.00023809374999999975" z="-0.001"/>
+      <right-front-bottom-point y="0.00023809374999999975" x="0.00023809374999999975" z="0.0"/>
+    </cuboid>
+    <algebra val="pixel-shape"/>
+  </type>
+
+  <!-- Shape for Monitors-->
+  <!-- TODO: Update to real shape -->
+  <type is="monitor" name="monitor">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="0.0" x="0.0" z="1.0"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
+    </cylinder>
+    <algebra val="some-shape"/>
+  </type>
+
+</instrument>

--- a/instrument/SNAP_Definition_PA.xml
+++ b/instrument/SNAP_Definition_PA.xml
@@ -1,0 +1,265 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- For help on the notation used to specify an Instrument Definition File
+     see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+            name="SNAP" valid-from   ="2025-01-31 10:00:00"
+                        valid-to     ="2100-01-31 23:59:59"
+		        last-modified="2026-05-28 00:00:00">
+  <!--Data taken from /SNS/SNAP/2010_2_3_CAL/calibrations/SNAP_geom_2010_03_22.xml-->
+  <!--Created by Vickie Lynch, modified by Janik Zikovsky -->
+  <!-- Modified by Vickie Lynch, Feb 17,2011 Bank names changed from local_name to name -->
+  <!-- Modified to include 3rd monitor 202050207-->
+  <!--DEFAULTS-->
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+      <theta-sign axis="x"/>
+    </reference-frame>
+  </defaults>
+
+  <!--SOURCE-->
+  <component type="moderator">
+    <location z="-15.0"/>
+  </component>
+  <type name="moderator" is="Source"/>
+
+  <!--SAMPLE-->
+  <component type="sample-position">
+    <location y="0.0" x="0.0" z="0.0"/>
+  </component>
+  <type name="sample-position" is="SamplePos"/>
+
+  <!--MONITORS-->
+  <idlist idname="monitors">
+    <id val="-1"/>
+    <id val="-2"/>
+    <id val="-3"/>
+  </idlist>
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type is="monitor" name="monitors">
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="-3.0" name="monitor1"/>
+    </component>
+   <component type="monitor">
+    <location x="0.0" y="0.0" z="1.95" name="monitor2" />
+   </component>
+   <component type="monitor">
+    <location x="0.0" y="0.0" z="1.9" name="monitor3" />
+   </component>
+  </type>
+
+  <!--DETECTORS-->
+  <component type="East">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc2" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin2" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc2" />
+      </parameter>
+    </location>
+  </component>
+  <component type="West">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc1" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin1" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc1" />
+      </parameter>
+    </location>
+  </component>
+
+  <type name="East">
+    <component type="Column1">
+      <location/>
+    </component>
+    <component type="Column2">
+      <location/>
+    </component>
+    <component type="Column3">
+      <location/>
+    </component>
+  </type>
+  <type name="West">
+    <component type="Column4">
+      <location/>
+    </component>
+    <component type="Column5">
+      <location/>
+    </component>
+    <component type="Column6">
+      <location/>
+    </component>
+  </type>
+
+  <!-- West -->
+  <type name="Column1">
+    <component type="panel"   idstart="131072" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.44" y="0.17"/>
+      <location name="bank13">  <!-- was bank1 - 720896 -->
+        <trans x="-0.167548" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"   idstart="65536" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.44" y="0"/>
+      <location name="bank12">  <!-- was bank4 - 655360 -->
+        <trans x="-0.167548" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"   idstart="0" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.44" y="-0.17"/>
+      <location name="bank11">  <!-- was bank7 - 589824 -->
+        <trans x="-0.167548" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+  <type name="Column2">
+    <component type="panel"   idstart="327680" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.27" y="0.17"/>
+      <location name="bank23">  <!-- was bank2 - 917504 -->
+        <trans x="0.0" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"  idstart="262144" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.27" y="0"/>
+      <location name="bank22">  <!-- was bank5 - 851968 -->
+        <trans x="0.0" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"   idstart="196608" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.27" y="-0.17"/>
+      <location name="bank21">  <!-- was bank8 - 786432 -->
+        <trans x="0.0" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+  <type name="Column3">
+    <component type="panel"   idstart="524288" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.1" y="0.17"/>
+      <location name="bank33">  <!-- was bank3 - 1114112 -->
+        <trans x="0.167548" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"   idstart="458752" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.1" y="0"/>
+      <location name="bank32">  <!-- was bank6 - 1048576 -->
+        <trans x="0.167548" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"   idstart="393216" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="-0.1" y="-0.17"/>
+      <location name="bank31">  <!-- was bank9 - 983040 -->
+        <trans x="0.167548" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+  <!-- East -->
+  <type name="Column4">
+    <component type="panel"   idstart="1114112" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.1" y="0.17"/>
+      <location name="bank63">  <!-- was bank10 - 524288 -->
+        <trans x="0.167548" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"   idstart="1048576" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.1" y="0"/>
+      <location name="bank62">  <!-- was bank13 - 458752 -->
+        <trans x="0.167548" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"   idstart="983040" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.1" y="-0.17"/>
+      <location name="bank61">  <!-- was bank16 - 393216 -->
+        <trans x="0.167548" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+  <type name="Column5">
+    <component type="panel"   idstart="917504" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.27" y="0.17"/>
+      <location name="bank53">  <!-- was bank11 - 327680 -->
+        <trans x="0.0" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"   idstart="851968" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.27" y="0"/>
+      <location name="bank52">  <!-- was bank14 - 262144 -->
+        <trans x="0.0" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"   idstart="786432" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.27" y="-0.17"/>
+      <location name="bank51">  <!-- was bank17 - 196608 -->
+        <trans x="0.0" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+  <type name="Column6">
+    <component type="panel"   idstart="720896" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.44" y="0.17"/>
+      <location name="bank43">  <!-- was bank12 - 131072 -->
+        <trans x="-0.167548" y="0.167548" />
+      </location>
+    </component>
+    <component type="panel"   idstart="655360" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.44" y="0"/>
+      <location name="bank42">  <!-- was bank15 - 65536 -->
+        <trans x="-0.167548" y="0.0" />
+      </location>
+    </component>
+    <component type="panel"  idstart="589824" idfillorder="yxz" idstep="1" >
+      <side-by-side-view-location x="0.44" y="-0.17"/>
+      <location name="bank41">  <!-- was bank18 - 0 -->
+        <trans x="-0.167548" y="-0.167548" />
+      </location>
+    </component>
+  </type>
+
+<!-- Pixel Assembly Panel (replaces rectangular_detector) -->
+<type name="panel" is="pixel_assembly" type="pixel"
+    xpixels="256" xstart="-0.078795" xstep="+0.000618"
+    ypixels="256" ystart="-0.078795" ystep="+0.000618" >
+  <properties/>
+</type>
+
+
+  <!-- Pixel for Detectors-->
+  <type is="detector" name="pixel">
+    <cuboid id="pixel-shape">
+      <left-front-bottom-point y="-0.000309" x="-0.000309" z="0.0"/>
+      <left-front-top-point y="0.000309" x="-0.000309" z="0.0"/>
+      <left-back-bottom-point y="-0.000309" x="-0.000309" z="-0.0001"/>
+      <right-front-bottom-point y="-0.000309" x="0.000309" z="0.0"/>
+    </cuboid>
+    <algebra val="pixel-shape"/>
+  </type>
+
+
+  <!-- Shape for Monitors-->
+  <!-- TODO: Update to real shape -->
+  <type is="monitor" name="monitor">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="0.0" x="0.0" z="1.0"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
+    </cylinder>
+    <algebra val="some-shape"/>
+  </type>
+
+</instrument>

--- a/instrument/SNAP_mini_Definition.xml
+++ b/instrument/SNAP_mini_Definition.xml
@@ -1,0 +1,284 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Mantid Repository : https://github.com/mantidproject/mantid
+     Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+       NScD Oak Ridge National Laboratory, European Spallation Source,
+       Institut Laue-Langevin & CSNS, Institute of High Energy Physics, CAS
+     SPDX-License-Identifier: GPL-3.0+
+
+     Mini SNAP-like instrument used to exercise the pixel_assembly IDF path.
+
+     Topology: two panels (West / East), each with three columns, each column
+     holding three banks — 18 banks total, matching real SNAP.
+
+     Differences from SNAP_Definition.xml:
+       • Each bank is 256x256 pixels — identical to the real SNAP detector.
+       • xstep = ystep = 0.000618 m; physical span +/-0.078795 m per bank.
+       • Bank type is "pixel_assembly" (vs "rectangular_detector").
+       • Panel positions are hard-coded (not logfile-driven) for testability.
+       • Detector IDs are 0 – 1179647 (18 banks x 65536 pixels, stride 65536).
+-->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+            name="SNAP_mini"
+            valid-from="2025-01-01 00:00:00"
+            valid-to  ="2100-01-01 00:00:00"
+            last-modified="2026-05-27 00:00:00">
+
+  <!-- ================================================================
+       DEFAULTS
+       ================================================================ -->
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam   axis="z"/>
+      <pointing-up  axis="y"/>
+      <handedness   val="right"/>
+      <theta-sign   axis="x"/>
+    </reference-frame>
+  </defaults>
+
+  <!-- ================================================================
+       SOURCE
+       ================================================================ -->
+  <component type="moderator">
+    <location z="-15.0"/>
+  </component>
+  <type name="moderator" is="Source"/>
+
+  <!-- ================================================================
+       SAMPLE
+       ================================================================ -->
+  <component type="sample-position">
+    <location x="0.0" y="0.0" z="0.0"/>
+  </component>
+  <type name="sample-position" is="SamplePos"/>
+
+  <!-- ================================================================
+       MONITORS
+       ================================================================ -->
+  <idlist idname="monitors">
+    <id val="-1"/>
+    <id val="-2"/>
+  </idlist>
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type is="monitor" name="monitors">
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="-3.0" name="monitor1"/>
+    </component>
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="1.95" name="monitor2"/>
+    </component>
+  </type>
+
+  <!-- ================================================================
+       DETECTOR PANELS
+       West panel:  x = -2 m, rotated +90deg about Y so the face points toward +x
+       East panel:  x = +2 m, rotated -90deg about Y so the face points toward -x
+       ================================================================ -->
+
+  <component type="West">
+    <location x="-2.0" y="0.0" z="0.0">
+      <rot val="90" axis-x="0" axis-y="1" axis-z="0"/>
+    </location>
+  </component>
+
+  <component type="East">
+    <location x="2.0" y="0.0" z="0.0">
+      <rot val="-90" axis-x="0" axis-y="1" axis-z="0"/>
+    </location>
+  </component>
+
+  <!-- West panel: three columns (mirrors SNAP Column1/2/3) -->
+  <type name="West">
+    <component type="WColumn1"><location/></component>
+    <component type="WColumn2"><location/></component>
+    <component type="WColumn3"><location/></component>
+  </type>
+
+  <!-- WColumn1 - left column, same offsets as SNAP Column1
+       bank11 idstart=0       (pixels   0 –  65535)
+       bank12 idstart=65536   (pixels  65536 – 131071)
+       bank13 idstart=131072  (pixels 131072 – 196607) -->
+  <type name="WColumn1">
+    <component type="mini_panel" idstart="131072" idfillorder="yxz" idstep="1">
+      <location name="bank13">
+        <trans x="-0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="65536" idfillorder="yxz" idstep="1">
+      <location name="bank12">
+        <trans x="-0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="0" idfillorder="yxz" idstep="1">
+      <location name="bank11">
+        <trans x="-0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- WColumn2 - centre column, same offsets as SNAP Column2
+       bank21 idstart=196608  (pixels 196608 – 262143)
+       bank22 idstart=262144  (pixels 262144 – 327679)
+       bank23 idstart=327680  (pixels 327680 – 393215) -->
+  <type name="WColumn2">
+    <component type="mini_panel" idstart="327680" idfillorder="yxz" idstep="1">
+      <location name="bank23">
+        <trans x="0.0" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="262144" idfillorder="yxz" idstep="1">
+      <location name="bank22">
+        <trans x="0.0" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="196608" idfillorder="yxz" idstep="1">
+      <location name="bank21">
+        <trans x="0.0" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- WColumn3 - right column, same offsets as SNAP Column3
+       bank31 idstart=393216  (pixels 393216 – 458751)
+       bank32 idstart=458752  (pixels 458752 – 524287)
+       bank33 idstart=524288  (pixels 524288 – 589823) -->
+  <type name="WColumn3">
+    <component type="mini_panel" idstart="524288" idfillorder="yxz" idstep="1">
+      <location name="bank33">
+        <trans x="0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="458752" idfillorder="yxz" idstep="1">
+      <location name="bank32">
+        <trans x="0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="393216" idfillorder="yxz" idstep="1">
+      <location name="bank31">
+        <trans x="0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- East panel: three columns (mirrors SNAP Column4/5/6) -->
+
+  <type name="East">
+    <component type="EColumn1"><location/></component>
+    <component type="EColumn2"><location/></component>
+    <component type="EColumn3"><location/></component>
+  </type>
+
+  <!-- EColumn1 - mirrors SNAP Column4
+       bank61 idstart=589824  (pixels  589824 –  655359)
+       bank62 idstart=655360  (pixels  655360 –  720895)
+       bank63 idstart=720896  (pixels  720896 –  786431) -->
+  <type name="EColumn1">
+    <component type="mini_panel" idstart="720896" idfillorder="yxz" idstep="1">
+      <location name="bank63">
+        <trans x="0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="655360" idfillorder="yxz" idstep="1">
+      <location name="bank62">
+        <trans x="0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="589824" idfillorder="yxz" idstep="1">
+      <location name="bank61">
+        <trans x="0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- EColumn2 - mirrors SNAP Column5
+       bank51 idstart=786432  (pixels  786432 –  851967)
+       bank52 idstart=851968  (pixels  851968 –  917503)
+       bank53 idstart=917504  (pixels  917504 –  983039) -->
+  <type name="EColumn2">
+    <component type="mini_panel" idstart="917504" idfillorder="yxz" idstep="1">
+      <location name="bank53">
+        <trans x="0.0" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="851968" idfillorder="yxz" idstep="1">
+      <location name="bank52">
+        <trans x="0.0" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="786432" idfillorder="yxz" idstep="1">
+      <location name="bank51">
+        <trans x="0.0" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- EColumn3 - mirrors SNAP Column6
+       bank41 idstart=983040  (pixels  983040 – 1048575)
+       bank42 idstart=1048576 (pixels 1048576 – 1114111)
+       bank43 idstart=1114112 (pixels 1114112 – 1179647) -->
+  <type name="EColumn3">
+    <component type="mini_panel" idstart="1114112" idfillorder="yxz" idstep="1">
+      <location name="bank43">
+        <trans x="-0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="1048576" idfillorder="yxz" idstep="1">
+      <location name="bank42">
+        <trans x="-0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="983040" idfillorder="yxz" idstep="1">
+      <location name="bank41">
+        <trans x="-0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- ================================================================
+       BANK TYPE — 256x256 pixel_assembly, same physical span as SNAP
+       (+/-0.078795 m in x and y)
+
+       With 256 pixels: xstep = 0.15759 / 255 = 0.000618 m (real SNAP value)
+                        xstart = -0.078795 m  (centre of pixel 0)
+       Fill order: Y-fastest ("yxz"), matching SNAP's idfillbyfirst="y".
+       ================================================================ -->
+  <type name="mini_panel" is="pixel_assembly" type="mini_pixel"
+        xpixels="256" xstart="-0.078795" xstep="+0.000618"
+        ypixels="256" ystart="-0.078795" ystep="+0.000618">
+    <properties/>
+  </type>
+
+  <!-- ================================================================
+       PIXEL SHAPE
+       Half-size matches xstep/2 = 0.000309 m in x and y.
+       Z depth kept at 0.1 mm (same as SNAP) for realistic solid angles.
+       ================================================================ -->
+  <type is="detector" name="mini_pixel">
+    <cuboid id="pixel-shape">
+      <left-front-bottom-point  y="-0.000309" x="-0.000309" z="0.0"    />
+      <left-front-top-point     y=" 0.000309" x="-0.000309" z="0.0"    />
+      <left-back-bottom-point   y="-0.000309" x="-0.000309" z="-0.0001"/>
+      <right-front-bottom-point y="-0.000309" x=" 0.000309" z="0.0"    />
+    </cuboid>
+    <algebra val="pixel-shape"/>
+  </type>
+
+  <!-- ================================================================
+       MONITOR SHAPE
+       ================================================================ -->
+  <type is="monitor" name="monitor">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="0.0" x="0.0" z="1.0"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
+    </cylinder>
+    <algebra val="some-shape"/>
+  </type>
+
+</instrument>

--- a/instrument/SNAP_mini_RD_Definition.xml
+++ b/instrument/SNAP_mini_RD_Definition.xml
@@ -1,0 +1,268 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Mantid Repository : https://github.com/mantidproject/mantid
+     Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+       NScD Oak Ridge National Laboratory, European Spallation Source,
+       Institut Laue-Langevin & CSNS, Institute of High Energy Physics, CAS
+     SPDX-License-Identifier: GPL-3.0+
+
+     Reference version of SNAP_mini using rectangular_detector banks.
+
+     Geometry is identical to SNAP_mini_Definition.xml in every respect —
+     same panel positions, same column/bank offsets, same pixel spans, same
+     detector IDs, same fill order — so that the two instruments can be
+     loaded side-by-side and verified to produce identical DetectorInfo.
+
+     The only difference is that bank types use "rectangular_detector"
+     (the established, tested code path) instead of the new "pixel_assembly".
+
+     Each bank: 256x256 pixels, xstep = ystep = 0.000618 m (real SNAP value).
+     18 banks x 65536 pixels = 1 179 648 total pixels, IDs 0 – 1 179 647.
+-->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+            name="SNAP_mini_RD"
+            valid-from="2025-01-01 00:00:00"
+            valid-to  ="2100-01-01 00:00:00"
+            last-modified="2026-05-27 00:00:00">
+
+  <!-- ================================================================
+       DEFAULTS
+       ================================================================ -->
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam   axis="z"/>
+      <pointing-up  axis="y"/>
+      <handedness   val="right"/>
+      <theta-sign   axis="x"/>
+    </reference-frame>
+  </defaults>
+
+  <!-- ================================================================
+       SOURCE
+       ================================================================ -->
+  <component type="moderator">
+    <location z="-15.0"/>
+  </component>
+  <type name="moderator" is="Source"/>
+
+  <!-- ================================================================
+       SAMPLE
+       ================================================================ -->
+  <component type="sample-position">
+    <location x="0.0" y="0.0" z="0.0"/>
+  </component>
+  <type name="sample-position" is="SamplePos"/>
+
+  <!-- ================================================================
+       MONITORS
+       ================================================================ -->
+  <idlist idname="monitors">
+    <id val="-1"/>
+    <id val="-2"/>
+  </idlist>
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type is="monitor" name="monitors">
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="-3.0" name="monitor1"/>
+    </component>
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="1.95" name="monitor2"/>
+    </component>
+  </type>
+
+  <!-- ================================================================
+       DETECTOR PANELS  (identical positions to SNAP_mini_Definition.xml)
+       West panel:  x = -2 m, rotated +90deg about Y so the face points toward +x
+       East panel:  x = +2 m, rotated -90deg about Y so the face points toward -x
+       ================================================================ -->
+
+  <component type="West">
+    <location x="-2.0" y="0.0" z="0.0">
+      <rot val="90" axis-x="0" axis-y="1" axis-z="0"/>
+    </location>
+  </component>
+
+  <component type="East">
+    <location x="2.0" y="0.0" z="0.0">
+      <rot val="-90" axis-x="0" axis-y="1" axis-z="0"/>
+    </location>
+  </component>
+
+  <!-- West panel: three columns (mirrors SNAP Column1/2/3) -->
+  <type name="West">
+    <component type="WColumn1"><location/></component>
+    <component type="WColumn2"><location/></component>
+    <component type="WColumn3"><location/></component>
+  </type>
+
+  <!-- WColumn1 - left column, same offsets as SNAP Column1
+       idfillbyfirst="y" idstepbyrow="256": Y-fastest, stride-per-X-column = ypixels = 256 -->
+  <type name="WColumn1">
+    <component type="mini_panel" idstart="131072" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank13">
+        <trans x="-0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="65536" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank12">
+        <trans x="-0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="0" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank11">
+        <trans x="-0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- WColumn2 - centre column, same offsets as SNAP Column2 -->
+  <type name="WColumn2">
+    <component type="mini_panel" idstart="327680" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank23">
+        <trans x="0.0" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="262144" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank22">
+        <trans x="0.0" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="196608" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank21">
+        <trans x="0.0" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- WColumn3 - right column, same offsets as SNAP Column3 -->
+  <type name="WColumn3">
+    <component type="mini_panel" idstart="524288" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank33">
+        <trans x="0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="458752" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank32">
+        <trans x="0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="393216" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank31">
+        <trans x="0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- East panel: three columns (mirrors SNAP Column4/5/6) -->
+  <type name="East">
+    <component type="EColumn1"><location/></component>
+    <component type="EColumn2"><location/></component>
+    <component type="EColumn3"><location/></component>
+  </type>
+
+  <!-- EColumn1 - mirrors SNAP Column4 -->
+  <type name="EColumn1">
+    <component type="mini_panel" idstart="720896" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank63">
+        <trans x="0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="655360" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank62">
+        <trans x="0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="589824" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank61">
+        <trans x="0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- EColumn2 - mirrors SNAP Column5 -->
+  <type name="EColumn2">
+    <component type="mini_panel" idstart="917504" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank53">
+        <trans x="0.0" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="851968" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank52">
+        <trans x="0.0" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="786432" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank51">
+        <trans x="0.0" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- EColumn3 - mirrors SNAP Column6 -->
+  <type name="EColumn3">
+    <component type="mini_panel" idstart="1114112" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank43">
+        <trans x="-0.167548" y="0.167548"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="1048576" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank42">
+        <trans x="-0.167548" y="0.0"/>
+      </location>
+    </component>
+    <component type="mini_panel" idstart="983040" idfillbyfirst="y" idstepbyrow="256">
+      <location name="bank41">
+        <trans x="-0.167548" y="-0.167548"/>
+      </location>
+    </component>
+  </type>
+
+  <!-- ================================================================
+       BANK TYPE — 256x256 rectangular_detector, same physical span as SNAP
+       (+/-0.078795 m in x and y)
+
+       xstep = 0.000618 m (real SNAP value: 0.15759 m / 255 gaps)
+       xstart = -0.078795 m  (centre of pixel 0)
+       idfillbyfirst="y": Y-fastest fill order
+       idstepbyrow="256": step between X columns = ypixels
+       ================================================================ -->
+  <type name="mini_panel" is="rectangular_detector" type="mini_pixel"
+        xpixels="256" xstart="-0.078795" xstep="+0.000618"
+        ypixels="256" ystart="-0.078795" ystep="+0.000618">
+    <properties/>
+  </type>
+
+  <!-- ================================================================
+       PIXEL SHAPE  (identical to SNAP_mini_Definition.xml)
+       Half-size matches xstep/2 = 0.000309 m in x and y.
+       Z depth = 0.1 mm (same as SNAP).
+       ================================================================ -->
+  <type is="detector" name="mini_pixel">
+    <cuboid id="pixel-shape">
+      <left-front-bottom-point  y="-0.000309" x="-0.000309" z="0.0"    />
+      <left-front-top-point     y=" 0.000309" x="-0.000309" z="0.0"    />
+      <left-back-bottom-point   y="-0.000309" x="-0.000309" z="-0.0001"/>
+      <right-front-bottom-point y="-0.000309" x=" 0.000309" z="0.0"    />
+    </cuboid>
+    <algebra val="pixel-shape"/>
+  </type>
+
+  <!-- ================================================================
+       MONITOR SHAPE
+       ================================================================ -->
+  <type is="monitor" name="monitor">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="0.0" x="0.0" z="1.0"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
+    </cylinder>
+    <algebra val="some-shape"/>
+  </type>
+
+</instrument>

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BankTextureBuilder.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BankTextureBuilder.h
@@ -40,6 +40,7 @@ private:
   void buildGridBankLayer(const std::vector<GLColor> &colors, bool picking, size_t layer);
   void buildGridBankTextures(const std::vector<GLColor> &colors, bool picking, bool isUsingLayer, size_t layer);
   void buildRectangularBankTextures(const std::vector<GLColor> &colors, bool picking);
+  void buildVirtualBankTextures(const std::vector<GLColor> &colors, bool picking);
   void uploadTubeBankTextures(bool picking);
   void uploadGridBankTexture(bool picking, GridTextureFace gridFace);
   void uploadRectangularBankTextures(bool picking);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
@@ -66,6 +66,7 @@ public:
 protected:
   virtual void draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) = 0;
   void drawGridBank(size_t bankIndex, bool picking);
+  void drawVirtualBank(size_t bankIndex, bool picking);
   void drawRectangularBank(size_t bankIndex, bool picking);
   void drawStructuredBank(size_t bankIndex, bool picking);
   void drawTube(size_t bankIndex, bool picking);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -75,6 +75,8 @@ protected:
 
   void processGrid(size_t rootIndex);
 
+  void processVirtualBank(size_t rootIndex);
+
   void processUnstructured(size_t rootIndex, std::vector<bool> &visited);
 
   void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const override;

--- a/qt/widgets/instrumentview/src/BankTextureBuilder.cpp
+++ b/qt/widgets/instrumentview/src/BankTextureBuilder.cpp
@@ -105,6 +105,7 @@ BankTextureBuilder::BankTextureBuilder(const Mantid::Geometry::ComponentInfo &co
     m_textSizes.resize(6);
     break;
   case ComponentType::Rectangular:
+  case ComponentType::VirtualAssembly:
   case ComponentType::OutlineComposite:
     m_colorTextureIDs.resize(1);
     m_pickTextureIDs.resize(1);
@@ -175,6 +176,9 @@ void BankTextureBuilder::buildOpenGLTextures(bool picking, const std::vector<GLC
   case ComponentType::Rectangular:
     buildRectangularBankTextures(colors, picking);
     break;
+  case ComponentType::VirtualAssembly:
+    buildVirtualBankTextures(colors, picking);
+    break;
   default:
     break;
   }
@@ -194,6 +198,7 @@ void BankTextureBuilder::uploadTextures(bool picking, GridTextureFace gridFace) 
     uploadGridBankTexture(picking, gridFace);
     break;
   case ComponentType::Rectangular:
+  case ComponentType::VirtualAssembly:
     uploadRectangularBankTextures(picking);
     break;
   default:
@@ -301,6 +306,32 @@ void BankTextureBuilder::buildRectangularBankTextures(const std::vector<GLColor>
   texture.resize(texSizeX * texSizeY * 3, 0); // fill with black
 
   createTexture(m_compInfo, m_compInfo.children(m_bankIndex), colors, texture, texSizeX);
+}
+
+void BankTextureBuilder::buildVirtualBankTextures(const std::vector<GLColor> &colors, bool picking) {
+  const auto *seg = m_compInfo.findVirtualBankByCompIdx(m_bankIndex);
+  if (!seg)
+    return;
+
+  auto &texture = picking ? m_detPickTextures[0] : m_detColorTextures[0];
+  const auto nx = static_cast<size_t>(seg->nx);
+  const auto ny = static_cast<size_t>(seg->ny);
+  auto res = BankRenderingHelpers::getCorrectedTextureSize(nx, ny);
+  m_textSizes[0] = res;
+  const auto texSizeX = res.first;
+
+  texture.resize(texSizeX * res.second * 3, 0);
+
+  for (size_t ix = 0; ix < nx; ++ix) {
+    for (size_t iy = 0; iy < ny; ++iy) {
+      const auto det = seg->indexAtXYZ(static_cast<int>(ix), static_cast<int>(iy));
+      const auto ti = (iy * texSizeX + ix) * 3;
+      const auto &col = colors[det];
+      texture[ti] = static_cast<char>(col.red());
+      texture[ti + 1] = static_cast<char>(col.green());
+      texture[ti + 2] = static_cast<char>(col.blue());
+    }
+  }
 }
 
 void BankTextureBuilder::uploadTubeBankTextures(bool picking) {

--- a/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
@@ -16,6 +16,7 @@
 #include "MantidQtWidgets/InstrumentView/BankRenderingHelpers.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/OpenGLError.h"
+#include <algorithm>
 
 using namespace MantidQt::MantidWidgets;
 using Mantid::Beamline::ComponentType;
@@ -43,7 +44,8 @@ InstrumentRenderer::InstrumentRenderer(const InstrumentActor &actor)
   }
   for (size_t i = componentInfo.root(); !componentInfo.isDetector(i); --i) {
     auto type = componentInfo.componentType(i);
-    if (type == ComponentType::Rectangular || type == ComponentType::OutlineComposite || type == ComponentType::Grid) {
+    if (type == ComponentType::Rectangular || type == ComponentType::OutlineComposite || type == ComponentType::Grid ||
+        type == ComponentType::VirtualAssembly) {
       m_textures.emplace_back(componentInfo, i);
       m_reverseTextureIndexMap[i] = textureIndex;
       textureIndex++;
@@ -76,6 +78,18 @@ void InstrumentRenderer::drawComponent(const size_t i, const std::vector<bool> &
       drawGridBank(i, picking);
       updateVisited(compInfo, i, visited);
     }
+    return;
+  }
+  if (type == ComponentType::VirtualAssembly) {
+    // Always mark virtual pixels visited — even when invisible — to prevent
+    // per-pixel fallback rendering (which would generate O(N) display lists).
+    const auto *seg = compInfo.findVirtualBankByCompIdx(i);
+    if (seg)
+      std::fill(visited.begin() + static_cast<std::ptrdiff_t>(seg->firstIndex),
+                visited.begin() + static_cast<std::ptrdiff_t>(seg->lastIndex) + 1, true);
+    if (visibleComps[i])
+      drawVirtualBank(i, picking);
+    visited[i] = true;
     return;
   }
   if (type == ComponentType::Rectangular) {
@@ -155,6 +169,12 @@ void InstrumentRenderer::drawGridBank(size_t bankIndex, bool picking) {
   }
   tex.unbindTextures();
   glPopMatrix();
+}
+
+void InstrumentRenderer::drawVirtualBank(size_t bankIndex, bool picking) {
+  // VirtualAssembly banks render identically to rectangular_detector banks:
+  // a single textured quad whose geometry comes from the VirtualBankSegment.
+  drawRectangularBank(bankIndex, picking);
 }
 
 void InstrumentRenderer::drawRectangularBank(size_t bankIndex, bool picking) {

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -24,6 +24,7 @@
 #include <QPainterPath>
 #include <QtDebug>
 
+#include <algorithm>
 #include <numeric>
 
 using namespace Mantid::Geometry;
@@ -226,6 +227,71 @@ void PanelsSurface::processGrid(size_t rootIndex) {
   const auto &layers = compInfo.children(rootIndex);
 
   processStructured(layers[layerIndex]);
+}
+
+void PanelsSurface::processVirtualBank(size_t rootIndex) {
+  const auto &componentInfo = m_instrActor->componentInfo();
+  const auto *seg = componentInfo.findVirtualBankByCompIdx(rootIndex);
+  if (!seg)
+    return;
+
+  // Compute the four corner world positions analytically — no children to traverse.
+  auto panel = componentInfo.quadrilateralComponent(rootIndex);
+  std::vector<V3D> corners = {componentInfo.position(panel.bottomLeft), componentInfo.position(panel.bottomRight),
+                              componentInfo.position(panel.topRight), componentInfo.position(panel.topLeft)};
+
+  // Apply half-pixel offsets to extend corners to the outer pixel edges,
+  // mirroring the logic in retrievePanelCorners.
+  const auto &shape = componentInfo.shape(panel.bottomLeft);
+  const auto &shapeInfo = shape.getGeometryHandler()->shapeInfo();
+  const auto &pts = shapeInfo.points();
+  double xoff = 0.0, yoff = 0.0;
+  for (size_t k = 0; k + 1 < pts.size(); ++k) {
+    const double xd = std::abs(pts[k + 1].X() - pts[k].X());
+    const double yd = std::abs(pts[k + 1].Y() - pts[k].Y());
+    if (xd != 0.0)
+      xoff = xd * 0.5;
+    if (yd != 0.0)
+      yoff = yd * 0.5;
+  }
+  double xmin = corners[0].X(), xmax = corners[0].X();
+  double ymin = corners[0].Y(), ymax = corners[0].Y();
+  for (const auto &c : corners) {
+    xmin = std::min(xmin, c.X());
+    xmax = std::max(xmax, c.X());
+    ymin = std::min(ymin, c.Y());
+    ymax = std::max(ymax, c.Y());
+  }
+  for (auto &c : corners) {
+    c.setX(c.X() == xmin ? c.X() - xoff : c.X() + xoff);
+    c.setY(c.Y() == ymin ? c.Y() - yoff : c.Y() + yoff);
+  }
+
+  auto normal = this->m_calculator.calculatePanelNormal(corners);
+
+  const int index = static_cast<int>(m_flatBanks.size());
+  auto *info = new FlatBankInfo(this);
+  m_flatBanks << info;
+  const auto ref = corners[0];
+  info->refPos = ref;
+  info->rotation = this->m_calculator.calcBankRotation(ref, normal, m_zaxis, m_yaxis, m_pos);
+  info->startDetectorIndex = seg->firstIndex;
+  info->endDetectorIndex = seg->lastIndex;
+
+  QVector<QPointF> verts;
+  for (auto &corner : corners) {
+    auto pos = corner - ref;
+    info->rotation.rotate(pos);
+    pos += ref;
+    verts << QPointF(pos.X(), pos.Y());
+  }
+  info->polygon = QPolygonF(verts);
+
+  for (size_t det = seg->firstIndex; det <= seg->lastIndex; ++det) {
+    addDetector(det, index);
+  }
+
+  info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, m_instrActor->getInstrument(), rootIndex);
 }
 
 /// Find an assembly containing detector tubes placed next to each other
@@ -458,6 +524,12 @@ void PanelsSurface::findFlatPanels(size_t rootIndex, std::vector<bool> &visited)
     return;
   }
 
+  if (componentType == ComponentType::VirtualAssembly) {
+    processVirtualBank(rootIndex);
+    this->m_calculator.setBankVisited(componentInfo, rootIndex, visited);
+    return;
+  }
+
   processUnstructured(rootIndex, visited);
 }
 
@@ -468,10 +540,11 @@ void PanelsSurface::constructFromComponentInfo() {
   for (int64_t i = static_cast<int64_t>(componentInfo.root() - 1); i > 0; --i) {
     auto children = componentInfo.children(i);
 
-    if (children.size() > 0 && !visited[i]) {
+    const bool isVirtualAssembly = componentInfo.componentType(i) == ComponentType::VirtualAssembly;
+    if ((children.size() > 0 || isVirtualAssembly) && !visited[i]) {
       visited[i] = true;
       findFlatPanels(i, visited);
-    } else if (children.size() == 0 && componentInfo.parent(i) == componentInfo.root()) {
+    } else if (children.size() == 0 && !isVirtualAssembly && componentInfo.parent(i) == componentInfo.root()) {
       visited[i] = true;
     }
   }


### PR DESCRIPTION
**DO NOT MERGE**

It was pointed out that instruments like IMAGINE occupy 20GB of RAM when loaded.  This is the memory corresponding only to the instrument object, and not to any extra memory occupied by storing data on the instrument.

IMAGINE has 20million pixels.  Each of these pixels is being initialized as an object in memory, holding multiple data artifacts, including its position, masking, ID, etc.  Over the 20 million pixels, this all adds up.  For a rectangular pixel array, all of this information can be easily predicted with simple formulae, negating the need to store the info somewhere.

It was predicted we could save a significant amount of space by switching to "virtual pixels"; these are pixels that do not exist as objects in memory, but whose properties are computed on-the-fly, whenever needed, using the simple formulae.

To prove this, I used Claude code to write a new bank type, "PixelAssembly", that handles virtual pixels.  I can prove that this can handle performing calibration with real data using the virtual instrument, and that the virtual instrument can be visualized.

For SNAP, this reduces the total memory footprint from 950MB down to 650KB.  It will fit on your :floppy_disk: 

In terms of scaling, behavior operates at $O(N_{banks})$, instead of $O(N_{pixels})$.

With these changes, every instrument IDF can be trivially updated by changing "rectangular-detector" to "pixel-assembly", and editing the "idsortby" label.

Related to: Issue #40839 

**DO NOT MERGE**

### To test:

This was written by a bot.  **DO NOT MERGE**

Build this branch, and run the following script:

```python
"""
Quick smoke test: SNAP pixel_assembly IDF vs rectangular_detector IDF.

Run from within Mantid's Python environment:
    python snap_pa_smoke_test.py

Uses a local SNAP full-mode run file (IPTS-24641/SNAP_46680).
"""
from mantid.simpleapi import (
    AlignAndFocusPowder,
    CompareWorkspaces,
    CreateGroupingWorkspace,
    Load,
    LoadInstrument,
)

RUN_FILE = "/SNS/SNAP/IPTS-24641/nexus/SNAP_46680.nxs.h5"
RD_IDF = "SNAP_Definition.xml"
PA_IDF = "SNAP_Definition_PA.xml"
BINNING = [0.5, -0.004, 7.0]


def load_override_focus(run_file, idf, raw_out, grp_out, focused_out):
    Load(Filename=run_file, OutputWorkspace=raw_out)
    LoadInstrument(Workspace=raw_out, Filename=idf, RewriteSpectraMap=False)
    CreateGroupingWorkspace(InstrumentFilename=idf, GroupDetectorsBy="bank", OutputWorkspace=grp_out)
    AlignAndFocusPowder(
        InputWorkspace=raw_out,
        OutputWorkspace=focused_out,
        GroupingWorkspace=grp_out,
        Params=BINNING,
        CompressTolerance=0.01,
    )
    print(f"  → {focused_out}: {focused_out} has been created")


print("=== SNAP PA smoke test ===")
print(f"Run file: {RUN_FILE}")

print("\n[1/2] rectangular_detector path ...")
load_override_focus(RUN_FILE, RD_IDF, "snap_rd_raw", "snap_rd_grp", "snap_rd_focused")

print("\n[2/2] pixel_assembly path ...")
load_override_focus(RUN_FILE, PA_IDF, "snap_pa_raw", "snap_pa_grp", "snap_pa_focused")

print("\nComparing outputs ...")
result, messages = CompareWorkspaces(
    Workspace1="snap_rd_focused",
    Workspace2="snap_pa_focused",
    CheckInstrument=False,
    Tolerance=1e-10,
)
if result:
    print("PASS: PA output matches RD output exactly.")
else:
    print("FAIL: outputs differ.")
    print(messages.cell(0, 0))
    
    
from mantid.simpleapi import mtd
snap2 = mtd["snap_pa_raw"].getInstrument()
print(snap2.getMemorySize()/1_000_000)
```

Trying viewing the instrument, and viewing the resulting data.

**DO NOT MERGE**

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
