### PR TITLE
Add option to normalise plots by Q^-4

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -396,7 +396,7 @@ public:
 
   const std::string &YUnit() const { return m_YUnit; }
   void setYUnit(const std::string &newUnit);
-  std::string YUnitLabel(bool useLatex = false, bool plotAsDistribution = false) const;
+  std::string YUnitLabel(bool useLatex = false) const;
   void setYUnitLabel(const std::string &newLabel);
 
   /// Are the Y-values dimensioned?

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1030,8 +1030,10 @@ void MatrixWorkspace::setYUnit(const std::string &newUnit) { m_YUnit = newUnit; 
 
 /**
  * Returns a caption for the units of the data in the workspace.
+ * @param plotAsDistribution :: If true, the Y-axis has been divided by bin
+ * width
  */
-std::string MatrixWorkspace::YUnitLabel(bool useLatex) const {
+std::string MatrixWorkspace::YUnitLabel(bool useLatex /* = false */) const {
   std::string retVal;
   if (!m_YUnitLabel.empty()) {
     retVal = m_YUnitLabel;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1030,31 +1030,20 @@ void MatrixWorkspace::setYUnit(const std::string &newUnit) { m_YUnit = newUnit; 
 
 /**
  * Returns a caption for the units of the data in the workspace.
- * @param useLatex :: Return label using Latex syntax
- * @param plotAsDistribution :: If true, the Y-axis has been divided by bin
- * width
  */
-std::string MatrixWorkspace::YUnitLabel(bool useLatex /* = false */, bool plotAsDistribution /* = false */) const {
+std::string MatrixWorkspace::YUnitLabel(bool useLatex) const {
   std::string retVal;
   if (!m_YUnitLabel.empty()) {
     retVal = m_YUnitLabel;
-    // If a custom label has been set and we are dividing by bin width when
-    // plotting (i.e. plotAsDistribution = true and the workspace is not a
-    // distribution), we must append the x-unit as a divisor. We assume the
-    // custom label contains the correct units for the data.
-    if (plotAsDistribution && !this->isDistribution())
-      retVal = appendUnitDenominatorUsingPer(retVal, *this, useLatex);
   } else {
     retVal = m_YUnit;
-    // If no custom label is set and the workspace is a distribution we need to
-    // append the divisor's unit to the label. If the workspace is not a
-    // distribution, but we are plotting it as a distribution, we must append
-    // the divisor's unit.
-    if (plotAsDistribution || this->isDistribution())
+    if (this->isDistribution()) {
       retVal = appendUnitDenominatorUsingPer(retVal, *this, useLatex);
+    }
   }
-  if (useLatex)
+  if (useLatex) {
     retVal = replacePerWithLatex(retVal);
+  }
   return retVal;
 }
 

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1030,7 +1030,7 @@ void MatrixWorkspace::setYUnit(const std::string &newUnit) { m_YUnit = newUnit; 
 
 /**
  * Returns a caption for the units of the data in the workspace.
- * @param plotAsDistribution :: If true, the Y-axis has been divided by bin
+ * @param useLatex :: Return label using Latex syntax
  * width
  */
 std::string MatrixWorkspace::YUnitLabel(bool useLatex /* = false */) const {

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -2035,34 +2035,26 @@ public:
 
   void test_YUnitLabel_Correct_For_Distribution_Workspace_Custom_m_YUnitLabel_Not_Set() {
     auto testWS = generateTestWorkspaceWithDistributionAndLabelSet(true, "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "Counts per microsecond");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), "Counts per microsecond");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "Counts ($\\mu s$)$^{-1}$");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "Counts ($\\mu s$)$^{-1}$");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "Counts per microsecond");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "Counts ($\\mu s$)$^{-1}$");
   }
 
   void test_YUnitLabel_Correct_For_Distribution_Workspace_Custom_m_YUnitLabel_Set() {
     auto testWS = generateTestWorkspaceWithDistributionAndLabelSet(true, "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "Custom Label");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "Custom Label");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "Custom Label");
   }
 
   void test_YUnitLabel_Correct_For_Non_Distribution_Workspace_Custom_m_YUnitLabel_Not_Set() {
     auto testWS = generateTestWorkspaceWithDistributionAndLabelSet(false, "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "Counts");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), "Counts per microsecond");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "Counts");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "Counts ($\\mu s$)$^{-1}$");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "Counts");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "Counts");
   }
 
   void test_YUnitLabel_Correct_For_Non_Distribution_Workspace_Custom_m_YUnitLabel_Set() {
     auto testWS = generateTestWorkspaceWithDistributionAndLabelSet(false, "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), "Custom Label per microsecond");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "Custom Label");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "Custom Label ($\\mu s$)$^{-1}$");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "Custom Label");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "Custom Label");
   }
 
   void test_YUnitLabel_Correct_For_Empty_Y_Labels() {
@@ -2070,20 +2062,16 @@ public:
     testWS->initialize(1, 2, 1);
     testWS->setDistribution(false);
     testWS->getAxis(0)->setUnit("TOF");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), " per microsecond");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "($\\mu s$)$^{-1}$");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "");
   }
 
   void test_YUnitLabel_Correct_For_Empty_X_And_Y_Labels() {
     auto testWS = std::make_shared<WorkspaceTester>();
     testWS->initialize(1, 2, 1);
     testWS->setDistribution(false);
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, false), "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(false, true), "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, false), "");
-    TS_ASSERT_EQUALS(testWS->YUnitLabel(true, true), "");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(false), "");
+    TS_ASSERT_EQUALS(testWS->YUnitLabel(true), "");
   }
 
   void test_findY() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -66,7 +66,7 @@ GNU_DIAG_OFF("conversion")
 // cppcheck-suppress unknownMacro
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_yIndexOfXOverloads, MatrixWorkspace::yIndexOfX, 1, 3)
 // Overloads for YUnitLabel which has 1 optional argument
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_YUnitLabelOverloads, YUnitLabel, 0, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_YUnitLabelOverloads, YUnitLabel, 0, 1)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 
@@ -406,8 +406,7 @@ void export_MatrixWorkspace() {
       .def("YUnit", &MatrixWorkspace::YUnit, arg("self"), return_value_policy<copy_const_reference>(),
            "Returns the current Y unit for the data (Y axis) in the workspace")
       .def("YUnitLabel", &MatrixWorkspace::YUnitLabel,
-           MatrixWorkspace_YUnitLabelOverloads((arg("self"), arg("useLatex"), arg("plotAsDistribution")),
-                                               "Returns the caption for the Y axis"))
+           MatrixWorkspace_YUnitLabelOverloads((arg("self"), arg("useLatex")), "Returns the caption for the Y axis"))
       .def("hasAnyMaskedBins", &MatrixWorkspace::hasAnyMaskedBins, (arg("self")),
            "Returns true if any of the bins in this workspace are masked.")
       .def("hasMaskedBins", &MatrixWorkspace::hasMaskedBins, (arg("self"), arg("workspaceIndex")),

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -140,7 +140,7 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
                 x = [spectrum_numbers[i] for i in x]
 
         elif axis == MantidAxType.SPECTRUM:
-            normalization_type = get_normalization_type(workspace, axes, **kwargs)
+            normalization_type, kwargs = get_normalization_type(workspace, axes, **kwargs)
             x, y, dy, dx = get_spectrum(workspace, workspace_index, normalization_type, with_dy, with_dx)
         else:
             raise ValueError("Axis {} is not a valid axis number.".format(axis))
@@ -175,7 +175,7 @@ def _plot_impl(axes, workspace, args, kwargs):
             axes.set_xlabel("Time")
         kwargs["drawstyle"] = "steps-post"
     else:
-        normalization = get_normalization_type(workspace, axes, **kwargs)
+        normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         # the get... function returns kwargs without 'normalize_by_bin_width', but it is needed in _get_data_for_plot to
         # avoid reverting to the default norm setting, in the event that this function is being called as part of a plot
         # restoration
@@ -316,7 +316,7 @@ def errorbar(axes, workspace, *args, **kwargs):
 
     x, y, dy, dx, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs, with_dy=withDy, with_dx=withDx)
     if kwargs.pop("update_axes_labels", True):
-        normalization = get_normalization_type(workspace, axes, **kwargs)
+        normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
     kwargs.pop("normalize_type", None)
@@ -550,7 +550,7 @@ def pcolor(axes, workspace, *args, **kwargs):
             kwargs["pcolortype"] = ""
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
-            normalization = get_normalization_type(workspace, axes, **kwargs)
+            normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
             _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
     return axes.pcolor(x, y, z, *args, **kwargs)
@@ -590,7 +590,7 @@ def pcolorfast(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        normalization = get_normalization_type(workspace, axes, **kwargs)
+        normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
             kwargs["pcolortype"] = "fast"
@@ -635,7 +635,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        normalization = get_normalization_type(workspace, axes, **kwargs)
+        normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
             kwargs["pcolortype"] = "mesh"
@@ -686,7 +686,7 @@ def imshow(axes, workspace, *args, **kwargs):
         return mantid.plots.modest_image.imshow(axes, z, *args, **kwargs)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        normalization = get_normalization_type(workspace, axes, **kwargs)
+        normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         kwargs["normalize_by_bin_width"] = normalization == PlotNormalizationType.BIN_WIDTH
         _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
         return samplingimage.imshow_sampling(axes, workspace=workspace, *args, **kwargs)

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -37,6 +37,7 @@ from mantid.plots.datafunctions import (
     check_resample_to_regular_grid,
     get_indices,
     get_normalize_by_bin_width,
+    get_normalization_type,
     get_spectrum_normalisation,
 )
 from mantid.plots.utility import MantidAxType, PlotNormalizationType
@@ -122,8 +123,7 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
     else:
         normalise_spectrum, kwargs = get_spectrum_normalisation(**kwargs)
         axis = MantidAxType(kwargs.pop("axis", MantidAxType.SPECTRUM))
-        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
-        workspace_index, distribution, kwargs = get_wksp_index_dist_and_label(workspace, axis, **kwargs)
+        workspace_index, _, kwargs = get_wksp_index_dist_and_label(workspace, axis, **kwargs)
         if axis == MantidAxType.BIN:
             # get_bin returns the bin *without the monitor data*
             x, y, dy, dx = get_bins(workspace, workspace_index, with_dy, with_dx)
@@ -141,8 +141,8 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
                 x = [spectrum_numbers[i] for i in x]
 
         elif axis == MantidAxType.SPECTRUM:
-            normalization = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
-            x, y, dy, dx = get_spectrum(workspace, workspace_index, normalization, with_dy, with_dx)
+            normalization_type = get_normalization_type(workspace, axes, **kwargs)
+            x, y, dy, dx = get_spectrum(workspace, workspace_index, normalization_type, with_dy, with_dx)
         else:
             raise ValueError("Axis {} is not a valid axis number.".format(axis))
         indices = None
@@ -185,6 +185,7 @@ def _plot_impl(axes, workspace, args, kwargs):
         if kwargs.pop("update_axes_labels", True):
             _setLabels1D(axes, workspace, indices, normalize_by_bin_width=normalize_by_bin_width, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
+    kwargs.pop("normalize_type", None)
     return x, y, args, kwargs
 
 
@@ -209,6 +210,10 @@ def plot(axes, workspace, *args, **kwargs):
     :param normalize_by_bin_width: ``None`` (default) ask the workspace. It can override
                           the value from distribution. Is implemented so get_normalize_by_bin_width
                           only need to be run once.
+    :param normalization_type: :class:`mantid.plots.utility.PlotNormalizationType` enum specifying the
+                          normalization to apply. Can be ``NONE``, ``BIN_WIDTH``, or ``INVERSE_Q_FOURTH_POWER``.
+                          If specified, this takes precedence over ``normalize_by_bin_width``.
+                          Applies to MatrixWorkspace spectra plots.
     :param LogName:   if specified, it will plot the corresponding sample log. The x-axis
                       of the plot is the time difference between the log time and the first
                       value of the `proton_charge` log (if available) or the sample log's
@@ -271,6 +276,10 @@ def errorbar(axes, workspace, *args, **kwargs):
                          Applies only when the workspace is a MatrixWorkspace histogram.
     :param normalize_by_bin_width: Plot the workspace as a distribution. If None default to global
                                    setting: config['graph1d.autodistribution']
+    :param normalization_type: :class:`mantid.plots.utility.PlotNormalizationType` enum specifying the
+                          normalization to apply. Can be ``NONE``, ``BIN_WIDTH``, or ``INVERSE_Q_FOURTH_POWER``.
+                          If specified, this takes precedence over ``normalize_by_bin_width``.
+                          Applies to MatrixWorkspace spectra plots.
     :param normalization: ``None`` (default) ask the workspace. Applies to MDHisto workspaces. It can override
                           the value from displayNormalizationHisto. It checks only if
                           the normalization is mantid.api.MDNormalization.NumEventsNormalization
@@ -311,6 +320,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     if kwargs.pop("update_axes_labels", True):
         _setLabels1D(axes, workspace, indices, normalize_by_bin_width=normalize_by_bin_width, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
+    kwargs.pop("normalize_type", None)
 
     if dy is not None and min(dy) < 0:
         dy = None
@@ -338,6 +348,10 @@ def scatter(axes, workspace, *args, **kwargs):
     :param distribution: ``None`` (default) asks the workspace. ``False`` means
                          divide by bin width. ``True`` means do not divide by bin width.
                          Applies only when the workspace is a MatrixWorkspace histogram.
+    :param normalization_type: :class:`mantid.plots.utility.PlotNormalizationType` enum specifying the
+                          normalization to apply. Can be ``NONE``, ``BIN_WIDTH``, or ``INVERSE_Q_FOURTH_POWER``.
+                          If specified, this takes precedence over ``distribution``.
+                          Applies to MatrixWorkspace spectra plots.
     :param normalization: ``None`` (default) ask the workspace. Applies to MDHisto workspaces. It can override
                           the value from displayNormalizationHisto. It checks only if
                           the normalization is mantid.api.MDNormalization.NumEventsNormalization

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -29,7 +29,7 @@ from mantid.plots.datafunctions import (
     get_md_data1d,
     get_md_data2d_bin_bounds,
     get_md_data2d_bin_centers,
-    get_normalization,
+    get_md_normalization,
     get_sample_log,
     get_spectrum,
     get_uneven_data,
@@ -39,7 +39,7 @@ from mantid.plots.datafunctions import (
     get_normalize_by_bin_width,
     get_spectrum_normalisation,
 )
-from mantid.plots.utility import MantidAxType
+from mantid.plots.utility import MantidAxType, PlotNormalizationType
 from mantid.plots.quad_mesh_wrapper import QuadMeshWrapper
 from mantid import logger
 
@@ -68,9 +68,9 @@ def _pcolormesh_nonortho(axes, workspace, nonortho_tr, *args, **kwargs):
     :param transpose: ``bool`` to transpose the x and y axes of the plotted dimensions of an MDHistoWorkspace
     """
     transpose = kwargs.pop("transpose", False)
-    (normalization, kwargs) = get_normalization(workspace, **kwargs)
+    (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
     indices, kwargs = get_indices(workspace, **kwargs)
-    x, y, z = get_md_data2d_bin_bounds(workspace, indices=indices, normalization=normalization, transpose=transpose)
+    x, y, z = get_md_data2d_bin_bounds(workspace, indices=indices, md_normalization=normalization, transpose=transpose)
     X, Y = numpy.meshgrid(x, y)
     xx, yy = nonortho_tr(X, Y)
     _setLabels2D(axes, workspace, indices, transpose)
@@ -109,7 +109,7 @@ def _setLabels2D(axes, workspace, indices=None, transpose=False, xscale=None, no
 
 def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         (x, y, dy) = get_md_data1d(workspace, normalization, indices)
         # Protect against unused arguments for MDHisto workspaces
@@ -141,7 +141,8 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
                 x = [spectrum_numbers[i] for i in x]
 
         elif axis == MantidAxType.SPECTRUM:
-            x, y, dy, dx = get_spectrum(workspace, workspace_index, normalize_by_bin_width, with_dy, with_dx)
+            normalization = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+            x, y, dy, dx = get_spectrum(workspace, workspace_index, normalization, with_dy, with_dx)
         else:
             raise ValueError("Axis {} is not a valid axis number.".format(axis))
         indices = None
@@ -356,13 +357,14 @@ def scatter(axes, workspace, *args, **kwargs):
     dimension
     """
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         (x, y, _) = get_md_data1d(workspace, normalization, indices)
         _setLabels1D(axes, workspace, indices)
     else:
         (wkspIndex, distribution, kwargs) = get_wksp_index_dist_and_label(workspace, **kwargs)
-        (x, y, _, _) = get_spectrum(workspace, wkspIndex, distribution)
+        normalization = PlotNormalizationType.BIN_WIDTH if distribution else PlotNormalizationType.NONE
+        (x, y, _, _) = get_spectrum(workspace, wkspIndex, normalization)
         _setLabels1D(axes, workspace)
     return axes.scatter(x, y, *args, **kwargs)
 
@@ -395,7 +397,7 @@ def contour(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_centers(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -434,7 +436,7 @@ def contourf(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_centers(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -524,7 +526,7 @@ def pcolor(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_bounds(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -569,7 +571,7 @@ def pcolorfast(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_bounds(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -614,7 +616,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_bounds(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -659,7 +661,7 @@ def imshow(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.get("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_bounds(workspace, normalization, indices, transpose)
         _setLabels2D(axes, workspace, indices, transpose)
@@ -707,7 +709,7 @@ def tripcolor(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x_temp, y_temp, z = get_md_data2d_bin_centers(workspace, normalization, indices, transpose)
         x, y = numpy.meshgrid(x_temp, y_temp)
@@ -750,7 +752,7 @@ def tricontour(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x_temp, y_temp, z = get_md_data2d_bin_centers(workspace, normalization, indices, transpose)
         x, y = numpy.meshgrid(x_temp, y_temp)
@@ -802,7 +804,7 @@ def tricontourf(axes, workspace, *args, **kwargs):
     """
     transpose = kwargs.pop("transpose", False)
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x_temp, y_temp, z = get_md_data2d_bin_centers(workspace, normalization, indices, transpose)
         x, y = numpy.meshgrid(x_temp, y_temp)

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -345,10 +345,6 @@ def scatter(axes, workspace, *args, **kwargs):
     :param distribution: ``None`` (default) asks the workspace. ``False`` means
                          divide by bin width. ``True`` means do not divide by bin width.
                          Applies only when the workspace is a MatrixWorkspace histogram.
-    :param normalization_type: :class:`mantid.plots.utility.PlotNormalizationType` enum specifying the
-                          normalization to apply. Can be ``NONE``, ``BIN_WIDTH``, or ``INVERSE_Q_FOURTH_POWER``.
-                          If specified, this takes precedence over ``distribution``.
-                          Applies to MatrixWorkspace spectra plots.
     :param normalization: ``None`` (default) ask the workspace. Applies to MDHisto workspaces. It can override
                           the value from displayNormalizationHisto. It checks only if
                           the normalization is mantid.api.MDNormalization.NumEventsNormalization

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -317,7 +317,7 @@ def errorbar(axes, workspace, *args, **kwargs):
         normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
-    kwargs.pop("normalizeation_type", None)
+    kwargs.pop("normalization_type", None)
 
     if dy is not None and min(dy) < 0:
         dy = None

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -182,7 +182,7 @@ def _plot_impl(axes, workspace, args, kwargs):
         if kwargs.pop("update_axes_labels", True):
             _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
-    kwargs.pop("normalize_type", None)
+    kwargs.pop("normalization_type", None)
     return x, y, args, kwargs
 
 
@@ -317,7 +317,7 @@ def errorbar(axes, workspace, *args, **kwargs):
         normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
         _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
-    kwargs.pop("normalize_type", None)
+    kwargs.pop("normalizeation_type", None)
 
     if dy is not None and min(dy) < 0:
         dy = None

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -36,7 +36,6 @@ from mantid.plots.datafunctions import (
     get_wksp_index_dist_and_label,
     check_resample_to_regular_grid,
     get_indices,
-    get_normalize_by_bin_width,
     get_normalization_type,
     get_spectrum_normalisation,
 )
@@ -80,21 +79,21 @@ def _pcolormesh_nonortho(axes, workspace, nonortho_tr, *args, **kwargs):
     return QuadMeshWrapper(mesh)
 
 
-def _setLabels1D(axes, workspace, indices=None, normalize_by_bin_width=True, axis=MantidAxType.SPECTRUM):
+def _setLabels1D(axes, workspace, indices=None, normalization=PlotNormalizationType.BIN_WIDTH, axis=MantidAxType.SPECTRUM):
     """
     helper function to automatically set axes labels for 1D plots
     """
-    labels = get_axes_labels(workspace, indices, normalize_by_bin_width)
+    labels = get_axes_labels(workspace, indices, normalization)
     # We assume that previous checking has ensured axis can only be 1 of 2 types
     axes.set_xlabel(labels[2 if axis == MantidAxType.BIN else 1])
     axes.set_ylabel(labels[0])
 
 
-def _setLabels2D(axes, workspace, indices=None, transpose=False, xscale=None, normalize_by_bin_width=True):
+def _setLabels2D(axes, workspace, indices=None, transpose=False, xscale=None, normalization=PlotNormalizationType.BIN_WIDTH):
     """
     helper function to automatically set axes labels for 2D plots
     """
-    labels = get_axes_labels(workspace, indices, normalize_by_bin_width)
+    labels = get_axes_labels(workspace, indices, normalization)
     if transpose:
         axes.set_xlabel(labels[2])
         axes.set_ylabel(labels[1])
@@ -176,14 +175,14 @@ def _plot_impl(axes, workspace, args, kwargs):
             axes.set_xlabel("Time")
         kwargs["drawstyle"] = "steps-post"
     else:
-        normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
+        normalization = get_normalization_type(workspace, axes, **kwargs)
         # the get... function returns kwargs without 'normalize_by_bin_width', but it is needed in _get_data_for_plot to
         # avoid reverting to the default norm setting, in the event that this function is being called as part of a plot
         # restoration
-        kwargs["normalize_by_bin_width"] = normalize_by_bin_width
+        kwargs["normalize_by_bin_width"] = normalization == PlotNormalizationType.BIN_WIDTH
         x, y, _, _, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs)
         if kwargs.pop("update_axes_labels", True):
-            _setLabels1D(axes, workspace, indices, normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+            _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
     kwargs.pop("normalize_type", None)
     return x, y, args, kwargs
@@ -315,10 +314,10 @@ def errorbar(axes, workspace, *args, **kwargs):
             withDy = True
             withDx = True
 
-    normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, axes, **kwargs)
     x, y, dy, dx, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs, with_dy=withDy, with_dx=withDx)
     if kwargs.pop("update_axes_labels", True):
-        _setLabels1D(axes, workspace, indices, normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+        normalization = get_normalization_type(workspace, axes, **kwargs)
+        _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
     kwargs.pop("normalize_type", None)
 
@@ -546,14 +545,14 @@ def pcolor(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
             kwargs["pcolortype"] = ""
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
+            normalization = get_normalization_type(workspace, axes, **kwargs)
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-            _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+            _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
     return axes.pcolor(x, y, z, *args, **kwargs)
 
 
@@ -591,14 +590,14 @@ def pcolorfast(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)
+        normalization = get_normalization_type(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
             kwargs["pcolortype"] = "fast"
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+        _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
     return axes.pcolorfast(x, y, z, *args, **kwargs)
 
 
@@ -636,14 +635,14 @@ def pcolormesh(axes, workspace, *args, **kwargs):
         _setLabels2D(axes, workspace, indices, transpose)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)
+        normalization = get_normalization_type(workspace, axes, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         if aligned:
             kwargs["pcolortype"] = "mesh"
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+        _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
     return axes.pcolormesh(x, y, z, *args, **kwargs)
 
 
@@ -687,9 +686,9 @@ def imshow(axes, workspace, *args, **kwargs):
         return mantid.plots.modest_image.imshow(axes, z, *args, **kwargs)
     else:
         (aligned, kwargs) = check_resample_to_regular_grid(workspace, **kwargs)
-        (normalize_by_bin_width, kwargs) = get_normalize_by_bin_width(workspace, axes, **kwargs)
-        kwargs["normalize_by_bin_width"] = normalize_by_bin_width
-        _setLabels2D(axes, workspace, transpose=transpose, normalize_by_bin_width=normalize_by_bin_width)
+        normalization = get_normalization_type(workspace, axes, **kwargs)
+        kwargs["normalize_by_bin_width"] = normalization == PlotNormalizationType.BIN_WIDTH
+        _setLabels2D(axes, workspace, transpose=transpose, normalization=normalization)
         return samplingimage.imshow_sampling(axes, workspace=workspace, *args, **kwargs)
 
 

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -176,10 +176,8 @@ def _plot_impl(axes, workspace, args, kwargs):
         kwargs["drawstyle"] = "steps-post"
     else:
         normalization, kwargs = get_normalization_type(workspace, axes, **kwargs)
-        # the get... function returns kwargs without 'normalize_by_bin_width', but it is needed in _get_data_for_plot to
-        # avoid reverting to the default norm setting, in the event that this function is being called as part of a plot
-        # restoration
         kwargs["normalize_by_bin_width"] = normalization == PlotNormalizationType.BIN_WIDTH
+        kwargs["normalization_type"] = normalization
         x, y, _, _, indices, axis, kwargs = _get_data_for_plot(axes, workspace, kwargs)
         if kwargs.pop("update_axes_labels", True):
             _setLabels1D(axes, workspace, indices, normalization=normalization, axis=axis)

--- a/Framework/PythonInterface/mantid/plots/axesfunctions3D.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions3D.py
@@ -28,7 +28,7 @@ def _set_labels_3d(axes, workspace, indices=None):
     """
     Helper function to automatically set axis labels for 3D plots
     """
-    labels = get_axes_labels(workspace, indices, normalize_by_bin_width=False)
+    labels = get_axes_labels(workspace, indices, PlotNormalizationType.NONE)
     axes.set_xlabel(labels[1])
     axes.set_ylabel(labels[2])
     axes.set_zlabel(labels[0])

--- a/Framework/PythonInterface/mantid/plots/axesfunctions3D.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions3D.py
@@ -11,7 +11,7 @@ import numpy
 
 from mantid.plots.datafunctions import (
     get_axes_labels,
-    get_normalization,
+    get_md_normalization,
     get_distribution,
     get_md_data2d_bin_centers,
     get_matrix_2d_data,
@@ -20,6 +20,7 @@ from mantid.plots.datafunctions import (
     get_spectrum,
     get_indices,
 )
+from mantid.plots.utility import PlotNormalizationType
 import mantid.dataobjects
 
 
@@ -35,7 +36,7 @@ def _set_labels_3d(axes, workspace, indices=None):
 
 def _extract_3d_data(workspace, **kwargs):
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        normalization, kwargs = get_normalization(workspace, **kwargs)
+        normalization, kwargs = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         x_temp, y_temp, z = get_md_data2d_bin_centers(workspace, normalization, indices)
         x, y = numpy.meshgrid(x_temp, y_temp)
@@ -65,12 +66,13 @@ def plot(axes, workspace, *args, **kwargs):
                        the dimension selected for the other 2 axes.
     """
     if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
-        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        (normalization, kwargs) = get_md_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         (x, y, z) = get_md_data1d(workspace, normalization, indices)
     else:
         (wksp_index, distribution, kwargs) = get_wksp_index_dist_and_label(workspace, **kwargs)
-        (x, z, _, _) = get_spectrum(workspace, wksp_index, distribution, withDy=False, withDx=False)
+        normalization = PlotNormalizationType.BIN_WIDTH if distribution else PlotNormalizationType.NONE
+        (x, z, _, _) = get_spectrum(workspace, wksp_index, normalization, withDy=False, withDx=False)
         y_val = workspace.getAxis(1).extractValues()[wksp_index]
         y = [y_val for _ in range(len(x))]  # fill x size array with y value
         _set_labels_3d(axes, workspace)

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -94,6 +94,40 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
     return normalization, kwargs
 
 
+def get_normalization_type(workspace, axes, **kwargs) -> PlotNormalizationType:
+    """
+    Infer PlotNormalizationType from kwargs or workspace state.
+
+    Priority (in order):
+    1. If 'normalization_type' in kwargs, use it (may be enum or string)
+    2. Else if 'normalize_by_bin_width' in kwargs, convert bool to enum
+    3. Else infer via get_normalize_by_bin_width() and convert to enum
+
+    Note: Does NOT pop from kwargs (reader only, idempotent).
+
+    :param workspace: :class:`mantid.api.MatrixWorkspace` workspace being plotted
+    :param axes: The axes being plotted on
+    :param kwargs: Plot keyword arguments
+    :return: PlotNormalizationType enum
+    """
+    # Priority 1: explicit normalization_type in kwargs
+    if "normalization_type" in kwargs:
+        norm_type = kwargs["normalization_type"]
+        # Handle string form (from plot restoration)
+        if isinstance(norm_type, str):
+            return PlotNormalizationType[norm_type]
+        return norm_type
+
+    # Priority 2: normalize_by_bin_width if explicit
+    if "normalize_by_bin_width" in kwargs:
+        normalize_by_bin_width = kwargs["normalize_by_bin_width"]
+        return PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+
+    # Priority 3: infer from workspace state
+    normalize_by_bin_width, _ = get_normalize_by_bin_width(workspace, axes, **kwargs)
+    return PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+
+
 def get_spectrum_normalisation(**kwargs):
     """
     Get the spectrum normalisation flag from the plot keyword arguments.
@@ -346,6 +380,9 @@ def get_spectrum(workspace, wkspIndex, normalization: PlotNormalizationType, wit
             y = y / (x[1:] - x[0:-1])
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
+        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER and not workspace.isDistribution():
+            # TODO: Implement Q^-4 normalization
+            pass
         x = points_from_boundaries(x)
     try:
         specInfo = workspace.spectrumInfo()

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -95,7 +95,7 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
     return normalization, kwargs
 
 
-def get_normalization_type(workspace, axes, **kwargs) -> PlotNormalizationType:
+def get_normalization_type(workspace, axes, **kwargs):
     """
     Infer PlotNormalizationType from kwargs or workspace state.
 
@@ -111,22 +111,21 @@ def get_normalization_type(workspace, axes, **kwargs) -> PlotNormalizationType:
     :param kwargs: Plot keyword arguments
     :return: PlotNormalizationType enum
     """
-    # Priority 1: explicit normalization_type in kwargs
     if "normalization_type" in kwargs:
-        norm_type = kwargs["normalization_type"]
+        norm_type = kwargs.pop("normalization_type")
         # Handle string form (from plot restoration)
         if isinstance(norm_type, str):
             return PlotNormalizationType[norm_type]
-        return norm_type
+        return norm_type, kwargs
 
-    # Priority 2: normalize_by_bin_width if explicit
     if "normalize_by_bin_width" in kwargs:
         normalize_by_bin_width = kwargs["normalize_by_bin_width"]
-        return PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+        norm_type = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+        return norm_type, kwargs
 
-    # Priority 3: infer from workspace state
     normalize_by_bin_width, _ = get_normalize_by_bin_width(workspace, axes, **kwargs)
-    return PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+    norm_type = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+    return norm_type, kwargs
 
 
 def get_spectrum_normalisation(**kwargs):

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -115,7 +115,7 @@ def get_normalization_type(workspace, axes, **kwargs):
         norm_type = kwargs.pop("normalization_type")
         # Handle string form (from plot restoration)
         if isinstance(norm_type, str):
-            return PlotNormalizationType[norm_type]
+            return PlotNormalizationType[norm_type], kwargs
         return norm_type, kwargs
 
     if "normalize_by_bin_width" in kwargs:
@@ -376,15 +376,16 @@ def get_spectrum(workspace, wkspIndex, normalization: PlotNormalizationType, wit
         dx = workspace.readDx(wkspIndex)
 
     if workspace.isHistogramData():
+        boundary_points = points_from_boundaries(x)
         if normalization == PlotNormalizationType.BIN_WIDTH and not workspace.isDistribution():
             y = y / (x[1:] - x[0:-1])
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
         elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
-            y = y / (points_from_boundaries(x) ** -4)
+            y = y / (boundary_points**-4)
             if dy is not None:
-                dy = dy / (points_from_boundaries(x) ** -4)
-        x = points_from_boundaries(x)
+                dy = dy / (boundary_points**-4)
+        x = boundary_points
     try:
         specInfo = workspace.spectrumInfo()
         if specInfo.isMasked(wkspIndex):
@@ -948,6 +949,8 @@ def get_axes_labels(workspace, indices=None, normalization=PlotNormalizationType
 
 def _get_y_axes_label(workspace, normalization, use_latex):
     y_unit = workspace.YUnitLabel(use_latex)
+    if normalization == PlotNormalizationType.NONE:
+        return y_unit
     x_label = ""
     if normalization == PlotNormalizationType.BIN_WIDTH and not workspace.isDistribution():
         x_label = workspace.getAxis(0).getUnit().symbol().latex() if use_latex else workspace.getAxis(0).getUnit().symbol().ascii()

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -22,7 +22,7 @@ import mantid.api
 import mantid.kernel
 from mantid.api import MultipleExperimentInfos, MatrixWorkspace
 from mantid.dataobjects import EventWorkspace, MDHistoWorkspace, Workspace2D
-from mantid.plots.utility import convert_color_to_hex, MantidAxType
+from mantid.plots.utility import convert_color_to_hex, MantidAxType, PlotNormalizationType
 
 
 # Helper functions for data extraction from a Mantid workspace and plot functionality
@@ -107,7 +107,7 @@ def get_spectrum_normalisation(**kwargs):
     return norm, kwargs
 
 
-def get_normalization(md_workspace, **kwargs):
+def get_md_normalization(md_workspace, **kwargs):
     """
     Gets the normalization flag of an MDHistoWorkspace. For workspaces
     derived similar to MSlice/Horace, one needs to average data, the so-called
@@ -266,24 +266,24 @@ def _get_wksp_index_and_spec_num(workspace, axis, **kwargs):
     return workspace_index, spectrum_number, kwargs
 
 
-def get_md_data1d(workspace, normalization, indices=None):
+def get_md_data1d(workspace, md_normalization, indices=None):
     """
     Function to transform data in an MDHisto workspace with exactly
     one non-integrated dimension into arrays of bin centers, data,
     and error, to be used in 1D plots (plot, scatter, errorbar)
     """
-    coordinate, data, err = get_md_data(workspace, normalization, indices, withError=True)
+    coordinate, data, err = get_md_data(workspace, md_normalization, indices, withError=True)
     assert len(coordinate) == 1, "The workspace is not 1D"
     coordinate = points_from_boundaries(coordinate[0])
     return coordinate, data, err
 
 
-def get_md_data(workspace, normalization, indices=None, withError=False):
+def get_md_data(workspace, md_normalization, indices=None, withError=False):
     """
     Generic function to extract data from an MDHisto workspace
 
     :param workspace: :class:`mantid.api.IMDHistoWorkspace` containing data
-    :param normalization: if :class:`mantid.api.MDNormalization.NumEventsNormalization`
+    :param md_normalization: if :class:`mantid.api.MDNormalization.NumEventsNormalization`
         it will divide intensity by the number of corresponding MDEvents
     :param indices: slice indices to select data
     :param withError: flag for if the error is calculated. If False, err is returned as None
@@ -299,13 +299,13 @@ def get_md_data(workspace, normalization, indices=None, withError=False):
     dim_arrays = [_dim2array(d) for d in dims]
     # get data
     data = workspace.getSignalArray()[indices].copy()
-    if normalization == mantid.api.MDNormalization.NumEventsNormalization:
+    if md_normalization == mantid.api.MDNormalization.NumEventsNormalization:
         nev = workspace.getNumEventsArray()[indices]
         data /= nev
     err = None
     if withError:
         err2 = workspace.getErrorSquaredArray()[indices].copy()
-        if normalization == mantid.api.MDNormalization.NumEventsNormalization:
+        if md_normalization == mantid.api.MDNormalization.NumEventsNormalization:
             err2 /= nev * nev
         err = np.sqrt(err2)
     data = data.squeeze().T
@@ -316,15 +316,13 @@ def get_md_data(workspace, normalization, indices=None, withError=False):
     return dim_arrays, data, err
 
 
-def get_spectrum(workspace, wkspIndex, normalize_by_bin_width, withDy=False, withDx=False):
+def get_spectrum(workspace, wkspIndex, normalization: PlotNormalizationType, withDy=False, withDx=False):
     """
     Extract a single spectrum and process the data into a frequency
 
     :param workspace: a Workspace2D or an EventWorkspace
     :param wkspIndex: workspace index
-    :param normalize_by_bin_width: flag to divide the data by bin width. The same
-        effect can be obtained by running the :ref:`algm-ConvertToDistribution`
-        algorithm
+    :param normalization: PlotNormalizationType, the type of normalization to apply
     :param withDy: if True, it will return the error in the "counts", otherwise None
     :param with Dx: if True, and workspace has them, it will return errors
         in the x coordinate, otherwise None
@@ -344,7 +342,7 @@ def get_spectrum(workspace, wkspIndex, normalize_by_bin_width, withDy=False, wit
         dx = workspace.readDx(wkspIndex)
 
     if workspace.isHistogramData():
-        if normalize_by_bin_width and not workspace.isDistribution():
+        if normalization == PlotNormalizationType.BIN_WIDTH and not workspace.isDistribution():
             y = y / (x[1:] - x[0:-1])
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
@@ -430,7 +428,7 @@ def get_bins(workspace, bin_index, withDy=False, withDx=False):
     return x_values, y_values, dy, dx
 
 
-def get_md_data2d_bin_bounds(workspace, normalization, indices=None, transpose=False):
+def get_md_data2d_bin_bounds(workspace, md_normalization, indices=None, transpose=False):
     """
     Function to transform data in an MDHisto workspace with exactly
     two non-integrated dimension into arrays of bin boundaries in each
@@ -438,7 +436,7 @@ def get_md_data2d_bin_bounds(workspace, normalization, indices=None, transpose=F
 
     Note: return coordinates are 1d vectors. Use numpy.meshgrid to generate 2d versions
     """
-    coordinate, data, _ = get_md_data(workspace, normalization, indices, withError=False)
+    coordinate, data, _ = get_md_data(workspace, md_normalization, indices, withError=False)
     assert len(coordinate) == 2, "The workspace is not 2D"
     if transpose:
         return coordinate[1], coordinate[0], data.T
@@ -446,7 +444,7 @@ def get_md_data2d_bin_bounds(workspace, normalization, indices=None, transpose=F
         return coordinate[0], coordinate[1], data
 
 
-def get_md_data2d_bin_centers(workspace, normalization, indices=None, transpose=False):
+def get_md_data2d_bin_centers(workspace, md_normalization, indices=None, transpose=False):
     """
     Function to transform data in an MDHisto workspace with exactly
     two non-integrated dimension into arrays of bin centers in each
@@ -455,7 +453,7 @@ def get_md_data2d_bin_centers(workspace, normalization, indices=None, transpose=
 
     Note: return coordinates are 1d vectors. Use numpy.meshgrid to generate 2d versions
     """
-    x, y, data = get_md_data2d_bin_bounds(workspace, normalization, indices, transpose)
+    x, y, data = get_md_data2d_bin_bounds(workspace, md_normalization, indices, transpose)
     x = points_from_boundaries(x)
     y = points_from_boundaries(y)
     return x, y, data
@@ -627,9 +625,8 @@ def interpolate_y_data(workspace, x, y, normalize_by_bin_width, spectrum_info=No
             continue
         previous_index = workspace_index
         if not (spectrum_info and spectrum_info.hasDetectors(workspace_index) and spectrum_info.isMonitor(workspace_index)):
-            centers, ztmp, _, _ = get_spectrum(
-                workspace, workspace_index, normalize_by_bin_width=normalize_by_bin_width, withDy=False, withDx=False
-            )
+            normalization = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
+            centers, ztmp, _, _ = get_spectrum(workspace, workspace_index, normalization=normalization, withDy=False, withDx=False)
             interpolation_function = interp1d(centers, ztmp, kind="nearest", bounds_error=False, fill_value="extrapolate")
             # only set values in the range of workspace
             x_range = np.where((x >= workspace.readX(workspace_index)[0]) & (x <= workspace.readX(workspace_index)[-1]))

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -391,9 +391,11 @@ def get_spectrum(workspace, wkspIndex, normalization: PlotNormalizationType, wit
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
         elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
-            y = y / (boundary_points**-4)
+            # multiply by x^4 instead of dividing by x^-4 for efficiency's sake
+            normalization_factor = boundary_points**4
+            y = y * normalization_factor
             if dy is not None:
-                dy = dy / (boundary_points**-4)
+                dy = dy * normalization_factor
         x = boundary_points
     try:
         specInfo = workspace.spectrumInfo()

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -87,7 +87,7 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
             current_artists = None
 
         if current_artists:
-            current_normalization = any([artist[0].is_normalized for artist in current_artists])
+            current_normalization = any([artist[0].is_normalized_by_bin_width() for artist in current_artists])
             normalization = current_normalization
         else:
             normalization = mantid.kernel.config["graph1d.autodistribution"].lower() == "on"
@@ -380,9 +380,10 @@ def get_spectrum(workspace, wkspIndex, normalization: PlotNormalizationType, wit
             y = y / (x[1:] - x[0:-1])
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
-        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER and not workspace.isDistribution():
-            # TODO: Implement Q^-4 normalization
-            pass
+        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
+            y = y / (points_from_boundaries(x) ** -4)
+            if dy is not None:
+                dy = dy / (points_from_boundaries(x) ** -4)
         x = points_from_boundaries(x)
     try:
         specInfo = workspace.spectrumInfo()

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -9,6 +9,7 @@
 #
 import datetime
 from itertools import tee
+import re
 
 import numpy as np
 from matplotlib.collections import PolyCollection, QuadMesh
@@ -897,7 +898,7 @@ def get_sample_log(workspace, **kwargs):
 # ====================================================
 
 
-def get_axes_labels(workspace, indices=None, normalize_by_bin_width=True, use_latex=True):
+def get_axes_labels(workspace, indices=None, normalization=PlotNormalizationType.BIN_WIDTH, use_latex=True):
     """
     Get axis labels from a Workspace2D or an MDHistoWorkspace
     Returns a tuple. The first element is the quantity label, such as "Intensity" or "Counts".
@@ -934,7 +935,7 @@ def get_axes_labels(workspace, indices=None, normalize_by_bin_width=True, use_la
         axes_labels.append(title.strip())
     else:
         # For matrix workspaces, return a tuple of ``(YUnit, <other units>)``
-        axes_labels = [workspace.YUnitLabel(useLatex=use_latex, plotAsDistribution=normalize_by_bin_width)]
+        axes_labels = [_get_y_axes_label(workspace, normalization, use_latex)]
         for index in range(workspace.axes()):
             axis = workspace.getAxis(index)
             unit = axis.getUnit()
@@ -944,6 +945,31 @@ def get_axes_labels(workspace, indices=None, normalize_by_bin_width=True, use_la
                 unit = unit.caption()
             axes_labels.append(unit)
     return tuple(axes_labels)
+
+
+def _get_y_axes_label(workspace, normalization, use_latex):
+    y_unit = workspace.YUnitLabel(use_latex)
+    x_label = ""
+    if normalization == PlotNormalizationType.BIN_WIDTH and not workspace.isDistribution():
+        x_label = workspace.getAxis(0).getUnit().symbol().latex() if use_latex else workspace.getAxis(0).getUnit().symbol().ascii()
+    elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
+        x_label = "Q^{-4}"
+    return _add_denominator_to_y_label(y_unit, x_label, use_latex)
+
+
+def _add_denominator_to_y_label(y_label, x_label, use_latex):
+    if use_latex:
+        if x_label:
+            label_expression = re.compile(r"(.*)\((.*)\)(\$\^\{-1\}\$)")
+            # if already normalised by a unit
+            if match := label_expression.match(y_label):
+                y_label = f"{match.group(1)}({match.group(2)} ${x_label}$){match.group(3)}"
+            else:
+                y_label += f" (${x_label}$)" + "$^{-1}$"
+    else:
+        y_label += f" per {x_label}"
+
+    return y_label
 
 
 def get_data_from_errorbar_container(err_cont):

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -66,7 +66,7 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
     """
     Determine whether or not the workspace should be plotted as a
     distribution. If the workspace is a distribution return False, else,
-    if there is already a curves on the axes, return according to
+    if there are already curves on the axes, return according to
     whether those curves are distributions. Else go by the global
     setting.
     :param workspace: :class:`mantid.api.MatrixWorkspace` workspace being plotted
@@ -104,8 +104,6 @@ def get_normalization_type(workspace, axes, **kwargs):
     2. Else if 'normalize_by_bin_width' in kwargs, convert bool to enum
     3. Else infer via get_normalize_by_bin_width() and convert to enum
 
-    Note: Does NOT pop from kwargs (reader only, idempotent).
-
     :param workspace: :class:`mantid.api.MatrixWorkspace` workspace being plotted
     :param axes: The axes being plotted on
     :param kwargs: Plot keyword arguments
@@ -118,14 +116,25 @@ def get_normalization_type(workspace, axes, **kwargs):
             return PlotNormalizationType[norm_type], kwargs
         return norm_type, kwargs
 
-    if "normalize_by_bin_width" in kwargs:
-        normalize_by_bin_width = kwargs["normalize_by_bin_width"]
-        norm_type = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
-        return norm_type, kwargs
+    # check if there are current artists that are all normalized by inverse Q^4
+    if _all_normalized_by_inverse_q_fourth_power(axes):
+        return PlotNormalizationType.INVERSE_Q_FOURTH_POWER, kwargs
 
     normalize_by_bin_width, _ = get_normalize_by_bin_width(workspace, axes, **kwargs)
     norm_type = PlotNormalizationType.BIN_WIDTH if normalize_by_bin_width else PlotNormalizationType.NONE
     return norm_type, kwargs
+
+
+def _all_normalized_by_inverse_q_fourth_power(axes):
+    try:
+        current_artists = axes.tracked_workspaces.values()
+    except AttributeError:
+        return False
+
+    if not current_artists:
+        return False
+
+    return all(artist[0].normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER for artist in current_artists)
 
 
 def get_spectrum_normalisation(**kwargs):

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -704,18 +704,16 @@ class MantidAxes(Axes):
 
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
-            normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
-            is_normalized = normalize_by_bin_width or (hasattr(workspace, "isDistribution") and workspace.isDistribution())
-            normalization = PlotNormalizationType.BIN_WIDTH if is_normalized else PlotNormalizationType.NONE
+            normalization_type = datafunctions.get_normalization_type(workspace, self, **kwargs)
             if isinstance(workspace, MatrixWorkspace):
                 kwargs = get_plot_specific_properties(workspace, workspace.getPlotType(), kwargs)
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(
                     workspace,
-                    axesfunctions.plot(self, normalize_by_bin_width=is_normalized, *args, **kwargs),
+                    axesfunctions.plot(self, normalize_type=normalization_type, *args, **kwargs),
                     _data_update,
                     spec_num,
-                    normalization,
+                    normalization_type,
                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
                     kwargs.get("LogName", None),
                     kwargs.get("Filtered", None),

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -832,16 +832,16 @@ class MantidAxes(Axes):
 
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
-            normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
-            is_normalized = normalize_by_bin_width or (hasattr(workspace, "isDistribution") and workspace.isDistribution())
-            normalization = PlotNormalizationType.BIN_WIDTH if is_normalized else PlotNormalizationType.NONE
+            normalization_type, kwargs = datafunctions.get_normalization_type(workspace, self, **kwargs)
+            if hasattr(workspace, "isDistribution") and workspace.isDistribution():
+                normalization_type = PlotNormalizationType.BIN_WIDTH
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(
                     workspace,
-                    axesfunctions.errorbar(self, normalize_by_bin_width=is_normalized, *args, **kwargs),
+                    axesfunctions.errorbar(self, normalization_type=normalization_type, *args, **kwargs),
                     _data_update,
                     spec_num,
-                    normalization,
+                    normalization_type,
                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
                 )
             return artist

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -703,7 +703,7 @@ class MantidAxes(Axes):
 
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
-            normalization_type = datafunctions.get_normalization_type(workspace, self, **kwargs)
+            normalization_type, kwargs = datafunctions.get_normalization_type(workspace, self, **kwargs)
             if hasattr(workspace, "isDistribution") and workspace.isDistribution():
                 normalization_type = PlotNormalizationType.BIN_WIDTH
             if isinstance(workspace, MatrixWorkspace):

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -711,7 +711,7 @@ class MantidAxes(Axes):
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(
                     workspace,
-                    axesfunctions.plot(self, normalize_type=normalization_type, *args, **kwargs),
+                    axesfunctions.plot(self, normalization_type=normalization_type, *args, **kwargs),
                     _data_update,
                     spec_num,
                     normalization_type,

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -32,7 +32,14 @@ from mantid.api import MatrixWorkspace
 from mantid.plots import datafunctions, axesfunctions, axesfunctions3D
 from mantid.plots.legend import LegendProperties
 from mantid.plots.datafunctions import get_normalize_by_bin_width
-from mantid.plots.utility import artists_hidden, autoscale_on_update, legend_set_draggable, MantidAxType, get_plot_specific_properties
+from mantid.plots.utility import (
+    artists_hidden,
+    autoscale_on_update,
+    legend_set_draggable,
+    MantidAxType,
+    get_plot_specific_properties,
+    PlotNormalizationType,
+)
 
 
 WATERFALL_XOFFSET_DEFAULT, WATERFALL_YOFFSET_DEFAULT = 10, 20
@@ -250,12 +257,12 @@ class MantidAxes(Axes):
                             return None
         raise ValueError("Artist: '{}' not tracked by axes.".format(artist))
 
-    def get_artist_normalization_state(self, artist):
+    def get_artist_normalized_by_bin_width(self, artist):
         for ws_name, ws_artists_list in self.tracked_workspaces.items():
             for ws_artists in ws_artists_list:
                 for ws_artist in ws_artists._artists:
                     if artist == ws_artist:
-                        return ws_artists.is_normalized
+                        return ws_artists.is_normalized_by_bin_width()
 
     def get_is_mdhisto_workspace_for_artist(self, artist) -> bool:
         workspace, _ = self.get_artists_workspace_and_workspace_index(artist)
@@ -267,7 +274,7 @@ class MantidAxes(Axes):
         artists,
         data_replace_cb=None,
         spec_num=None,
-        is_normalized=None,
+        normalization=None,
         is_spec=True,
         log_name=None,
         filtered=True,
@@ -281,9 +288,7 @@ class MantidAxes(Axes):
         :param data_replace_cb: A function to call when the data is replaced to update
         the artist (optional)
         :param spec_num: The spectrum number associated with the artist (optional)
-        :param is_normalized: bool. The line being plotted is normalized by bin width
-            This can be from either a distribution workspace or a workspace being
-            plotted as a distribution
+        :param normalization: PlotNormalizationType.
         :param is_spec: bool. True if spec_num represents a spectrum, and False if it is a bin index
         :param log_name: string. The name of the plotted log
         :param filtered: bool. True if log plotted was filtered, and False if unfiltered.
@@ -305,7 +310,7 @@ class MantidAxes(Axes):
             artist_info = self.tracked_workspaces.setdefault(name, [])
 
             artist_info.append(
-                _WorkspaceArtists(artists, data_replace_cb, is_normalized, name, spec_num, is_spec, log_name, filtered, expt_info_index)
+                _WorkspaceArtists(artists, data_replace_cb, normalization, name, spec_num, is_spec, log_name, filtered, expt_info_index)
             )
             self.check_axes_distribution_consistency()
         return artists
@@ -318,8 +323,8 @@ class MantidAxes(Axes):
         tracked_ws_distributions = []
         for artists in self.tracked_workspaces.values():
             for artist in artists:
-                if artist.is_normalized is not None:
-                    tracked_ws_distributions.append(artist.is_normalized)
+                if artist.is_normalized_by_bin_width():
+                    tracked_ws_distributions.append(True)
 
         if len(tracked_ws_distributions) > 0:
             num_normalized = sum(tracked_ws_distributions)
@@ -503,7 +508,7 @@ class MantidAxes(Axes):
         For keywords related to workspaces, see :func:`plotfunctions.plot` or
         :func:`plotfunctions.errorbar`
         """
-        kwargs["distribution"] = not self.get_artist_normalization_state(artist)
+        kwargs["distribution"] = not self.get_artist_normalized_by_bin_width(artist)
         workspace, spec_num = self.get_artists_workspace_and_spec_num(artist)
 
         # deal with MDHisto workspace
@@ -701,6 +706,7 @@ class MantidAxes(Axes):
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or (hasattr(workspace, "isDistribution") and workspace.isDistribution())
+            normalization = PlotNormalizationType.BIN_WIDTH if is_normalized else PlotNormalizationType.NONE
             if isinstance(workspace, MatrixWorkspace):
                 kwargs = get_plot_specific_properties(workspace, workspace.getPlotType(), kwargs)
             with autoscale_on_update(self, autoscale_on):
@@ -709,7 +715,7 @@ class MantidAxes(Axes):
                     axesfunctions.plot(self, normalize_by_bin_width=is_normalized, *args, **kwargs),
                     _data_update,
                     spec_num,
-                    is_normalized,
+                    normalization,
                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
                     kwargs.get("LogName", None),
                     kwargs.get("Filtered", None),
@@ -829,13 +835,14 @@ class MantidAxes(Axes):
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or (hasattr(workspace, "isDistribution") and workspace.isDistribution())
+            normalization = PlotNormalizationType.BIN_WIDTH if is_normalized else PlotNormalizationType.NONE
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(
                     workspace,
                     axesfunctions.errorbar(self, normalize_by_bin_width=is_normalized, *args, **kwargs),
                     _data_update,
                     spec_num,
-                    is_normalized,
+                    normalization,
                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
                 )
             return artist
@@ -963,9 +970,10 @@ class MantidAxes(Axes):
             workspace = args[0]
             normalize_by_bin_width, _ = get_normalize_by_bin_width(workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or (hasattr(workspace, "isDistribution") and workspace.isDistribution())
+            normalization = PlotNormalizationType.BIN_WIDTH if is_normalized else PlotNormalizationType.NONE
             # We return the last mesh so the return type is a single artist like the standard Axes
             artists = self.track_workspace_artist(
-                workspace, plotfunctions_func(self, *args, **kwargs), _update_data, is_normalized=is_normalized
+                workspace, plotfunctions_func(self, *args, **kwargs), _update_data, normalization=normalization
             )
             try:
                 return artists[-1]
@@ -1625,7 +1633,7 @@ class _WorkspaceArtists(object):
         self,
         artists,
         data_replace_cb,
-        is_normalized,
+        normalization,
         workspace_name=None,
         spec_num=None,
         is_spec=True,
@@ -1637,7 +1645,7 @@ class _WorkspaceArtists(object):
         Initialize an instance
         :param artists: A reference to a list of artists "attached" to a workspace
         :param data_replace_cb: A reference to a callable with signature (artists, workspace) -> new_artists
-        :param is_normalized: bool specifying whether the line being plotted is a distribution
+        :param normalization: bool specifying whether the line being plotted is a distribution
         :param workspace_name: String. The name of the associated workspace
         :param spec_num: The spectrum number of the spectrum used to plot the artist
         :param is_spec: True if spec_num represents a spectrum rather than a bin
@@ -1653,7 +1661,7 @@ class _WorkspaceArtists(object):
         self.spec_num = spec_num
         self.is_spec = is_spec
         self.workspace_index = self._get_workspace_index()
-        self.is_normalized = is_normalized
+        self.normalization = normalization
         self.log_name = log_name
         self.filtered = filtered
         self.expt_info_index = expt_info_index
@@ -1750,3 +1758,6 @@ class _WorkspaceArtists(object):
                 hiddenChar = "⁪"
                 new_workspace_name = hiddenChar + new_workspace_name
             artist.set_label(re.sub(rf"\b{old_workspace_name}\b", new_workspace_name, prev_label))
+
+    def is_normalized_by_bin_width(self):
+        return self.normalization == PlotNormalizationType.BIN_WIDTH

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -704,7 +704,7 @@ class MantidAxes(Axes):
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalization_type, kwargs = datafunctions.get_normalization_type(workspace, self, **kwargs)
-            if hasattr(workspace, "isDistribution") and workspace.isDistribution():
+            if normalization_type == PlotNormalizationType.NONE and hasattr(workspace, "isDistribution") and workspace.isDistribution():
                 normalization_type = PlotNormalizationType.BIN_WIDTH
             if isinstance(workspace, MatrixWorkspace):
                 kwargs = get_plot_specific_properties(workspace, workspace.getPlotType(), kwargs)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -323,8 +323,7 @@ class MantidAxes(Axes):
         tracked_ws_distributions = []
         for artists in self.tracked_workspaces.values():
             for artist in artists:
-                if artist.is_normalized_by_bin_width():
-                    tracked_ws_distributions.append(True)
+                tracked_ws_distributions.append(artist.is_normalized_by_bin_width())
 
         if len(tracked_ws_distributions) > 0:
             num_normalized = sum(tracked_ws_distributions)
@@ -705,6 +704,8 @@ class MantidAxes(Axes):
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalization_type = datafunctions.get_normalization_type(workspace, self, **kwargs)
+            if hasattr(workspace, "isDistribution") and workspace.isDistribution():
+                normalization_type = PlotNormalizationType.BIN_WIDTH
             if isinstance(workspace, MatrixWorkspace):
                 kwargs = get_plot_specific_properties(workspace, workspace.getPlotType(), kwargs)
             with autoscale_on_update(self, autoscale_on):

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -79,6 +79,12 @@ class MantidAxType(Enum):
     SPECTRUM = 1
 
 
+class PlotNormalizationType(Enum):
+    NONE = 0
+    BIN_WIDTH = 1
+    INVERSE_Q_FOURTH_POWER = 2  # Q^-4
+
+
 @contextmanager
 def artists_hidden(artists):
     """Context manager that hides matplotlib artists."""

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -241,6 +241,11 @@ class DataFunctionsTest(unittest.TestCase):
         labels = funcs.get_axes_labels(ws, normalization=PlotNormalizationType.NONE, use_latex=True)
         self.assertEqual(labels[0], "Counts (microAmp.hour)$^{-1}$")
 
+    def test_y_units_for_distribution_and_autodist_off_with_ascii(self):
+        ws = self.ws2d_distribution
+        labels = funcs.get_axes_labels(ws, normalization=PlotNormalizationType.NONE, use_latex=False)
+        self.assertEqual(labels[0], "Counts per microAmp.hour")
+
     def test_y_units_for_non_distribution_and_autodist_on_with_ascii(self):
         ws = self.ws2d_non_distribution
         labels = funcs.get_axes_labels(ws, use_latex=False)

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -18,7 +18,7 @@ import mantid.api
 import mantid.plots.datafunctions as funcs
 from unittest.mock import Mock
 from mantid.kernel import config, ConfigService
-from mantid.plots.utility import MantidAxType
+from mantid.plots.utility import MantidAxType, PlotNormalizationType
 from mantid.simpleapi import (
     AddSampleLog,
     AddTimeSeriesLog,
@@ -229,28 +229,28 @@ class DataFunctionsTest(unittest.TestCase):
 
     def test_y_units_for_distribution_and_autodist_off_with_latex(self):
         ws = self.ws2d_distribution
-        labels = funcs.get_axes_labels(ws, normalize_by_bin_width=False, use_latex=True)
+        labels = funcs.get_axes_labels(ws, normalization=PlotNormalizationType.NONE, use_latex=True)
         self.assertEqual(labels[0], "Counts (microAmp.hour)$^{-1}$")
 
     def test_y_units_for_non_distribution_and_autodist_on_with_ascii(self):
         ws = self.ws2d_non_distribution
-        labels = funcs.get_axes_labels(ws, normalize_by_bin_width=True, use_latex=False)
+        labels = funcs.get_axes_labels(ws, use_latex=False)
         self.assertEqual(labels[0], "Counts per microAmp.hour per Angstrom")
 
     def test_y_units_for_non_distribution_and_autodist_on_with_latex(self):
         ws = self.ws2d_non_distribution
-        labels = funcs.get_axes_labels(ws, normalize_by_bin_width=True)
+        labels = funcs.get_axes_labels(ws)
         self.assertEqual(labels[0], "Counts (microAmp.hour $\\AA$)$^{-1}$")
 
     def test_y_units_for_non_distribution_with_no_x_or_y_unit_and_autodist_on(self):
         ws = self.ws1d_point
-        labels = funcs.get_axes_labels(ws, normalize_by_bin_width=True, use_latex=True)
+        labels = funcs.get_axes_labels(ws, use_latex=True)
         self.assertEqual(labels[0], "")
 
     def test_y_units_for_non_distribution_with_no_x_unit_and_autodist_on(self):
         ws = self.ws2d_point
         ws.setYUnit("Counts")
-        labels = funcs.get_axes_labels(ws, normalize_by_bin_width=True, use_latex=True)
+        labels = funcs.get_axes_labels(ws, use_latex=True)
         self.assertEqual(labels[0], "Counts")
         ws.setYUnit("")
 
@@ -304,13 +304,15 @@ class DataFunctionsTest(unittest.TestCase):
 
     def test_get_spectrum_non_distribution_workspace(self):
         # get data divided by bin width
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalization=True, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(
+            self.ws2d_non_distribution, 1, normalization=PlotNormalizationType.BIN_WIDTH, withDy=True, withDx=True
+        )
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([0.4, 0.5])))
         self.assertTrue(np.array_equal(dy, np.array([0.3, 0.4])))
         self.assertEqual(dx, None)
         # get data not divided by bin width
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalization=False, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalization=PlotNormalizationType.NONE, withDy=True, withDx=True)
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([4, 5])))
         self.assertTrue(np.array_equal(dy, np.array([3, 4])))

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -96,6 +96,15 @@ class DataFunctionsTest(unittest.TestCase):
             VerticalAxisValues=[4, 6, 8],
             OutputWorkspace="ws2d_non_distribution",
         )
+        cls.ws2d_q = CreateWorkspace(
+            DataX=[0.5, 1, 1.5, 2, 2.5],
+            DataY=[2, 3, 4, 5],
+            DataE=[1, 2, 3, 4],
+            NSpec=1,
+            UnitX="MomentumTransfer",
+            YUnitLabel="Counts",
+            OutputWorkspace="ws2d_q",
+        )
         cls.ws2d_distribution = CreateWorkspace(
             DataX=[10, 20, 30, 10, 20, 30],
             DataY=[2, 3, 4, 5, 6],
@@ -264,6 +273,10 @@ class DataFunctionsTest(unittest.TestCase):
         # should get the first two dimension labels only
         self.assertEqual(axs, ("Intensity", "Dim2 (EnergyTransfer)", "Dim1=-2.4; Dim3=0.0;"))
 
+    def test_get_axes_label_inverse_Q_normalization(self):
+        labels = funcs.get_axes_labels(self.ws2d_q, normalization=PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+        self.assertEqual(labels[0], "Counts ($Q^{-4}$)$^{-1}$")
+
     def test_get_data_uneven_flag(self):
         flag, kwargs = funcs.get_data_uneven_flag(self.ws2d_histo_rag, axisaligned=True, other_kwarg=1)
         self.assertTrue(flag)
@@ -319,6 +332,22 @@ class DataFunctionsTest(unittest.TestCase):
         self.assertEqual(dx, None)
         # fail case - try to find spectrum out of range
         self.assertRaises(RuntimeError, funcs.get_spectrum, self.ws2d_non_distribution, 10, normalization=PlotNormalizationType.BIN_WIDTH)
+
+    def test_get_spectrum_q_workspace(self):
+        # get data divided by Q^-4
+        x, y, dy, dx = funcs.get_spectrum(
+            self.ws2d_q, 0, normalization=PlotNormalizationType.INVERSE_Q_FOURTH_POWER, withDy=True, withDx=True
+        )
+        self.assertTrue(np.array_equal(x, np.array([0.75, 1.25, 1.75, 2.25])))
+        self.assertTrue(np.array_equal(y, np.array([0.6328125, 7.32421875, 37.515625, 128.14453125])))
+        self.assertTrue(np.array_equal(dy, np.array([0.31640625, 4.8828125, 28.13671875, 102.515625])))
+        self.assertEqual(dx, None)
+        # get data not divided by Q^-4
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_q, 0, normalization=PlotNormalizationType.NONE, withDy=True, withDx=True)
+        self.assertTrue(np.array_equal(x, np.array([0.75, 1.25, 1.75, 2.25])))
+        self.assertTrue(np.array_equal(y, np.array([2, 3, 4, 5])))
+        self.assertTrue(np.array_equal(dy, np.array([1, 2, 3, 4])))
+        self.assertEqual(dx, None)
 
     def test_get_md_data2d_bin_bounds(self):
         x, y, data = funcs.get_md_data2d_bin_bounds(self.ws_MD_2d, mantid.api.MDNormalization.NoNormalization)

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -304,13 +304,13 @@ class DataFunctionsTest(unittest.TestCase):
 
     def test_get_spectrum_non_distribution_workspace(self):
         # get data divided by bin width
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalize_by_bin_width=True, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalization=True, withDy=True, withDx=True)
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([0.4, 0.5])))
         self.assertTrue(np.array_equal(dy, np.array([0.3, 0.4])))
         self.assertEqual(dx, None)
         # get data not divided by bin width
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalize_by_bin_width=False, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_non_distribution, 1, normalization=False, withDy=True, withDx=True)
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([4, 5])))
         self.assertTrue(np.array_equal(dy, np.array([3, 4])))
@@ -680,7 +680,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_md_workspace_with_data
     def test_get_md_data_no_error(self, mdws):
-        dim_arrays, data, err = funcs.get_md_data(mdws, normalization=None)
+        dim_arrays, data, err = funcs.get_md_data(mdws, md_normalization=None)
         self.assertEqual(11, len(dim_arrays[0]))
         self.assertEqual(-3, dim_arrays[0][0])
         self.assertEqual(3, dim_arrays[0][-1])
@@ -697,7 +697,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_md_workspace_with_data
     def test_get_md_data_with_error(self, mdws):
-        dim_arrays, data, err = funcs.get_md_data(mdws, normalization=None, withError=True)
+        dim_arrays, data, err = funcs.get_md_data(mdws, md_normalization=None, withError=True)
         self.assertEqual(11, len(dim_arrays[0]))
         self.assertEqual(-3, dim_arrays[0][0])
         self.assertEqual(3, dim_arrays[0][-1])
@@ -716,7 +716,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_workspace_with_data
     def test_get_spectrum_no_dy_dx(self, ws):
-        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalize_by_bin_width=False, withDy=False, withDx=False)
+        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=False, withDy=False, withDx=False)
         self.assertTrue(np.array_equal([13.5, 14.5, 15.5], x))
         self.assertTrue(np.array_equal([10.0, 11.0, 12.0], y))
         self.assertIsNone(dy)
@@ -724,7 +724,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_workspace_with_data
     def test_get_spectrum_with_dy_dx(self, ws):
-        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalize_by_bin_width=False, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=False, withDy=True, withDx=True)
 
         self.assertTrue(np.array_equal([13.5, 14.5, 15.5], x))
         self.assertTrue(np.array_equal([10.0, 11.0, 12.0], y))

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -287,20 +287,20 @@ class DataFunctionsTest(unittest.TestCase):
 
     def test_get_spectrum_distribution_workspace(self):
         # Since the workspace being plotted is a distribution, we should not
-        # divide by bin width whether or not normalize_by_bin_width is True
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_histo, 1, True, withDy=True, withDx=True)
+        # divide by bin width whether or not the normalisation type is BIN_WIDTH
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_histo, 1, PlotNormalizationType.BIN_WIDTH, withDy=True, withDx=True)
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([4, 5])))
         self.assertTrue(np.array_equal(dy, np.array([3, 4])))
         self.assertEqual(dx, None)
 
-        x, y, dy, dx = funcs.get_spectrum(self.ws2d_histo, 0, False, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(self.ws2d_histo, 0, PlotNormalizationType.NONE, withDy=True, withDx=True)
         self.assertTrue(np.array_equal(x, np.array([15.0, 25.0])))
         self.assertTrue(np.array_equal(y, np.array([2, 3])))
         self.assertTrue(np.array_equal(dy, np.array([1, 2])))
         self.assertEqual(dx, None)
         # fail case - try to find spectrum out of range
-        self.assertRaises(RuntimeError, funcs.get_spectrum, self.ws2d_histo, 10, True)
+        self.assertRaises(RuntimeError, funcs.get_spectrum, self.ws2d_histo, 10, PlotNormalizationType.BIN_WIDTH)
 
     def test_get_spectrum_non_distribution_workspace(self):
         # get data divided by bin width
@@ -318,7 +318,7 @@ class DataFunctionsTest(unittest.TestCase):
         self.assertTrue(np.array_equal(dy, np.array([3, 4])))
         self.assertEqual(dx, None)
         # fail case - try to find spectrum out of range
-        self.assertRaises(RuntimeError, funcs.get_spectrum, self.ws2d_non_distribution, 10, True)
+        self.assertRaises(RuntimeError, funcs.get_spectrum, self.ws2d_non_distribution, 10, normalization=PlotNormalizationType.BIN_WIDTH)
 
     def test_get_md_data2d_bin_bounds(self):
         x, y, data = funcs.get_md_data2d_bin_bounds(self.ws_MD_2d, mantid.api.MDNormalization.NoNormalization)
@@ -718,7 +718,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_workspace_with_data
     def test_get_spectrum_no_dy_dx(self, ws):
-        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=False, withDy=False, withDx=False)
+        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=PlotNormalizationType.BIN_WIDTH, withDy=False, withDx=False)
         self.assertTrue(np.array_equal([13.5, 14.5, 15.5], x))
         self.assertTrue(np.array_equal([10.0, 11.0, 12.0], y))
         self.assertIsNone(dy)
@@ -726,7 +726,7 @@ class DataFunctionsTest(unittest.TestCase):
 
     @add_workspace_with_data
     def test_get_spectrum_with_dy_dx(self, ws):
-        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=False, withDy=True, withDx=True)
+        x, y, dy, dx = funcs.get_spectrum(ws, 3, normalization=PlotNormalizationType.NONE, withDy=True, withDx=True)
 
         self.assertTrue(np.array_equal([13.5, 14.5, 15.5], x))
         self.assertTrue(np.array_equal([10.0, 11.0, 12.0], y))

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -16,7 +16,7 @@ import unittest
 
 from mantid.kernel import config
 from mantid.plots import datafunctions
-from mantid.plots.utility import convert_color_to_hex, MantidAxType
+from mantid.plots.utility import convert_color_to_hex, MantidAxType, PlotNormalizationType
 from mantid.plots.axesfunctions import get_colorplot_extents
 from unittest.mock import Mock, patch
 from mantid.simpleapi import CreateWorkspace, CreateSampleWorkspace, DeleteWorkspace, RemoveSpectra, AnalysisDataService as ADS
@@ -297,6 +297,22 @@ class MantidAxesTest(unittest.TestCase):
         ax = fig.add_subplot(111, projection="3d")
         self.assertRaises(Exception, ax.plot_wireframe, self.ws2d_histo)
         self.assertRaises(Exception, ax.plot_surface, self.ws2d_histo)
+
+    def test_plot_normalised_by_inverse_q_given_normalization_type_argument(self):
+        workspace = CreateWorkspace(
+            DataX=[10, 20], DataY=[2, 3, 4, 5, 6], DataE=[1, 2, 1, 2, 1], NSpec=5, Distribution=False, OutputWorkspace="workspace"
+        )
+        self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN, normalization_type=PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+        self.ax.plot(
+            workspace, specNum=1, axis=MantidAxType.BIN, distribution=False, normalization_type=PlotNormalizationType.INVERSE_Q_FOURTH_POWER
+        )
+        self.ax.plot(
+            workspace, specNum=1, axis=MantidAxType.BIN, distribution=True, normalization_type=PlotNormalizationType.INVERSE_Q_FOURTH_POWER
+        )
+        ws_artists = self.ax.tracked_workspaces[workspace.name()]
+        self.assertEqual(ws_artists[0].normalization, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+        self.assertEqual(ws_artists[1].normalization, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+        self.assertEqual(ws_artists[2].normalization, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
 
     def test_plot_is_not_normalized_for_bin_plots(self):
         workspace = CreateWorkspace(

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -306,9 +306,9 @@ class MantidAxesTest(unittest.TestCase):
         self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN, distribution=True)
         self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN)
         ws_artists = self.ax.tracked_workspaces[workspace.name()]
-        self.assertFalse(ws_artists[0].is_normalized)
-        self.assertFalse(ws_artists[1].is_normalized)
-        self.assertFalse(ws_artists[2].is_normalized)
+        self.assertFalse(ws_artists[0].is_normalized_by_bin_width())
+        self.assertFalse(ws_artists[1].is_normalized_by_bin_width())
+        self.assertFalse(ws_artists[2].is_normalized_by_bin_width())
 
     def test_artists_normalization_state_labeled_correctly_for_dist_workspace(self):
         dist_ws = CreateWorkspace(DataX=[10, 20], DataY=[2, 3], DataE=[1, 2], NSpec=1, Distribution=True, OutputWorkspace="dist_workpace")
@@ -316,25 +316,25 @@ class MantidAxesTest(unittest.TestCase):
         self.ax.plot(dist_ws, specNum=1, distribution=True)
         self.ax.plot(dist_ws, specNum=1)
         ws_artists = self.ax.tracked_workspaces[dist_ws.name()]
-        self.assertTrue(ws_artists[0].is_normalized)
-        self.assertTrue(ws_artists[1].is_normalized)
-        self.assertTrue(ws_artists[2].is_normalized)
+        self.assertTrue(ws_artists[0].is_normalized_by_bin_width())
+        self.assertTrue(ws_artists[1].is_normalized_by_bin_width())
+        self.assertTrue(ws_artists[2].is_normalized_by_bin_width())
 
     def test_artists_normalization_state_labeled_correctly_for_non_dist_workspace(self):
         non_dist_ws = CreateWorkspace(
             DataX=[10, 20], DataY=[2, 3], DataE=[1, 2], NSpec=1, Distribution=False, OutputWorkspace="non_dist_workpace"
         )
         self.ax.plot(non_dist_ws, specNum=1, distribution=False)
-        self.assertTrue(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
+        self.assertTrue(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized_by_bin_width())
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
         self.ax.errorbar(non_dist_ws, specNum=1, distribution=True)
-        self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
+        self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized_by_bin_width())
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
         auto_dist = config["graph1d.autodistribution"] == "On"
         self.ax.plot(non_dist_ws, specNum=1)
-        self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
+        self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized_by_bin_width())
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
     def test_artists_normalization_state_labeled_correctly_for_non_dist_workspace_and_global_setting_off(self):
@@ -343,7 +343,7 @@ class MantidAxesTest(unittest.TestCase):
         )
         config["graph1d.autodistribution"] = "Off"
         self.ax.plot(non_dist_ws, specNum=1)
-        self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized)
+        self.assertFalse(self.ax.tracked_workspaces[non_dist_ws.name()][0].is_normalized_by_bin_width())
         del self.ax.tracked_workspaces[non_dist_ws.name()]
 
     def test_artists_normalization_state_labeled_correctly_for_2d_plots_of_dist_workspace(self):
@@ -357,9 +357,9 @@ class MantidAxesTest(unittest.TestCase):
             func(dist_2d_ws, distribution=True)
             func(dist_2d_ws)
             ws_artists = self.ax.tracked_workspaces[dist_2d_ws.name()]
-            self.assertTrue(ws_artists[0].is_normalized)
-            self.assertTrue(ws_artists[1].is_normalized)
-            self.assertTrue(ws_artists[2].is_normalized)
+            self.assertTrue(ws_artists[0].is_normalized_by_bin_width())
+            self.assertTrue(ws_artists[1].is_normalized_by_bin_width())
+            self.assertTrue(ws_artists[2].is_normalized_by_bin_width())
 
     def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_dist_argument_false(self):
         plot_funcs = ["imshow", "pcolor", "pcolormesh", "pcolorfast", "tripcolor", "contour", "contourf", "tricontour", "tricontourf"]
@@ -369,7 +369,7 @@ class MantidAxesTest(unittest.TestCase):
         for plot_func in plot_funcs:
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws, distribution=False)
-            self.assertTrue(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
+            self.assertTrue(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized_by_bin_width())
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
     def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_dist_argument_true(self):
@@ -380,7 +380,7 @@ class MantidAxesTest(unittest.TestCase):
         for plot_func in plot_funcs:
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws, distribution=True)
-            self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
+            self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized_by_bin_width())
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
     def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_global_setting_on(self):
@@ -392,7 +392,7 @@ class MantidAxesTest(unittest.TestCase):
             auto_dist = config["graph1d.autodistribution"] == "On"
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws)
-            self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
+            self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized_by_bin_width())
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
     def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_global_setting_off(self):
@@ -409,7 +409,7 @@ class MantidAxesTest(unittest.TestCase):
             config["graph1d.autodistribution"] = "Off"
             func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws)
-            self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
+            self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized_by_bin_width())
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
     def test_check_axes_distribution_consistency_mixed_normalization(self):
@@ -793,9 +793,15 @@ class MantidAxesTest(unittest.TestCase):
         self.ax.rename_workspace(new_name="new_name", old_name="ws")
 
     def _run_check_axes_distribution_consistency(self, normalization_states):
+        mock_artists = []
+        for normalization_state in normalization_states:
+            mock_artist = Mock()
+            mock_artist.is_normalized_by_bin_width.return_value = normalization_state
+            mock_artists.append(mock_artist)
+
         mock_tracked_workspaces = {
-            "ws": [Mock(is_normalized=normalization_states[0]), Mock(is_normalized=normalization_states[1])],
-            "ws1": [Mock(is_normalized=normalization_states[2])],
+            "ws": [mock_artists[0], mock_artists[1]],
+            "ws1": [mock_artists[2]],
         }
         with patch("mantid.kernel.logger.warning", Mock()) as mock_logger:
             with patch.object(self.ax, "tracked_workspaces", mock_tracked_workspaces):

--- a/docs/source/api/python/mantid/plots/index.rst
+++ b/docs/source/api/python/mantid/plots/index.rst
@@ -306,7 +306,7 @@ Functions to use when **mantid3d** projection is not available
 Helper functions
 ----------------
 .. automodule:: mantid.plots.datafunctions
-   :members: get_distribution, get_normalization,
+   :members: get_distribution, get_md_normalization,
              points_from_boundaries, boundaries_from_points,
              get_wksp_index_dist_and_label, get_md_data, get_md_data1d,
              get_md_data2d_bin_bounds, get_md_data2d_bin_centers,

--- a/docs/source/release/v6.16.0/Workbench/New_features/39473.rst
+++ b/docs/source/release/v6.16.0/Workbench/New_features/39473.rst
@@ -1,0 +1,1 @@
+- Plots can now be normalised by :math:`Q^{-4}` (provided the X dimension is in :math:`Q`) via the right-click menu.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -815,11 +815,11 @@ class FigureInteraction(object):
     def _get_normalization_from_artists(ax):
         artists = [art for art in ax.tracked_workspaces.values()]
         normalizations = [art[0].normalization for art in artists]
-        all_the_same = all(map(operator.eq, normalizations[1:], normalizations[:-1]))
-        if all_the_same:
-            return normalizations[0]
-        else:
-            return PlotNormalizationType.NONE
+        if normalizations:
+            all_the_same = all(map(operator.eq, normalizations[1:], normalizations[:-1]))
+            if all_the_same:
+                return normalizations[0]
+        return PlotNormalizationType.NONE
 
     def _toggle_normalization(self, selected_ax, normalization: PlotNormalizationType):
         if figure_type(self.canvas.figure) == FigureType.Image and len(self.canvas.figure.get_axes()) > 1:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -904,6 +904,9 @@ class FigureInteraction(object):
                     if ws_artist.spec_num == arg_set_copy.get("specNum"):
                         ws_artist.normalization = normalization
 
+                        if "normalization_type" not in arg_set_copy:
+                            arg_set_copy["normalization_type"] = normalization
+
                         # This check is to prevent the contour lines being re-plotted using the colorfill plot args.
                         if isinstance(ws_artist._artists[0], QuadContourSet):
                             contour_line_colour = ws_artist._artists[0].get_edgecolor()

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from collections import OrderedDict
 from copy import copy
 from functools import partial
+import operator
 
 # third party imports
 from matplotlib.container import ErrorbarContainer
@@ -30,7 +31,7 @@ from mpl_toolkits.mplot3d.axes3d import Axes3D
 # mantid imports
 from mantid.api import AnalysisDataService as ads
 from mantid.plots import datafunctions, MantidAxes, axesfunctions, MantidAxes3D, LegendProperties
-from mantid.plots.utility import zoom, MantidAxType, legend_set_draggable
+from mantid.plots.utility import zoom, MantidAxType, legend_set_draggable, PlotNormalizationType
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.plotting.markers import SingleMarker
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
@@ -487,23 +488,29 @@ class FigureInteraction(object):
 
     def _add_normalization_option_menu(self, menu, ax):
         # Check if toggling normalization makes sense
-        can_toggle_normalization = self._can_toggle_normalization(ax)
-        if not can_toggle_normalization:
+        # TODO: Add check here for inverse Q normalisation
+        can_toggle_normalize_by_bin_width = self._can_toggle_normalize_by_bin_width(ax)
+        if not can_toggle_normalize_by_bin_width:
             return None
 
         # Create menu
         norm_menu = QMenu("Normalization", menu)
         norm_actions_group = QActionGroup(norm_menu)
-        none_action = norm_menu.addAction("None", lambda: self._set_normalization_none(ax))
-        norm_action = norm_menu.addAction("Bin Width", lambda: self._set_normalization_bin_width(ax))
-        for action in [none_action, norm_action]:
+        none_action = norm_menu.addAction("None", lambda: self._normalization_type_changed(ax, PlotNormalizationType.NONE))
+        bin_width_action = norm_menu.addAction("Bin Width", lambda: self._normalization_type_changed(ax, PlotNormalizationType.BIN_WIDTH))
+        inverse_q_action = norm_menu.addAction(
+            "Q^-4", lambda: self._normalization_type_changed(ax, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+        )
+        for action in [none_action, bin_width_action, inverse_q_action]:
             norm_actions_group.addAction(action)
             action.setCheckable(True)
 
         # Update menu state
-        is_normalized = self._is_normalized(ax)
-        if is_normalized:
-            norm_action.setChecked(True)
+        normalization = self._get_normalization_from_artists(ax)
+        if normalization == PlotNormalizationType.BIN_WIDTH:
+            bin_width_action.setChecked(True)
+        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
+            inverse_q_action.setChecked(True)
         else:
             none_action.setChecked(True)
 
@@ -793,21 +800,22 @@ class FigureInteraction(object):
         if hasattr(event, "button") and event.button is not None:
             self.redraw_annotations()
 
-    def _is_normalized(self, ax):
+    def _normalization_type_changed(self, ax, norm_type: PlotNormalizationType):
+        if norm_type == self._get_normalization_from_artists(ax):
+            return
+        self._toggle_normalization(ax, norm_type)
+
+    @staticmethod
+    def _get_normalization_from_artists(ax):
         artists = [art for art in ax.tracked_workspaces.values()]
-        return all(art[0].is_normalized for art in artists)
+        normalizations = [art[0].normalization for art in artists]
+        all_the_same = all(map(operator.eq, normalizations[1:], normalizations[:-1]))
+        if all_the_same:
+            return normalizations[0]
+        else:
+            return PlotNormalizationType.NONE
 
-    def _set_normalization_bin_width(self, ax):
-        if self._is_normalized(ax):
-            return
-        self._toggle_normalization(ax)
-
-    def _set_normalization_none(self, ax):
-        if not self._is_normalized(ax):
-            return
-        self._toggle_normalization(ax)
-
-    def _toggle_normalization(self, selected_ax):
+    def _toggle_normalization(self, selected_ax, normalization: PlotNormalizationType):
         if figure_type(self.canvas.figure) == FigureType.Image and len(self.canvas.figure.get_axes()) > 1:
             axes = datafunctions.get_axes_from_figure(self.canvas.figure)
         else:
@@ -839,7 +847,7 @@ class FigureInteraction(object):
                 if colorbar_log:
                     self._change_colorbar_axes(Normalize)
 
-            self._change_plot_normalization(ax)
+            self._change_plot_normalization(ax, normalization)
 
             if ax.lines:  # Relim causes issues with colour plots, which have no lines.
                 ax.relim()
@@ -869,14 +877,14 @@ class FigureInteraction(object):
 
         self.canvas.draw()
 
-    def _change_plot_normalization(self, ax):
-        is_normalized = self._is_normalized(ax)
+    def _change_plot_normalization(self, ax, normalization: PlotNormalizationType):
+        current_normalization = self._get_normalization_from_artists(ax)
         for arg_set in ax.creation_args:
             if arg_set["function"] == "contour":
                 continue
             if "workspaces" in arg_set and arg_set["workspaces"] in ax.tracked_workspaces:
                 workspace = ads.retrieve(arg_set["workspaces"])
-                arg_set["distribution"] = is_normalized
+                arg_set["distribution"] = current_normalization == PlotNormalizationType.BIN_WIDTH
                 if "specNum" not in arg_set:
                     if "wkspIndex" in arg_set:
                         arg_set["specNum"] = workspace.getSpectrum(arg_set.pop("wkspIndex")).getSpectrumNo()
@@ -894,7 +902,7 @@ class FigureInteraction(object):
                     arg_set_copy.pop("specNum")
                 for ws_artist in ax.tracked_workspaces[workspace.name()]:
                     if ws_artist.spec_num == arg_set_copy.get("specNum"):
-                        ws_artist.is_normalized = not is_normalized
+                        ws_artist.normalization = normalization
 
                         # This check is to prevent the contour lines being re-plotted using the colorfill plot args.
                         if isinstance(ws_artist._artists[0], QuadContourSet):
@@ -907,7 +915,7 @@ class FigureInteraction(object):
                         else:
                             ws_artist.replace_data(workspace, arg_set_copy)
 
-    def _can_toggle_normalization(self, ax):
+    def _can_toggle_normalize_by_bin_width(self, ax):
         """
         Return True if no plotted workspaces are distributions, all curves
         on the figure are either distributions or non-distributions,
@@ -916,7 +924,7 @@ class FigureInteraction(object):
         :param ax: A MantidAxes object
         :return: bool
         """
-        plotted_normalized = []
+        plotted_normalized_by_bin_width = []
         if not ax.creation_args:
             return False
         axis = ax.creation_args[0].get("axis", None)
@@ -926,10 +934,10 @@ class FigureInteraction(object):
             else:
                 is_dist = True
             if axis != MantidAxType.BIN and not is_dist and ax.data_replaced:
-                plotted_normalized += [a.is_normalized for a in artists]
+                plotted_normalized_by_bin_width += [a.normalization == PlotNormalizationType.BIN_WIDTH for a in artists]
             else:
                 return False
-        if all(plotted_normalized) or not any(plotted_normalized):
+        if all(plotted_normalized_by_bin_width) or not any(plotted_normalized_by_bin_width):
             return True
         return False
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -952,10 +952,13 @@ class FigureInteraction(object):
             return True
         return False
 
-    @staticmethod
-    def _can_normalize_by_q(ax):
+    def _can_normalize_by_q(self, ax):
+        fig_type = figure_type(self.canvas.figure)
+        if fig_type not in [FigureType.Line, FigureType.Errorbar, FigureType.Waterfall]:
+            return False
+
         plotted_x_is_q = []
-        for workspace_name, artists in ax.tracked_workspaces.items():
+        for workspace_name, _ in ax.tracked_workspaces.items():
             ws = ads.retrieve(workspace_name)
             plotted_x_is_q.append(ws.getAxis(0).getUnit().unitID() == "MomentumTransfer")
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -487,25 +487,31 @@ class FigureInteraction(object):
             menu.addMenu(axes_menu)
 
     def _add_normalization_option_menu(self, menu, ax):
-        # Check if toggling normalization makes sense
-        # TODO: Add check here for inverse Q normalisation
         can_toggle_normalize_by_bin_width = self._can_toggle_normalize_by_bin_width(ax)
-        if not can_toggle_normalize_by_bin_width:
+        can_normalise_by_inverse_q = self._can_normalize_by_q(ax)
+        if not can_toggle_normalize_by_bin_width and not can_normalise_by_inverse_q:
             return None
 
         # Create menu
+        actions = []
         norm_menu = QMenu("Normalization", menu)
         norm_actions_group = QActionGroup(norm_menu)
         none_action = norm_menu.addAction("None", lambda: self._normalization_type_changed(ax, PlotNormalizationType.NONE))
-        bin_width_action = norm_menu.addAction("Bin Width", lambda: self._normalization_type_changed(ax, PlotNormalizationType.BIN_WIDTH))
-        inverse_q_action = norm_menu.addAction(
-            "Q^-4", lambda: self._normalization_type_changed(ax, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
-        )
-        for action in [none_action, bin_width_action, inverse_q_action]:
+        actions.append(none_action)
+        if can_toggle_normalize_by_bin_width:
+            bin_width_action = norm_menu.addAction(
+                "Bin Width", lambda: self._normalization_type_changed(ax, PlotNormalizationType.BIN_WIDTH)
+            )
+            actions.append(bin_width_action)
+        if can_normalise_by_inverse_q:
+            inverse_q_action = norm_menu.addAction(
+                "Q^-4", lambda: self._normalization_type_changed(ax, PlotNormalizationType.INVERSE_Q_FOURTH_POWER)
+            )
+            actions.append(inverse_q_action)
+        for action in actions:
             norm_actions_group.addAction(action)
             action.setCheckable(True)
 
-        # Update menu state
         normalization = self._get_normalization_from_artists(ax)
         if normalization == PlotNormalizationType.BIN_WIDTH:
             bin_width_action.setChecked(True)
@@ -943,6 +949,15 @@ class FigureInteraction(object):
         if all(plotted_normalized_by_bin_width) or not any(plotted_normalized_by_bin_width):
             return True
         return False
+
+    @staticmethod
+    def _can_normalize_by_q(ax):
+        plotted_x_is_q = []
+        for workspace_name, artists in ax.tracked_workspaces.items():
+            ws = ads.retrieve(workspace_name)
+            plotted_x_is_q.append(ws.getAxis(0).getUnit().unitID() == "MomentumTransfer")
+
+        return all(plotted_x_is_q)
 
     def _quick_change_axes(self, ax, x_scale_type=None, y_scale_type=None):
         """

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -498,6 +498,8 @@ class FigureInteraction(object):
         norm_actions_group = QActionGroup(norm_menu)
         none_action = norm_menu.addAction("None", lambda: self._normalization_type_changed(ax, PlotNormalizationType.NONE))
         actions.append(none_action)
+        bin_width_action = None
+        inverse_q_action = None
         if can_toggle_normalize_by_bin_width:
             bin_width_action = norm_menu.addAction(
                 "Bin Width", lambda: self._normalization_type_changed(ax, PlotNormalizationType.BIN_WIDTH)
@@ -513,9 +515,9 @@ class FigureInteraction(object):
             action.setCheckable(True)
 
         normalization = self._get_normalization_from_artists(ax)
-        if normalization == PlotNormalizationType.BIN_WIDTH:
+        if normalization == PlotNormalizationType.BIN_WIDTH and can_toggle_normalize_by_bin_width:
             bin_width_action.setChecked(True)
-        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER:
+        elif normalization == PlotNormalizationType.INVERSE_Q_FOURTH_POWER and can_normalise_by_inverse_q:
             inverse_q_action.setChecked(True)
         else:
             none_action.setChecked(True)

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/colorfills.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/colorfills.py
@@ -115,4 +115,4 @@ def _get_mantid_specific_plot_kwargs(artist):
     ax = artist.axes
     if artist not in ax.get_tracked_artists():
         return dict()
-    return {"distribution": not ax.get_artist_normalization_state(artist)}
+    return {"distribution": not ax.get_artist_normalized_by_bin_width(artist)}

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
@@ -152,7 +152,7 @@ def _get_mantid_specific_plot_kwargs(artist):
         plot_kwargs = dict()
         if not ax.get_is_mdhisto_workspace_for_artist(artist):
             plot_kwargs["wkspIndex"] = ax.get_artists_workspace_and_workspace_index(artist)[1]
-        plot_kwargs["distribution"] = not ax.get_artist_normalization_state(artist)
+        plot_kwargs["distribution"] = not ax.get_artist_normalized_by_bin_width(artist)
         ax_type = ax.creation_args[0].get("axis", None)
         if ax_type:
             plot_kwargs["axis"] = ax_type

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -25,6 +25,7 @@ from numpy.testing import assert_almost_equal
 
 # local package imports
 from mantid.plots import MantidAxes
+from mantid.plots.utility import PlotNormalizationType
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, call, patch
 from mantid.simpleapi import CreateWorkspace
@@ -144,8 +145,8 @@ class FigureInteractionTest(unittest.TestCase):
                 self.assertEqual(3, mock_list[1].addAction.call_count)
                 # 3 actions in Y-Axis submenu
                 self.assertEqual(3, mock_list[2].addAction.call_count)
-                # 2 actions in Normalization submenu
-                self.assertEqual(2, mock_list[3].addAction.call_count)
+                # 3 actions in Normalization submenu
+                self.assertEqual(3, mock_list[3].addAction.call_count)
                 # 3 actions in Colorbar submenu
                 self.assertEqual(3, mock_list[4].addAction.call_count)
 
@@ -186,8 +187,8 @@ class FigureInteractionTest(unittest.TestCase):
                         self.assertEqual(3, mock_list[1].addAction.call_count)
                         # 3 actions in Y-Axis submenu
                         self.assertEqual(3, mock_list[2].addAction.call_count)
-                        # 2 actions in Normalization submenu
-                        self.assertEqual(2, mock_list[3].addAction.call_count)
+                        # 3 actions in Normalization submenu
+                        self.assertEqual(3, mock_list[3].addAction.call_count)
                         # 3 actions in Colorbar submenu
                         self.assertEqual(3, mock_list[4].addAction.call_count)
 
@@ -266,7 +267,7 @@ class FigureInteractionTest(unittest.TestCase):
         fig_interactor = FigureInteraction(fig_manager_mock)
 
         ax = fig.axes[0]
-        fig_interactor._toggle_normalization(ax)
+        fig_interactor._toggle_normalization(ax, PlotNormalizationType.BIN_WIDTH)
         self.assertEqual(r"Counts ($\AA$)$^{-1}$", ax.get_ylabel())
         plot([self.ws1], spectrum_nums=[1], errors=errors, overplot=True, fig=fig)
         self.assertEqual(r"Counts ($\AA$)$^{-1}$", ax.get_ylabel())
@@ -432,10 +433,10 @@ class FigureInteractionTest(unittest.TestCase):
         mock_canvas = MagicMock(figure=fig)
         fig_manager_mock = MagicMock(canvas=mock_canvas)
         fig_interactor = FigureInteraction(fig_manager_mock)
-        fig_interactor._toggle_normalization(fig.axes[0])
+        fig_interactor._toggle_normalization(fig.axes[0], PlotNormalizationType.BIN_WIDTH)
 
         clim = fig.axes[0].images[0].get_clim()
-        fig_interactor._toggle_normalization(fig.axes[0])
+        fig_interactor._toggle_normalization(fig.axes[0], PlotNormalizationType.NONE)
         self.assertEqual(clim, fig.axes[0].images[0].get_clim())
         self.assertNotEqual((-0.1, 0.1), fig.axes[0].images[0].get_clim())
 
@@ -447,7 +448,7 @@ class FigureInteractionTest(unittest.TestCase):
         fig_interactor = FigureInteraction(fig_manager_mock)
         fig_interactor._change_colorbar_axes(LogNorm)
 
-        fig_interactor._toggle_normalization(fig.axes[0])
+        fig_interactor._toggle_normalization(fig.axes[0], PlotNormalizationType.BIN_WIDTH)
 
         self.assertTrue(isinstance(fig.axes[0].images[-1].norm, LogNorm))
 
@@ -649,7 +650,7 @@ class FigureInteractionTest(unittest.TestCase):
         mock_canvas = MagicMock(figure=fig)
         fig_manager_mock = MagicMock(canvas=mock_canvas)
         fig_interactor = FigureInteraction(fig_manager_mock)
-        fig_interactor._toggle_normalization(fig.axes[0])
+        fig_interactor._toggle_normalization(fig.axes[0], PlotNormalizationType.BIN_WIDTH)
 
         self.assertTrue(all(convert_color_to_hex(col.get_edgecolor()[0]) == "#ff9900" for col in fig.get_axes()[0].collections))
 
@@ -663,13 +664,13 @@ class FigureInteractionTest(unittest.TestCase):
         # there should be 3 axes, 2 colorplots and 1 colorbar
         self.assertEqual(3, len(fig.axes))
         fig.axes[0].tracked_workspaces.values()
-        self.assertTrue(fig.axes[0].tracked_workspaces["ws"][0].is_normalized)
-        self.assertTrue(fig.axes[1].tracked_workspaces["ws"][0].is_normalized)
+        self.assertTrue(fig.axes[0].tracked_workspaces["ws"][0].is_normalized_by_bin_width())
+        self.assertTrue(fig.axes[1].tracked_workspaces["ws"][0].is_normalized_by_bin_width())
 
-        fig_interactor._toggle_normalization(fig.axes[0])
+        fig_interactor._toggle_normalization(fig.axes[0], PlotNormalizationType.NONE)
 
-        self.assertFalse(fig.axes[0].tracked_workspaces["ws"][0].is_normalized)
-        self.assertFalse(fig.axes[1].tracked_workspaces["ws"][0].is_normalized)
+        self.assertFalse(fig.axes[0].tracked_workspaces["ws"][0].is_normalized_by_bin_width())
+        self.assertFalse(fig.axes[1].tracked_workspaces["ws"][0].is_normalized_by_bin_width())
 
     def test_marker_annotations_are_removed_and_redrawn_on_scroll_zoom(self):
         event = MagicMock()
@@ -973,11 +974,11 @@ class FigureInteractionTest(unittest.TestCase):
             decimal_tol = 7
 
         ax = fig.axes[0]
-        fig_interactor._toggle_normalization(ax)
+        fig_interactor._toggle_normalization(ax, PlotNormalizationType.BIN_WIDTH)
         assert_almost_equal(ax.lines[0].get_xdata(), [15, 25])
         assert_almost_equal(ax.lines[0].get_ydata(), [0.2, 0.3], decimal=decimal_tol)
         self.assertEqual("Counts ($\\AA$)$^{-1}$", ax.get_ylabel())
-        fig_interactor._toggle_normalization(ax)
+        fig_interactor._toggle_normalization(ax, PlotNormalizationType.NONE)
         assert_almost_equal(ax.lines[0].get_xdata(), [15, 25])
         assert_almost_equal(ax.lines[0].get_ydata(), [2, 3], decimal=decimal_tol)
         self.assertEqual("Counts", ax.get_ylabel())

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -146,7 +146,7 @@ class FigureInteractionTest(unittest.TestCase):
                 # 3 actions in Y-Axis submenu
                 self.assertEqual(3, mock_list[2].addAction.call_count)
                 # 3 actions in Normalization submenu
-                self.assertEqual(3, mock_list[3].addAction.call_count)
+                self.assertEqual(2, mock_list[3].addAction.call_count)
                 # 3 actions in Colorbar submenu
                 self.assertEqual(3, mock_list[4].addAction.call_count)
 

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -325,6 +325,7 @@ def pcolormesh_on_axis(ax, ws, color_norm=None, normalize_by_bin_width=None):
         # remove normalize_by_bin_width from cargs if present so that this can be toggled in future
         for cargs in pcm.axes.creation_args:
             cargs.pop("normalize_by_bin_width")
+            cargs.pop("normalize_type", None)
     else:
         pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale)
 

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -325,7 +325,7 @@ def pcolormesh_on_axis(ax, ws, color_norm=None, normalize_by_bin_width=None):
         # remove normalize_by_bin_width from cargs if present so that this can be toggled in future
         for cargs in pcm.axes.creation_args:
             cargs.pop("normalize_by_bin_width")
-            cargs.pop("normalize_type", None)
+            cargs.pop("normalizeation_type", None)
     else:
         pcm = ax.pcolormesh(ws, cmap=ConfigService.getString("plots.images.Colormap"), norm=scale)
 

--- a/qt/python/mantidqt/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/mantidqt/project/plotssaver.py
@@ -148,7 +148,7 @@ class PlotsSaver(object):
 
         # add value to determine if ax has been normalised
         ws_artists = [art for art in ax.tracked_workspaces.values()]
-        is_norm = all(art[0].is_normalized for art in ws_artists)
+        is_norm = all(art[0].is_normalized_by_bin_width() for art in ws_artists)
         ax_dict["_is_norm"] = is_norm
 
         return ax_dict

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -160,7 +160,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             if hasattr(workspace, "isDistribution") and workspace.isDistribution():
                 ws_is_distribution = True
         ws_artist = self._get_selected_workspace_artist()
-        should_normalise_before_fit = ws_artist.is_normalized and not ws_is_distribution
+        should_normalise_before_fit = ws_artist.is_normalized_by_bin_width() and not ws_is_distribution
         self.normaliseData(should_normalise_before_fit)
 
     def _set_peak_initial_fwhm(self, fun, fwhm):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -10,7 +10,7 @@ from typing import List, Sequence, Tuple, Optional
 
 from mantid.api import MatrixWorkspace, MultipleExperimentInfos
 from mantid.kernel import SpecialCoordinateSystem
-from mantid.plots.datafunctions import get_indices, get_normalization, get_md_data2d_bin_bounds
+from mantid.plots.datafunctions import get_indices, get_md_normalization, get_md_data2d_bin_bounds
 from mantid.simpleapi import BinMD, IntegrateMDHistoWorkspace, TransposeMD
 
 from .base_model import SliceViewerBaseModel
@@ -181,7 +181,7 @@ class SliceViewerModel(SliceViewerBaseModel):
 
     def get_data_MDH(self, slicepoint, transpose=False):
         indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
-        mdh_normalization, _ = get_normalization(self.get_ws())
+        mdh_normalization, _ = get_md_normalization(self.get_ws())
         _, _, z = get_md_data2d_bin_bounds(self.get_ws(), mdh_normalization, indices, not (transpose))
         return z
 
@@ -196,7 +196,7 @@ class SliceViewerModel(SliceViewerBaseModel):
         :param transpose: If true then transpose the data before returning
         """
         mdh = self.get_ws_MDE(slicepoint, bin_params, limits, dimension_indices)
-        mdh_normalization, _ = get_normalization(mdh)
+        mdh_normalization, _ = get_md_normalization(mdh)
         _, _, z = get_md_data2d_bin_bounds(mdh, mdh_normalization, transpose=not (transpose))
         return z
 

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -42,7 +42,8 @@ class FitPropertyBrowserTest(unittest.TestCase):
     @patch("mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData")
     def test_normalise_data_set_on_fit_menu_shown(self, normaliseData_mock):
         for normalised in [True, False]:
-            ws_artist_mock = Mock(is_normalized=normalised, workspace_index=0)
+            ws_artist_mock = Mock(workspace_index=0)
+            ws_artist_mock.is_normalized_by_bin_width.return_value = normalised
             axes_mock = Mock(tracked_workspaces={"ws_name": [ws_artist_mock]})
             property_browser = self._create_widget()
             with patch.object(property_browser, "get_axes", lambda: axes_mock):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_model.py
@@ -21,7 +21,7 @@ class ExternalPlottingModel(object):
         for i, axis in enumerate(axes):
             artists = axis.get_tracked_artists()
             for artist in artists:
-                is_normalised = axis.get_artist_normalization_state(artist)
+                is_normalised = axis.get_artist_normalized_by_bin_width(artist)
                 workspace, index = axis.get_artists_workspace_and_spec_num(artist)
                 plotted_data.append(PlotInformation(workspace=workspace, specNum=index, axis=i, normalised=is_normalised))
         return plotted_data

--- a/qt/python/mantidqtinterfaces/test/Muon/external_plotting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/external_plotting_model_test.py
@@ -24,7 +24,7 @@ class ExternalPlottingModelTest(unittest.TestCase):
         mock_axes = []
         for i in range(NUM_AXES):
             mock_axis = mock.Mock(spec=MantidAxes)
-            mock_axis.get_artist_normalization_state.return_value = NORMALISATION_STATE
+            mock_axis.get_artist_normalized_by_bin_width.return_value = NORMALISATION_STATE
             mock_axis.get_artists_workspace_and_spec_num.return_value = EXAMPLE_DATA[i]
             mock_axis.get_tracked_artists.return_value = [self.mock_artist]
             mock_axes.append(mock_axis)


### PR DESCRIPTION
### Description of work

Add option to the `Normalization` right-click menu on plots for normalising by Q^-4.
The normalisation option has been added to the standard `plot()` function (so standard 2d line plots), not sure if the others are needed?

Closes #39473

### To test:
Follow the Refl GUI manual testing instructions to load the test batch file and process a row.
https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#processing-rows
Plot the final curve (one spectrum workspace where X is Q) and try out the normalisation option.

Do all the other plot testing you can think of, this does touch quite a lot. I've tested a lot but, given it's plots, I wouldn't be surprised if I've broken something else.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
