### PR TITLE
Read release notes with utf encoding when building docs

### DIFF
--- a/Framework/MPIAlgorithms/CMakeLists.txt
+++ b/Framework/MPIAlgorithms/CMakeLists.txt
@@ -23,6 +23,12 @@ set_target_properties(MPIAlgorithms PROPERTIES OUTPUT_NAME MantidMPIAlgorithms)
 # Add to the 'Framework' group in VS
 set_property(TARGET MPIAlgorithms PROPERTY FOLDER "MantidFramework")
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set_target_properties(MPIAlgorithms PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MPIAlgorithms PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR};\$ORIGIN/../${PLUGINS_DIR}")
+endif()
+
 target_link_libraries(
   MPIAlgorithms
   PUBLIC Mantid::API Mantid::DataObjects
@@ -40,7 +46,8 @@ if(MPI_BUILD)
   # Add the unit tests directory
   add_subdirectory(test)
   # libMantidMPIAlgorithms.so is always built so documentation for the algorithms can be built
-  mtd_install_targets(TARGETS MPIAlgorithms INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})
+  message(STATUS "Installing MPIAlgorithms")
+  mtd_install_framework_lib(TARGETS MPIAlgorithms PLUGIN_LIB)
 endif()
 
 target_include_directories(

--- a/Framework/MPIAlgorithms/CMakeLists.txt
+++ b/Framework/MPIAlgorithms/CMakeLists.txt
@@ -23,10 +23,10 @@ set_target_properties(MPIAlgorithms PROPERTIES OUTPUT_NAME MantidMPIAlgorithms)
 # Add to the 'Framework' group in VS
 set_property(TARGET MPIAlgorithms PROPERTY FOLDER "MantidFramework")
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set_target_properties(MPIAlgorithms PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  set_target_properties(MPIAlgorithms PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR};\$ORIGIN/../${PLUGINS_DIR}")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MPIAlgorithms PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
+else()
+  message(STATUS "Only linux builds are currently supported")
 endif()
 
 target_link_libraries(

--- a/docs/source/release/v6.16.0/Framework/Data_Objects/Bugfixes/41072.rst
+++ b/docs/source/release/v6.16.0/Framework/Data_Objects/Bugfixes/41072.rst
@@ -1,2 +1,2 @@
 - adds persistence and round-trip support for the MonitorCount field on peaks
-  when saving/loading Mantid “processed” NeXus peak workspaces.
+  when saving/loading Mantid "processed" NeXus peak workspaces.

--- a/docs/sphinxext/mantiddoc/directives/amalgamate.py
+++ b/docs/sphinxext/mantiddoc/directives/amalgamate.py
@@ -36,7 +36,7 @@ class CompilationDirective(BaseDirective):
         if os.path.exists(script_dir):
             for file in os.listdir(script_dir):
                 if file.endswith(".rst"):
-                    with open(script_dir.joinpath(file)) as f:
+                    with open(script_dir.joinpath(file), encoding="utf-8") as f:
                         contents = f.read()
                         self.add_rst(contents)
 


### PR DESCRIPTION
Otherwise when building the docs on Windows, any release notes with non-ASCII characters will cause sphinx to fail.

#41072 had Unicode quotes in the release note, which causes the docs to not build on Windows.

This is a problem for developers when testing the docs on other PRs, but the user won't see any difference, so no release note required.

This PR also fixes the MPI build

### To test:

Build docs on Windows and other platforms, check generated release notes

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
