### PR TITLE
Fix crash on QENS Fitting Interface

### DIFF
--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.cpp
@@ -7,8 +7,6 @@
 #include "ConvolutionDataPresenter.h"
 #include "ConvolutionAddWorkspaceDialog.h"
 
-#include "MantidAPI/AnalysisDataService.h"
-
 namespace MantidQt::CustomInterfaces::Inelastic {
 
 ConvolutionDataPresenter::ConvolutionDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view)
@@ -16,20 +14,29 @@ ConvolutionDataPresenter::ConvolutionDataPresenter(IFitTab *tab, IDataModel *mod
 
 bool ConvolutionDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) {
   if (const auto convDialog = dynamic_cast<ConvolutionAddWorkspaceDialog const *>(dialog)) {
-    addWorkspace(convDialog->workspaceName(), convDialog->workspaceIndices());
-    setResolution(convDialog->resolutionName());
+    const auto &wsName = convDialog->workspaceName();
+    const auto &spectra = convDialog->workspaceIndices();
+    addWorkspace(wsName, spectra);
+    setResolution(convDialog->resolutionName(), wsName, spectra);
     return true;
   }
   return false;
 }
 
+void ConvolutionDataPresenter::setResolution(const std::string &resName, const std::string &wsName,
+                                             const FunctionModelSpectra &spectra) {
+  if (!m_model->setResolution(resName, wsName, spectra)) {
+    m_model->removeSpecialValues(resName);
+    displayWarning("Replaced the NaN's and infinities in " + resName + " with zeros");
+  }
+}
+
 void ConvolutionDataPresenter::addTableEntry(FitDomainIndex row) {
   const auto &name = m_model->getWorkspace(row)->getName();
-  auto resolutionVector = m_model->getResolutionsForFit();
-  const auto &resolution = resolutionVector.at(row.value).first;
   const auto workspaceIndex = m_model->getSpectrum(row);
   const auto range = m_model->getFittingRange(row);
   const auto exclude = m_model->getExcludeRegion(row);
+  const auto resolution = m_model->getResolutionName(m_model->getWorkspaceID(name), workspaceIndex);
 
   FitDataRow newRow;
   newRow.name = name;
@@ -38,7 +45,6 @@ void ConvolutionDataPresenter::addTableEntry(FitDomainIndex row) {
   newRow.startX = range.first;
   newRow.endX = range.second;
   newRow.exclude = exclude;
-
   m_view->addTableEntry(row.value, newRow);
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.h
@@ -18,6 +18,7 @@ class ConvolutionAddWorkspaceDialog;
 class MANTIDQT_INELASTIC_DLL ConvolutionDataPresenter : public FitDataPresenter {
 public:
   ConvolutionDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
+  ~ConvolutionDataPresenter() override = default;
 
   void setResolution(const std::string &resName, const std::string &wsName,
                      const FunctionModelSpectra &spectra) override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataPresenter.h
@@ -19,6 +19,8 @@ class MANTIDQT_INELASTIC_DLL ConvolutionDataPresenter : public FitDataPresenter 
 public:
   ConvolutionDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
 
+  void setResolution(const std::string &resName, const std::string &wsName,
+                     const FunctionModelSpectra &spectra) override;
   bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) override;
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FitDataPresenter.h"
 #include "FitTab.h"
+#include "MantidAPI/AnalysisDataService.h"
 
 #include <map>
 #include <utility>
@@ -94,7 +95,9 @@ void FitDataPresenter::handleAddData(MantidWidgets::IAddWorkspaceDialog const *d
 void FitDataPresenter::updateTableFromModel() {
   m_view->clearTable();
   for (auto domainIndex = FitDomainIndex{0}; domainIndex < getNumberOfDomains(); domainIndex++) {
-    addTableEntry(domainIndex);
+    if (AnalysisDataService::Instance().doesExist(m_model->getWorkspace(domainIndex)->getName())) {
+      addTableEntry(domainIndex);
+    }
   }
 }
 
@@ -224,12 +227,20 @@ void FitDataPresenter::handleRemoveClicked() {
   m_tab->handleDataChanged();
 }
 
+std::vector<std::string> FitDataPresenter::getWorkspaceNames() const { return m_model->getWorkspaceNames(); }
+
 void FitDataPresenter::handleUnifyClicked() {
   auto selectedIndices = m_view->getSelectedIndexes();
   if (selectedIndices.size() == 0) {
     // check that there are selected indexes.
     return;
   }
+  for (const auto &index : selectedIndices) {
+    const auto &[wsId, wsIndex] = m_model->getSubIndices(index.row());
+    std::cout << "id " << wsId << " index" << wsIndex << std::endl;
+  }
+  return;
+
   std::sort(selectedIndices.begin(), selectedIndices.end());
   auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -28,12 +28,13 @@ void FitDataPresenter::handleADSDelete(const std::string &wsName) {
   }
 }
 
-void FitDataPresenter::handleADSRename(const std::string &newName, const std::string &oldName) {
+void FitDataPresenter::handleADSRename(const std::string &oldName, const std::string &newName) {
   if (const auto removedNew = removeADSWorkspace(newName), removedOld = removeADSWorkspace(oldName);
       removedNew || removedOld) {
     updateTab();
     auto names = removedNew ? newName : "";
     names = removedOld ? names + " , " + oldName : names;
+    names = names.starts_with(",") ? names.substr(1) : names;
     displayWarning("Data " + names + " was removed from the ADS.");
   }
 }
@@ -267,11 +268,6 @@ void FitDataPresenter::handleUnifyClicked() {
     // check that there are selected indexes.
     return;
   }
-  for (const auto &index : selectedIndices) {
-    const auto &[wsId, wsIndex] = m_model->getSubIndices(index.row());
-    std::cout << "id " << wsId << " index" << wsIndex << std::endl;
-  }
-
   std::sort(selectedIndices.begin(), selectedIndices.end());
   auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -8,6 +8,7 @@
 #include "FitTab.h"
 #include "MantidAPI/AnalysisDataService.h"
 
+#include <algorithm>
 #include <map>
 #include <utility>
 
@@ -18,10 +19,49 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 FitDataPresenter::FitDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view)
     : m_tab(tab), m_model(model), m_view(view) {
   m_view->subscribePresenter(this);
-  observeReplace(true);
 }
 
-FitDataPresenter::~FitDataPresenter() { observeReplace(false); }
+void FitDataPresenter::handleADSDelete(const std::string &wsName) {
+  if (removeADSWorkspace(wsName)) {
+    updateTab();
+    displayWarning("Data " + wsName + " was removed from the ADS.");
+  }
+}
+
+void FitDataPresenter::handleADSRename(const std::string &newName, const std::string &oldName) {
+  if (const auto removedNew = removeADSWorkspace(newName), removedOld = removeADSWorkspace(oldName);
+      removedNew || removedOld) {
+    updateTab();
+    auto names = removedNew ? newName : "";
+    names = removedOld ? names + " , " + oldName : names;
+    displayWarning("Data " + names + " was removed from the ADS.");
+  }
+}
+
+void FitDataPresenter::handleADSClear() {
+  if (!m_model->getFittingData()->empty()) {
+    m_model->clearModel();
+    updateTab();
+  }
+}
+
+void FitDataPresenter::updateTab() {
+  updateTableFromModel();
+  m_tab->handleDataRemoved();
+  m_tab->handleDataChanged();
+}
+
+bool FitDataPresenter::removeADSWorkspace(const std::string &wsName) const {
+  const auto containsWs = m_model->workspaceNames().contains(wsName);
+  const auto containsResWs = m_model->resolutionNames().contains(wsName);
+  if (containsWs) {
+    m_model->removeWorkspaceByName(wsName);
+  }
+  if (containsResWs) {
+    m_model->removeResolution(wsName);
+  }
+  return containsWs || containsResWs;
+}
 
 IFitDataView const *FitDataPresenter::getView() const { return m_view; }
 
@@ -37,13 +77,6 @@ bool FitDataPresenter::addWorkspaceFromDialog(MantidWidgets::IAddWorkspaceDialog
 
 void FitDataPresenter::addWorkspace(const std::string &workspaceName, const FunctionModelSpectra &workspaceIndices) {
   m_model->addWorkspace(workspaceName, workspaceIndices);
-}
-
-void FitDataPresenter::setResolution(const std::string &name) {
-  if (m_model->setResolution(name) == false) {
-    m_model->removeSpecialValues(name);
-    displayWarning("Replaced the NaN's and infinities in " + name + " with zeros");
-  }
 }
 
 void FitDataPresenter::setStartX(double startX, WorkspaceID workspaceID) {
@@ -94,10 +127,9 @@ void FitDataPresenter::handleAddData(MantidWidgets::IAddWorkspaceDialog const *d
 
 void FitDataPresenter::updateTableFromModel() {
   m_view->clearTable();
+  m_model->updateWorkspaceNames();
   for (auto domainIndex = FitDomainIndex{0}; domainIndex < getNumberOfDomains(); domainIndex++) {
-    if (AnalysisDataService::Instance().doesExist(m_model->getWorkspace(domainIndex)->getName())) {
-      addTableEntry(domainIndex);
-    }
+    addTableEntry(domainIndex);
   }
 }
 
@@ -239,7 +271,6 @@ void FitDataPresenter::handleUnifyClicked() {
     const auto &[wsId, wsIndex] = m_model->getSubIndices(index.row());
     std::cout << "id " << wsId << " index" << wsIndex << std::endl;
   }
-  return;
 
   std::sort(selectedIndices.begin(), selectedIndices.end());
   auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -32,7 +32,7 @@ public:
   virtual void handleUnifyClicked() = 0;
   virtual void handleCellChanged(int row, int column) = 0;
   virtual void handleADSDelete(const std::string &wsName) = 0;
-  virtual void handleADSRename(const std::string &newName, const std::string &oldName) = 0;
+  virtual void handleADSRename(const std::string &oldName, const std::string &newName) = 0;
   virtual void handleADSClear() = 0;
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -73,6 +73,7 @@ public:
   };
 
   std::string tabName() const override;
+  std::vector<std::string> getWorkspaceNames() const;
 
   void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
   void handleRemoveClicked() override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -13,7 +13,6 @@
 
 #include "DllConfig.h"
 #include "InelasticFitPropertyBrowser.h"
-#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 
@@ -31,15 +30,17 @@ public:
   virtual void handleRemoveClicked() = 0;
   virtual void handleUnifyClicked() = 0;
   virtual void handleCellChanged(int row, int column) = 0;
+  virtual void handleADSDelete(const std::string &wsName) = 0;
+  virtual void handleADSRename(const std::string &newName, const std::string &oldName) = 0;
+  virtual void handleADSClear() = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL FitDataPresenter : public IFitDataPresenter, public AnalysisDataServiceObserver {
+class MANTIDQT_INELASTIC_DLL FitDataPresenter : public IFitDataPresenter {
 public:
   FitDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
-  ~FitDataPresenter() override;
+  ~FitDataPresenter() = default;
   virtual bool addWorkspaceFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog);
   void addWorkspace(const std::string &workspaceName, const FunctionModelSpectra &workspaceIndices);
-  void setResolution(const std::string &name);
   void setStartX(double startX, WorkspaceID workspaceID);
   void setStartX(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
   void setEndX(double startX, WorkspaceID workspaceID);
@@ -48,6 +49,7 @@ public:
   std::vector<std::pair<std::string, size_t>> getResolutionsForFit() const;
 
   void updateTableFromModel();
+  void updateTab();
   WorkspaceID getNumberOfWorkspaces() const;
   size_t getNumberOfDomains() const;
   QList<FunctionModelDataset> getDatasets() const;
@@ -62,7 +64,14 @@ public:
     UNUSED_ARG(workspaceName);
     UNUSED_ARG(paramType);
     UNUSED_ARG(spectrum_index);
-  };
+  }
+
+  virtual void setResolution(const std::string &resName, const std::string &wsName,
+                             const FunctionModelSpectra &spectra) {
+    UNUSED_ARG(resName);
+    UNUSED_ARG(wsName);
+    UNUSED_ARG(spectra);
+  }
 
   virtual void setActiveSpectra(std::vector<std::size_t> const &activeParameterSpectra, std::size_t parameterIndex,
                                 WorkspaceID dataIndex, bool single = true) {
@@ -79,6 +88,9 @@ public:
   void handleRemoveClicked() override;
   void handleUnifyClicked() override;
   void handleCellChanged(int row, int column) override;
+  void handleADSDelete(const std::string &wsName) override;
+  void handleADSRename(const std::string &oldName, const std::string &newName) override;
+  void handleADSClear() override;
 
 protected:
   IFitDataView const *getView() const;
@@ -96,6 +108,7 @@ private:
   void setTableEndXAndEmit(double X, int row, int column);
   void setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row);
   std::map<int, QModelIndex> getUniqueIndices(const QModelIndexList &selectedIndices);
+  bool removeADSWorkspace(const std::string &wsName) const;
 };
 
 } // namespace Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -24,6 +24,7 @@ class IFitTab;
 
 class MANTIDQT_INELASTIC_DLL IFitDataPresenter {
 public:
+  virtual ~IFitDataPresenter() = default;
   virtual std::string tabName() const = 0;
 
   virtual void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) = 0;
@@ -38,7 +39,7 @@ public:
 class MANTIDQT_INELASTIC_DLL FitDataPresenter : public IFitDataPresenter {
 public:
   FitDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
-  ~FitDataPresenter() = default;
+  ~FitDataPresenter() override = default;
   virtual bool addWorkspaceFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog);
   void addWorkspace(const std::string &workspaceName, const FunctionModelSpectra &workspaceIndices);
   void setStartX(double startX, WorkspaceID workspaceID);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -58,7 +58,7 @@ FitDataView::~FitDataView() {
 
 void FitDataView::clearHandle() { QMetaObject::invokeMethod(this, "notifyADSClear", Qt::AutoConnection); }
 
-void FitDataView::renameHandle(const std::string &newName, const std::string &oldName) {
+void FitDataView::renameHandle(const std::string &oldName, const std::string &newName) {
   QMetaObject::invokeMethod(this, "notifyADSRename", Qt::AutoConnection, Q_ARG(const std::string &, newName),
                             Q_ARG(const std::string &, oldName));
 }
@@ -72,8 +72,8 @@ void FitDataView::notifyADSClear() const { m_presenter->handleADSClear(); }
 
 void FitDataView::notifyADSDelete(const std::string &wsName) const { m_presenter->handleADSDelete(wsName); }
 
-void FitDataView::notifyADSRename(const std::string &newName, const std::string &oldName) const {
-  m_presenter->handleADSRename(newName, oldName);
+void FitDataView::notifyADSRename(const std::string &oldName, const std::string &newName) const {
+  m_presenter->handleADSRename(oldName, newName);
 }
 
 void FitDataView::subscribePresenter(IFitDataPresenter *presenter) { m_presenter = presenter; }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -32,7 +32,6 @@ QStringList defaultHeaders() {
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace Inelastic {
-
 FitDataView::FitDataView(QWidget *parent) : FitDataView(defaultHeaders(), parent) {}
 
 FitDataView::FitDataView(const QStringList &headers, QWidget *parent)
@@ -45,6 +44,36 @@ FitDataView::FitDataView(const QStringList &headers, QWidget *parent)
   connect(m_uiForm->pbRemove, &QPushButton::clicked, this, &FitDataView::notifyRemoveClicked);
   connect(m_uiForm->pbUnify, &QPushButton::clicked, this, &FitDataView::notifyUnifyClicked);
   connect(m_uiForm->tbFitData, &QTableWidget::cellChanged, this, &FitDataView::notifyCellChanged);
+  // ADS Observer
+  observeDelete(true);
+  observeRename(true);
+  observeClear(true);
+}
+
+FitDataView::~FitDataView() {
+  observeDelete(false);
+  observeRename(false);
+  observeClear(false);
+}
+
+void FitDataView::clearHandle() { QMetaObject::invokeMethod(this, "notifyADSClear", Qt::AutoConnection); }
+
+void FitDataView::renameHandle(const std::string &newName, const std::string &oldName) {
+  QMetaObject::invokeMethod(this, "notifyADSRename", Qt::AutoConnection, Q_ARG(const std::string &, newName),
+                            Q_ARG(const std::string &, oldName));
+}
+
+void FitDataView::deleteHandle(const std::string &name, const Workspace_sptr &ws) {
+  UNUSED_ARG(ws);
+  QMetaObject::invokeMethod(this, "notifyADSDelete", Qt::AutoConnection, Q_ARG(const std::string &, name));
+}
+
+void FitDataView::notifyADSClear() const { m_presenter->handleADSClear(); }
+
+void FitDataView::notifyADSDelete(const std::string &wsName) const { m_presenter->handleADSDelete(wsName); }
+
+void FitDataView::notifyADSRename(const std::string &newName, const std::string &oldName) const {
+  m_presenter->handleADSRename(newName, oldName);
 }
 
 void FitDataView::subscribePresenter(IFitDataPresenter *presenter) { m_presenter = presenter; }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
@@ -49,7 +49,7 @@ public:
   void displayWarning(const std::string &warning) override;
   void clearHandle() override;
   void deleteHandle(const std::string &name, const Workspace_sptr &ws) override;
-  void renameHandle(const std::string &newName, const std::string &oldName) override;
+  void renameHandle(const std::string &oldName, const std::string &newName) override;
 
 protected slots:
   void notifyAddData(MantidWidgets::IAddWorkspaceDialog *dialog);
@@ -70,7 +70,7 @@ private slots:
   void notifyUnifyClicked();
   void notifyCellChanged(int row, int column);
   void notifyADSDelete(const std::string &wsName) const;
-  void notifyADSRename(const std::string &newName, const std::string &oldName) const;
+  void notifyADSRename(const std::string &oldName, const std::string &newName) const;
   void notifyADSClear() const;
 
 private:

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
@@ -14,6 +14,7 @@
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
+#include <MantidAPI/AnalysisDataServiceObserver.h>
 #include <QTabWidget>
 
 namespace MantidQt {
@@ -25,11 +26,11 @@ namespace Inelastic {
 
 class IFitDataPresenter;
 
-class MANTIDQT_INELASTIC_DLL FitDataView : public QTabWidget, public IFitDataView {
+class MANTIDQT_INELASTIC_DLL FitDataView : public QTabWidget, public IFitDataView, public AnalysisDataServiceObserver {
   Q_OBJECT
 public:
   FitDataView(QWidget *parent);
-  ~FitDataView() override = default;
+  ~FitDataView() override;
 
   void subscribePresenter(IFitDataPresenter *presenter) override;
 
@@ -46,6 +47,9 @@ public:
   bool columnContains(std::string const &columnHeader, std::string const &text) const override;
 
   void displayWarning(const std::string &warning) override;
+  void clearHandle() override;
+  void deleteHandle(const std::string &name, const Workspace_sptr &ws) override;
+  void renameHandle(const std::string &newName, const std::string &oldName) override;
 
 protected slots:
   void notifyAddData(MantidWidgets::IAddWorkspaceDialog *dialog);
@@ -65,6 +69,9 @@ private slots:
   void notifyRemoveClicked();
   void notifyUnifyClicked();
   void notifyCellChanged(int row, int column);
+  void notifyADSDelete(const std::string &wsName) const;
+  void notifyADSRename(const std::string &newName, const std::string &oldName) const;
+  void notifyADSClear() const;
 
 private:
   QStringList m_HeaderLabels;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -608,7 +608,9 @@ IAlgorithm_sptr FittingModel::createSimultaneousFit(const MultiDomainFunction_sp
   fitAlgorithm->setProperty("OutputWorkspace", *outputName);
   return fitAlgorithm;
 }
+
 std::string FittingModel::getResultsSuffix() const { return isMultiFit() ? "_Results" : "_Result"; }
+
 std::string FittingModel::singleFitOutputName(std::string workspaceName, WorkspaceIndex spectrum) const {
   std::string inputWorkspace = isMultiFit() ? "Multi" : workspaceName;
   std::string spectra = std::to_string(spectrum.value);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.h
@@ -27,6 +27,7 @@ class MANTIDQT_INELASTIC_DLL FunctionQDataPresenter : public FitDataPresenter, p
 
 public:
   FunctionQDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
+  ~FunctionQDataPresenter() override = default;
   bool addWorkspaceFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
   void addWorkspace(const std::string &workspaceName, const std::string &paramType, const int &spectrum_index) override;
   void setActiveSpectra(std::vector<std::size_t> const &activeParameterSpectra, std::size_t parameterIndex,

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -435,7 +435,6 @@ void InelasticFitPropertyBrowser::updateFunctionBrowserData(
     m_templatePresenter->setResolution(fitResolutions);
   } catch (Mantid::Kernel::Exception::NotFoundError &) {
     // Convolution Function may have tried to access non-existent ADS workspaces
-    m_functionBrowser->resetLocalParameters();
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -425,12 +425,21 @@ FitDomainIndex InelasticFitPropertyBrowser::currentDataset() const {
 void InelasticFitPropertyBrowser::updateFunctionBrowserData(
     int nData, const QList<FunctionModelDataset> &datasets, const std::vector<double> &qValues,
     const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
-  m_functionBrowser->setNumberOfDatasets(nData);
-  m_functionBrowser->setDatasets(datasets);
-  m_templatePresenter->setNumberOfDatasets(nData);
-  m_templatePresenter->setDatasets(datasets);
-  m_templatePresenter->setQValues(qValues);
-  m_templatePresenter->setResolution(fitResolutions);
+  try {
+    m_functionBrowser->setNumberOfDatasets(nData);
+    m_functionBrowser->setDatasets(datasets);
+    m_templatePresenter->setResolution(fitResolutions);
+    m_templatePresenter->setNumberOfDatasets(nData);
+    m_templatePresenter->setDatasets(datasets);
+    m_templatePresenter->setQValues(qValues);
+  } catch (Mantid::Kernel::Exception::NotFoundError &) {
+    m_functionBrowser->setNumberOfDatasets(0);
+    // m_functionBrowser->setDatasets(datasets);
+    // //m_templatePresenter->setResolution(fitResolutions);
+    m_templatePresenter->setNumberOfDatasets(0);
+    // m_templatePresenter->setDatasets(datasets);
+    // m_templatePresenter->setQValues(qValues);
+  }
 }
 
 void InelasticFitPropertyBrowser::setFitEnabled(bool) {}

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -428,17 +428,14 @@ void InelasticFitPropertyBrowser::updateFunctionBrowserData(
   try {
     m_functionBrowser->setNumberOfDatasets(nData);
     m_functionBrowser->setDatasets(datasets);
-    m_templatePresenter->setResolution(fitResolutions);
+
     m_templatePresenter->setNumberOfDatasets(nData);
     m_templatePresenter->setDatasets(datasets);
     m_templatePresenter->setQValues(qValues);
+    m_templatePresenter->setResolution(fitResolutions);
   } catch (Mantid::Kernel::Exception::NotFoundError &) {
-    m_functionBrowser->setNumberOfDatasets(0);
-    // m_functionBrowser->setDatasets(datasets);
-    // //m_templatePresenter->setResolution(fitResolutions);
-    m_templatePresenter->setNumberOfDatasets(0);
-    // m_templatePresenter->setDatasets(datasets);
-    // m_templatePresenter->setQValues(qValues);
+    // Convolution Function may have tried to access non-existent ADS workspaces
+    m_functionBrowser->resetLocalParameters();
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionDataPresenterTest.h
@@ -94,21 +94,21 @@ public:
   }
 
   void test_setResolution_calls_to_model() {
-    ON_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).WillByDefault(Return(true));
-    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).Times(Exactly(1));
+    ON_CALL(*m_model, setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"))).WillByDefault(Return(true));
+    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"))).Times(Exactly(1));
     EXPECT_CALL(*m_model, removeSpecialValues("ResWs")).Times(Exactly(0));
     EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in ResWs with zeros")).Times(Exactly(0));
 
-    m_presenter->setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"));
+    m_presenter->setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"));
   }
 
   void test_setResolution_has_bad_values() {
-    ON_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).WillByDefault(Return(false));
-    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).Times(Exactly(1));
+    ON_CALL(*m_model, setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"))).WillByDefault(Return(false));
+    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"))).Times(Exactly(1));
     EXPECT_CALL(*m_model, removeSpecialValues("ResWs")).Times(Exactly(1));
     EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in ResWs with zeros")).Times(Exactly(1));
 
-    m_presenter->setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"));
+    m_presenter->setResolution("ResWs", "TestWs", FunctionModelSpectra("0-3"));
   }
 
   void test_updateTableFromModel_clears_table_and_adds_new_row_for_each_entry() {

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionDataPresenterTest.h
@@ -52,8 +52,8 @@ public:
     m_presenter = std::make_unique<ConvolutionDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
 
     m_workspace = createWorkspace(6);
-    m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
-    m_model->addWorkspace("WorkspaceName", FunctionModelSpectra("0-5"));
+    m_ads = std::make_unique<SetUpADSWithWorkspace>("TestWs", m_workspace);
+    m_model->addWorkspace("TestWs", FunctionModelSpectra("0-5"));
   }
 
   void tearDown() override {
@@ -93,19 +93,39 @@ public:
     TS_ASSERT(m_presenter->addWorkspaceFromDialog(dialog));
   }
 
+  void test_setResolution_calls_to_model() {
+    ON_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).WillByDefault(Return(true));
+    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).Times(Exactly(1));
+    EXPECT_CALL(*m_model, removeSpecialValues("ResWs")).Times(Exactly(0));
+    EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in ResWs with zeros")).Times(Exactly(0));
+
+    m_presenter->setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"));
+  }
+
+  void test_setResolution_has_bad_values() {
+    ON_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).WillByDefault(Return(false));
+    EXPECT_CALL(*m_model, setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"))).Times(Exactly(1));
+    EXPECT_CALL(*m_model, removeSpecialValues("ResWs")).Times(Exactly(1));
+    EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in ResWs with zeros")).Times(Exactly(1));
+
+    m_presenter->setResolution("ResWs", "TestWS", FunctionModelSpectra("0-3"));
+  }
+
   void test_updateTableFromModel_clears_table_and_adds_new_row_for_each_entry() {
     EXPECT_CALL(*m_view, clearTable()).Times(Exactly(1));
+    EXPECT_CALL(*m_model, updateWorkspaceNames()).Times(Exactly(1));
     EXPECT_CALL(*m_model, getNumberOfDomains()).Times(Exactly(4)).WillRepeatedly(Return(3));
-    EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(0))).Times(Exactly(1)).WillOnce(Return(m_workspace));
-    EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(1))).Times(Exactly(1)).WillOnce(Return(m_workspace));
-    EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(2))).Times(Exactly(1)).WillOnce(Return(m_workspace));
-    std::vector<std::pair<std::string, size_t>> resolutionsForFit(
-        {{"Workspace", 1}, {"Workspace", 1}, {"Workspace", 1}});
-    EXPECT_CALL(*m_model, getResolutionsForFit()).Times(Exactly(3)).WillRepeatedly(Return(resolutionsForFit));
+    EXPECT_CALL(*m_model, getWorkspaceID("TestWs")).Times(Exactly(3)).WillRepeatedly(Return(WorkspaceID{0}));
+
     FitDataRow newRow;
-    EXPECT_CALL(*m_view, addTableEntry(0, _)).Times(Exactly(1));
-    EXPECT_CALL(*m_view, addTableEntry(1, _)).Times(Exactly(1));
-    EXPECT_CALL(*m_view, addTableEntry(2, _)).Times(Exactly(1));
+    for (size_t index = 0; index < 3; index++) {
+      EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(index))).Times(Exactly(1)).WillOnce(Return(m_workspace));
+      EXPECT_CALL(*m_model, getSpectrum(FitDomainIndex(index))).Times(Exactly(1)).WillOnce(Return(index));
+      EXPECT_CALL(*m_model, getResolutionName(WorkspaceID{0}, WorkspaceIndex{index}))
+          .Times(Exactly(1))
+          .WillOnce(Return("ResWs"));
+      EXPECT_CALL(*m_view, addTableEntry(index, _)).Times(Exactly(1));
+    }
 
     m_presenter->updateTableFromModel();
   }

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
@@ -117,7 +117,7 @@ public:
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_table.get()));
     m_presenter = std::make_unique<FitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspace(5);
-    m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
+    m_ads = std::make_unique<SetUpADSWithWorkspace>("TestWs", m_workspace);
   }
 
   void tearDown() override {
@@ -145,27 +145,8 @@ public:
 
   void test_addWorkspace_with_spectra_calls_to_model() {
     auto workpaceIndices = FunctionModelSpectra("0-3");
-    EXPECT_CALL(*m_model, addWorkspace("WorkspaceName", workpaceIndices)).Times(Exactly(1));
-    m_presenter->addWorkspace("WorkspaceName", workpaceIndices);
-  }
-
-  void test_setResolution_calls_to_model() {
-    ON_CALL(*m_model, setResolution("WorkspaceName")).WillByDefault(Return(true));
-    EXPECT_CALL(*m_model, setResolution("WorkspaceName")).Times(Exactly(1));
-    m_presenter->setResolution("WorkspaceName");
-    EXPECT_CALL(*m_model, removeSpecialValues("WorkspaceName")).Times(Exactly(0));
-    EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in WorkspaceName with zeros"))
-        .Times(Exactly(0));
-  }
-
-  void test_setResolution_has_bad_values() {
-    ON_CALL(*m_model, setResolution("WorkspaceName")).WillByDefault(Return(false));
-    EXPECT_CALL(*m_model, setResolution("WorkspaceName")).Times(Exactly(1));
-    EXPECT_CALL(*m_model, removeSpecialValues("WorkspaceName")).Times(Exactly(1));
-    EXPECT_CALL(*m_view, displayWarning("Replaced the NaN's and infinities in WorkspaceName with zeros"))
-        .Times(Exactly(1));
-
-    m_presenter->setResolution("WorkspaceName");
+    EXPECT_CALL(*m_model, addWorkspace("TestWs", workpaceIndices)).Times(Exactly(1));
+    m_presenter->addWorkspace("TestWs", workpaceIndices);
   }
 
   void test_getResolutionsForFit_calls_from_model() {
@@ -180,6 +161,7 @@ public:
     EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(0))).Times(Exactly(1)).WillOnce(Return(m_workspace));
     EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(1))).Times(Exactly(1)).WillOnce(Return(m_workspace));
     EXPECT_CALL(*m_model, getWorkspace(FitDomainIndex(2))).Times(Exactly(1)).WillOnce(Return(m_workspace));
+    EXPECT_CALL(*m_model, updateWorkspaceNames()).Times(Exactly(1));
     FitDataRow newRow;
     EXPECT_CALL(*m_view, addTableEntry(0, _)).Times(Exactly(1));
     EXPECT_CALL(*m_view, addTableEntry(1, _)).Times(Exactly(1));

--- a/qt/widgets/common/src/ConvolutionFunctionModel.cpp
+++ b/qt/widgets/common/src/ConvolutionFunctionModel.cpp
@@ -67,21 +67,17 @@ void ConvolutionFunctionModel::setModel(const std::string &background,
                                         const std::string &lorentzianPeaks, const std::string &fitType,
                                         bool hasDeltaFunction, const std::vector<double> &qValues,
                                         const bool isQDependent, bool hasTempCorrection, double tempValue) {
-  auto fitFunction = std::make_shared<MultiDomainFunction>();
-  auto nf = std::min(resolutionWorkspaces.size(), qValues.size());
-  if (m_numberDomains * nf < 0) {
-    nf = 1;
-  }
-
+  const auto fitFunction = std::make_shared<MultiDomainFunction>();
+  const auto nf = m_numberDomains > 0 ? m_numberDomains : 1;
   for (size_t i = 0; i < nf; ++i) {
     CompositeFunction_sptr domainFunction;
-    auto qValue = qValues.empty() ? 0.0 : qValues[i];
+    const auto qValue = qValues.empty() || i >= qValues.size() ? 0.0 : qValues[i];
     auto innerFunction = createInnerFunction(lorentzianPeaks, fitType, hasDeltaFunction, isQDependent, qValue,
                                              hasTempCorrection, tempValue);
-    auto workspace = resolutionWorkspaces.empty() ? "" : resolutionWorkspaces[i].first;
-    auto workspaceIndex = resolutionWorkspaces.empty() ? 0 : resolutionWorkspaces[i].second;
-    auto resolutionFunction = createResolutionFunction(workspace, workspaceIndex);
-    auto convolutionFunction = createConvolutionFunction(resolutionFunction, innerFunction);
+    const auto &[workspace, workspaceIndex] =
+        resolutionWorkspaces.empty() || i >= resolutionWorkspaces.size() ? std::pair("", 0.0) : resolutionWorkspaces[i];
+    const auto resolutionFunction = createResolutionFunction(workspace, workspaceIndex);
+    const auto convolutionFunction = createConvolutionFunction(resolutionFunction, innerFunction);
     domainFunction = addBackground(convolutionFunction, background);
 
     fitFunction->addFunction(domainFunction);
@@ -92,7 +88,7 @@ void ConvolutionFunctionModel::setModel(const std::string &background,
   // structure subtly changing. For example composite functions of only one
   // member are removed and unneeded brackets are removed from user defined
   // functions. As function cloning is used later on in the workflow it seems
-  // safer to clone twice here to get the function in it's final state early on
+  // safer to clone twice here to get the function in its final state early on
   // rather than have it change during the workflow.
   setFunction(fitFunction->clone()->clone());
 }

--- a/qt/widgets/common/src/ConvolutionFunctionModel.cpp
+++ b/qt/widgets/common/src/ConvolutionFunctionModel.cpp
@@ -68,8 +68,12 @@ void ConvolutionFunctionModel::setModel(const std::string &background,
                                         bool hasDeltaFunction, const std::vector<double> &qValues,
                                         const bool isQDependent, bool hasTempCorrection, double tempValue) {
   auto fitFunction = std::make_shared<MultiDomainFunction>();
-  auto const nf = m_numberDomains > 0 ? static_cast<int>(m_numberDomains) : 1;
-  for (int i = 0; i < nf; ++i) {
+  auto nf = std::min(resolutionWorkspaces.size(), qValues.size());
+  if (m_numberDomains * nf < 0) {
+    nf = 1;
+  }
+
+  for (size_t i = 0; i < nf; ++i) {
     CompositeFunction_sptr domainFunction;
     auto qValue = qValues.empty() ? 0.0 : qValues[i];
     auto innerFunction = createInnerFunction(lorentzianPeaks, fitType, hasDeltaFunction, isQDependent, qValue,

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataModel.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataModel.h
@@ -77,6 +77,7 @@ public:
   std::vector<double> getExcludeRegionVector(WorkspaceID workspaceID, WorkspaceIndex spectrum) const override;
   std::vector<double> getExcludeRegionVector(FitDomainIndex index) const override;
   void removeSpecialValues(const std::string &name) override;
+  void removeWorkspaceByName(const std::string &name) override;
 
 protected:
   void addNewWorkspace(const Mantid::API::MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra);

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataModel.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataModel.h
@@ -39,6 +39,7 @@ public:
   std::vector<std::string> getWorkspaceNames() const override;
   WorkspaceID getNumberOfWorkspaces() const override;
   bool hasWorkspace(std::string const &workspaceName) const override;
+  WorkspaceID getWorkspaceID(std::string const &workspaceName) const override;
 
   void setSpectra(const std::string &spectra, WorkspaceID workspaceID) override;
   void setSpectra(FunctionModelSpectra &&spectra, WorkspaceID workspaceID) override;
@@ -55,6 +56,7 @@ public:
   std::pair<WorkspaceID, WorkspaceIndex> getSubIndices(FitDomainIndex) const override;
   std::vector<double> getQValuesForData() const override;
   std::vector<std::pair<std::string, size_t>> getResolutionsForFit() const override;
+  std::string getResolutionName(const WorkspaceID &wsID, const WorkspaceIndex &index) const override;
   std::string createDisplayName(WorkspaceID workspaceID) const override;
 
   void removeWorkspace(WorkspaceID workspaceID) override;
@@ -68,8 +70,11 @@ public:
   void setEndX(double startX, FitDomainIndex fitDomainIndex) override;
   void setExcludeRegion(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum) override;
   void setExcludeRegion(const std::string &exclude, FitDomainIndex index) override;
-  bool setResolution(const std::string &name) override;
-  bool setResolution(const std::string &name, WorkspaceID workspaceID) override;
+  bool setResolution(const std::string &resName, const std::string &wsName,
+                     const FunctionModelSpectra &spectra) override;
+  bool setResolution(const std::string &resName, WorkspaceID workspaceID, const FunctionModelSpectra &spectra) override;
+  void removeResolution(const std::string &resName) override;
+  std::set<std::string> getResolutionNames() override;
   std::pair<double, double> getFittingRange(WorkspaceID workspaceID, WorkspaceIndex spectrum) const override;
   std::pair<double, double> getFittingRange(FitDomainIndex index) const override;
   std::string getExcludeRegion(WorkspaceID workspaceID, WorkspaceIndex spectrum) const override;
@@ -78,6 +83,11 @@ public:
   std::vector<double> getExcludeRegionVector(FitDomainIndex index) const override;
   void removeSpecialValues(const std::string &name) override;
   void removeWorkspaceByName(const std::string &name) override;
+  void clearModel() override;
+  void updateWorkspaceNames() override;
+
+  std::set<std::string> const &resolutionNames() const override;
+  std::set<std::string> const &workspaceNames() const override;
 
 protected:
   void addNewWorkspace(const Mantid::API::MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra);
@@ -85,7 +95,8 @@ protected:
 private:
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   std::unique_ptr<std::vector<FitData>> m_fittingData;
-  std::unique_ptr<std::vector<std::weak_ptr<Mantid::API::MatrixWorkspace>>> m_resolutions;
+  std::set<std::string> m_uniqueWsNames;
+  std::set<std::string> m_uniqueResWsNames;
 };
 
 } // namespace Inelastic

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
@@ -40,7 +40,7 @@ public:
   std::string displayName(const std::string &formatString, const std::string &rangeDelimiter) const;
   std::string displayName(const std::string &formatString, WorkspaceIndex spectrum) const;
   std::string getBasename() const;
-  std::string getWsName() const;
+  const std::string &getWsName() const;
 
   Mantid::API::MatrixWorkspace_sptr workspace() const;
   const FunctionModelSpectra &spectra() const;
@@ -54,7 +54,7 @@ public:
 
   std::vector<double> excludeRegionsVector(WorkspaceIndex spectrum) const;
   std::vector<double> getQValues() const;
-  std::map<WorkspaceIndex, std::string> getResolutions() const;
+  const std::map<WorkspaceIndex, std::string> &getResolutions() const;
   void removeResolutionEntry(const WorkspaceIndex &index);
   std::set<std::string> getResolutionNames() const;
   std::string getResolutionFromWsIndex(const WorkspaceIndex &index) const;

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
@@ -35,9 +35,12 @@ public:
   FitData(const Mantid::API::MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra,
           const std::string &wsName);
 
+  void setupFitData(FunctionModelSpectra const &spectra, Mantid::API::MatrixWorkspace_sptr const &workspace);
+
   std::string displayName(const std::string &formatString, const std::string &rangeDelimiter) const;
   std::string displayName(const std::string &formatString, WorkspaceIndex spectrum) const;
   std::string getBasename() const;
+  std::string getWsName() const;
 
   Mantid::API::MatrixWorkspace_sptr workspace() const;
   const FunctionModelSpectra &spectra() const;
@@ -51,6 +54,10 @@ public:
 
   std::vector<double> excludeRegionsVector(WorkspaceIndex spectrum) const;
   std::vector<double> getQValues() const;
+  std::map<WorkspaceIndex, std::string> getResolutions() const;
+  void removeResolutionEntry(const WorkspaceIndex &index);
+  std::set<std::string> getResolutionNames() const;
+  std::string getResolutionFromWsIndex(const WorkspaceIndex &index) const;
 
   template <typename F> void applySpectra(F &&functor) const { ApplySpectra<F>(std::forward<F>(functor))(m_spectra); }
 
@@ -62,6 +69,9 @@ public:
   void setSpectra(std::string const &spectra);
   void setSpectra(FunctionModelSpectra &&spectra);
   void setSpectra(FunctionModelSpectra const &spectra);
+  void setResolution(std::string const &wsName, WorkspaceIndex const &spectrum);
+  void setResolution(std::string const &wsName, FunctionModelSpectra const &spectra);
+  void removeResolution(std::string const &resName);
   void setStartX(double const &startX, WorkspaceIndex const &spectrum);
   void setStartX(double const &startX);
   void setEndX(double const &endX, WorkspaceIndex const &spectrum);
@@ -74,6 +84,7 @@ private:
   Mantid::API::MatrixWorkspace_sptr m_workspace;
   FunctionModelSpectra m_spectra;
   std::map<WorkspaceIndex, std::string> m_excludeRegions;
+  std::map<WorkspaceIndex, std::string> m_resolutions;
   std::map<WorkspaceIndex, std::pair<double, double>> m_ranges;
   std::string m_name;
 };

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
@@ -32,6 +32,8 @@ using namespace MantidWidgets;
 class MANTID_SPECTROSCOPY_DLL FitData {
 public:
   FitData(const Mantid::API::MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra);
+  FitData(const Mantid::API::MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra,
+          const std::string &wsName);
 
   std::string displayName(const std::string &formatString, const std::string &rangeDelimiter) const;
   std::string displayName(const std::string &formatString, WorkspaceIndex spectrum) const;
@@ -73,6 +75,7 @@ private:
   FunctionModelSpectra m_spectra;
   std::map<WorkspaceIndex, std::string> m_excludeRegions;
   std::map<WorkspaceIndex, std::pair<double, double>> m_ranges;
+  std::string m_name;
 };
 
 } // namespace Inelastic

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/IDataModel.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/IDataModel.h
@@ -31,6 +31,7 @@ public:
   virtual ~IDataModel() = default;
   virtual std::vector<FitData> *getFittingData() = 0;
   virtual bool hasWorkspace(std::string const &workspaceName) const = 0;
+  virtual WorkspaceID getWorkspaceID(const std::string &wsName) const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getWorkspace(WorkspaceID workspaceID) const = 0;
   virtual FunctionModelSpectra getSpectra(WorkspaceID workspaceID) const = 0;
   virtual FunctionModelDataset getDataset(WorkspaceID workspaceID) const = 0;
@@ -40,6 +41,7 @@ public:
   virtual FitDomainIndex getDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum) const = 0;
   virtual std::vector<double> getQValuesForData() const = 0;
   virtual std::vector<std::pair<std::string, size_t>> getResolutionsForFit() const = 0;
+  virtual std::string getResolutionName(const WorkspaceID &wsID, const WorkspaceIndex &index) const = 0;
 
   virtual std::vector<std::string> getWorkspaceNames() const = 0;
   virtual std::string createDisplayName(WorkspaceID workspaceID) const = 0;
@@ -63,18 +65,27 @@ public:
   virtual void setEndX(double endX, WorkspaceID workspaceID) = 0;
   virtual void setEndX(double startX, FitDomainIndex fitDomainIndex) = 0;
   virtual void setExcludeRegion(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum) = 0;
-  virtual bool setResolution(const std::string &name) = 0;
-  virtual bool setResolution(const std::string &name, WorkspaceID workspaceID) = 0;
+  virtual bool setResolution(const std::string &resName, const std::string &wsName,
+                             const FunctionModelSpectra &spectra) = 0;
+  virtual bool setResolution(const std::string &resName, WorkspaceID workspaceID,
+                             const FunctionModelSpectra &spectra) = 0;
+  virtual void removeResolution(const std::string &resName) = 0;
+  virtual std::set<std::string> getResolutionNames() = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getWorkspace(FitDomainIndex index) const = 0;
   virtual std::pair<double, double> getFittingRange(FitDomainIndex index) const = 0;
   virtual size_t getSpectrum(FitDomainIndex index) const = 0;
   virtual std::vector<double> getExcludeRegionVector(FitDomainIndex index) const = 0;
   virtual std::string getExcludeRegion(FitDomainIndex index) const = 0;
   virtual void setExcludeRegion(const std::string &exclude, FitDomainIndex index) = 0;
+  virtual void updateWorkspaceNames() = 0;
 
   virtual std::pair<WorkspaceID, WorkspaceIndex> getSubIndices(FitDomainIndex) const = 0;
   virtual void removeSpecialValues(const std::string &name) = 0;
   virtual void removeWorkspaceByName(const std::string &name) = 0;
+  virtual void clearModel() = 0;
+
+  virtual const std::set<std::string> &resolutionNames() const = 0;
+  virtual const std::set<std::string> &workspaceNames() const = 0;
 };
 
 } // namespace Inelastic

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/IDataModel.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/IDataModel.h
@@ -74,6 +74,7 @@ public:
 
   virtual std::pair<WorkspaceID, WorkspaceIndex> getSubIndices(FitDomainIndex) const = 0;
   virtual void removeSpecialValues(const std::string &name) = 0;
+  virtual void removeWorkspaceByName(const std::string &name) = 0;
 };
 
 } // namespace Inelastic

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
@@ -145,6 +145,7 @@ public:
   MOCK_CONST_METHOD0(getWorkspaceNames, std::vector<std::string>());
   MOCK_CONST_METHOD0(getNumberOfWorkspaces, WorkspaceID());
   MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
+  MOCK_CONST_METHOD1(getWorkspaceID, WorkspaceID(const std::string &name));
 
   MOCK_METHOD2(setSpectra, void(const std::string &spectra, WorkspaceID workspaceID));
   MOCK_METHOD2(setSpectra, void(FunctionModelSpectra &&spectra, WorkspaceID workspaceID));
@@ -155,6 +156,7 @@ public:
   MOCK_CONST_METHOD1(getNumberOfSpectra, size_t(WorkspaceID workspaceID));
 
   MOCK_METHOD0(clear, void());
+  MOCK_METHOD0(clearModel, void());
 
   MOCK_CONST_METHOD0(getNumberOfDomains, size_t());
   MOCK_CONST_METHOD2(getDomainIndex, FitDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum));
@@ -162,10 +164,12 @@ public:
 
   MOCK_CONST_METHOD0(getQValuesForData, std::vector<double>());
   MOCK_CONST_METHOD0(getResolutionsForFit, std::vector<std::pair<std::string, size_t>>());
+  MOCK_CONST_METHOD2(getResolutionName, std::string(const WorkspaceID &wsID, const WorkspaceIndex &index));
   MOCK_CONST_METHOD1(createDisplayName, std::string(WorkspaceID workspaceID));
 
   MOCK_METHOD1(removeWorkspace, void(WorkspaceID workspaceID));
   MOCK_METHOD1(removeDataByIndex, void(FitDomainIndex fitDomainIndex));
+  MOCK_METHOD1(removeWorkspaceByName, void(const std::string &name));
 
   MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
@@ -176,14 +180,21 @@ public:
   MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
   MOCK_METHOD1(removeSpecialValues, void(const std::string &name));
-  MOCK_METHOD1(setResolution, bool(const std::string &name));
-  MOCK_METHOD2(setResolution, bool(const std::string &name, WorkspaceID workspaceID));
+  MOCK_METHOD3(setResolution,
+               bool(const std::string &name, WorkspaceID workspaceID, const FunctionModelSpectra &spectra));
+  MOCK_METHOD3(setResolution,
+               bool(const std::string &name, const std::string &wsName, const FunctionModelSpectra &spectra));
   MOCK_CONST_METHOD2(getFittingRange, std::pair<double, double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_METHOD1(removeResolution, void(const std::string &resName));
+  MOCK_METHOD0(getResolutionNames, std::set<std::string>());
   MOCK_CONST_METHOD1(getFittingRange, std::pair<double, double>(FitDomainIndex index));
   MOCK_CONST_METHOD2(getExcludeRegion, std::string(WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_CONST_METHOD1(getExcludeRegion, std::string(FitDomainIndex index));
   MOCK_CONST_METHOD2(getExcludeRegionVector, std::vector<double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_CONST_METHOD1(getExcludeRegionVector, std::vector<double>(FitDomainIndex index));
+  MOCK_METHOD0(updateWorkspaceNames, void());
+  MOCK_CONST_METHOD0(resolutionNames, const std::set<std::string> &());
+  MOCK_CONST_METHOD0(workspaceNames, const std::set<std::string> &());
 };
 
 class MockSettingsModel : public SettingsModel {

--- a/qt/widgets/spectroscopy/src/DataModel.cpp
+++ b/qt/widgets/spectroscopy/src/DataModel.cpp
@@ -134,7 +134,11 @@ std::string DataModel::getResolutionName(const WorkspaceID &wsID, const Workspac
 
 bool DataModel::setResolution(const std::string &resName, const std::string &wsName,
                               const FunctionModelSpectra &spectra) {
-  return setResolution(resName, getWorkspaceID(wsName), spectra);
+  const auto workspaceID = getWorkspaceID(wsName);
+  if (workspaceID.value >= getNumberOfWorkspaces().value) {
+    throw std::runtime_error("Workspace '" + wsName + "' not found in the model.");
+  }
+  return setResolution(resName, workspaceID, spectra);
 }
 
 bool DataModel::setResolution(const std::string &resName, WorkspaceID workspaceID,

--- a/qt/widgets/spectroscopy/src/DataModel.cpp
+++ b/qt/widgets/spectroscopy/src/DataModel.cpp
@@ -37,8 +37,8 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 
 DataModel::DataModel()
     : m_adsInstance(Mantid::API::AnalysisDataService::Instance()),
-      m_fittingData(std::make_unique<std::vector<FitData>>()),
-      m_resolutions(std::make_unique<std::vector<std::weak_ptr<Mantid::API::MatrixWorkspace>>>()) {}
+      m_fittingData(std::make_unique<std::vector<FitData>>()), m_uniqueWsNames(std::set<std::string>()),
+      m_uniqueResWsNames(std::set<std::string>()) {}
 
 std::vector<FitData> *DataModel::getFittingData() { return m_fittingData.get(); }
 
@@ -47,6 +47,15 @@ bool DataModel::hasWorkspace(std::string const &workspaceName) const {
   auto const iter = std::find(names.cbegin(), names.cend(), workspaceName);
   return iter != names.cend();
 }
+
+WorkspaceID DataModel::getWorkspaceID(const std::string &workspaceName) const {
+  auto const names = getWorkspaceNames();
+  auto const iter = std::find(names.cbegin(), names.cend(), workspaceName);
+
+  return {static_cast<size_t>(iter - names.cbegin())};
+}
+
+void DataModel::clearModel() { m_fittingData->clear(); }
 
 Mantid::API::MatrixWorkspace_sptr DataModel::getWorkspace(WorkspaceID workspaceID) const {
   if (workspaceID < m_fittingData->size())
@@ -102,48 +111,69 @@ std::vector<double> DataModel::getQValuesForData() const {
 
 std::vector<std::pair<std::string, size_t>> DataModel::getResolutionsForFit() const {
   std::vector<std::pair<std::string, size_t>> resolutionVector;
-  for (size_t index = 0; index < m_resolutions->size(); ++index) {
-    const auto resolutionWorkspace = m_resolutions->at(index).lock();
-    const auto spectra = getSpectra(WorkspaceID{index});
-    if (!resolutionWorkspace || !m_adsInstance.doesExist(resolutionWorkspace->getName())) {
-      resolutionVector.reserve(spectra.size().value);
-      std::transform(spectra.begin(), spectra.end(), std::back_inserter(resolutionVector),
-                     [](const auto &spectraIndex) { return std::make_pair("", spectraIndex.value); });
-      continue;
-    }
-
-    const auto singleSpectraResolution = m_resolutions->at(index).lock()->getNumberHistograms() == 1;
-    for (auto const &spectraIndex : spectra) {
-      const auto resolutionIndex = singleSpectraResolution ? 0 : spectraIndex.value;
-      resolutionVector.emplace_back(m_resolutions->at(index).lock()->getName(), resolutionIndex);
+  for (const auto &fittingData : *m_fittingData) {
+    std::map<std::string, bool> checkedResolutions;
+    for (const auto &[spectrum, resName] : fittingData.getResolutions()) {
+      if (!checkedResolutions.contains(resName)) {
+        if (m_adsInstance.doesExist(resName)) {
+          const auto resWs = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(resName);
+          checkedResolutions.insert_or_assign(resName, resWs->getNumberHistograms() == 1);
+        }
+      }
+      const auto name = checkedResolutions.contains(resName) ? resName : "";
+      const auto spIndex = !name.empty() && checkedResolutions.at(resName) ? 0 : spectrum.value;
+      resolutionVector.emplace_back(name, spIndex);
     }
   }
   return resolutionVector;
 }
 
-bool DataModel::setResolution(const std::string &name) {
-  return setResolution(name, getNumberOfWorkspaces() - WorkspaceID{1});
+std::string DataModel::getResolutionName(const WorkspaceID &wsID, const WorkspaceIndex &index) const {
+  return wsID.value < m_fittingData->size() ? m_fittingData->at(wsID.value).getResolutionFromWsIndex(index) : "";
 }
 
-bool DataModel::setResolution(const std::string &name, WorkspaceID workspaceID) {
-  bool hasValidValues = true;
-  if (!name.empty() && m_adsInstance.doesExist(name)) {
-    const auto resolution = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(name);
-    const auto &y = resolution->readY(0);
-    hasValidValues = std::all_of(y.cbegin(), y.cend(), [](double value) { return value == value; });
+bool DataModel::setResolution(const std::string &resName, const std::string &wsName,
+                              const FunctionModelSpectra &spectra) {
+  return setResolution(resName, getWorkspaceID(wsName), spectra);
+}
 
-    if (m_resolutions->size() > workspaceID.value) {
-      m_resolutions->at(workspaceID.value) = resolution;
-    } else if (m_resolutions->size() == workspaceID.value) {
-      m_resolutions->emplace_back(resolution);
-    } else {
-      throw std::out_of_range("Provided resolution index '" + std::to_string(workspaceID.value) +
-                              "' was out of range.");
+bool DataModel::setResolution(const std::string &resName, WorkspaceID workspaceID,
+                              const FunctionModelSpectra &spectra) {
+  bool hasValidValues = true;
+  if (!resName.empty() && m_adsInstance.doesExist(resName)) {
+    const auto resolution = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(resName);
+    const auto resSpectra = resolution->getNumberHistograms() == 1 ? FunctionModelSpectra(0, 0) : spectra;
+    for (const auto &spIndex : resSpectra) {
+      try {
+        const auto &y = resolution->readY(spIndex.value);
+        hasValidValues = hasValidValues && std::ranges::all_of(y, [](double value) { return value == value; });
+      } catch (std::range_error const &) {
+        // Either resolution has one histogram, or there should be 1-1 correspondence
+      }
     }
+    m_fittingData->at(workspaceID.value).setResolution(resName, spectra);
   } else {
     throw std::runtime_error("A valid resolution file needs to be selected.");
   }
   return hasValidValues;
+}
+
+void DataModel::removeResolution(const std::string &resName) {
+  for (auto it = m_fittingData->begin(); it != m_fittingData->end();) {
+    auto &fitData = *it;
+    if (const auto names = fitData.getResolutionNames(); names.contains(resName)) {
+      if (names.size() == 1) {
+        // If there's only one resolution ws linked to a ws we remove the ws from the model as convolution is not
+        // possible.
+        it = m_fittingData->erase(it);
+      } else {
+        fitData.removeResolution(resName);
+        ++it;
+      }
+    } else {
+      ++it;
+    }
+  }
 }
 
 void DataModel::removeSpecialValues(const std::string &name) {
@@ -176,7 +206,7 @@ std::vector<std::string> DataModel::getWorkspaceNames() const {
   std::vector<std::string> names;
   names.reserve(m_fittingData->size());
   std::transform(m_fittingData->cbegin(), m_fittingData->cend(), std::back_inserter(names),
-                 [](const auto &fittingData) -> const std::string & { return fittingData.workspace()->getName(); });
+                 [](const auto &fittingData) { return fittingData.getWsName(); });
   return names;
 }
 
@@ -228,6 +258,25 @@ FitDomainIndex DataModel::getDomainIndex(WorkspaceID workspaceID, WorkspaceIndex
 }
 
 void DataModel::clear() { m_fittingData->clear(); }
+
+std::set<std::string> DataModel::getResolutionNames() {
+  std::set<std::string> names;
+  for (const auto &fitData : *m_fittingData) {
+    const auto resNames = fitData.getResolutionNames();
+    names.insert(resNames.begin(), resNames.end());
+  }
+  return names;
+}
+
+std::set<std::string> const &DataModel::resolutionNames() const { return m_uniqueResWsNames; }
+std::set<std::string> const &DataModel::workspaceNames() const { return m_uniqueWsNames; }
+
+void DataModel::updateWorkspaceNames() {
+  // This makes it faster for the observers
+  const auto names = getWorkspaceNames();
+  m_uniqueWsNames = std::set<std::string>(names.begin(), names.end());
+  m_uniqueResWsNames = getResolutionNames();
+}
 
 std::pair<double, double> DataModel::getFittingRange(WorkspaceID workspaceID, WorkspaceIndex spectrum) const {
   if (workspaceID.value < m_fittingData->size() && !m_fittingData->at(workspaceID.value).zeroSpectra()) {
@@ -289,8 +338,10 @@ void DataModel::setExcludeRegion(const std::string &exclude, WorkspaceID workspa
 
 void DataModel::removeWorkspaceByName(const std::string &name) {
   auto it = std::find_if(m_fittingData->cbegin(), m_fittingData->cend(),
-                         [&name](const auto &fittingData) { return fittingData.workspace()->getName() == name; });
-  m_fittingData->erase(it);
+                         [&name](const auto &fittingData) { return fittingData.getWsName() == name; });
+  if (it != m_fittingData->cend()) {
+    m_fittingData->erase(it);
+  }
 }
 
 void DataModel::removeWorkspace(WorkspaceID workspaceID) {
@@ -303,8 +354,11 @@ void DataModel::removeWorkspace(WorkspaceID workspaceID) {
 
 void DataModel::removeDataByIndex(FitDomainIndex fitDomainIndex) {
   auto subIndices = getSubIndices(fitDomainIndex);
-  auto &spectra = m_fittingData->at(subIndices.first.value).getMutableSpectra();
+  auto &fitData = m_fittingData->at(subIndices.first.value);
+  auto &spectra = fitData.getMutableSpectra();
   spectra.erase(subIndices.second);
+  fitData.removeResolutionEntry(subIndices.second);
+
   // If the spectra list corresponding to a workspace is empty, remove workspace
   // at this index, else we'll have a workspace persist with no spectra loaded.
   if (spectra.empty()) {

--- a/qt/widgets/spectroscopy/src/DataModel.cpp
+++ b/qt/widgets/spectroscopy/src/DataModel.cpp
@@ -105,7 +105,7 @@ std::vector<std::pair<std::string, size_t>> DataModel::getResolutionsForFit() co
   for (size_t index = 0; index < m_resolutions->size(); ++index) {
     const auto resolutionWorkspace = m_resolutions->at(index).lock();
     const auto spectra = getSpectra(WorkspaceID{index});
-    if (!resolutionWorkspace) {
+    if (!resolutionWorkspace || !m_adsInstance.doesExist(resolutionWorkspace->getName())) {
       resolutionVector.reserve(spectra.size().value);
       std::transform(spectra.begin(), spectra.end(), std::back_inserter(resolutionVector),
                      [](const auto &spectraIndex) { return std::make_pair("", spectraIndex.value); });
@@ -129,7 +129,7 @@ bool DataModel::setResolution(const std::string &name, WorkspaceID workspaceID) 
   bool hasValidValues = true;
   if (!name.empty() && m_adsInstance.doesExist(name)) {
     const auto resolution = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(name);
-    const auto &y = resolution->readY(workspaceID.value);
+    const auto &y = resolution->readY(0);
     hasValidValues = std::all_of(y.cbegin(), y.cend(), [](double value) { return value == value; });
 
     if (m_resolutions->size() > workspaceID.value) {
@@ -192,11 +192,11 @@ void DataModel::addWorkspace(const std::string &workspaceName, const FunctionMod
 
 void DataModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra) {
   if (!m_fittingData->empty()) {
-    auto it = std::find_if((*m_fittingData).begin(), (*m_fittingData).end(), [&](FitData const &fitData) {
+    auto it = std::find_if(m_fittingData->begin(), m_fittingData->end(), [&](FitData const &fitData) {
       return equivalentWorkspaces(workspace, fitData.workspace());
     });
-    if (it != (*m_fittingData).end()) {
-      (*it).combine(FitData(workspace, spectra));
+    if (it != m_fittingData->end()) {
+      it->combine(FitData(workspace, spectra));
       return;
     }
   }
@@ -285,6 +285,12 @@ void DataModel::setExcludeRegion(const std::string &exclude, WorkspaceID workspa
   if (m_fittingData->empty())
     return;
   m_fittingData->at(workspaceID.value).setExcludeRegionString(exclude, spectrum);
+}
+
+void DataModel::removeWorkspaceByName(const std::string &name) {
+  auto it = std::find_if(m_fittingData->cbegin(), m_fittingData->cend(),
+                         [&name](const auto &fittingData) { return fittingData.workspace()->getName() == name; });
+  m_fittingData->erase(it);
 }
 
 void DataModel::removeWorkspace(WorkspaceID workspaceID) {

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -15,7 +15,10 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <ranges>
 
+#include <MantidAPI/AnalysisDataService.h>
+#include <MantidQtWidgets/Common/FunctionModel.h>
 #include <sstream>
 
 using namespace Mantid::API;
@@ -171,19 +174,22 @@ std::string createExcludeRegionString(std::string regionString) {
 namespace MantidQt::CustomInterfaces::Inelastic {
 
 FitData::FitData(const MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra)
-    : m_workspace(workspace), m_spectra(FunctionModelSpectra("")) {
-  setSpectra(spectra);
-  if (const auto &name = m_workspace->getName(); name != "") {
+    : m_workspace(workspace), m_spectra(FunctionModelSpectra("")),
+      m_resolutions(std::map<WorkspaceIndex, std::string>()) {
+
+  if (const auto &name = m_workspace->getName(); !name.empty()) {
     m_name = name;
   }
-  auto const range = !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
-  for (auto const &spectrum : spectra) {
-    m_ranges[spectrum] = range;
-  }
+  setupFitData(spectra, workspace);
 }
 
 FitData::FitData(const MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra, const std::string &wsName)
-    : m_workspace(workspace), m_spectra(FunctionModelSpectra("")), m_name(std::move(wsName)) {
+    : m_workspace(workspace), m_spectra(FunctionModelSpectra("")),
+      m_resolutions(std::map<WorkspaceIndex, std::string>()), m_name(std::move(wsName)) {
+  setupFitData(spectra, workspace);
+}
+
+void FitData::setupFitData(FunctionModelSpectra const &spectra, MatrixWorkspace_sptr const &workspace) {
   setSpectra(spectra);
   auto const range = !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
   for (auto const &spectrum : spectra) {
@@ -203,6 +209,8 @@ std::string FitData::displayName(const std::string &formatString, const std::str
   std::replace(name.begin(), name.end(), ',', '+');
   return name;
 }
+
+std::string FitData::getWsName() const { return m_name; }
 
 std::string FitData::displayName(const std::string &formatString, WorkspaceIndex spectrum) const {
   const auto workspaceName = getBasename();
@@ -330,6 +338,55 @@ void FitData::setEndX(double const &endX) {
   for (auto const &spectrum : m_spectra) {
     setEndX(endX, spectrum);
   }
+}
+
+void FitData::setResolution(std::string const &wsName, WorkspaceIndex const &spectrum) {
+  if (m_ranges.contains(spectrum)) {
+    m_resolutions[spectrum] = wsName;
+  }
+}
+
+void FitData::setResolution(std::string const &wsName, FunctionModelSpectra const &spectra) {
+  for (const auto &spectrum : spectra) {
+    setResolution(wsName, spectrum);
+  }
+}
+
+void FitData::removeResolution(std::string const &resName) {
+  std::vector<WorkspaceIndex> indexesToRemove;
+  for (const auto &[wsIndex, name] : m_resolutions) {
+    if (name == resName) {
+      indexesToRemove.push_back(wsIndex);
+    }
+  }
+  for (const auto &wsIndex : indexesToRemove) {
+    m_resolutions.erase(wsIndex);
+    m_ranges.erase(wsIndex);
+    m_excludeRegions.erase(wsIndex);
+    m_spectra.erase(wsIndex);
+  }
+}
+
+std::string FitData::getResolutionFromWsIndex(const WorkspaceIndex &index) const {
+  return m_resolutions.contains(index) ? m_resolutions.at(index) : "";
+}
+
+void FitData::removeResolutionEntry(const WorkspaceIndex &index) {
+  if (const auto it = m_resolutions.find(index); it != m_resolutions.cend()) {
+    m_resolutions.erase(it);
+  }
+}
+
+std::map<WorkspaceIndex, std::string> FitData::getResolutions() const { return m_resolutions; }
+
+std::set<std::string> FitData::getResolutionNames() const {
+  auto resNames = std::set<std::string>();
+  if (!m_resolutions.empty()) {
+    for (const auto &value : m_resolutions | std::views::values) {
+      resNames.emplace(value);
+    }
+  }
+  return resNames;
 }
 
 void FitData::setExcludeRegionString(std::string const &excludeRegionString, WorkspaceIndex const &spectrum) {

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -210,7 +210,7 @@ std::string FitData::displayName(const std::string &formatString, const std::str
   return name;
 }
 
-std::string FitData::getWsName() const { return m_name; }
+const std::string &FitData::getWsName() const { return m_name; }
 
 std::string FitData::displayName(const std::string &formatString, WorkspaceIndex spectrum) const {
   const auto workspaceName = getBasename();
@@ -377,7 +377,7 @@ void FitData::removeResolutionEntry(const WorkspaceIndex &index) {
   }
 }
 
-std::map<WorkspaceIndex, std::string> FitData::getResolutions() const { return m_resolutions; }
+const std::map<WorkspaceIndex, std::string> &FitData::getResolutions() const { return m_resolutions; }
 
 std::set<std::string> FitData::getResolutionNames() const {
   auto resNames = std::set<std::string>();

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -173,6 +173,18 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 FitData::FitData(const MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra)
     : m_workspace(workspace), m_spectra(FunctionModelSpectra("")) {
   setSpectra(spectra);
+  if (const auto &name = m_workspace->getName(); name != "") {
+    m_name = name;
+  }
+  auto const range = !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
+  for (auto const &spectrum : spectra) {
+    m_ranges[spectrum] = range;
+  }
+}
+
+FitData::FitData(const MatrixWorkspace_sptr &workspace, const FunctionModelSpectra &spectra, const std::string &wsName)
+    : m_workspace(workspace), m_spectra(FunctionModelSpectra("")), m_name(std::move(wsName)) {
+  setSpectra(spectra);
   auto const range = !spectra.empty() ? getBinRange(workspace) : std::make_pair(0.0, 0.0);
   for (auto const &spectrum : spectra) {
     m_ranges[spectrum] = range;

--- a/qt/widgets/spectroscopy/test/DataModelTest.h
+++ b/qt/widgets/spectroscopy/test/DataModelTest.h
@@ -19,14 +19,34 @@
 #include <gmock/gmock.h>
 #include <math.h>
 
-namespace {
+namespace DataModelTestingNamespace {
 auto &ads_instance = Mantid::API::AnalysisDataService::Instance();
+constexpr std::string DATA_WS1 = "DataWorkspace1";
+constexpr std::string DATA_WS2 = "DataWorkspace2";
+constexpr std::string RES_WS = "ResolutionWs";
+constexpr std::string SPEC_RANGE = "0-3";
+
+void createInvalidResolutionWorkspace(const std::string &name, bool storeADS = true) {
+  const std::vector<double> x = {0., 1., 2., 0., 1., 2., 0., 1., 2., 0., 1., 2.};
+  const std::vector<double> y = {sqrt(-1.), 1., 2., sqrt(-1.), 1., 2., sqrt(-1.), 1., 2., sqrt(-1.), 1., 2.};
+
+  const auto alg = Mantid::API::AlgorithmManager::Instance().create("CreateWorkspace");
+  alg->initialize();
+  alg->setLogging(false);
+  alg->setAlwaysStoreInADS(storeADS);
+  alg->setProperty("OutputWorkspace", name);
+  alg->setProperty("DataX", x);
+  alg->setProperty("DataY", y);
+  alg->setProperty("NSpec", 4);
+  alg->execute();
 }
+} // namespace DataModelTestingNamespace
 
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
 using namespace MantidQt::CustomInterfaces::Inelastic;
 using namespace MantidQt::MantidWidgets;
+using namespace DataModelTestingNamespace;
 
 class DataModelTest : public CxxTest::TestSuite {
 public:
@@ -39,44 +59,54 @@ public:
     auto resolutionWorkspace = Mantid::IndirectFitDataCreationHelper::createWorkspace(4, 5);
     auto dataWorkspace1 = Mantid::IndirectFitDataCreationHelper::createWorkspace(4, 5);
     auto dataWorkspace2 = Mantid::IndirectFitDataCreationHelper::createWorkspace(4, 5);
-    ads_instance.addOrReplace("resolution workspace", std::move(resolutionWorkspace));
-    ads_instance.addOrReplace("data workspace 1", std::move(dataWorkspace1));
-    ads_instance.addOrReplace("data workspace 2", std::move(dataWorkspace2));
-    m_fitData->addWorkspace("data workspace 1", FunctionModelSpectra("0-3"));
-    m_fitData->addWorkspace("data workspace 2", FunctionModelSpectra("0-3"));
-    m_fitData->setResolution("resolution workspace", WorkspaceID{0});
+    ads_instance.addOrReplace(RES_WS, std::move(resolutionWorkspace));
+    ads_instance.addOrReplace(DATA_WS1, std::move(dataWorkspace1));
+    ads_instance.addOrReplace(DATA_WS2, std::move(dataWorkspace2));
+    m_fitData->addWorkspace(DATA_WS1, FunctionModelSpectra(SPEC_RANGE));
+    m_fitData->addWorkspace(DATA_WS2, FunctionModelSpectra(SPEC_RANGE));
+    m_fitData->setResolution(RES_WS, WorkspaceID{0}, FunctionModelSpectra(SPEC_RANGE));
+    m_fitData->setResolution(RES_WS, WorkspaceID{1}, FunctionModelSpectra(SPEC_RANGE));
   }
 
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
-  void test_setResolution() { TS_ASSERT_EQUALS(m_fitData->setResolution("resolution workspace"), true); }
-
-  void test_setResolution_bad_data() {
-    std::vector<double> x = {0., 1., 2., 0., 1., 2., 0., 1., 2., 0., 1., 2.};
-    std::vector<double> y = {sqrt(-1.), 1., 2., sqrt(-1.), 1., 2., sqrt(-1.), 1., 2., sqrt(-1.), 1., 2.};
-
-    auto alg = AlgorithmManager::Instance().create("CreateWorkspace");
-    alg->initialize();
-    alg->setLogging(false);
-    alg->setAlwaysStoreInADS(true);
-    alg->setProperty("OutputWorkspace", "NAN");
-    alg->setProperty("DataX", x);
-    alg->setProperty("DataY", y);
-    alg->setProperty("NSpec", 4);
-    alg->execute();
-    TS_ASSERT_EQUALS(m_fitData->setResolution("NAN"), false);
+  void test_get_workspace_by_id() {
+    TS_ASSERT_EQUALS(m_fitData->getWorkspaceID(DATA_WS1).value, 0);
+    TS_ASSERT_EQUALS(m_fitData->getWorkspaceID(DATA_WS2).value, 1);
+    TS_ASSERT(m_fitData->getWorkspaceID("NotInModel").value >= m_fitData->getNumberOfWorkspaces().value);
   }
 
-  void test_hasWorkspace_returns_true_for_ws_in_model() { TS_ASSERT(m_fitData->hasWorkspace("data workspace 1")); }
+  void test_setResolution() {
+    TS_ASSERT_EQUALS(m_fitData->setResolution(RES_WS, WorkspaceID{0}, FunctionModelSpectra(SPEC_RANGE)), true);
+  }
 
-  void test_hasWorkspace_returns_false_for_ws_in_model() { TS_ASSERT(!m_fitData->hasWorkspace("fake workspace")); }
+  void test_setResolution_bad_data() {
+    createInvalidResolutionWorkspace("NAN");
+    TS_ASSERT_EQUALS(m_fitData->setResolution("NAN", WorkspaceID{0}, FunctionModelSpectra(SPEC_RANGE)), false);
+  }
+
+  void test_setResolution_ws_not_in_ads() {
+    createInvalidResolutionWorkspace("NotADS_WS", false);
+    TS_ASSERT_THROWS(m_fitData->setResolution("NotADS_WS", WorkspaceID{0}, FunctionModelSpectra(SPEC_RANGE)),
+                     std::runtime_error const &);
+  }
+
+  void test_setResolution_wrong_name() {
+    createInvalidResolutionWorkspace("res");
+    TS_ASSERT_THROWS(m_fitData->setResolution("", WorkspaceID{0}, FunctionModelSpectra(SPEC_RANGE)),
+                     std::runtime_error const &);
+  }
+
+  void test_hasWorkspace_returns_true_for_ws_in_model() { TS_ASSERT(m_fitData->hasWorkspace(DATA_WS1)); }
+
+  void test_hasWorkspace_returns_false_for_ws_in_model() { TS_ASSERT(!m_fitData->hasWorkspace("FakeWS")); }
 
   void test_getWorkspace_returns_nullptr_is_outside_of_range() {
     TS_ASSERT_EQUALS(m_fitData->getWorkspace(WorkspaceID{2}), nullptr);
   }
 
   void test_getWorkspace_returns_ws_in_range() {
-    TS_ASSERT_EQUALS(m_fitData->getWorkspace(WorkspaceID{0})->getName(), "data workspace 1");
+    TS_ASSERT_EQUALS(m_fitData->getWorkspace(WorkspaceID{0})->getName(), DATA_WS1);
   }
 
   void test_getSpectra_returns_empty_spectra_is_outside_of_range() {
@@ -84,22 +114,22 @@ public:
   }
 
   void test_getSpectra_returns_spectra_in_range() {
-    TS_ASSERT_EQUALS(m_fitData->getSpectra(WorkspaceID{0}).getString(), "0-3");
+    TS_ASSERT_EQUALS(m_fitData->getSpectra(WorkspaceID{0}).getString(), SPEC_RANGE);
   }
 
   void test_getNumberOfWorkspaces_returns_correct_number_of_workspaces() {
     TS_ASSERT_EQUALS(m_fitData->getNumberOfWorkspaces(), 2);
     auto dataWorkspace = Mantid::IndirectFitDataCreationHelper::createWorkspace(4, 5);
-    ads_instance.addOrReplace("data workspace 3", std::move(dataWorkspace));
-    m_fitData->addWorkspace("data workspace 3", FunctionModelSpectra("0"));
+    ads_instance.addOrReplace("DataWorkspace3", std::move(dataWorkspace));
+    m_fitData->addWorkspace("DataWorkspace3", FunctionModelSpectra("0"));
     TS_ASSERT_EQUALS(m_fitData->getNumberOfWorkspaces(), 3);
   }
 
   void test_getNumberOfSpectra_returns_correct_number_of_spectra() {
     TS_ASSERT_EQUALS(m_fitData->getNumberOfSpectra(WorkspaceID{0}), 4);
     auto dataWorkspace = Mantid::IndirectFitDataCreationHelper::createWorkspace(5, 5);
-    ads_instance.addOrReplace("data workspace 3", std::move(dataWorkspace));
-    m_fitData->addWorkspace("data workspace 3", FunctionModelSpectra("0-4"));
+    ads_instance.addOrReplace("DataWorkspace3", std::move(dataWorkspace));
+    m_fitData->addWorkspace("DataWorkspace3", FunctionModelSpectra("0-4"));
     TS_ASSERT_EQUALS(m_fitData->getNumberOfSpectra(WorkspaceID{2}), 5);
   }
 
@@ -122,8 +152,8 @@ public:
 
   void test_getQValuesForData_returns_correct_value() {
     auto dataWorkspace = Mantid::IndirectFitDataCreationHelper::createWorkspaceWithInelasticInstrument(4);
-    ads_instance.addOrReplace("data workspace Inelastic", dataWorkspace);
-    m_fitData->addWorkspace("data workspace Inelastic", FunctionModelSpectra("0"));
+    ads_instance.addOrReplace("DataWorkspaceInelastic", dataWorkspace);
+    m_fitData->addWorkspace("DataWorkspaceInelastic", FunctionModelSpectra("0"));
     auto spectrumInfo = dataWorkspace->spectrumInfo();
     auto detID = spectrumInfo.detector(0).getID();
     double efixed = dataWorkspace->getEFixed(detID);
@@ -136,7 +166,7 @@ public:
   void test_that_getResolutionsForFit_return_correctly() {
     auto resolutionVector = m_fitData->getResolutionsForFit();
 
-    TS_ASSERT_EQUALS(resolutionVector[2].first, "resolution workspace");
+    TS_ASSERT_EQUALS(resolutionVector[2].first, RES_WS);
     TS_ASSERT_EQUALS(resolutionVector[2].second, 2);
   }
 
@@ -150,19 +180,19 @@ public:
   }
 
   void test_getWorkspaceNames_returns_all_names() {
-    std::vector<std::string> wsNames = {"data workspace 1", "data workspace 2"};
+    std::vector<std::string> wsNames = {DATA_WS1, DATA_WS2};
     TS_ASSERT_EQUALS(m_fitData->getWorkspaceNames(), wsNames);
   }
 
   void test_removeWorkspace_functions_as_required() {
-    std::vector<std::string> wsNames = {"data workspace 1"};
+    std::vector<std::string> wsNames = {DATA_WS1};
     m_fitData->removeWorkspace(WorkspaceID{1});
     TS_ASSERT_EQUALS(m_fitData->getWorkspaceNames(), wsNames);
   }
 
   void test_removeDataByIndex_removes_only_single_spectra() {
     m_fitData->removeDataByIndex(FitDomainIndex{2});
-    TS_ASSERT(m_fitData->hasWorkspace("data workspace 1"));
+    TS_ASSERT(m_fitData->hasWorkspace(DATA_WS1));
     TS_ASSERT_EQUALS(m_fitData->getSpectra(WorkspaceID{0}).getString(), "0-1,3");
   }
 
@@ -204,6 +234,42 @@ public:
     TS_ASSERT_THROWS(m_fitData->setStartX(0, WorkspaceID{2}), const std::out_of_range &)
     TS_ASSERT_THROWS(m_fitData->setStartX(0, WorkspaceID{2}, WorkspaceIndex{10}), const std::out_of_range &)
     TS_ASSERT_THROWS(m_fitData->setStartX(0, FitDomainIndex{20}), const std::runtime_error &)
+  }
+
+  void test_clear_model() {
+    m_fitData->clearModel();
+    TS_ASSERT(m_fitData->getFittingData()->size() == 0);
+  }
+
+  void test_names_reference() {
+    m_fitData->updateWorkspaceNames();
+    TS_ASSERT_EQUALS(m_fitData->workspaceNames(), std::set<std::string>({DATA_WS1, DATA_WS2}));
+
+    m_fitData->removeWorkspaceByName(DATA_WS1);
+    m_fitData->updateWorkspaceNames();
+    TS_ASSERT_EQUALS(m_fitData->workspaceNames(), std::set<std::string>{DATA_WS2});
+
+    m_fitData->removeWorkspaceByName(DATA_WS2);
+    m_fitData->updateWorkspaceNames();
+    TS_ASSERT(m_fitData->workspaceNames().empty());
+  }
+
+  void test_resolutions_reference() {
+    m_fitData->updateWorkspaceNames();
+    TS_ASSERT_EQUALS(m_fitData->resolutionNames(), std::set<std::string>({RES_WS}));
+
+    m_fitData->removeResolution(RES_WS);
+    m_fitData->updateWorkspaceNames();
+    TS_ASSERT(m_fitData->resolutionNames().empty());
+    // There can't be workspaces without resolution
+    TS_ASSERT(m_fitData->workspaceNames().empty());
+  }
+
+  void test_get_resolution_name_by_id_and_index() {
+    TS_ASSERT_EQUALS(m_fitData->getResolutionName(0, 0), RES_WS);
+    TS_ASSERT_EQUALS(m_fitData->getResolutionName(1, 2), RES_WS);
+    TS_ASSERT_EQUALS(m_fitData->getResolutionName(1, 5), "");
+    TS_ASSERT_EQUALS(m_fitData->getResolutionName(5, 1), "");
   }
 
 private:

--- a/qt/widgets/spectroscopy/test/FitDataTest.h
+++ b/qt/widgets/spectroscopy/test/FitDataTest.h
@@ -25,8 +25,11 @@ using namespace MantidQt::CustomInterfaces;
 
 namespace {
 
-std::unique_ptr<FitData> getFitData(int const &numberOfSpectra) {
+std::unique_ptr<FitData> getFitData(int const &numberOfSpectra, const std::string &adsName = "") {
   auto const workspace = createWorkspace(numberOfSpectra);
+  if (!adsName.empty()) {
+    SetUpADSWithWorkspace(adsName, workspace);
+  }
   FunctionModelSpectra const spec =
       FunctionModelSpectra(WorkspaceIndex{0}, WorkspaceIndex{workspace->getNumberHistograms() - 1});
   FitData data(workspace, spec);
@@ -460,5 +463,47 @@ public:
     double usignTheta = 0.5 * spectrumInfo.twoTheta(0);
     double q = Mantid::Kernel::UnitConversion::convertToElasticQ(usignTheta, efixed);
     TS_ASSERT_EQUALS(data->getQValues()[0], q);
+  }
+
+  void test_that_fit_Data_stores_name_field_when_is_ads_ws() {
+    const auto testName = "testADSName";
+    auto fitData = getFitData(10, testName);
+    TS_ASSERT_EQUALS(fitData->getWsName(), testName);
+
+    // Name should be kept even if it disappears from ads
+    AnalysisDataService::Instance().remove(testName);
+    TS_ASSERT_EQUALS(fitData->getWsName(), testName);
+  }
+
+  void test_set_resolution_from_spectrum() {
+    auto fitData = getFitData(10);
+    fitData->setResolution("resWs", WorkspaceIndex{0});
+    TS_ASSERT(fitData->getResolutionFromWsIndex(WorkspaceIndex{0}) == "resWs");
+  }
+
+  void test_set_resolution_from_spectra() {
+    auto fitData = getFitData(10);
+    fitData->setResolution("resWs", FunctionModelSpectra("0-9"));
+    TS_ASSERT(fitData->getResolutionFromWsIndex(WorkspaceIndex{0}) == "resWs");
+    TS_ASSERT(fitData->getResolutionFromWsIndex(WorkspaceIndex{9}) == "resWs");
+    TS_ASSERT(fitData->getResolutionFromWsIndex(WorkspaceIndex{10}) == "");
+  }
+
+  void test_remove_resolution_from_fit_Data() {
+    auto fitData = getFitData(10);
+    fitData->setResolution("resWs", FunctionModelSpectra("0-9"));
+
+    fitData->removeResolution("resWs");
+    // As there was only one resolution associated with the fit data, all spectra are removed
+    TS_ASSERT(fitData->zeroSpectra());
+  }
+
+  void test_remove_resolution_entry() {
+    auto fitData = getFitData(10);
+    fitData->setResolution("resWs", FunctionModelSpectra("0-9"));
+
+    fitData->removeResolutionEntry(WorkspaceIndex(1));
+    // As there was only one resolution associated with the fit data, all spectra are removed
+    TS_ASSERT(fitData->getResolutionFromWsIndex(WorkspaceIndex{1}).empty());
   }
 };


### PR DESCRIPTION
### Description of work

This issue closes #40731 , #41020. Origin of both crashes are two aspects of the same feature: the management of resolution workspaces from the DataModel. The resolution workspaces are stored as a vector of weak pointers to resolution workspaces loaded on the ADS. When data from the ADS revolving these workspaces is removed, the function browser tries to access a pointer that's been voided.  Additionally, there was a problem when setting the spectra for resolutions when new spectra were added to the interface, this made impossible to add new spectra. 
The fix this issue, there had been two main changes: 

1. DataModel does not store pointers to resolution workspaces, instead the data structure containing every fit data (fitdata) contains a map of resolution ws names vs. spectra. This makes the model more sturdy against changes in resolution, additionally it adds the bonus that it is now possible to select two different resolution workspaces for a given workspace. 
2. As the QENS Fitting interface relies on the ADS due to the Function Browser, I have added an observer to the table of the interface to synchronize delete/clear/and rename operations and avoid trying to fit data that is not on the ads. This part was the main thing taking me a bit off track, as there was already a sort of broken implementation of the ADSObserver on the presenter of the table but it was not really used, also, to use the ADSObserver with qt it is better to let qt integrate it into its thread by using the QMetaObject::invokeMethod, otherwise, weird race conditions occur. 


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40731 , #41020 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Try to test the problems in both linked issues, no crashes should appear. 
- Do all of the QENS Fitting manual testing to ensure everything works: https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
