### PR TITLE
Remember the `Draw Shapes` setting in new Instrument View

### DIFF
--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -221,6 +221,9 @@ Mantid Graphical User Interface Properties
 | ``InstrumentView.MaintainAspectRatio``             |Value of the "Maintain Aspect Ratio" option in the  | ``Yes``, ``No`` |
 |                                                    |Instrument View                                     |                 |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``InstrumentView.DrawShapes``                      |Value of the "Draw Shapes" option in the Instrument | ``Yes``, ``No`` |
+|                                                    |View                                                |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``MantidOptions.InvisibleWorkspaces``              |Do not show 'invisible' workspaces                  | ``0``, ``1``    |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``PeakColumn.hklPrec``                             |Precision of hkl values shown in tables             | ``2``           |

--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/41144.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/41144.rst
@@ -1,0 +1,1 @@
+- In the new Instrument View, the "Draw Shapes" option is now stored in the Mantid properties file, and the option is applied when the view is opened. This means that if you check "Draw Shapes", close the view, and open it again, it will still be checked and shapes will be drawn. The option is stored under the key "InstrumentView.DrawShapes".

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -80,7 +80,7 @@ class FullInstrumentViewPresenter:
         self._point_cloud_renderer = PointCloudRenderer()
         self._shape_renderer = ShapeRenderer(self._model.workspace)
         self._sbs_shape_renderer = SideBySideShapeRenderer(self._model.workspace)
-        self._renderer = self._point_cloud_renderer
+        self._renderer = self._shape_renderer if view.is_show_shapes_checkbox_checked() else self._point_cloud_renderer
         self._select_bank_tube = False
         self.setup()
         self._callback_queue = Queue()
@@ -705,6 +705,7 @@ class FullInstrumentViewPresenter:
         self.update_plotter()
 
     def on_show_shapes_toggled(self, checked: bool) -> None:
+        self._view.store_draw_shapes_option()
         self._callback_queue.put((self._on_show_shapes_toggled, (checked,)))
 
     def _reload_renderers(self) -> None:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -99,7 +99,8 @@ class FullInstrumentViewWindow(QMainWindow):
     detector, and a line plot of selected detector(s)"""
 
     _detector_spectrum_fig = None
-    _ASPECT_RATIO_SETTING_STRING = "InstrumentView.MaintainAspectRato"
+    _ASPECT_RATIO_SETTING_STRING = "InstrumentView.MaintainAspectRatio"
+    _DRAW_SHAPES_SETTING_STRING = "InstrumentView.DrawShapes"
 
     def __init__(self, parent=None, off_screen=False):
         """The instrument in the given workspace will be displayed. The off_screen option is for testing or rendering an image
@@ -196,8 +197,11 @@ class FullInstrumentViewWindow(QMainWindow):
             "If checked, the detectors will be drawn in 2D projections in their original aspect ratio, "
             "otherwise they will fill the available area."
         )
-        aspect_ratio_option = ConfigService.Instance()[self._ASPECT_RATIO_SETTING_STRING]
-        self._aspect_ratio_check_box.setChecked(aspect_ratio_option.casefold() == "yes")
+
+        def is_config_setting_true(key: str) -> bool:
+            return ConfigService.Instance()[key].casefold() == "yes"
+
+        self._aspect_ratio_check_box.setChecked(is_config_setting_true(self._ASPECT_RATIO_SETTING_STRING))
         self._show_monitors_check_box = QCheckBox()
         self._show_monitors_check_box.setText("Show Monitors?")
         self._count_scale_combo_box = NoWheelComboBox(self)
@@ -211,6 +215,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self._select_bank_tube.setCheckable(True)
         self._show_shapes_check_box = QCheckBox()
         self._show_shapes_check_box.setText("Draw Shapes")
+        self._show_shapes_check_box.setChecked(is_config_setting_true(self._DRAW_SHAPES_SETTING_STRING))
         self._show_shapes_check_box.setToolTip(
             "If checked, detectors are drawn using their actual geometric shapes "
             "(cuboids, cylinders, etc.) instead of points. May be slower for large instruments."
@@ -359,8 +364,14 @@ class FullInstrumentViewWindow(QMainWindow):
         return self._aspect_ratio_check_box.isChecked()
 
     def store_maintain_aspect_ratio_option(self) -> None:
-        option = "Yes" if self.is_maintain_aspect_ratio_checkbox_checked() else "No"
-        ConfigService.Instance()[self._ASPECT_RATIO_SETTING_STRING] = option
+        self._store_checkbox_option(self._aspect_ratio_check_box, self._ASPECT_RATIO_SETTING_STRING)
+
+    def store_draw_shapes_option(self) -> None:
+        self._store_checkbox_option(self._show_shapes_check_box, self._DRAW_SHAPES_SETTING_STRING)
+
+    def _store_checkbox_option(self, checkbox: QCheckBox, config_key: str) -> None:
+        option = "Yes" if checkbox.isChecked() else "No"
+        ConfigService.Instance()[config_key] = option
 
     def enable_or_disable_aspect_ratio_box(self) -> None:
         self._aspect_ratio_check_box.setDisabled(self.current_selected_projection() == ProjectionType.THREE_D)

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -11,6 +11,7 @@ from instrumentview.Peaks.DetectorPeaks import DetectorPeaks
 from instrumentview.Peaks.Peak import Peak
 from instrumentview.Projections.ProjectionType import ProjectionType
 from instrumentview.renderers.shape_renderer import ShapeRenderer
+from instrumentview.renderers.side_by_side_shape_renderer import SideBySideShapeRenderer
 from instrumentview.renderers.point_cloud_renderer import PointCloudRenderer
 
 
@@ -758,14 +759,19 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self.assertIs(shape_renderer1, shape_renderer2)
         self.assertEqual(mock_update_plotter.call_count, 3)
 
-    def test_on_show_shapes_toggled_stores_draw_shapes_option_when_enabled(self):
-        """Test that on_show_shapes_toggled calls store_draw_shapes_option on the view when checked."""
-        self._presenter.on_show_shapes_toggled(True)
-        self._mock_view.store_draw_shapes_option.assert_called_once()
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
+    def test_on_show_shapes_toggled_side_by_side_uses_sbs_renderer(self, mock_update_plotter):
+        """Test that enabling shapes with SIDE_BY_SIDE projection switches to SideBySideShapeRenderer."""
+        self._model.projection_type = ProjectionType.SIDE_BY_SIDE
+        self._presenter._on_show_shapes_toggled(checked=True)
+        self.assertIsInstance(self._presenter._renderer, SideBySideShapeRenderer)
+        self.assertIs(self._presenter._renderer, self._presenter._sbs_shape_renderer)
+        mock_update_plotter.assert_called_once()
 
-    def test_on_show_shapes_toggled_stores_draw_shapes_option_when_disabled(self):
-        """Test that on_show_shapes_toggled calls store_draw_shapes_option on the view when unchecked."""
-        self._presenter.on_show_shapes_toggled(False)
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.update_plotter")
+    def test_on_show_shapes_toggled_stores_draw_shapes_option(self, mock_update_plotter):
+        """Test that on_show_shapes_toggled calls store_draw_shapes_option on the view when toggled."""
+        self._presenter.on_show_shapes_toggled(True)
         self._mock_view.store_draw_shapes_option.assert_called_once()
 
 

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -758,6 +758,16 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self.assertIs(shape_renderer1, shape_renderer2)
         self.assertEqual(mock_update_plotter.call_count, 3)
 
+    def test_on_show_shapes_toggled_stores_draw_shapes_option_when_enabled(self):
+        """Test that on_show_shapes_toggled calls store_draw_shapes_option on the view when checked."""
+        self._presenter.on_show_shapes_toggled(True)
+        self._mock_view.store_draw_shapes_option.assert_called_once()
+
+    def test_on_show_shapes_toggled_stores_draw_shapes_option_when_disabled(self):
+        """Test that on_show_shapes_toggled calls store_draw_shapes_option on the view when unchecked."""
+        self._presenter.on_show_shapes_toggled(False)
+        self._mock_view.store_draw_shapes_option.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -164,6 +164,46 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         mock_repr.SetWidgetBounds.assert_called_with([1 - border, 2 + border, 1 - border, 2 + border, 0, 1])
         self.assertEqual(self._view._current_widget, mock_cylinder_widget())
 
+    @mock.patch("instrumentview.FullInstrumentViewWindow.ConfigService")
+    def test_store_draw_shapes_option_stores_yes_when_checked(self, mock_config):
+        self._view._show_shapes_check_box.setChecked(True)
+        self._view.store_draw_shapes_option()
+        mock_config.Instance.return_value.__setitem__.assert_called_once_with(self._view._DRAW_SHAPES_SETTING_STRING, "Yes")
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.ConfigService")
+    def test_store_draw_shapes_option_stores_no_when_unchecked(self, mock_config):
+        self._view._show_shapes_check_box.setChecked(False)
+        self._view.store_draw_shapes_option()
+        mock_config.Instance.return_value.__setitem__.assert_called_once_with(self._view._DRAW_SHAPES_SETTING_STRING, "No")
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.FigureCanvas")
+    @mock.patch("qtpy.QtWidgets.QHBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QVBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.ConfigService")
+    def test_draw_shapes_checkbox_initialised_checked_when_config_is_yes(
+        self, mock_config, mock_plotter, mock_splitter, mock_v_layout, mock_h_layout, mock_canvas
+    ):
+        mock_config.Instance.return_value.__getitem__.return_value = "Yes"
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            view = FullInstrumentViewWindow()
+        self.assertTrue(view.is_show_shapes_checkbox_checked())
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.FigureCanvas")
+    @mock.patch("qtpy.QtWidgets.QHBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QVBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.ConfigService")
+    def test_draw_shapes_checkbox_initialised_unchecked_when_config_is_no(
+        self, mock_config, mock_plotter, mock_splitter, mock_v_layout, mock_h_layout, mock_canvas
+    ):
+        mock_config.Instance.return_value.__getitem__.return_value = "No"
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            view = FullInstrumentViewWindow()
+        self.assertFalse(view.is_show_shapes_checkbox_checked())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `Draw Shapes` setting is now remembered between instances of the new Instrument View. It can also be set in the `Mantid.properties` file.

Closes #41144 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Open and close the new IV with the pixels drawn as both points and shapes, check the setting is persisted. Try enabling shapes, closing Workbench, then reopening and checking the setting is persisted in the interface.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
