### PR TITLE
Add new VULCAN instrument geometry

### DIFF
--- a/docs/source/release/v6.16.0/Diffraction/Engineering/New_features/41243.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Engineering/New_features/41243.rst
@@ -1,0 +1,1 @@
+- Add new IDF for new VULCAN instrument configuration

--- a/instrument/VULCAN_Definition_2022-05-15.xml
+++ b/instrument/VULCAN_Definition_2022-05-15.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='ASCII'?>
 <instrument xmlns="http://www.mantidproject.org/IDF/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	    xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
-	    name="VULCAN" valid-from="2026-04-21 00:00:01"
-                          valid-to="2100-01-31 23:59:59"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+            name="VULCAN" valid-from   ="2022-05-15 00:00:01"
+                          valid-to     ="2026-04-20 23:59:59"
                           last-modified="2026-04-16 10:46">
-  <!--Created by Peter Peterson, Malcolm Guthrie, Chen Zhang, Luc Dessieux-->
+  <!--Created by Peter Peterson, Malcolm Guthrie, Chen Zhang-->
   <!--DEFAULTS-->
   <defaults>
     <length unit="metre"/>
@@ -65,387 +65,372 @@
       <rot val="0" axis-x="0" axis-y="1" axis-z="0"/>
     </location>
   </component>
-  <component type="bank7" idlist="bank7">
-    <location x="0" y="0" z="0">
-      <rot val="0" axis-x="0" axis-y="1" axis-z="0"/>
-    </location>
-  </component>
-  <component type="bank8" idlist="bank8">
-    <location x="0" y="0" z="0">
-      <rot val="0" axis-x="0" axis-y="1" axis-z="0"/>
-    </location>
-  </component>
-  <component type="bank9" idlist="bank9">
-    <location x="0" y="0" z="0">
-      <rot val="0" axis-x="0" axis-y="1" axis-z="0"/>
-    </location>
-  </component>
   <type name="bank1">
-    <component type="eightpack" name="pack1.0">
-      <location x="-2.2575167499999997" y="-0.0010727499999999834" z="0.4182165">
-        <rot val="-112.18998629580211" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2530550425194491">
-            <rot val="-147.07412698678087" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack20">
+      <location x="-2.2569747500000004" y="-0.0008815000000000073" z="-0.42433075000000003">
+        <rot val="-163.48248266329068" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.13992291039477195">
+            <rot val="-116.97493410017032" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack2.0">
-      <location x="-2.26525425" y="-0.0009737499999999955" z="0.37448225">
-        <rot val="-119.32609193318575" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.24060081396380062">
-            <rot val="-140.97821724620619" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack19">
+      <location x="-2.2644782500000002" y="-0.0011769999999999836" z="-0.38018850000000004">
+        <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.141915262177984">
+            <rot val="-98.70725277047943" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack3.0">
-      <location x="-2.2722587499999998" y="-0.001050499999999982" z="0.33045424999999995">
-        <rot val="-113.03372767414612" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.28532973137696344">
-            <rot val="-148.86828656646196" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack18">
+      <location x="-2.27169025" y="-0.0012947500000000112" z="-0.33647">
+        <rot val="-173.24750323050745" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.13336175088018082">
+            <rot val="-105.24940973853461" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack4.0">
-      <location x="-2.27823875" y="-0.0012189999999999979" z="0.28589624999999996">
-        <rot val="-116.90962111198665" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2549229220789548">
-            <rot val="-145.8479232507441" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack17">
+      <location x="-2.2777745" y="-0.0017260000000000053" z="-0.29222325000000005">
+        <rot val="-167.24470425596263" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.14212674833431765">
+            <rot val="-109.83593913880736" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack5.0">
-      <location x="-2.2834547499999998" y="-0.0011555000000000037" z="0.24093024999999998">
-        <rot val="-116.35004292551658" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2516435479551966">
-            <rot val="-147.35990303839424" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack16">
+      <location x="-2.283112" y="-0.0018349999999999755" z="-0.24720775">
+        <rot val="-161.73081166378225" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.14682766165728545">
+            <rot val="-114.4559240602165" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack6.0">
-      <location x="-2.2875835" y="-0.001225250000000011" z="0.196765">
-        <rot val="-117.91586483606885" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.23722915632710945">
-            <rot val="-147.24650893753162" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack15">
+      <location x="-2.287394" y="-0.001917000000000002" z="-0.20291175">
+        <rot val="-162.8687372785679" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.14977500846117076">
+            <rot val="-112.16477244389856" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack7.0">
-      <location x="-2.29110725" y="-0.0014317500000000094" z="0.15210925">
-        <rot val="-116.32628734713207" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.26780415630847737">
-            <rot val="-149.70422223734207" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack14">
+      <location x="-2.29103675" y="-0.00211699999999998" z="-0.1582015">
+        <rot val="-166.45910399741516" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.15153194251140495">
+            <rot val="-107.41876038627196" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack8.0">
-      <location x="-2.2935659999999998" y="-0.0014267500000000044" z="0.10724424999999999">
-        <rot val="-116.4817881021279" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.26161354699413253">
-            <rot val="-150.68111796696678" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack13">
+      <location x="-2.2935795000000003" y="-0.002217500000000011" z="-0.1133545">
+        <rot val="-166.93994247658878" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1475281903213638">
+            <rot val="-105.75105805642364" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack9.0">
-      <location x="-2.2952095" y="-0.0016122499999999818" z="0.06271175">
-        <rot val="-116.39550352314421" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.24451518462817073">
-            <rot val="-151.78668790108836" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack12">
+      <location x="-2.29539325" y="-0.0024875000000000036" z="-0.06897825">
+        <rot val="-167.54975184614312" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.15830904939911064">
+            <rot val="-104.1771699182449" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack10.0">
-      <location x="-2.29604175" y="-0.0015112499999999918" z="0.017879">
-        <rot val="-120.39776215845035" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.24328232104402925">
-            <rot val="-148.96938310437721" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack11">
+      <location x="-2.29622775" y="-0.0023999999999999855" z="-0.024003999999999998">
+        <rot val="-157.42282589527375" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.15565319315400697">
+            <rot val="-112.9259206775672" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack11.0">
-      <location x="-2.29590175" y="-0.00148100000000001" z="-0.02688875">
-        <rot val="-120.37247117652235" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.23880346195247298">
-            <rot val="-150.05472845560342" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack10">
+      <location x="-2.2963822499999997" y="-0.002355999999999997" z="0.020711">
+        <rot val="-161.5915947493558" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1684123039867728">
+            <rot val="-107.85874850228359" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack12.0">
-      <location x="-2.29496625" y="-0.0014510000000000078" z="-0.07189675">
-        <rot val="-123.50435318470409" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2416834734930343">
-            <rot val="-148.23664026932389" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack09">
+      <location x="-2.2954775" y="-0.002498750000000022" z="0.06561075000000001">
+        <rot val="-165.83627479752016" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.15540490623966519">
+            <rot val="-102.31101541117368" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack13.0">
-      <location x="-2.2931340000000002" y="-0.0014037500000000092" z="-0.11630774999999999">
-        <rot val="-120.84696686646136" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2468717393172097">
-            <rot val="-151.9454630853958" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack08">
+      <location x="-2.2937892499999997" y="-0.002302500000000013" z="0.11014825">
+        <rot val="-164.69525100967596" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.17212456449775038">
+            <rot val="-102.6422595093073" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack14.0">
-      <location x="-2.2905282500000004" y="-0.001265499999999975" z="-0.16152975">
-        <rot val="-124.73742263424391" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2351063768397893">
-            <rot val="-149.24470304356683" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack07">
+      <location x="-2.29129675" y="-0.0022260000000000058" z="0.15526974999999998">
+        <rot val="-158.86692694053377" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.17936652107113163">
+            <rot val="-107.13701122334506" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack15.0">
-      <location x="-2.2869085" y="-0.0011309999999999931" z="-0.2056455">
-        <rot val="-121.88741270177806" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.24566875843731206">
-            <rot val="-152.926213517578" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack06">
+      <location x="-2.28769725" y="-0.0019362499999999727" z="0.19955425">
+        <rot val="-167.81556953664995" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.15784884507244573">
+            <rot val="-97.40020039192666" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack16.0">
-      <location x="-2.2824772500000003" y="-0.0010217500000000157" z="-0.250288">
-        <rot val="-121.54536022377093" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.25344839611827713">
-            <rot val="-154.6059531647613" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack05">
+      <location x="-2.2836145" y="-0.0019917500000000143" z="0.24395250000000002">
+        <rot val="-168.1890119008101" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1770845068752133">
+            <rot val="-95.67466596972598" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack17.0">
-      <location x="-2.2771865" y="-0.0008594999999999575" z="-0.29462275">
-        <rot val="-124.75408783629085" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.23100294285598816">
-            <rot val="-152.39978252313975" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack04">
+      <location x="-2.278508" y="-0.0019144999999999857" z="0.288664">
+        <rot val="-154.1671234004896" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1995355897531742">
+            <rot val="-108.51819960733964" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack18.0">
-      <location x="-2.2711069999999998" y="-0.0007399999999999907" z="-0.33916525000000003">
-        <rot val="-128.0889207078544" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2260952257694147">
-            <rot val="-150.26902946366587" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack03">
+      <location x="-2.272457" y="-0.0016837499999999839" z="0.3332885">
+        <rot val="-152.31358568681048" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.2129692327877505">
+            <rot val="-109.44755803290482" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack19.0">
-      <location x="-2.2639225" y="-0.0005499999999999949" z="-0.38323925000000003">
-        <rot val="-123.92700826258601" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.24646161817092843">
-            <rot val="-155.69983933148708" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack02">
+      <location x="-2.2655077500000003" y="-0.0011432500000000123" z="0.377177">
+        <rot val="-162.34952804820227" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.19570074623538167">
+            <rot val="-98.08413574578995" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack20.0">
-      <location x="-2.25621775" y="-0.0005214999999999803" z="-0.42716224999999997">
-        <rot val="-124.61255701040969" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.25748798108953747">
-            <rot val="-156.14864969204208" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack01">
+      <location x="-2.25767875" y="-0.0013704999999999967" z="0.42124925">
+        <rot val="-160.14972897970412" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.19094851755117398">
+            <rot val="-99.01076671295034" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
   <type name="bank2">
-    <component type="eightpack" name="pack1.0">
-      <location x="2.255054" y="-0.0002224999999999866" z="0.4262795">
-        <rot val="-294.4894316220529" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20588673458707793">
-            <rot val="-166.40814335930972" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack01">
+      <location x="2.2575582499999998" y="-0.0006482499999999891" z="-0.422589">
+        <rot val="-324.2183399190491" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.11749898333786937">
+            <rot val="-114.9261041705881" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack2.0">
-      <location x="2.26307675" y="-0.0003025000000000111" z="0.38201025">
-        <rot val="-293.90480480770816" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2074267363016078">
-            <rot val="-165.68867512596032" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack02">
+      <location x="2.26532625" y="-0.0008927499999999977" z="-0.378061">
+        <rot val="-336.49750740040776" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.09570078004112703">
+            <rot val="-103.91688850441554" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack3.0">
-      <location x="2.27018875" y="-0.0005124999999999991" z="0.337889">
-        <rot val="-292.9920577937299" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.19679898588324465">
-            <rot val="-165.40189734046743" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack03">
+      <location x="2.27218675" y="-0.0012075000000000002" z="-0.333731">
+        <rot val="-340.90224201865834" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.09365811948712739">
+            <rot val="-100.58678539157293" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack4.0">
-      <location x="2.276352" y="-0.0008292500000000036" z="0.29357025000000003">
-        <rot val="-289.32476442217506" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20718913246292006">
-            <rot val="-168.0484686563769" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack04">
+      <location x="2.2782082499999996" y="-0.0013257500000000144" z="-0.28928975">
+        <rot val="0.0" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07701612195927764">
+            <rot val="-82.56046293123785" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack5.0">
-      <location x="2.2817865" y="-0.0009284999999999988" z="0.249048">
-        <rot val="-288.27524311913106" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20534971816685738">
-            <rot val="-167.73901513783935" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack05">
+      <location x="2.2834955" y="-0.0016535000000000022" z="-0.24470150000000002">
+        <rot val="-347.0709618273087" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.08257966452027073">
+            <rot val="-96.5576228700005" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack6.0">
-      <location x="2.28617675" y="-0.0009507500000000002" z="0.2046445">
-        <rot val="-286.4580428411163" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2084090463595321">
-            <rot val="-168.63623087608582" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack06">
+      <location x="2.28770625" y="-0.0016025000000000067" z="-0.20060224999999998">
+        <rot val="-340.26870845033676" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.08045236213395243">
+            <rot val="-104.54040710873082" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack7.0">
-      <location x="2.289759" y="-0.0009727500000000222" z="0.16000425000000001">
-        <rot val="-286.17844413629524" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.194489593493891">
-            <rot val="-167.6204397463455" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack07">
+      <location x="2.29140325" y="-0.0017230000000000023" z="-0.155883">
+        <rot val="-342.00163091744275" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.09673296455106561">
+            <rot val="-104.03184416342343" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack8.0">
-      <location x="2.29252225" y="-0.0011819999999999609" z="0.11526800000000001">
-        <rot val="-283.1444656255993" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20512715158539677">
-            <rot val="-169.86897674544312" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack08">
+      <location x="2.29397375" y="-0.0018167500000000059" z="-0.11130175">
+        <rot val="-347.5096896391713" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1017842311960848">
+            <rot val="-99.75149854774845" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack9.0">
-      <location x="2.294291" y="-0.0011672500000000086" z="0.07036675">
-        <rot val="-282.66963242112104" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.19605859622630878">
-            <rot val="-169.08925250071988" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack09">
+      <location x="2.29566775" y="-0.0018207500000000376" z="-0.06655649999999999">
+        <rot val="-324.3082205246244" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.11493376116018976">
+            <rot val="-124.01324530132364" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack10.0">
-      <location x="2.29535675" y="-0.0011467499999999742" z="0.025536749999999997">
-        <rot val="-283.7640074843688" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20297925055977462">
-            <rot val="-166.8709831399802" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack10">
+      <location x="2.29630375" y="-0.0017514999999999892" z="-0.021562">
+        <rot val="-354.47673387572763" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.08259591896251231">
+            <rot val="-95.24538098933628" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack11.0">
-      <location x="2.29531775" y="-0.001221250000000007" z="-0.0189775">
-        <rot val="-279.18172387603414" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.19884855643968646">
-            <rot val="-170.5662008209287" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack11">
+      <location x="2.296441" y="-0.001927000000000012" z="0.02285075">
+        <rot val="-344.6422889489733" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.09802064300859432">
+            <rot val="-105.92720222819501" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack12.0">
-      <location x="2.2947777499999997" y="-0.0012044999999999695" z="-0.063881">
-        <rot val="-277.60816804825043" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2379928559137054">
-            <rot val="-170.70502439827146" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack12">
+      <location x="2.2952707500000002" y="-0.0016884999999999817" z="0.06797975">
+        <rot val="0.0" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07301591273938465">
+            <rot val="-91.8187614009989" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack13.0">
-      <location x="2.293045" y="-0.001279499999999989" z="-0.10846825">
-        <rot val="-276.6939830895402" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20843993888431747">
-            <rot val="-170.56930412533515" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack13">
+      <location x="2.2936120000000004" y="-0.0017374999999999752" z="0.11243024999999998">
+        <rot val="-345.76420738849697" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07636785876252551">
+            <rot val="-107.06890398290837" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack14.0">
-      <location x="2.29049325" y="-0.0010525000000000118" z="-0.153237">
-        <rot val="-272.19176653622503" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2230189302716916">
-            <rot val="-174.06246633602578" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack14">
+      <location x="2.2909439999999996" y="-0.0015419999999999878" z="0.15723325">
+        <rot val="-352.2812927712494" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07612540800992432">
+            <rot val="-101.53325146166091" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack15.0">
-      <location x="2.28708525" y="-0.0011940000000000006" z="-0.19786199999999998">
-        <rot val="-272.6025622024993" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.21077297142441867">
-            <rot val="-172.36578575839974" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack15">
+      <location x="2.2873409999999996" y="-0.0014575000000000282" z="0.20187325">
+        <rot val="-345.71676814721206" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.06478613961290079">
+            <rot val="-109.08730100672045" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack16.0">
-      <location x="2.28294125" y="-0.0011629999999999974" z="-0.2421705">
-        <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.1953098713665359">
-            <rot val="-173.9011740366978" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack16">
+      <location x="2.28307575" y="-0.0013407500000000017" z="0.24627749999999998">
+        <rot val="-340.21629583520894" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07403644801294117">
+            <rot val="-115.64240206689581" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack17.0">
-      <location x="2.27767675" y="-0.0008677499999999727" z="-0.286775">
-        <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2031088602851741">
-            <rot val="-172.74116010687683" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack17">
+      <location x="2.27780175" y="-0.001148750000000004" z="0.29092225000000005">
+        <rot val="-348.87251113418444" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07430443728583369">
+            <rot val="-108.38698066615528" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack18.0">
-      <location x="2.27165675" y="-0.0008125000000000215" z="-0.33105249999999997">
-        <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.20255367697328353">
-            <rot val="-171.8198620959936" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack18">
+      <location x="2.27167825" y="-0.0008315000000000128" z="0.33513525">
+        <rot val="-353.9667469937985" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.06444031492489166">
+            <rot val="-104.2991861723782" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack19.0">
-      <location x="2.26489825" y="-0.00044825000000001114" z="-0.37529975">
-        <rot val="-266.152463592951" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.21864567305237279">
-            <rot val="-174.4788368559599" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack19">
+      <location x="2.2645955" y="-0.0006250000000000144" z="0.3793845">
+        <rot val="-352.1733389949816" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.06442254323344197">
+            <rot val="-107.27613640608348" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack20.0">
-      <location x="2.25724725" y="-0.00033550000000001634" z="-0.41955925000000005">
-        <rot val="-266.4814678242078" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.2560555973008179">
-            <rot val="-172.71725621322653" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpack" name="pack20">
+      <location x="2.2566224999999998" y="-0.0005357500000000015" z="0.42344925">
+        <rot val="-13.919714777421847" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.052312572375509604">
+            <rot val="-87.00706250630022" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
   <type name="bank3">
-    <component type="eightpack" name="pack1.0">
+    <component type="eightpack" name="pack01">
       <location x="1.57289375" y="0.0010980000000000156" z="-1.3438815000000002">
         <rot val="-334.22398084893626" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.11666308385112538">
@@ -454,7 +439,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack2.0">
+    <component type="eightpack" name="pack02">
       <location x="1.6016264999999998" y="0.0008599999999999997" z="-1.30948275">
         <rot val="-336.42453459851646" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10345314209640051">
@@ -463,7 +448,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack3.0">
+    <component type="eightpack" name="pack03">
       <location x="1.62969125" y="0.0006357499999999905" z="-1.2748422499999998">
         <rot val="-331.9562913257512" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10596609226324888">
@@ -472,7 +457,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack4.0">
+    <component type="eightpack" name="pack04">
       <location x="1.6569095000000003" y="0.0005672499999999914" z="-1.2390290000000002">
         <rot val="-318.56654620043497" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09911437083047824">
@@ -481,7 +466,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack5.0">
+    <component type="eightpack" name="pack05">
       <location x="1.6832522499999998" y="0.0003917499999999685" z="-1.2028732500000001">
         <rot val="-345.45099207068904" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09288157983979553">
@@ -490,7 +475,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack6.0">
+    <component type="eightpack" name="pack06">
       <location x="1.709033" y="0.00031274999999997277" z="-1.166448">
         <rot val="-325.926810857443" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09552152231422907">
@@ -499,7 +484,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack7.0">
+    <component type="eightpack" name="pack07">
       <location x="1.7338795" y="0.0002165000000000361" z="-1.1291315000000002">
         <rot val="-327.51811720091604" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09015562145176237">
@@ -508,7 +493,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack8.0">
+    <component type="eightpack" name="pack08">
       <location x="1.757961" y="8.675000000002431e-05" z="-1.0913417500000002">
         <rot val="-323.7175425014986" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.08558531064279508">
@@ -517,7 +502,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack9.0">
+    <component type="eightpack" name="pack09">
       <location x="1.7813565" y="-6.849999999999912e-05" z="-1.053031">
         <rot val="-342.1292917415275" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.08452656950404869">
@@ -526,7 +511,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack10.0">
+    <component type="eightpack" name="pack10">
       <location x="1.80344575" y="-0.00028375000000002704" z="-1.014343">
         <rot val="-321.4216500589228" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.07228155297752402">
@@ -535,7 +520,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack11.0">
+    <component type="eightpack" name="pack11">
       <location x="1.82512425" y="-0.0003262499999999724" z="-0.97511825">
         <rot val="-325.6415862923628" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.06845696920155334">
@@ -544,7 +529,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack12.0">
+    <component type="eightpack" name="pack12">
       <location x="1.84599625" y="-0.0002045000000000241" z="-0.93518325">
         <rot val="-327.6234052897093" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.07133041658709127">
@@ -553,7 +538,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack13.0">
+    <component type="eightpack" name="pack13">
       <location x="1.86563675" y="-0.0002489999999999992" z="-0.8951255">
         <rot val="-331.85032628674963" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.059859520624736935">
@@ -562,7 +547,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack14.0">
+    <component type="eightpack" name="pack14">
       <location x="1.88475575" y="-0.00027850000000001485" z="-0.854498">
         <rot val="-324.7824070318136" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.06332068290378519">
@@ -571,16 +556,16 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack15.0">
+    <component type="eightpack" name="pack15">
       <location x="1.9026740000000002" y="-0.0002462500000000034" z="-0.8135495">
         <rot val="-335.1905916245365" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.0576286248861325">
+          <rot val="-0.05762862488613251">
             <rot val="-91.58281186425931" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack16.0">
+    <component type="eightpack" name="pack16">
       <location x="1.920026" y="-0.0004704999999999848" z="-0.77213775">
         <rot val="-323.99267157225023" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.06337893915092158">
@@ -589,7 +574,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack17.0">
+    <component type="eightpack" name="pack17">
       <location x="1.93610725" y="-0.0002304999999999946" z="-0.7304809999999999">
         <rot val="-341.0306547593036" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.043690989318246685">
@@ -598,7 +583,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack18.0">
+    <component type="eightpack" name="pack18">
       <location x="1.95149875" y="-0.0002687499999999843" z="-0.6882945">
         <rot val="-337.4856131719658" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.0629952192531635">
@@ -609,7 +594,7 @@
     </component>
   </type>
   <type name="bank4">
-    <component type="eightpack" name="pack1.0">
+    <component type="eightpack" name="pack01">
       <location x="0.68984125" y="-0.001277499999999987" z="-1.94881075">
         <rot val="-58.36775394406836" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.1039633541819064">
@@ -618,7 +603,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack2.0">
+    <component type="eightpack" name="pack02">
       <location x="0.7316942500000001" y="-0.0012334999999999985" z="-1.93323225">
         <rot val="-60.47863816541249" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10723100124706075">
@@ -627,7 +612,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack3.0">
+    <component type="eightpack" name="pack03">
       <location x="0.7735412500000001" y="-0.001362000000000002" z="-1.91694425">
         <rot val="-63.714882798086315" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10792394508798003">
@@ -636,7 +621,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack4.0">
+    <component type="eightpack" name="pack04">
       <location x="0.814778" y="-0.0016140000000000043" z="-1.899927">
         <rot val="-70.9973833310523" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09802185248109126">
@@ -645,7 +630,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack5.0">
+    <component type="eightpack" name="pack05">
       <location x="0.85577025" y="-0.0020739999999999925" z="-1.88161275">
         <rot val="-66.53639450108717" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.09488545977449418">
@@ -654,7 +639,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack6.0">
+    <component type="eightpack" name="pack06">
       <location x="0.89653425" y="-0.0016825000000000034" z="-1.8627847499999999">
         <rot val="-69.21136628679464" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10514206009662236">
@@ -663,7 +648,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack7.0">
+    <component type="eightpack" name="pack07">
       <location x="0.93652725" y="-0.0016787500000000066" z="-1.8428345000000002">
         <rot val="-75.30342505996236" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.1004039845583736">
@@ -672,7 +657,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack8.0">
+    <component type="eightpack" name="pack08">
       <location x="0.97634425" y="-0.0017195000000000127" z="-1.8221595000000002">
         <rot val="-85.09962929782738" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10496954066380534">
@@ -681,7 +666,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack9.0">
+    <component type="eightpack" name="pack09">
       <location x="1.0155112499999999" y="-0.001741249999999972" z="-1.80050975">
         <rot val="-84.11357017109309" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.1093560324946849">
@@ -690,7 +675,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack10.0">
+    <component type="eightpack" name="pack10">
       <location x="1.0544772500000001" y="-0.001742500000000008" z="-1.7781075">
         <rot val="-75.63913802525627" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.11972962217182229">
@@ -699,7 +684,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack11.0">
+    <component type="eightpack" name="pack11">
       <location x="1.09276575" y="-0.001785250000000016" z="-1.7548645">
         <rot val="-79.92303020641462" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10420601134318119">
@@ -708,7 +693,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack12.0">
+    <component type="eightpack" name="pack12">
       <location x="1.13022175" y="-0.0015045000000000197" z="-1.7306934999999999">
         <rot val="-82.92065194471446" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.11949015052013748">
@@ -717,7 +702,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack13.0">
+    <component type="eightpack" name="pack13">
       <location x="1.1676085" y="-0.0016167500000000001" z="-1.7057529999999999">
         <rot val="-82.06346373210852" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.11478790716924482">
@@ -726,7 +711,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack14.0">
+    <component type="eightpack" name="pack14">
       <location x="1.20413025" y="-0.001572999999999991" z="-1.68012725">
         <rot val="-84.07716431225248" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10973966730397682">
@@ -735,7 +720,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack15.0">
+    <component type="eightpack" name="pack15">
       <location x="1.24010525" y="-0.001504000000000033" z="-1.65355525">
         <rot val="-93.03072747370484" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.11046395056294404">
@@ -744,7 +729,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack16.0">
+    <component type="eightpack" name="pack16">
       <location x="1.27566625" y="-0.0015262500000000068" z="-1.6262500000000002">
         <rot val="-90.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.10769576925075439">
@@ -753,7 +738,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack17.0">
+    <component type="eightpack" name="pack17">
       <location x="1.31039475" y="-0.0015369999999999828" z="-1.5985552500000002">
         <rot val="-99.94651731093175" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.08587588052282062">
@@ -762,7 +747,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack18.0">
+    <component type="eightpack" name="pack18">
       <location x="1.34451375" y="-0.0013315000000000132" z="-1.5699665">
         <rot val="-122.61017594434726" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.08757074207804119">
@@ -773,63 +758,90 @@
     </component>
   </type>
   <type name="bank5">
-    <component type="eightpackshort" name="pack1.0">
-      <location x="-1.001698" y="0.0017652500000000099" z="-1.7608989999999998">
-        <rot val="-133.75255035449672" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.03127322095062368">
-            <rot val="-202.62716509778517" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack09">
+      <location x="-0.62313225" y="-0.0018704999999999972" z="-1.921375">
+        <rot val="-15.382215121785627" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.0601675807929074">
+            <rot val="-322.48822796061535" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpackshort" name="pack9.0">
-      <location x="-0.6811215" y="0.002330250000000006" z="-1.90815525">
-        <rot val="-74.98795759486877" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.023780534838721057">
-            <rot val="-260.57438158646437" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack08">
+      <location x="-0.6637315" y="-0.0015059999999999935" z="-1.9044240000000001">
+        <rot val="-321.883477994764" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.02927854251188092">
+            <rot val="-15.528454064337105" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpackshort" name="pack2.0">
-      <location x="-1.78467125" y="0.004089000000000009" z="-1.7164675">
-        <rot val="-6.781049249119234" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.06962344990544103">
-            <rot val="-312.1066772608197" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack07">
+      <location x="-0.7039875" y="-0.0015727500000000116" z="-1.8874057499999999">
+        <rot val="-247.5901626284724" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.027246227698246594">
+            <rot val="-89.86212975046351" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpackshort" name="pack18.0">
-      <location x="-1.52281675" y="0.004044500000000006" z="-1.9527055">
-        <rot val="0.0" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.08868206267713578">
-            <rot val="-318.27860446019423" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack06">
+      <location x="-0.7440155" y="-0.0017419999999999797" z="-1.8698592499999998">
+        <rot val="-32.934490383230745" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.053871733277434664">
+            <rot val="-303.1400478936117" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpackshort" name="pack3.0">
-      <location x="-1.3897412500000002" y="0.0027957499999999857" z="-1.7352619999999999">
-        <rot val="-77.62403890109704" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.05269176517734986">
-            <rot val="-249.17814676307972" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack05">
+      <location x="-0.78478125" y="-0.0018520000000000064" z="-1.85301325">
+        <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.006930307421899672">
+            <rot val="-67.56435476328431" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
-    <component type="eightpackshort" name="pack27.0">
-      <location x="-1.097925" y="0.003013249999999995" z="-1.9332552499999998">
-        <rot val="-26.335792862736792" axis-x="0" axis-y="1" axis-z="0">
-          <rot val="-0.049745771089339016">
-            <rot val="-299.9133652535598" axis-x="0" axis-y="1" axis-z="0"/>
+    <component type="eightpackshort" name="pack04">
+      <location x="-0.8252487500000001" y="-0.0016675000000000023" z="-1.8360585">
+        <rot val="-281.76828893201434" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.07364221559516106">
+            <rot val="-54.84227507753802" axis-x="0" axis-y="1" axis-z="0"/>
+          </rot>
+        </rot>
+      </location>
+    </component>
+    <component type="eightpackshort" name="pack03">
+      <location x="-0.86622825" y="-0.0013027499999999914" z="-1.81849025">
+        <rot val="-263.91815643804847" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.1053141288593712">
+            <rot val="-74.15617002760236" axis-x="0" axis-y="1" axis-z="0"/>
+          </rot>
+        </rot>
+      </location>
+    </component>
+    <component type="eightpackshort" name="pack02">
+      <location x="-0.90625275" y="-0.0015642500000000031" z="-1.801348">
+        <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.0784112277824259">
+            <rot val="-67.20197868397078" axis-x="0" axis-y="1" axis-z="0"/>
+          </rot>
+        </rot>
+      </location>
+    </component>
+    <component type="eightpackshort" name="pack01">
+      <location x="-0.9473545" y="-0.0016742499999999882" z="-1.78359125">
+        <rot val="-285.7811998582893" axis-x="0" axis-y="1" axis-z="0">
+          <rot val="-0.09951570866794901">
+            <rot val="-51.94664850239168" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
       </location>
     </component>
   </type>
   <type name="bank6">
-    <component type="eightpack" name="pack0.0">
+    <component type="eightpack" name="pack11">
       <location x="-2.3815385" y="-0.0009234999999999938" z="0.841804">
         <rot val="-170.87433659554551" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.04908727204290472">
@@ -838,7 +850,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack1.0">
+    <component type="eightpack" name="pack10">
       <location x="-2.3660829999999997" y="-0.0007797499999999957" z="0.88378875">
         <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.03695746110660878">
@@ -847,7 +859,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack2.0">
+    <component type="eightpack" name="pack09">
       <location x="-2.350151" y="-0.001115250000000012" z="0.9256135">
         <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.035035690286040165">
@@ -856,7 +868,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack3.0">
+    <component type="eightpack" name="pack08">
       <location x="-2.332845" y="-0.0005457499999999837" z="0.9669595">
         <rot val="-164.56126963036328" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.03151299610397386">
@@ -865,7 +877,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack4.0">
+    <component type="eightpack" name="pack07">
       <location x="-2.3149345" y="-0.00029124999999996515" z="1.0078785">
         <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.011348863440783907">
@@ -874,7 +886,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack5.0">
+    <component type="eightpack" name="pack06">
       <location x="-2.29686475" y="-0.000850500000000004" z="1.04893225">
         <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.013242222302457701">
@@ -883,7 +895,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack6.0">
+    <component type="eightpack" name="pack05">
       <location x="-2.27773975" y="-0.0009779999999999789" z="1.08939225">
         <rot val="-115.12782418066332" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.017106839172842253">
@@ -892,7 +904,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack7.0">
+    <component type="eightpack" name="pack04">
       <location x="-2.25791025" y="-0.0007667500000000105" z="1.1295709999999999">
         <rot val="-180.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.022125764149139308">
@@ -901,7 +913,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack8.0">
+    <component type="eightpack" name="pack03">
       <location x="-2.23735275" y="-0.0005584999999999896" z="1.1693885">
         <rot val="-140.5560384231164" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.01501993609104224">
@@ -910,7 +922,7 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack9.0">
+    <component type="eightpack" name="pack02">
       <location x="-2.21585125" y="-0.0007695000000000063" z="1.208605">
         <rot val="-270.0" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.014640063005652685">
@@ -919,249 +931,13 @@
         </rot>
       </location>
     </component>
-    <component type="eightpack" name="pack10.0">
+    <component type="eightpack" name="pack01">
       <location x="-2.1942835" y="-6.724999999996317e-05" z="1.2477165">
         <rot val="-215.98679564433365" axis-x="0" axis-y="1" axis-z="0">
           <rot val="-0.011385583858767444">
             <rot val="-24.336807600385214" axis-x="0" axis-y="1" axis-z="0"/>
           </rot>
         </rot>
-      </location>
-    </component>
-  </type>
-  <type name="bank7">
-    <component type="eightpack" name="pack21.0">
-      <location x="1.428822214" y="-0.0007949999999999346" z="1.3974886155000001">
-        <rot val="-135.6577540106317" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack22.0">
-      <location x="1.397128891" y="-0.0007949999999999346" z="1.4284624885">
-        <rot val="-135.65775401063112" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack23.0">
-      <location x="1.3791801645" y="-0.0007949999999999346" z="1.4465024795">
-        <rot val="-137.6577534215877" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack24.0">
-      <location x="1.3464251755" y="-0.0007949999999999346" z="1.4763514034999998">
-        <rot val="-137.65775342158656" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack25.0">
-      <location x="1.3278577965" y="-0.0007949999999999346" z="1.4937540029999998">
-        <rot val="-139.65775452551006" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack26.0">
-      <location x="1.2940810485" y="-0.0007949999999999346" z="1.5224416109999999">
-        <rot val="-139.65775452551006" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack27.0">
-      <location x="1.2749176389999999" y="-0.0007949999999999346" z="1.539185617">
-        <rot val="-141.65775353666297" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack28.0">
-      <location x="1.240160284" y="-0.0007949999999999346" z="1.566676958">
-        <rot val="-141.65775353666297" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack29.0">
-      <location x="1.2204241900000001" y="-0.0007949999999999346" z="1.5827419705">
-        <rot val="-143.6577541685083" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack30.0">
-      <location x="1.1847285740000002" y="-0.0007949999999999346" z="1.6090035505">
-        <rot val="-143.65775416850875" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack31.0">
-      <location x="1.1644438419999998" y="-0.0007949999999999346" z="1.6243699974999999">
-        <rot val="-145.6577543242331" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack32.0">
-      <location x="1.1278534555" y="-0.0007949999999999346" z="1.6493698195">
-        <rot val="-145.65775529673525" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack33.0">
-      <location x="1.107044799" y="-0.0007949999999999346" z="1.6640189785000001">
-        <rot val="-147.65775554095174" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack34.0">
-      <location x="1.069604221" y="-0.0007949999999999346" z="1.6877265860000001">
-        <rot val="-147.65775408449974" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack35.0">
-      <location x="1.0482969925" y="-0.0007949999999999346" z="1.7016406094999998">
-        <rot val="-149.65775403055028" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack36.0">
-      <location x="1.01005183845" y="-0.0007949999999999346" z="1.7240271175000002">
-        <rot val="-149.65775411763508" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack37.0">
-      <location x="0.98827199765" y="-0.0007949999999999346" z="1.7371890535">
-        <rot val="-151.65775403775268" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack38.0">
-      <location x="0.9492688636" y="-0.0007949999999999346" z="1.7582271875">
-        <rot val="-151.65775379223538" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack39.0">
-      <location x="0.9270429453" y="-0.0007949999999999346" z="1.770621">
-        <rot val="-153.65775510492435" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack40.0">
-      <location x="0.8873293507500001" y="-0.0007949999999999346" z="1.790285129">
-        <rot val="-153.65775502842968" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-  </type>
-  <type name="bank8">
-    <component type="eightpack" name="pack41.0">
-      <location x="0.86468443405" y="-0.0007949999999999346" z="1.801895718">
-        <rot val="-155.65775426872804" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack42.0">
-      <location x="0.8243087637500001" y="-0.0007949999999999346" z="1.820161883">
-        <rot val="-155.65775426872804" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack43.0">
-      <location x="0.80127243795" y="-0.0007949999999999346" z="1.8309751035">
-        <rot val="-157.6577537080506" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack44.0">
-      <location x="0.7602838834499999" y="-0.0007949999999999346" z="1.8478210510000002">
-        <rot val="-157.65775530252085" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack45.0">
-      <location x="0.73688421485" y="-0.0007949999999999346" z="1.857823728">
-        <rot val="-159.65775443786342" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack46.0">
-      <location x="0.6953327144" y="-0.0007949999999999346" z="1.873228933">
-        <rot val="-159.65775449779022" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack47.0">
-      <location x="0.67159821185" y="-0.0007949999999999346" z="1.8824088795">
-        <rot val="-161.65775417078765" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack48.0">
-      <location x="0.6295343895000001" y="-0.0007949999999999346" z="1.8963545745000001">
-        <rot val="-161.65775422503694" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack49.0">
-      <location x="0.60549396985" y="-0.0007949999999999346" z="1.9047006065">
-        <rot val="-163.65775388792994" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack50.0">
-      <location x="0.56296907395" y="-0.0007949999999999346" z="1.9171697995">
-        <rot val="-163.65775388792972" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack51.0">
-      <location x="0.53865202675" y="-0.0007949999999999346" z="1.9246717494999999">
-        <rot val="-165.65775382811418" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack52.0">
-      <location x="0.49571786729999995" y="-0.0007949999999999346" z="1.9356492490000001">
-        <rot val="-165.65775554097215" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack53.0">
-      <location x="0.4711538191" y="-0.0007949999999999346" z="1.942297976">
-        <rot val="-167.65775419317612" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack54.0">
-      <location x="0.42786270479999994" y="-0.0007949999999999346" z="1.951770408">
-        <rot val="-167.65775419317544" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack55.0">
-      <location x="0.40308158315" y="-0.0007949999999999346" z="1.9575578120000001">
-        <rot val="-169.65775361614945" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack56.0">
-      <location x="0.35948625749999996" y="-0.0007949999999999346" z="1.9655136350000002">
-        <rot val="-169.65775358520105" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack57.0">
-      <location x="0.33451825435" y="-0.0007949999999999346" z="1.970432665">
-        <rot val="-171.6577535139493" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack58.0">
-      <location x="0.29067183155" y="-0.0007949999999999346" z="1.976862187">
-        <rot val="-171.65775351394933" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack59.0">
-      <location x="0.26554736655" y="-0.0007949999999999346" z="1.980906849">
-        <rot val="-173.65775508492055" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack60.0">
-      <location x="0.22150326674999998" y="-0.0007949999999999346" z="1.9858022365">
-        <rot val="-173.65775337158988" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-  </type>
-  <type name="bank9">
-    <component type="eightpack" name="pack61.0">
-      <location x="0.19625295025" y="-0.0007949999999999346" z="1.988967604">
-        <rot val="-175.65775457842378" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack62.0">
-      <location x="0.15206483434999996" y="-0.0007949999999999346" z="1.9923228920000002">
-        <rot val="-175.65775457842528" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack63.0">
-      <location x="0.12671942989999996" y="-0.0007949999999999346" z="1.994605108">
-        <rot val="-177.65775420327066" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack64.0">
-      <location x="0.08244113436" y="-0.0007949999999999346" z="1.996416209">
-        <rot val="-177.65775420749782" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack65.0">
-      <location x="0.05703152147499999" y="-0.0007949999999999346" z="1.9978124925">
-        <rot val="-179.6577539875129" axis-x="0" axis-y="1" axis-z="0"/>
-      </location>
-    </component>
-    <component type="eightpack" name="pack66.0">
-      <location x="0.0127169925545" y="-0.0007949999999999346" z="1.9980772">
-        <rot val="-179.6577557113744" axis-x="0" axis-y="1" axis-z="0"/>
       </location>
     </component>
   </type>
@@ -2247,26 +2023,26 @@
   </type>
   <!--DETECTOR IDs - panel is an 8-pack-->
   <idlist idname="bank1">
-    <id start="0" end="4095"/>
-    <id start="5000" end="9095"/>
-    <id start="10000" end="14095"/>
-    <id start="15000" end="19095"/>
-    <id start="20000" end="24095"/>
-    <id start="25000" end="29095"/>
-    <id start="30000" end="34095"/>
-    <id start="35000" end="39095"/>
-    <id start="40000" end="44095"/>
-    <id start="45000" end="49095"/>
-    <id start="50000" end="54095"/>
-    <id start="55000" end="59095"/>
-    <id start="60000" end="64095"/>
-    <id start="65000" end="69095"/>
-    <id start="70000" end="74095"/>
-    <id start="75000" end="79095"/>
-    <id start="80000" end="84095"/>
-    <id start="85000" end="89095"/>
-    <id start="90000" end="94095"/>
     <id start="95000" end="99095"/>
+    <id start="90000" end="94095"/>
+    <id start="85000" end="89095"/>
+    <id start="80000" end="84095"/>
+    <id start="75000" end="79095"/>
+    <id start="70000" end="74095"/>
+    <id start="65000" end="69095"/>
+    <id start="60000" end="64095"/>
+    <id start="55000" end="59095"/>
+    <id start="50000" end="54095"/>
+    <id start="45000" end="49095"/>
+    <id start="40000" end="44095"/>
+    <id start="35000" end="39095"/>
+    <id start="30000" end="34095"/>
+    <id start="25000" end="29095"/>
+    <id start="20000" end="24095"/>
+    <id start="15000" end="19095"/>
+    <id start="10000" end="14095"/>
+    <id start="5000" end="9095"/>
+    <id start="0" end="4095"/>
   </idlist>
   <idlist idname="bank2">
     <id start="100000" end="104095"/>
@@ -2331,77 +2107,28 @@
     <id start="385000" end="389095"/>
   </idlist>
   <idlist idname="bank5">
-    <id start="400000" end="404095"/>
-    <id start="405000" end="409095"/>
-    <id start="410000" end="414095"/>
-    <id start="415000" end="419095"/>
-    <id start="420000" end="424095"/>
+    <id start="440000" end="444095"/>
+    <id start="435000" end="439095"/>
+    <id start="430000" end="434095"/>
     <id start="425000" end="429095"/>
+    <id start="420000" end="424095"/>
+    <id start="415000" end="419095"/>
+    <id start="410000" end="414095"/>
+    <id start="405000" end="409095"/>
+    <id start="400000" end="404095"/>
   </idlist>
   <idlist idname="bank6">
-    <id start="500000" end="504095"/>
-    <id start="505000" end="509095"/>
-    <id start="510000" end="514095"/>
-    <id start="515000" end="519095"/>
-    <id start="520000" end="524095"/>
-    <id start="525000" end="529095"/>
-    <id start="530000" end="534095"/>
-    <id start="535000" end="539095"/>
-    <id start="540000" end="544095"/>
-    <id start="545000" end="549095"/>
     <id start="550000" end="554095"/>
-  </idlist>
-  <idlist idname="bank7">
-    <id start="600000" end="604095"/>
-    <id start="605000" end="609095"/>
-    <id start="610000" end="614095"/>
-    <id start="615000" end="619095"/>
-    <id start="620000" end="624095"/>
-    <id start="625000" end="629095"/>
-    <id start="630000" end="634095"/>
-    <id start="635000" end="639095"/>
-    <id start="640000" end="644095"/>
-    <id start="645000" end="649095"/>
-    <id start="650000" end="654095"/>
-    <id start="655000" end="659095"/>
-    <id start="660000" end="664095"/>
-    <id start="665000" end="669095"/>
-    <id start="670000" end="674095"/>
-    <id start="675000" end="679095"/>
-    <id start="680000" end="684095"/>
-    <id start="685000" end="689095"/>
-    <id start="690000" end="694095"/>
-    <id start="695000" end="699095"/>
-  </idlist>
-  <idlist idname="bank8">
-    <id start="700000" end="704095"/>
-    <id start="705000" end="709095"/>
-    <id start="710000" end="714095"/>
-    <id start="715000" end="719095"/>
-    <id start="720000" end="724095"/>
-    <id start="725000" end="729095"/>
-    <id start="730000" end="734095"/>
-    <id start="735000" end="739095"/>
-    <id start="740000" end="744095"/>
-    <id start="745000" end="749095"/>
-    <id start="750000" end="754095"/>
-    <id start="755000" end="759095"/>
-    <id start="760000" end="764095"/>
-    <id start="765000" end="769095"/>
-    <id start="770000" end="774095"/>
-    <id start="775000" end="779095"/>
-    <id start="780000" end="784095"/>
-    <id start="785000" end="789095"/>
-    <id start="790000" end="794095"/>
-    <id start="795000" end="799095"/>
-  </idlist>
-  <idlist idname="bank9">
-    <id start="800000" end="804095"/>
-    <id start="805000" end="809095"/>
-    <id start="810000" end="814095"/>
-    <id start="815000" end="819095"/>
-    <id start="820000" end="824095"/>
-    <id start="825000" end="829095"/>
+    <id start="545000" end="549095"/>
+    <id start="540000" end="544095"/>
+    <id start="535000" end="539095"/>
+    <id start="530000" end="534095"/>
+    <id start="525000" end="529095"/>
+    <id start="520000" end="524095"/>
+    <id start="515000" end="519095"/>
+    <id start="510000" end="514095"/>
+    <id start="505000" end="509095"/>
+    <id start="500000" end="504095"/>
   </idlist>
   <!-- Shape for Monitors-->
   <!-- TODO: Update to real shape -->


### PR DESCRIPTION
This is the new IDF for VULCAN in spring 2026. Luc created it and I have tested it.

There is no associate issue, but this is associated with [EWM15052](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15052)

### To test:

`LoadEventNexus` with `VULCAN_260112.nxs.h5`, then reload the file (to a different workspace) with `LoadNexusInstrumentXML=False` to get the IDF from this file. 

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
