### PR TITLE
Remove check for setuptools 48.0 because we're using >80.0

### DIFF
--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -65,7 +65,7 @@ function(add_python_package pkg_name)
   )
 
   # Generate a sitecustomize.py file in the egg link directory as setuptools no longer generates site.py for v>=49.0.0
-  if(_parsed_arg_GENERATE_SITECUSTOMIZE AND Python_SETUPTOOLS_VERSION VERSION_GREATER_EQUAL 49.0.0)
+  if(_parsed_arg_GENERATE_SITECUSTOMIZE)
     add_custom_command(
       OUTPUT ${_egg_link_dir}/sitecustomize.py
       COMMAND ${CMAKE_COMMAND} -DSITECUSTOMIZE_DIR=${_egg_link_dir} -P ${CMAKE_MODULE_PATH}/WriteSiteCustomize.cmake

--- a/dev-docs/source/BuildingOnOSX.rst
+++ b/dev-docs/source/BuildingOnOSX.rst
@@ -58,13 +58,7 @@ In order to be able to 'tap' the ``mantidproject/mantid`` 'tap' we need to have 
    # If you have enabled Zsh
    echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.zshenv
 
-9. Downgrade setuptools to 48.0.0 until https://github.com/mantidproject/mantid/issues/29010 is fixed.
-
-.. code-block:: sh
-
-   python3 -m pip install setuptools==48.0.0
-
-10. Install python requirements
+9. Install python requirements
 
 .. code-block:: sh
 


### PR DESCRIPTION
While investigating failed builds, I discovered some configuration and notes for a very old version of setuptools. This removes the checks to make things a tiny bit easier to read. The change to the osx dev-docs simply remove a step that shouldn't be done. 

There is no associated issue.

### To test:

All the builds should continue to pass.

*This does not require release notes* because it is a minor change to build configuration.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
