### PR TITLE
Added warnings to HFIRPowderReduction 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -561,6 +561,21 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
 
         return issues
 
+    def _warn_unset_optional_fields(self):
+        """Log warnings for optional fields that are not set (excludes fields already checked by validateInputs)."""
+        if not self._has_data_to_load("Vanadium"):
+            logger.warning("No vanadium run supplied. Data will not be normalized by vanadium.")
+        if not self._has_data_to_load("VanadiumBackground"):
+            logger.warning("VanadiumBackground is not set.")
+        if not self._has_data_to_load("SampleBackground"):
+            logger.warning("SampleBackground is not set.")
+        if self.getProperty("MaskWorkspace").value is None:
+            logger.warning("MaskWorkspace is not set.")
+        if self.getProperty("MaskAngle").value == Property.EMPTY_DBL:
+            logger.warning("MaskAngle is not set.")
+        if self.getProperty("AttenuationmuR").value == Property.EMPTY_DBL:
+            logger.warning("AttenuationmuR is not set.")
+
     def _loadMIDASData(self, filename, ws):
         # Check if the file has the expected fields
         with h5py.File(filename, "r") as f:
@@ -643,6 +658,8 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         6. Save (optional)
         7. Cleanup
         """
+        self._warn_unset_optional_fields()
+
         # Initialize temp workspace list for cleanup
         self.temp_workspace_list = ["_ws_cal", "_ws_cal_background"]
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -399,21 +399,21 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_warnings_when_all_optional_fields_set(self):
         """Test that no warnings are logged when all optional fields are provided."""
+        mask_workspace = CreateSampleWorkspace()
         algo = self._create_algo(
             Instrument="WAND^2",
             VanadiumFilename="HB2C_7000.nxs.h5",
             VanadiumBackgroundFilename="HB2C_7000.nxs.h5",
             SampleBackgroundFilename="HB2C_7000.nxs.h5",
+            MaskWorkspace=mask_workspace,
             MaskAngle=60.0,
             AttenuationmuR=1.5,
         )
-        # MaskWorkspace requires a real workspace, so we still expect that one warning
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
-            # Only MaskWorkspace warning should remain (requires a real workspace object)
-            self.assertEqual(mock_warning.call_count, 1)
-            self.assertIn("MaskWorkspace is not set.", messages)
+            self.assertEqual(mock_warning.call_count, 0)
+            self.assertEqual(messages, [])
 
 
 class AutoPopulateTests(unittest.TestCase):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -9,6 +9,7 @@ import unittest
 from mantid.simpleapi import (
     HFIRPowderReduction,
     CreateSampleWorkspace,
+    ExtractMask,
     RotateInstrumentComponent,
     MoveInstrumentComponent,
     CloneWorkspace,
@@ -27,6 +28,16 @@ import numpy as np
 import tempfile
 import shutil
 from unittest.mock import patch
+
+
+def _create_algo(**kwargs):
+    """Helper to create and initialize an HFIRPowderReduction algorithm with properties set."""
+    algo = _HFIRPowderReduction()
+    algo.initialize()
+    algo.temp_workspace_list = []
+    for key, value in kwargs.items():
+        algo.setProperty(key, value)
+    return algo
 
 
 class LoadInputErrorMessages(unittest.TestCase):
@@ -224,18 +235,9 @@ class LoadInputErrorMessages(unittest.TestCase):
         self.assertIn("VanadiumDiameter", error_msg)
         self.assertIn("VanadiumDiameter must be provided", error_msg)
 
-    def _create_algo(self, **kwargs):
-        """Helper to create and initialize an HFIRPowderReduction algorithm with properties set."""
-        algo = _HFIRPowderReduction()
-        algo.initialize()
-        algo.temp_workspace_list = []
-        for key, value in kwargs.items():
-            algo.setProperty(key, value)
-        return algo
-
     def test_load_wand_data(self):
         # Test that valid WAND^2 data loads without error via _load_WAND
-        algo = self._create_algo(SampleFilename="HB2C_7000.nxs.h5", Instrument="WAND^2")
+        algo = _create_algo(SampleFilename="HB2C_7000.nxs.h5", Instrument="WAND^2")
         try:
             algo._load_WAND_Data("HB2C_7000.nxs.h5", "test_wand_load")
         except RuntimeError as e:
@@ -246,7 +248,7 @@ class LoadInputErrorMessages(unittest.TestCase):
 
     def test_load_wand_workspaces(self):
         # Test loading WAND^2 for each type of input and verify workspaces are created
-        algo = self._create_algo(
+        algo = _create_algo(
             SampleFilename="HB2C_7000.nxs.h5",
             VanadiumFilename="HB2C_7000.nxs.h5",
             SampleBackgroundFilename="HB2C_7000.nxs.h5",
@@ -264,14 +266,14 @@ class LoadInputErrorMessages(unittest.TestCase):
 
     def test_load_existing_wand(self):
         # Test that _load_WAND creates a workspace in the ADS
-        algo = self._create_algo(Instrument="WAND^2")
+        algo = _create_algo(Instrument="WAND^2")
         algo._load_WAND_Data("HB2C_7000.nxs.h5", "test_existing_wand")
         self.assertTrue(mtd.doesExist("test_existing_wand"))
 
     # These tests will be uncommented and verified once real MIDAS data is obtained
     # def test_load_midas_data(self):
     #     # Test that valid MIDAS data loads without error via _loadMIDASData
-    #     algo = self._create_algo(Instrument="MIDAS")
+    #     algo = _create_algo(Instrument="MIDAS")
     #     try:
     #         algo._loadMIDASData(["Midas_HFIR_1234.nxs.h5"], None, [], "test_midas_load")
     #     except RuntimeError as e:
@@ -282,7 +284,7 @@ class LoadInputErrorMessages(unittest.TestCase):
 
     # def test_load_midas_contents(self):
     #     # Test loading MIDAS data and verify contents
-    #     algo = self._create_algo(Instrument="MIDAS")
+    #     algo = _create_algo(Instrument="MIDAS")
     #     algo._loadMIDASData(["Midas_HFIR_1234.nxs.h5"], None, [], "test_midas_contents")
     #     ws = mtd["test_midas_contents"]
     #     self.assertTrue(ws)
@@ -302,7 +304,7 @@ class LoadInputErrorMessages(unittest.TestCase):
 
     # def test_load_midas_workspaces(self):
     #     # Test loading MIDAS for each type of input and verify workspaces are created
-    #     algo = self._create_algo(
+    #     algo = _create_algo(
     #         SampleFilename="Midas_HFIR_1234.nxs.h5",
     #         VanadiumFilename="Midas_HFIR_1234.nxs.h5",
     #         SampleBackgroundFilename="Midas_HFIR_1234.nxs.h5",
@@ -320,24 +322,15 @@ class LoadInputErrorMessages(unittest.TestCase):
 
     # def test_load_existing_midas(self):
     #     # Test that _loadMIDASData creates a workspace in the ADS
-    #     algo = self._create_algo(Instrument="MIDAS")
+    #     algo = _create_algo(Instrument="MIDAS")
     #     algo._loadMIDASData(["HB2C_7000.nxs.h5"], None, [], "test_existing_midas")
     #     self.assertTrue(mtd.doesExist("test_existing_midas"))
 
 
 class WarnUnsetOptionalFieldsTests(unittest.TestCase):
-    def _create_algo(self, **kwargs):
-        """Helper to create and initialize an HFIRPowderReduction algorithm with properties set."""
-        algo = _HFIRPowderReduction()
-        algo.initialize()
-        algo.temp_workspace_list = []
-        for key, value in kwargs.items():
-            algo.setProperty(key, value)
-        return algo
-
     def test_all_warnings_when_no_optional_fields_set(self):
         """Test that all optional field warnings are logged when none are set."""
-        algo = self._create_algo(Instrument="WAND^2")
+        algo = _create_algo(Instrument="WAND^2")
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -351,7 +344,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_vanadium_warning_when_vanadium_filename_set(self):
         """Test that no vanadium warning is logged when VanadiumFilename is provided."""
-        algo = self._create_algo(Instrument="WAND^2", VanadiumFilename="HB2C_7000.nxs.h5")
+        algo = _create_algo(Instrument="WAND^2", VanadiumFilename="HB2C_7000.nxs.h5")
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -359,7 +352,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_vanadium_warning_when_vanadium_ipts_and_runs_set(self):
         """Test that no vanadium warning is logged when VanadiumIPTS and VanadiumRunNumbers are provided."""
-        algo = self._create_algo(Instrument="WAND^2", VanadiumIPTS=123, VanadiumRunNumbers=[456])
+        algo = _create_algo(Instrument="WAND^2", VanadiumIPTS=123, VanadiumRunNumbers=[456])
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -367,7 +360,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_vanadium_background_warning_when_set(self):
         """Test that no VanadiumBackground warning is logged when it is provided."""
-        algo = self._create_algo(Instrument="WAND^2", VanadiumBackgroundFilename="HB2C_7000.nxs.h5")
+        algo = _create_algo(Instrument="WAND^2", VanadiumBackgroundFilename="HB2C_7000.nxs.h5")
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -375,7 +368,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_sample_background_warning_when_set(self):
         """Test that no SampleBackground warning is logged when it is provided."""
-        algo = self._create_algo(Instrument="WAND^2", SampleBackgroundFilename="HB2C_7000.nxs.h5")
+        algo = _create_algo(Instrument="WAND^2", SampleBackgroundFilename="HB2C_7000.nxs.h5")
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -383,7 +376,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_mask_angle_warning_when_set(self):
         """Test that no MaskAngle warning is logged when it is provided."""
-        algo = self._create_algo(Instrument="WAND^2", MaskAngle=60.0)
+        algo = _create_algo(Instrument="WAND^2", MaskAngle=60.0)
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -391,7 +384,7 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_attenuation_warning_when_set(self):
         """Test that no AttenuationmuR warning is logged when it is provided."""
-        algo = self._create_algo(Instrument="WAND^2", AttenuationmuR=1.5)
+        algo = _create_algo(Instrument="WAND^2", AttenuationmuR=1.5)
         with patch.object(Logger, "warning") as mock_warning:
             algo._warn_unset_optional_fields()
             messages = [call.args[0] for call in mock_warning.call_args_list]
@@ -399,8 +392,9 @@ class WarnUnsetOptionalFieldsTests(unittest.TestCase):
 
     def test_no_warnings_when_all_optional_fields_set(self):
         """Test that no warnings are logged when all optional fields are provided."""
-        mask_workspace = CreateSampleWorkspace()
-        algo = self._create_algo(
+        sample_ws = CreateSampleWorkspace()
+        mask_workspace = ExtractMask(InputWorkspace=sample_ws, OutputWorkspace="test_mask").OutputWorkspace
+        algo = _create_algo(
             Instrument="WAND^2",
             VanadiumFilename="HB2C_7000.nxs.h5",
             VanadiumBackgroundFilename="HB2C_7000.nxs.h5",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -325,6 +325,97 @@ class LoadInputErrorMessages(unittest.TestCase):
     #     self.assertTrue(mtd.doesExist("test_existing_midas"))
 
 
+class WarnUnsetOptionalFieldsTests(unittest.TestCase):
+    def _create_algo(self, **kwargs):
+        """Helper to create and initialize an HFIRPowderReduction algorithm with properties set."""
+        algo = _HFIRPowderReduction()
+        algo.initialize()
+        algo.temp_workspace_list = []
+        for key, value in kwargs.items():
+            algo.setProperty(key, value)
+        return algo
+
+    def test_all_warnings_when_no_optional_fields_set(self):
+        """Test that all optional field warnings are logged when none are set."""
+        algo = self._create_algo(Instrument="WAND^2")
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertIn("No vanadium run supplied. Data will not be normalized by vanadium.", messages)
+            self.assertIn("VanadiumBackground is not set.", messages)
+            self.assertIn("SampleBackground is not set.", messages)
+            self.assertIn("MaskWorkspace is not set.", messages)
+            self.assertIn("MaskAngle is not set.", messages)
+            self.assertIn("AttenuationmuR is not set.", messages)
+            self.assertEqual(mock_warning.call_count, 6)
+
+    def test_no_vanadium_warning_when_vanadium_filename_set(self):
+        """Test that no vanadium warning is logged when VanadiumFilename is provided."""
+        algo = self._create_algo(Instrument="WAND^2", VanadiumFilename="HB2C_7000.nxs.h5")
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("No vanadium run supplied. Data will not be normalized by vanadium.", messages)
+
+    def test_no_vanadium_warning_when_vanadium_ipts_and_runs_set(self):
+        """Test that no vanadium warning is logged when VanadiumIPTS and VanadiumRunNumbers are provided."""
+        algo = self._create_algo(Instrument="WAND^2", VanadiumIPTS=123, VanadiumRunNumbers=[456])
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("No vanadium run supplied. Data will not be normalized by vanadium.", messages)
+
+    def test_no_vanadium_background_warning_when_set(self):
+        """Test that no VanadiumBackground warning is logged when it is provided."""
+        algo = self._create_algo(Instrument="WAND^2", VanadiumBackgroundFilename="HB2C_7000.nxs.h5")
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("VanadiumBackground is not set.", messages)
+
+    def test_no_sample_background_warning_when_set(self):
+        """Test that no SampleBackground warning is logged when it is provided."""
+        algo = self._create_algo(Instrument="WAND^2", SampleBackgroundFilename="HB2C_7000.nxs.h5")
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("SampleBackground is not set.", messages)
+
+    def test_no_mask_angle_warning_when_set(self):
+        """Test that no MaskAngle warning is logged when it is provided."""
+        algo = self._create_algo(Instrument="WAND^2", MaskAngle=60.0)
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("MaskAngle is not set.", messages)
+
+    def test_no_attenuation_warning_when_set(self):
+        """Test that no AttenuationmuR warning is logged when it is provided."""
+        algo = self._create_algo(Instrument="WAND^2", AttenuationmuR=1.5)
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            self.assertNotIn("AttenuationmuR is not set.", messages)
+
+    def test_no_warnings_when_all_optional_fields_set(self):
+        """Test that no warnings are logged when all optional fields are provided."""
+        algo = self._create_algo(
+            Instrument="WAND^2",
+            VanadiumFilename="HB2C_7000.nxs.h5",
+            VanadiumBackgroundFilename="HB2C_7000.nxs.h5",
+            SampleBackgroundFilename="HB2C_7000.nxs.h5",
+            MaskAngle=60.0,
+            AttenuationmuR=1.5,
+        )
+        # MaskWorkspace requires a real workspace, so we still expect that one warning
+        with patch.object(Logger, "warning") as mock_warning:
+            algo._warn_unset_optional_fields()
+            messages = [call.args[0] for call in mock_warning.call_args_list]
+            # Only MaskWorkspace warning should remain (requires a real workspace object)
+            self.assertEqual(mock_warning.call_count, 1)
+            self.assertIn("MaskWorkspace is not set.", messages)
+
+
 class AutoPopulateTests(unittest.TestCase):
     def test_auto_populate_instrument_from_filename(self):
         algo = AlgorithmManager.create("HFIRPowderReduction")

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41206.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41206.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-HFIRPowderReduction` now throws warnings for unset optional fields

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41206.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41206.rst
@@ -1,1 +1,1 @@
-- :ref:`algm-HFIRPowderReduction` now throws warnings for unset optional fields
+- :ref:`algm-HFIRPowderReduction` now logs warnings for unset optional fields.


### PR DESCRIPTION
### Description of work

This adds warnings to HFIRPowderReduction so that when certain fields are not set, a warning is logged. This checks for fields that are not already checked.

EWM item [13309](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13309)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run HFIRPowderReduction with only the sample set and the other minimum required fields. You should now see the following warnings in the logs:

No vanadium run supplied. Data will not be normalized by vanadium.
VanadiumBackground is not set.
SampleBackground is not set.
MaskWorkspace is not set.
MaskAngle is not set.
AttenuationmuR is not set.

Set the log level to warning so that you can easily see the warnings.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
