### PR TITLE
fix dependency spotter for windows

### DIFF
--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -175,7 +175,9 @@ def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, 
     :param log_file: Name of the file to compare, e.g. mantid_build_environment.txt
     :return: URL for build artifact
     """
-    return f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/env_logs/{os_name}/{log_file}"
+    url_base = f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/"
+
+    return url_base + (f"env_logs/{os_name}/{log_file}" if not os_name == "win-64" else f"bld/env_logs/win-64/{log_file}")
 
 
 def extract_package_versions(url: str, os_name: str) -> Dict[str, str]:

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -176,7 +176,6 @@ def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, 
     :return: URL for build artifact
     """
     url_base = f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/"
-
     return url_base + (f"env_logs/{os_name}/{log_file}" if not os_name == "win-64" else f"bld/env_logs/win-64/{log_file}")
 
 


### PR DESCRIPTION
### Description of work

When investigating a recent build issue I noted that the dependency spotter does not work for windows.

This is because the env logs are archived in a different place for windows due to rattler-build peculiarities. This PR fixes this.

### To test:

Pixi:
`pixi run python tools/Jenkins/dependency_spotter.py -f 1270 -s 1271 -os linux-64 --pipeline main_nightly`

Conda, with env active:
`python tools/Jenkins/dependency_spotter.py -f 1270 -s 1271 -os linux-64 --pipeline main_nightly`

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
