### PR TITLE
Add finalized flag to `Instrument` to ensure the cache is finalized

### DIFF
--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -513,7 +513,7 @@ Instrument_sptr CreateSampleWorkspace::createTestInstrumentRectangular(
         std::shared_ptr<Detector> detector = bank->getAtXY(x, y);
         if (detector) {
           // Mark it as a detector (add to the instrument cache)
-          testInst->markAsDetector(detector.get());
+          testInst->markAsDetectorIncomplete(detector.get());
         }
       }
     }
@@ -535,12 +535,15 @@ Instrument_sptr CreateSampleWorkspace::createTestInstrumentRectangular(
 
     Detector *detector = new Detector(monitorName, monitorNumber, monitorShape, testInst.get());
     // Mark it as a monitor (add to the instrument cache)
-    testInst->markAsMonitor(detector);
+    testInst->markAsMonitorIncomplete(detector);
 
     testInst->add(detector);
     // Set the bank along the z-axis of the instrument, between the detectors.
     detector->setPos(V3D(0.0, 0.0, bankDistanceFromSample * (monitorNumber - monitorsStart + 0.5)));
   }
+
+  // finalize the instrument
+  testInst->markAsDetectorFinalize();
 
   // Define a source component
   ObjComponent *source = new ObjComponent("moderator", IObject_sptr(new CSGObject), testInst.get());

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -102,6 +102,7 @@ public:
   /// to be a monitor and also add it to _detectorCache for possible later
   /// retrieval
   void markAsMonitor(const IDetector *);
+  void markAsMonitorIncomplete(const IDetector *);
 
   /// Remove a detector from the instrument
   void removeDetector(IDetector *);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -270,6 +270,15 @@ private:
   /// monitor flags.
   std::vector<std::tuple<detid_t, IDetector_const_sptr, bool>> m_detectorCache;
 
+  bool m_detectorCacheFinalized{true};
+  bool isFinalized() const {
+    if (m_map) {
+      return m_instr->isFinalized();
+    } else {
+      return m_detectorCacheFinalized;
+    }
+  }
+
   /// Purpose to hold copy of source component. For now assumed to be just one
   /// component
   const IComponent *m_sourceCache = nullptr;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -511,9 +511,10 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
  */
 const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   // ensure instrument is finalized
-  if (!m_instr->isFinalized())
+  if (!m_map)
+    throw std::runtime_error("Instrument::getBaseDetector() called on a non-parametrized instrument.");
+  if (!isFinalized())
     throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " + std::to_string(detector_id));
-
   auto it = find(m_instr->m_detectorCache, detector_id);
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
@@ -680,7 +681,7 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsDetector() called on a "
                              "parametrized Instrument object.");
 
-  m_detectorCacheFinalized &= false;
+  m_detectorCacheFinalized = false;
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   bool isMonitorFlag = false;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -264,6 +264,10 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
  * @param max :: set to the max detector ID
  */
 void Instrument::getMinMaxDetectorIDs(detid_t &min, detid_t &max) const {
+  // ensure instrument is finalized
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't find min/max ids");
+
   const auto *in_dets = m_map ? &m_instr->m_detectorCache : &m_detectorCache;
 
   if (in_dets->empty())
@@ -480,6 +484,10 @@ template <class T> auto find(T &map, const detid_t key) -> decltype(map.begin())
  *  @throw   NotFoundError If no detector is found for the detector ID given
  */
 IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
+  // ensure instrument is finalized
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't search for detector ID " + std::to_string(detector_id));
+
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detector_id);
   if (it == baseInstr.m_detectorCache.end()) {
@@ -502,6 +510,10 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
  *  @returns A const pointer to the detector object
  */
 const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
+  // ensure instrument is finalized
+  if (!m_instr->isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " + std::to_string(detector_id));
+
   auto it = find(m_instr->m_detectorCache, detector_id);
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
@@ -510,6 +522,10 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
 }
 
 bool Instrument::isMonitor(const detid_t &detector_id) const {
+  // ensure instrument is finalized
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't search for monitor ID " + std::to_string(detector_id));
+
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detector_id);
   if (it == baseInstr.m_detectorCache.end())
@@ -642,6 +658,9 @@ void Instrument::markAsDetector(const IDetector *det) {
   if (m_map)
     throw std::runtime_error("Instrument::markAsDetector() called on a "
                              "parametrized Instrument object.");
+  // ensure instrument is finalized
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized.  Add detector with markAsDetectorIncomplete, then call markAsDetectorFinalized when finished.");
 
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
@@ -661,6 +680,7 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsDetector() called on a "
                              "parametrized Instrument object.");
 
+  m_detectorCacheFinalized &= false;
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   bool isMonitorFlag = false;
@@ -670,6 +690,10 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
 /// Sorts the detector cache. Called after all detectors have been marked via
 /// markAsDetectorIncomplete.
 void Instrument::markAsDetectorFinalize() {
+  // We're already finalized! We can't finalize any further!
+  if (isFinalized())
+    return;
+
   // Detectors (even when different objects) are NOT allowed to have duplicate
   // ids. This method establishes the presence of duplicates.
   std::sort(
@@ -685,6 +709,7 @@ void Instrument::markAsDetectorFinalize() {
   if (resultIt != m_detectorCache.end()) {
     raiseDuplicateDetectorError(std::get<0>(*resultIt));
   }
+  m_detectorCacheFinalized = true;
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -699,6 +724,11 @@ void Instrument::markAsMonitor(const IDetector *det) {
   if (m_map)
     throw std::runtime_error("Instrument::markAsMonitor() called on a "
                              "parametrized Instrument object.");
+  // NOTE markAsMonitor is not designed to be used with an unfinalized detector cache.
+  // However, actual usage in the codebase is inconsistent.  Finalizing here prevents some errors.
+  if (!isFinalized()) {
+    markAsDetectorFinalize();
+  }
 
   // attempt to add monitor to instrument detector cache
   markAsDetector(det);
@@ -716,6 +746,8 @@ void Instrument::removeDetector(IDetector *det) {
   if (m_map)
     throw std::runtime_error("Instrument::removeDetector() called on a "
                              "parameterized Instrument object.");
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't remove detector with ID " + std::to_string(det->getID()));
 
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
@@ -1140,6 +1172,9 @@ bool Instrument::isEmptyInstrument() const { return this->nelements() == 0; }
 
 /// Returns the index for a detector ID. Used for accessing DetectorInfo.
 size_t Instrument::detectorIndex(const detid_t detID) const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't get detector index for ID " + std::to_string(detID));
+
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detID);
   return std::distance(baseInstr.m_detectorCache.cbegin(), it);
@@ -1148,6 +1183,9 @@ size_t Instrument::detectorIndex(const detid_t detID) const {
 /// Returns a legacy ParameterMap, containing information that is now stored in
 /// DetectorInfo (masking, positions, rotations, scale factors).
 std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
+  if (!isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't create legacy ParameterMap.");
+
   auto pmap = std::make_shared<ParameterMap>(*getParameterMap());
   // Instrument is only needed for DetectorInfo access so it is not needed. This
   // also clears DetectorInfo and ComponentInfo (information will be stored

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -86,14 +86,21 @@ Instrument::Instrument(const Instrument &instr)
   // into the new instrument
   std::vector<IComponent_const_sptr> children;
   getChildren(children, true);
-  std::vector<IComponent_const_sptr>::const_iterator it;
-  for (it = children.begin(); it != children.end(); ++it) {
-    // First check if the current component is a detector and add to cache if it is
-    if (const IDetector *det = dynamic_cast<const Detector *>(it->get())) {
-      if (instr.isMonitor(det->getID()))
-        markAsMonitor(det);
-      else
-        markAsDetector(det);
+  // First check if the current component is a detector and add to cache if it is
+  // NOTE this does not require the copied instrument to be finalized
+  for (auto it = instr.m_detectorCache.begin(); it != instr.m_detectorCache.end(); ++it) {
+    if (std::get<2>(*it)) { // check if isMonitor
+      markAsMonitorIncomplete(std::get<1>(*it).get());
+    } else {
+      markAsDetectorIncomplete(std::get<1>(*it).get());
+    }
+  }
+  // finalize detector cache
+  markAsDetectorFinalize();
+  // Now loop through all children to find the source and sample components.
+  for (auto it = children.begin(); it != children.end(); ++it) {
+    // if this is a detector, it was already handled above.
+    if (dynamic_cast<const Detector *>(it->get())) {
       continue;
     }
     // Now check whether the current component is the source or sample.
@@ -674,8 +681,7 @@ void Instrument::markAsDetector(const IDetector *det) {
   if ((it != m_detectorCache.end()) && (std::get<0>(*it) == det->getID())) {
     raiseDuplicateDetectorError(det->getID());
   }
-  bool isMonitorFlag = false;
-  m_detectorCache.emplace(it, det->getID(), det_sptr, isMonitorFlag);
+  m_detectorCache.emplace(it, det->getID(), det_sptr, false);
 }
 
 /// As markAsDetector but without the required sorting. Must call
@@ -688,8 +694,7 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
   m_detectorCacheFinalized = false;
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  bool isMonitorFlag = false;
-  m_detectorCache.emplace_back(det->getID(), det_sptr, isMonitorFlag);
+  m_detectorCache.emplace_back(det->getID(), det_sptr, false);
 }
 
 /// Sorts the detector cache. Called after all detectors have been marked via
@@ -732,7 +737,8 @@ void Instrument::markAsMonitor(const IDetector *det) {
   // NOTE markAsMonitor is not designed to be used with an unfinalized detector cache.
   // However, actual usage in the codebase is inconsistent.  Finalizing here prevents some errors.
   if (!isFinalized()) {
-    markAsDetectorFinalize();
+    throw std::runtime_error("Instrument definition is not finalized.  Add monitor with markAsMonitorIncomplete, then "
+                             "call markAsDetectorFinalized when finished.");
   }
 
   // attempt to add monitor to instrument detector cache
@@ -741,6 +747,23 @@ void Instrument::markAsMonitor(const IDetector *det) {
   // mark detector as a monitor
   auto it = find(m_detectorCache, det->getID());
   std::get<2>(*it) = true;
+}
+
+/** Mark a Component which has already been added to the Instrument class
+ * as a monitor and add it to the detector cache, but without requiring sorting
+ *
+ * @param det :: Component to be marked (stored for later retrieval) as a
+ *detector Component
+ */
+void Instrument::markAsMonitorIncomplete(const IDetector *det) {
+  if (m_map)
+    throw std::runtime_error("Instrument::markAsMonitorIncomplete() called on a "
+                             "parametrized Instrument object.");
+
+  m_detectorCacheFinalized = false;
+  // Create a (non-deleting) shared pointer to it
+  IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
+  m_detectorCache.emplace_back(det->getID(), det_sptr, true);
 }
 
 /** Removes a detector from the instrument and from the detector cache.

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -63,53 +63,41 @@ Instrument::Instrument(const std::shared_ptr<const Instrument> &instr, const std
       m_defaultView(instr->m_defaultView), m_defaultViewAxis(instr->m_defaultViewAxis), m_instr(instr),
       m_map_nonconst(map), m_ValidFrom(instr->m_ValidFrom), m_ValidTo(instr->m_ValidTo),
       m_referenceFrame(new ReferenceFrame) {
-  // Note that we do not copy m_detectorInfo and m_componentInfo into the
-  // parametrized instrument since the ParameterMap will make a copy, if
-  // applicable.
+  // Note that we do not copy m_detectorInfo and m_componentInfo into the parametrized instrument since the ParameterMap
+  // will make a copy, if applicable.
 }
 
 /** Copy constructor
- *  This method was added to deal with having distinct neutronic and physical
- * positions
- *  in indirect instruments.
+ *  This method was added to deal with having distinct neutronic and physical positions in indirect instruments.
+ *  NOTE the copied instrument MUST be finalized first
  */
 Instrument::Instrument(const Instrument &instr)
     : CompAssembly(instr), m_sourceCache(nullptr), m_sampleCache(nullptr), /* Should only be temporarily null */
       m_logfileCache(instr.m_logfileCache), m_logfileUnit(instr.m_logfileUnit), m_defaultView(instr.m_defaultView),
       m_defaultViewAxis(instr.m_defaultViewAxis), m_instr(), m_map_nonconst(), /* Should not be parameterized */
       m_ValidFrom(instr.m_ValidFrom), m_ValidTo(instr.m_ValidTo), m_referenceFrame(instr.m_referenceFrame) {
-  // Note that we do not copy m_detectorInfo and m_componentInfo into the new
-  // instrument since they are only non-NULL for the base instrument, which
-  // should usually not be copied.
+  // Note that we do not copy m_detectorInfo and m_componentInfo into the new instrument since they are only non-NULL
+  // for the base instrument, which should usually not be copied.
 
-  // Now we need to fill the detector, source and sample caches with pointers
-  // into the new instrument
+  // Now we need to fill the detector, source and sample caches with pointers into the new instrument
   std::vector<IComponent_const_sptr> children;
   getChildren(children, true);
-  // First check if the current component is a detector and add to cache if it is
-  // NOTE this does not require the copied instrument to be finalized
-  for (auto it = instr.m_detectorCache.begin(); it != instr.m_detectorCache.end(); ++it) {
-    if (std::get<2>(*it)) { // check if isMonitor
-      markAsMonitorIncomplete(std::get<1>(*it).get());
-    } else {
-      markAsDetectorIncomplete(std::get<1>(*it).get());
-    }
-  }
-  // finalize detector cache
-  markAsDetectorFinalize();
-  // Now loop through all children to find the source and sample components.
-  for (auto it = children.begin(); it != children.end(); ++it) {
-    // if this is a detector, it was already handled above.
-    if (dynamic_cast<const Detector *>(it->get())) {
+  std::vector<IComponent_const_sptr>::const_iterator it;
+  for (it = children.begin(); it != children.end(); ++it) {
+    // First check if the current component is a detector and add to cache if it is
+    if (const IDetector *det = dynamic_cast<const Detector *>(it->get())) {
+      if (instr.isMonitor(det->getID()))
+        markAsMonitor(det);
+      else
+        markAsDetector(det);
       continue;
     }
     // Now check whether the current component is the source or sample.
     // As the majority of components will be detectors, we will rarely get to here
     if (const auto *obj = dynamic_cast<const Component *>(it->get())) {
       const std::string objName = obj->getName();
-      // This relies on the source and sample having a unique name.
-      // I think the way our instrument definition files work ensures this is
-      // the case.
+      // This relies on the source and sample having a unique name. I think the way our instrument definition files work
+      // ensures this is the case.
       if (objName == instr.m_sourceCache->getName()) {
         markAsSource(obj);
         continue;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -486,7 +486,8 @@ template <class T> auto find(T &map, const detid_t key) -> decltype(map.begin())
 IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
   // ensure instrument is finalized
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't search for detector ID " + std::to_string(detector_id));
+    throw std::runtime_error("Instrument definition is not finalized. Can't search for detector ID " +
+                             std::to_string(detector_id));
 
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detector_id);
@@ -514,7 +515,8 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   if (!m_map)
     throw std::runtime_error("Instrument::getBaseDetector() called on a non-parametrized instrument.");
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " + std::to_string(detector_id));
+    throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " +
+                             std::to_string(detector_id));
   auto it = find(m_instr->m_detectorCache, detector_id);
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
@@ -525,7 +527,8 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
 bool Instrument::isMonitor(const detid_t &detector_id) const {
   // ensure instrument is finalized
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't search for monitor ID " + std::to_string(detector_id));
+    throw std::runtime_error("Instrument definition is not finalized. Can't search for monitor ID " +
+                             std::to_string(detector_id));
 
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detector_id);
@@ -661,7 +664,8 @@ void Instrument::markAsDetector(const IDetector *det) {
                              "parametrized Instrument object.");
   // ensure instrument is finalized
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized.  Add detector with markAsDetectorIncomplete, then call markAsDetectorFinalized when finished.");
+    throw std::runtime_error("Instrument definition is not finalized.  Add detector with markAsDetectorIncomplete, "
+                             "then call markAsDetectorFinalized when finished.");
 
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
@@ -748,7 +752,8 @@ void Instrument::removeDetector(IDetector *det) {
     throw std::runtime_error("Instrument::removeDetector() called on a "
                              "parameterized Instrument object.");
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't remove detector with ID " + std::to_string(det->getID()));
+    throw std::runtime_error("Instrument definition is not finalized. Can't remove detector with ID " +
+                             std::to_string(det->getID()));
 
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
@@ -1174,7 +1179,8 @@ bool Instrument::isEmptyInstrument() const { return this->nelements() == 0; }
 /// Returns the index for a detector ID. Used for accessing DetectorInfo.
 size_t Instrument::detectorIndex(const detid_t detID) const {
   if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't get detector index for ID " + std::to_string(detID));
+    throw std::runtime_error("Instrument definition is not finalized. Can't get detector index for ID " +
+                             std::to_string(detID));
 
   const auto &baseInstr = m_map ? *m_instr : *this;
   const auto it = find(baseInstr.m_detectorCache, detID);

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -266,15 +266,16 @@ Instrument_sptr InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progr
   // <component-link> XML elements
   setComponentLinks(m_instrument, pRootElem);
 
-  if (m_indirectPositions) {
-    createNeutronicInstrument();
-  }
-
   // Instrument::markAsDetector is slow unless the detector IDs in the IDF are
   // sorted. To circumvent this we use the 2-part interface,
   // markAsDetectorIncomplete (which does not sort) and markAsDetectorFinalize
   // (which does the final sorting).
   m_instrument->markAsDetectorFinalize();
+
+  if (m_indirectPositions) {
+    // NOTE this MUST be called on a finalized instrument, as it calls the copy constructor
+    createNeutronicInstrument();
+  }
 
   // And give back what we created
   return m_instrument;
@@ -2604,8 +2605,7 @@ void InstrumentDefinitionParser::createNeutronicInstrument() {
           throw Exception::InstrumentDefinitionError("Requested type " + shapeName + " not defined in IDF");
         }
       }
-    } else // We have a null Element*, which signals a detector with no
-           // neutronic position
+    } else // We have a null Element*, which signals a detector with no neutronic position
     {
       // This should only happen for detectors
       auto *det = dynamic_cast<Detector *>(component.first);

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -266,8 +266,9 @@ Instrument_sptr InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progr
   // <component-link> XML elements
   setComponentLinks(m_instrument, pRootElem);
 
-  if (m_indirectPositions)
+  if (m_indirectPositions) {
     createNeutronicInstrument();
+  }
 
   // Instrument::markAsDetector is slow unless the detector IDs in the IDF are
   // sorted. To circumvent this we use the 2-part interface,
@@ -1290,15 +1291,16 @@ void InstrumentDefinitionParser::createDetectorOrMonitor(Geometry::ICompAssembly
   }
 
   try {
-    if (category == "Monitor" || category == "monitor")
-      m_instrument->markAsMonitor(detector);
-    else {
+    if (category == "Monitor" || category == "monitor") {
+      m_instrument->markAsMonitorIncomplete(detector);
+    } else {
       // for backwards compatibility look for mark-as="monitor"
       if ((pCompElem->hasAttribute("mark-as") && pCompElem->getAttribute("mark-as") == "monitor") ||
           (pLocElem->hasAttribute("mark-as") && pLocElem->getAttribute("mark-as") == "monitor")) {
-        m_instrument->markAsMonitor(detector);
-      } else
+        m_instrument->markAsMonitorIncomplete(detector);
+      } else {
         m_instrument->markAsDetectorIncomplete(detector);
+      }
     }
 
   } catch (Kernel::Exception::ExistsError &) {

--- a/Framework/NexusGeometry/src/InstrumentBuilder.cpp
+++ b/Framework/NexusGeometry/src/InstrumentBuilder.cpp
@@ -117,7 +117,7 @@ void InstrumentBuilder::addMonitor(const std::string &detName, detid_t detId, co
   detector->setShape(shape);
 
   m_instrument->add(detector);
-  m_instrument->markAsMonitor(detector);
+  m_instrument->markAsMonitorIncomplete(detector);
 }
 
 /// Sorts detectors


### PR DESCRIPTION
### Description of work

`Instrument` has a cache implemented as a vector of tuples.  The vector implementation is non-standard, but was meant to allow for faster insertion and for faster lookup by detector index.  However, the cache itself is expected to be ordered by detector ID.  Any method accessing the cache expects an ordered detector cache.  

It is possible to put the detector cache into a state of being out of order (for faster insertion) through `markAsDetectorIncomplete()`, with the expectation that `markAsDetectorFinalize()` will be called at the end.  This last method sorts the array by detector ID and checks for duplicates.

However, there is nothing to ensure that this last method is called, meaning the instrument could be put into an unfinalized state and still have code attempt to access the unordered cache.  Since this access assumes an ordered cache, this can lead to unexpected behavior.

This PR corrects this, by adding a new flag when the cache is in an unfinalized state, and throwing errors if access methods are called with an unfinalized cache.

It seems many places were relying on the single method `markAsMonitor()` for inserting monitors, which used the (ordered) `markAsDetector()` method.  However, `markAsMonitor()` was sometimes called with finalized or unfinalized caches.  This was the main source of errors related to operations on unfinalized caches.

To fix this, a new method, `markAsMonitorIncomplete()` was added, parallel to the `markAsDetectorIncomplete()` method.  Relevant code portions were updated, and any places with pre-existent errors were fixed.

Refs:
[EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15489&tab=com.ibm.team.workitem.tab.links)

Related to:
- PR #41183
- PR #41176

### To test:

This is a refactor, and it is expected the existing tests are sufficient.

*This does not require release notes* because it is an internal refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
