### PR TITLE
Remove the delete banks feature from `LoadEventNexus`

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -169,7 +169,7 @@ void checkDetectorInfoSize(const Instrument &instr, const Geometry::DetectorInfo
   if (numDets != detInfo.size())
     throw std::runtime_error("ExperimentInfo: size mismatch between "
                              "DetectorInfo and number of detectors in "
-                             "instrument" +
+                             "instrument: " +
                              std::to_string(numDets) + " vs " + std::to_string(detInfo.size()));
 }
 } // namespace

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1146,15 +1146,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
 
   prog->report("Initializing all pixels");
 
-  // Remove unused banks if parameter is set
-  if (m_ws->getInstrument()->hasParameter("remove-unused-banks")) {
-    std::vector<double> instrumentUnused = m_ws->getInstrument()->getNumberParameter("remove-unused-banks", true);
-    if (!instrumentUnused.empty()) {
-      const auto unused = static_cast<int>(instrumentUnused.front());
-      if (unused == 1)
-        deleteBanks(m_ws, bankNames);
-    }
-  }
   //----------------- Pad Empty Pixels -------------------------------
   createSpectraMapping(m_filename, monitors, someBanks);
 

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41183.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41183.rst
@@ -1,1 +1,1 @@
-* The algorithm `LoadEventNexus` will no longer delete unused banks for the TOPAZ and MANDI instruments.  This feature had not truly worked since Mantid 6.6, and was causing long loading times or errors.
+- The algorithm `LoadEventNexus` will no longer delete unused banks for the TOPAZ and MANDI instruments.  This feature had not truly worked since Mantid 6.6, and was causing long loading times or errors.

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41183.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41183.rst
@@ -1,0 +1,1 @@
+* The algorithm `LoadEventNexus` will no longer delete unused banks for the TOPAZ and MANDI instruments.  This feature had not truly worked since Mantid 6.6, and was causing long loading times or errors.


### PR DESCRIPTION
### Description of work

Just over 13 years ago, at request of TOPAZ users, `LoadEventNexus` was updated so that for the two instruments MANDI and TOPAZ, if users selected to load a single bank, then the algorithm would also delete all of the other banks from the instrument.
- [the commit (pre-PRs)](https://github.com/mantidproject/mantid/commit/406d04f3bc5e5833f76c8d8ea01998585e51eefb)
- [a related ticket](https://trac.mantidproject.org/mantid/ticket/9606)

Recently, a user noted that for MANDI (run 13064), loading the entire file takes a few seconds, while loading a single bank takes several hours (or more... I let it run overnight and it finished, but didn't get a precise time).

This issue is related to a problem in how the `Instrument`'s detector cache was defined: it is defined as a vector when it really wants to be an ordered map.  This means the operations `find` and `lower_bound`, acting on the cache, take $O(N)$ so that the overall process is $O(N^2)$ if not $O(N^3)$, and in the case of MANDI acting over 2,400,000 pixels.  The problem can be fixed by switching to an ordered map, but this leads to other issues due to the finalization state (see [PR 41176](https://github.com/mantidproject/mantid/pull/41176)).

While trying to fix this time-delay problem, I noted another problem.  Even when the time complexity issue is fixed, so that deletion process finishes, there is no output workspace produced due to an error that is raised within  `ExperimentInfo` that ensures the instrument and the detector info objects match in size.

Using VULCAN run 189186 and only loading bank 23, I was able to show that the latter error was present as far back as Mantid 6.6 (from Feb 2023).

Because we must have at least three years of this feature not working, the most sensible solution is just to remove this feature.  The minimal way to remove it is to just delete this code block that calls the `deleteBanks()` method.  The method that actually does the deletion is still there, in case later users ask for this feature back.

Related to:
[EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15489)

A previous attempt, only deleting banks.  Finished quickly, but left dangling references.
PR #41063

### To test:

Please follow these steps. 

1. Get the MANDI file, `"/SNS/MANDI/IPTS-34720/nexus/MANDI_13064.nxs.h5"`
2. From `main`, build and run workbench.  Run this script
```python
outws = LoadEventNexus("MANDI_13064.nxs.h5", BankName="bank26")
```
3. Verify, this hangs, taking more than five minutes.  
4. Now run from `main` without the `BankName` parameter, and it finishes in a few seconds.  This proves the time-complexity issue.
5. We will run with a VULCAN run which will finish, but we need to do some work.  First, open the `VULCAN_Parameters.xml` file and add this code block somewhere near the top:
```xml
<component-link name = "VULCAN">
<!-- Specify that any banks not in NeXus file are to be removed -->
<parameter name="remove-unused-banks">
  <value val="1"/>
</parameter>
</component-link>
```
6. Open `CompAssembly.cpp`, and comment-out L167 (this throws an error if a component isn't found):
```cpp
  } else {
    //throw std::runtime_error("Component " + comp->getName() + " is not a child of this assembly.");
  }
```
7. Now run from `main` this script (you may need to `ninja SystemTest` first)
```python
file = "~/mantid/build/ExternalData/Testing/Data/SystemTest/VULCAN_189186.nxs.h5"
outws = LoadEventNexus(file, BankName = "bank23")
```
8. Verify that this finishes, but with an error about mismatching instrument and detector info.
9. Now build this branch and run both scripts.  They should finish in a few seconds, and without errors.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
