### PR TITLE
Fix crash in some fitting functions

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -207,7 +207,7 @@ void IFunctionAdapter::setAttributePythonValue(IFunction &self, const std::strin
  */
 void IFunctionAdapter::setAttribute(const std::string &attName, const Attribute &attr) {
   auto self = getSelf();
-  if (typeHasAttribute(self, "setAttributeValue")) {
+  if (GlobalInterpreterLock gil; typeHasAttribute(self, "setAttributeValue")) {
     object value = object(handle<>(getAttributeValue(*this, attr)));
     callMethod<void, std::string, object>(self, "setAttributeValue", attName, value);
     storeAttributeValue(attName, attr);


### PR DESCRIPTION
### Description of work

The crash was ocurring in the `WrapperHelpers` helper function `typeHasAttribute`, this function gets a pointer to the python object that needs checking and checks that an attribute belongs to that object by first converting  a char array with the attribute name to a python str and comparing this key against the `__dict__ `of the object. 
The line that was crashing is : `object key(handle<>(to_python_value<char const *&>()(attr)));` , particularly when trying to check that the `setAttributeValue` attribute of a python function exists, and when called from the function adapter `setAttribute` method. Any thread (like the fitting plot widget or the qens fitting interface) that tries to check an attribute of a function using this method crashes Mantid.
 `typeHasAttribute` is also called from `callMethod` in the function adapter and this does not raise any issue, so I think the problem is that the gil was not acquired in `setAttribute` before getting the handle to a python object. 
I think this may be related to python 3.12 having a more strict GC: https://docs.python.org/3.12/whatsnew/3.12.html . In any case, gil should be acquired before calling `typeHasAttribute`

__This does not need release notes as it is a regression introduced after 6.15__


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41115
. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Build from this branch and follow issue testing instructions. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
