### PR TITLE
Add windows unit test workflow

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,4 +1,4 @@
-name: Linux
+name: PR Build and Test
 
 on:
   pull_request:
@@ -37,12 +37,22 @@ jobs:
         name: Build doxygen
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
 
+
   build-and-test:
     needs: [doxygen]
+
+    strategy:
+      matrix:
+        include:
+          - os: Linux
+            cmake_preset: linux-64-ci
+          - os: Windows
+            cmake_preset: win-64-ci
+
     runs-on:
       - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
       - self-hosted
-      - Linux
+      - ${{ matrix.os }}
       - X64
     #
     # If the user who clicked "Run Workflow" button left the RUNNER_LABEL field blank,
@@ -50,12 +60,16 @@ jobs:
     # Otherwise set it to the value the user specified when they clicked "Run Workflow"
     #
 
+    defaults:
+      run:
+        shell: bash
+
     env:
-      CMAKE_PRESET: linux-64-ci
+      CMAKE_PRESET: ${{ matrix.cmake_preset }}
       EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
       ENABLE_BUILD_CODE: true
       ENABLE_UNIT_TESTS: true
-      ENABLE_SYSTEM_TESTS: true # default is false
+      ENABLE_SYSTEM_TESTS: ${{ matrix.os == 'Linux' }}
       ENABLE_DOCS: false
       ENABLE_DOC_TESTS: false
       ENABLE_DEV_DOCS: false
@@ -66,6 +80,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           env -0 | while IFS='' read -d '' line ; do printf '%s\t: %s\n' "${line%%=*}" "${line#*=}" | expand -t 30 | sed ':a;N;$!ba;s/\n/ /g'; done | LC_COLLATE=C sort -b
+
       #
       # If this workflow was triggered manually,
       # print a sorted list of all shell environment variables
@@ -105,15 +120,24 @@ jobs:
           # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false true $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
-      - name: Unit test report
+      - name: Unit test report (Linux)
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        if: ${{ failure() && steps.testunit.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Linux' && failure() && steps.testunit.conclusion == 'failure' }}
         with:
-          check_name: "Unit test results"
+          check_name: "Unit test results (${{ matrix.os }})"
+          check_run: false
+          files: build/Testing/*unittest.xml
+
+      - name: Unit test report (Windows)
+        uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2
+        if: ${{ matrix.os == 'Windows' && failure() && steps.testunit.conclusion == 'failure' }}
+        with:
+          check_name: "Unit test results (${{ matrix.os }})"
           check_run: false
           files: build/Testing/*unittest.xml
 
       - name: Run system tests
+        if: matrix.os == 'Linux'
         id: testsystem
         run: |
           cd ${GITHUB_WORKSPACE}
@@ -125,7 +149,7 @@ jobs:
 
       - name: Upload system test mismatch files
         uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.testsystem.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Linux' && failure() && steps.testsystem.conclusion == 'failure' }}
         with:
           name: system_test_mismatches
           if-no-files-found: ignore
@@ -133,7 +157,7 @@ jobs:
 
       - name: System test report
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        if: ${{ failure() && steps.testsystem.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Linux' && failure() && steps.testsystem.conclusion == 'failure' }}
         with:
           check_name: "System test results"
           check_run: false
@@ -143,5 +167,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test_logs
+          name: test_logs_${{ matrix.os }}
+          if-no-files-found: ignore
           path: ${{ github.workspace }}/build/test_logs/*.log

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -34,7 +34,7 @@ if [[ -n "${MANTID_DATA_STORE}" ]]; then
 fi
 
 if [[ $OSTYPE == "msys"* ]]; then
-    eval "$($WORKSPACE/buildconfig/Jenkins/Conda/vcvarsall.sh x64 -vcvars_ver=14.38.17.8)"
+    eval "$($WORKSPACE/buildconfig/Jenkins/Conda/vcvarsall.sh x64)"
 fi
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then

--- a/buildconfig/Jenkins/Conda/pixi-utils
+++ b/buildconfig/Jenkins/Conda/pixi-utils
@@ -21,7 +21,9 @@ install_pixi() {
     curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=$VERSION_PIXI sh
     set -x # turn logging back on (enable xtrace)
     # source bashrc for updated PATH
+    if [ -f "$HOME/.bashrc" ]; then
     . "$HOME/.bashrc"
+    fi
     # Verify pixi was installed successfully
     if [ ! -f "$HOME/.pixi/bin/pixi" ]; then
       echo "ERROR: pixi installation failed"


### PR DESCRIPTION
### Description of work

This PR extends the PR build and test workflow to run on both Linux and Windows runners. The Windows GitHub Actions runner is configured in the [dockerfiles repository](https://github.com/mantidproject/dockerfiles/pull/162).

- **Added Windows to the build matrix**: the `build-and-test` job now runs on both Linux (`linux-64-ci`) and Windows (`win-64-ci`) using a strategy matrix, with runner selection driven by `matrix.os`.
- **Set `shell: bash` as the default**: ensures consistent shell behaviour on Windows (Git Bash).
- **System tests are Linux-only**: gated with `matrix.os == 'Linux'`.
- **Separate unit test report steps**: Linux uses `publish-unit-test-result-action/linux@v2`, Windows uses `windows/bash@v2` (required as the action path differs per OS)
- **Removed pinned MSVC toolset version** (`-vcvars_ver=14.38.17.8`) from `vcvarsall.sh` invocation; The pin has also been removed from the runner Docker image. The pin was added due to a bug in the Jenkins node, which is no longer required in the GitHub runner. 
- **Source bash on Linux only in `pixi-utils`**: `.bashrc` sourcing now only runs when `.bashrc` exists, preventing a not-found error on Windows.


**NOTE: This is a test PR, and it must not be merged until all Windows nodes are configured with the self-hosted GitHub runner.**


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
