### PR TITLE
Fix dev-docs only builds

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -133,6 +133,7 @@ if [ -d $BUILD_DIR ]; then
       ENABLE_UNIT_TESTS=false
       ENABLE_SYSTEM_TESTS=false
       ENABLE_DOC_TESTS=false
+      ENABLE_DOCS=false
     fi
 else
   mkdir -p $BUILD_DIR

--- a/dev-docs/source/Architecture.rst
+++ b/dev-docs/source/Architecture.rst
@@ -16,7 +16,7 @@ Context
 -------
 
 People and other systems interact with the Mantid software package
-as decribed by the following context diagram.
+as described by the following context diagram.
 
 
 .. figure:: /images/architecture-context.png


### PR DESCRIPTION
### Description of work
Turns off building user docs when only dev-docs are changed in a PR. This will speed things up and prevent the failures we are seeing with pull requests that change only dev-docs:
```
/jenkins_workdir/workspace/pull_requests-doc-tests/docs/source/concepts/MPI.md:307: WARNING: undefined label: 'algm-broadcastworkspace' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/docs/source/concepts/MPI.md:307: WARNING: undefined label: 'algm-gatherworkspaces' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/build/docs/release/v6.16.0/framework:3: WARNING: undefined label: 'algm-broadcastworkspace' [ref.ref]
/jenkins_workdir/workspace/pull_requests-doc-tests/build/docs/release/v6.16.0/framework:3: WARNING: undefined label: 'algm-gatherworkspaces' [ref.ref]
```

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
There is a [test PR ](https://github.com/mantidproject/mantid/pull/41264) that pretends that only dev-docs are changed. Ensure that dev-docs build successfully on that PR. The docs build is [here](https://builds.mantidproject.org/job/pull_requests-doc-tests/9418/). Verify that only the dev-docs build is run, and not user docs.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
