### PR TITLE
Fixed the help documentation launch link when the plot is a superplot 

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/38044.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/38044.rst
@@ -1,0 +1,1 @@
+- The documentation of :ref:`Superplot <WorkbenchSuperplot>` is launched when the help button is clicked instead of the Basic 1D and Tiled Plots documentation.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -223,7 +223,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_copy_to_clipboard_triggered.connect(self.copy_to_clipboard)
             self.toolbar.sig_plot_options_triggered.connect(self.launch_plot_options)
             self.toolbar.sig_plot_help_triggered.connect(self.launch_plot_help)
-            self.toolbar.super_plot_help_triggered.connect(self.launch_superplot_help)
+            self.toolbar.sig_superplot_help_triggered.connect(self.launch_superplot_help)
             self.toolbar.sig_generate_plot_script_clipboard_triggered.connect(self.generate_plot_script_clipboard)
             self.toolbar.sig_generate_plot_script_file_triggered.connect(self.generate_plot_script_file)
             self.toolbar.sig_home_clicked.connect(self.set_figure_zoom_to_display_all)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -223,6 +223,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_copy_to_clipboard_triggered.connect(self.copy_to_clipboard)
             self.toolbar.sig_plot_options_triggered.connect(self.launch_plot_options)
             self.toolbar.sig_plot_help_triggered.connect(self.launch_plot_help)
+            self.toolbar.super_plot_help_triggered.connect(self.launch_superplot_help)
             self.toolbar.sig_generate_plot_script_clipboard_triggered.connect(self.generate_plot_script_clipboard)
             self.toolbar.sig_generate_plot_script_file_triggered.connect(self.generate_plot_script_file)
             self.toolbar.sig_home_clicked.connect(self.set_figure_zoom_to_display_all)
@@ -373,6 +374,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def launch_plot_help(self):
         PlotHelpPages.show_help_page_for_figure(self.canvas.figure)
+
+    def launch_superplot_help(self):
+        PlotHelpPages.show_help_page_for_figure(None, superplot=True)
 
     def hide_plot(self):
         self.window.hide()

--- a/qt/applications/workbench/workbench/plotting/plothelppages.py
+++ b/qt/applications/workbench/workbench/plotting/plothelppages.py
@@ -15,6 +15,7 @@ WATERFALL_PAGE = "WaterfallPlotsHelp.html"
 PLOT3D_PAGE = "3DPlotsHelp.html"
 COLORFILL_PAGE = "ColorfillPlotsHelp.html"
 MESH_PAGE = "MeshPlotHelp.html"
+SUPERPLOT_PAGE = "superplot.html"
 
 # Create a plot page for each enumeration in FigureType
 # The values can be edited if there is a more relevant documentation page
@@ -29,12 +30,16 @@ HELP_PAGES = {
     FigureType.Image: BASE_PATH + COLORFILL_PAGE,
     FigureType.Contour: BASE_PATH + COLORFILL_PAGE,
     FigureType.Mesh: BASE_PATH + MESH_PAGE,
+    FigureType.Superplot: "workbench/" + SUPERPLOT_PAGE,
 }
 
 
 class PlotHelpPages(object):
     @classmethod
-    def show_help_page_for_figure(cls, figure):
-        fig_type = figure_type(figure)
+    def show_help_page_for_figure(cls, figure, superplot=False):
+        if superplot:
+            fig_type = FigureType.Superplot
+        else:
+            fig_type = figure_type(figure)
         doc_url = HELP_PAGES[fig_type]
         InterfaceManager().showHelpPage(doc_url)

--- a/qt/applications/workbench/workbench/plotting/plothelppages.py
+++ b/qt/applications/workbench/workbench/plotting/plothelppages.py
@@ -16,6 +16,7 @@ PLOT3D_PAGE = "3DPlotsHelp.html"
 COLORFILL_PAGE = "ColorfillPlotsHelp.html"
 MESH_PAGE = "MeshPlotHelp.html"
 SUPERPLOT_PAGE = "superplot.html"
+WORKBENCH_PATH = "workbench/"
 
 # Create a plot page for each enumeration in FigureType
 # The values can be edited if there is a more relevant documentation page
@@ -30,7 +31,7 @@ HELP_PAGES = {
     FigureType.Image: BASE_PATH + COLORFILL_PAGE,
     FigureType.Contour: BASE_PATH + COLORFILL_PAGE,
     FigureType.Mesh: BASE_PATH + MESH_PAGE,
-    FigureType.Superplot: "workbench/" + SUPERPLOT_PAGE,
+    FigureType.Superplot: WORKBENCH_PATH + SUPERPLOT_PAGE,
 }
 
 

--- a/qt/applications/workbench/workbench/plotting/test/test_plothelppages.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_plothelppages.py
@@ -11,7 +11,17 @@ from matplotlib import use as mpl_use
 
 mpl_use("Agg")
 import numpy as np
-from workbench.plotting.plothelppages import BASE_PATH, COLORFILL_PAGE, INDEX_PAGE, PLOT1D_PAGE, PLOT3D_PAGE, WATERFALL_PAGE, PlotHelpPages
+from workbench.plotting.plothelppages import (
+    BASE_PATH,
+    COLORFILL_PAGE,
+    INDEX_PAGE,
+    PLOT1D_PAGE,
+    PLOT3D_PAGE,
+    WATERFALL_PAGE,
+    SUPERPLOT_PAGE,
+    WORKBENCH_PATH,
+    PlotHelpPages,
+)
 from matplotlib.pyplot import figure
 
 
@@ -76,6 +86,11 @@ class PlotHelpPagesTest(unittest.TestCase):
         PlotHelpPages.show_help_page_for_figure(fig)
 
         mock_show_page.assert_called_once_with(BASE_PATH + COLORFILL_PAGE)
+
+    @patch("workbench.plotting.plothelppages.InterfaceManager.showHelpPage")
+    def test_show_help_page_correctly_returns_superplot_plot_page(self, mock_show_page):
+        PlotHelpPages.show_help_page_for_figure(None, superplot=True)
+        mock_show_page.assert_called_once_with(WORKBENCH_PATH + SUPERPLOT_PAGE)
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -52,6 +52,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     sig_waterfall_conversion = QtCore.Signal(bool)
     sig_change_line_collection_colour_triggered = QtCore.Signal(QtGui.QColor)
     sig_hide_plot_triggered = QtCore.Signal()
+    super_plot_help_triggered = QtCore.Signal()
 
     toolitems = (
         MantidNavigationTool("Home", "Reset axes limits", "mdi.home", "on_home_clicked", None),
@@ -145,7 +146,12 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         self._actions["toggle_fit"].trigger()
 
     def launch_plot_help(self):
-        self.sig_plot_help_triggered.emit()
+        superplot_action = self._actions["toggle_superplot"]
+        is_checked = superplot_action.isChecked()
+        if is_checked:
+            self.super_plot_help_triggered.emit()
+        else:
+            self.sig_plot_help_triggered.emit()
 
     def print_figure(self):
         printer = QtPrintSupport.QPrinter(QtPrintSupport.QPrinter.HighResolution)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -52,7 +52,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     sig_waterfall_conversion = QtCore.Signal(bool)
     sig_change_line_collection_colour_triggered = QtCore.Signal(QtGui.QColor)
     sig_hide_plot_triggered = QtCore.Signal()
-    super_plot_help_triggered = QtCore.Signal()
+    sig_superplot_help_triggered = QtCore.Signal()
 
     toolitems = (
         MantidNavigationTool("Home", "Reset axes limits", "mdi.home", "on_home_clicked", None),
@@ -149,7 +149,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         superplot_action = self._actions["toggle_superplot"]
         is_checked = superplot_action.isChecked()
         if is_checked:
-            self.super_plot_help_triggered.emit()
+            self.sig_superplot_help_triggered.emit()
         else:
             self.sig_plot_help_triggered.emit()
 

--- a/qt/python/mantidqt/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/figuretype.py
@@ -45,6 +45,8 @@ class FigureType(Enum):
     Contour = 7
     # A 3D Mesh plot
     Mesh = 8
+    # A super plot
+    Superplot = 9
     # Any other type of plot
     Other = 100
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #38044 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Create a workspace `ws = CreateSampleWorkspace()`
2) Open a **Superplot**
<img width="557" height="316" alt="Screenshot 2026-03-18 at 4 33 34 pm" src="https://github.com/user-attachments/assets/6e104fbe-37c9-49e8-ab05-f4e0560316c4" />

3) Click Help 
<img width="34" height="34" alt="image" src="https://github.com/user-attachments/assets/22818332-98f2-4971-aab0-173c81fcd181" />

4) Verify that the help page that opens is the documentation for **Superplot**.
<img width="1027" height="792" alt="image" src="https://github.com/user-attachments/assets/74fa59e5-591d-4060-80f9-fd4ffd14d189" />

5) Unclick **Superplot**
<img width="68" height="31" alt="image" src="https://github.com/user-attachments/assets/c7a71a5b-3cb7-45d3-a641-333503e0b2f5" />

6) Click Help 
<img width="34" height="34" alt="image" src="https://github.com/user-attachments/assets/22818332-98f2-4971-aab0-173c81fcd181" />

7) Verify that the help page that opens is the documentation for **Basic 1D and Tiled Plots**.
<img width="1020" height="792" alt="image" src="https://github.com/user-attachments/assets/7eb17029-9af2-4f4d-a07a-d370e2b05898" />


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
