### PR TITLE
Instrument View 2.0: Fix integration box edit crash on close

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/39884.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/39884.rst
@@ -1,0 +1,1 @@
+- The New Instrument Viewer no longer crashes when the integration range is edited through text boxes and window is closed.

--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/39884.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/39884.rst
@@ -1,0 +1,1 @@
+- The New Instrument Viewer now updates the counts data when the integration range has min == max.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -218,7 +218,7 @@ class FullInstrumentViewModel:
     def integration_limits(self, limits) -> None:
         try:
             min, max = limits
-            assert float(max) > float(min)
+            assert float(max) >= float(min)
         except (ValueError, AssertionError):
             return
         self._integration_limits = limits

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -784,6 +784,8 @@ class FullInstrumentViewWindow(QMainWindow):
         with suppress(TypeError):
             self._contour_range_max_edit.disconnect()
             self._contour_range_min_edit.disconnect()
+            self._integration_limit_max_edit.disconnect()
+            self._integration_limit_min_edit.disconnect()
         self.main_plotter.close()
         if self._detector_spectrum_fig is not None:
             plt.close(self._detector_spectrum_fig.get_label())


### PR DESCRIPTION
### Description of work
Editing the integration limits using the text box and then closing instrument view caused a mantid crash. Not anymore.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39884 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- [x] Edit both integration and contour ranges using text boxes, close the window. There should be no crash.
- [x] Edit the integration range by typing a lower value in the max text box. the slider should update the max so that it's equal to min and the plotter should be updated

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
