### PR TITLE
Removed clean external projects flag

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -22,7 +22,6 @@
 #   --enable-doctests: Run the documentation tests
 #   --enable-coverity: Run coverity and submit results; ignores all other options and does not run unit tests
 #   --clean-build: Clear the build folder and build from scratch
-#   --clean-external-projects: Clear the external projects from the build folder
 #
 # Possible parameters:
 #   --extra-cmake-flags: Extra flags to pass directly to cmake, enclose in "", defaults to nothing
@@ -96,7 +95,6 @@ do
             ENABLE_UNIT_TESTS=false
 	    ;;
         --clean-build) CLEAN_BUILD=true ;;
-        --clean-external-projects) CLEAN_EXTERNAL_PROJECTS=true ;;
         --extra-cmake-flags)
             EXTRA_CMAKE_FLAGS="$2"
             shift

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -588,7 +588,7 @@ def checkoutSource(sha) {
 
 def build_and_test(platform) {
   def buildscript_path = "${CISCRIPT_DIR}/conda-buildscript"
-  def common_args = '--clean-build --clean-external-projects --enable-systemtests'
+  def common_args = '--clean-build --enable-systemtests'
   def cmake_preset = "${platform}-ci"
   if(platform.startsWith('win')) {
     def workspace_unix_style = toUnixStylePath("${WORKSPACE}")


### PR DESCRIPTION
### Description of work

The `--clean-external-projects` argument was removed in this PR yesterday: https://github.com/mantidproject/mantid/pull/41177

However, it still remained in some of the Jenkins files. This PR cleans it up everywhere.

### To test:

Check that this build from branch passes: https://builds.mantidproject.org/job/build_branch/1546/

  *This does not require release notes* because it only impacts our CI pipeline.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
