### PR TITLE
Only archive build test results on failure

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -94,6 +94,7 @@ jobs:
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY $EXTRA_CMAKE_FLAGS
 
       - name: Run unit tests
+        id: testunit
         run: |
           cd ${GITHUB_WORKSPACE}
           # Not physical but logical cores, includes hyper threaded - different for darwin
@@ -102,7 +103,16 @@ jobs:
           # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false true $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
+      - name: Unit test report
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        if: ${{ failure() && steps.testunit.conclusion == 'failure' }}
+        with:
+          check_name: "Unit test results"
+          check_run: false
+          files: build/Testing/*unittest.xml
+
       - name: Run system tests
+        id: testsystem
         run: |
           cd ${GITHUB_WORKSPACE}
           # Not physical but logical cores, includes hyper threaded - different for darwin
@@ -111,33 +121,25 @@ jobs:
           # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} true false $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
+      - name: Upload system test mismatch files
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.testsystem.conclusion == 'failure' }}
+        with:
+          name: system_test_mismatches
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/**/*-mismatch.nxs
+
+      - name: System test report
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        if: ${{ failure() && steps.testsystem.conclusion == 'failure' }}
+        with:
+          check_name: "System test results"
+          check_run: false
+          files: build/Testing/SystemTests/**/TEST-systemtests*.xml
+
       - name: Upload build and test log artifacts
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test_logs
           path: ${{ github.workspace }}/build/test_logs/*.log
-
-      - name: Upload system test mismatch files
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: system_test_mismatches
-          if-no-files-found: ignore
-          path: ${{ github.workspace }}/build/**/*-mismatch.nxs
-
-      - name: Unit test report
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        if: (!cancelled())
-        with:
-          check_name: "Unit test results"
-          check_run: false
-          files: build/Testing/*unittest.xml
-
-      - name: System test report
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        if: (!cancelled())
-        with:
-          check_name: "System test results"
-          check_run: false
-          files: build/Testing/SystemTests/**/TEST-systemtests*.xml

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -73,7 +73,7 @@ public:
     // ensure that the properties are not changed in default mode
     // the "Params" property should still have a single value, 2.0
     std::vector<double> rbParams = rebin.getProperty("Params");
-    TS_ASSERT_EQUALS(rbParams.size(), 1);
+    TS_ASSERT_EQUALS(rbParams.size(), 42);
     TS_ASSERT_EQUALS(2.0, rbParams[0]);
 
     AnalysisDataService::Instance().remove(IN_WKSP);

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -73,7 +73,7 @@ public:
     // ensure that the properties are not changed in default mode
     // the "Params" property should still have a single value, 2.0
     std::vector<double> rbParams = rebin.getProperty("Params");
-    TS_ASSERT_EQUALS(rbParams.size(), 42);
+    TS_ASSERT_EQUALS(rbParams.size(), 1);
     TS_ASSERT_EQUALS(2.0, rbParams[0]);
 
     AnalysisDataService::Instance().remove(IN_WKSP);


### PR DESCRIPTION
When a build passes all tests, there is no need to parse the test logs. This skips archiving them and the mismatch nxs files from the system tests if they passed. 

It should also get around write issues seen in #41175 that we're seeing (dependabot isn't part of the organization). This may be a false understanding of the error seen since I think other dependabot PRs have been merged.

This selection mode is documented [here](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#failure).

Refs #39497

### To test:

Look at the logs for the linux PR build in github actions, the steps for parsing the test logs and archiving mismatch nxs files are skipped.

*This does not require release notes* because it is a change to CI


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
