### PR TITLE
Change Doxygen publish  back to reusable action with token

### DIFF
--- a/.github/workflows/doxygen-publish.yml
+++ b/.github/workflows/doxygen-publish.yml
@@ -36,9 +36,11 @@ jobs:
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
-        run: |
-          git clone https://$DOXYGEN_REPO_TOKEN@github.com/mantidproject/doxygen.git doxygen_repo
-          rm -rf doxygen_repo/*
+        uses: actions/checkout@v6
+        with:
+          repository: mantidproject/doxygen
+          path: doxygen_repo
+          token: ${{ secrets.DOXYGEN_REPO_TOKEN }}
 
       - name: Copy Doxygen artifacts
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}


### PR DESCRIPTION
Try to use the reusable action again. Turns out that one can supply a `token` according to [the docs](https://github.com/actions/checkout?tab=readme-ov-file).

Refs #39497 

### To test:

The best test is to merge into `main` and see it work.

*This does not require release notes* because it is modifying CI.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
