### PR TITLE
Added a filtering function for the pcolormesh plots to filter out workspaces with 1 bin or less

### DIFF
--- a/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
+++ b/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
@@ -1,1 +1,1 @@
-- Fixed a crash by adding a check to verify the workspaces have more than one bin before creating :ref:`Colorfill_Plots` from the ``Stretch`` tab in the :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>`.
+- The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting> ``Stretch`` tab now verifies that workspaces have more than one bin before creating :ref:`Colorfill_Plots`.

--- a/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
+++ b/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
@@ -1,0 +1,1 @@
+- Fixed a crash by adding a check to verify the workspaces have more than one bin before creating :ref:`Colorfill_Plots` from the ``Stretch`` tab in the :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>`.

--- a/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
+++ b/docs/source/release/v6.16.0/Inelastic/Bugfixes/41142.rst
@@ -1,1 +1,1 @@
-- The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting> ``Stretch`` tab now verifies that workspaces have more than one bin before creating :ref:`Colorfill_Plots`.
+- The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` ``Stretch`` tab now verifies that workspaces have more than one bin before creating :ref:`Colorfill_Plots`.

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -245,7 +245,9 @@ def pcolormesh(workspaces, fig=None, color_norm=None, normalize_by_bin_width=Non
     """
     # check inputs
     _validate_pcolormesh_inputs(workspaces)
-    workspaces = [ws for ws in workspaces if isinstance(ws, MatrixWorkspace)]
+    workspaces = _filter_pcolormesh_inputs(workspaces)
+    if len(workspaces) == 0:
+        return None
 
     # create a subplot of the appropriate number of dimensions
     # extend in number of columns if the number of plottables is not a square number
@@ -332,6 +334,19 @@ def pcolormesh_on_axis(ax, ws, color_norm=None, normalize_by_bin_width=None):
 def _validate_pcolormesh_inputs(workspaces):
     """Raises a ValueError if any arguments have the incorrect types"""
     raise_if_not_sequence(workspaces, "workspaces", MatrixWorkspace)
+
+
+def _filter_pcolormesh_inputs(workspaces):
+    """Returns a list of only MatrixWorkspaces with more than 1 bin from the input list"""
+    filtered_workspaces = []
+    for ws in workspaces:
+        if isinstance(ws, MatrixWorkspace):
+            n_bins = len(ws.readX(0))
+            if n_bins <= 1:
+                LOGGER.error(f"Workspace '{ws.name()}' contains only {n_bins} bin. It must contain more than 1 bin for a Colorfill plot.")
+            else:
+                filtered_workspaces.append(ws)
+    return filtered_workspaces
 
 
 def _get_colorbar_scale():

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -336,16 +336,15 @@ def _validate_pcolormesh_inputs(workspaces):
     raise_if_not_sequence(workspaces, "workspaces", MatrixWorkspace)
 
 
-def _filter_pcolormesh_inputs(workspaces):
+def _filter_pcolormesh_inputs(workspaces: list[MatrixWorkspace]):
     """Returns a list of only MatrixWorkspaces with more than 1 bin from the input list"""
     filtered_workspaces = []
     for ws in workspaces:
-        if isinstance(ws, MatrixWorkspace):
-            n_bins = len(ws.readX(0)) - 1
-            if n_bins <= 1:
-                LOGGER.error(f"Workspace '{ws.name()}' contains only {n_bins} bin. It must contain more than 1 bin for a Colorfill plot.")
-            else:
-                filtered_workspaces.append(ws)
+        n_bins = len(ws.readX(0)) - 1
+        if n_bins <= 1:
+            LOGGER.error(f"Workspace '{ws.name()}' contains only {n_bins} bin. It must contain more than 1 bin for a Colorfill plot.")
+        else:
+            filtered_workspaces.append(ws)
     return filtered_workspaces
 
 

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -342,7 +342,7 @@ def _filter_pcolormesh_inputs(workspaces: list[MatrixWorkspace]):
     for ws in workspaces:
         n_bins = len(ws.readX(0)) - 1
         if n_bins <= 1:
-            LOGGER.error(f"Workspace '{ws.name()}' contains only {n_bins} bin. It must contain more than 1 bin for a Colorfill plot.")
+            LOGGER.error(f"Workspace '{ws.name()}' must contain more than 1 bin for a Colorfill plot (Number of bins found: {n_bins}).")
         else:
             filtered_workspaces.append(ws)
     return filtered_workspaces

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -341,7 +341,7 @@ def _filter_pcolormesh_inputs(workspaces):
     filtered_workspaces = []
     for ws in workspaces:
         if isinstance(ws, MatrixWorkspace):
-            n_bins = len(ws.readX(0))
+            n_bins = len(ws.readX(0)) - 1
             if n_bins <= 1:
                 LOGGER.error(f"Workspace '{ws.name()}' contains only {n_bins} bin. It must contain more than 1 bin for a Colorfill plot.")
             else:

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_functions.py
@@ -37,6 +37,9 @@ from mantidqt.plotting.functions import (
     pcolormesh_from_names,
     plot_surface,
     plot_wireframe,
+    pcolormesh,
+    _filter_pcolormesh_inputs,
+    _validate_pcolormesh_inputs,
 )
 
 IMAGE_PLOT_OPTIONS = {
@@ -434,6 +437,25 @@ class FunctionsTest(TestCase):
         # the colorbar limits default to +-0.1 when it can't find max and min of array
         self.assertNotEqual(cmax, 0.1)
         self.assertNotEqual(cmin, -0.1)
+
+    def test_filter_pcolormesh_inputs(self):
+        ws1 = CreateWorkspace(DataX=[1, 2, 3], DataY=[2] * 3, NSpec=1)
+        ws2 = CreateWorkspace(DataX=[1, 2, 3], DataY=[2] * 3, NSpec=1)
+        ws3 = CreateWorkspace(DataX=[1, 2], DataY=[2] * 2, NSpec=1)
+        table = WorkspaceFactory.Instance().createTable()
+        workspaces = [ws1, table, ws2, ws3]
+        filtered_workspaces = _filter_pcolormesh_inputs(workspaces)
+        self.assertEqual(filtered_workspaces, [ws1, ws2])
+
+    def test_validate_pcolormesh_inputs(self):
+        ws = CreateWorkspace(DataX=[1, 2, 3], DataY=[2] * 3, NSpec=1)
+        table = WorkspaceFactory.Instance().createTable()
+        workspaces = [ws, table]
+        self.assertRaises(ValueError, _validate_pcolormesh_inputs, workspaces)
+
+    def test_pcolormesh_returns_none_with_invalid_inputs(self):
+        ws = CreateWorkspace(DataX=[1, 2], DataY=[2] * 2, NSpec=1)
+        self.assertEqual(pcolormesh([ws, ws]), None)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_functions.py
@@ -442,8 +442,7 @@ class FunctionsTest(TestCase):
         ws1 = CreateWorkspace(DataX=[1, 2, 3], DataY=[2] * 3, NSpec=1)
         ws2 = CreateWorkspace(DataX=[1, 2, 3], DataY=[2] * 3, NSpec=1)
         ws3 = CreateWorkspace(DataX=[1, 2], DataY=[2] * 2, NSpec=1)
-        table = WorkspaceFactory.Instance().createTable()
-        workspaces = [ws1, table, ws2, ws3]
+        workspaces = [ws1, ws2, ws3]
         filtered_workspaces = _filter_pcolormesh_inputs(workspaces)
         self.assertEqual(filtered_workspaces, [ws1, ws2])
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41142. <!-- One line per closed issue. -->
Fixed a crash in the Bayes Fitting Interface.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Build the branch `using pixi run cmake --build .` and launch the **workbench**.
2) Open `Interfaces > Inelastic > Bayes Fitting`
3) Navigate to the **Stretch** tab.
4) Type `irs26176_graphite002_red` into the Sample field.
5) Type `irs26173_graphite002_res` in the resolution field.
6) Set **Beta** to 1.
7) Select `quickbayes` from the drop down menu and click **run**.
8) Select **Beta** or **All** from the Plot results drop down menu and click Plot.
9) Verify that the Beta plot is not plotted and an error is logged into the messages window.
10) Verify that Mantid crashes when workbench is build on the **main** branch.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
