### PR TITLE
Change `Instrument` detector cache for cleaner code

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -170,7 +170,7 @@ void checkDetectorInfoSize(const Instrument &instr, const Geometry::DetectorInfo
     throw std::runtime_error("ExperimentInfo: size mismatch between "
                              "DetectorInfo and number of detectors in "
                              "instrument: " +
-                             std::to_string(numDets) + " vs " + std::to_string(detInfo.size()));
+                             std::to_string(detInfo.size()) + " vs " + std::to_string(numDets));
 }
 } // namespace
 
@@ -184,8 +184,9 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
   // instrument may now suddenly be valid, so we have to reinitialize the
   // detector grouping. Also the index corresponding to specific IDs may have
   // changed.
-  if (sptr_instrument != (instr->isParametrized() ? instr->baseInstrument() : instr))
+  if (sptr_instrument != (instr->isParametrized() ? instr->baseInstrument() : instr)) {
     invalidateAllSpectrumDefinitions();
+  }
   if (instr->isParametrized()) {
     sptr_instrument = instr->baseInstrument();
     // We take a *copy* of the ParameterMap since we are modifying it by setting

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1376,11 +1376,12 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
       const auto children = componentInfo.children(parentIndex);
       for (const auto &colIndex : children) {
         const auto grandchildren = componentInfo.children(colIndex);
-
         for (const auto &rowIndex : grandchildren) {
           auto *d = dynamic_cast<Detector *>(const_cast<IComponent *>(componentInfo.componentID(rowIndex)));
-          if (d)
+          if (d) {
+            // NOTE the call to erase within Instrument::removeDetector makes this entire loop run in O(N^2)
             inst->removeDetector(d);
+          }
         }
       }
       auto *comp = dynamic_cast<IComponent *>(det.get());

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -78,29 +78,22 @@ public:
   /// Returns a list of Detectors for the given detectors ids
   std::vector<IDetector_const_sptr> getDetectors(const std::set<detid_t> &det_ids) const;
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be 'the' samplePos Component. For now it is assumed that we have
-  /// at most one of these.
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be 'the' samplePos Component. For now it is assumed that we have at most one of these.
   void markAsSamplePos(const IComponent *);
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be 'the' source Component. For now it is assumed that we have
-  /// at most one of these.
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be 'the' source Component. For now it is assumed that we have at most one of these.
   void markAsSource(const IComponent *);
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
   /// to be a Detector component by adding it to _detectorCache
   void markAsDetector(const IDetector *);
   void markAsDetectorIncomplete(const IDetector *);
   void markAsDetectorFinalize();
 
-  /// mark a Component which has already been added to the Instrument (as a
-  /// child comp.)
-  /// to be a monitor and also add it to _detectorCache for possible later
-  /// retrieval
+  /// mark a Component which has already been added to the Instrument (as a child comp.)
+  /// to be a monitor and also add it to _detectorCache for possible later retrieval
   void markAsMonitor(const IDetector *);
   void markAsMonitorIncomplete(const IDetector *);
 
@@ -267,9 +260,13 @@ private:
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
   makeWrappers(ParameterMap &pmap, const ComponentInfo &componentInfo, const DetectorInfo &detectorInfo) const;
 
-  /// Map which holds detector-IDs and pointers to detector components, and
-  /// monitor flags.
-  std::vector<std::tuple<detid_t, IDetector_const_sptr, bool>> m_detectorCache;
+  /// Map which holds detector-IDs and pointers to detector components, and monitor flags.
+  struct DetectorCacheEntry : std::tuple<detid_t, IDetector_const_sptr, bool> {
+    detid_t const &id() const { return std::get<0>(*this); }
+    IDetector_const_sptr const &detector() const { return std::get<1>(*this); }
+    bool const &isMonitor() const { return std::get<2>(*this); }
+  };
+  std::vector<DetectorCacheEntry> m_detectorCache;
 
   bool m_detectorCacheFinalized{true};
   bool isFinalized() const {

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -260,20 +260,59 @@ private:
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
   makeWrappers(ParameterMap &pmap, const ComponentInfo &componentInfo, const DetectorInfo &detectorInfo) const;
 
-  /// Map which holds detector-IDs and pointers to detector components, and monitor flags.
-  struct DetectorCacheEntry : std::tuple<detid_t, IDetector_const_sptr, bool> {
+  /// @brief Tuple which holds detector-IDs and pointers to detector components, and monitor flags.
+  /// This is the type of the elements in the detector cache vector.
+  /// Provides a more convenient interface to the elements of the detector cache vector than a raw tuple.
+  /// @extends std::tuple<detid_t, IDetector_const_sptr, bool>
+  struct DetectorCacheEntry : public std::tuple<detid_t, IDetector_const_sptr, bool> {
+    DetectorCacheEntry(detid_t id, IDetector_const_sptr det, bool isMonitorFlag)
+        : std::tuple<detid_t, IDetector_const_sptr, bool>(id, det, isMonitorFlag) {}
     detid_t const &id() const { return std::get<0>(*this); }
     IDetector_const_sptr const &detector() const { return std::get<1>(*this); }
     bool const &isMonitor() const { return std::get<2>(*this); }
+    bool &isMonitor() { return std::get<2>(*this); }
   };
-  std::vector<DetectorCacheEntry> m_detectorCache;
 
-  bool m_detectorCacheFinalized{true};
+  /// @brief A vector of DetectorCacheEntry, which holds the detector cache
+  /// This is implemented as a vector rather than an ordered map to facilitate
+  /// faster (unsorted) insertion some hotpaths requiring access by index.
+  /// This vector otherwise should act like an ordered map.
+  /// @note this class anticipates future extension by optimizing the lower_bound and find methods
+  struct DetectorCache : public std::vector<DetectorCacheEntry> {
+    bool m_isFinalized{true};
+    bool isFinalized() const { return m_isFinalized; }
+    void setIncomplete() { m_isFinalized &= false; }
+    void setFinalized(bool const flag = true) { m_isFinalized = flag; }
+    detid_t const minID() const {
+      if (isFinalized()) {
+        return front().id();
+      } else {
+        throwUnfinalized("minID()");
+      }
+    }
+    detid_t const maxID() const {
+      if (isFinalized()) {
+        return back().id();
+      } else {
+        throwUnfinalized("maxID()");
+      }
+    }
+    DetectorCache::iterator lower_bound(detid_t id);
+    DetectorCache::const_iterator lower_bound(detid_t id) const;
+    DetectorCache::iterator find(detid_t id);
+    DetectorCache::const_iterator find(detid_t id) const;
+
+  private:
+    detid_t const throwUnfinalized(std::string const &method) const {
+      throw std::runtime_error(method + " called on non-finalized DetectorCache");
+    }
+  } m_detectorCache;
+
   bool isFinalized() const {
     if (m_map) {
       return m_instr->isFinalized();
     } else {
-      return m_detectorCacheFinalized;
+      return m_detectorCache.isFinalized();
     }
   }
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -95,8 +95,8 @@ public:
 
   /// mark a Component which has already been added to the Instrument (as a child comp.)
   /// to be a monitor and also add it to _detectorCache for possible later retrieval
-  void markAsMonitor(const IDetector *);
-  void markAsMonitorIncomplete(const IDetector *);
+  void markAsMonitor(IDetector const *);
+  void markAsMonitorIncomplete(IDetector const *);
 
   /// Remove a detector from the instrument
   void removeDetector(IDetector *);
@@ -288,14 +288,14 @@ private:
       if (isFinalized() && !empty()) {
         return front().id();
       } else {
-        throw std::runtime_error("minID() called on non-finalized DetectorCache");
+        throw std::runtime_error("minID() called on non-finalized or empty DetectorCache");
       }
     }
     detid_t maxID() const {
       if (isFinalized() && !empty()) {
         return back().id();
       } else {
-        throw std::runtime_error("maxID() called on non-finalized DetectorCache");
+        throw std::runtime_error("maxID() called on non-finalized or empty DetectorCache");
       }
     }
     DetectorCache::iterator lower_bound(detid_t id);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <queue>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <unordered_map>

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -281,17 +281,17 @@ private:
   struct DetectorCache : public std::vector<DetectorCacheEntry> {
     bool m_isFinalized{true};
     bool isFinalized() const { return m_isFinalized; }
-    void setIncomplete() { m_isFinalized &= false; }
+    void setIncomplete() { m_isFinalized = false; }
     void setFinalized(bool const flag = true) { m_isFinalized = flag; }
     detid_t minID() const {
-      if (isFinalized()) {
+      if (isFinalized() && !empty()) {
         return front().id();
       } else {
         throw std::runtime_error("minID() called on non-finalized DetectorCache");
       }
     }
     detid_t maxID() const {
-      if (isFinalized()) {
+      if (isFinalized() && !empty()) {
         return back().id();
       } else {
         throw std::runtime_error("maxID() called on non-finalized DetectorCache");

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -283,29 +283,24 @@ private:
     bool isFinalized() const { return m_isFinalized; }
     void setIncomplete() { m_isFinalized &= false; }
     void setFinalized(bool const flag = true) { m_isFinalized = flag; }
-    detid_t const minID() const {
+    detid_t minID() const {
       if (isFinalized()) {
         return front().id();
       } else {
-        throwUnfinalized("minID()");
+        throw std::runtime_error("minID() called on non-finalized DetectorCache");
       }
     }
-    detid_t const maxID() const {
+    detid_t maxID() const {
       if (isFinalized()) {
         return back().id();
       } else {
-        throwUnfinalized("maxID()");
+        throw std::runtime_error("maxID() called on non-finalized DetectorCache");
       }
     }
     DetectorCache::iterator lower_bound(detid_t id);
     DetectorCache::const_iterator lower_bound(detid_t id) const;
     DetectorCache::iterator find(detid_t id);
     DetectorCache::const_iterator find(detid_t id) const;
-
-  private:
-    detid_t const throwUnfinalized(std::string const &method) const {
-      throw std::runtime_error(method + " called on non-finalized DetectorCache");
-    }
   } m_detectorCache;
 
   bool isFinalized() const {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -442,7 +442,7 @@ std::vector<std::shared_ptr<const IComponent>> Instrument::getAllComponentsWithN
  */
 Instrument::DetectorCache::iterator Instrument::DetectorCache::lower_bound(detid_t id) {
   if (!isFinalized()) {
-    throwUnfinalized("lower_bound()");
+    throw std::runtime_error("lower_bound() called on non-finalized DetectorCache");
   }
   return std::lower_bound(begin(), end(), id,
                           [](DetectorCacheEntry const &entry, detid_t id) { return entry.id() < id; });
@@ -459,7 +459,7 @@ Instrument::DetectorCache::iterator Instrument::DetectorCache::lower_bound(detid
  */
 Instrument::DetectorCache::const_iterator Instrument::DetectorCache::lower_bound(detid_t id) const {
   if (!isFinalized()) {
-    throwUnfinalized("lower_bound()");
+    throw std::runtime_error("lower_bound() called on non-finalized DetectorCache");
   }
   return std::lower_bound(cbegin(), cend(), id,
                           [](DetectorCacheEntry const &entry, detid_t id) { return entry.id() < id; });
@@ -474,7 +474,7 @@ Instrument::DetectorCache::const_iterator Instrument::DetectorCache::lower_bound
  */
 Instrument::DetectorCache::iterator Instrument::DetectorCache::find(detid_t id) {
   if (!isFinalized()) {
-    throwUnfinalized("find()");
+    throw std::runtime_error("find() called on non-finalized DetectorCache");
   }
   auto it = lower_bound(id);
   if (it != end() && it->id() == id) {
@@ -493,7 +493,7 @@ Instrument::DetectorCache::iterator Instrument::DetectorCache::find(detid_t id) 
  */
 Instrument::DetectorCache::const_iterator Instrument::DetectorCache::find(detid_t id) const {
   if (!isFinalized()) {
-    throwUnfinalized("find()");
+    throw std::runtime_error("find() called on non-finalized DetectorCache");
   }
   auto const it = lower_bound(id);
   if (it != cend() && it->id() == id) {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -176,36 +176,33 @@ void Instrument::setPhysicalInstrument(std::unique_ptr<Instrument> physInst) {
 /**	Fills a copy of the detector cache
  */
 void Instrument::getDetectors(detid2det_map &out_map) const {
+  out_map.clear();
+  auto it = out_map.end();
   if (m_map) {
     // Get the base instrument detectors
-    out_map.clear();
     const auto &in_dets = m_instr->m_detectorCache;
     // And turn them into parametrized versions
     for (const auto &in_det : in_dets) {
-      out_map.emplace(std::get<0>(in_det), getDetector(std::get<0>(in_det)));
+      it = out_map.emplace_hint(it, in_det.id(), getDetector(in_det.id()));
     }
   } else {
     // You can just return the detector cache directly.
-    out_map.clear();
-    for (const auto &in_det : m_detectorCache)
-      out_map.emplace(std::get<0>(in_det), std::get<1>(in_det));
+    for (const auto &in_det : m_detectorCache) {
+      it = out_map.emplace_hint(it, in_det.id(), in_det.detector());
+    }
   }
 }
 
 //------------------------------------------------------------------------------------------
 /** Return a vector of detector IDs in this instrument */
 std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
   std::vector<detid_t> out;
-  if (m_map) {
-    const auto &in_dets = m_instr->m_detectorCache;
-    for (const auto &in_det : in_dets)
-      if (!skipMonitors || !std::get<2>(in_det))
-        out.emplace_back(std::get<0>(in_det));
-  } else {
-    const auto &in_dets = m_detectorCache;
-    for (const auto &in_det : in_dets)
-      if (!skipMonitors || !std::get<2>(in_det))
-        out.emplace_back(std::get<0>(in_det));
+  out.reserve(in_dets.size());
+  for (const auto &in_det : in_dets) {
+    if (!skipMonitors || !in_det.isMonitor()) {
+      out.emplace_back(in_det.id());
+    }
   }
   return out;
 }
@@ -220,33 +217,21 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 
   std::vector<detid_t> mons;
   for (const auto &item : m_detectorCache)
-    if (std::get<2>(item))
-      mons.emplace_back(std::get<0>(item));
+    if (item.isMonitor())
+      mons.emplace_back(item.id());
   return mons;
 }
 
 /// @return The total number of detector IDs in the instrument */
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
-  std::size_t numDetIDs(0);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
 
-  if (m_map) {
-    numDetIDs = m_instr->m_detectorCache.size();
-  } else {
-    numDetIDs = m_detectorCache.size();
-  }
+  std::size_t numDetIDs = in_dets.size();
 
   if (skipMonitors) // this slow, but gets the right answer
   {
     std::size_t monitors(0);
-    if (m_map) {
-      const auto &in_dets = m_instr->m_detectorCache;
-      monitors =
-          std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return std::get<2>(in_det); });
-    } else {
-      const auto &in_dets = m_detectorCache;
-      monitors =
-          std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return std::get<2>(in_det); });
-    }
+    monitors = std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });
     return (numDetIDs - monitors);
   } else {
     return numDetIDs;
@@ -263,13 +248,13 @@ void Instrument::getMinMaxDetectorIDs(detid_t &min, detid_t &max) const {
   if (!isFinalized())
     throw std::runtime_error("Instrument definition is not finalized. Can't find min/max ids");
 
-  const auto *in_dets = m_map ? &m_instr->m_detectorCache : &m_detectorCache;
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
 
-  if (in_dets->empty())
+  if (in_dets.empty())
     throw std::runtime_error("No detectors on this instrument. Can't find min/max ids");
   // Maps are sorted by key. So it is easy to find
-  min = std::get<0>(*in_dets->begin());
-  max = std::get<0>(*in_dets->rbegin());
+  min = in_dets.front().id();
+  max = in_dets.back().id();
 }
 
 /** Fill a vector with all the detectors contained (at any depth) in a named
@@ -484,14 +469,14 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't search for detector ID " +
                              std::to_string(detector_id));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detector_id);
-  if (it == baseInstr.m_detectorCache.end()) {
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = find(in_dets, detector_id);
+  if (it == in_dets.end()) {
     std::stringstream readInt;
     readInt << detector_id;
     throw Kernel::Exception::NotFoundError("Instrument: Detector with ID " + readInt.str() + " not found.", "");
   }
-  IDetector_const_sptr baseDet = std::get<1>(*it);
+  IDetector_const_sptr baseDet = it->detector();
 
   if (!m_map)
     return baseDet;
@@ -516,7 +501,7 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
   }
-  return std::get<1>(*it).get();
+  return it->detector().get();
 }
 
 bool Instrument::isMonitor(const detid_t &detector_id) const {
@@ -525,11 +510,11 @@ bool Instrument::isMonitor(const detid_t &detector_id) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't search for monitor ID " +
                              std::to_string(detector_id));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detector_id);
-  if (it == baseInstr.m_detectorCache.end())
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = find(in_dets, detector_id);
+  if (it == in_dets.end())
     return false;
-  return std::get<2>(*it);
+  return it->isMonitor();
 }
 
 bool Instrument::isMonitor(const std::set<detid_t> &detector_ids) const {
@@ -666,7 +651,7 @@ void Instrument::markAsDetector(const IDetector *det) {
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   auto it = lower_bound(m_detectorCache, det->getID());
   // Duplicate detector ids are forbidden
-  if ((it != m_detectorCache.end()) && (std::get<0>(*it) == det->getID())) {
+  if ((it != m_detectorCache.end()) && (it->id() == det->getID())) {
     raiseDuplicateDetectorError(det->getID());
   }
   m_detectorCache.emplace(it, det->getID(), det_sptr, false);
@@ -694,18 +679,14 @@ void Instrument::markAsDetectorFinalize() {
 
   // Detectors (even when different objects) are NOT allowed to have duplicate
   // ids. This method establishes the presence of duplicates.
-  std::sort(
-      m_detectorCache.begin(), m_detectorCache.end(),
-      [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
-         const std::tuple<detid_t, IDetector_const_sptr, bool> &b) -> bool { return std::get<0>(a) < std::get<0>(b); });
+  std::sort(m_detectorCache.begin(), m_detectorCache.end(),
+            [](DetectorCacheEntry const &a, DetectorCacheEntry const &b) -> bool { return a.id() < b.id(); });
 
-  auto resultIt = std::adjacent_find(m_detectorCache.begin(), m_detectorCache.end(),
-                                     [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
-                                        const std::tuple<detid_t, IDetector_const_sptr, bool> &b) -> bool {
-                                       return std::get<0>(a) == std::get<0>(b);
-                                     });
+  auto resultIt = std::adjacent_find(
+      m_detectorCache.begin(), m_detectorCache.end(),
+      [](DetectorCacheEntry const &a, DetectorCacheEntry const &b) -> bool { return a.id() == b.id(); });
   if (resultIt != m_detectorCache.end()) {
-    raiseDuplicateDetectorError(std::get<0>(*resultIt));
+    raiseDuplicateDetectorError(resultIt->id());
   }
   m_detectorCacheFinalized = true;
 }
@@ -1179,10 +1160,8 @@ bool Instrument::addAssemblyChildrenToQueue(std::queue<IComponent_const_sptr> &q
 
 /// Temporary helper for refactoring. Argument is index, *not* ID!
 bool Instrument::isMonitorViaIndex(const size_t index) const {
-  if (m_map)
-    return std::get<2>(m_instr->m_detectorCache[index]);
-  else
-    return std::get<2>(m_detectorCache[index]);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  return in_dets[index].isMonitor();
 }
 
 bool Instrument::isEmptyInstrument() const { return this->nelements() == 0; }
@@ -1193,9 +1172,9 @@ size_t Instrument::detectorIndex(const detid_t detID) const {
     throw std::runtime_error("Instrument definition is not finalized. Can't get detector index for ID " +
                              std::to_string(detID));
 
-  const auto &baseInstr = m_map ? *m_instr : *this;
-  const auto it = find(baseInstr.m_detectorCache, detID);
-  return std::distance(baseInstr.m_detectorCache.cbegin(), it);
+  const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  const auto it = find(in_dets, detID);
+  return std::distance(in_dets.cbegin(), it);
 }
 
 /// Returns a legacy ParameterMap, containing information that is now stored in
@@ -1243,11 +1222,9 @@ std::shared_ptr<ParameterMap> Instrument::makeLegacyParameterMap() const {
     }
 
     if (componentInfo.isDetector(i)) {
-
-      const std::shared_ptr<const IDetector> &baseDet = std::get<1>(baseInstr.m_detectorCache[i]);
-
       isDetFixedInBank = ComponentInfoBankHelpers::isDetectorFixedInBank(componentInfo, i);
       if (detectorInfo.isMasked(i)) {
+        auto const &baseDet = baseInstr.m_detectorCache[i].detector();
         pmap->forceUnsafeSetMasked(baseDet.get(), true);
       }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -438,7 +438,7 @@ std::vector<std::shared_ptr<const IComponent>> Instrument::getAllComponentsWithN
  * @param id the detector ID to search for
  * @returns an iterator to the first DetectorCacheEntry with ID >= the given ID, or end() if no such element exists
  * @throws std::runtime_error if the detector cache is not finalized
- * @note optimizations in this method could improve performance in lookuo speeds
+ * @note optimizations in this method could improve performance in lookup speeds
  */
 Instrument::DetectorCache::iterator Instrument::DetectorCache::lower_bound(detid_t id) {
   if (!isFinalized()) {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -455,7 +455,7 @@ Instrument::DetectorCache::iterator Instrument::DetectorCache::lower_bound(detid
  * @returns a constant iterator to the first DetectorCacheEntry with ID >= the given ID, or cend() if no such element
  * exists
  * @throws std::runtime_error if the detector cache is not finalized
- * @note optimizations in this method could improve performance in lookuo speeds
+ * @note optimizations in this method could improve performance in lookup speeds
  */
 Instrument::DetectorCache::const_iterator Instrument::DetectorCache::lower_bound(detid_t id) const {
   if (!isFinalized()) {
@@ -798,6 +798,7 @@ void Instrument::removeDetector(IDetector *det) {
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
   const auto it = m_detectorCache.find(id);
+  // NOTE this operation is O(N) for the vector cache
   m_detectorCache.erase(it);
 
   // Remove it from the parent assembly (and thus the instrument).
@@ -1345,11 +1346,13 @@ void Instrument::parseTreeAndCacheBeamline() {
 std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
 Instrument::makeBeamline(ParameterMap &pmap, const ParameterMap *source) const {
   // If we have source and it has Beamline objects just copy them
-  if (source && source->hasComponentInfo(this))
+  if (source && source->hasComponentInfo(this)) {
     return makeWrappers(pmap, source->componentInfo(), source->detectorInfo());
+  }
   // If pmap is empty and base instrument has Beamline objects just copy them
-  if (pmap.empty() && m_componentInfo)
+  if (pmap.empty() && m_componentInfo) {
     return makeWrappers(pmap, *m_componentInfo, *m_detectorInfo);
+  }
   // pmap not empty and/or no cached Beamline objects found
   return InstrumentVisitor::makeWrappers(*this, &pmap);
 }

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -242,19 +242,18 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
  *
  * @param min :: set to the min detector ID
  * @param max :: set to the max detector ID
+ * @throws std::runtime_error if there are no detectors, or if the detector cache is not finalized
  */
 void Instrument::getMinMaxDetectorIDs(detid_t &min, detid_t &max) const {
-  // ensure instrument is finalized
-  if (!isFinalized())
-    throw std::runtime_error("Instrument definition is not finalized. Can't find min/max ids");
-
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-
+  // ensure there are detectors
   if (in_dets.empty())
     throw std::runtime_error("No detectors on this instrument. Can't find min/max ids");
-  // Maps are sorted by key. So it is easy to find
-  min = in_dets.front().id();
-  max = in_dets.back().id();
+  // ensure the cache is finalized
+  if (!in_dets.isFinalized())
+    throw std::runtime_error("Instrument definition is not finalized. Can't find min/max ids");
+  min = in_dets.minID();
+  max = in_dets.maxID();
 }
 
 /** Fill a vector with all the detectors contained (at any depth) in a named
@@ -397,8 +396,7 @@ std::shared_ptr<const IComponent> Instrument::getComponentByID(const IComponent 
  *  has a unique name use instead getComponentByName(), which is as fast or
  * faster for retrieving a uniquely
  *  named component.
- *  @param cname :: The name of the component. If there are multiple matches,
- * the first one found is returned.
+ *  @param cname :: The name of the component. If there are multiple matches, the first one found is returned.
  *  @returns Pointers to components
  */
 std::vector<std::shared_ptr<const IComponent>> Instrument::getAllComponentsWithName(const std::string &cname) const {
@@ -434,30 +432,80 @@ std::vector<std::shared_ptr<const IComponent>> Instrument::getAllComponentsWithN
   return retVec;
 }
 
-namespace {
-// Helpers for accessing m_detectorCache, which is a vector of tuples used as a
-// map. Lookup is by first element in a tuple. Templated to support const and
-// non-const.
-template <class T> auto lower_bound(T &map, const detid_t key) -> decltype(map.begin()) {
-  return std::lower_bound(map.begin(), map.end(), std::make_tuple(key, IDetector_const_sptr(nullptr), false),
-                          [](const typename T::value_type &a, const typename T::value_type &b) -> bool {
-                            return std::get<0>(a) < std::get<0>(b);
-                          });
+/** @brief Perform a lower bound search on the detector cache, for the element with the given ID.
+ * Note that this method is only valid for a finalized (sorted) detector cache; otherwise the results are undefined.
+ * This method should complete in O(log N), where N is the number of detectors in the cache.
+ * @param id the detector ID to search for
+ * @returns an iterator to the first DetectorCacheEntry with ID >= the given ID, or end() if no such element exists
+ * @throws std::runtime_error if the detector cache is not finalized
+ * @note optimizations in this method could improve performance in lookuo speeds
+ */
+Instrument::DetectorCache::iterator Instrument::DetectorCache::lower_bound(detid_t id) {
+  if (!isFinalized()) {
+    throwUnfinalized("lower_bound()");
+  }
+  return std::lower_bound(begin(), end(), id,
+                          [](DetectorCacheEntry const &entry, detid_t id) { return entry.id() < id; });
 }
 
-template <class T> auto find(T &map, const detid_t key) -> decltype(map.begin()) {
-  auto it = lower_bound(map, key);
-  if ((it != map.end()) && (std::get<0>(*it) == key))
-    return it;
-  return map.end();
+/** @brief Perform a lower bound search on the detector cache, for the element with the given ID.
+ * Note that this method is only valid for a finalized (sorted) detector cache; otherwise the results are undefined.
+ * This method should complete in O(log N), where N is the number of detectors in the cache.
+ * @param id the detector ID to search for
+ * @returns a constant iterator to the first DetectorCacheEntry with ID >= the given ID, or cend() if no such element
+ * exists
+ * @throws std::runtime_error if the detector cache is not finalized
+ * @note optimizations in this method could improve performance in lookuo speeds
+ */
+Instrument::DetectorCache::const_iterator Instrument::DetectorCache::lower_bound(detid_t id) const {
+  if (!isFinalized()) {
+    throwUnfinalized("lower_bound()");
+  }
+  return std::lower_bound(cbegin(), cend(), id,
+                          [](DetectorCacheEntry const &entry, detid_t id) { return entry.id() < id; });
 }
-} // namespace
+
+/** @brief Find the element in the detector cache with the given ID.
+ * Note that this method is only valid for a finalized (sorted) instrument cache; otherwise the results are undefined.
+ * This method should complete in O(log N), where N is the number of detectors in the cache.
+ * @param id the detector ID to search for
+ * @returns an iterator to the DetectorCacheEntry with the given ID, or end() if no such element exists
+ * @throws std::runtime_error if the detector cache is not finalized
+ */
+Instrument::DetectorCache::iterator Instrument::DetectorCache::find(detid_t id) {
+  if (!isFinalized()) {
+    throwUnfinalized("find()");
+  }
+  auto it = lower_bound(id);
+  if (it != end() && it->id() == id) {
+    return it;
+  } else {
+    return end();
+  }
+}
+
+/** @brief Find the element in the detector cache with the given ID.
+ * Note that this method is only valid for a finalized (sorted) instrument cache; otherwise the results are undefined.
+ * This method should complete in O(log N), where N is the number of detectors in the cache.
+ * @param id the detector ID to search for
+ * @returns a const iterator to the DetectorCacheEntry with the given ID, or end() if no such element exists
+ * @throws std::runtime_error if the detector cache is not finalized
+ */
+Instrument::DetectorCache::const_iterator Instrument::DetectorCache::find(detid_t id) const {
+  if (!isFinalized()) {
+    throwUnfinalized("find()");
+  }
+  auto const it = lower_bound(id);
+  if (it != cend() && it->id() == id) {
+    return it;
+  } else {
+    return cend();
+  }
+}
 
 /**	Gets a pointer to the detector from its ID
- *  Note that for getting the detector associated with a spectrum, the
- * MatrixWorkspace::getDetector
- *  method should be used rather than this one because it takes account of the
- * possibility of more
+ *  Note that for getting the detector associated with a spectrum, the MatrixWorkspace::getDetector
+ *  method should be used rather than this one because it takes account of the possibility of more
  *  than one detector contributing to a single spectrum
  *  @param   detector_id The requested detector ID
  *  @returns A pointer to the detector object
@@ -470,7 +518,7 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
                              std::to_string(detector_id));
 
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  const auto it = find(in_dets, detector_id);
+  const auto it = in_dets.find(detector_id);
   if (it == in_dets.end()) {
     std::stringstream readInt;
     readInt << detector_id;
@@ -497,7 +545,8 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   if (!isFinalized())
     throw std::runtime_error("Instrument definition is not finalized. Can't find base detector ID " +
                              std::to_string(detector_id));
-  auto it = find(m_instr->m_detectorCache, detector_id);
+
+  auto it = m_instr->m_detectorCache.find(detector_id);
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
   }
@@ -511,7 +560,7 @@ bool Instrument::isMonitor(const detid_t &detector_id) const {
                              std::to_string(detector_id));
 
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  const auto it = find(in_dets, detector_id);
+  const auto it = in_dets.find(detector_id);
   if (it == in_dets.end())
     return false;
   return it->isMonitor();
@@ -647,13 +696,13 @@ void Instrument::markAsDetector(const IDetector *det) {
     throw std::runtime_error("Instrument definition is not finalized.  Add detector with markAsDetectorIncomplete, "
                              "then call markAsDetectorFinalized when finished.");
 
-  // Create a (non-deleting) shared pointer to it
-  IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  auto it = lower_bound(m_detectorCache, det->getID());
   // Duplicate detector ids are forbidden
+  auto it = m_detectorCache.lower_bound(det->getID());
   if ((it != m_detectorCache.end()) && (it->id() == det->getID())) {
     raiseDuplicateDetectorError(det->getID());
   }
+  // Create a (non-deleting) shared pointer to it
+  IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   m_detectorCache.emplace(it, det->getID(), det_sptr, false);
 }
 
@@ -664,7 +713,7 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsDetector() called on a "
                              "parametrized Instrument object.");
 
-  m_detectorCacheFinalized = false;
+  m_detectorCache.setIncomplete();
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   m_detectorCache.emplace_back(det->getID(), det_sptr, false);
@@ -687,8 +736,9 @@ void Instrument::markAsDetectorFinalize() {
       [](DetectorCacheEntry const &a, DetectorCacheEntry const &b) -> bool { return a.id() == b.id(); });
   if (resultIt != m_detectorCache.end()) {
     raiseDuplicateDetectorError(resultIt->id());
+  } else {
+    m_detectorCache.setFinalized();
   }
-  m_detectorCacheFinalized = true;
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -703,8 +753,6 @@ void Instrument::markAsMonitor(const IDetector *det) {
   if (m_map)
     throw std::runtime_error("Instrument::markAsMonitor() called on a "
                              "parametrized Instrument object.");
-  // NOTE markAsMonitor is not designed to be used with an unfinalized detector cache.
-  // However, actual usage in the codebase is inconsistent.  Finalizing here prevents some errors.
   if (!isFinalized()) {
     throw std::runtime_error("Instrument definition is not finalized.  Add monitor with markAsMonitorIncomplete, then "
                              "call markAsDetectorFinalized when finished.");
@@ -714,8 +762,8 @@ void Instrument::markAsMonitor(const IDetector *det) {
   markAsDetector(det);
 
   // mark detector as a monitor
-  auto it = find(m_detectorCache, det->getID());
-  std::get<2>(*it) = true;
+  auto it = m_detectorCache.find(det->getID());
+  it->isMonitor() = true;
 }
 
 /** Mark a Component which has already been added to the Instrument class
@@ -729,7 +777,7 @@ void Instrument::markAsMonitorIncomplete(const IDetector *det) {
     throw std::runtime_error("Instrument::markAsMonitorIncomplete() called on a "
                              "parametrized Instrument object.");
 
-  m_detectorCacheFinalized = false;
+  m_detectorCache.setIncomplete();
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
   m_detectorCache.emplace_back(det->getID(), det_sptr, true);
@@ -749,11 +797,11 @@ void Instrument::removeDetector(IDetector *det) {
 
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
-  const auto it = find(m_detectorCache, id);
+  const auto it = m_detectorCache.find(id);
   m_detectorCache.erase(it);
 
-  // Remove it from the parent assembly (and thus the instrument). Evilness
-  // required here unfortunately.
+  // Remove it from the parent assembly (and thus the instrument).
+  // Evilness required here unfortunately.
   auto *parentAssembly = dynamic_cast<CompAssembly *>(const_cast<IComponent *>(det->getBareParent()));
   if (parentAssembly) // Should always be true, but check just in case
   {
@@ -810,8 +858,7 @@ std::shared_ptr<const std::vector<IObjComponent_const_sptr>> Instrument::getPlot
     // Get the 'base' plottable components
     std::shared_ptr<const std::vector<IObjComponent_const_sptr>> objs = m_instr->getPlottable();
 
-    // Get a reference to the underlying vector, casting away the constness so
-    // that we
+    // Get a reference to the underlying vector, casting away the constness so that we
     // can modify it to get our result rather than creating another long vector
     auto &res = const_cast<std::vector<IObjComponent_const_sptr> &>(*objs);
     const std::vector<IObjComponent_const_sptr>::size_type total = res.size();
@@ -1161,6 +1208,10 @@ bool Instrument::addAssemblyChildrenToQueue(std::queue<IComponent_const_sptr> &q
 /// Temporary helper for refactoring. Argument is index, *not* ID!
 bool Instrument::isMonitorViaIndex(const size_t index) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
+  if (!in_dets.isFinalized())
+    throw std::runtime_error("Instrument::isMonitorViaIndex: detector cache is not finalized");
+  if (index >= in_dets.size())
+    throw std::out_of_range("Instrument::isMonitorViaIndex: index out of range");
   return in_dets[index].isMonitor();
 }
 
@@ -1173,7 +1224,7 @@ size_t Instrument::detectorIndex(const detid_t detID) const {
                              std::to_string(detID));
 
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
-  const auto it = find(in_dets, detID);
+  const auto it = in_dets.find(detID);
   return std::distance(in_dets.cbegin(), it);
 }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -183,7 +183,7 @@ void Instrument::getDetectors(detid2det_map &out_map) const {
     const auto &in_dets = m_instr->m_detectorCache;
     // And turn them into parametrized versions
     for (const auto &in_det : in_dets) {
-      it = out_map.emplace_hint(it, in_det.id(), getDetector(in_det.id()));
+      it = out_map.emplace_hint(it, in_det.id(), ParComponentFactory::createDetector(in_det.detector().get(), m_map));
     }
   } else {
     // You can just return the detector cache directly.

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -112,8 +112,9 @@ void InstrumentVisitor::walkInstrument() {
   if (m_pmap && m_pmap->empty()) {
     // Go through the base instrument for speed.
     m_instrument->baseInstrument()->registerContents(*this);
-  } else
+  } else {
     m_instrument->registerContents(*this);
+  }
 }
 
 size_t InstrumentVisitor::commonRegistration(const IComponent &component) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -58,7 +58,7 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Paramet
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Run.h:39
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Workspace.h:32
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/WorkspaceProperty.hxx:91
-nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:890
+nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/ExperimentInfo.cpp:891
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:156
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:167
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateDIFC.cpp:41


### PR DESCRIPTION
### Description of work

The `Instrument` object defines a detector cache.  Though the logic of the cache should follow that of an ordered map, at some point this cache was implemented as vector.  For a vector, the [`erase`](https://en.cppreference.com/w/cpp/container/vector/erase.html) method is always $O(N)$.  The `erase` method was called with the `Instrument::removeDetector()` method.

One particular hot path for this method occurred in `LoadEventNexus::deleteBanks()`, which called `removeDetector()` for (almost) every single detector in the instrument.  This results in a time-complexity of at least $O(N^2)$.

The error was discovered as the cause of a user-reported error, where calling `LoadEventNexus` for a single bank for data in the MANDI instrument was apparently freezing.  It was in fact taking hours to loop through every pixel, find it, and erase it from the detector cache.

A previous attempt in PR #41176 tried to replace the cache with an ordered map.  This *did* improve search speeds; however, some other operations which may occur on hot paths became more time-complex, leading to longer run times in some tests.

Moreover, even when the time-complexity issue was fixed, `Instrument::deleteBanks()` *still* cause an unrelated error arising from a mismatch between the instrument's cache size, and the instrument size recorded in the `DetectorInfo` object. This latter error was proven to exist as far back as Mantid 6.6.  

Because of the error, previous work  in PR #41183  removed the feature to delete unused banks in MANDI and TOPAZ instruments (the section of code causing the freeze).

This PR is the remainder of a separate attempt to improve the search speed, keeping a vector cache, but ensuring a sorted vector and using binary searching.  While this did *not* have the intended effect, the changes to the code did make the `Instrument` class methods easier to read and overall cleaner.

Refs:
- [EWM 15489](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15489&tab=com.ibm.team.workitem.tab.links)
- #41183 
- #41187 
- #41176 
- #41063

### To test:

This is a refactor.  Existing tests should be sufficient.

Try building workbench and loading some event data file.  Make sure the instrument is visible, and has spectra.

*This does not require release notes because* it is an internal issue that does not change user experience.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
