### PR TITLE
Change clone of doxygen deploy repository

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -35,7 +35,7 @@ jobs:
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
         # TODO
-        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         uses: actions/checkout@v6
         with:
           repo: mantidproject/doxygen
@@ -43,14 +43,14 @@ jobs:
 
       - name: Copy Doxygen artifacts
         # TODO
-        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         run: |
           rm -rf doxygen_repo/*
           cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
 
       - name: Commit Doxygen and push
         # TODO
-        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         working-directory: doxygen_repo
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,6 +1,10 @@
+name: doxygen documentation build and publish
 on:
   push:
     branches: [main]
+  # TODO
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 # cancel previous job if new commit is pushed
 concurrency:
@@ -45,7 +49,7 @@ jobs:
         # TODO
         if: ${{ steps.changes.outputs.doxygen == 'true' }}
         run: |
-          rm -rf doxygen_repo/*
+          rm -rf doxygen_repo/* # delete old version of the repository
           cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
 
       - name: Commit Doxygen and push
@@ -57,4 +61,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update Doxygen docs"
-          # TODO uncommentgit push origin main
+          # TODO uncomment git push origin main

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,4 +1,3 @@
-name: doxygen documentation build and publish
 on:
   push:
     branches: [main]

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -34,25 +34,27 @@ jobs:
 
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
-        if: ${{ steps.changes.outputs.doxygen == 'true' }}
-        env:
-          DOXYGEN_REPO_TOKEN: ${{ secrets.DOXYGEN_REPO_TOKEN }}
-        run: |
-          git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
-          rm -rf doxygen_repo/*
+        # TODO
+        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          repo: mantidproject/doxygen
+          path: doxygen_repo
 
       - name: Copy Doxygen artifacts
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        # TODO
+        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
         run: |
-          rm -rf doxygen_repo/* # delete old version of the repository
+          rm -rf doxygen_repo/*
           cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
 
       - name: Commit Doxygen and push
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        # TODO
+        if: ${{ github.ref_name == 'publish_doxygen' && steps.changes.outputs.doxygen == 'true' }}
         working-directory: doxygen_repo
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update Doxygen docs"
-          git push origin main
+          # TODO uncommentgit push origin main

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ steps.changes.outputs.doxygen == 'true' }}
         uses: actions/checkout@v6
         with:
-          repo: mantidproject/doxygen
+          repository: mantidproject/doxygen
           path: doxygen_repo
 
       - name: Copy Doxygen artifacts

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -2,9 +2,6 @@ name: doxygen documentation build and publish
 on:
   push:
     branches: [main]
-  # TODO
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 # cancel previous job if new commit is pushed
 concurrency:
@@ -38,27 +35,24 @@ jobs:
 
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
-        # TODO
-        if: ${{ steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
         uses: actions/checkout@v6
         with:
           repository: mantidproject/doxygen
           path: doxygen_repo
 
       - name: Copy Doxygen artifacts
-        # TODO
-        if: ${{ steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
         run: |
           rm -rf doxygen_repo/* # delete old version of the repository
           cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
 
       - name: Commit Doxygen and push
-        # TODO
-        if: ${{ steps.changes.outputs.doxygen == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
         working-directory: doxygen_repo
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update Doxygen docs"
-          # TODO uncomment git push origin main
+          git push origin main

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -37,7 +37,6 @@ jobs:
         name: Build doxygen
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
 
-
   build-and-test:
     needs: [doxygen]
     runs-on:

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,8 +1,10 @@
 name: Linux
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Check for merge conflicts"]
+    types:
+      - completed
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,10 +1,8 @@
 name: Linux
 
 on:
-  workflow_run:
-    workflows: ["Check for merge conflicts"]
-    types:
-      - completed
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:
@@ -42,7 +40,7 @@ jobs:
   build-and-test:
     needs: [doxygen]
     runs-on:
-      - ${{ inputs.RUNNER_LABEL || 'self-hosted' }}
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
       - self-hosted
       - Linux
       - X64

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
   build-and-test:
     needs: [doxygen]
     runs-on:
-      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - ${{ inputs.RUNNER_LABEL || 'self-hosted' }}
       - self-hosted
       - Linux
       - X64


### PR DESCRIPTION
According to the [checkout multiple repos (side by side) example in `actions/checkout`](https://github.com/actions/checkout?tab=readme-ov-file#checkout-multiple-repos-side-by-side), we can use the action to checkout the deploy repository.

Refs #39497

### To test:

Look at the logs of [this build](https://github.com/mantidproject/mantid/actions/runs/23861562094/job/69569354871?pr=41123) of https://github.com/mantidproject/mantid/pull/41123/commits/4b53617cb654e0a57fee57b165b8095dc85287ea which had changes to actually run the build on the PR. The commit after that removes building on PRs.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
