### PR TITLE
In Inelastic > Bayes Fitting > Stretch tab, improve naming of output workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -209,11 +209,21 @@ class BayesStretch(PythonAlgorithm):
         # create workspaces for sigma and beta
         workflow_prog.report("Creating OutputWorkspace")
 
-        self._create_workspace(fname + "_Sigma", [xSig, ySig, eSig], nsam, Qaxis)
-        self._create_workspace(fname + "_Beta", [xBet, yBet, eBet], nsam, Qaxis)
+        sigma_ws_name = fname + "_Sigma"
+        beta_ws_name = fname + "_Beta"
+        if not self.getProperty("OutputWorkspaceFit").isDefault:
+            # append the backend name i.e. QuickBayes or QuasiElasticBayes to individual ws names
+            backendName = self.getPropertyValue("OutputWorkspaceFit").split("_")[-1]
+            sigma_ws_name += f"_{backendName}"
+            beta_ws_name += f"_{backendName}"
+            fit_ws = self.getPropertyValue("OutputWorkspaceFit")
+        else:
+            fit_ws = fname + "_Fit"
 
-        group = fname + "_Sigma," + fname + "_Beta"
-        fit_ws = fname + "_Fit" if self.getProperty("OutputWorkspaceFit").isDefault else self.getPropertyValue("OutputWorkspaceFit")
+        self._create_workspace(sigma_ws_name, [xSig, ySig, eSig], nsam, Qaxis)
+        self._create_workspace(beta_ws_name, [xBet, yBet, eBet], nsam, Qaxis)
+
+        group = f"{sigma_ws_name},{beta_ws_name}"
         contour_ws = (
             fname + "_Contour" if self.getProperty("OutputWorkspaceContour").isDefault else self.getPropertyValue("OutputWorkspaceContour")
         )

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -209,15 +209,15 @@ class BayesStretch(PythonAlgorithm):
         # create workspaces for sigma and beta
         workflow_prog.report("Creating OutputWorkspace")
 
-        sigma_ws_name = fname + "_Sigma"
-        beta_ws_name = fname + "_Beta"
         if not self.getProperty("OutputWorkspaceFit").isDefault:
             # append the backend name i.e. QuickBayes or QuasiElasticBayes to individual ws names
             backendName = self.getPropertyValue("OutputWorkspaceFit").split("_")[-1]
-            sigma_ws_name += f"_{backendName}"
-            beta_ws_name += f"_{backendName}"
+            sigma_ws_name = f"{fname}_{backendName}_Sigma"
+            beta_ws_name = f"{fname}_{backendName}_Beta"
             fit_ws = self.getPropertyValue("OutputWorkspaceFit")
         else:
+            sigma_ws_name = f"{fname}_Sigma"
+            beta_ws_name = f"{fname}_Beta"
             fit_ws = fname + "_Fit"
 
         self._create_workspace(sigma_ws_name, [xSig, ySig, eSig], nsam, Qaxis)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -210,7 +210,7 @@ class BayesStretch(PythonAlgorithm):
         workflow_prog.report("Creating OutputWorkspace")
 
         if not self.getProperty("OutputWorkspaceFit").isDefault:
-            # append the backend name i.e. QuickBayes or QuasiElasticBayes to individual ws names
+            # include the backend name i.e. QuickBayes or QuasiElasticBayes to individual ws names
             backendName = self.getPropertyValue("OutputWorkspaceFit").split("_")[-1]
             sigma_ws_name = f"{fname}_{backendName}_Sigma"
             beta_ws_name = f"{fname}_{backendName}_Beta"

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch2.py
@@ -268,8 +268,8 @@ class BayesStretch2(QuickBayesTemplate):
         :param name: the name of the output worksapce
         :return group workspaces with the FWHM and beta slices
         """
-        beta = self.make_slice_ws(slice_list=beta_list, x_data=x_data, x_unit=x_unit, name=f"{name}_Stretch_Beta")
-        FWHM = self.make_slice_ws(slice_list=FWHM_list, x_data=x_data, x_unit="FWHM", name=f"{name}_Stretch_FWHM")
+        beta = self.make_slice_ws(slice_list=beta_list, x_data=x_data, x_unit=x_unit, name=f"{name}_Beta")
+        FWHM = self.make_slice_ws(slice_list=FWHM_list, x_data=x_data, x_unit="FWHM", name=f"{name}_FWHM")
         FWHM = self.set_label(ws_str=FWHM, label="FWHM", unit="eV")
         beta = self.set_label(ws_str=beta, label="beta", unit="")
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
@@ -134,7 +134,7 @@ class BayesStretch2Test(unittest.TestCase):
         x_data = [9]
 
         self._alg.make_results(beta_list, FWHM_list, x_data, "MomentumTransfer", "test")
-        self._alg.group_ws.assert_called_once_with(["test_Stretch_Beta", "test_Stretch_FWHM"], "test")
+        self._alg.group_ws.assert_called_once_with(["test_Beta", "test_FWHM"], "test")
 
         self.assert_mock_called_with(
             self._alg.make_slice_ws,
@@ -143,7 +143,7 @@ class BayesStretch2Test(unittest.TestCase):
             slice_list=beta_list,
             x_data=x_data,
             x_unit="MomentumTransfer",
-            name="test_Stretch_Beta",
+            name="test_Beta",
         )
         self.assert_mock_called_with(
             self._alg.make_slice_ws,
@@ -152,10 +152,10 @@ class BayesStretch2Test(unittest.TestCase):
             slice_list=FWHM_list,
             x_data=x_data,
             x_unit="FWHM",
-            name="test_Stretch_FWHM",
+            name="test_FWHM",
         )
-        self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=2, ws_str="test_Stretch_Beta", label="beta", unit="")
-        self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=1, ws_str="test_Stretch_FWHM", label="FWHM", unit="eV")
+        self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=2, ws_str="test_Beta", label="beta", unit="")
+        self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=1, ws_str="test_FWHM", label="FWHM", unit="eV")
 
     def test_do_one_spec(self):
         data = {

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
@@ -111,11 +111,13 @@ class BayesStretchTest(unittest.TestCase):
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[14], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[48], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[49], 0.0, places=tol_places)
+        self.assertEqual(fit_ws_sigma.name().split("_")[-1], fit_group.name().split("_")[-1])
         fit_ws_beta = fit_group.getItem(1)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[11], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[12], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[21], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[22], 0.0, places=tol_places)
+        self.assertEqual(fit_ws_beta.name().split("_")[-1], fit_group.name().split("_")[-1])
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
@@ -111,13 +111,15 @@ class BayesStretchTest(unittest.TestCase):
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[14], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[48], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_sigma.dataY(0)[49], 0.0, places=tol_places)
-        self.assertEqual(fit_ws_sigma.name().split("_")[-1], fit_group.name().split("_")[-1])
+        self.assertEqual(fit_ws_sigma.name().split("_")[-1], "Sigma")
+        self.assertEqual(fit_ws_sigma.name().split("_")[-2], fit_group.name().split("_")[-1])
         fit_ws_beta = fit_group.getItem(1)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[11], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[12], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[21], 0.0, places=tol_places)
         self.assertAlmostEqual(fit_ws_beta.dataY(0)[22], 0.0, places=tol_places)
-        self.assertEqual(fit_ws_beta.name().split("_")[-1], fit_group.name().split("_")[-1])
+        self.assertEqual(fit_ws_beta.name().split("_")[-1], "Beta")
+        self.assertEqual(fit_ws_beta.name().split("_")[-2], fit_group.name().split("_")[-1])
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v6.16.0/Inelastic/Algorithms/Bugfixes/41002.rst
+++ b/docs/source/release/v6.16.0/Inelastic/Algorithms/Bugfixes/41002.rst
@@ -1,2 +1,2 @@
-- The :ref:`BayesStretch <algm-BayesStretch>` algorithm was updated to append the backend name to the name of each workspace in its fit workspaces group in ``Stretch`` tab of :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>`
+- The :ref:`BayesStretch <algm-BayesStretch>` algorithm was updated to include the backend name to the name of each workspace in its fit workspaces group in ``Stretch`` tab of :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>`
 - In addition a duplicate ``Stretch`` word was removed from names of workspaces in the fit workspace group resulting from :ref:`BayesStretch2 <algm-BayesStretch2>` when the backend is set to ``quickbayes`` in ``Stretch`` tab.

--- a/docs/source/release/v6.16.0/Inelastic/Algorithms/Bugfixes/41002.rst
+++ b/docs/source/release/v6.16.0/Inelastic/Algorithms/Bugfixes/41002.rst
@@ -1,0 +1,2 @@
+- The :ref:`BayesStretch <algm-BayesStretch>` algorithm was updated to append the backend name to the name of each workspace in its fit workspaces group in ``Stretch`` tab of :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>`
+- In addition a duplicate ``Stretch`` word was removed from names of workspaces in the fit workspace group resulting from :ref:`BayesStretch2 <algm-BayesStretch2>` when the backend is set to ``quickbayes`` in ``Stretch`` tab.


### PR DESCRIPTION
### Description of work
In Inelastic > Bayes Fitting > Stretch tab, the backend name(quasielasticbayes) was appended to the output workspace names of fit workspace group. In addition when the backend is `quickbayes` , workspaces naming inside the fit workspace group was improved by removing a duplicate `Stretch` word in its name.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41002. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Follow test instructions for [Stretch Tab](https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html#id4) 
(To speed things up its recommended to extract a limited number of spectrumes(say 10) from `rs26176_graphite002_red` and setting `beta` to 3)
3. Test both quickbayes and QuasiElasticBayes backends
4. Observe names of the output workspaces inside the ``_Fit_`` workspace group being appended with `QuasiElasticBayes` when the back end is set to `QuasiElasticBayes`.
5. when the backend is set to `quickbayes` the workspace names inside the fit group should not have a duplicate `Stretch` word, but contains `QuickBayes`.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
