### PR TITLE
Fix failing doc example for Engg algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -128,7 +128,7 @@ def find_bg_of_spectrum(wsname, ispec, xwindow, niter, do_sg_filter, prog):
     # find kernel size
     nwindow = _get_nbins_in_xwindow(ws.readX(ispec), xwindow)
     # do initial filter to remove very high intensity points
-    ybg = ws.dataY(ispec)[:]  # copy
+    ybg = ws.readY(ispec).copy()  # copy
     if do_sg_filter:
         ybg = savgol_filter(ybg, nwindow, polyorder=1)
     yavg = ybg.mean()

--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -128,7 +128,7 @@ def find_bg_of_spectrum(wsname, ispec, xwindow, niter, do_sg_filter, prog):
     # find kernel size
     nwindow = _get_nbins_in_xwindow(ws.readX(ispec), xwindow)
     # do initial filter to remove very high intensity points
-    ybg = ws.readY(ispec)[:]  # copy
+    ybg = ws.dataY(ispec)[:]  # copy
     if do_sg_filter:
         ybg = savgol_filter(ybg, nwindow, polyorder=1)
     yavg = ybg.mean()

--- a/docs/source/algorithms/EnggEstimateFocussedBackground-v1.rst
+++ b/docs/source/algorithms/EnggEstimateFocussedBackground-v1.rst
@@ -18,7 +18,7 @@ Useage
 
 **Example:**
 
-.. code-block:: python
+.. testcode:: EnggEstimateFocussedBackground
 
 	from mantid.simpleapi import *
 

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41131.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41131.rst
@@ -1,0 +1,1 @@
+- `EnggEstimateFocussedBackground` will no longer throw an error related to writing to a read-only destination.


### PR DESCRIPTION
### Description of work

The `EnggEstimateFocussedBackground` was failing, even when running its example code.  The error output:
```
RuntimeError: EnggEstimateFocussedBackground-v1: assignment destination is read-only
```
This error indicates trying to write to a view, instead of to a modifiable list or vector.  The error seemed to be due to a single line, that was using a slice (`[:]`) to make a shallow copy, rather than using the `.copy()` method.

Since the method `readY()` returns a view, then copying with a slice likely also returns a copy of the same view.  Whereas the `copy()` method creates a new object with the same values as the view.

### To test:

Build and run the following script ([from the documentation](https://docs.mantidproject.org/nightly/algorithms/EnggEstimateFocussedBackground-v1.html#useage)):
```python
from mantid.simpleapi import *

CreateSampleWorkspace(OutputWorkspace='ws', Function='Multiple Peaks', NumBanks=1, BankPixelWidth=1, XMax=20, BinWidth=0.2)
EnggEstimateFocussedBackground(InputWorkspace='ws', OutputWorkspace='ws_bg', NIterations='200', XWindow=2.5, ApplyFilterSG=False)
```

Ensure the docs tests for this algorithm have passed.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
