### PR TITLE
Instrument View: Fix picking when detector shapes are drawn

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -717,10 +717,10 @@ class FullInstrumentViewModel:
         ``(detector_ids, bank_type)``.
         """
         if self._projection_type != ProjectionType.SIDE_BY_SIDE:
-            return None
+            return []
         projection = self.active_projection
         if projection is None:
-            return None
+            return []
         return projection.get_bank_groups_by_detector_id()
 
     def component_tree_indices_selected(self, component_indices: np.ndarray) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -8,9 +8,7 @@ from instrumentview.Detectors import DetectorInfo
 from instrumentview.Globals import CurrentTab
 from instrumentview.Peaks.Peak import Peak
 from instrumentview.Peaks.DetectorPeaks import DetectorPeaks
-from instrumentview.Projections.SphericalProjection import SphericalProjection
-from instrumentview.Projections.CylindricalProjection import CylindricalProjection
-from instrumentview.Projections.SideBySide import SideBySide
+from instrumentview.Projections.Projection import Projection
 from instrumentview.Projections.ProjectionType import ProjectionType
 from instrumentview.ConvertUnitsCalculator import ConvertUnitsCalculator
 
@@ -343,30 +341,19 @@ class FullInstrumentViewModel:
         """Calculate the 2D projection with the specified axis. Can be either cylindrical or spherical."""
         cache_key = self._cache_key_for_projection(self._projection_type)
         if cache_key not in self._cached_projection_objects.keys():
-            axis = [1, 0, 0]
-            if self._projection_type in (ProjectionType.SPHERICAL_Y, ProjectionType.CYLINDRICAL_Y):
-                axis = [0, 1, 0]
-            elif self._projection_type in (ProjectionType.SPHERICAL_Z, ProjectionType.CYLINDRICAL_Z):
-                axis = [0, 0, 1]
-
             detector_positions = self._detector_positions_3d
             if self._flip_z:
                 detector_positions = detector_positions.copy()
                 detector_positions[:, 2] *= -1
 
-            if self._projection_type in (ProjectionType.SPHERICAL_X, ProjectionType.SPHERICAL_Y, ProjectionType.SPHERICAL_Z):
-                projection = SphericalProjection(self._sample_position, self._root_position, detector_positions, np.array(axis))
-            elif self._projection_type in (ProjectionType.CYLINDRICAL_X, ProjectionType.CYLINDRICAL_Y, ProjectionType.CYLINDRICAL_Z):
-                projection = CylindricalProjection(self._sample_position, self._root_position, detector_positions, np.array(axis))
-            else:
-                projection = SideBySide(
-                    self._workspace,
-                    self._detector_ids,
-                    self._sample_position,
-                    self._root_position,
-                    detector_positions,
-                    np.array(axis),
-                )
+            projection = Projection(
+                type=self._projection_type,
+                workspace=self._workspace,
+                detector_ids=self._detector_ids,
+                sample_position=self._sample_position,
+                root_position=self._root_position,
+                detector_positions=detector_positions,
+            )
             self._cached_projection_objects[cache_key] = projection
 
         projection = self._cached_projection_objects[cache_key]
@@ -716,12 +703,9 @@ class FullInstrumentViewModel:
         doesn't support bank grouping.  Each element is
         ``(detector_ids, bank_type)``.
         """
-        if self._projection_type != ProjectionType.SIDE_BY_SIDE:
+        if self.active_projection is None or self.active_projection.type is not ProjectionType.SIDE_BY_SIDE:
             return []
-        projection = self.active_projection
-        if projection is None:
-            return []
-        return projection.get_bank_groups_by_detector_id()
+        return self.active_projection.get_bank_groups_by_detector_id()
 
     def component_tree_indices_selected(self, component_indices: np.ndarray) -> None:
         if len(component_indices) == 0:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -79,7 +79,7 @@ class FullInstrumentViewPresenter:
         self._model.setup()
         self._point_cloud_renderer = PointCloudRenderer()
         self._shape_renderer = ShapeRenderer(self._model.workspace)
-        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace, self._model.bank_groups_by_detector_id)
+        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace)
         self._renderer = self._point_cloud_renderer
         self.setup()
         self._callback_queue = Queue()
@@ -700,7 +700,7 @@ class FullInstrumentViewPresenter:
         """
         self._point_cloud_renderer = PointCloudRenderer()
         self._shape_renderer = ShapeRenderer(self._model.workspace)
-        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace, self._model.bank_groups_by_detector_id)
+        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace)
         self._on_show_shapes_toggled(self._view.is_show_shapes_checkbox_checked())
 
     def _reload_everything(self) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -76,11 +76,11 @@ class FullInstrumentViewPresenter:
         self._counts_label = "Integrated Counts"
         self._visible_label = "Visible Picked"
         self._count_scale_mode = self._LINEAR
-        self._point_cloud_renderer = PointCloudRenderer()
-        self._shape_renderer = None  # lazily created
-        self._sbs_shape_renderer = None  # lazily created
-        self._renderer = self._point_cloud_renderer
         self._model.setup()
+        self._point_cloud_renderer = PointCloudRenderer()
+        self._shape_renderer = ShapeRenderer(self._model.workspace)
+        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace, self._model.bank_groups_by_detector_id)
+        self._renderer = self._point_cloud_renderer
         self.setup()
         self._callback_queue = Queue()
         self._callback_stop_sentinel = object()
@@ -550,7 +550,7 @@ class FullInstrumentViewPresenter:
             self._model._workspace = AnalysisDataService.retrieve(ws_name)
             self._model.setup()
             self._setup_component_tree()
-            self._clear_renderers()  # Clear cached renderers before rendering
+            self._reload_renderers()  # Clear cached renderers before rendering
             self.update_plotter()
 
     def replace_workspace_callback(self, ws_name, ws):
@@ -679,59 +679,37 @@ class FullInstrumentViewPresenter:
         self._model.component_tree_indices_selected(component_indices)
         self.update_plotter()
 
-    def _get_point_cloud_renderer(self) -> PointCloudRenderer:
-        if self._point_cloud_renderer is None:
-            self._point_cloud_renderer = PointCloudRenderer()
-        return self._point_cloud_renderer
-
-    def _get_shape_renderer(self) -> ShapeRenderer:
-        """Get or create a cached shape renderer instance.
-
-        Returns a :class:`SideBySideShapeRenderer` when the current
-        projection is side-by-side, otherwise a plain :class:`ShapeRenderer`.
-        On first call for each type, precomputes geometry from the workspace
-        which may be expensive.  Subsequent calls return the cached instance.
-        """
-        is_sbs = self._model.projection_type == ProjectionType.SIDE_BY_SIDE
-        if is_sbs:
-            if self._sbs_shape_renderer is None:
-                self._sbs_shape_renderer = SideBySideShapeRenderer()
-                self._sbs_shape_renderer.precompute(self._model.workspace, self._model.bank_groups_by_detector_id)
-            return self._sbs_shape_renderer
-        else:
-            if self._shape_renderer is None:
-                self._shape_renderer = ShapeRenderer()
-                self._shape_renderer.precompute(self._model.workspace)
-            return self._shape_renderer
-
     def _on_show_shapes_toggled(self, checked: bool) -> None:
         if checked:
-            self._renderer = self._get_shape_renderer()
+            if self._model.projection_type == ProjectionType.SIDE_BY_SIDE:
+                self._renderer = self._sbs_shape_renderer
+            else:
+                self._renderer = self._shape_renderer
         else:
-            self._renderer = self._get_point_cloud_renderer()
+            self._renderer = self._point_cloud_renderer
 
         self.update_plotter()
 
     def on_show_shapes_toggled(self, checked: bool) -> None:
         self._callback_queue.put((self._on_show_shapes_toggled, (checked,)))
 
-    def _clear_renderers(self) -> None:
-        """Clear cached renderer instances, forcing recreation on next use.
-
+    def _reload_renderers(self) -> None:
+        """
         Called when the workspace changes to ensure renderers recompute geometry
         from the new workspace data.
         """
-        self._shape_renderer = None
-        self._sbs_shape_renderer = None
-        self._point_cloud_renderer = None
-        self._renderer = self._get_shape_renderer() if self._view.is_show_shapes_checkbox_checked() else self._get_point_cloud_renderer()
+        self._point_cloud_renderer = PointCloudRenderer()
+        self._shape_renderer = ShapeRenderer(self._model.workspace)
+        self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace, self._model.bank_groups_by_detector_id)
+        self._on_show_shapes_toggled(self._view.is_show_shapes_checkbox_checked())
 
     def _reload_everything(self) -> None:
         """Reload all workspace-dependent data (peaks, masks, groupings) and clear renderer cache.
 
         Called when workspaces are added to or removed from the ADS.
         """
-        self._clear_renderers()
-        self._reload_peaks_workspaces()
-        self._reload_mask_workspaces()
-        self._reload_grouping_workspaces()
+        with SuppressRendering(self._view.main_plotter):
+            self._reload_renderers()
+            self._reload_peaks_workspaces()
+            self._reload_mask_workspaces()
+            self._reload_grouping_workspaces()

--- a/qt/python/instrumentview/instrumentview/Projections/CylindricalProjection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/CylindricalProjection.py
@@ -5,10 +5,18 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from instrumentview.Projections.Projection import Projection
+from instrumentview.Projections.ProjectionType import ProjectionType
 import numpy as np
 
 
-class CylindricalProjection(Projection):
+class CylindricalProjection(
+    Projection,
+    projection_types={
+        ProjectionType.CYLINDRICAL_X: {"axis": [1, 0, 0]},
+        ProjectionType.CYLINDRICAL_Y: {"axis": [0, 1, 0]},
+        ProjectionType.CYLINDRICAL_Z: {"axis": [0, 0, 1]},
+    },
+):
     """2D projection with a cylindrical coordinate system, see https://en.wikipedia.org/wiki/Cylindrical_coordinate_system"""
 
     def _calculate_2d_coordinates(self) -> tuple[np.ndarray, np.ndarray]:

--- a/qt/python/instrumentview/instrumentview/Projections/Projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/Projection.py
@@ -169,3 +169,6 @@ class Projection:
 
 # Import subclasses at the BOTTOM to avoid circular imports,
 # but ensure they're always registered when Projection is imported
+from instrumentview.Projections.CylindricalProjection import CylindricalProjection  # noqa: F401 E402
+from instrumentview.Projections.SphericalProjection import SphericalProjection  # noqa: F401 E402
+from instrumentview.Projections.SideBySide import SideBySide  # noqa: F401 E402

--- a/qt/python/instrumentview/instrumentview/Projections/Projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/Projection.py
@@ -4,27 +4,48 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 import numpy as np
 from instrumentview.Detectors import DetectorPosition
 
 
-class Projection(ABC):
+class Projection:
     """Base class for calculating a 2D projection with a specified axis"""
+
+    _registry = {}
+
+    def __init_subclass__(cls, projection_types=None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if projection_types:
+            for projection_type, defaults in projection_types.items():
+                Projection._registry[projection_type] = (cls, defaults)
+
+    def __new__(cls, type, **kwargs):
+        if cls is Projection:
+            entry = Projection._registry.get(type)
+            if not entry:
+                raise ValueError(f"Unknown projection type: '{type}'. Available: {list(Projection._registry)}")
+            subclass, _ = entry
+            return super().__new__(subclass)
+        return super().__new__(cls)
 
     def __init__(
         self,
+        type,
         sample_position: np.ndarray,
         root_position: np.ndarray,
         detector_positions: list[DetectorPosition] | np.ndarray,
-        axis: np.ndarray,
+        **kwargs,
     ):
         """For the given workspace and detectors, calculate 2D points with specified projection axis"""
+
+        self.type = type
+        _, defaults = Projection._registry[type]
+        self._projection_axis = np.asarray(defaults["axis"], dtype=np.float64)
 
         self._sample_position = np.asarray(sample_position, dtype=np.float64)
         self._root_position = np.asarray(root_position, dtype=np.float64)
         self._detector_positions = np.asarray(detector_positions, dtype=np.float64)
-        self._projection_axis = np.asarray(axis, dtype=np.float64)
 
         self._x_axis = np.zeros_like(self._projection_axis, dtype=np.float64)
         self._y_axis = np.zeros_like(self._projection_axis, dtype=np.float64)
@@ -144,3 +165,7 @@ class Projection(ABC):
     # Overwritten in side-by-side
     def get_bank_groups_by_detector_id(self) -> list[tuple[list[int], str]]:
         return []
+
+
+# Import subclasses at the BOTTOM to avoid circular imports,
+# but ensure they're always registered when Projection is imported

--- a/qt/python/instrumentview/instrumentview/Projections/Projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/Projection.py
@@ -140,3 +140,7 @@ class Projection(ABC):
 
     def positions(self) -> np.ndarray:
         return np.vstack([self._detector_x_coordinates, self._detector_y_coordinates]).transpose()
+
+    # Overwritten in side-by-side
+    def get_bank_groups_by_detector_id(self) -> list[tuple[list[int], str]]:
+        return []

--- a/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
+++ b/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from instrumentview.Projections.Projection import Projection
+from instrumentview.Projections.ProjectionType import ProjectionType
 import numpy as np
-from instrumentview.Detectors import DetectorPosition
 from mantid.api import PanelsSurfaceCalculator
 from mantid.dataobjects import Workspace2D
 from mantid.geometry import ComponentInfo
@@ -67,15 +67,17 @@ class FlatBankInfo:
                 self.detector_id_position_map[id] = detector_position
 
 
-class SideBySide(Projection):
+class SideBySide(Projection, projection_types={ProjectionType.SIDE_BY_SIDE: {"axis": [1, 0, 0]}}):
     def __init__(
         self,
+        type,
         workspace: Workspace2D,
         detector_ids: np.ndarray,
-        sample_position: np.ndarray,
-        root_position: np.ndarray,
-        detector_positions: list[DetectorPosition] | np.ndarray,
-        axis: np.ndarray,
+        **kwargs,
+        # sample_position: np.ndarray,
+        # root_position: np.ndarray,
+        # detector_positions: list[DetectorPosition] | np.ndarray,
+        # axis: np.ndarray,
     ):
         self._calculator = PanelsSurfaceCalculator()
         self._detector_id_to_flat_bank_map: dict[int, FlatBankInfo] = {}
@@ -89,7 +91,8 @@ class SideBySide(Projection):
         detector_component_indices = np.where(np.isin(all_detector_ids, detector_ids))[0]
         self._component_index_detector_id_map = dict(zip(detector_component_indices, detector_ids))
         self._detector_id_component_index_map = {id: c for c, id in self._component_index_detector_id_map.items()}
-        super().__init__(sample_position, root_position, detector_positions, axis)
+        # super().__init__(sample_position, root_position, detector_positions, axis)
+        super().__init__(type, **kwargs)
 
     def _find_and_correct_x_gap(self) -> None:
         # We don't want any gaps corrected

--- a/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
+++ b/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
@@ -74,10 +74,6 @@ class SideBySide(Projection, projection_types={ProjectionType.SIDE_BY_SIDE: {"ax
         workspace: Workspace2D,
         detector_ids: np.ndarray,
         **kwargs,
-        # sample_position: np.ndarray,
-        # root_position: np.ndarray,
-        # detector_positions: list[DetectorPosition] | np.ndarray,
-        # axis: np.ndarray,
     ):
         self._calculator = PanelsSurfaceCalculator()
         self._detector_id_to_flat_bank_map: dict[int, FlatBankInfo] = {}
@@ -91,7 +87,6 @@ class SideBySide(Projection, projection_types={ProjectionType.SIDE_BY_SIDE: {"ax
         detector_component_indices = np.where(np.isin(all_detector_ids, detector_ids))[0]
         self._component_index_detector_id_map = dict(zip(detector_component_indices, detector_ids))
         self._detector_id_component_index_map = {id: c for c, id in self._component_index_detector_id_map.items()}
-        # super().__init__(sample_position, root_position, detector_positions, axis)
         super().__init__(type, **kwargs)
 
     def _find_and_correct_x_gap(self) -> None:

--- a/qt/python/instrumentview/instrumentview/Projections/SphericalProjection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/SphericalProjection.py
@@ -5,10 +5,18 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from instrumentview.Projections.Projection import Projection
+from instrumentview.Projections.ProjectionType import ProjectionType
 import numpy as np
 
 
-class SphericalProjection(Projection):
+class SphericalProjection(
+    Projection,
+    projection_types={
+        ProjectionType.SPHERICAL_X: {"axis": [1, 0, 0]},
+        ProjectionType.SPHERICAL_Y: {"axis": [0, 1, 0]},
+        ProjectionType.SPHERICAL_Z: {"axis": [0, 0, 1]},
+    },
+):
     """2D projection with a spherical coordinate system, see https://en.wikipedia.org/wiki/Spherical_coordinate_system"""
 
     def _calculate_2d_coordinates(self) -> tuple[np.ndarray, np.ndarray]:

--- a/qt/python/instrumentview/instrumentview/Projections/test/test_SideBySide.py
+++ b/qt/python/instrumentview/instrumentview/Projections/test/test_SideBySide.py
@@ -4,7 +4,9 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from instrumentview.Projections.SideBySide import SideBySide, FlatBankInfo
+from instrumentview.Projections.ProjectionType import ProjectionType
+from instrumentview.Projections.Projection import SideBySide
+from instrumentview.Projections.SideBySide import FlatBankInfo
 
 import numpy as np
 from unittest.mock import MagicMock, patch
@@ -72,12 +74,12 @@ class TestSideBySideProjection(unittest.TestCase):
         mock_detector_info.detectorIDs.return_value = detector_ids + [100] if has_other_detectors else detector_ids
         mock_workspace.detectorInfo.return_value = mock_detector_info
         side_by_side = SideBySide(
+            type=ProjectionType.SIDE_BY_SIDE,
             workspace=mock_workspace,
             detector_ids=np.array(detector_ids),
             sample_position=np.zeros(3),
             root_position=np.zeros(3),
             detector_positions=np.array([[1, 1, 1], [0, 1, 0], [0, 0, 1]]),
-            axis=np.array([0, 0, 1]),
         )
         return side_by_side
 
@@ -105,7 +107,7 @@ class TestSideBySideProjection(unittest.TestCase):
         self.assertEqual(3, len(args))
         np.testing.assert_allclose([0, 0, 0], args[0])
         np.testing.assert_allclose([0, 0, 0], args[1])
-        np.testing.assert_allclose([0, 0, 1], args[2])
+        np.testing.assert_allclose([1, 0, 0], args[2])
 
     @patch("instrumentview.Projections.SideBySide.SideBySide._arrange_panels")
     @patch("instrumentview.Projections.Projection.Projection._calculate_detector_coordinates")

--- a/qt/python/instrumentview/instrumentview/Projections/test/test_cylindrical_projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/test/test_cylindrical_projection.py
@@ -5,7 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest.mock
-from instrumentview.Projections.CylindricalProjection import CylindricalProjection
+from instrumentview.Projections.ProjectionType import ProjectionType
+from instrumentview.Projections.Projection import CylindricalProjection
 import unittest
 import numpy as np
 
@@ -23,7 +24,7 @@ class TestCylindricalProjection(unittest.TestCase):
         # No need to mock out the x adjustments because in this case there isn't any need for
         # the projection class to call it.
         self._run_test(
-            projection_axis=[1, 0, 0],
+            projection_type=ProjectionType.CYLINDRICAL_X,
             expected_x_axis=[0, 1, 0],
             expected_y_axis=[0, 0, 1],
             expected_projections=[(0, 0), (0, 3 / np.sqrt(10)), (0, -3 / np.sqrt(10))],
@@ -32,7 +33,7 @@ class TestCylindricalProjection(unittest.TestCase):
     def test_calculate_2d_coordinates_y(self):
         # y-axis projection
         self._run_test(
-            projection_axis=[0, 1, 0],
+            projection_type=ProjectionType.CYLINDRICAL_Y,
             expected_x_axis=[0, 0, 1],
             expected_y_axis=[1, 0, 0],
             expected_projections=[(0, 1), (-np.pi / 2, 1 / np.sqrt(10)), (np.pi / 2, 1 / np.sqrt(10))],
@@ -42,16 +43,20 @@ class TestCylindricalProjection(unittest.TestCase):
     def test_calculate_2d_coordinates_z(self):
         # z-axis projection
         self._run_test(
-            projection_axis=[0, 0, 1],
+            projection_type=ProjectionType.CYLINDRICAL_Z,
             expected_x_axis=[1, 0, 0],
             expected_y_axis=[0, 1, 0],
             expected_projections=[(-np.pi / 2, 0), (-np.atan2(1, 3), 0), (-np.atan2(1, -3), 0)],
             mock_apply_x_correction=None,
         )
 
-    def _run_test(self, projection_axis, expected_x_axis, expected_y_axis, expected_projections, mock_apply_x_correction=None):
-        cylinder = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array(projection_axis))
-        np.testing.assert_allclose(cylinder._projection_axis, projection_axis, atol=self.abs_tol)
+    def _run_test(self, projection_type, expected_x_axis, expected_y_axis, expected_projections, mock_apply_x_correction=None):
+        cylinder = CylindricalProjection(
+            type=projection_type,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(cylinder._x_axis, expected_x_axis, atol=self.abs_tol)
         np.testing.assert_allclose(cylinder._y_axis, expected_y_axis, atol=self.abs_tol)
         calculated = cylinder.positions()

--- a/qt/python/instrumentview/instrumentview/Projections/test/test_projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/test/test_projection.py
@@ -6,7 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import unittest.mock
-from instrumentview.Projections.CylindricalProjection import CylindricalProjection
+from instrumentview.Projections.ProjectionType import ProjectionType
+from instrumentview.Projections.Projection import Projection
 
 import numpy as np
 import unittest
@@ -20,7 +21,12 @@ class TestProjection(unittest.TestCase):
         cls.detector_positions = np.array([[0, 1, 0], [2, 1, 0], [-2, 1, 0]])
 
     def test_apply_x_correction_below_min(self):
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 1, 0]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Y,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         x_min = proj._x_range[0]
         x_max = proj._x_range[1]
         proj._detector_x_coordinates[0] = x_min - 3 * np.pi / 2
@@ -30,7 +36,12 @@ class TestProjection(unittest.TestCase):
         self.assertLessEqual(proj._detector_x_coordinates[0], x_max)
 
     def test_apply_x_correction_above_max(self):
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 1, 0]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Y,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         x_min = proj._x_range[0]
         x_max = proj._x_range[1]
         proj._detector_x_coordinates[0] = x_max + 3 * np.pi / 2
@@ -42,7 +53,12 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_find_and_correct_x_gap_multiple_similar_gaps(self, mock_calc_2d_coords):
         mock_calc_2d_coords.return_value = np.array([0, np.pi / 4, -np.pi / 4]), np.array([0, 0, 0])
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(proj._detector_x_coordinates, [0, np.pi / 4, -np.pi / 4], rtol=1e-3)
         np.testing.assert_allclose(proj._x_range, [-np.pi / 4, np.pi / 4], rtol=1e-3)
         proj._u_period = np.pi / 2
@@ -53,7 +69,12 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_find_and_correct_x_gap_one_big_gap(self, mock_calc_2d_coords):
         mock_calc_2d_coords.return_value = np.array([0, np.pi / 8, -np.pi / 4]), np.array([0, 0, 0])
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(proj._detector_x_coordinates, [0, np.pi / 8, -np.pi / 4], rtol=1e-3)
         np.testing.assert_allclose(proj._x_range, [-np.pi / 4, np.pi / 8], rtol=1e-3)
         proj._u_period = np.pi / 2
@@ -65,7 +86,12 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_find_and_correct_x_gap_not_applied(self, mock_calc_2d_coords, mock_apply_x_correction):
         mock_calc_2d_coords.return_value = np.array([0, -np.pi / 8, np.pi / 4]), np.array([0, 0, 0])
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(proj._detector_x_coordinates, [0, -np.pi / 8, np.pi / 4], rtol=1e-3)
         np.testing.assert_allclose(proj._x_range, [-np.pi / 8, np.pi / 4], rtol=1e-3)
         proj._u_period = np.pi
@@ -78,7 +104,12 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_calculate_detector_coordinates(self, mock_calc_2d_coords, mock_find_and_correct_x_gap):
         mock_calc_2d_coords.return_value = (np.arange(5).astype(float), np.arange(1, 6).astype(float))
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_array_equal(proj._x_range, np.array([0, 4]))
         np.testing.assert_array_equal(proj._y_range, np.array([1, 5]))
 
@@ -86,7 +117,12 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_coordinate_for_detector(self, mock_calc_2d_coords, mock_find_and_correct_x_gap):
         mock_calc_2d_coords.return_value = (np.arange(5).astype(float), np.arange(1, 6).astype(float))
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_array_equal(proj.coordinate_for_detector(0), [0, 1])
         np.testing.assert_array_equal(proj.coordinate_for_detector(4), [4, 5])
 
@@ -94,9 +130,19 @@ class TestProjection(unittest.TestCase):
     @unittest.mock.patch("instrumentview.Projections.CylindricalProjection.CylindricalProjection._calculate_2d_coordinates")
     def test_positions(self, mock_calc_2d_coords, mock_find_and_correct_x_gap):
         mock_calc_2d_coords.return_value = (np.arange(5).astype(float), np.arange(1, 6).astype(float))
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_array_equal(proj.positions(), np.vstack([np.arange(5), np.arange(1, 6)]).T)
 
     def test_project_points_matches_positions_for_detector_centers(self):
-        proj = CylindricalProjection(self.sample_position, self.root_position, self.detector_positions, np.array([0, 0, 1]))
+        proj = Projection(
+            type=ProjectionType.CYLINDRICAL_Z,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(proj.project_points(self.detector_positions), proj.positions())

--- a/qt/python/instrumentview/instrumentview/Projections/test/test_spherical_projection.py
+++ b/qt/python/instrumentview/instrumentview/Projections/test/test_spherical_projection.py
@@ -5,7 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest.mock
-from instrumentview.Projections.SphericalProjection import SphericalProjection
+from instrumentview.Projections.Projection import SphericalProjection
+from instrumentview.Projections.ProjectionType import ProjectionType
 import unittest
 import numpy as np
 
@@ -22,7 +23,7 @@ class TestSphericalProjection(unittest.TestCase):
     def test_calculate_2d_coordinates_x(self):
         # x-axis projection
         self._run_test(
-            projection_axis=[1, 0, 0],
+            projection_type=ProjectionType.SPHERICAL_X,
             expected_x_axis=[0, 1, 0],
             expected_y_axis=[0, 0, 1],
             expected_projections=[(0, -np.pi / 2), (-np.pi / 2, -np.pi / 2), (0, 0)],
@@ -31,7 +32,7 @@ class TestSphericalProjection(unittest.TestCase):
     def test_calculate_2d_coordinates_y(self):
         # y-axis projection
         self._run_test(
-            projection_axis=[0, 1, 0],
+            projection_type=ProjectionType.SPHERICAL_Y,
             expected_x_axis=[0, 0, 1],
             expected_y_axis=[1, 0, 0],
             expected_projections=[(0, 0), (0, -np.pi / 2), (-np.pi / 2, -np.pi / 2)],
@@ -40,15 +41,19 @@ class TestSphericalProjection(unittest.TestCase):
     def test_calculate_2d_coordinates_z(self):
         # z-axis projection
         self._run_test(
-            projection_axis=[0, 0, 1],
+            projection_type=ProjectionType.SPHERICAL_Z,
             expected_x_axis=[1, 0, 0],
             expected_y_axis=[0, 1, 0],
             expected_projections=[(-np.pi / 2, -np.pi / 2), (0, 0), (0, -np.pi / 2)],
         )
 
-    def _run_test(self, projection_axis, expected_x_axis, expected_y_axis, expected_projections):
-        sphere = SphericalProjection(self.sample_position, self.root_position, self.detector_positions, np.array(projection_axis))
-        np.testing.assert_allclose(sphere._projection_axis, projection_axis, atol=self.abs_tol)
+    def _run_test(self, projection_type, expected_x_axis, expected_y_axis, expected_projections):
+        sphere = SphericalProjection(
+            type=projection_type,
+            sample_position=self.sample_position,
+            root_position=self.root_position,
+            detector_positions=self.detector_positions,
+        )
         np.testing.assert_allclose(sphere._x_axis, expected_x_axis, atol=self.abs_tol)
         np.testing.assert_allclose(sphere._y_axis, expected_y_axis, atol=self.abs_tol)
         calculated = sphere.positions()

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -380,20 +380,23 @@ class ShapeRenderer(InstrumentRenderer):
             # Tile template: (n_group, n_verts, 3)
             tiled = np.tile(template_verts, (n_group, 1, 1))
 
+            # Scale
+            native_scales = scales[group_indices][:, np.newaxis, :]
+            tiled = tiled * native_scales
+
             if projection is not None and projection.type is ProjectionType.SIDE_BY_SIDE:
                 if per_detector_rotate is None or per_detector_scales is None:
                     return pv.PolyData(), np.array([], dtype=np.int64), np.array([], dtype=np.int64)
 
+                projection_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
+                tiled = tiled * projection_scales
+
                 rotate_mask = per_detector_rotate[group_indices]
-                group_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
                 group_pos = detector_positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
             else:
                 rotate_mask = np.ones(n_group).astype(bool)
-                group_scales = scales[group_indices][:, np.newaxis, :]
                 group_pos = self._all_positions_3d[detector_indices[group_indices]][:, np.newaxis, :]
 
-            # Scale
-            tiled = tiled * group_scales
             # Rotate
             group_rots = rotations[group_indices[rotate_mask]]
             tiled[rotate_mask] = np.einsum("nij,nvj->nvi", group_rots, tiled[rotate_mask])

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -20,7 +20,6 @@ surface can be translated back to a logical detector index.
 import numpy as np
 import pyvista as pv
 from pyvistaqt import BackgroundPlotter
-from scipy.spatial import cKDTree
 from scipy.spatial.transform import Rotation
 from typing import Callable, Optional
 
@@ -40,7 +39,8 @@ class ShapeRenderer(InstrumentRenderer):
     _MASKED_COLOUR = (0.25, 0.25, 0.25)
     _PICKING_TOLERANCE = 0.001
 
-    def __init__(self):
+    def __init__(self, workspace):
+        self._workspace = workspace
         # Populated by ``precompute``.
         self._precomputed = False
         # Per-unique-shape: {xml_hash: (local_verts (V,3), local_faces (F,3))}
@@ -60,14 +60,14 @@ class ShapeRenderer(InstrumentRenderer):
     # -----------------------------------------------------------------
     # Pre-computation: fetch shape meshes and detector transforms once
     # -----------------------------------------------------------------
-    def precompute(self, workspace) -> None:
+    def precompute(self) -> None:
         """Extract shape meshes and per-detector transforms from *workspace*.
 
         This should be called once when the workspace is first loaded or
         replaced, *before* any ``build_*`` calls.
         """
-        comp_info = workspace.componentInfo()
-        det_info = workspace.detectorInfo()
+        comp_info = self._workspace.componentInfo()
+        det_info = self._workspace.detectorInfo()
         n_det = det_info.size()
 
         shape_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
@@ -122,16 +122,6 @@ class ShapeRenderer(InstrumentRenderer):
         self._precomputed = True
         logger.information(f"ShapeRenderer: precomputed {n_det} detectors, {len(shape_cache)} unique shapes")
 
-    def _is_spherical_or_cylindrical_projection(self, model) -> bool:
-        return model.projection_type in (
-            ProjectionType.SPHERICAL_X,
-            ProjectionType.SPHERICAL_Y,
-            ProjectionType.SPHERICAL_Z,
-            ProjectionType.CYLINDRICAL_X,
-            ProjectionType.CYLINDRICAL_Y,
-            ProjectionType.CYLINDRICAL_Z,
-        )
-
     # -----------------------------------------------------------------
     # Build meshes
     # -----------------------------------------------------------------
@@ -143,7 +133,7 @@ class ShapeRenderer(InstrumentRenderer):
         compute the 3D→2D offset per detector and apply it to every vertex.
         """
         if not self._precomputed:
-            raise RuntimeError("ShapeRenderer.precompute() must be called before build_detector_mesh().")
+            self.precompute()
 
         indices = self._resolve_detector_indices(positions, model, masked=False)
 
@@ -317,42 +307,6 @@ class ShapeRenderer(InstrumentRenderer):
             indices[i] = det_info.indexOf(int(did))
         return indices
 
-    def _compute_projection_scale(self, det_indices: np.ndarray, projected_positions: np.ndarray) -> float:
-        """Compute a uniform scale factor so shapes in 2D projections are
-        proportional to the inter-detector spacing.
-
-        Compares median nearest-neighbour distance in 3D (metres) to the
-        median nearest-neighbour distance in the projected coordinate space.
-        """
-        n = len(det_indices)
-        if n < 2:
-            return 1.0
-
-        # Sample to avoid O(n log n) overhead on very large instruments
-        max_sample = 2000
-        if n > max_sample:
-            rng = np.random.default_rng(42)
-            sample = rng.choice(n, max_sample, replace=False)
-        else:
-            sample = np.arange(n)
-
-        pos_3d = self._all_positions_3d[det_indices[sample]]
-        pos_2d = projected_positions[sample, :2]
-
-        tree_3d = cKDTree(pos_3d)
-        nnd_3d = tree_3d.query(pos_3d, k=2)[0][:, 1]
-
-        tree_2d = cKDTree(pos_2d)
-        nnd_2d = tree_2d.query(pos_2d, k=2)[0][:, 1]
-
-        med_3d = np.median(nnd_3d)
-        med_2d = np.median(nnd_2d)
-
-        if med_3d < 1e-12:
-            return 1.0
-
-        return med_2d / med_3d
-
     def _assemble_mesh(
         self,
         det_indices: np.ndarray,
@@ -366,11 +320,10 @@ class ShapeRenderer(InstrumentRenderer):
         """Vectorised mesh assembly.
 
         For each unique shape (group of detectors sharing the same template
-        mesh), we:
+        shape), we:
 
         1. Tile the template vertices for each detector in the group.
-        2. Apply per-detector scale, rotation and translation (via
-           ``np.einsum``).
+        2. Apply per-detector scale, rotation and translation.
         3. Concatenate with face arrays, offsetting vertex indices.
         4. Return a single merged ``pv.PolyData`` plus a mapping from cell
            index to detector-in-group index.
@@ -383,9 +336,6 @@ class ShapeRenderer(InstrumentRenderer):
         display_positions : np.ndarray
             (N, 3) display positions (may be 2D projected).  These are used
             as the centre of each shape.
-        flatten_2d : bool
-            If True, skip 3D rotations and rescale shapes so they are
-            proportional to the projected inter-detector spacing.
         per_detector_scales : np.ndarray or None
             If provided, (N,) per-detector scale factors to use instead of
             a single uniform projection_scale.  Only used when *flatten_2d*

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -23,6 +23,7 @@ from pyvistaqt import BackgroundPlotter
 from scipy.spatial.transform import Rotation
 from typing import Callable, Optional
 
+from instrumentview.Projections.Projection import Projection
 from instrumentview.Projections.ProjectionType import ProjectionType
 from instrumentview.renderers.base_renderer import InstrumentRenderer
 from mantid.kernel import logger
@@ -135,12 +136,11 @@ class ShapeRenderer(InstrumentRenderer):
         if not self._precomputed:
             self.precompute()
 
-        indices = self._resolve_detector_indices(positions, model.pickable_detector_ids)
+        indices = self._resolve_detector_indices(model.pickable_detector_ids)
 
         mesh, c2d, fpd = self._assemble_mesh(
-            indices,
-            positions,
-            projection_type=model.projection_type,
+            detector_indices=indices,
+            detector_positions=positions,
             projection=model.active_projection,
             flip_z=flip_z,
         )
@@ -166,12 +166,11 @@ class ShapeRenderer(InstrumentRenderer):
     def build_masked_mesh(self, positions: np.ndarray, flip_z: bool, model) -> pv.PolyData:
         if len(positions) == 0:
             return pv.PolyData()
-        indices = self._resolve_detector_indices(positions, model.masked_detector_ids)
+        indices = self._resolve_detector_indices(model.masked_detector_ids)
 
         mesh, _, _ = self._assemble_mesh(
-            indices,
-            positions,
-            projection_type=model.projection_type,
+            detector_indices=indices,
+            detector_positions=positions,
             projection=model.active_projection,
             flip_z=flip_z,
         )
@@ -275,7 +274,7 @@ class ShapeRenderer(InstrumentRenderer):
             # No shape mesh available — fall back to point data
             mesh.point_data[label] = visibility
 
-    def _resolve_detector_indices(self, positions: np.ndarray, detector_ids: np.ndarray) -> np.ndarray:
+    def _resolve_detector_indices(self, detector_ids: np.ndarray) -> np.ndarray:
         """Return indices into ``self._all_positions_3d`` for the detectors
         represented by *positions*.
 
@@ -299,12 +298,11 @@ class ShapeRenderer(InstrumentRenderer):
 
     def _assemble_mesh(
         self,
-        det_indices: np.ndarray,
-        display_positions: np.ndarray,
+        detector_indices: np.ndarray,
+        detector_positions: np.ndarray,
+        projection: Projection | None = None,
         per_detector_scales: np.ndarray | None = None,
         per_detector_rotate: np.ndarray | None = None,
-        projection_type: ProjectionType | None = None,
-        projection=None,
         flip_z: bool = False,
     ) -> tuple[pv.PolyData, np.ndarray, np.ndarray]:
         """Vectorised mesh assembly.
@@ -320,20 +318,18 @@ class ShapeRenderer(InstrumentRenderer):
 
         Parameters
         ----------
-        det_indices : np.ndarray
-            Indices into the precomputed arrays (``_det_shape_keys``, etc.)
-            for the detectors to render.
-        display_positions : np.ndarray
-            (N, 3) display positions (may be 2D projected).  These are used
-            as the centre of each shape.
+        detector_indices : np.ndarray
+            Indices of the detectors matching detector positions.
+        detector_positions: np.ndarray
+            (N, 3) positions of detectors that may be in 2d, spherical, cylindrical or side-by-side projections.
+            Offers a good shortcut to centres of detector shapes.
         per_detector_scales : np.ndarray or None
             If provided, (N,) per-detector scale factors to use instead of
-            a single uniform projection_scale.  Only used when *flatten_2d*
-            is True.
+            a single uniform projection_scale.  Only used for side-by-side projections
         per_detector_rotate : np.ndarray or None
             If provided, (N,) boolean array.  Detectors marked True have
-            their 3D rotation applied before flattening (tube banks);
-            False detectors stay axis-aligned (grid banks).
+            their 3D rotation applied; False detectors stay axis-aligned (grid banks).
+            Only used for side-by-side projection
 
         Returns
         -------
@@ -341,23 +337,29 @@ class ShapeRenderer(InstrumentRenderer):
         cell_to_detector : np.ndarray   (total_cells,) → index in 0..N-1
         faces_per_detector : np.ndarray  (N,)
         """
-        if len(det_indices) == 0:
+        if (
+            len(detector_indices) == 0
+            or self._det_shape_keys is None
+            or self._det_rotations is None
+            or self._det_scales is None
+            or self._all_positions_3d is None
+        ):
             return pv.PolyData(), np.array([], dtype=np.int64), np.array([], dtype=np.int64)
 
-        shape_keys = self._det_shape_keys[det_indices]
-        rotations = self._det_rotations[det_indices]  # (N, 3, 3)
-        scales = self._det_scales[det_indices]  # (N, 3)
+        shape_keys = self._det_shape_keys[detector_indices]
+        rotations = self._det_rotations[detector_indices]  # (N, 3, 3)
+        scales = self._det_scales[detector_indices]  # (N, 3)
 
         all_verts_list: list[np.ndarray] = []
         all_faces_list: list[np.ndarray] = []
         cell_to_det_list: list[np.ndarray] = []
-        faces_per_det = np.empty(len(det_indices), dtype=np.int64)
+        faces_per_det = np.empty(len(detector_indices), dtype=np.int64)
 
         vertex_offset = 0
 
         # Centroid of all display positions (2D) — used for z-offset
         # so detectors farther from the mesh centre sit above closer ones.
-        mesh_centre_2d = display_positions[:, :2].mean(axis=0)
+        mesh_centre_2d = detector_positions[:, :2].mean(axis=0)
 
         # Group detectors by shape key for batch processing
         unique_keys = np.unique(shape_keys)
@@ -378,14 +380,17 @@ class ShapeRenderer(InstrumentRenderer):
             # Tile template: (n_group, n_verts, 3)
             tiled = np.tile(template_verts, (n_group, 1, 1))
 
-            if projection_type is ProjectionType.SIDE_BY_SIDE:
+            if projection is not None and projection.type is ProjectionType.SIDE_BY_SIDE:
+                if per_detector_rotate is None or per_detector_scales is None:
+                    return pv.PolyData(), np.array([], dtype=np.int64), np.array([], dtype=np.int64)
+
                 rotate_mask = per_detector_rotate[group_indices]
                 group_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
-                group_pos = display_positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
+                group_pos = detector_positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
             else:
                 rotate_mask = np.ones(n_group).astype(bool)
                 group_scales = scales[group_indices][:, np.newaxis, :]
-                group_pos = self._all_positions_3d[det_indices[group_indices]][:, np.newaxis, :]
+                group_pos = self._all_positions_3d[detector_indices[group_indices]][:, np.newaxis, :]
 
             # Scale
             tiled = tiled * group_scales
@@ -395,7 +400,7 @@ class ShapeRenderer(InstrumentRenderer):
             # Translate
             tiled = tiled + group_pos
 
-            if projection_type is not ProjectionType.THREE_D and projection_type is not ProjectionType.SIDE_BY_SIDE:
+            if projection is not None and projection.type is not ProjectionType.SIDE_BY_SIDE:
                 if flip_z:
                     tiled[:, :, 2] *= -1
 
@@ -405,7 +410,7 @@ class ShapeRenderer(InstrumentRenderer):
                 if np.isfinite(u_period) and abs(u_period) > 0.0:
                     # Keep each detector polygon contiguous at the periodic seam
                     # by wrapping vertices near the projected detector center.
-                    centre_x = display_positions[group_indices, 0][:, np.newaxis]
+                    centre_x = detector_positions[group_indices, 0][:, np.newaxis]
                     projected_vertices[:, :, 0] += np.round((centre_x - projected_vertices[:, :, 0]) / u_period) * u_period
 
                 tiled[:, :, :2] = projected_vertices
@@ -413,7 +418,7 @@ class ShapeRenderer(InstrumentRenderer):
                 # Assign tiny z offsets so detectors farther from the mesh
                 # centre sit above those closer, preventing picking
                 # ambiguity on overlapping coplanar cells.
-                group_center_dist = np.linalg.norm(display_positions[group_indices, :2] - mesh_centre_2d, axis=1)
+                group_center_dist = np.linalg.norm(detector_positions[group_indices, :2] - mesh_centre_2d, axis=1)
                 tiled[:, :, 2] = group_center_dist[:, np.newaxis] * 1e-4
 
             # Flatten to (n_group * n_verts, 3)

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -441,6 +441,10 @@ class ShapeRenderer(InstrumentRenderer):
 
         vertex_offset = 0
 
+        # Centroid of all display positions (2D) — used for z-offset
+        # so detectors farther from the mesh centre sit above closer ones.
+        mesh_centre_2d = positions[:, :2].mean(axis=0)
+
         # Group detectors by shape key for batch processing
         unique_keys = np.unique(shape_keys)
 
@@ -487,7 +491,6 @@ class ShapeRenderer(InstrumentRenderer):
                         projected_vertices[:, :, 0] += np.round((centre_x - projected_vertices[:, :, 0]) / u_period) * u_period
 
                     tiled[:, :, :2] = projected_vertices
-                    tiled[:, :, 2] = 0.0
                 elif per_detector_scales is not None:
                     group_rotate = per_detector_rotate[group_indices] if per_detector_rotate is not None else np.zeros(n_group, dtype=bool)
                     if np.all(group_rotate):
@@ -502,8 +505,11 @@ class ShapeRenderer(InstrumentRenderer):
                     tiled = tiled * group_proj_scales
                 else:
                     tiled = tiled * projection_scale
-                # Flatten z so shapes lie in the XY plane.
-                tiled[:, :, 2] = 0.0
+                # Assign tiny z offsets so detectors farther from the mesh
+                # centre sit above those closer, preventing picking
+                # ambiguity on overlapping coplanar cells.
+                group_center_dist = np.linalg.norm(positions[group_indices, :2] - mesh_centre_2d, axis=1)
+                tiled[:, :, 2] = group_center_dist[:, np.newaxis] * 1e-4
             else:
                 # Rotate: R @ v  →  einsum('nij,nvj->nvi', R, V)
                 group_rots = rotations[group_indices]  # (n_group, 3, 3)

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -147,19 +147,11 @@ class ShapeRenderer(InstrumentRenderer):
 
         indices = self._resolve_detector_indices(positions, model, masked=False)
 
-        project_vertices_2d = False
-        projection = None
-        if model.is_2d_projection:
-            if self._is_spherical_or_cylindrical_projection(model):
-                projection = model.active_projection
-                project_vertices_2d = projection is not None
-
         mesh, c2d, fpd = self._assemble_mesh(
             indices,
             positions,
-            flatten_2d=model.is_2d_projection,
-            project_vertices_2d=project_vertices_2d,
-            projection=projection,
+            projection_type=model.projection_type,
+            projection=model.active_projection,
             flip_z=flip_z,
         )
         self._cell_to_detector = c2d
@@ -186,19 +178,11 @@ class ShapeRenderer(InstrumentRenderer):
             return pv.PolyData()
         indices = self._resolve_detector_indices(positions, model, masked=True)
 
-        project_vertices_2d = False
-        projection = None
-        if model.is_2d_projection:
-            if self._is_spherical_or_cylindrical_projection(model):
-                projection = model.active_projection
-                project_vertices_2d = projection is not None
-
         mesh, _, _ = self._assemble_mesh(
             indices,
             positions,
-            flatten_2d=model.is_2d_projection,
-            project_vertices_2d=project_vertices_2d,
-            projection=projection,
+            projection_type=model.projection_type,
+            projection=model.active_projection,
             flip_z=flip_z,
         )
         return mesh
@@ -373,10 +357,9 @@ class ShapeRenderer(InstrumentRenderer):
         self,
         det_indices: np.ndarray,
         display_positions: np.ndarray,
-        flatten_2d: bool = False,
         per_detector_scales: np.ndarray | None = None,
         per_detector_rotate: np.ndarray | None = None,
-        project_vertices_2d: bool = False,
+        projection_type: ProjectionType | None = None,
         projection=None,
         flip_z: bool = False,
     ) -> tuple[pv.PolyData, np.ndarray, np.ndarray]:
@@ -425,15 +408,6 @@ class ShapeRenderer(InstrumentRenderer):
         rotations = self._det_rotations[det_indices]  # (N, 3, 3)
         scales = self._det_scales[det_indices]  # (N, 3)
 
-        # In 2D projection mode, compute a scale factor so that shapes
-        # are proportional to the projected inter-detector spacing.
-        projection_scale = 1.0
-        if flatten_2d and not project_vertices_2d and per_detector_scales is None and len(det_indices) > 1:
-            projection_scale = self._compute_projection_scale(det_indices, display_positions)
-
-        # Use display_positions as centres (they might be projected)
-        positions = display_positions
-
         all_verts_list: list[np.ndarray] = []
         all_faces_list: list[np.ndarray] = []
         cell_to_det_list: list[np.ndarray] = []
@@ -443,7 +417,7 @@ class ShapeRenderer(InstrumentRenderer):
 
         # Centroid of all display positions (2D) — used for z-offset
         # so detectors farther from the mesh centre sit above closer ones.
-        mesh_centre_2d = positions[:, :2].mean(axis=0)
+        mesh_centre_2d = display_positions[:, :2].mean(axis=0)
 
         # Group detectors by shape key for batch processing
         unique_keys = np.unique(shape_keys)
@@ -461,64 +435,46 @@ class ShapeRenderer(InstrumentRenderer):
                 faces_per_det[group_indices] = 0
                 continue
 
-            # --- Vectorised transform: scale → rotate → translate -----------
             # Tile template: (n_group, n_verts, 3)
             tiled = np.tile(template_verts, (n_group, 1, 1))
 
-            # Scale: (n_group, 1, 3) * (n_group, n_verts, 3)
-            group_scales = scales[group_indices][:, np.newaxis, :]
+            if projection_type is ProjectionType.SIDE_BY_SIDE:
+                rotate_mask = per_detector_rotate[group_indices]
+                group_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
+                group_pos = display_positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
+            else:
+                rotate_mask = np.ones(n_group).astype(bool)
+                group_scales = scales[group_indices][:, np.newaxis, :]
+                group_pos = self._all_positions_3d[det_indices[group_indices]][:, np.newaxis, :]
+
+            # Scale
             tiled = tiled * group_scales
+            # Rotate
+            group_rots = rotations[group_indices[rotate_mask]]
+            tiled[rotate_mask] = np.einsum("nij,nvj->nvi", group_rots, tiled[rotate_mask])
+            # Translate
+            tiled = tiled + group_pos
 
-            if flatten_2d:
-                if project_vertices_2d and projection is not None:
-                    # Keep detector orientation in 3D before projecting vertices.
-                    group_rots = rotations[group_indices]
-                    tiled = np.einsum("nij,nvj->nvi", group_rots, tiled)
+            if projection_type is not ProjectionType.THREE_D and projection_type is not ProjectionType.SIDE_BY_SIDE:
+                if flip_z:
+                    tiled[:, :, 2] *= -1
 
-                    group_world_pos = self._all_positions_3d[det_indices[group_indices]][:, np.newaxis, :]
-                    world_vertices = tiled + group_world_pos
-                    if flip_z:
-                        world_vertices[:, :, 2] *= -1
-                    projected_vertices = projection.project_points(world_vertices.reshape(-1, 3), apply_x_correction=False).reshape(
-                        n_group, n_verts, 2
-                    )
+                projected_vertices = projection.project_points(tiled.reshape(-1, 3), apply_x_correction=False).reshape(n_group, n_verts, 2)
 
-                    u_period = projection.u_period
-                    if np.isfinite(u_period) and abs(u_period) > 0.0:
-                        # Keep each detector polygon contiguous at the periodic seam
-                        # by wrapping vertices near the projected detector center.
-                        centre_x = positions[group_indices, 0][:, np.newaxis]
-                        projected_vertices[:, :, 0] += np.round((centre_x - projected_vertices[:, :, 0]) / u_period) * u_period
+                u_period = projection.u_period
+                if np.isfinite(u_period) and abs(u_period) > 0.0:
+                    # Keep each detector polygon contiguous at the periodic seam
+                    # by wrapping vertices near the projected detector center.
+                    centre_x = display_positions[group_indices, 0][:, np.newaxis]
+                    projected_vertices[:, :, 0] += np.round((centre_x - projected_vertices[:, :, 0]) / u_period) * u_period
 
-                    tiled[:, :, :2] = projected_vertices
-                elif per_detector_scales is not None:
-                    group_rotate = per_detector_rotate[group_indices] if per_detector_rotate is not None else np.zeros(n_group, dtype=bool)
-                    if np.all(group_rotate):
-                        group_rots = rotations[group_indices]
-                        tiled = np.einsum("nij,nvj->nvi", group_rots, tiled)
-                    elif np.any(group_rotate):
-                        rot_mask = group_rotate
-                        group_rots = rotations[group_indices[rot_mask]]
-                        tiled[rot_mask] = np.einsum("nij,nvj->nvi", group_rots, tiled[rot_mask])
-                    # else: no rotation for this entire shape group
-                    group_proj_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
-                    tiled = tiled * group_proj_scales
-                else:
-                    tiled = tiled * projection_scale
+                tiled[:, :, :2] = projected_vertices
+
                 # Assign tiny z offsets so detectors farther from the mesh
                 # centre sit above those closer, preventing picking
                 # ambiguity on overlapping coplanar cells.
-                group_center_dist = np.linalg.norm(positions[group_indices, :2] - mesh_centre_2d, axis=1)
+                group_center_dist = np.linalg.norm(display_positions[group_indices, :2] - mesh_centre_2d, axis=1)
                 tiled[:, :, 2] = group_center_dist[:, np.newaxis] * 1e-4
-            else:
-                # Rotate: R @ v  →  einsum('nij,nvj->nvi', R, V)
-                group_rots = rotations[group_indices]  # (n_group, 3, 3)
-                tiled = np.einsum("nij,nvj->nvi", group_rots, tiled)
-
-            # Translate
-            if not (flatten_2d and project_vertices_2d and projection is not None):
-                group_pos = positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
-                tiled = tiled + group_pos
 
             # Flatten to (n_group * n_verts, 3)
             flat_verts = tiled.reshape(-1, 3)

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -135,7 +135,7 @@ class ShapeRenderer(InstrumentRenderer):
         if not self._precomputed:
             self.precompute()
 
-        indices = self._resolve_detector_indices(positions, model, masked=False)
+        indices = self._resolve_detector_indices(positions, model.pickable_detector_ids)
 
         mesh, c2d, fpd = self._assemble_mesh(
             indices,
@@ -166,7 +166,7 @@ class ShapeRenderer(InstrumentRenderer):
     def build_masked_mesh(self, positions: np.ndarray, flip_z: bool, model) -> pv.PolyData:
         if len(positions) == 0:
             return pv.PolyData()
-        indices = self._resolve_detector_indices(positions, model, masked=True)
+        indices = self._resolve_detector_indices(positions, model.masked_detector_ids)
 
         mesh, _, _ = self._assemble_mesh(
             indices,
@@ -275,7 +275,7 @@ class ShapeRenderer(InstrumentRenderer):
             # No shape mesh available — fall back to point data
             mesh.point_data[label] = visibility
 
-    def _resolve_detector_indices(self, positions: np.ndarray, model, masked: bool) -> np.ndarray:
+    def _resolve_detector_indices(self, positions: np.ndarray, detector_ids: np.ndarray) -> np.ndarray:
         """Return indices into ``self._all_positions_3d`` for the detectors
         represented by *positions*.
 
@@ -286,24 +286,14 @@ class ShapeRenderer(InstrumentRenderer):
         We match by looking up the detector IDs that correspond to the
         pickable/masked subset and converting them via ``detectorInfo.indexOf``.
         """
-        if model is None:
-            # Fallback: assume positions indexing matches precomputed
-            return np.arange(len(positions))
-
-        ws = model.workspace
-        det_info = ws.detectorInfo()
-
-        if masked:
-            det_ids = model.masked_detector_ids
-        else:
-            det_ids = model.pickable_detector_ids
+        det_info = self._workspace.detectorInfo()
 
         # Convert detector IDs → detectorInfo indices (vectorised via the
         # C++ call).  ``detectorInfo().indexOf(id)`` works element-wise in C++
         # but not in Python, so we loop.  For large instruments this is fast
         # because it's just a dict lookup in C++.
-        indices = np.empty(len(det_ids), dtype=np.int64)
-        for i, did in enumerate(det_ids):
+        indices = np.empty(len(detector_ids), dtype=np.int64)
+        for i, did in enumerate(detector_ids):
             indices[i] = det_info.indexOf(int(did))
         return indices
 

--- a/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
@@ -34,9 +34,8 @@ class SideBySideShapeRenderer(ShapeRenderer):
     no shape extends past half the inter-detector spacing.
     """
 
-    def __init__(self, workspace: Workspace2D, bank_groups_by_detector_id: list[tuple[list[int], str]] | None) -> None:
+    def __init__(self, workspace: Workspace2D) -> None:
         super().__init__(workspace)
-        self._bank_groups_by_detector_id = [] if bank_groups_by_detector_id is None else bank_groups_by_detector_id
 
     def precompute(self):
         super().precompute()
@@ -45,13 +44,14 @@ class SideBySideShapeRenderer(ShapeRenderer):
         if not self._precomputed:
             self.precompute()
 
-        flatten_2d = model is not None and model.is_2d_projection
-        indices = self._resolve_detector_indices(positions, model, masked=False)
+        indices = self._resolve_detector_indices(positions, model.pickable_detector_ids)
 
         per_detector_scales = None
         per_detector_rotate = None
-        if flatten_2d and model is not None:
-            per_detector_scales, per_detector_rotate = self._compute_bank_projection_scales(indices, positions, model)
+        if model is not None and model.is_2d_projection:
+            per_detector_scales, per_detector_rotate = self._compute_bank_projection_scales(
+                indices, positions, model.bank_groups_by_detector_id
+            )
 
         mesh, c2d, fpd = self._assemble_mesh(
             indices,
@@ -68,13 +68,15 @@ class SideBySideShapeRenderer(ShapeRenderer):
     def build_masked_mesh(self, positions: np.ndarray, flip_z: bool, model=None) -> pv.PolyData:
         if len(positions) == 0:
             return pv.PolyData()
-        flatten_2d = model is not None and model.is_2d_projection
-        indices = self._resolve_detector_indices(positions, model, masked=True)
+
+        indices = self._resolve_detector_indices(positions, model.masked_detector_ids)
 
         per_detector_scales = None
         per_detector_rotate = None
-        if flatten_2d and model is not None:
-            per_detector_scales, per_detector_rotate = self._compute_bank_projection_scales(indices, positions, model)
+        if model is not None and model.is_2d_projection:
+            per_detector_scales, per_detector_rotate = self._compute_bank_projection_scales(
+                indices, positions, model.bank_groups_by_detector_id
+            )
 
         mesh, _, _ = self._assemble_mesh(
             indices,
@@ -89,7 +91,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
         self,
         det_indices: np.ndarray,
         projected_positions: np.ndarray,
-        model,
+        bank_groups_by_detector_id,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Compute per-detector scale factors using vertex-based overlap detection.
 
@@ -112,8 +114,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
             Per-detector boolean flag, True if the 3D rotation should be
             applied (tube banks), False otherwise (grid banks).
         """
-        ws = model.workspace
-        det_info = ws.detectorInfo()
+        det_info = self._workspace.detectorInfo()
         all_det_ids = np.array(det_info.detectorIDs())
         det_id_to_global = {int(did): idx for idx, did in enumerate(all_det_ids)}
 
@@ -122,7 +123,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
 
         # Convert detector-ID-based bank groups to local-index-based groups
         bank_local_groups: list[tuple[list[int], str]] = []
-        for bank_det_ids, bank_type in self._bank_groups_by_detector_id:
+        for bank_det_ids, bank_type in bank_groups_by_detector_id:
             local_indices = []
             for did in bank_det_ids:
                 global_idx = det_id_to_global.get(int(did))

--- a/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
@@ -53,7 +53,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
         mesh, c2d, fpd = self._assemble_mesh(
             indices,
             positions,
-            flatten_2d=flatten_2d,
+            projection_type=model.projection_type,
             per_detector_scales=per_detector_scales,
             per_detector_rotate=per_detector_rotate,
         )
@@ -76,7 +76,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
         mesh, _, _ = self._assemble_mesh(
             indices,
             positions,
-            flatten_2d=flatten_2d,
+            projection_type=model.projection_type,
             per_detector_scales=per_detector_scales,
             per_detector_rotate=per_detector_rotate,
         )

--- a/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
@@ -34,13 +34,16 @@ class SideBySideShapeRenderer(ShapeRenderer):
     no shape extends past half the inter-detector spacing.
     """
 
-    def precompute(self, workspace: Workspace2D, bank_groups_by_detector_id: list[tuple[list[int], str]] | None) -> None:
-        super().precompute(workspace)
+    def __init__(self, workspace: Workspace2D, bank_groups_by_detector_id: list[tuple[list[int], str]] | None) -> None:
+        super().__init__(workspace)
         self._bank_groups_by_detector_id = [] if bank_groups_by_detector_id is None else bank_groups_by_detector_id
+
+    def precompute(self):
+        super().precompute()
 
     def build_detector_mesh(self, positions: np.ndarray, flip_z: bool, model=None) -> pv.PolyData:
         if not self._precomputed:
-            raise RuntimeError("SideBySideShapeRenderer.precompute() must be called before build_detector_mesh().")
+            self.precompute()
 
         flatten_2d = model is not None and model.is_2d_projection
         indices = self._resolve_detector_indices(positions, model, masked=False)
@@ -135,8 +138,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
         per_det_rotate = np.zeros(len(det_indices), dtype=bool)
 
         if not bank_local_groups:
-            uniform = self._compute_projection_scale(det_indices, projected_positions)
-            per_det_scale[:] = uniform
+            per_det_scale[:] = 1.0
             return per_det_scale, per_det_rotate
 
         for local_indices, bank_type in bank_local_groups:

--- a/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
@@ -139,6 +139,10 @@ class SideBySideShapeRenderer(ShapeRenderer):
         per_det_rotate = np.zeros(len(det_indices), dtype=bool)
 
         if not bank_local_groups:
+            # It should not be possible for bank_local_groups to be empty,
+            # as any detectors not in a grid in the IDF are put into a custom flat bank.
+            # If there are some detectors then there will be at least one bank.
+            # Safeguard anyway by setting a default scale of 1
             per_det_scale[:] = 1.0
             return per_det_scale, per_det_rotate
 

--- a/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/side_by_side_shape_renderer.py
@@ -40,11 +40,11 @@ class SideBySideShapeRenderer(ShapeRenderer):
     def precompute(self):
         super().precompute()
 
-    def build_detector_mesh(self, positions: np.ndarray, flip_z: bool, model=None) -> pv.PolyData:
+    def build_detector_mesh(self, positions: np.ndarray, flip_z: bool, model) -> pv.PolyData:
         if not self._precomputed:
             self.precompute()
 
-        indices = self._resolve_detector_indices(positions, model.pickable_detector_ids)
+        indices = self._resolve_detector_indices(model.pickable_detector_ids)
 
         per_detector_scales = None
         per_detector_rotate = None
@@ -54,9 +54,9 @@ class SideBySideShapeRenderer(ShapeRenderer):
             )
 
         mesh, c2d, fpd = self._assemble_mesh(
-            indices,
-            positions,
-            projection_type=model.projection_type,
+            detector_indices=indices,
+            detector_positions=positions,
+            projection=model.active_projection,
             per_detector_scales=per_detector_scales,
             per_detector_rotate=per_detector_rotate,
         )
@@ -69,7 +69,7 @@ class SideBySideShapeRenderer(ShapeRenderer):
         if len(positions) == 0:
             return pv.PolyData()
 
-        indices = self._resolve_detector_indices(positions, model.masked_detector_ids)
+        indices = self._resolve_detector_indices(model.masked_detector_ids)
 
         per_detector_scales = None
         per_detector_rotate = None
@@ -79,9 +79,9 @@ class SideBySideShapeRenderer(ShapeRenderer):
             )
 
         mesh, _, _ = self._assemble_mesh(
-            indices,
-            positions,
-            projection_type=model.projection_type,
+            detector_indices=indices,
+            detector_positions=positions,
+            projection=model.active_projection,
             per_detector_scales=per_detector_scales,
             per_detector_rotate=per_detector_rotate,
         )

--- a/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
+++ b/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
@@ -139,8 +139,7 @@ class TestShapeRenderer(unittest.TestCase):
     """Tests for the ShapeRenderer class."""
 
     def setUp(self):
-        self._workspace = self._create_mock_workspace(n_detectors=4)
-        self.renderer = ShapeRenderer(self._workspace)
+        self._workspace = self._refresh_render_with_mock_workspace(n_detectors=4)
 
     def test_is_instrument_renderer(self):
         self.assertIsInstance(self.renderer, InstrumentRenderer)
@@ -156,8 +155,8 @@ class TestShapeRenderer(unittest.TestCase):
     def test_precompute_and_build_mesh(self):
         """Integration test: create a mock workspace with detectors that have shapes
         and verify mesh assembly produces valid geometry."""
-        self.renderer.precompute()
 
+        # Test precomputing before building a mesh
         self.assertTrue(self.renderer._precomputed)
         self.assertGreater(len(self.renderer._shape_cache), 0)
 
@@ -172,7 +171,6 @@ class TestShapeRenderer(unittest.TestCase):
     def test_build_pickable_mesh_returns_shape_copy(self):
         """build_pickable_mesh should return a shape mesh copy (not a point cloud)
         so that cell picking works on the full detector surface."""
-        self.renderer.precompute()
 
         model = self._create_mock_model(self._workspace, n_pickable=4)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
@@ -187,9 +185,7 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_set_pickable_scalars_sets_cell_data(self):
         """Visibility should be set as cell data via _cell_to_detector."""
-        workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=2)
 
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float64)
@@ -207,9 +203,7 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_cell_to_detector_mapping(self):
         """Verify that each cell in the assembled mesh maps to a valid detector index."""
-        workspace = self._create_mock_workspace(n_detectors=3)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=3)
 
         model = self._create_mock_model(workspace, n_pickable=3)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
@@ -224,9 +218,7 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_set_detector_scalars_cell_data(self):
         """Scalars should be repeated per-cell for each detector."""
-        workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=2)
 
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float64)
@@ -244,17 +236,13 @@ class TestShapeRenderer(unittest.TestCase):
             np.testing.assert_array_equal(cell_scalars[mask], expected)
 
     def test_empty_positions_returns_empty_mesh(self):
-        workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        self._refresh_render_with_mock_workspace(n_detectors=2)
         mesh = self.renderer.build_masked_mesh(np.empty((0, 3)), False, model=None)
         self.assertEqual(mesh.number_of_points, 0)
 
     def test_shape_deduplication(self):
         """Detectors sharing the same shape XML should reuse the cached template."""
-        workspace = self._create_mock_workspace(n_detectors=10, same_shape=True)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        self._refresh_render_with_mock_workspace(n_detectors=10, same_shape=True)
         # Only 1 unique shape (plus potentially the fallback)
         # Since all share the same XML, cache should have exactly 1 entry
         self.assertEqual(len(self.renderer._shape_cache), 1)
@@ -275,9 +263,7 @@ class TestShapeRenderer(unittest.TestCase):
         """Rebuilding the detector mesh with fewer detectors should not cause
         an array shape mismatch in set_pickable_scalars.
         """
-        workspace = self._create_mock_workspace(n_detectors=6, same_shape=True)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=6, same_shape=True)
 
         # First render: 6 detectors
         model_6 = self._create_mock_model(workspace, n_pickable=6)
@@ -300,9 +286,7 @@ class TestShapeRenderer(unittest.TestCase):
         self.assertEqual(len(pickable_4.cell_data["Visible Picked"]), pickable_4.number_of_cells)
 
     def test_build_detector_mesh_projects_shape_vertices_for_cylindrical_projection(self):
-        workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=1)
 
         projection = MagicMock()
         projection.project_points.side_effect = lambda points, apply_x_correction=True: np.column_stack(
@@ -324,9 +308,7 @@ class TestShapeRenderer(unittest.TestCase):
         self.assertLess(np.max(mesh.points[:, 1]), -2.9)
 
     def test_build_detector_mesh_keeps_projected_shape_contiguous_across_seam(self):
-        workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=1)
 
         projection = MagicMock()
         projection.u_period = 2 * np.pi
@@ -370,9 +352,7 @@ class TestShapeRenderer(unittest.TestCase):
         """When _detector_mesh_ref has been built, build_pickable_mesh should
         return a shape mesh copy regardless of flip_z — the flip is already
         baked into the detector mesh vertices."""
-        workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=2)
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
         ref_mesh = self.renderer.build_detector_mesh(positions, False, model)
@@ -385,9 +365,7 @@ class TestShapeRenderer(unittest.TestCase):
     def test_build_detector_mesh_flip_z_negates_world_z_before_projection(self):
         """In cylindrical projections, flip_z=True must negate the world-space
         z-coordinate of each shape vertex before it is passed to project_points."""
-        workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=1)
         # Override the stored 3D position so the flip is observable (z ≠ 0)
         self.renderer._all_positions_3d = np.array([[0.0, 0.0, 1.5]])
 
@@ -428,9 +406,8 @@ class TestShapeRenderer(unittest.TestCase):
     def test_build_masked_mesh_flip_z_negates_world_z_before_projection(self):
         """flip_z=True should also negate world-space z for masked detector vertices
         before projection (same _assemble_mesh path as build_detector_mesh)."""
-        workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer = ShapeRenderer(workspace)
-        self.renderer.precompute()
+
+        workspace = self._refresh_render_with_mock_workspace(n_detectors=1)
         self.renderer._all_positions_3d = np.array([[0.0, 0.0, 2.0]])
 
         model = self._create_mock_model(workspace, n_pickable=0)
@@ -469,6 +446,13 @@ class TestShapeRenderer(unittest.TestCase):
     # ------------------------------------------------------------------
     # Helper methods to create mock objects
     # ------------------------------------------------------------------
+
+    def _refresh_render_with_mock_workspace(self, **kwargs):
+        mock_ws = self._create_mock_workspace(**kwargs)
+        self.renderer = ShapeRenderer(mock_ws)
+        self.renderer.precompute()
+        return mock_ws
+
     def _create_mock_workspace(self, n_detectors=4, same_shape=False):
         """Create a mock workspace with mock componentInfo and detectorInfo."""
         workspace = MagicMock()

--- a/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
+++ b/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
@@ -139,26 +139,29 @@ class TestShapeRenderer(unittest.TestCase):
     """Tests for the ShapeRenderer class."""
 
     def setUp(self):
-        self.renderer = ShapeRenderer()
+        self._workspace = self._create_mock_workspace(n_detectors=4)
+        self.renderer = ShapeRenderer(self._workspace)
 
     def test_is_instrument_renderer(self):
         self.assertIsInstance(self.renderer, InstrumentRenderer)
 
-    def test_build_detector_mesh_raises_without_precompute(self):
+    def test_build_detector_mesh_auto_precomputes(self):
+        """build_detector_mesh should auto-precompute if not already done."""
+        model = self._create_mock_model(self._workspace, n_pickable=1)
         positions = np.array([[0.0, 0.0, 0.0]])
-        with self.assertRaises(RuntimeError):
-            self.renderer.build_detector_mesh(positions, False, MagicMock())
+        mesh = self.renderer.build_detector_mesh(positions, False, model)
+        self.assertTrue(self.renderer._precomputed)
+        self.assertIsInstance(mesh, pv.PolyData)
 
     def test_precompute_and_build_mesh(self):
         """Integration test: create a mock workspace with detectors that have shapes
         and verify mesh assembly produces valid geometry."""
-        workspace = self._create_mock_workspace(n_detectors=4)
-        self.renderer.precompute(workspace)
+        self.renderer.precompute()
 
         self.assertTrue(self.renderer._precomputed)
         self.assertGreater(len(self.renderer._shape_cache), 0)
 
-        model = self._create_mock_model(workspace, n_pickable=4)
+        model = self._create_mock_model(self._workspace, n_pickable=4)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
         mesh = self.renderer.build_detector_mesh(positions, False, model)
 
@@ -169,10 +172,9 @@ class TestShapeRenderer(unittest.TestCase):
     def test_build_pickable_mesh_returns_shape_copy(self):
         """build_pickable_mesh should return a shape mesh copy (not a point cloud)
         so that cell picking works on the full detector surface."""
-        workspace = self._create_mock_workspace(n_detectors=4)
-        self.renderer.precompute(workspace)
+        self.renderer.precompute()
 
-        model = self._create_mock_model(workspace, n_pickable=4)
+        model = self._create_mock_model(self._workspace, n_pickable=4)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
         self.renderer.build_detector_mesh(positions, False, model)
 
@@ -186,7 +188,8 @@ class TestShapeRenderer(unittest.TestCase):
     def test_set_pickable_scalars_sets_cell_data(self):
         """Visibility should be set as cell data via _cell_to_detector."""
         workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float64)
@@ -205,7 +208,8 @@ class TestShapeRenderer(unittest.TestCase):
     def test_cell_to_detector_mapping(self):
         """Verify that each cell in the assembled mesh maps to a valid detector index."""
         workspace = self._create_mock_workspace(n_detectors=3)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         model = self._create_mock_model(workspace, n_pickable=3)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
@@ -221,7 +225,8 @@ class TestShapeRenderer(unittest.TestCase):
     def test_set_detector_scalars_cell_data(self):
         """Scalars should be repeated per-cell for each detector."""
         workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float64)
@@ -240,14 +245,16 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_empty_positions_returns_empty_mesh(self):
         workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
         mesh = self.renderer.build_masked_mesh(np.empty((0, 3)), False, model=None)
         self.assertEqual(mesh.number_of_points, 0)
 
     def test_shape_deduplication(self):
         """Detectors sharing the same shape XML should reuse the cached template."""
         workspace = self._create_mock_workspace(n_detectors=10, same_shape=True)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
         # Only 1 unique shape (plus potentially the fallback)
         # Since all share the same XML, cache should have exactly 1 entry
         self.assertEqual(len(self.renderer._shape_cache), 1)
@@ -269,7 +276,8 @@ class TestShapeRenderer(unittest.TestCase):
         an array shape mismatch in set_pickable_scalars.
         """
         workspace = self._create_mock_workspace(n_detectors=6, same_shape=True)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         # First render: 6 detectors
         model_6 = self._create_mock_model(workspace, n_pickable=6)
@@ -293,7 +301,8 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_build_detector_mesh_projects_shape_vertices_for_cylindrical_projection(self):
         workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         projection = MagicMock()
         projection.project_points.side_effect = lambda points, apply_x_correction=True: np.column_stack(
@@ -316,7 +325,8 @@ class TestShapeRenderer(unittest.TestCase):
 
     def test_build_detector_mesh_keeps_projected_shape_contiguous_across_seam(self):
         workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
 
         projection = MagicMock()
         projection.u_period = 2 * np.pi
@@ -361,7 +371,8 @@ class TestShapeRenderer(unittest.TestCase):
         return a shape mesh copy regardless of flip_z — the flip is already
         baked into the detector mesh vertices."""
         workspace = self._create_mock_workspace(n_detectors=2)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
         model = self._create_mock_model(workspace, n_pickable=2)
         positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
         ref_mesh = self.renderer.build_detector_mesh(positions, False, model)
@@ -375,7 +386,8 @@ class TestShapeRenderer(unittest.TestCase):
         """In cylindrical projections, flip_z=True must negate the world-space
         z-coordinate of each shape vertex before it is passed to project_points."""
         workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
         # Override the stored 3D position so the flip is observable (z ≠ 0)
         self.renderer._all_positions_3d = np.array([[0.0, 0.0, 1.5]])
 
@@ -417,7 +429,8 @@ class TestShapeRenderer(unittest.TestCase):
         """flip_z=True should also negate world-space z for masked detector vertices
         before projection (same _assemble_mesh path as build_detector_mesh)."""
         workspace = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(workspace)
+        self.renderer = ShapeRenderer(workspace)
+        self.renderer.precompute()
         self.renderer._all_positions_3d = np.array([[0.0, 0.0, 2.0]])
 
         model = self._create_mock_model(workspace, n_pickable=0)

--- a/qt/python/instrumentview/instrumentview/renderers/test/test_side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/test/test_side_by_side_shape_renderer.py
@@ -15,28 +15,35 @@ from scipy.spatial.transform import Rotation
 
 from instrumentview.renderers.shape_renderer import ShapeRenderer
 from instrumentview.renderers.side_by_side_shape_renderer import SideBySideShapeRenderer
+from instrumentview.Projections.ProjectionType import ProjectionType
 
 
 class TestSideBySideShapeRenderer(unittest.TestCase):
     """Tests for the SideBySideShapeRenderer class."""
-
-    def setUp(self):
-        self.renderer = SideBySideShapeRenderer()
 
     # ------------------------------------------------------------------
     # Basics
     # ------------------------------------------------------------------
 
     def test_is_shape_renderer_subclass(self):
-        self.assertIsInstance(self.renderer, ShapeRenderer)
+        ws = self._create_mock_workspace(n_detectors=1)
+        renderer = SideBySideShapeRenderer(ws, None)
+        self.assertIsInstance(renderer, ShapeRenderer)
 
-    def test_build_detector_mesh_raises_without_precompute(self):
+    def test_build_detector_mesh_auto_precomputes(self):
+        """build_detector_mesh should auto-precompute if not already done."""
+        ws = self._create_mock_workspace(n_detectors=1)
+        renderer = SideBySideShapeRenderer(ws, None)
+        model = self._create_mock_model(ws, n_pickable=1)
         positions = np.array([[0.0, 0.0, 0.0]])
-        with self.assertRaises(RuntimeError):
-            self.renderer.build_detector_mesh(positions, False)
+        mesh = renderer.build_detector_mesh(positions, False, model)
+        self.assertTrue(renderer._precomputed)
+        self.assertIsInstance(mesh, pv.PolyData)
 
     def test_build_masked_mesh_empty_positions(self):
-        mesh = self.renderer.build_masked_mesh(np.empty((0, 3)), False)
+        ws = self._create_mock_workspace(n_detectors=1)
+        renderer = SideBySideShapeRenderer(ws, None)
+        mesh = renderer.build_masked_mesh(np.empty((0, 3)), False)
         self.assertEqual(mesh.number_of_points, 0)
 
     # ------------------------------------------------------------------
@@ -47,11 +54,12 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Detectors in a grid bank should produce a valid mesh with no rotation."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        mesh = self.renderer.build_detector_mesh(positions, model)
+        mesh = self.renderer.build_detector_mesh(positions, False, model)
 
         self.assertIsInstance(mesh, pv.PolyData)
         self.assertGreater(mesh.number_of_points, 0)
@@ -61,11 +69,12 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Detectors in a tube bank should produce a valid mesh."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "tube")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
         positions = np.array([[0, 0, 0], [0, 0.1, 0], [0, 0.2, 0], [0, 0.3, 0]], dtype=np.float64)
-        mesh = self.renderer.build_detector_mesh(positions, model)
+        mesh = self.renderer.build_detector_mesh(positions, False, model)
 
         self.assertIsInstance(mesh, pv.PolyData)
         self.assertGreater(mesh.number_of_points, 0)
@@ -74,14 +83,15 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Multiple banks of different types should all be included."""
         ws = self._create_mock_workspace(n_detectors=6)
         bank_groups = [([0, 1, 2], "grid"), ([3, 4, 5], "tube")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=6)
         positions = np.array(
             [[0, 0, 0], [0.1, 0, 0], [0.2, 0, 0], [0.5, 0, 0], [0.5, 0.1, 0], [0.5, 0.2, 0]],
             dtype=np.float64,
         )
-        mesh = self.renderer.build_detector_mesh(positions, model)
+        mesh = self.renderer.build_detector_mesh(positions, False, model)
 
         self.assertIsInstance(mesh, pv.PolyData)
         self.assertGreater(mesh.number_of_cells, 0)
@@ -94,12 +104,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """build_masked_mesh should also apply bank-aware scaling."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=0)
         model.masked_detector_ids = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        mesh = self.renderer.build_masked_mesh(positions, model)
+        mesh = self.renderer.build_masked_mesh(positions, False, model)
 
         self.assertIsInstance(mesh, pv.PolyData)
         self.assertGreater(mesh.number_of_cells, 0)
@@ -107,11 +118,12 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_no_bank_groups_falls_back_to_uniform_scale(self):
         """When bank_groups_by_detector_id is None, uniform scaling is used."""
         ws = self._create_mock_workspace(n_detectors=4)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
         positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
-        mesh = self.renderer.build_detector_mesh(positions, model)
+        mesh = self.renderer.build_detector_mesh(positions, False, model)
 
         self.assertIsInstance(mesh, pv.PolyData)
         self.assertGreater(mesh.number_of_cells, 0)
@@ -124,7 +136,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Grid bank detectors should have per_det_rotate = False."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
@@ -140,7 +153,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Tube bank detectors should have per_det_rotate = True."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "tube")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0, 0.1, 0], [0, 0.2, 0], [0, 0.3, 0]], dtype=np.float64)
@@ -156,7 +170,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Mixed grid + tube banks: only tube detectors should have rotate=True."""
         ws = self._create_mock_workspace(n_detectors=6)
         bank_groups = [([0, 1, 2], "grid"), ([3, 4, 5], "tube")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(6)
         positions = np.array(
@@ -177,7 +192,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """All computed scales should be positive."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
@@ -192,7 +208,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """All detectors in the same bank should get the same scale factor."""
         ws = self._create_mock_workspace(n_detectors=4, same_shape=True)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
@@ -208,7 +225,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """A bank with only one detector should still produce a valid scale."""
         ws = self._create_mock_workspace(n_detectors=3)
         bank_groups = [([0], "grid"), ([1, 2], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(3)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0.2, 0, 0]], dtype=np.float64)
@@ -228,7 +246,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         direction should not exceed half the nearest-neighbour distance."""
         ws = self._create_mock_workspace(n_detectors=4, same_shape=True)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer.precompute(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
@@ -252,7 +271,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_x_direction(self):
         """Extent along x should match the shape's x span."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         direction = np.array([1.0, 0.0])
         extent = self.renderer._shape_extent_along_direction_2d(0, direction)
@@ -263,7 +283,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_y_direction(self):
         """Extent along y should match the shape's y span."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         direction = np.array([0.0, 1.0])
         extent = self.renderer._shape_extent_along_direction_2d(0, direction)
@@ -274,7 +295,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_diagonal(self):
         """Extent along [1,1]/sqrt(2) should be larger than along axis."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         diag = np.array([1.0, 1.0]) / np.sqrt(2)
         extent_diag = self.renderer._shape_extent_along_direction_2d(0, diag)
@@ -284,6 +306,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
 
     def test_extent_with_empty_shape(self):
         """An empty shape should return 0.0."""
+        ws = self._create_mock_workspace(n_detectors=1)
+        self.renderer = SideBySideShapeRenderer(ws, None)
         self.renderer._precomputed = True
         self.renderer._shape_cache = {0: (np.empty((0, 3)), np.empty((0, 3)))}
         self.renderer._det_shape_keys = np.array([0])
@@ -296,7 +320,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_with_rotation(self):
         """When apply_rotation=True, the extent should reflect the rotated shape."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         # Force a 90° rotation around z so x→y and y→-x
         rot_90z = Rotation.from_euler("z", 90, degrees=True).as_matrix()
@@ -321,7 +346,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_radial_extent(self):
         """Radial extent should be the max distance from origin to any vertex."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer.precompute(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer.precompute()
 
         extent = self.renderer._shape_radial_extent_2d(0)
 
@@ -331,6 +357,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
 
     def test_radial_extent_empty_shape(self):
         """An empty shape should return 0.0."""
+        ws = self._create_mock_workspace(n_detectors=1)
+        self.renderer = SideBySideShapeRenderer(ws, None)
         self.renderer._precomputed = True
         self.renderer._shape_cache = {0: (np.empty((0, 3)), np.empty((0, 3)))}
         self.renderer._det_shape_keys = np.array([0])
@@ -409,6 +437,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         model = MagicMock()
         model.workspace = workspace
         model.is_2d_projection = True
+        model.projection_type = ProjectionType.SIDE_BY_SIDE
+        model.active_projection = None
         model.pickable_detector_ids = np.arange(n_pickable)
         model.masked_detector_ids = np.array([], dtype=np.int64)
         return model

--- a/qt/python/instrumentview/instrumentview/renderers/test/test_side_by_side_shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/test/test_side_by_side_shape_renderer.py
@@ -27,13 +27,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
 
     def test_is_shape_renderer_subclass(self):
         ws = self._create_mock_workspace(n_detectors=1)
-        renderer = SideBySideShapeRenderer(ws, None)
+        renderer = SideBySideShapeRenderer(ws)
         self.assertIsInstance(renderer, ShapeRenderer)
 
     def test_build_detector_mesh_auto_precomputes(self):
         """build_detector_mesh should auto-precompute if not already done."""
         ws = self._create_mock_workspace(n_detectors=1)
-        renderer = SideBySideShapeRenderer(ws, None)
+        renderer = SideBySideShapeRenderer(ws)
         model = self._create_mock_model(ws, n_pickable=1)
         positions = np.array([[0.0, 0.0, 0.0]])
         mesh = renderer.build_detector_mesh(positions, False, model)
@@ -42,7 +42,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
 
     def test_build_masked_mesh_empty_positions(self):
         ws = self._create_mock_workspace(n_detectors=1)
-        renderer = SideBySideShapeRenderer(ws, None)
+        renderer = SideBySideShapeRenderer(ws)
         mesh = renderer.build_masked_mesh(np.empty((0, 3)), False)
         self.assertEqual(mesh.number_of_points, 0)
 
@@ -54,10 +54,11 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Detectors in a grid bank should produce a valid mesh with no rotation."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
+        model.bank_groups_by_detector_id = bank_groups
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
         mesh = self.renderer.build_detector_mesh(positions, False, model)
 
@@ -69,10 +70,11 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Detectors in a tube bank should produce a valid mesh."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "tube")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
+        model.bank_groups_by_detector_id = bank_groups
         positions = np.array([[0, 0, 0], [0, 0.1, 0], [0, 0.2, 0], [0, 0.3, 0]], dtype=np.float64)
         mesh = self.renderer.build_detector_mesh(positions, False, model)
 
@@ -83,10 +85,11 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Multiple banks of different types should all be included."""
         ws = self._create_mock_workspace(n_detectors=6)
         bank_groups = [([0, 1, 2], "grid"), ([3, 4, 5], "tube")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=6)
+        model.bank_groups_by_detector_id = bank_groups
         positions = np.array(
             [[0, 0, 0], [0.1, 0, 0], [0.2, 0, 0], [0.5, 0, 0], [0.5, 0.1, 0], [0.5, 0.2, 0]],
             dtype=np.float64,
@@ -104,10 +107,11 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """build_masked_mesh should also apply bank-aware scaling."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=0)
+        model.bank_groups_by_detector_id = bank_groups
         model.masked_detector_ids = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
         mesh = self.renderer.build_masked_mesh(positions, False, model)
@@ -118,7 +122,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_no_bank_groups_falls_back_to_uniform_scale(self):
         """When bank_groups_by_detector_id is None, uniform scaling is used."""
         ws = self._create_mock_workspace(n_detectors=4)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         model = self._create_mock_model(ws, n_pickable=4)
@@ -136,15 +140,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Grid bank detectors should have per_det_rotate = False."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         self.assertEqual(len(scales), 4)
         self.assertFalse(np.any(rotate))
@@ -153,15 +155,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Tube bank detectors should have per_det_rotate = True."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "tube")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0, 0.1, 0], [0, 0.2, 0], [0, 0.3, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         self.assertEqual(len(scales), 4)
         self.assertTrue(np.all(rotate))
@@ -170,7 +170,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """Mixed grid + tube banks: only tube detectors should have rotate=True."""
         ws = self._create_mock_workspace(n_detectors=6)
         bank_groups = [([0, 1, 2], "grid"), ([3, 4, 5], "tube")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(6)
@@ -178,10 +178,8 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
             [[0, 0, 0], [0.1, 0, 0], [0.2, 0, 0], [0.5, 0, 0], [0.5, 0.1, 0], [0.5, 0.2, 0]],
             dtype=np.float64,
         )
-        model = MagicMock()
-        model.workspace = ws
 
-        _, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        _, rotate = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         # Grid detectors (0,1,2) should not rotate
         self.assertFalse(np.any(rotate[:3]))
@@ -192,15 +190,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """All computed scales should be positive."""
         ws = self._create_mock_workspace(n_detectors=4)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         self.assertTrue(np.all(scales > 0))
 
@@ -208,15 +204,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """All detectors in the same bank should get the same scale factor."""
         ws = self._create_mock_workspace(n_detectors=4, same_shape=True)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         # All four should have the same scale
         np.testing.assert_array_almost_equal(scales, scales[0])
@@ -225,15 +219,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         """A bank with only one detector should still produce a valid scale."""
         ws = self._create_mock_workspace(n_detectors=3)
         bank_groups = [([0], "grid"), ([1, 2], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(3)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0.2, 0, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         self.assertTrue(np.all(scales > 0))
 
@@ -246,15 +238,13 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         direction should not exceed half the nearest-neighbour distance."""
         ws = self._create_mock_workspace(n_detectors=4, same_shape=True)
         bank_groups = [([0, 1, 2, 3], "grid")]
-        self.renderer = SideBySideShapeRenderer(ws, bank_groups)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         det_indices = np.arange(4)
         positions = np.array([[0, 0, 0], [0.1, 0, 0], [0, 0.1, 0], [0.1, 0.1, 0]], dtype=np.float64)
-        model = MagicMock()
-        model.workspace = ws
 
-        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, model)
+        scales, _ = self.renderer._compute_bank_projection_scales(det_indices, positions, bank_groups)
 
         scale = scales[0]
         nnd = 0.1  # nearest-neighbour distance in the grid
@@ -271,7 +261,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_x_direction(self):
         """Extent along x should match the shape's x span."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         direction = np.array([1.0, 0.0])
@@ -283,7 +273,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_y_direction(self):
         """Extent along y should match the shape's y span."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         direction = np.array([0.0, 1.0])
@@ -295,7 +285,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_along_diagonal(self):
         """Extent along [1,1]/sqrt(2) should be larger than along axis."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         diag = np.array([1.0, 1.0]) / np.sqrt(2)
@@ -307,7 +297,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_with_empty_shape(self):
         """An empty shape should return 0.0."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer._precomputed = True
         self.renderer._shape_cache = {0: (np.empty((0, 3)), np.empty((0, 3)))}
         self.renderer._det_shape_keys = np.array([0])
@@ -320,7 +310,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_extent_with_rotation(self):
         """When apply_rotation=True, the extent should reflect the rotated shape."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         # Force a 90° rotation around z so x→y and y→-x
@@ -346,7 +336,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_radial_extent(self):
         """Radial extent should be the max distance from origin to any vertex."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer.precompute()
 
         extent = self.renderer._shape_radial_extent_2d(0)
@@ -358,7 +348,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
     def test_radial_extent_empty_shape(self):
         """An empty shape should return 0.0."""
         ws = self._create_mock_workspace(n_detectors=1)
-        self.renderer = SideBySideShapeRenderer(ws, None)
+        self.renderer = SideBySideShapeRenderer(ws)
         self.renderer._precomputed = True
         self.renderer._shape_cache = {0: (np.empty((0, 3)), np.empty((0, 3)))}
         self.renderer._det_shape_keys = np.array([0])
@@ -441,6 +431,7 @@ class TestSideBySideShapeRenderer(unittest.TestCase):
         model.active_projection = None
         model.pickable_detector_ids = np.arange(n_pickable)
         model.masked_detector_ids = np.array([], dtype=np.int64)
+        model.bank_groups_by_detector_id = []
         return model
 
 

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -162,17 +162,17 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         np.testing.assert_array_equal(model._is_valid, [True, True, False, False])
         np.testing.assert_array_equal(model._counts, [100, 200, 0, 0])
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.SphericalProjection")
-    def test_calculate_spherical_projection(self, mock_spherical_projection):
-        self._run_projection_test(mock_spherical_projection, ProjectionType.SPHERICAL_Y)
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_calculate_spherical_projection(self, mock_projection):
+        self._run_projection_test(mock_projection, ProjectionType.SPHERICAL_Y)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
-    def test_calculate_cylindrical_projection(self, mock_cylindrical_projection):
-        self._run_projection_test(mock_cylindrical_projection, ProjectionType.CYLINDRICAL_Y)
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_calculate_cylindrical_projection(self, mock_projection):
+        self._run_projection_test(mock_projection, ProjectionType.CYLINDRICAL_Y)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.SideBySide")
-    def test_calculate_side_by_side_projection(self, mock_side_by_side):
-        self._run_projection_test(mock_side_by_side, ProjectionType.SIDE_BY_SIDE)
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_calculate_side_by_side_projection(self, mock_projection):
+        self._run_projection_test(mock_projection, ProjectionType.SIDE_BY_SIDE)
 
     def _run_projection_test(self, mock_projection_constructor, projection_option):
         model, _ = self._setup_model([1, 2, 3])
@@ -184,36 +184,36 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         mock_projection_constructor.assert_called_once()
         self.assertTrue(all(all(point == [1, 2, 0]) for point in points))
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
-    def test_flip_z_negates_z_in_projection(self, mock_cylindrical_projection):
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_flip_z_negates_z_in_projection(self, mock_projection_cls):
         """When flip_z is True, detector positions passed to projection should have negated Z coordinates"""
         model, _ = self._setup_model([1, 2, 3])
         mock_projection = MagicMock()
         mock_projection.positions.return_value = [[1, 2], [1, 2], [1, 2]]
-        mock_cylindrical_projection.return_value = mock_projection
+        mock_projection_cls.return_value = mock_projection
         original_positions = model._detector_positions_3d.copy()
         model._projection_type = ProjectionType.CYLINDRICAL_Y
         model.flip_z = True
         model._calculate_projection()
-        call_args = mock_cylindrical_projection.call_args
-        passed_positions = call_args[0][2]
+        call_args = mock_projection_cls.call_args
+        passed_positions = call_args.kwargs["detector_positions"]
         expected_positions = original_positions.copy()
         expected_positions[:, 2] *= -1
         np.testing.assert_array_equal(passed_positions, expected_positions)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
-    def test_flip_z_false_passes_original_positions(self, mock_cylindrical_projection):
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_flip_z_false_passes_original_positions(self, mock_projection_cls):
         """When flip_z is False, detector positions passed to projection should be unchanged"""
         model, _ = self._setup_model([1, 2, 3])
         mock_projection = MagicMock()
         mock_projection.positions.return_value = [[1, 2], [1, 2], [1, 2]]
-        mock_cylindrical_projection.return_value = mock_projection
+        mock_projection_cls.return_value = mock_projection
         original_positions = model._detector_positions_3d.copy()
         model._projection_type = ProjectionType.CYLINDRICAL_Y
         model.flip_z = False
         model._calculate_projection()
-        call_args = mock_cylindrical_projection.call_args
-        passed_positions = call_args[0][2]
+        call_args = mock_projection_cls.call_args
+        passed_positions = call_args.kwargs["detector_positions"]
         np.testing.assert_array_equal(passed_positions, original_positions)
 
     def test_flip_z_same_value_preserves_cache(self):
@@ -224,20 +224,20 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         model.flip_z = original_flip_z
         self.assertEqual(len(model._cached_projection_objects), 1)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
-    def test_flip_z_uses_separate_cache_keys(self, mock_cylindrical_projection):
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
+    def test_flip_z_uses_separate_cache_keys(self, mock_projection_cls):
         """Flipped and non-flipped projections should use different cache keys"""
         model, _ = self._setup_model([1, 2, 3])
         mock_projection = MagicMock()
         mock_projection.positions.return_value = [[1, 2], [1, 2], [1, 2]]
-        mock_cylindrical_projection.return_value = mock_projection
+        mock_projection_cls.return_value = mock_projection
         model._projection_type = ProjectionType.CYLINDRICAL_Y
         model.flip_z = False
         model._calculate_projection()
-        self.assertEqual(mock_cylindrical_projection.call_count, 1)
+        self.assertEqual(mock_projection_cls.call_count, 1)
         model.flip_z = True
         model._calculate_projection()
-        self.assertEqual(mock_cylindrical_projection.call_count, 2)
+        self.assertEqual(mock_projection_cls.call_count, 2)
 
     def test_sample_position(self):
         expected_position = np.array([1.0, 2.0, 1.0])
@@ -585,7 +585,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         iv_qlab = model._calculate_q_lab_direction(detector_id)
         np.testing.assert_allclose(q_lab_direction, iv_qlab, rtol=1e-5)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
     def test_cached_projection_objects_empty(self, mock_projection_constructor):
         model, _ = self._setup_model([1, 2, 3])
         model.projection_type = ProjectionType.CYLINDRICAL_X
@@ -597,7 +597,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         np.testing.assert_almost_equal(positions, np.array([[1, 2, 0], [1, 2, 0], [1, 2, 0]]))
         self.assertEqual(mock_projection, model._cached_projection_objects[cache_key])
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.CylindricalProjection")
+    @mock.patch("instrumentview.FullInstrumentViewModel.Projection")
     def test_cached_projection_objects_already_cached(self, mock_projection_constructor):
         model, _ = self._setup_model([1, 2, 3])
         model.projection_type = ProjectionType.CYLINDRICAL_X

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -141,7 +141,8 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter._replace_workspace_callback(ws_name, None)
         self._model.setup.assert_called_once()
         mock_setup_component_tree.assert_called_once()
-        mock_update_plotter.assert_called_once()
+        # update_plotter is called once explicitly and once via _reload_renderers
+        self.assertEqual(mock_update_plotter.call_count, 2)
         self._mock_view.setup.reset_mock()
         mock_update_plotter.reset_mock()
         self._presenter._replace_workspace_callback("not_my_workspace", None)
@@ -625,40 +626,22 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         transformed = self._presenter._transform_counts(counts)
         np.testing.assert_allclose(transformed, np.log10(counts + 1))
 
-    def test_get_point_cloud_renderer_lazy_initialization(self):
-        """Test that point cloud renderer is lazily initialized and cached."""
-        # Should already be initialized from __init__
-        renderer1 = self._presenter._get_point_cloud_renderer()
-        self.assertIsNotNone(renderer1)
-        # Second call should return the same cached instance
-        renderer2 = self._presenter._get_point_cloud_renderer()
-        self.assertIs(renderer1, renderer2)
+    def test_renderers_eagerly_initialized(self):
+        """Test that all renderers are initialized at construction time."""
+        self.assertIsNotNone(self._presenter._point_cloud_renderer)
+        self.assertIsNotNone(self._presenter._shape_renderer)
+        self.assertIsNotNone(self._presenter._sbs_shape_renderer)
 
-    def test_get_point_cloud_renderer_after_clear(self):
-        """Test that point cloud renderer is recreated after clearing."""
-        renderer1 = self._presenter._get_point_cloud_renderer()
-        self._presenter._clear_renderers()
-        renderer2 = self._presenter._get_point_cloud_renderer()
-        self.assertIsNot(renderer1, renderer2)
-
-    def test_get_shape_renderer_lazy_initialization(self):
-        """Test that shape renderer is lazily initialized with precomputation."""
-        with mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.set_peaks_workspaces"):
-            presenter = FullInstrumentViewPresenter(self._mock_view, self._model)
-        self.assertIsNone(presenter._shape_renderer)
-        renderer1 = presenter._get_shape_renderer()
-        self.assertIsNotNone(renderer1)
-        self.assertIsNotNone(presenter._shape_renderer)
-        # Second call should return the same cached instance
-        renderer2 = presenter._get_shape_renderer()
-        self.assertIs(renderer1, renderer2)
-
-    def test_get_shape_renderer_after_clear(self):
-        """Test that shape renderer is recreated after clearing."""
-        renderer1 = self._presenter._get_shape_renderer()
-        self._presenter._clear_renderers()
-        renderer2 = self._presenter._get_shape_renderer()
-        self.assertIsNot(renderer1, renderer2)
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
+    def test_reload_renderers_creates_new_instances(self, mock_update_plotter):
+        """Test that _reload_renderers creates fresh renderer instances."""
+        old_pc = self._presenter._point_cloud_renderer
+        old_shape = self._presenter._shape_renderer
+        old_sbs = self._presenter._sbs_shape_renderer
+        self._presenter._reload_renderers()
+        self.assertIsNot(self._presenter._point_cloud_renderer, old_pc)
+        self.assertIsNot(self._presenter._shape_renderer, old_shape)
+        self.assertIsNot(self._presenter._sbs_shape_renderer, old_sbs)
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
     def test_on_show_shapes_toggled_enable_shapes(self, mock_update_plotter):
@@ -683,15 +666,17 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self.assertIsNot(self._presenter._renderer, shape_renderer)
         mock_update_plotter.assert_called_once()
 
-    def test_clear_renderers(self):
-        """Test that _clear_renderers nulls both cached renderers."""
-        # Initialize both renderers
-        self._presenter._get_point_cloud_renderer()
-        self._presenter._get_shape_renderer()
-        self.assertIsNotNone(self._presenter._point_cloud_renderer)
-        self.assertIsNotNone(self._presenter._shape_renderer)
-        self._presenter._clear_renderers()
-        self.assertIsNone(self._presenter._shape_renderer)
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
+    def test_reload_renderers_sets_active_renderer(self, mock_update_plotter):
+        """Test that _reload_renderers sets the active renderer based on shapes checkbox."""
+        self._mock_view.is_show_shapes_checkbox_checked.return_value = False
+        self._presenter._reload_renderers()
+        self.assertIs(self._presenter._renderer, self._presenter._point_cloud_renderer)
+
+        self._mock_view.is_show_shapes_checkbox_checked.return_value = True
+        self._model.projection_type = ProjectionType.CYLINDRICAL_Y
+        self._presenter._reload_renderers()
+        self.assertIs(self._presenter._renderer, self._presenter._shape_renderer)
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
     def test_on_projection_option_changed_syncs_model(self, mock_update_plotter):


### PR DESCRIPTION
### Description of work
Drawing the detector shapes causes the projection in 2d to often overlap shapes, leading to inconsistent picking. This PR uses a trick to assign each detector shape in 2d a small height in Z, with the detectors closer to the centre of the mesh having the lowest Z height and the detectors away from the centre have increasing Z height. 

The idea is to make tiles overlap like a roof, so that picking will always choose the tile that is in front of another.

I also did some general cleaning of the tiling implementation during assembling the mesh.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Draw shapes in 3d, projections and side-by-side
- Pick detectors in different zones and for different projections
- Check that the highlighted detectors are the ones picked.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
