### PR TITLE
Split buildscript for separate github action steps

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -80,7 +80,8 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           frozen: true
-          post-cleanup: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           # ${{ runner.temp }}\Scripts\pixi.exe on Windows
           pixi-bin-path: ${{ runner.temp }}/bin/pixi
 

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           source ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/pixi-utils
           install_pixi
-          echo "Add pixi to path for future use"
+          # Add pixi to path for use in other steps
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
 
       - name: Clean build tree
         # supplying --clean-build or CLEAN_BUILD=true should be added here
@@ -90,16 +91,25 @@ jobs:
       - name: Build code
         run: |
           cd ${GITHUB_WORKSPACE}
-          export PATH="$PATH:$HOME/.pixi/bin"
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY $EXTRA_CMAKE_FLAGS
 
-      - name: Run unit tests and system tests on Linux
+      - name: Run unit tests
         run: |
           cd ${GITHUB_WORKSPACE}
           # Not physical but logical cores, includes hyper threaded - different for darwin
           BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
-          export PATH="$PATH:$HOME/.pixi/bin"
-          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
+          # bool flags for this are
+          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false true $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
+
+      - name: Run system tests
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          # Not physical but logical cores, includes hyper threaded - different for darwin
+          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          # bool flags for this are
+          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} true false $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
       - name: Upload build and test log artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -50,6 +50,17 @@ jobs:
     # Otherwise set it to the value the user specified when they clicked "Run Workflow"
     #
 
+    env:
+      CMAKE_PRESET: linux-64-ci
+      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
+      ENABLE_BUILD_CODE: true
+      ENABLE_UNIT_TESTS: true
+      ENABLE_SYSTEM_TESTS: true # default is false
+      ENABLE_DOCS: false
+      ENABLE_DOC_TESTS: false
+      ENABLE_DEV_DOCS: false
+      ENABLE_COVERITY: false
+
     steps:
       - name: Print shell environment vars (debug)
         if: github.event_name == 'workflow_dispatch'
@@ -66,8 +77,25 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
+      - uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          frozen: true
+
+      - name: Clean build tree
+        # supplying --clean-build or CLEAN_BUILD=true should be added here
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+
+      - name: Build code
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY $EXTRA_CMAKE_FLAGS
+
       - name: Run unit tests and system tests on Linux
-        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/conda-buildscript ${GITHUB_WORKSPACE} linux-64-ci --enable-systemtests
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          # Not physical but logical cores, includes hyper threaded - different for darwin
+          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
       - name: Upload build and test log artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -80,6 +80,9 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           frozen: true
+          post-cleanup: true
+          # ${{ runner.temp }}\Scripts\pixi.exe on Windows
+          pixi-bin-path: ${{ runner.temp }}/bin/pixi
 
       - name: Clean build tree
         # supplying --clean-build or CLEAN_BUILD=true should be added here

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -77,13 +77,19 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
-      - uses: prefix-dev/setup-pixi@v0.9.4
-        with:
-          frozen: true
-          cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          # ${{ runner.temp }}\Scripts\pixi.exe on Windows
-          pixi-bin-path: ${{ runner.temp }}/bin/pixi
+      # TODO remove one of these pixi setup steps
+      - name: Install pixi
+        run: |
+          source ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/pixi-utils
+          install_pixi
+
+      #- uses: prefix-dev/setup-pixi@v0.9.4
+      #  with:
+      #    frozen: true
+      #    cache: true
+      #    cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+      #    # ${{ runner.temp }}\Scripts\pixi.exe on Windows
+      #    pixi-bin-path: ${{ runner.temp }}/bin/pixi
 
       - name: Clean build tree
         # supplying --clean-build or CLEAN_BUILD=true should be added here

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -77,19 +77,11 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
-      # TODO remove one of these pixi setup steps
       - name: Install pixi
         run: |
           source ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/pixi-utils
           install_pixi
-
-      #- uses: prefix-dev/setup-pixi@v0.9.4
-      #  with:
-      #    frozen: true
-      #    cache: true
-      #    cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-      #    # ${{ runner.temp }}\Scripts\pixi.exe on Windows
-      #    pixi-bin-path: ${{ runner.temp }}/bin/pixi
+          echo "Add pixi to path for future use"
 
       - name: Clean build tree
         # supplying --clean-build or CLEAN_BUILD=true should be added here
@@ -98,6 +90,7 @@ jobs:
       - name: Build code
         run: |
           cd ${GITHUB_WORKSPACE}
+          export PATH="$PATH:$HOME/.pixi/bin"
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY $EXTRA_CMAKE_FLAGS
 
       - name: Run unit tests and system tests on Linux
@@ -105,7 +98,8 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           # Not physical but logical cores, includes hyper threaded - different for darwin
           BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
-          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
+          export PATH="$PATH:$HOME/.pixi/bin"
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
       - name: Upload build and test log artifacts
         uses: actions/upload-artifact@v7

--- a/buildconfig/Jenkins/Conda/clean-builder
+++ b/buildconfig/Jenkins/Conda/clean-builder
@@ -68,7 +68,5 @@ fi
 rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
 # Remove test logs from previous builds
 rm -rf  $BUILD_DIR/test_logs
-# Remake the directory for the test logs.
-mkdir $BUILD_DIR/test_logs
 
 popd # go back to starting location

--- a/buildconfig/Jenkins/Conda/clean-builder
+++ b/buildconfig/Jenkins/Conda/clean-builder
@@ -18,8 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 start_time=$(date +%s)
 
 # Check arguments passed are 2 or higher, and aren't optional flags.
-if [[ $# < 2 || $1 == "--"* || $2 == "--"* ]]; then
-    echo "Pass 1 argument followed by optional flags usage: conda-buildscript <path-to-workspace> [options]"
+if [[ $# < 1 || $1 == "--"* || $2 == "--"* ]]; then
+    echo "Pass 1 argument followed by optional flags usage: clean-builder <path-to-workspace> [options]"
     exit 1
 fi
 

--- a/buildconfig/Jenkins/Conda/clean-builder
+++ b/buildconfig/Jenkins/Conda/clean-builder
@@ -1,0 +1,74 @@
+#!/bin/bash -ex
+
+# This script expects to be in a POSIX environment, it will run our CI workflow on a POSIX environment depending
+# on the flags and args passed. This script will clean up build areas
+#
+# Script usage:
+# clean-builder <path-to-workspace> [options]
+#
+# Example command to run a PR build on ubuntu:
+# clean-builder /jenkins/workspace_dir/
+#
+# Expected args:
+#   1. WORKSPACE: path to the workspace/source code that this should run inside
+#
+# Possible flags:
+#   --clean-build: Clear the build folder and build from scratch
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+start_time=$(date +%s)
+
+# Check arguments passed are 2 or higher, and aren't optional flags.
+if [[ $# < 2 || $1 == "--"* || $2 == "--"* ]]; then
+    echo "Pass 1 argument followed by optional flags usage: conda-buildscript <path-to-workspace> [options]"
+    exit 1
+fi
+
+WORKSPACE=$1
+shift
+
+BUILD_DIR=$WORKSPACE/build
+
+CLEAN_BUILD=false
+
+# Handle flag inputs
+while [ ! $# -eq 0 ]
+do
+    case "$1" in
+        --clean-build) CLEAN_BUILD=true ;;
+        *)
+            echo "Argument not accepted: $1"
+            exit 1
+            ;;
+  esac
+  shift
+done
+
+# Clean the source tree to remove stale configured files. Only remove
+# the build and Miniforge directories if this is a clean build
+pushd $WORKSPACE
+if [[ $CLEAN_BUILD  == true ]]; then
+    # git clean will delete most things in build but leave subrepositories such as build/_deps/span-src
+    # so we need to remove the whole of build/ by hand
+    rm -fr $BUILD_DIR
+    rm -fr "$WORKSPACE/.pixi/" # less logs with rm
+else
+    git_clean_excludes_extra="--exclude=build --exclude=miniforge --exclude=.pixi"
+fi
+# -d is recurse into directories
+# -x ignores what is listed in the .gitignore
+git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
+
+# Delete old files from incremental builds
+if [ -d $BUILD_DIR ]; then
+    rm -rf ${BUILD_DIR}/bin ${BUILD_DIR}/ExternalData ${BUILD_DIR}/Testing
+    find $WORKSPACE \( -iname 'TEST-*.xml' -o -name 'Test.xml' \) -delete
+fi
+
+# Clean up artifacts from previous builds
+rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
+# Remove test logs from previous builds
+rm -rf  $BUILD_DIR/test_logs
+# Remake the directory for the test logs.
+mkdir $BUILD_DIR/test_logs
+
+popd # go back to starting location

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -110,20 +110,14 @@ do
   shift
 done
 
-# Clean the source tree to remove stale configured files. Only remove
-# the build and Miniforge directories if this is a clean build
-pushd $WORKSPACE
+# Clean the source tree to remove stale configured files
 if [[ $CLEAN_BUILD  == true ]]; then
-    # git clean will delete most things in build but leave subrepositories such as build/_deps/span-src
-    # so we need to remove the whole of build/ by hand
-    rm -fr $BUILD_DIR
-    rm -fr "$WORKSPACE/.pixi/" # less logs with rm
+    $SCRIPT_DIR/clean-builder --clean-build
 else
-    git_clean_excludes_extra="--exclude=build --exclude=miniforge --exclude=.pixi"
+    $SCRIPT_DIR/clean-builder
 fi
-# -d is recurse into directories
-# -x ignores what is listed in the .gitignore
-git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra
+
+pushd $WORKSPACE
 
 # install pixi if not already installed
 install_pixi
@@ -140,16 +134,10 @@ if [ -d $BUILD_DIR ]; then
       ENABLE_SYSTEM_TESTS=false
       ENABLE_DOC_TESTS=false
     fi
-    rm -rf ${BUILD_DIR}/bin ${BUILD_DIR}/ExternalData ${BUILD_DIR}/Testing
-    find $WORKSPACE \( -iname 'TEST-*.xml' -o -name 'Test.xml' \) -delete
 else
   mkdir -p $BUILD_DIR
 fi
 
-# Clean up artifacts from previous builds
-rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
-# Remove test logs from previous builds
-rm -rf  $BUILD_DIR/test_logs
 # Remake the directory for the test logs.
 mkdir $BUILD_DIR/test_logs
 

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -139,7 +139,7 @@ else
 fi
 
 # Remake the directory for the test logs.
-mkdir $BUILD_DIR/test_logs
+mkdir -p $BUILD_DIR/test_logs
 
 # Set locale to avoid problems building the docs
 # See https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -22,7 +22,6 @@
 #   --enable-doctests: Run the documentation tests
 #   --enable-coverity: Run coverity and submit results; ignores all other options and does not run unit tests
 #   --clean-build: Clear the build folder and build from scratch
-#   --clean-external-projects: Clear the external projects from the build folder
 #
 # Possible parameters:
 #   --extra-cmake-flags: Extra flags to pass directly to cmake, enclose in "", defaults to nothing
@@ -61,7 +60,6 @@ ENABLE_DOC_TESTS=false
 ENABLE_DEV_DOCS=false
 ENABLE_COVERITY=false
 CLEAN_BUILD=false
-CLEAN_EXTERNAL_PROJECTS=false
 EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 
 # This removes '-ci' from the end of the cmake preset to get the target platform
@@ -96,7 +94,6 @@ do
             ENABLE_UNIT_TESTS=false
 	    ;;
         --clean-build) CLEAN_BUILD=true ;;
-        --clean-external-projects) CLEAN_EXTERNAL_PROJECTS=true ;;
         --extra-cmake-flags)
             EXTRA_CMAKE_FLAGS="$2"
             shift
@@ -147,11 +144,6 @@ if [ -d $BUILD_DIR ]; then
     find $WORKSPACE \( -iname 'TEST-*.xml' -o -name 'Test.xml' \) -delete
 else
   mkdir -p $BUILD_DIR
-fi
-
-if [[ ${CLEAN_EXTERNAL_PROJECTS} == true ]]; then
-    rm -rf $BUILD_DIR/eigen-*
-    rm -rf $BUILD_DIR/googletest-*
 fi
 
 # Clean up artifacts from previous builds

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -112,9 +112,9 @@ done
 
 # Clean the source tree to remove stale configured files
 if [[ $CLEAN_BUILD  == true ]]; then
-    $SCRIPT_DIR/clean-builder --clean-build
+    $SCRIPT_DIR/clean-builder $WORKSPACE --clean-build
 else
-    $SCRIPT_DIR/clean-builder
+    $SCRIPT_DIR/clean-builder $WORKSPACE
 fi
 
 pushd $WORKSPACE


### PR DESCRIPTION
This job breaks up the work of `buildconfig/Jenkins/Conda/conda-buildscript` into separate steps of "clean," "build," and "test." This increased granularity makes it easier to see where in the chain the failure came from and reduces the amount of logs you have to read to see the specific error.

The variables that were parsed via command line arguments and positional arguments are now supplied as "env" variables in the job as a whole.

As bonus items, this removes the "clean external projects" option from buildscripts because all dependencies are now supplied by conda.

Refs #39497 

### To test:

Look at the steps for the PR build for linux with github-actions. They should be easier to navigate and still pass.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
