### PR TITLE
check the range is not empty in sequential fit dialog

### DIFF
--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -287,8 +287,8 @@ QString SequentialFitDialog::getIndex(int row) const {
   QString wsIndex = ui.tWorkspaces->model()->data(ui.tWorkspaces->model()->index(row, 3)).toString();
   QString range = ui.tWorkspaces->model()->data(ui.tWorkspaces->model()->index(row, 4)).toString();
 
-  if (!isValidRangeFormat(range)) {
-    g_log.error() << "Invaild range please use the format start:end." << std::endl;
+  if (!range.isEmpty() && !isValidRangeFormat(range)) {
+    g_log.error() << "Invalid range please use the format start:end." << std::endl;
     return "";
   }
 

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -288,7 +288,7 @@ QString SequentialFitDialog::getIndex(int row) const {
   QString range = ui.tWorkspaces->model()->data(ui.tWorkspaces->model()->index(row, 4)).toString();
 
   if (!range.isEmpty() && !isValidRangeFormat(range)) {
-    g_log.error() << "Invalid range please use the format start:end." << std::endl;
+    g_log.error() << "Invalid range. Please use the format start:end." << std::endl;
     return "";
   }
 


### PR DESCRIPTION
### Description of work
Added additional check so that `isValidRangeFormat` only executed for non-empty ranges. Otherwise it breaks all the sequential fits that do not use this input.

Addresses [EWM 15793](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.apt.viewPlan&planMode=com.ibm.team.apt.viewmodes.internal.workBreakdown&id=_6R7kQNwiEfC-MORA6aNvnA)

Release notes not necessary since this is a small change, and unnoticiable by the user.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
