### PR TITLE
Instrument View: Improve zoom

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -264,6 +264,8 @@ class FullInstrumentViewPresenter:
 
         monitor_mesh = self._create_and_add_monitor_mesh()
 
+        renderer.set_parallel_view(self._view.main_plotter)
+
         # Update transform needs to happen after adding to plotter
         # Uses display coordinates
         self._update_transform()
@@ -277,8 +279,12 @@ class FullInstrumentViewPresenter:
         self._view.enable_or_disable_aspect_ratio_box()
         self._view.enable_or_disable_flip_z_axis_box()
         self.on_integration_limits_reset_clicked()
+
         self._view.cache_camera_position()
         self._view.reset_camera()
+
+        # Set style after camera reset for correct camera defaults
+        renderer.set_interactive_style(self._view.main_plotter, self._model.is_2d_projection)
 
     def _update_transform(self) -> None:
         if not self._model.is_2d_projection or self._view.is_maintain_aspect_ratio_checkbox_checked():
@@ -342,11 +348,6 @@ class FullInstrumentViewPresenter:
         return [x for pair in zip(min_point, max_point) for x in pair]
 
     def update_detector_picker(self) -> None:
-        """Change between single and multi point picking"""
-        # Remove any custom interactor to avoid artifacts in 2D or 3D
-        if hasattr(self._view, "interactor_style"):
-            self._view.interactor_style.remove_interactor()
-
         def detector_picked(detector_index: int) -> None:
             self._model.update_point_picked_detectors(detector_index)
             self.update_picked_detectors_on_view()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -339,6 +339,7 @@ class FullInstrumentViewPresenter:
     def on_aspect_ratio_check_box_clicked(self) -> None:
         self._view.store_maintain_aspect_ratio_option()
         self.update_plotter()
+        self._view.reset_camera()
 
     def on_flip_z_axis_check_box_clicked(self) -> None:
         self.update_plotter()

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -245,6 +245,8 @@ class FullInstrumentViewPresenter:
             return np.log10(counts + 1)
 
     def _update_view_main_plotter(self):
+        self._view.cache_current_camera_position()
+
         self._view.clear_main_plotter()
         renderer = self._renderer
 
@@ -280,11 +282,14 @@ class FullInstrumentViewPresenter:
         self._view.enable_or_disable_flip_z_axis_box()
         self.on_integration_limits_reset_clicked()
 
-        self._view.cache_camera_position()
+        self._view.cache_default_camera_position()
         self._view.reset_camera()
 
         # Set style after camera reset for correct camera defaults
         renderer.set_interactive_style(self._view.main_plotter, self._model.is_2d_projection)
+
+        self._view.set_camera_to_cached_state()
+        self._view.cache_current_selected_projection()
 
     def _update_transform(self) -> None:
         if not self._model.is_2d_projection or self._view.is_maintain_aspect_ratio_checkbox_checked():

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -340,8 +340,11 @@ class FullInstrumentViewWindow(QMainWindow):
         self.move(window_geometry.topLeft())
 
         self._current_widget = None
-        self._projection_camera_map = {}
-        self._parallel_scales = {}
+        self._default_camera_position_map = {}
+        self._default_parallel_scales = {}
+        self._last_selected_projection = None
+        self._last_camera_position = None
+        self._last_parallel_scale = None
 
         UsageService.registerFeatureUsage(FeatureType.Interface, "InstrumentView2025", False)
 
@@ -380,22 +383,34 @@ class FullInstrumentViewWindow(QMainWindow):
     def hide_status_box(self) -> None:
         self.status_group_box.hide()
 
+    def cache_current_camera_position(self) -> None:
+        self._last_camera_position = self.main_plotter.camera_position
+        self._last_parallel_scale = self.main_plotter.parallel_scale
+
+    def cache_current_selected_projection(self) -> None:
+        self._last_selected_projection = self.current_selected_projection()
+
+    def set_camera_to_cached_state(self) -> None:
+        if self._last_selected_projection == self.current_selected_projection():
+            self.main_plotter.camera_position = self._last_camera_position
+            self.main_plotter.camera.parallel_scale = self._last_parallel_scale
+
+    def cache_default_camera_position(self) -> None:
+        self.main_plotter.reset_camera()
+        self._default_camera_position_map[self.current_selected_projection()] = self.main_plotter.camera_position
+        self._default_parallel_scales[self.current_selected_projection()] = self.main_plotter.camera.parallel_scale
+
     def reset_camera(self) -> None:
         if self._off_screen:
             return
 
-        if self.current_selected_projection() in self._projection_camera_map.keys():
-            self.main_plotter.camera_position = self._projection_camera_map[self.current_selected_projection()]
-            self.main_plotter.camera.parallel_scale = self._parallel_scales[self.current_selected_projection()]
+        if self.current_selected_projection() in self._default_camera_position_map.keys():
+            self.main_plotter.camera_position = self._default_camera_position_map[self.current_selected_projection()]
+            self.main_plotter.camera.parallel_scale = self._default_parallel_scales[self.current_selected_projection()]
         else:
             # Apply default position, in case cache not available
             self.main_plotter.reset_camera()
         return
-
-    def cache_camera_position(self) -> None:
-        self.main_plotter.reset_camera()
-        self._projection_camera_map[self.current_selected_projection()] = self.main_plotter.camera_position
-        self._parallel_scales[self.current_selected_projection()] = self.main_plotter.camera.parallel_scale
 
     def _add_min_max_group_box(self, parent_box: QGroupBox) -> tuple[QLineEdit, QLineEdit, QDoubleRangeSlider, QPushButton]:
         """Creates a minimum and a maximum box (with labels) inside the given group box. The callbacks will be attached to textEdited

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -34,8 +34,6 @@ from superqt import QDoubleRangeSlider
 from pyvistaqt import BackgroundPlotter
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.widgets import Cursor
-from pyvista.plotting.picking import RectangleSelection
-from pyvista.plotting.opts import PickerType
 from vtkmodules.vtkCommonDataModel import vtkBox, vtkCylinder, vtkImplicitFunction
 from vtkmodules.vtkInteractionWidgets import (
     vtkImplicitCylinderRepresentation,
@@ -52,7 +50,6 @@ from mantidqt.utils.qt.qappthreadcall import run_on_qapp_thread
 from mantidqt.io import open_a_file_dialog
 
 from instrumentview.Detectors import DetectorInfo
-from instrumentview.InteractorStyles import CustomInteractorStyleZoomAndSelect, CustomInteractorStyleRubberBand3D
 from instrumentview.Projections.ProjectionType import ProjectionType
 from instrumentview.Globals import CurrentTab
 from instrumentview.ComponentTreeView import ComponentTreeView
@@ -332,7 +329,6 @@ class FullInstrumentViewWindow(QMainWindow):
         component_layout.addWidget(self.component_tree)
         tab_widget.addTab(component_tree_tab, "Component Tree")
 
-        self.interactor_style = CustomInteractorStyleZoomAndSelect()
         self._overlay_meshes = []
         self._lineplot_overlays = []
 
@@ -896,45 +892,6 @@ class FullInstrumentViewWindow(QMainWindow):
     def add_rgba_mesh(self, mesh: PolyData, scalars: np.ndarray | str):
         """Draw the given mesh in the main plotter window, and set the colours manually with RGBA numbers"""
         self.main_plotter.add_mesh(mesh, scalars=scalars, rgba=True, pickable=False, render_points_as_spheres=True, point_size=10)
-
-    def enable_point_picking(self, is_projection: bool, callback: Callable) -> None:
-        """Switch on point picking, i.e. picking a single point with right-click"""
-        self.main_plotter.disable_picking()
-        # NOTE: Need to remove interactor to avoid artifacts in 2D or 3D
-        self.interactor_style.remove_interactor()
-        picking_tolerance = 0.01
-        if not self.main_plotter.off_screen:
-            if is_projection:
-                self.main_plotter.enable_zoom_style()
-            else:
-                self.main_plotter.enable_trackball_style()
-            self.main_plotter.enable_surface_point_picking(
-                show_message=False,
-                use_picker=True,
-                callback=callback,
-                show_point=False,
-                pickable_window=False,
-                picker="point",
-                tolerance=picking_tolerance,
-            )
-
-    def enable_rectangle_picking(self, is_projection: bool, callback: Callable) -> None:
-        """Switch on rectangle picking, i.e. draw a rectangle to select all detectors within the rectangle"""
-        self.main_plotter.disable_picking()
-
-        if not self.main_plotter.off_screen:
-            if is_projection:
-                self.interactor_style.set_interactor(self.main_plotter.iren.interactor)
-                self.main_plotter.iren.style = self.interactor_style
-            else:
-                self.main_plotter.iren.style = CustomInteractorStyleRubberBand3D()
-
-            def _end_pick_helper(picker, *_):
-                callback(RectangleSelection(frustum=picker.GetFrustum(), viewport=(-1, -1, -1, -1)))
-
-            self.main_plotter.iren.picker = PickerType.RENDERED
-            self.main_plotter.iren.add_pick_observer(_end_pick_helper)
-            self.main_plotter._picker_in_use = True
 
     def show_axes(self) -> None:
         """Show axes on the main plotter"""

--- a/qt/python/instrumentview/instrumentview/InteractorStyles.py
+++ b/qt/python/instrumentview/instrumentview/InteractorStyles.py
@@ -1,73 +1,134 @@
-from vtkmodules.vtkInteractionStyle import vtkInteractorStyleRubberBand3D, vtkInteractorStyleRubberBand2D, vtkInteractorStyleRubberBandZoom
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleUser
 from vtkmodules.vtkCommonCore import vtkCommand
+import numpy as np
 
 
-class CustomInteractorStyleRubberBand3D(vtkInteractorStyleRubberBand3D):
-    """Wrapper for RubberBand3D style"""
+class _PlotterWrapper:
+    """Wrapper to provide PyVista-compatible interface for picking."""
 
-    def __init__(self):
+    def __init__(self, plotter):
+        self._plotter = plotter
         super().__init__()
-        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self.OnLeftButtonDown())
-        self.AddObserver(vtkCommand.RightButtonReleaseEvent, lambda *_: self.OnLeftButtonUp())
-        self.AddObserver(vtkCommand.LeftButtonPressEvent, lambda *_: self.OnRightButtonDown())
-        self.AddObserver(vtkCommand.LeftButtonReleaseEvent, lambda *_: self.OnRightButtonUp())
-        self.AddObserver(vtkCommand.SelectionChangedEvent, on_selection_changed)
 
 
-class CustomInteractorStyleZoomAndSelect(vtkInteractorStyleRubberBandZoom):
-    def __init__(self):
+class CursorZoomInteractorStyle(vtkInteractorStyleUser):
+    """Custom interactor style for cursor-centered zoom with parallel projection."""
+
+    def __init__(self, plotter):
         super().__init__()
-        self.rubber_band = _ReversedInteractorStyleRubberBand2D()
 
-        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: None)
-        self.AddObserver(vtkCommand.RightButtonReleaseEvent, lambda *_: None)
+        self.plotter = plotter
+        self._pyvista_plotter = _PlotterWrapper(plotter)  # HACK: Wrapper for PyVista compatibility
+        self.zoom_factor = 1.1
 
-    def set_interactor(self, interactor):
-        self.rubber_band.SetInteractor(interactor)
-        self.SetInteractor(interactor)
+        # Cache the current camera state, used to reset to this default
+        camera = self.plotter.renderer.camera
+        self._default_position = np.array(camera.position).copy()
+        self._default_focal_point = np.array(camera.focal_point).copy()
+        self._default_parallel_scale = camera.parallel_scale
 
-    def remove_interactor(self):
-        self.SetInteractor(None)
-        self.rubber_band.SetInteractor(None)
+        # Cache the current world coordinates under the cursor
+        self._cursor_world_pos = None
+        self._zoom_in_progress = False
+
+        # Setup plotter
+        self.plotter.track_mouse_position()
+
+        # Register observers on the style using VTK command constants
+        self.AddObserver(vtkCommand.MouseMoveEvent, self._on_mouse_move)
+        self.AddObserver(vtkCommand.MouseWheelForwardEvent, self._on_wheel_forward)
+        self.AddObserver(vtkCommand.MouseWheelBackwardEvent, self._on_wheel_backward)
+        self.AddObserver(vtkCommand.LeftButtonPressEvent, lambda *_: self._reset_camera())
+
+    def _on_mouse_move(self, obj, event):
+        if self._zoom_in_progress:
+            return
+        x, y = self.plotter.mouse_position
+        self._cursor_world_pos = _display_to_world(self.plotter.renderer, x, y)
+
+    def _on_wheel_forward(self, obj, event):
+        self._zoom(self.zoom_factor)
+
+    def _on_wheel_backward(self, obj, event):
+        self._zoom(1.0 / self.zoom_factor)
+
+    def _parent(self):
+        """Return a reference to the plotter for PyVista compatibility."""
+        return self._pyvista_plotter
+
+    def _zoom(self, factor):
+        """Zoom keeping the world-space point under the cursor fixed."""
+        renderer = self.plotter.renderer
+        camera = renderer.camera
+
+        # Calculate dynamic zoom factor based on current parallel_scale
+        zoom_sensitivity = 7  # Arbitrary
+        scale_ratio = camera.parallel_scale * zoom_sensitivity
+        base_zoom_power = self.zoom_factor - 1.0
+        dynamic_base = 1.0 + base_zoom_power * scale_ratio
+        dynamic_base = max(1.001, dynamic_base)  # Clamp to minimum
+
+        # Adjust factor based on the dynamic base
+        if factor > 1:  # zoom in
+            factor = dynamic_base
+        else:  # zoom out
+            factor = 1.0 / dynamic_base
+
+        # HACK: PyVista has a bug where the mouse position is only accurate
+        # if it's called from a mouse move event.
+        # The cached mouse position is the accurate one, the position measured
+        # inside this call is inacurate. Zooming in uses the inacurate one, hence
+        # the reason for needing both mouse positions to predict shift of camera.
+
+        # Use cached mouse position from last mouse move
+        world_cursor = self._cursor_world_pos
+        if world_cursor is None:
+            return
+
+        # Inacurate mouse position
+        x, y = self.plotter.mouse_position
+        distorted_before = _display_to_world(renderer, x, y)
+        if distorted_before is None:
+            return
+
+        focal = np.array(camera.focal_point)
+        cam_pos = np.array(camera.position)
+
+        # Calculate shift to keep cursor at same screen position
+        # In parallel projection: when parallel_scale changes by factor,
+        # offset from focal point needs to change by 1/factor to maintain screen position
+        offset_before = world_cursor - focal
+        offset_after = (distorted_before - focal) / factor  # Use inacurate mouse position due to PyVista bug
+        shift = offset_before - offset_after
+
+        new_parallel_scale = camera.parallel_scale / factor
+
+        # If parallel_scale exceeds the default (zoom out too far), reset to default camera state
+        if new_parallel_scale > self._default_parallel_scale:
+            self._reset_camera()
+        else:
+            camera.parallel_scale = new_parallel_scale
+            camera.focal_point = (focal + shift).tolist()
+            camera.position = (cam_pos + shift).tolist()
+
+        renderer.reset_camera_clipping_range()
+        self.plotter.render_window.Render()
+
+    def _reset_camera(self):
+        renderer = self.plotter.renderer
+        camera = renderer.camera
+        camera.position = self._default_position.tolist()
+        camera.focal_point = self._default_focal_point.tolist()
+        camera.parallel_scale = self._default_parallel_scale
 
 
-class _ReversedInteractorStyleRubberBand2D(vtkInteractorStyleRubberBand2D):
-    def __init__(self):
-        super().__init__()
-        self.AddObserver(vtkCommand.LeftButtonPressEvent, lambda *_: None)
-        self.AddObserver(vtkCommand.LeftButtonReleaseEvent, lambda *_: None)
-        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self.OnLeftButtonDown())
-        self.AddObserver(vtkCommand.RightButtonReleaseEvent, lambda *_: self.OnLeftButtonUp())
-        self.AddObserver(vtkCommand.SelectionChangedEvent, on_selection_changed)
-
-
-def on_selection_changed(caller, *_):
-    start_position = caller.GetStartPosition()
-    end_position = caller.GetEndPosition()
-    render_window_interactor = caller.GetInteractor()
-    windows_size = render_window_interactor.GetRenderWindow().GetSize()
-
-    min_x = min(start_position[0], end_position[0])
-    min_y = min(start_position[1], end_position[1])
-    max_x = max(start_position[0], end_position[0])
-    max_y = max(start_position[1], end_position[1])
-
-    min_x = max(0, min_x)
-    min_y = max(0, min_y)
-    max_x = max(0, max_x)
-    max_y = max(0, max_y)
-
-    def _clamp_to_window(coord, window_size):
-        return min(coord, window_size - 2)
-
-    # Clamp to window boundaries (from VTK C++ source)
-    min_x = _clamp_to_window(min_x, windows_size[0])
-    min_y = _clamp_to_window(min_y, windows_size[1])
-    max_x = _clamp_to_window(max_x, windows_size[0])
-    max_y = _clamp_to_window(max_y, windows_size[1])
-
-    # Trigger picker
-    render_window_interactor.StartPickCallback()
-    render_window_interactor.GetPicker().AreaPick(min_x, min_y, max_x, max_y, caller.GetCurrentRenderer())
-    render_window_interactor.EndPickCallback()
-    render_window_interactor.Render()
+def _display_to_world(renderer, dx, dy):
+    """Convert display (pixel) coords to world coords on the z=0 plane."""
+    # VTK's viewport picking: map display → view → world
+    # Set z to zero since points assumed to be in xy plane
+    renderer.SetDisplayPoint(dx, dy, 0.0)
+    renderer.DisplayToWorld()
+    wx, wy, wz, ww = renderer.GetWorldPoint()
+    if abs(ww) < 1e-10:
+        return None
+    return np.array([wx / ww, wy / ww, 0])  # project onto z=0

--- a/qt/python/instrumentview/instrumentview/InteractorStyles.py
+++ b/qt/python/instrumentview/instrumentview/InteractorStyles.py
@@ -1,4 +1,4 @@
-from vtkmodules.vtkInteractionStyle import vtkInteractorStyleUser
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleUser, vtkInteractorStyleTrackballCamera
 from vtkmodules.vtkCommonCore import vtkCommand
 import numpy as np
 
@@ -38,7 +38,7 @@ class CursorZoomInteractorStyle(vtkInteractorStyleUser):
         self.AddObserver(vtkCommand.MouseMoveEvent, self._on_mouse_move)
         self.AddObserver(vtkCommand.MouseWheelForwardEvent, self._on_wheel_forward)
         self.AddObserver(vtkCommand.MouseWheelBackwardEvent, self._on_wheel_backward)
-        self.AddObserver(vtkCommand.LeftButtonPressEvent, lambda *_: self._reset_camera())
+        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self._reset_camera())
 
     def _on_mouse_move(self, obj, event):
         if self._zoom_in_progress:
@@ -132,3 +132,12 @@ def _display_to_world(renderer, dx, dy):
     if abs(ww) < 1e-10:
         return None
     return np.array([wx / ww, wy / ww, 0])  # project onto z=0
+
+
+class SwappedButtonTrackballCamera(vtkInteractorStyleTrackballCamera):
+    def __init__(self):
+        super().__init__()
+        self.AddObserver(vtkCommand.LeftButtonPressEvent, lambda *_: self.OnRightButtonDown())
+        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self.OnLeftButtonDown())
+        self.AddObserver(vtkCommand.LeftButtonReleaseEvent, lambda *_: self.OnRightButtonUp())
+        self.AddObserver(vtkCommand.RightButtonReleaseEvent, lambda *_: self.OnLeftButtonUp())

--- a/qt/python/instrumentview/instrumentview/renderers/base_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/base_renderer.py
@@ -11,6 +11,8 @@ import numpy as np
 import pyvista as pv
 from pyvistaqt import BackgroundPlotter
 
+from instrumentview.InteractorStyles import CursorZoomInteractorStyle
+
 
 class InstrumentRenderer(ABC):
     """Abstract base class defining the interface for rendering detectors in the instrument view.
@@ -121,3 +123,14 @@ class InstrumentRenderer(ABC):
         label : str
             Scalar array name.
         """
+
+    def set_parallel_view(self, plotter):
+        plotter.view_xy()
+        plotter.enable_parallel_projection()
+
+    def set_interactive_style(self, plotter, is_projection):
+        if not is_projection:
+            plotter.enable_trackball_style()
+            return
+        style = CursorZoomInteractorStyle(plotter)
+        plotter.iren.style = style

--- a/qt/python/instrumentview/instrumentview/renderers/base_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/base_renderer.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyvista as pv
 from pyvistaqt import BackgroundPlotter
 
-from instrumentview.InteractorStyles import CursorZoomInteractorStyle
+from instrumentview.InteractorStyles import CursorZoomInteractorStyle, SwappedButtonTrackballCamera
 
 
 class InstrumentRenderer(ABC):
@@ -130,7 +130,6 @@ class InstrumentRenderer(ABC):
 
     def set_interactive_style(self, plotter, is_projection):
         if not is_projection:
-            plotter.enable_trackball_style()
+            plotter.iren.style = SwappedButtonTrackballCamera()
             return
-        style = CursorZoomInteractorStyle(plotter)
-        plotter.iren.style = style
+        plotter.iren.style = CursorZoomInteractorStyle(plotter)

--- a/qt/python/instrumentview/instrumentview/renderers/point_cloud_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/point_cloud_renderer.py
@@ -51,14 +51,6 @@ class PointCloudRenderer(InstrumentRenderer):
         if plotter.off_screen:
             return
 
-        if not is_projection:
-            plotter.enable_trackball_style()
-            return
-
-        plotter.view_xy()
-        plotter.enable_parallel_projection()
-        plotter.enable_zoom_style()
-
     def add_pickable_mesh_to_plotter(self, plotter: BackgroundPlotter, mesh: pv.PolyData, scalars) -> None:
         plotter.add_mesh(
             mesh,

--- a/qt/python/instrumentview/instrumentview/renderers/point_cloud_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/point_cloud_renderer.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional
 import numpy as np
 import pyvista as pv
 from pyvistaqt import BackgroundPlotter
+from vtkmodules.vtkRenderingCore import vtkPointPicker
 
 from instrumentview.renderers.base_renderer import InstrumentRenderer
 
@@ -77,27 +78,31 @@ class PointCloudRenderer(InstrumentRenderer):
 
     # --------------------------------------------------------------- picking
     def enable_picking(self, plotter: BackgroundPlotter, callback: Callable[[int], None]) -> None:
-        """Set up point picking.  *callback* receives ``(detector_index: int)``."""
+        """Set up left-click point picking.  *callback* receives ``(detector_index: int)``."""
         plotter.disable_picking()
 
+        if plotter.off_screen:
+            return
+
         picking_tolerance = 0.01
-        if not plotter.off_screen:
+        picker = vtkPointPicker()
+        picker.SetTolerance(picking_tolerance)
+        interactor = plotter.iren
 
-            def _point_picked(point_position, picker):
-                if point_position is None:
-                    return
-                point_index = picker.GetPointId()
-                callback(point_index)
+        def _on_left_button_press(obj, event):
+            """Handle left mouse button press for picking."""
+            # Get the current mouse position from the interactor
+            x, y = interactor.get_event_position()
+            # Perform the pick operation
+            pick_result = picker.Pick(x, y, 0, plotter.renderer)
+            if pick_result > 0:
+                # Get the picked point ID
+                point_id = picker.GetPointId()
+                if point_id >= 0:
+                    callback(point_id)
 
-            plotter.enable_surface_point_picking(
-                show_message=False,
-                use_picker=True,
-                callback=_point_picked,
-                show_point=False,
-                pickable_window=False,
-                picker="point",
-                tolerance=picking_tolerance,
-            )
+        # Register callback for left button press
+        plotter.iren.style.AddObserver("LeftButtonPressEvent", _on_left_button_press)
 
     # -------------------------------------------------------------- scalars
     def set_detector_scalars(self, mesh: pv.PolyData, counts: np.ndarray, label: str) -> None:

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -23,6 +23,7 @@ from pyvistaqt import BackgroundPlotter
 from scipy.spatial import cKDTree
 from scipy.spatial.transform import Rotation
 from typing import Callable, Optional
+from vtkmodules.vtkRenderingCore import vtkCellPicker
 
 from instrumentview.Projections.ProjectionType import ProjectionType
 from instrumentview.renderers.base_renderer import InstrumentRenderer
@@ -38,7 +39,7 @@ class ShapeRenderer(InstrumentRenderer):
     """
 
     _MASKED_COLOUR = (0.25, 0.25, 0.25)
-    _PICKING_TOLERANCE = 0.001
+    _PICKING_TOLERANCE = 0.0001
 
     def __init__(self):
         # Populated by ``precompute``.
@@ -250,31 +251,33 @@ class ShapeRenderer(InstrumentRenderer):
         )
 
     def enable_picking(self, plotter: BackgroundPlotter, callback: Callable[[int], None]) -> None:
-        """Set up cell picking on the shape surface.  *callback* receives ``(detector_index: int)``."""
+        """Set up left-click cell picking on the shape surface.  *callback* receives ``(detector_index: int)``."""
         plotter.disable_picking()
 
         if plotter.off_screen:
             return
 
         c2d = self._cell_to_detector
+        picker = vtkCellPicker()
+        picker.SetTolerance(self._PICKING_TOLERANCE)
+        interactor = plotter.iren
 
-        def _cell_picked(point_position, picker):
-            if point_position is None:
+        def _on_left_button_press(obj, event):
+            """Handle left mouse button press for picking."""
+            if c2d is None:
                 return
-            cell_id = picker.GetCellId()
-            if cell_id < 0 or c2d is None:
-                return
-            callback(int(c2d[cell_id]))
+            # Get the current mouse position from the interactor
+            x, y = interactor.get_event_position()
+            # Perform the pick operation
+            pick_result = picker.Pick(x, y, 0, plotter.renderer)
+            if pick_result > 0:
+                # Get the picked cell ID
+                cell_id = picker.GetCellId()
+                if cell_id >= 0:
+                    callback(int(c2d[cell_id]))
 
-        plotter.enable_surface_point_picking(
-            show_message=False,
-            use_picker=True,
-            callback=_cell_picked,
-            show_point=False,
-            pickable_window=False,
-            picker="cell",
-            tolerance=self._PICKING_TOLERANCE,
-        )
+        # Register callback for left button press
+        plotter.iren.style.AddObserver("LeftButtonPressEvent", _on_left_button_press)
 
     def set_detector_scalars(self, mesh: pv.PolyData, counts: np.ndarray, label: str) -> None:
         if self._cell_to_detector is not None and len(counts) > 0:

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -220,14 +220,6 @@ class ShapeRenderer(InstrumentRenderer):
         if plotter.off_screen:
             return
 
-        if not is_projection:
-            plotter.enable_trackball_style()
-            return
-
-        plotter.view_xy()
-        plotter.enable_parallel_projection()
-        plotter.enable_zoom_style()
-
     def add_pickable_mesh_to_plotter(self, plotter: BackgroundPlotter, mesh: pv.PolyData, scalars) -> None:
         if mesh.number_of_cells == 0:
             return

--- a/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
+++ b/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
@@ -1,65 +1,141 @@
-from instrumentview.InteractorStyles import CustomInteractorStyleRubberBand3D, CustomInteractorStyleZoomAndSelect, on_selection_changed
+from instrumentview.InteractorStyles import CursorZoomInteractorStyle, SwappedButtonTrackballCamera, _display_to_world
 import unittest
 from unittest import mock
 
+import numpy as np
+from numpy.testing import assert_array_almost_equal
 
-class TestInteractorStyles(unittest.TestCase):
-    def _make_mock_caller(self, start_position, end_position, window_size):
-        mock_caller = mock.MagicMock()
-        mock_caller.GetStartPosition.return_value = start_position
-        mock_caller.GetEndPosition.return_value = end_position
-        mock_picker = mock.MagicMock()
-        mock_picker.AreaPick.return_value = mock.MagicMock()
-        mock_interactor = mock.MagicMock()
-        mock_interactor.GetPicker.return_value = mock_picker
-        render_window_mock = mock.MagicMock()
-        render_window_mock.GetSize.return_value = window_size
-        mock_interactor.GetRenderWindow.return_value = render_window_mock
-        mock_caller.GetInteractor.return_value = mock_interactor
-        mock_caller.GetCurrentRenderer.return_value = mock.MagicMock()
-        return mock_caller, mock_picker
 
-    @mock.patch("instrumentview.InteractorStyles.on_selection_changed")
-    def test_custom_3d_selection_changed(self, callback_mock):
-        style = CustomInteractorStyleRubberBand3D()
-        style.InvokeEvent("SelectionChangedEvent")
-        callback_mock.assert_called_once()
+def _make_mock_plotter(position=(0, 0, 1), focal_point=(0, 0, 0), parallel_scale=1.0):
+    """Create a mock plotter with a camera that behaves like a real one."""
+    camera = mock.MagicMock()
+    camera.position = list(position)
+    camera.focal_point = list(focal_point)
+    camera.parallel_scale = parallel_scale
 
-    @mock.patch("instrumentview.InteractorStyles.on_selection_changed")
-    def test_custom_2d_selection_changed(self, callback_mock):
-        style = CustomInteractorStyleZoomAndSelect()
-        style.rubber_band.InvokeEvent("SelectionChangedEvent")
-        callback_mock.assert_called_once()
+    renderer = mock.MagicMock()
+    renderer.camera = camera
 
-    def test_set_interacor(self):
-        style = CustomInteractorStyleZoomAndSelect()
-        style.SetInteractor = mock.MagicMock()
-        style.rubber_band = mock.MagicMock()
-        style.rubber_band.SetInteractor = mock.MagicMock()
-        style.set_interactor(0)
-        style.rubber_band.SetInteractor.assert_called_with(0)
-        style.SetInteractor.assert_called_with(0)
+    plotter = mock.MagicMock()
+    plotter.renderer = renderer
+    plotter.mouse_position = (100, 100)
+    plotter.render_window = mock.MagicMock()
+    return plotter
 
-    def test_remove_interacor(self):
-        style = CustomInteractorStyleZoomAndSelect()
-        style.SetInteractor = mock.MagicMock()
-        style.rubber_band = mock.MagicMock()
-        style.rubber_band.SetInteractor = mock.MagicMock()
-        style.remove_interactor()
-        style.rubber_band.SetInteractor.assert_called_with(None)
-        style.SetInteractor.assert_called_with(None)
 
-    def test_on_selection_changed_good_coords(self):
-        mock_caller, mock_picker = self._make_mock_caller((5, 10), (4, 11), (15, 15))
-        on_selection_changed(mock_caller)
-        mock_picker.AreaPick.assert_called_with(4, 10, 5, 11, mock_caller.GetCurrentRenderer())
+class TestCursorZoomInteractorStyle(unittest.TestCase):
+    def _create_style(self, **plotter_kwargs):
+        plotter = _make_mock_plotter(**plotter_kwargs)
+        style = CursorZoomInteractorStyle(plotter)
+        return style, plotter
 
-    def test_on_selection_changed_coords_bigger_than_window(self):
-        mock_caller, mock_picker = self._make_mock_caller((5, 17), (20, 11), (15, 15))
-        on_selection_changed(mock_caller)
-        mock_picker.AreaPick.assert_called_with(5, 11, 13, 13, mock_caller.GetCurrentRenderer())
+    def test_caches_default_camera_state(self):
+        style, plotter = self._create_style(position=(1, 2, 3), focal_point=(4, 5, 6), parallel_scale=2.5)
+        assert_array_almost_equal(style._default_position, [1, 2, 3])
+        assert_array_almost_equal(style._default_focal_point, [4, 5, 6])
+        self.assertAlmostEqual(style._default_parallel_scale, 2.5)
 
-    def test_on_selection_changed_coords_less_than_zero(self):
-        mock_caller, mock_picker = self._make_mock_caller((0, 10), (4, -1), (15, 15))
-        on_selection_changed(mock_caller)
-        mock_picker.AreaPick.assert_called_with(0, 0, 4, 10, mock_caller.GetCurrentRenderer())
+    def test_track_mouse_position_called(self):
+        style, plotter = self._create_style()
+        plotter.track_mouse_position.assert_called_once()
+
+    def test_on_mouse_move_updates_cursor_world_pos(self):
+        style, plotter = self._create_style()
+        plotter.mouse_position = (50, 60)
+        # Mock _display_to_world to return a known value
+        with mock.patch("instrumentview.InteractorStyles._display_to_world", return_value=np.array([1.0, 2.0, 0.0])):
+            style._on_mouse_move(None, None)
+        assert_array_almost_equal(style._cursor_world_pos, [1.0, 2.0, 0.0])
+
+    def test_on_mouse_move_skipped_during_zoom(self):
+        style, plotter = self._create_style()
+        style._zoom_in_progress = True
+        style._cursor_world_pos = None
+        style._on_mouse_move(None, None)
+        self.assertIsNone(style._cursor_world_pos)
+
+    def test_zoom_does_nothing_when_no_cursor_pos(self):
+        style, plotter = self._create_style()
+        style._cursor_world_pos = None
+        camera = plotter.renderer.camera
+        original_scale = camera.parallel_scale
+        style._zoom(1.1)
+        # Camera should not have been modified
+        self.assertEqual(camera.parallel_scale, original_scale)
+
+    def test_zoom_in_decreases_parallel_scale(self):
+        style, plotter = self._create_style(parallel_scale=1.0)
+        style._cursor_world_pos = np.array([0.0, 0.0, 0.0])
+        with mock.patch("instrumentview.InteractorStyles._display_to_world", return_value=np.array([0.0, 0.0, 0.0])):
+            style._zoom(style.zoom_factor)
+        camera = plotter.renderer.camera
+        self.assertLess(camera.parallel_scale, 1.0)
+
+    def test_zoom_out_past_default_resets_camera(self):
+        style, plotter = self._create_style(position=(0, 0, 1), focal_point=(0, 0, 0), parallel_scale=1.0)
+        # Set camera to a state close to default so one zoom-out step exceeds it
+        plotter.renderer.camera.parallel_scale = 0.9
+        plotter.renderer.camera.focal_point = [0.1, 0.1, 0.0]
+        plotter.renderer.camera.position = [0.1, 0.1, 1.0]
+        style._cursor_world_pos = np.array([0.0, 0.0, 0.0])
+        # Zoom out — the dynamic factor will push parallel_scale past the default
+        with mock.patch("instrumentview.InteractorStyles._display_to_world", return_value=np.array([0.0, 0.0, 0.0])):
+            style._zoom(1.0 / style.zoom_factor)
+        camera = plotter.renderer.camera
+        # Should have reset to defaults
+        self.assertEqual(camera.position, [0, 0, 1])
+        self.assertEqual(camera.focal_point, [0, 0, 0])
+        self.assertAlmostEqual(camera.parallel_scale, 1.0)
+
+    def test_reset_camera_restores_defaults(self):
+        style, plotter = self._create_style(position=(1, 2, 3), focal_point=(4, 5, 6), parallel_scale=2.5)
+        # Modify camera state
+        plotter.renderer.camera.position = [9, 9, 9]
+        plotter.renderer.camera.focal_point = [8, 8, 8]
+        plotter.renderer.camera.parallel_scale = 99.0
+        style._reset_camera()
+        camera = plotter.renderer.camera
+        self.assertEqual(camera.position, [1, 2, 3])
+        self.assertEqual(camera.focal_point, [4, 5, 6])
+        self.assertAlmostEqual(camera.parallel_scale, 2.5)
+
+    def test_wheel_forward_calls_zoom_in(self):
+        style, plotter = self._create_style()
+        with mock.patch.object(style, "_zoom") as zoom_mock:
+            style._on_wheel_forward(None, None)
+            zoom_mock.assert_called_once_with(style.zoom_factor)
+
+    def test_wheel_backward_calls_zoom_out(self):
+        style, plotter = self._create_style()
+        with mock.patch.object(style, "_zoom") as zoom_mock:
+            style._on_wheel_backward(None, None)
+            zoom_mock.assert_called_once_with(1.0 / style.zoom_factor)
+
+
+class TestDisplayToWorld(unittest.TestCase):
+    def test_returns_none_for_zero_w(self):
+        renderer = mock.MagicMock()
+        renderer.GetWorldPoint.return_value = (1.0, 2.0, 0.0, 0.0)
+        result = _display_to_world(renderer, 100, 200)
+        self.assertIsNone(result)
+
+    def test_converts_display_to_world(self):
+        renderer = mock.MagicMock()
+        renderer.GetWorldPoint.return_value = (2.0, 4.0, 0.0, 2.0)
+        result = _display_to_world(renderer, 100, 200)
+        renderer.SetDisplayPoint.assert_called_with(100, 200, 0.0)
+        renderer.DisplayToWorld.assert_called_once()
+        assert_array_almost_equal(result, [1.0, 2.0, 0.0])
+
+    def test_projects_onto_z_zero_plane(self):
+        renderer = mock.MagicMock()
+        renderer.GetWorldPoint.return_value = (3.0, 6.0, 9.0, 3.0)
+        result = _display_to_world(renderer, 50, 50)
+        # z component should always be 0
+        self.assertAlmostEqual(result[2], 0.0)
+
+
+class TestSwappedButtonTrackballCamera(unittest.TestCase):
+    def test_instantiates(self):
+        style = SwappedButtonTrackballCamera()
+        self.assertIsNotNone(style)

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -76,60 +76,6 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
             mock_mesh, scalars=mock_scalars, rgba=True, pickable=False, render_points_as_spheres=True, point_size=10
         )
 
-    def test_enable_point_picking(self):
-        self._view.main_plotter.reset_mock()
-        self._view.main_plotter.off_screen = False
-        mock_callback = MagicMock()
-        self._view.interactor_style = MagicMock()
-        self._view.enable_point_picking(False, mock_callback)
-        self._view.interactor_style.remove_interactor.assert_called_once()
-        self._view.main_plotter.disable_picking.assert_called_once()
-        self._view.main_plotter.enable_surface_point_picking.assert_called_once_with(
-            show_message=False,
-            use_picker=True,
-            callback=mock_callback,
-            show_point=False,
-            pickable_window=False,
-            picker="point",
-            tolerance=0.01,
-        )
-
-    def test_enable_point_picking_off_screen(self):
-        self._view.main_plotter.reset_mock()
-        self._view.main_plotter.off_screen = True
-        mock_callback = MagicMock()
-        self._view.interactor_style = MagicMock()
-        self._view.enable_point_picking(False, mock_callback)
-        self._view.main_plotter.disable_picking.assert_called_once()
-        self._view.interactor_style.remove_interactor.assert_called_once()
-        self._view.main_plotter.enable_surface_point_picking.assert_not_called()
-
-    @mock.patch("instrumentview.FullInstrumentViewWindow.CustomInteractorStyleRubberBand3D")
-    def test_enable_rectangle_picking_3d(self, mock_style_3d):
-        self._view.main_plotter.reset_mock()
-        self._view.main_plotter.off_screen = False
-        mock_callback = MagicMock()
-        self._view.enable_rectangle_picking(False, mock_callback)
-        self._view.main_plotter.disable_picking.assert_called_once()
-        mock_style_3d.assert_called_once()
-
-    def test_enable_rectangle_picking_2d(self):
-        self._view.main_plotter.reset_mock()
-        self._view.main_plotter.off_screen = False
-        self._view.interactor_style = MagicMock()
-        mock_callback = MagicMock()
-        self._view.enable_rectangle_picking(True, mock_callback)
-        self._view.main_plotter.disable_picking.assert_called_once()
-        self._view.interactor_style.set_interactor.assert_called_once()
-
-    def test_enable_rectangle_picking_off_screen(self):
-        self._view.main_plotter.reset_mock()
-        self._view.main_plotter.off_screen = True
-        mock_callback = MagicMock()
-        self._view.enable_rectangle_picking(False, mock_callback)
-        self._view.main_plotter.disable_picking.assert_called_once()
-        self._view.main_plotter.enable_rectangle_picking.assert_not_called()
-
     @mock.patch("instrumentview.FullInstrumentViewWindow.QListWidgetItem")
     def test_refresh_peaks_ws_list(self, mock_qlist_widget_item):
         mock_list = MagicMock()


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Users gave feedback on the difficulty of constantly needing to zoom in and out to either apply masks of group detectors.
- Changed the zoom so that using the scroll wheel of the mouse it zooms into the position of the cursor.
- Switched the picking mouse button so that clicking on right-click resets the projection, which is something the users miss from the old IV.
- Cache the camera position when settings/groupings/masking changes, so that the projection is not reset needlessly. 

Closes #40984 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Try zooming in and out on different projections
- Apply mask, draw shapes and other options that update the view and the camera should stay in the same place

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
