### PR TITLE
Define project metadata for sip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [project]
 requires-python = ">=3.12"
 
+[tool.sip.metadata]
+# this is deprecated as of v6.8 and will use project metadata
+# https://python-sip.readthedocs.io/en/stable/pyproject_toml.html#tool-sip-metadata-section
+name = "mantid"
+
 [tool.ruff]
 line-length = 140
 # https://beta.ruff.rs/docs/rules/


### PR DESCRIPTION
This add metadata so sip will stop creating the error message
```sh
14:25:35 sip-build: pyproject.toml: the '[tool.sip.metadata]' section is missing
14:25:35 CMake Warning at buildconfig/CMake/FindSIP.cmake:110 (message):
14:25:35   FindSIP failed to determine sip version
14:25:35 Call Stack (most recent call first):
14:25:35   CMakeLists.txt:136 (find_package)
```

There is no associate issue

### To test:

Look at the build logs and see that the version of sip is logged from cmake rather than the error that is listed above.

*This does not require release notes* because it only gets rid of a warning in the builds.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
