### PR TITLE
Fix doc-test builds

### DIFF
--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -53,6 +53,7 @@ function(add_python_package pkg_name)
   set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}.pip.stamp")
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
   set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})
+  message(WARNING "Using mantid version string ${_version_str}")
   add_custom_command(
     OUTPUT ${_stamp}
     COMMAND

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -53,12 +53,11 @@ function(add_python_package pkg_name)
   set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}.pip.stamp")
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
   set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})
-  message(WARNING "Using mantid version string ${_version_str}")
   add_custom_command(
     OUTPUT ${_stamp}
     COMMAND
       ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir} PATH=${_egg_link_dir}:$PATH
-      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --editable .
+      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --ignore-installed --editable .
     COMMAND ${CMAKE_COMMAND} -E touch ${_stamp}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${_setup_py}

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -57,7 +57,7 @@ function(add_python_package pkg_name)
     OUTPUT ${_stamp}
     COMMAND
       ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir} PATH=${_egg_link_dir}:$PATH
-      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --ignore-installed --editable .
+      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --editable .
     COMMAND ${CMAKE_COMMAND} -E touch ${_stamp}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${_setup_py}

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -131,6 +131,8 @@ git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
 # install pixi if not already installed
 install_pixi
 
+pixi run --frozen python -m pip uninstall -y mantid mantidqt MantidWorkbench mantidqtinterfaces instrumentview
+
 # Check whether this is an incremental build that only changes rst files
 if [ -d $BUILD_DIR ]; then
     if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then


### PR DESCRIPTION
A lot of recent docs-test builds have been ending with an error
```sh
14:47:04 Successfully built mantid
14:47:04 Installing collected packages: mantid
14:47:04   Attempting uninstall: mantid
14:47:04     Found existing installation: mantid None
14:47:04 error: uninstall-no-record-file
14:47:04 
14:47:04 × Cannot uninstall mantid None
14:47:04 ╰─> The package's contents are unknown: no RECORD file was found for mantid.
```
This solves the problem by running `pip uninstall` to remove the editable installs before it starts doing even cmake. Since things are editable installed, recreating the targets should not take long. 

It doesn't make sense that only the docs-test build is affected.

This does not have an associated issue.

### To test:

See that the builds all pass

*This does not require release notes* because it is modifying CI and not user facing.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
