### PR TITLE
Fixed argument check in clean-builder

### DIFF
--- a/buildconfig/Jenkins/Conda/clean-builder
+++ b/buildconfig/Jenkins/Conda/clean-builder
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 start_time=$(date +%s)
 
 # Check arguments passed are 2 or higher, and aren't optional flags.
-if [[ $# < 1 || $1 == "--"* || $2 == "--"* ]]; then
+if [[ $# < 1 || $1 == "--"* ]]; then
     echo "Pass 1 argument followed by optional flags usage: clean-builder <path-to-workspace> [options]"
     exit 1
 fi


### PR DESCRIPTION
### Description of work

The nightly builds started failing due to an argument check in clean-builder that rejected correct arguments.


### To test:

Code review.

The fix was applied to the branch that is used for the following build from branch: https://builds.mantidproject.org/job/build_branch/1549/. Verify that this build does not error on the `build and test: win-64` step.

  *This does not require release notes* because it only impacts the CI pipeline.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
