### PR TITLE
Rename `Instrument::getMonitors()` --> `Instrument::getMonitorIDs()`

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -169,7 +169,8 @@ void checkDetectorInfoSize(const Instrument &instr, const Geometry::DetectorInfo
   if (numDets != detInfo.size())
     throw std::runtime_error("ExperimentInfo: size mismatch between "
                              "DetectorInfo and number of detectors in "
-                             "instrument");
+                             "instrument" +
+                             std::to_string(numDets) + " vs " + std::to_string(detInfo.size()));
 }
 } // namespace
 

--- a/Framework/Algorithms/src/FindCenterOfMassPosition.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition.cpp
@@ -101,7 +101,7 @@ void FindCenterOfMassPosition::exec() {
 
   // Get the number of monitors. We assume that all monitors are stored in the
   // first spectra
-  int n_monitors = static_cast<int>(inputWS->getInstrument()->getMonitors().size());
+  int n_monitors = static_cast<int>(inputWS->getInstrument()->getMonitorIDs().size());
   const auto numSpec = static_cast<int>(inputWS->getNumberHistograms());
 
   // Find center of mass and iterate until we converge

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -106,7 +106,7 @@ bool MonIDPropChanger::monitorIdReader(const MatrixWorkspace_const_sptr &inputWS
     return false;
 
   // are these monitors really there?
-  std::vector<detid_t> monitorIDList = pInstr->getMonitors();
+  std::vector<detid_t> monitorIDList = pInstr->getMonitorIDs();
   {
     const auto &specInfo = inputWS->spectrumInfo();
     std::set<detid_t> idsInWorkspace;

--- a/Framework/DataHandling/src/LoadCalFile.cpp
+++ b/Framework/DataHandling/src/LoadCalFile.cpp
@@ -333,7 +333,7 @@ void LoadCalFile::readCalFile(const std::string &calFileName, const GroupingWork
  * @return True if a monitor, false otherwise
  */
 bool LoadCalFile::idIsMonitor(const Instrument_const_sptr &inst, int detID) {
-  auto monitorList = inst->getMonitors();
+  auto monitorList = inst->getMonitorIDs();
   auto it = std::find(monitorList.begin(), monitorList.end(), detID);
   return (it != monitorList.end());
 }

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -135,7 +135,7 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(
   const auto &spec = spectrumDetectorMapping.first;
   const auto &udet = spectrumDetectorMapping.second;
 
-  const std::vector<detid_t> monitors = m_instrumentWorkspace->getInstrument()->getMonitors();
+  const std::vector<detid_t> monitors = m_instrumentWorkspace->getInstrument()->getMonitorIDs();
   const auto &detectorInfo = m_instrumentWorkspace->detectorInfo();
   if (monitorsOnly) {
     std::vector<Indexing::SpectrumNumber> spectrumNumbers;

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -713,7 +713,7 @@ void LoadILLTOF2::fillScanWorkspace(const LegacyNexus::NXEntry &entry, const std
   LegacyLoadHelper::fillStaticWorkspace(m_localWorkspace, data, xAxis, 0, true, detectorIDs, std::set<int>(), dimOrder);
 
   // Load monitor data, there is only one monitor
-  const std::vector<int> monitorIDs = m_localWorkspace->getInstrument()->getMonitors();
+  const std::vector<int> monitorIDs = m_localWorkspace->getInstrument()->getMonitorIDs();
   const auto spectrumNo = data.dim1() * data.dim2();
   auto monitorData = LegacyLoadHelper::getDoubleDataset(entry, monitorList[0]);
   monitorData.load();

--- a/Framework/DataHandling/src/LoadILLTOF3.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF3.cpp
@@ -435,7 +435,7 @@ void LoadILLTOF3::fillScanWorkspace(const Nexus::NXEntry &entry, const std::vect
   LoadHelper::fillStaticWorkspace(m_localWorkspace, data, xAxis, 0, true, detectorIDs, std::set<detid_t>(), dimOrder);
 
   // Load monitor data, there is only one monitor
-  const std::vector<int> monitorIDs = m_localWorkspace->getInstrument()->getMonitors();
+  const std::vector<int> monitorIDs = m_localWorkspace->getInstrument()->getMonitorIDs();
   const auto spectrumNo = data.dim1() * data.dim2();
   auto monitorData = LoadHelper::getDoubleDataset(entry, monitorList[0]);
   monitorData.load();

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -240,7 +240,7 @@ void LoadInstrument::exec() {
   } // end of mutex scope
 
   // Set the monitors output property
-  setProperty("MonitorList", (ws->getInstrument())->getMonitors());
+  setProperty("MonitorList", (ws->getInstrument())->getMonitorIDs());
 
   // Rebuild the spectra map for this workspace so that it matches the
   // instrument, if required

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -140,7 +140,7 @@ void LoadInstrumentFromRaw::exec() {
   }
   localWorkspace->setInstrument(instrument);
 
-  std::vector<detid_t> monitorList = instrument->getMonitors();
+  std::vector<detid_t> monitorList = instrument->getMonitorIDs();
   setProperty("MonitorList", monitorList);
   // Information to the user about what info is extracted from raw file
   g_log.information() << "SamplePos component added with position set to (0,0,0).\n"

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -1354,7 +1354,7 @@ public:
     TS_ASSERT_EQUALS(inst->getName(), "HYSPECA");
     TS_ASSERT_EQUALS(inst->getValidFromDate(), std::string("2011-Jul-20 17:02:48.437294000"));
     TS_ASSERT_EQUALS(inst->getNumberDetectors(), 20483);
-    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitors().size(), 3);
+    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitorIDs().size(), 3);
     auto params = inst->getParameterMap();
     // Previously this was 49. Position/rotations are now stored in
     // ComponentInfo and DetectorInfo so the following four parameters are no
@@ -1386,7 +1386,7 @@ public:
                                              // file
     TS_ASSERT_EQUALS(inst->getName(), "CNCS");
     TS_ASSERT_EQUALS(inst->getNumberDetectors(), 51203);
-    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitors().size(), 3);
+    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitorIDs().size(), 3);
 
     // check that CNCS_Parameters.xml has been loaded
     auto params = inst->getParameterMap();

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -109,7 +109,10 @@ public:
   /// return reference to detector cache
   void getDetectors(detid2det_map &out_map) const;
 
+  /// Returns a list containing the detector ids of all detectors, optionally skipping monitors
   std::vector<detid_t> getDetectorIDs(bool skipMonitors = false) const;
+  /// Returns a list containing the detector ids of monitors
+  std::vector<detid_t> getMonitorIDs() const;
 
   std::size_t getNumberDetectors(bool skipMonitors = false) const;
 
@@ -118,9 +121,6 @@ public:
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const IComponent &comp) const;
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const std::string &bankName) const;
   std::set<detid_t> getDetectorIDsInBank(const std::string &bankName) const;
-
-  /// Returns a list containing the detector ids of monitors
-  std::vector<detid_t> getMonitors() const;
 
   /// Get the bounding box for this component and store it in the given argument
   void getBoundingBox(BoundingBox &assemblyBox) const override;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -215,6 +215,21 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
   return out;
 }
 
+/** This method returns monitor detector ids
+ *  @return a vector holding detector ids of  monitors
+ */
+std::vector<detid_t> Instrument::getMonitorIDs() const {
+  // Monitors cannot be parametrized. So just return the base.
+  if (m_map)
+    return m_instr->getMonitorIDs();
+
+  std::vector<detid_t> mons;
+  for (const auto &item : m_detectorCache)
+    if (std::get<2>(item))
+      mons.emplace_back(std::get<0>(item));
+  return mons;
+}
+
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   std::size_t numDetIDs(0);
@@ -716,21 +731,6 @@ void Instrument::removeDetector(IDetector *det) {
   }
 }
 
-/** This method returns monitor detector ids
- *  @return a vector holding detector ids of  monitors
- */
-std::vector<detid_t> Instrument::getMonitors() const {
-  // Monitors cannot be parametrized. So just return the base.
-  if (m_map)
-    return m_instr->getMonitors();
-
-  std::vector<detid_t> mons;
-  for (const auto &item : m_detectorCache)
-    if (std::get<2>(item))
-      mons.emplace_back(std::get<0>(item));
-  return mons;
-}
-
 /**
  * Get the bounding box for this instrument. It is simply the sum of the
  * bounding boxes of its children excluding the source
@@ -918,23 +918,19 @@ void Instrument::saveNexus(Nexus::File *file, const std::string &group) const {
     params->saveNexus(file, "instrument_parameter_map");
   }
 
-  // Add physical detector and monitor data
-  auto detmonIDs = getDetectorIDs(false);
-  if (!detmonIDs.empty()) {
-    auto detectorIDs = getDetectorIDs(true);
+  // Add physical detector data
+  auto detectorIDs = getDetectorIDs(true);
+  if (!detectorIDs.empty()) {
     // Add detectors group
     file->makeGroup("physical_detectors", "NXdetector", true);
     file->writeData("number_of_detectors", uint64_t(detectorIDs.size()));
     saveDetectorSetInfoToNexus(file, detectorIDs);
     file->closeGroup(); // detectors
+  }
 
-    // Create Monitor IDs vector
-    std::vector<detid_t> monitorIDs;
-    for (size_t i = 0; i < detmonIDs.size(); i++) {
-      if (isMonitorViaIndex(i))
-        monitorIDs.emplace_back(detmonIDs[i]);
-    }
-
+  // Add monitor data
+  auto monitorIDs = getMonitorIDs();
+  if (!monitorIDs.empty()) {
     // Add Monitors group
     file->makeGroup("physical_monitors", "NXmonitor", true);
     file->writeData("number_of_monitors", uint64_t(monitorIDs.size()));

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -81,7 +81,7 @@ public:
     TS_ASSERT_EQUALS(i.nelements(), instrument.nelements());
     TS_ASSERT_EQUALS(i.getLogfileCache(), instrument.getLogfileCache());
     TS_ASSERT_EQUALS(i.getLogfileUnit(), instrument.getLogfileUnit());
-    TS_ASSERT_EQUALS(i.getMonitors(), instrument.getMonitors());
+    TS_ASSERT_EQUALS(i.getMonitorIDs(), instrument.getMonitorIDs());
     TS_ASSERT_EQUALS(i.getDefaultView(), instrument.getDefaultView());
     TS_ASSERT_EQUALS(i.getDefaultAxis(), instrument.getDefaultAxis());
     // Should not be parameterized - there's a different constructor for that
@@ -211,9 +211,9 @@ public:
     Detector *m = new Detector("mon", 1, &i);
     TS_ASSERT_THROWS_NOTHING(i.add(m));
     TS_ASSERT_THROWS_NOTHING(i.markAsMonitor(m));
-    TS_ASSERT_EQUALS(i.getMonitors().size(), 1);
+    TS_ASSERT_EQUALS(i.getMonitorIDs().size(), 1);
     TS_ASSERT_THROWS_NOTHING(i.removeDetector(m));
-    TS_ASSERT(i.getMonitors().empty());
+    TS_ASSERT(i.getMonitorIDs().empty());
     TS_ASSERT(i.getDetectorIDs(false).empty());
   }
 

--- a/Framework/Geometry/test/ParInstrumentTest.h
+++ b/Framework/Geometry/test/ParInstrumentTest.h
@@ -62,7 +62,7 @@ public:
     // Instrument::getMonitors will then cause a segmentation fault, so this
     // test must run before we have invalid pointers.
     Instrument pinstrument(instrument, pmap);
-    TS_ASSERT_EQUALS(pinstrument.getMonitors().size(), 1)
+    TS_ASSERT_EQUALS(pinstrument.getMonitorIDs().size(), 1)
   }
 
   void testDetector() {

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -1337,7 +1337,7 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
 /// Creates a monitor workspace sized to the number of monitors, with the
 /// monitor IDs set
 void SNSLiveEventDataListener::initMonitorWorkspace() {
-  auto monitors = m_eventBuffer->getInstrument()->getMonitors();
+  auto monitors = m_eventBuffer->getInstrument()->getMonitorIDs();
 
   // don't create monitor workspace if there are no monitors
   if (monitors.size() == 0)

--- a/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
@@ -95,7 +95,7 @@ void SANSInstrumentCreationHelper::runLoadMappingTable(const Mantid::DataObjects
   size_t nMonitors(0);
   size_t nXbins, nYbins;
   std::shared_ptr<const Instrument> instrument = workspace->getInstrument();
-  std::vector<detid_t> monitors = instrument->getMonitors();
+  std::vector<detid_t> monitors = instrument->getMonitorIDs();
   nMonitors = monitors.size();
 
   // Number of monitors should be consistent with data file format

--- a/Framework/WorkflowAlgorithms/src/EQSANSMonitorTOF.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSMonitorTOF.cpp
@@ -50,7 +50,7 @@ void EQSANSMonitorTOF::exec() {
   // const double MD = MONITORPOS/1000.0;
 
   // Get the monitor
-  const std::vector<detid_t> monitor_list = inputWS->getInstrument()->getMonitors();
+  const std::vector<detid_t> monitor_list = inputWS->getInstrument()->getMonitorIDs();
   if (monitor_list.size() != 1)
     g_log.error() << "EQSANS workspace does not have exactly ones monitor! "
                      "This should not happen\n";

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -58,7 +58,7 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Paramet
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Run.h:39
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Workspace.h:32
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/WorkspaceProperty.hxx:91
-nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:889
+nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:890
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:156
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:167
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateDIFC.cpp:41


### PR DESCRIPTION
### Description of work

> "A foolish consistency is the hobgoblin of little minds"
> - Ralph Waldo Emerson

If `getDetectorIDs()` returns a vector of detector IDs, and if `getDetectors()` returns the detectors themselves, then the method to return a vector of monitor detector IDs should be `getMonitorIDs()` and not `getMonitors()`.

There isn't a "problem", but this was a minor frustration when I was working on
[EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15489), fixing issues with loading single banks.

### To test:

This is a pure refactor.  I just changed the name of a method.

If I missed any changes, then the code won't compile.  Make sure tests pass.

*No release notes needed* because this is a pure refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
