### PR TITLE
Updated developer documentation to include -c mantid for creating mantid-developer conda env

### DIFF
--- a/dev-docs/source/GettingStarted/MantidDeveloperCondaSetup.md
+++ b/dev-docs/source/GettingStarted/MantidDeveloperCondaSetup.md
@@ -6,7 +6,7 @@ Create `mantid-developer` conda environment by following the steps below:
   but you are free to choose any name. The `neutrons` channel is also required for PyStoG.
 
   ```sh
-  mamba create -n mantid-developer mantid/label/nightly::mantid-developer -c neutrons
+  mamba create -n mantid-developer mantid/label/nightly::mantid-developer -c neutrons -c mantid
   ```
 
 - Then activate the conda environment with
@@ -19,7 +19,7 @@ Create `mantid-developer` conda environment by following the steps below:
   With your `mantid-developer` environment activated, run the following command:
 
   ```sh
-  mamba update -c mantid/label/nightly -c neutrons --all
+  mamba update -c mantid/label/nightly -c neutrons -c mantid --all
   ```
 
 See [packaging](../Packaging) for more information on this topic.


### PR DESCRIPTION
### Description of work
After switching to [mantid-sphinx-theme](https://github.com/mantidproject/mantid/pull/40999) the documentation for creating `mantid-developer` conda environment needs to be updated to include `-c mantid` channel.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Doc test should pass and the [Getting Started](https://developer.mantidproject.org/GettingStarted/GettingStarted.html) pages should reflect the updated instructions to create `mantid-developer` conda environment.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
