### PR TITLE
Fix check for whether to publish doxygen

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -25,13 +25,13 @@ jobs:
           filters: .github/filters.yaml
 
       - uses: prefix-dev/setup-pixi@v0.9.5
-        if: steps.changes.outputs.doxygen == 'true'
+        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
         with:
           frozen: true
 
       - uses: ./.github/actions/doxygen-build
         name: build doxygen
-        if: steps.changes.outputs.doxygen == 'true'
+        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
 
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
@@ -54,5 +54,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Update Doxygen docs"
+          git commit -m "Update Doxygen docs from mantidproject/mantid@${{ github.sha }}"
           git push origin main

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -36,10 +36,9 @@ jobs:
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
-        uses: actions/checkout@v6
-        with:
-          repository: mantidproject/doxygen
-          path: doxygen_repo
+        run: |
+          git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
+          rm -rf doxygen_repo/*
 
       - name: Copy Doxygen artifacts
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
@@ -52,7 +51,7 @@ jobs:
         working-directory: doxygen_repo
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update Doxygen docs from mantidproject/mantid@${{ github.sha }}"
           git push origin main


### PR DESCRIPTION
During the the finalizing of #41123, it was missed that both cpp and doxygen changes needed to be checked for all steps. This was checked in some steps, but not all. Also, change back to the "old" method for checking out the second repository so the commit can be published.

Refs #39497

### To test:

This is best tested on `main` which, unfortunately, means merging it to see that it works. Bonus hiccup in testing: a cpp file needs to change without changing the doxygen related files for the bug to show.

This does not need a release note

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
