### PR TITLE
Enable MPI for docs builds too

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -41,7 +41,8 @@ if [[ ${JOB_NAME} == *pull_requests* ]]; then
     EXTRA_CMAKE_FLAGS+=" -DPR_JOB=True"
 fi
 
-if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
+# MPI library is needed for some system tests and doc tests
+if [[ $ENABLE_SYSTEM_TESTS == true || $ENABLE_DOCS == true ]]; then
     EXTRA_CMAKE_FLAGS+=" -DMPI_BUILD=ON"
 fi
 


### PR DESCRIPTION
The user docs builds were failing with
```
/jenkins_workdir/workspace/pull_requests-doc-tests/docs/source/concepts/MPI.md:307: WARNING: undefined label: 'algm-broadcastworkspace' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/docs/source/concepts/MPI.md:307: WARNING: undefined label: 'algm-gatherworkspaces' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/build/docs/release/v6.16.0/framework:3: WARNING: undefined label: 'algm-broadcastworkspace' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/build/docs/release/v6.16.0/framework:3: WARNING: undefined label: 'algm-gatherworkspaces' [ref.ref]
```
The problem is that the `libMantidMPIAlgorithms.so` isn't getting created so AlgorithmManager isn't parsing the library. This is a periodic problem because builds that have the system tests run will create the library. This change makes it always get created.


There is no associated issue.

### To test:

Look for
```
EXTRA_CMAKE_FLAGS+=' -DMPI_BUILD=ON'
```
in the build logs and see that the docs-test job doesn't have a warning.

*This does not require release notes* because it is a CI change

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
