### PR TITLE
Change Instrument detector cache for faster lookup

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -78,29 +78,22 @@ public:
   /// Returns a list of Detectors for the given detectors ids
   std::vector<IDetector_const_sptr> getDetectors(const std::set<detid_t> &det_ids) const;
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be 'the' samplePos Component. For now it is assumed that we have
-  /// at most one of these.
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be 'the' samplePos Component. For now it is assumed that we have at most one of these.
   void markAsSamplePos(const IComponent *);
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be 'the' source Component. For now it is assumed that we have
-  /// at most one of these.
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be 'the' source Component. For now it is assumed that we have at most one of these.
   void markAsSource(const IComponent *);
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
   /// to be a Detector component by adding it to _detectorCache
   void markAsDetector(const IDetector *);
   void markAsDetectorIncomplete(const IDetector *);
   void markAsDetectorFinalize();
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be a monitor and also add it to _detectorCache for possible later
-  /// retrieval
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be a monitor and also add it to _detectorCache for possible later retrieval
   void markAsMonitor(const IDetector *);
   void markAsMonitorIncomplete(const IDetector *);
 
@@ -269,14 +262,20 @@ private:
 
   /// Map which holds detector-IDs and pointers to detector components, and
   /// monitor flags.
-  std::vector<std::tuple<detid_t, IDetector_const_sptr, bool>> m_detectorCache;
+  struct DetectorCacheEntry {
+    IDetector_const_sptr detector{nullptr};
+    bool isMonitor{false};
+  };
+  std::map<detid_t, DetectorCacheEntry> m_detectorCache;
 
-  bool m_detectorCacheFinalized{true};
+  /// temporary unsorted detector cache
+  std::vector<std::pair<detid_t, DetectorCacheEntry>> m_unsortedDetectorCache;
+
   bool isFinalized() const {
     if (m_map) {
       return m_instr->isFinalized();
     } else {
-      return m_detectorCacheFinalized;
+      return m_unsortedDetectorCache.empty();
     }
   }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1183,6 +1183,10 @@ size_t Instrument::detectorIndex(const detid_t detID) const {
 
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   const auto it = in_dets.find(detID);
+  if (it == in_dets.end()) {
+    throw Mantid::Kernel::Exception::NotFoundError("Instrument: Detector with ID not found in instrument: ",
+                                                   std::to_string(detID));
+  }
   return std::distance(in_dets.cbegin(), it);
 }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1241,6 +1241,8 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
           transformation.prescale(scale);
         }
       }
+      // keep track of the current detector in the base instrument
+      detIt++;
     }
 
     const auto componentId = componentInfo.componentID(i);
@@ -1266,8 +1268,6 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
     if ((relRot * toQuaterniond(baseComponent->getRelativeRot()).conjugate()).vec().norm() >= imag_norm_max) {
       pmap->addQuat(componentId, ParameterMap::rot(), Kernel::toQuat(relRot));
     }
-    // keep track of the current detector in the base instrument
-    detIt++;
   }
 
   return pmap;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -176,6 +176,9 @@ void Instrument::setPhysicalInstrument(std::unique_ptr<Instrument> physInst) {
 /**	Fills a copy of the detector cache
  */
 void Instrument::getDetectors(detid2det_map &out_map) const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't get detectors");
+
   out_map.clear();
   if (m_map) {
     // Get the base instrument detectors
@@ -195,6 +198,9 @@ void Instrument::getDetectors(detid2det_map &out_map) const {
 //------------------------------------------------------------------------------------------
 /** Return a vector of detector IDs in this instrument */
 std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't get detector IDs");
+
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   std::vector<detid_t> out;
   out.reserve(in_dets.size());
@@ -210,6 +216,9 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
  *  @return a vector holding detector ids of  monitors
  */
 std::vector<detid_t> Instrument::getMonitorIDs() const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't get monitor IDs");
+
   // Monitors cannot be parametrized. So just return the base.
   if (m_map)
     return m_instr->getMonitorIDs();
@@ -223,6 +232,9 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't get number of detectors");
+
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
 
   std::size_t numDetIDs = in_dets.size();

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -176,36 +176,32 @@ void Instrument::setPhysicalInstrument(std::unique_ptr<Instrument> physInst) {
 /**	Fills a copy of the detector cache
  */
 void Instrument::getDetectors(detid2det_map &out_map) const {
+  out_map.clear();
   if (m_map) {
     // Get the base instrument detectors
-    out_map.clear();
     const auto &in_dets = m_instr->m_detectorCache;
     // And turn them into parametrized versions
     for (const auto &in_det : in_dets) {
-      out_map.emplace(std::get<0>(in_det), getDetector(std::get<0>(in_det)));
+      out_map.emplace_hint(out_map.cend(), in_det.first, getDetector(in_det.first));
     }
   } else {
     // You can just return the detector cache directly.
-    out_map.clear();
-    for (const auto &in_det : m_detectorCache)
-      out_map.emplace(std::get<0>(in_det), std::get<1>(in_det));
+    for (const auto &in_det : m_detectorCache) {
+      out_map.emplace_hint(out_map.cend(), in_det.first, in_det.second.detector);
+    }
   }
 }
 
 //------------------------------------------------------------------------------------------
 /** Return a vector of detector IDs in this instrument */
 std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   std::vector<detid_t> out;
-  if (m_map) {
-    const auto &in_dets = m_instr->m_detectorCache;
-    for (const auto &in_det : in_dets)
-      if (!skipMonitors || !std::get<2>(in_det))
-        out.emplace_back(std::get<0>(in_det));
-  } else {
-    const auto &in_dets = m_detectorCache;
-    for (const auto &in_det : in_dets)
-      if (!skipMonitors || !std::get<2>(in_det))
-        out.emplace_back(std::get<0>(in_det));
+  out.reserve(in_dets.size());
+  for (const auto &in_det : in_dets) {
+    if (!skipMonitors || !in_det.second.isMonitor) {
+      out.emplace_back(in_det.first);
+    }
   }
   return out;
 }
@@ -220,33 +216,22 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 
   std::vector<detid_t> mons;
   for (const auto &item : m_detectorCache)
-    if (std::get<2>(item))
-      mons.emplace_back(std::get<0>(item));
+    if (item.second.isMonitor)
+      mons.emplace_back(item.first);
   return mons;
 }
 
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
-  std::size_t numDetIDs(0);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
 
-  if (m_map) {
-    numDetIDs = m_instr->m_detectorCache.size();
-  } else {
-    numDetIDs = m_detectorCache.size();
-  }
+  std::size_t numDetIDs = in_dets.size();
 
   if (skipMonitors) // this slow, but gets the right answer
   {
     std::size_t monitors(0);
-    if (m_map) {
-      const auto &in_dets = m_instr->m_detectorCache;
-      monitors =
-          std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return std::get<2>(in_det); });
-    } else {
-      const auto &in_dets = m_detectorCache;
-      monitors =
-          std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return std::get<2>(in_det); });
-    }
+    monitors =
+        std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.second.isMonitor; });
     return (numDetIDs - monitors);
   } else {
     return numDetIDs;
@@ -268,8 +253,8 @@ void Instrument::getMinMaxDetectorIDs(detid_t &min, detid_t &max) const {
   if (in_dets->empty())
     throw std::runtime_error("No detectors on this instrument. Can't find min/max ids");
   // Maps are sorted by key. So it is easy to find
-  min = std::get<0>(*in_dets->begin());
-  max = std::get<0>(*in_dets->rbegin());
+  min = in_dets->begin()->first;
+  max = in_dets->rbegin()->first;
 }
 
 /** Fill a vector with all the detectors contained (at any depth) in a named
@@ -449,25 +434,6 @@ std::vector<std::shared_ptr<const IComponent>> Instrument::getAllComponentsWithN
   return retVec;
 }
 
-namespace {
-// Helpers for accessing m_detectorCache, which is a vector of tuples used as a
-// map. Lookup is by first element in a tuple. Templated to support const and
-// non-const.
-template <class T> auto lower_bound(T &map, const detid_t key) -> decltype(map.begin()) {
-  return std::lower_bound(map.begin(), map.end(), std::make_tuple(key, IDetector_const_sptr(nullptr), false),
-                          [](const typename T::value_type &a, const typename T::value_type &b) -> bool {
-                            return std::get<0>(a) < std::get<0>(b);
-                          });
-}
-
-template <class T> auto find(T &map, const detid_t key) -> decltype(map.begin()) {
-  auto it = lower_bound(map, key);
-  if ((it != map.end()) && (std::get<0>(*it) == key))
-    return it;
-  return map.end();
-}
-} // namespace
-
 /**	Gets a pointer to the detector from its ID
  *  Note that for getting the detector associated with a spectrum, the
  * MatrixWorkspace::getDetector
@@ -484,14 +450,14 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't search for detector ID " +
                              std::to_string(detector_id));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detector_id);
-  if (it == baseInstr.m_detectorCache.end()) {
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = in_dets.find(detector_id);
+  if (it == in_dets.end()) {
     std::stringstream readInt;
     readInt << detector_id;
     throw Kernel::Exception::NotFoundError("Instrument: Detector with ID " + readInt.str() + " not found.", "");
   }
-  IDetector_const_sptr baseDet = std::get<1>(*it);
+  IDetector_const_sptr baseDet = it->second.detector;
 
   if (!m_map)
     return baseDet;
@@ -512,11 +478,12 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   if (!isFinalized())
     throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " +
                              std::to_string(detector_id));
-  auto it = find(m_instr->m_detectorCache, detector_id);
+
+  auto it = m_instr->m_detectorCache.find(detector_id);
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
   }
-  return std::get<1>(*it).get();
+  return it->second.detector.get();
 }
 
 bool Instrument::isMonitor(const detid_t &detector_id) const {
@@ -525,11 +492,11 @@ bool Instrument::isMonitor(const detid_t &detector_id) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't search for monitor ID " +
                              std::to_string(detector_id));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detector_id);
-  if (it == baseInstr.m_detectorCache.end())
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = in_dets.find(detector_id);
+  if (it == in_dets.end())
     return false;
-  return std::get<2>(*it);
+  return it->second.isMonitor;
 }
 
 bool Instrument::isMonitor(const std::set<detid_t> &detector_ids) const {
@@ -664,12 +631,12 @@ void Instrument::markAsDetector(const IDetector *det) {
 
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  auto it = lower_bound(m_detectorCache, det->getID());
+  auto it = m_detectorCache.lower_bound(det->getID());
   // Duplicate detector ids are forbidden
-  if ((it != m_detectorCache.end()) && (std::get<0>(*it) == det->getID())) {
+  if ((it != m_detectorCache.end()) && (it->first == det->getID())) {
     raiseDuplicateDetectorError(det->getID());
   }
-  m_detectorCache.emplace(it, det->getID(), det_sptr, false);
+  m_detectorCache.emplace_hint(it, det->getID(), DetectorCacheEntry{det_sptr, false});
 }
 
 /// As markAsDetector but without the required sorting. Must call
@@ -679,10 +646,9 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsDetector() called on a "
                              "parametrized Instrument object.");
 
-  m_detectorCacheFinalized = false;
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  m_detectorCache.emplace_back(det->getID(), det_sptr, false);
+  m_unsortedDetectorCache.emplace_back(det->getID(), DetectorCacheEntry{det_sptr, false});
 }
 
 /// Sorts the detector cache. Called after all detectors have been marked via
@@ -694,20 +660,28 @@ void Instrument::markAsDetectorFinalize() {
 
   // Detectors (even when different objects) are NOT allowed to have duplicate
   // ids. This method establishes the presence of duplicates.
-  std::sort(
-      m_detectorCache.begin(), m_detectorCache.end(),
-      [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
-         const std::tuple<detid_t, IDetector_const_sptr, bool> &b) -> bool { return std::get<0>(a) < std::get<0>(b); });
+  std::sort(m_unsortedDetectorCache.begin(), m_unsortedDetectorCache.end(),
+            [](std::pair<detid_t, DetectorCacheEntry> const &a,
+               std::pair<detid_t, DetectorCacheEntry> const &b) -> bool { return a.first < b.first; });
 
-  auto resultIt = std::adjacent_find(m_detectorCache.begin(), m_detectorCache.end(),
-                                     [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
-                                        const std::tuple<detid_t, IDetector_const_sptr, bool> &b) -> bool {
-                                       return std::get<0>(a) == std::get<0>(b);
-                                     });
-  if (resultIt != m_detectorCache.end()) {
-    raiseDuplicateDetectorError(std::get<0>(*resultIt));
+  auto resultIt =
+      std::adjacent_find(m_unsortedDetectorCache.begin(), m_unsortedDetectorCache.end(),
+                         [](std::pair<detid_t, DetectorCacheEntry> const &a,
+                            std::pair<detid_t, DetectorCacheEntry> const &b) -> bool { return a.first == b.first; });
+  if (resultIt != m_unsortedDetectorCache.end()) {
+    raiseDuplicateDetectorError(resultIt->first);
   }
-  m_detectorCacheFinalized = true;
+
+  // now insert the values into the map
+  for (auto &item : m_unsortedDetectorCache) {
+    auto it = m_detectorCache.lower_bound(item.first);
+    if (it != m_detectorCache.end() && it->first == item.first) {
+      raiseDuplicateDetectorError(item.first);
+    } else {
+      m_detectorCache.emplace_hint(it, item.first, std::move(item.second));
+    }
+  }
+  m_unsortedDetectorCache.clear();
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -733,8 +707,8 @@ void Instrument::markAsMonitor(const IDetector *det) {
   markAsDetector(det);
 
   // mark detector as a monitor
-  auto it = find(m_detectorCache, det->getID());
-  std::get<2>(*it) = true;
+  auto it = m_detectorCache.find(det->getID());
+  it->second.isMonitor = true;
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -748,10 +722,9 @@ void Instrument::markAsMonitorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsMonitorIncomplete() called on a "
                              "parametrized Instrument object.");
 
-  m_detectorCacheFinalized = false;
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  m_detectorCache.emplace_back(det->getID(), det_sptr, true);
+  m_unsortedDetectorCache.emplace_back(det->getID(), DetectorCacheEntry{det_sptr, true});
 }
 
 /** Removes a detector from the instrument and from the detector cache.
@@ -768,8 +741,12 @@ void Instrument::removeDetector(IDetector *det) {
 
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
-  const auto it = find(m_detectorCache, id);
-  m_detectorCache.erase(it);
+  const auto it = m_detectorCache.find(id);
+  if (it != m_detectorCache.end()) {
+    m_detectorCache.erase(it);
+  } else {
+    g_log.warning() << "Attempted to remove a detector with ID " << id << " that is not in the instrument.\n";
+  }
 
   // Remove it from the parent assembly (and thus the instrument). Evilness
   // required here unfortunately.
@@ -1178,11 +1155,10 @@ bool Instrument::addAssemblyChildrenToQueue(std::queue<IComponent_const_sptr> &q
 }
 
 /// Temporary helper for refactoring. Argument is index, *not* ID!
+/// NOTE: Slow. Try to use isMonitor(detid_t) instead.
 bool Instrument::isMonitorViaIndex(const size_t index) const {
-  if (m_map)
-    return std::get<2>(m_instr->m_detectorCache[index]);
-  else
-    return std::get<2>(m_detectorCache[index]);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  return std::next(in_dets.cbegin(), index)->second.isMonitor;
 }
 
 bool Instrument::isEmptyInstrument() const { return this->nelements() == 0; }
@@ -1193,9 +1169,9 @@ size_t Instrument::detectorIndex(const detid_t detID) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't get detector index for ID " +
                              std::to_string(detID));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detID);
-  return std::distance(baseInstr.m_detectorCache.cbegin(), it);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = in_dets.find(detID);
+  return std::distance(in_dets.cbegin(), it);
 }
 
 /// Returns a legacy ParameterMap, containing information that is now stored in
@@ -1227,6 +1203,7 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
 
   const auto &componentInfo = getParameterMap()->componentInfo();
   const auto &detectorInfo = getParameterMap()->detectorInfo();
+  auto detIt = baseInstr.m_detectorCache.cbegin(); // an iterator tracking inside with index i inside instrument
   for (size_t i = 0; i < componentInfo.size(); ++i) {
 
     const int64_t parentIndex = componentInfo.parent(i);
@@ -1243,11 +1220,9 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
     }
 
     if (componentInfo.isDetector(i)) {
-
-      const std::shared_ptr<const IDetector> &baseDet = std::get<1>(baseInstr.m_detectorCache[i]);
-
       isDetFixedInBank = ComponentInfoBankHelpers::isDetectorFixedInBank(componentInfo, i);
       if (detectorInfo.isMasked(i)) {
+        auto const &baseDet = detIt->second.detector;
         pmap->forceUnsafeSetMasked(baseDet.get(), true);
       }
 
@@ -1291,6 +1266,8 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
     if ((relRot * toQuaterniond(baseComponent->getRelativeRot()).conjugate()).vec().norm() >= imag_norm_max) {
       pmap->addQuat(componentId, ParameterMap::rot(), Kernel::toQuat(relRot));
     }
+    // keep track of the current detector in the base instrument
+    detIt++;
   }
 
   return pmap;

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -317,7 +317,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
   (*m_detectorRotations)[detectorIndex] = Kernel::toQuaterniond(detector.getRotation());
   (*m_shapes)[detectorIndex] = detector.shape();
   (*m_scaleFactors)[detectorIndex] = Kernel::toVector3d(detector.getScaleFactor());
-  if (m_instrument->isMonitorViaIndex(detectorIndex)) {
+  if (m_instrument->isMonitor(detector.getID())) {
     m_monitorIndices->emplace_back(detectorIndex);
   }
   (*m_names)[detectorIndex] = detector.getName();


### PR DESCRIPTION
### Description of work

The `Instrument` object defines a detector cache.  Though the logic of the cache should follow that of an ordered map, at some point this cache was implemented as vector.  This implementation had tradeoffs.

On the positive side, detectors could be more quickly inserted into the cache.  For a vector, inserting an element is $O(1)$, and inserting $n$ elements is $O(n)$; the cache can then be sorted later at $O(\log N)$.  With an ordered map, each must have its correct location determined first which is $O(\log N)$, so the total time-complexity is $O(n \log N)$.  It also makes lookup by detector index significantly faster.

On the negative side, searching for an element becomes $O(N)$.  One particularly bad side-effect is that any operation needing to loop over and lookup each detector in the instrument ended up taking $O(N^2)$.  For an instrument like MANDI, with +2,400,000 pixels, this takes multiple hours.

The error was discovered as the cause of a user-reported error, where calling `LoadEventNexus` for a single bank for data in the MANDI instrument was apparently freezing.

Previous work removed the feature to delete unused banks in MANDI and TOPAZ instruments (the section of code causing the freeze), and then to add a flag to ensure a finalized instrument.

This PR continues, getting the best of both worlds by using an ordered map as the cache (automatically sorted), with an unsorted temporary vector cache for faster insertion.  Because PR #41187 guarantees the instrument ins finalized before any use, the unsorted temporary cache can be filled quickly, then sorted and placed into the detector cache quickly, keeping time complexity at $O(\log N)$.  Because the detectors are in an ordered map, lookup is also down to $O(\log N)$.

Refs:
- [EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15489&tab=com.ibm.team.workitem.tab.links)
- PR #41183 
- PR #41187 

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
