### PR TITLE
Fix regression to `SumSpectra`

### DIFF
--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -430,12 +430,11 @@ void SumSpectra::doSimpleWeightedSum(MatrixWorkspace_const_sptr const &inWS, ISp
       double y = inWS->y(iwksp)[jbin];
       if (std::isnormal(e)) {
         weight = 1. / (e * e);
+        normalization += weight;
+        YSum[jbin] += weight * y;
       } else {
-        weight = 0.;
         nZeroes[jbin]++;
       }
-      normalization += weight;
-      YSum[jbin] += weight * y;
     }
     // apply the normalization factor
     if (normalization != 0.) {
@@ -542,12 +541,11 @@ void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, 
       double weight = 0.;
       if (std::isnormal(e)) { // is non-zero, nan, or infinity
         weight = 1. / (e * e);
+        normalization += weight;
+        YSum[jbin] += weight * y;
       } else {
-        weight = 0.;
         nZeroes[jbin]++;
       }
-      normalization += weight;
-      YSum[jbin] += weight * y;
       FracSum[jbin] += inWS->readF(iwksp)[jbin];
     }
     // apply the normalization factor

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -425,11 +425,10 @@ void SumSpectra::doSimpleWeightedSum(MatrixWorkspace_const_sptr const &inWS, ISp
     YErrorSum[jbin] = 0.;
     // loop over spectra
     for (size_t iwksp : m_indices) {
-      double weight = 0.;
       double e = inWS->e(iwksp)[jbin];
       double y = inWS->y(iwksp)[jbin];
       if (std::isnormal(e)) {
-        weight = 1. / (e * e);
+        double weight = 1. / (e * e);
         normalization += weight;
         YSum[jbin] += weight * y;
       } else {
@@ -538,9 +537,8 @@ void SumSpectra::doFractionalWeightedSum(RebinnedOutput_const_sptr const &inWS, 
       double y = inWS->y(iwksp)[jbin] * fracVal;
       double e = inWS->e(iwksp)[jbin] * fracVal;
       // now perform weghted sum of the mapped values
-      double weight = 0.;
       if (std::isnormal(e)) { // is non-zero, nan, or infinity
-        weight = 1. / (e * e);
+        double weight = 1. / (e * e);
         normalization += weight;
         YSum[jbin] += weight * y;
       } else {

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -1203,7 +1203,7 @@ class ReductionExecutionTests(unittest.TestCase):
 
         self.assertAlmostEqual(x.min(), 0.05)
         self.assertAlmostEqual(x.max(), 69.95)
-        self.assertTrue(np.isnan(y[0, 0]))
+        self.assertEqual(y[0, 0], 0.0)
         assert isinstance(pd_out, MatrixWorkspace)
 
         # CASE 3


### PR DESCRIPTION
### Description of work

In PR #41039, the `SumSpectra` algo was edited to properly perform error propagation on weighted sums.

However, an issue with the case of 0 weights led to the output domain being artificially contracted.

For the test script below, the results were as follows:

**Expected**
<img width="614" height="460" alt="Si_514_Workbench" src="https://github.com/user-attachments/assets/34e3e8e8-96e9-4893-bd97-e614f42de87d" />

**Observed**
<img width="614" height="460" alt="Si_514_Sum_nightly-1" src="https://github.com/user-attachments/assets/44fad1e5-0000-4a4e-a563-856237cce2ff" />

Importantly, the angular range should be from ~5 to ~140.

Note that between PR #41039 and this fix, PR #41055 was merged which adds an algorithm closely mirroring `WANDPowderReduction` that calls `SumSpectra`, and had a test reflecting behavior of `SumSpectra` at that time.  This small change fixes that test for the fix.

### To test:

Build this branch and run the following:
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import numpy as np
from mantid.kernel import UnitConversion, Elastic

sample_ipts = 22745
sample_runs = '1708919-1708920'
van_ipts = 23858
van_runs = '1708902'
tth_min = 5.0       # starting 2theta of the series of runs
wl = 1.4865         # neutron wavelength
norm = 'Monitor'    # or 'Time' or 'None'

LoadWAND(IPTS=sample_ipts,RunNumbers=sample_runs,ApplyMask=True,OutputWorkspace='sample_ws')
LoadWAND(IPTS=van_ipts,RunNumbers=van_runs,ApplyMask=True,OutputWorkspace='van_ws')
WANDPowderReduction(InputWorkspace='sample_ws',OutputWorkspace='sample_red',CalibrationWorkspace='van_ws',Target='Theta',Wavelength=wl,XMin=tth_min,XMax=tth_min+140,NumberBins=1200,NormaliseBy=norm,Sum=True)
```

Note that you will need to pull these files from analysis.  They are located in
```
/HFIR/HB2C/shared/software_tickets/15254/
```


Plot the resulting spectrum.  If this PR worked, then the the plot will look like the expected, having the full range of angle.

*This does not require release notes* because it fixes a defect in a previous PR which already had release notes; the prior release notes apply to this PR.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
