### PR TITLE
Reverse channel order for create package

### DIFF
--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -142,7 +142,7 @@ fi
 
 echo "Creating conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
-  --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
+  --channel $mantid_channel --channel conda-forge --channel "$conda_channel" --yes \
   mantidworkbench \
   mantiddocs \
   mslice \

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -216,7 +216,7 @@ fi
 
 echo "Creating conda environment in '$bundle_conda_prefix'"
 CONDA_SUBDIR="$platform" "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
-  --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
+  --channel $mantid_channel --channel conda-forge --channel "$conda_channel" --yes \
   mantidworkbench \
   mantiddocs \
   mslice \

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -83,7 +83,7 @@ fi
 
 echo "Creating conda env from mantidworkbench and jq"
 "$CONDA_EXE" create --prefix $CONDA_ENV_PATH \
-  --copy --channel $CONDA_CHANNEL --channel conda-forge --channel $MANTID_CHANNEL -y \
+  --copy --channel $MANTID_CHANNEL --channel conda-forge --channel $CONDA_CHANNEL -y \
   mantidworkbench \
   mantiddocs \
   mslice \


### PR DESCRIPTION
### Description of work

Mantid nightly crashed recently mainly for the reason that it could not find a suitable version of MSlice. While investigating, it turned out that the mantidworkbench Conda package from the Mantid channel instead of the local channel was used to build to standalone Mantid packages. This PR reverses the order the channels are used for finding the correct Conda packages. Now the local channel is used for searching first, followed by conda-forge and then the Mantid Conda channel. As a consequence, mantidworkbench is installed from the local channel.

Closes #41220 


### To test:

Check the build from branch (https://builds.mantidproject.org/job/build_branch/1558/) and confirm that the correct mantidworkbench package is used.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
