### PR TITLE
getLogAsSingleValue can handle time-series

### DIFF
--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -252,7 +252,7 @@ std::unique_ptr<IPeak> PeaksWorkspace::createPeakQSample(const V3D &position) co
   // Then assume constant wavelenth
   double wavelength(0);
   if (props->hasProperty("wavelength")) {
-    wavelength = props->getPropertyValueAsType<double>("wavelength");
+    wavelength = props->getLogAsSingleValue("wavelength");
   } else if (props->hasProperty("energy")) {
     wavelength = Kernel::UnitConversion::run("Energy", "Wavelength", props->getPropertyValueAsType<double>("energy"), 0,
                                              0, 0, Kernel::DeltaEMode::Elastic, 0);

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -249,7 +249,7 @@ std::unique_ptr<IPeak> PeaksWorkspace::createPeakQSample(const V3D &position) co
 
   LogManager_const_sptr props = getLogs();
   // See if we can get a wavelength/energy
-  // Then assume constant wavelenth
+  // Then assume constant wavelength
   double wavelength(0);
   if (props->hasProperty("wavelength")) {
     wavelength = props->getLogAsSingleValue("wavelength");


### PR DESCRIPTION
### Description of work
Updates peak creation in `PeaksWorkspace` to correctly handle the `wavelength` sample log when it is stored as a time-series, avoiding failures when adding peaks from Slice Viewer workflows.

**Changes:**
- Switch wavelength retrieval in `PeaksWorkspace::createPeakQSample` from `getPropertyValueAsType<double>` to `getLogAsSingleValue`.

companion to PR #41219 
implements [EWM 15955](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15955)

This does not require release notes because notes it's a one-line bugfix that doesn't change the functionality or behavior of the slice viewer.

### To test:
(assumes access to the /SNS filesystem)  
Run this script in the workbench:
```python
from mantid.simpleapi import *

Load(Filename='/SNS/TOPAZ/IPTS-36038/nexus/TOPAZ_57086.nxs.h5', OutputWorkspace='TOPAZ_57086.nxs_event', FilterByTofMin=500, FilterByTofMax=16666)
FilterBadPulses(InputWorkspace='TOPAZ_57086.nxs_event', OutputWorkspace='TOPAZ_57086.nxs_event', LowerCutoff=85)
LoadIsawDetCal(InputWorkspace='TOPAZ_57086.nxs_event', Filename='/SNS/TOPAZ/shared/calibration/2025B_CG/calibration.DetCal')
ConvertToMD(
    InputWorkspace='TOPAZ_57086.nxs_event',
    QDimensions='Q3D',
    dEAnalysisMode='Elastic',
    Q3DFrames='Q_sample',
    LorentzCorrection=True,
    OutputWorkspace='TOPAZ_57086.nxs_md',
    MinValues='-15,-15,-15', MaxValues='15,15,15',
    SplitInto='2',
    SplitThreshold=50,
    MaxRecursionDepth=13,
    MinRecursionDepth=7
)
FindPeaksMD(
    InputWorkspace='TOPAZ_57086.nxs_md',
    PeakDistanceThreshold=0.12286956521739131,
    MaxPeaks=200,
    DensityThresholdFactor=100,
    OutputWorkspace='TOPAZ_57086.nxs_peaks'
)
```
Then:
1. Right-click in workspace `TOPAZ_57086.nxs_md` to "Show  Slice Viewer"
2. Click button "Add peaks overlays on/off"
3. In the popup dialog, click in workspace "TOPAZ_57086.nxs_peaks", then "OK"
4. Click on any of the rows showing the peaks
5. Click on button "Add Peaks"
6. Click anywhere on the slice. A new red "X" should show up, and no error message being shown in the log message windows.

Note: the reason for step "4. Click on any of the rows showing the peaks" is to take the slice view out of the Qz=0 plane. 


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
