### PR TITLE
Added a check to BayesQuasi2 that validates if the fitted parameters have converged to their final values

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
@@ -201,6 +201,13 @@ class BayesQuasi2(QuickBayesTemplate):
                 engine=engine, max_features=max_num_peaks, ws_list=ws_list, x_unit="DeltaE", name=f"{name}_{prog}_Workspace_{spec}"
             )
 
+            # Check if the results have converged
+            if spec > 0:
+                converged = self.validate_results_convergence(results)
+                if converged:
+                    self.log().warning("Fitting stopped because the fitted parameters values have converged.")
+                    break
+
         sample_logs = [("background", BG_str), ("elastic_peak", elastic), ("energy_min", start_x), ("energy_max", end_x)]
 
         return ws_list, results, results_errors, sample_logs
@@ -310,6 +317,20 @@ class BayesQuasi2(QuickBayesTemplate):
 
         self.setProperty("OutputWorkspaceResult", params)
         self.setProperty("OutputWorkspaceProb", prob)
+
+    def validate_results_convergence(self, results):
+        """
+        Takes the output of quickBayes and checks if the fitted
+        parameters have converged or not.
+        :param results: dict of quickBayes parameter results
+        """
+        stopping_criteria = 5e-3
+        parameters = results.keys()
+        converged = dict.fromkeys(results, False)
+        for parameter in parameters:
+            if abs(results[parameter][-2] - results[parameter][-1]) <= stopping_criteria:
+                converged[parameter] = True
+        return all(converged.values())
 
 
 # Register algorithm with Mantid

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2Test.py
@@ -157,9 +157,11 @@ class BayesQuasi2Test(unittest.TestCase):
             VerticalAxisValues=["1 feature(s)", "2 feature(s)"],
         )
 
-    def test_calculate(self):
+    @mock.patch("BayesQuasi2.BayesQuasi2.validate_results_convergence")
+    def test_calculate(self, validate_mock):
         func_mock = mock.Mock()
         engine_mock = mock.Mock()
+        validate_mock.return_value = False
 
         self._alg.get_background_function = mock.Mock(return_value=func_mock)
 
@@ -500,6 +502,17 @@ class BayesQuasi2Test(unittest.TestCase):
             name_params="results",
             name_prob="prob",
         )
+
+    def test_validate_results_convergence(self):
+        results = [
+            {"a": [np.float64(1.0), np.float64(1.5)], "b": [np.float64(2.0), np.float64(2.5)], "c": [np.float64(3), np.float64(3.5)]},
+            {"a": [np.float64(1.0), np.float64(1.005)], "b": [np.float64(2.0), np.float64(2.5)], "c": [np.float64(3), np.float64(3.5)]},
+            {"a": [np.float64(1.0), np.float64(1.005)], "b": [np.float64(2.0), np.float64(2.005)], "c": [np.float64(3), np.float64(3.5)]},
+            {"a": [np.float64(1.0), np.float64(1.005)], "b": [np.float64(2.0), np.float64(2.005)], "c": [np.float64(3), np.float64(3.005)]},
+        ]
+        converged = [False, False, False, True]
+        for r, c in zip(results, converged):
+            self.assertEqual(self._alg.validate_results_convergence(r), c)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40814 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
