### PR TITLE
Eng Diff UI: GSAS-II tab allows filtering the region when loading focused data

### DIFF
--- a/docs/source/release/v6.16.0/Diffraction/Engineering/New_features/39609.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Engineering/New_features/39609.rst
@@ -1,0 +1,1 @@
+- The :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` GSAS-II tab allows filtering the region when loading focused data.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -31,8 +31,6 @@ class FittingDataPresenter(object):
         self.view.set_on_remove_all_clicked(self._remove_all_tracked_workspaces)
         self.view.set_on_plotBG_clicked(self._plotBG)
         self.view.set_on_table_cell_changed(self._handle_table_cell_changed)
-        self.view.set_on_region_changed(self._update_file_filter)
-        self.view.set_on_xunit_changed(self._update_file_filter)
         self.view.set_table_selection_changed(self._handle_selection_changed)
 
         # Observable Setup
@@ -49,8 +47,7 @@ class FittingDataPresenter(object):
 
     def set_default_files_texture(self, filepaths):
         if self.model.texture_auto_populate():
-            index = self.view.combo_xunit.findText("dSpacing")
-            self.view.combo_xunit.setCurrentIndex(index)
+            self.view.finder_data.set_filter_option("Unit", "dSpacing")
             self._set_default_files(filepaths)
 
     def _set_default_files(self, filepaths):
@@ -68,9 +65,6 @@ class FittingDataPresenter(object):
 
     def get_log_ws_group_name(self):
         return self.model.get_log_workspace_group_name()
-
-    def _update_file_filter(self, region, xunit):
-        self.view.update_file_filter(region, xunit)
 
     def on_load_clicked(self):
         if self._validate():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_view.py
@@ -4,58 +4,59 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from qtpy import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore
 from os import path
 
 from mantidqt.utils.qt import load_ui
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
-from fnmatch import fnmatch
-from os.path import splitext
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.filtered_file_finder import FilteredFileFinderWidget
 
 Ui_data, _ = load_ui(__file__, "data_widget.ui")
 
+_unit_filter_values = {
+    "No Unit Filter": "",
+    "TOF": "TOF",
+    "dSpacing": "dSpacing",
+}
 
-class FileFilterProxyModel(QtCore.QSortFilterProxyModel):
-    text_filter = None
+_region_filter_values = {
+    "No Region Filter": "",
+    "1 (North)": "bank_1",
+    "2 (South)": "bank_2",
+    "Both Banks": "bank_",
+    "Custom": "Custom",
+    "Cropped": "Cropped",
+    "Texture": "Texture",
+}
 
-    def __init__(self, parent=None):
-        super(FileFilterProxyModel, self).__init__(parent)
 
-    def filterAcceptsRow(self, source_row, source_parent):
-        model = self.sourceModel()
-        index0 = model.index(source_row, 0, source_parent)
-        fname = model.fileName(index0)
-        fname = splitext(fname)[0]
-
-        if self.text_filter is None:
-            return True
-        else:
-            return model.isDir(index0) or fnmatch(fname, self.text_filter)
-
-    def sort(self, column, order):
-        self.sourceModel().sort(column, order)
+def _file_filter_generator(filter_options: dict[str, str]) -> str:
+    region_option = filter_options["Region"]
+    xunit = filter_options["Unit"]
+    if xunit == "No Unit Filter":
+        return f"*{_region_filter_values[region_option]}*"
+    else:
+        return f"*{_region_filter_values[region_option]}*_{_unit_filter_values[xunit]}*"
 
 
 class FittingDataView(QtWidgets.QWidget, Ui_data):
     sig_enable_load_button = QtCore.Signal(bool)
     sig_enable_inspect_bg_button = QtCore.Signal(bool)
-    proxy_model = None
+    finder_data: FilteredFileFinderWidget
 
     def __init__(self, parent=None):
         super(FittingDataView, self).__init__(parent)
         self.setupUi(self)
         # file finder
         self.finder_data.readSettings(output_settings.INTERFACES_SETTINGS_GROUP + "/" + output_settings.ENGINEERING_PREFIX)
-        self.finder_data.setUseNativeWidget(False)
-        self.proxy_model = FileFilterProxyModel()
-        self.finder_data.setProxyModel(self.proxy_model)
         self.finder_data.setLabelText("")
         self.finder_data.isForRunFiles(False)
         self.finder_data.allowMultipleFiles(True)
         self.finder_data.setFileExtensions([".nxs"])
-        # xunit combo box
-        self.setup_combo_boxes()
-        self.update_file_filter(self.combo_region.currentText(), self.combo_xunit.currentText())
+        self.finder_data.add_filter("Unit", _unit_filter_values.keys())
+        self.finder_data.add_filter("Region", _region_filter_values.keys())
+        self.finder_data.set_filter_option("Unit", "TOF")
+        self.finder_data.set_filter_generator(_file_filter_generator)
 
     def saveSettings(self):
         self.finder_data.saveSettings(output_settings.INTERFACES_SETTINGS_GROUP + "/" + output_settings.ENGINEERING_PREFIX)
@@ -66,12 +67,6 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
 
     def set_on_load_clicked(self, slot):
         self.button_load.clicked.connect(slot)
-
-    def set_on_region_changed(self, slot):
-        self.combo_region.currentIndexChanged.connect(lambda: slot(self.combo_region.currentText(), self.combo_xunit.currentText()))
-
-    def set_on_xunit_changed(self, slot):
-        self.combo_xunit.currentIndexChanged.connect(lambda: slot(self.combo_region.currentText(), self.combo_xunit.currentText()))
 
     def set_enable_load_button_connection(self, slot):
         self.sig_enable_load_button.connect(slot)
@@ -190,32 +185,6 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
     def set_table_column(self, row, col, value):
         self.get_table_item(row, col).setData(QtCore.Qt.EditRole, int(value))
 
-    def update_file_filter(self, region, xunit):
-        self.proxy_model.text_filter = "*"
-        if region == "1 (North)":
-            self.proxy_model.text_filter += "bank_1"
-        elif region == "2 (South)":
-            self.proxy_model.text_filter += "bank_2"
-        elif region == "Cropped" or region == "Custom":
-            self.proxy_model.text_filter += region
-        elif region == "Texture":
-            self.proxy_model.text_filter += "Texture*"
-        elif region == "Both Banks":
-            self.proxy_model.text_filter += "bank*"
-        if xunit != "No Unit Filter":
-            self.proxy_model.text_filter += "_" + xunit
-        self.proxy_model.text_filter += "*"  # Allows browse for '(No Unit Filter)' with a specified region
-
-        # Keep "No Region/Unit Filter" text grey and other text black
-        for combo_box, current_text in ((self.combo_region, region), (self.combo_xunit, xunit)):
-            if current_text[0:2] == "No":  # No Unit or Region Filter
-                combo_box.setStyleSheet("color: grey")
-                for index in range(1, combo_box.count()):
-                    combo_box.setItemData(index, QtGui.QColor("black"), QtCore.Qt.ForegroundRole)
-            else:
-                combo_box.setStyleSheet("color: black")
-                combo_box.setItemData(0, QtGui.QColor("grey"), QtCore.Qt.ForegroundRole)
-
     # =================
     # Component Getters
     # =================
@@ -251,23 +220,6 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
 
     def is_searching(self):
         return self.finder_data.isSearching()
-
-    # =================
-    # Internal Setup
-    # =================
-
-    def setup_combo_boxes(self):
-        # set "No Region/Unit Filter" text grey and other text black
-        for combo_box, type_name in ((self.combo_region, "Region"), (self.combo_xunit, "Unit")):
-            combo_box.setEditable(True)
-            combo_box.lineEdit().setReadOnly(True)
-            combo_box.lineEdit().setEnabled(False)
-            no_filter_index = combo_box.findText("No " + type_name + " Filter")
-            combo_box.setItemData(no_filter_index, QtGui.QColor("grey"), QtCore.Qt.ForegroundRole)
-
-        # make TOF default for combo_xunit
-        index = self.combo_xunit.findText("TOF")
-        self.combo_xunit.setCurrentIndex(index)
 
 
 def create_workspace_table(table_column_headers, table_loaded_data, row_count):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_widget.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_widget.ui
@@ -57,111 +57,36 @@ QGroupBox:title {
      <property name="title">
       <string>Load Focused Data</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0" colspan="4">
-         <widget class="FileFinderWidget" name="finder_data" native="true"/>
-        </item>
-        <item row="3" column="3">
-         <widget class="QPushButton" name="button_load">
-          <property name="text">
-           <string>Load</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="filterLabel">
-          <property name="text">
-           <string>Browse Filters:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QComboBox" name="combo_xunit">
-          <property name="toolTip">
-           <string>Unit Filter </string>
-          </property>
-          <item>
-           <property name="text">
-            <string>No Unit Filter</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>TOF</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>dSpacing</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QComboBox" name="combo_region">
-          <property name="toolTip">
-           <string>Region Filter </string>
-          </property>
-          <item>
-           <property name="text">
-            <string>No Region Filter</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1 (North)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2 (South)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Both Banks</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Custom</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Cropped</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Texture</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QCheckBox" name="check_addToPlot">
-          <property name="text">
-           <string>Add to Plot</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="4">
-         <widget class="Line" name="line">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="4">
+       <widget class="FilteredFileFinderWidget" name="finder_data" native="true"/>
+      </item>
+      <item row="2" column="3">
+       <widget class="QPushButton" name="button_load">
+        <property name="text">
+         <string>Load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="check_addToPlot">
+        <property name="text">
+         <string>Add to Plot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="4">
+       <widget class="Line" name="line">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -288,15 +213,13 @@ QGroupBox:title {
  </widget>
  <customwidgets>
   <customwidget>
-   <class>FileFinderWidget</class>
+   <class>FilteredFileFinderWidget</class>
    <extends>QWidget</extends>
-   <header>mantidqt.widgets.filefinderwidget</header>
+   <header>mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.filtered_file_finder</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>combo_xunit</tabstop>
-  <tabstop>combo_region</tabstop>
   <tabstop>check_addToPlot</tabstop>
   <tabstop>button_load</tabstop>
   <tabstop>button_removeSelected</tabstop>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/filtered_file_finder/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/filtered_file_finder/__init__.py
@@ -1,0 +1,10 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from .filtered_file_finder_widget import FilteredFileFinderWidget
+
+__all__ = ["FilteredFileFinderWidget"]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/filtered_file_finder/filtered_file_finder_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/filtered_file_finder/filtered_file_finder_widget.py
@@ -1,0 +1,103 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from collections.abc import Callable, Iterable
+from fnmatch import fnmatch
+from os.path import splitext
+from typing import Any
+
+from qtpy import QtWidgets, QtCore
+from qtpy.QtWidgets import QSizePolicy
+
+from mantidqt.widgets.filefinderwidget import FileFinderWidget
+
+
+class FileFilterProxyModel(QtCore.QSortFilterProxyModel):
+    text_filter: str | None = None
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def filterAcceptsRow(self, source_row, source_parent):
+        if self.text_filter is None:
+            return True
+        model = self.sourceModel()
+        index0 = model.index(source_row, 0, source_parent)
+        fname = model.fileName(index0)
+        fname = splitext(fname)[0]
+
+        return model.isDir(index0) or fnmatch(fname, self.text_filter)
+
+    def sort(self, column, order):
+        self.sourceModel().sort(column, order)
+
+
+class FilteredFileFinderWidget(QtWidgets.QWidget):
+    """
+    Wrapper for FileFinderWidget with a built-in filters
+    """
+
+    filters: dict[str, QtWidgets.QComboBox]
+    filter_generator: Callable[[dict[str, str]], str]
+
+    def __init__(self, parent: QtWidgets.QWidget):
+        super().__init__(parent)
+        self.setLayout(QtWidgets.QVBoxLayout())
+
+        self.finder = FileFinderWidget()
+        self.layout().addWidget(self.finder)
+
+        self.filter_row = QtWidgets.QWidget()
+        self.layout().addWidget(self.filter_row)
+        self.filter_row.setLayout(QtWidgets.QHBoxLayout())
+        self.filter_label = QtWidgets.QLabel("Browse filters:")
+        self.filter_row.layout().addWidget(self.filter_label)
+        self.filter_row.layout().addSpacerItem(QtWidgets.QSpacerItem(0, 0, QSizePolicy.Expanding, QSizePolicy.Minimum))
+
+        self.finder.setUseNativeWidget(False)
+        self.proxy_model = FileFilterProxyModel()
+        self.finder.setProxyModel(self.proxy_model)
+        self.filters = {}
+        self.filter_generator = lambda _: "*"
+
+    def __getattr__(self, attr: str) -> Any:
+        """
+        Pass any undefined attributes and methods to the FileFinderWidget
+        """
+        if attr not in self.__dict__:
+            return getattr(self.finder, attr)
+        return super().__getattr__(attr)
+
+    def add_filter(self, name: str, options: Iterable[str]) -> None:
+        """
+        Add a QComboBox dropdown with the list of options
+        """
+        new_filter = QtWidgets.QComboBox()
+        new_filter.addItems(list(options))
+        new_filter.setToolTip(f"{name} Filter")
+        new_filter.currentIndexChanged.connect(self._handle_filter_change)
+        self.filters[name] = new_filter
+        self.filter_row.layout().addWidget(new_filter)
+
+    def set_filter_generator(self, filter_generator: Callable[[dict[str, str]], str]) -> None:
+        """
+        Set a function that converts the selected options into a search string
+        """
+        self.filter_generator = filter_generator
+        self._handle_filter_change()
+
+    def set_filter_option(self, filter_name: str, option_name: str) -> None:
+        """
+        Set a given filter to a given option
+        """
+        filter_widget = self.filters[filter_name]
+        index = filter_widget.findText(option_name)
+        filter_widget.setCurrentIndex(index)
+
+    def _handle_filter_change(self) -> None:
+        filter_options = {name: widget.currentText() for name, widget in self.filters.items()}
+        text_filter = self.filter_generator(filter_options)
+        self.proxy_model.text_filter = text_filter

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/gsas2_tab.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/gsas2_tab.ui
@@ -196,7 +196,7 @@ QGroupBox:title {
                  <widget class="FileFinderWidget" name="phase_file_finder" native="true"/>
                 </item>
                 <item row="2" column="0">
-                 <widget class="FileFinderWidget" name="focused_data_file_finder" native="true"/>
+                 <widget class="FilteredFileFinderWidget" name="focused_data_file_finder" native="true"/>
                 </item>
                 <item row="0" column="0">
                  <widget class="FileFinderWidget" name="instrument_group_file_finder" native="true"/>
@@ -698,6 +698,12 @@ QGroupBox:title {
    <class>FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>mantidqt.widgets.filefinderwidget</header>
+   <container>1</container>
+  </customwidget>
+   <customwidget>
+   <class>FilteredFileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.filtered_file_finder</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -16,9 +16,26 @@ import matplotlib.lines as lines
 from mantidqt.MPLwidgets import FigureCanvas
 
 from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.filtered_file_finder import FilteredFileFinderWidget
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.gsas2.plot_toolbar import GSAS2PlotToolbar
 
 Ui_calib, _ = load_ui(__file__, "gsas2_tab.ui")
+
+
+_region_filter_values = {
+    "No Region Filter": "",
+    "1 (North)": "bank_1",
+    "2 (South)": "bank_2",
+    "Both Banks": "bank_",
+    "Custom": "Custom",
+    "Cropped": "Cropped",
+    "Texture": "Texture",
+}
+
+
+def _file_filter_generator(filter_options: dict[str, str]) -> str:
+    region_option = filter_options["Region"]
+    return f"*{_region_filter_values[region_option]}*"
 
 
 class GSAS2View(QtWidgets.QWidget, Ui_calib):
@@ -26,7 +43,9 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
     sig_update_sample_field = QtCore.Signal()
     fit_range_changed = QtCore.Signal(list)
 
-    def __init__(self, parent=None, instrument="ENGINX"):
+    focused_data_file_finder: FilteredFileFinderWidget
+
+    def __init__(self, parent=None, instrument="ENGINX") -> None:
         super(GSAS2View, self).__init__(parent)
         self.setupUi(self)
 
@@ -44,6 +63,9 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
         self.focused_data_file_finder.isForRunFiles(False)
         self.focused_data_file_finder.setFileExtensions([".gss", ".gsa"])
         self.focused_data_file_finder.allowMultipleFiles(True)
+
+        self.focused_data_file_finder.add_filter("Region", _region_filter_values.keys())
+        self.focused_data_file_finder.set_filter_generator(_file_filter_generator)
 
         self.mark_project_name_invalid_when_empty()
         self.project_name_line_edit.textChanged.connect(self.mark_project_name_invalid_when_empty)


### PR DESCRIPTION
### Description of work

Closes #39609 

Add a region filter to the GSAS-II tab when selecting the focused .gss files.

Implement a `FilteredFileFinderWidget` that is shared with the fitting tab. This encapsulates the `FileFinderWidget` and filter option `QComboBox`es, into a single widget to simplify its use.

**Report to: Tung-Lik (ENGIN-X)


Note this introduces some visual changes to the filter QComboBoxes on the filter tab.

- Previously they are set to have disabled QLineEdit in `setup_combo_boxes()`. This makes it look like you could type in a filter, but you can't and it does not seem to have been implemented.
- Previously the text colour was set to gray when the "No ... filter" option was selected. I think this is confusing because it makes it look like the widget is disabled. So I have not re-implmented this.

### To test:

**Check that filtering still works on the Fitting tab**

Follow steps 1-3 of Test 5 at https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-5-focused-data
Then jump to Test 6


**Check that filtering still works on the GSAS II tab**

Back on the Run Processing tab:

- Tick "Set Calibration Region of Interest" and select "1 (North)".
- Click Calibrate
- Click Focus
- Change to "2 (South)" and run Calibrate and Focus again

Switch to the GSAS-II tab.
There should be a Browse filters section under the Focused Data loader. This should allow selecting the region similar to the Fitting tab.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
