### PR TITLE
Improve validation on `LoadMask` algo

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMask.h
@@ -52,6 +52,9 @@ private:
   void init() override;
   /// Run the algorithm
   void exec() override;
+  /// Valudate inputs
+  std::vector<std::string> validExtensions() const { return {"xml", "msk"}; }
+  std::map<std::string, std::string> validateInputs() override;
   /// Initialize XML parser
   void initializeXMLParser(const std::string &filename);
   /// Parse XML
@@ -68,8 +71,6 @@ private:
   void processMaskOnWorkspaceIndex(bool mask, std::vector<specnum_t> &maskedSpecID, std::vector<detid_t> &singleDetIds);
 
   void initDetectors();
-
-  std::map<std::string, std::string> validateInputs() override;
 
   void convertSpMasksToDetIDs(const API::MatrixWorkspace &sourceWS, const std::vector<specnum_t> &maskedSpecID,
                               std::vector<detid_t> &singleDetIds);

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -22,6 +22,7 @@
 
 #include "MantidKernel/Strings.h"
 
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <sstream>
@@ -246,8 +247,7 @@ void LoadMask::init() {
   declareProperty("Instrument", "", std::make_shared<MandatoryValidator<std::string>>(),
                   "The name of the instrument to apply the mask.");
 
-  const std::vector<std::string> maskExts{".xml", ".msk"};
-  declareProperty(std::make_unique<FileProperty>("InputFile", "", FileProperty::Load, maskExts),
+  declareProperty(std::make_unique<FileProperty>("InputFile", "", FileProperty::Load, validExtensions()),
                   "Masking file for masking. Supported file format is XML and "
                   "ISIS ASCII. ");
   declareProperty(std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>("RefWorkspace", "", Direction::Input,
@@ -293,7 +293,6 @@ void LoadMask::exec() {
 
   // 2. Parse Mask File
   std::string filename = getProperty("InputFile");
-
   if (filename.ends_with("l") || filename.ends_with("L")) {
     // 2.1 XML File
     this->initializeXMLParser(filename);
@@ -303,9 +302,11 @@ void LoadMask::exec() {
     loadISISMaskFile(filename, m_maskSpecID);
     m_defaultToUse = true;
   } else {
-    g_log.error() << "File " << filename << " is not in supported format. \n";
-    return;
+    // we have already validated, so this should not occur
+    throw std::runtime_error("Error reading mask from file " + filename +
+                             ".  Supported formats are XML and ISIS mask files.  No mask was loaded.");
   }
+
   // 3. Translate and set geometry
   g_log.information() << "To Mask: \n";
 
@@ -701,6 +702,17 @@ if no errors is found.
 std::map<std::string, std::string> LoadMask::validateInputs() {
 
   std::map<std::string, std::string> result;
+
+  // check the extensions of the file
+  // NOTE the validator on the file property does not error if not correct
+  std::string filename = getProperty("InputFile");
+  std::transform(filename.begin(), filename.end(), filename.begin(), ::tolower);
+  auto exts = validExtensions();
+  if (std::none_of(exts.cbegin(), exts.cend(),
+                   [&filename](std::string const &ext) { return filename.ends_with(ext); })) {
+    result["InputFile"] =
+        "File " + filename + " is not in supported format.  Supported formats are XML and ISIS mask files.";
+  }
 
   API::MatrixWorkspace_sptr inputWS = getProperty("RefWorkspace");
   std::string InstrName = getProperty("Instrument");

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -568,6 +568,11 @@ void LoadMask::parseXML() {
   Poco::AutoPtr<NodeList> pNL_type = m_pRootElem->getElementsByTagName("type");
   g_log.information() << "Node Size = " << pNL_type->length() << '\n';
 
+  Poco::AutoPtr<NodeList> masking_nodes = m_pDoc->getElementsByTagName("detector-masking");
+  if (masking_nodes->length() == 0 && m_pRootElem->nodeName() != "detector-masking") {
+    throw std::runtime_error("No node with name 'detector-masking' is found in the mask file.  Wrong format.");
+  }
+
   Poco::XML::NodeIterator it(m_pDoc, Poco::XML::NodeFilter::SHOW_ELEMENT);
   Poco::XML::Node *pNode = it.nextNode();
 

--- a/Framework/DataHandling/test/LoadMaskTest.h
+++ b/Framework/DataHandling/test/LoadMaskTest.h
@@ -35,6 +35,39 @@ public:
   static LoadMaskTest *createSuite() { return new LoadMaskTest(); }
   static void destroySuite(LoadMaskTest *suite) { delete suite; }
 
+  // Loading a nonexistent mask should throw an exception
+  void test_LoadNonexistentThrow() {
+    LoadMask loadfile;
+    loadfile.initialize();
+    loadfile.setRethrows(true);
+
+    // this file does not exist, but has the right extensions
+    std::string const not_a_mask_file = "does_not_exist.msk";
+
+    loadfile.setProperty("Instrument", POWGEN_INSTR);
+    TS_ASSERT_THROWS_ASSERT(loadfile.setProperty("InputFile", not_a_mask_file), std::invalid_argument const &e,
+                            TS_ASSERT(strstr(e.what(), "Invalid value for property InputFile (string) from string")));
+    TS_ASSERT(!loadfile.isExecuted());
+  }
+
+  // Loading a file with the wrong format should throw an exception, not create an empty workspace
+  void test_LoadBadThrow() {
+    LoadMask loadfile;
+    loadfile.initialize();
+    loadfile.setRethrows(true);
+
+    // this is some file in the unit test data that is not a mask
+    std::string const not_a_mask_file = "48098.Q";
+
+    loadfile.setProperty("Instrument", POWGEN_INSTR);
+    loadfile.setProperty("InputFile", not_a_mask_file);
+    loadfile.setProperty("OutputWorkspace", "PG3Mask");
+
+    TS_ASSERT_THROWS_ASSERT(loadfile.execute(), std::runtime_error const &e,
+                            TS_ASSERT(strstr(e.what(), " is not in supported format.")));
+    TS_ASSERT(!loadfile.isExecuted());
+  }
+
   void test_LoadXML() {
     LoadMask loadfile;
     loadfile.initialize();

--- a/Framework/DataHandling/test/LoadMaskTest.h
+++ b/Framework/DataHandling/test/LoadMaskTest.h
@@ -51,7 +51,7 @@ public:
   }
 
   // Loading a file with the wrong format should throw an exception, not create an empty workspace
-  void test_LoadBadThrow() {
+  void test_LoadBadExtensionThrow() {
     LoadMask loadfile;
     loadfile.initialize();
     loadfile.setRethrows(true);
@@ -65,6 +65,23 @@ public:
 
     TS_ASSERT_THROWS_ASSERT(loadfile.execute(), std::runtime_error const &e,
                             TS_ASSERT(strstr(e.what(), " is not in supported format.")));
+    TS_ASSERT(!loadfile.isExecuted());
+  }
+
+  void test_LoadBadMaskFileThrow() {
+    LoadMask loadfile;
+    loadfile.initialize();
+    loadfile.setRethrows(true);
+
+    // this is some file in the unit test data that is not a mask
+    std::string const not_a_mask_file = "BASIS_Definition.xml";
+
+    loadfile.setProperty("Instrument", POWGEN_INSTR);
+    loadfile.setProperty("InputFile", not_a_mask_file);
+    loadfile.setProperty("OutputWorkspace", "PG3Mask");
+
+    TS_ASSERT_THROWS_ASSERT(loadfile.execute(), std::runtime_error const &e,
+                            TS_ASSERT(strstr(e.what(), "No node with name 'detector-masking' is found")));
     TS_ASSERT(!loadfile.isExecuted());
   }
 
@@ -103,6 +120,29 @@ public:
     }
 
   } // test_LoadXML
+
+  void test_LoadBlankMask() {
+    std::vector<int> banks1(0);
+    std::vector<int> detids(0);
+    auto emptyMaskFile = genMaskingFile("maskingdet.xml", detids, banks1);
+
+    // run and check
+    LoadMask loadfile;
+    loadfile.initialize();
+    loadfile.setProperty("Instrument", VULCAN_INSTR);
+    loadfile.setProperty("InputFile", emptyMaskFile.getFileName());
+    loadfile.setProperty("OutputWorkspace", "Empty_Mask");
+
+    TS_ASSERT_EQUALS(loadfile.execute(), true);
+    DataObjects::MaskWorkspace_sptr maskws =
+        AnalysisDataService::Instance().retrieveWS<DataObjects::MaskWorkspace>("Empty_Mask");
+
+    // check it is empty
+    std::set<detid_t> maskFlags = maskws->getMaskedDetectors();
+    TS_ASSERT(maskFlags.empty());
+    std::set<std::size_t> maskWkspIndices = maskws->getMaskedWkspIndices();
+    TS_ASSERT(maskWkspIndices.empty());
+  }
 
   /*
    * Test mask by detector ID

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41256.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41256.rst
@@ -1,0 +1,1 @@
+- Algorithm `LoadMask` will now throw an error if given invalid file extensions.

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41256.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41256.rst
@@ -1,1 +1,1 @@
-- Algorithm `LoadMask` will now throw an error if given invalid file extensions.
+- Algorithm `LoadMask` will now throw an error if given an invalid file.


### PR DESCRIPTION
### Description of work

This old and venerable algorithm had logic to check the file extensions that would only quietly point out an issue.

`LoadMask` has a `FileProperty` for the mask file.  This includes validation against a set of allowed extensions.  However, though `FileValidator` checks the validity of extensions against the allowed list, it doesn't invalidate if the extension is wrong.

The only check that `LoadMask` had a file type it could load was inside its `exec` method.  If a mismatch was detected, it logged an error and then exited the algorithm without loading anything.

This led to unexpected behavior in `BASISReduction.py` (see Issue #40972).

This PR adds extension validation inside the `validateInputs()` method, so that the algorithm will throw an error if the wrong extensions are passed to it.  If this disrupts someone's workflow, they can easily add `try/except` blocks around their use of `LoadMask`.  New tests ensure the validation of the file works as expected.

### To test:

Build and run.  Try to load a mask (there is one at `mantid/build/ExternalData/Testing/Data/SystemTest/BASIS/BASISReduction/BASIS_Mask_default_111.xml` you can point to).  Try to load a made-up string.  Try to load some other data file that is neither `.xml` or `.msk` (could be `.txt`)

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
