### PR TITLE
Throw errors for invalid masks in BASIS

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -421,7 +421,17 @@ the first two hours"""
             self._maskFile = self._reflection["mask_file"]
 
         self._maskWs = tws("BASIS_MASK")
-        sapi.LoadMask(Instrument="BASIS", OutputWorkspace=self._maskWs, InputFile=self._maskFile)
+        try:
+            sapi.LoadMask(Instrument="BASIS", OutputWorkspace=self._maskWs, InputFile=self._maskFile)
+        except ValueError as exc:
+            raise ValueError(f"Mask file {self._maskFile} could not be loaded. Please check the file path and try again.") from exc
+        except RuntimeError as exc:
+            if "Supported formats are XML and ISIS mask files" in str(exc):
+                raise RuntimeError(f"Mask file {self._maskFile} is not of the correct format.  Please use an XML mask file.") from exc
+            else:
+                raise RuntimeError(
+                    f"An unexpected error occurred when loading mask file {self._maskFile}. Please check the file and try again."
+                ) from exc
 
         # Work around length issue
         _dMask = sapi.ExtractMask(InputWorkspace=self._maskWs, OutputWorkspace=tws("ExtractMask"))

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -384,7 +384,7 @@ the first two hours"""
         with pyexec_setup(remove_temp, config_new_options) as self._temps:
             self._PyExec()
 
-    def _PyExec(self):  # noqa: C901
+    def _PyExec(self):
         # Collect Flux Normalization
         if self.getProperty("DoFluxNormalization").value is True:
             self._flux_normalization_type = self.getProperty("FluxNormalizationType").value
@@ -420,18 +420,8 @@ the first two hours"""
             mantid_config.appendDataSearchDir(DEFAULT_MASK_GROUP_DIR)
             self._maskFile = self._reflection["mask_file"]
 
-        self._maskWs = tws("BASIS_MASK")
-        try:
-            sapi.LoadMask(Instrument="BASIS", OutputWorkspace=self._maskWs, InputFile=self._maskFile)
-        except ValueError as exc:
-            raise ValueError(f"Mask file {self._maskFile} could not be loaded. Please check the file path and try again.") from exc
-        except RuntimeError as exc:
-            if "Supported formats are XML and ISIS mask files" in str(exc):
-                raise RuntimeError(f"Mask file {self._maskFile} is not of the correct format.  Please use an XML mask file.") from exc
-            else:
-                raise RuntimeError(
-                    f"An unexpected error occurred when loading mask file {self._maskFile}. Please check the file and try again."
-                ) from exc
+        # load the mask
+        self._load_mask()
 
         # Work around length issue
         _dMask = sapi.ExtractMask(InputWorkspace=self._maskWs, OutputWorkspace=tws("ExtractMask"))
@@ -671,6 +661,23 @@ the first two hours"""
         sapi.LoadEventNexus(**kwargs)
         if str(run) + ":" in self.getProperty("ExcludeTimeSegment").value:
             self._filterEvents(run, name)
+
+    def _load_mask(self):
+        r"""
+        Load a mask file into a workspace
+        """
+        self._maskWs = tws("BASIS_MASK")
+        try:
+            sapi.LoadMask(Instrument="BASIS", OutputWorkspace=self._maskWs, InputFile=self._maskFile)
+        except ValueError as exc:
+            raise ValueError(f"Mask file {self._maskFile} could not be loaded. Please check the file path and try again.") from exc
+        except RuntimeError as exc:
+            if "Supported formats are XML and ISIS mask files" in str(exc):
+                raise RuntimeError(f"Mask file {self._maskFile} is not of the correct format.  Please use an XML mask file.") from exc
+            else:
+                raise RuntimeError(
+                    f"An unexpected error occurred when loading mask file {self._maskFile}. Please check the file and try again."
+                ) from exc
 
     def _sum_monitors(self, run_set, mon_ws):
         r"""

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -384,7 +384,7 @@ the first two hours"""
         with pyexec_setup(remove_temp, config_new_options) as self._temps:
             self._PyExec()
 
-    def _PyExec(self):
+    def _PyExec(self):  # noqa: C901
         # Collect Flux Normalization
         if self.getProperty("DoFluxNormalization").value is True:
             self._flux_normalization_type = self.getProperty("FluxNormalizationType").value

--- a/Testing/SystemTests/scripts/CMakeLists.txt
+++ b/Testing/SystemTests/scripts/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Data search directories
 set(DATA_DIRS "")
 # Input data
-set(SYSTEM_TEST_DATA_DIR ${ExternalData_BINARY_ROOT}/Testing/Data/SystemTest)
+set(SYSTEM_TEST_DATA_DIR "${ExternalData_BINARY_ROOT}/Testing/Data/SystemTest")
 list(APPEND DATA_DIRS ${SYSTEM_TEST_DATA_DIR})
 list(APPEND DATA_DIRS ${SYSTEM_TEST_DATA_DIR}/INTER)
 # Reference results

--- a/Testing/SystemTests/tests/framework/BASISTest.py
+++ b/Testing/SystemTests/tests/framework/BASISTest.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import systemtesting
-from mantid import config
+from mantid import config, FileFinder
 from mantid.simpleapi import (
     BASISCrystalDiffraction,
     GroupWorkspaces,
@@ -17,6 +17,8 @@ from mantid.simpleapi import (
     Divide,
     ReplaceSpecialValues,
 )
+
+from unittest import mock
 
 
 class PreppingMixin(object):
@@ -312,6 +314,69 @@ class BASISReduction6Test(systemtesting.MantidSystemTest, PreppingMixin):
         self.tolerance = 0.1
         self.disableChecking.extend(["SpectraMap", "Instrument"])
         return "BSS_90146_divided_sqw", "BASIS_90146_divided_sqw.nxs"
+
+
+class BASISReduction7Test(systemtesting.MantidSystemTest, PreppingMixin):
+    r"""Ensure an error is thrown if no mask file is given nor can be found in the defaults"""
+
+    def __init__(self):
+        super(BASISReduction7Test, self).__init__()
+        self.config = None
+        self.prepset("BASISReduction")
+
+    def runTest(self):
+        import sys
+        import os
+        import tempfile
+
+        def_args = {
+            "RunNumbers": "90146",
+            "DoFluxNormalization": True,
+            "FluxNormalizationType": "Monitor",
+            "ReflectionType": "silicon_333",
+            "EnergyBins": [-330, 4.0, 330],
+            "MomentumTransferBins": [3.05, 4.30, 3.05],
+        }
+
+        # step 1: run with a file that does not exist -- should throw a runtime error
+        dnemask = "does_not_exist.xml"
+        assert not FileFinder.getFullPath(dnemask)
+        assert not os.path.exists(dnemask)
+        with self.assertRaisesRegex(RuntimeError, f"Mask file {dnemask} could not be loaded"):
+            BASISReduction(**def_args, MaskFile=dnemask)
+
+        # step 2: run with a file that does exist but is wrong format -- should throw a runtime error
+        mask = FileFinder.getFullPath("arg_si.dat")
+        assert os.path.exists(mask)
+        with self.assertRaisesRegex(RuntimeError, f"Mask file {mask} is not of the correct format"):
+            BASISReduction(**def_args, MaskFile=mask)
+
+        # lookup the module object for BASISReduction to patch the lookups to simulate situations where a mask is not found
+        mod = sys.modules.get("BASISReduction", None)
+        if mod is None:
+            raise RuntimeError("Could not locate BASISReduction module to patch default mask lookups")
+
+        # step 3: run with no mask -- should resort to default, which will not exist
+        with tempfile.TemporaryDirectory() as dir:
+            mask = os.path.join(dir, "BASIS_Mask_default_333.xml")
+            assert not os.path.exists(mask)
+            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": dir}):
+                with self.assertRaisesRegex(RuntimeError, f"Mask file {mask} could not be loaded"):
+                    BASISReduction(**def_args, MaskFile=None)  # run with no mask, set None for clarity
+
+        # step 4: run with no mask -- should resort to default, which we set to exist but be unreadable
+        with tempfile.TemporaryDirectory() as dir:
+            mask = os.path.join(dir, "BASIS_Mask_default_333.xml")
+            with open(mask, "w", encoding="utf-8") as f:
+                f.write("This is an XML file!")
+            assert os.path.exists(mask)
+            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": dir}):
+                with self.assertRaisesRegex(RuntimeError, f"An unexpected error occurred when loading mask file {mask}"):
+                    BASISReduction(**def_args, MaskFile=None)
+
+    def validate(self):
+        print("done")
+        return True
 
 
 class BASISReductionOutputSEnergyNXSTest(systemtesting.MantidSystemTest, PreppingMixin):

--- a/Testing/SystemTests/tests/framework/BASISTest.py
+++ b/Testing/SystemTests/tests/framework/BASISTest.py
@@ -357,25 +357,27 @@ class BASISReduction7Test(systemtesting.MantidSystemTest, PreppingMixin):
             raise RuntimeError("Could not locate BASISReduction module to patch default mask lookups")
 
         # step 3: run with no mask -- should resort to default, which will not exist
-        with tempfile.TemporaryDirectory() as dir:
-            mask = os.path.join(dir, "BASIS_Mask_default_333.xml")
+        with tempfile.TemporaryDirectory() as tdir:
+            mask = os.path.join(tdir, "BASIS_Mask_default_333.xml")
             assert not os.path.exists(mask)
-            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": dir}):
+            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": tdir}):
                 with self.assertRaisesRegex(RuntimeError, f"Mask file {mask} could not be loaded"):
                     BASISReduction(**def_args, MaskFile=None)  # run with no mask, set None for clarity
 
         # step 4: run with no mask -- should resort to default, which we set to exist but be unreadable
-        with tempfile.TemporaryDirectory() as dir:
-            mask = os.path.join(dir, "BASIS_Mask_default_333.xml")
+        with tempfile.TemporaryDirectory() as tdir:
+            mask = os.path.join(tdir, "BASIS_Mask_default_333.xml")
             with open(mask, "w", encoding="utf-8") as f:
                 f.write("This is an XML file!")
             assert os.path.exists(mask)
-            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": dir}):
+            with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": tdir}):
                 with self.assertRaisesRegex(RuntimeError, f"An unexpected error occurred when loading mask file {mask}"):
                     BASISReduction(**def_args, MaskFile=None)
 
+        # cleanup
+        self.preptear()
+
     def validate(self):
-        print("done")
         return True
 
 

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41259.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41259.rst
@@ -1,0 +1,1 @@
+- The algorithm `BASISReduction` has been updated to throw an error if a mask workspace cannot be found.


### PR DESCRIPTION
### Description of work

In `BASISReduction`, there were several situations where `LoadMask` would fail to find a mask workspace, but no error was thrown to indicate that no mask was found.

In PR #41256, better validation was added to `LoadMask` so that errors are thrown if a mask cannot be loaded.  These errors are now used inside `BASISReduction` to ensure that a mask is loaded and throw an error if not.

There is no set of unit tests for `BASISReduction`.  The closest was the system test `BASISTest.py`.  This was given a new test of validation.  The new tests should be pretty convincing.

Refs [EWM 15243](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15243)
Closes #40972 
Associated docs change in PR #41268

### To test:

Check the new tests, as they should exhaust the possibilities.  Ensure they run successfully.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
