### PR TITLE
Fix wild imports of mantid.simpleapi

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -31,7 +31,7 @@ Importing this module starts the FrameworkManager instance.
 # std libs
 from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
-from datetime import datetime
+import datetime
 import os
 import sys
 
@@ -1008,7 +1008,7 @@ def _create_algorithm_function(name, version, algm_object):  # noqa: C901
                 deprecated = algm_object.aliasDeprecated()  # non-empty string when alias set to be deprecated
                 if deprecated:
                     try:
-                        datetime.fromisoformat(deprecated)
+                        datetime.datetime.fromisoformat(deprecated)
                     except ValueError:
                         deprecated = ""
                         logger.error(f"Alias deprecation date {deprecated} must be in ISO8601 format")
@@ -1041,7 +1041,7 @@ def _create_algorithm_function(name, version, algm_object):  # noqa: C901
 
                 # Check at runtime whether to throw upon alias deprecation.
                 if self._alias and self._alias.deprecated:
-                    deprecated = datetime.fromisoformat(self._alias.deprecated) < datetime.today()
+                    deprecated = datetime.datetime.fromisoformat(self._alias.deprecated) < datetime.datetime.today()
                     deprecated_action = ConfigService.Instance().get("algorithms.alias.deprecated", "Log").lower()
                     if deprecated and deprecated_action == "raise":
                         raise RuntimeError(f"Use of algorithm alias {self._alias.name} not allowed. Use {name} instead")


### PR DESCRIPTION
In #41034 the import of datetime.datetime into the namespace so people that `import datetime` then `from mantid.simpleapi import *` will have their `datetime` in the local namespace overwritten from the module to the object.

There is no associated issue

### To test:

Run
```py
import datetime
print('before', datetime.__file__)
from mantid.simpleapi import *
print('after', datetime.__file__)
```
The two print statements should show the same location. 

*This does not require release notes* because it is fixing a bug introduced during the development cycle.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
