### PR TITLE
Fix `SaveNexusProcessed` for ragged Event Data

### DIFF
--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -406,22 +406,22 @@ void SaveNexusProcessed::appendEventListData(const std::vector<T> &events, size_
  * */
 void SaveNexusProcessed::execEvent(const Mantid::Nexus::NexusFileIO *nexusFile, const bool uniformSpectra,
                                    const bool raggedSpectra, const std::vector<int> &spec) {
-  m_progress = std::make_unique<Progress>(this, m_timeProgInit, 1.0, m_eventWorkspace->getNumberEvents() * 2);
+  std::vector<int64_t> indices;
+  indices.reserve(spec.size() + 1);
+  // First we need to index the events in each spectrum
+  size_t index = 0;
+  for (auto s : spec) {
+    indices.emplace_back(index);
+    index += m_eventWorkspace->getSpectrum(s).getNumberEvents();
+  }
+  indices.emplace_back(index);
+
+  m_progress = std::make_unique<Progress>(this, m_timeProgInit, 1.0, index * 2);
 
   // Start by writing out the axes and crap
   nexusFile->writeNexusProcessedData2D(m_eventWorkspace, uniformSpectra, raggedSpectra, spec, "event_workspace", false);
 
   // Make a super long list of tofs, weights, etc.
-  std::vector<int64_t> indices;
-  indices.reserve(m_eventWorkspace->getNumberHistograms() + 1);
-  // First we need to index the events in each spectrum
-  size_t index = 0;
-  for (int wi = 0; wi < static_cast<int>(m_eventWorkspace->getNumberHistograms()); wi++) {
-    indices.emplace_back(index);
-    // Track the total # of events
-    index += m_eventWorkspace->getSpectrum(wi).getNumberEvents();
-  }
-  indices.emplace_back(index);
 
   // Initialize all the arrays
   int64_t num = index;
@@ -464,9 +464,9 @@ void SaveNexusProcessed::execEvent(const Mantid::Nexus::NexusFileIO *nexusFile, 
 
   // --- Fill in the combined event arrays ----
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int wi = 0; wi < static_cast<int>(m_eventWorkspace->getNumberHistograms()); wi++) {
+  for (int wi = 0; wi < static_cast<int>(spec.size()); wi++) {
     PARALLEL_START_INTERRUPT_REGION
-    const DataObjects::EventList &el = m_eventWorkspace->getSpectrum(wi);
+    const DataObjects::EventList &el = m_eventWorkspace->getSpectrum(spec[wi]);
 
     // This is where it will land in the output array.
     // It is okay to write in parallel since none should step on each other.

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -128,7 +128,7 @@ void SaveNexusProcessed::init() {
                   "Index of last spectrum to write, only for single period\n"
                   "data.");
   declareProperty(std::make_unique<ArrayProperty<int>>("WorkspaceIndexList"),
-                  "List of spectrum numbers to read, only for single period\n"
+                  "List of spectrum numbers to write, only for single period\n"
                   "data.");
 
   declareProperty("Append", false,

--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -818,6 +818,50 @@ public:
     AnalysisDataService::Instance().remove("testSpace");
   }
 
+  void test_event_workspace_ragged_bins_with_workspace_index_list() {
+    std::vector<std::vector<int>> groups(2);
+    groups[0].emplace_back(10);
+    groups[1].emplace_back(20);
+    EventWorkspace_sptr ws = WorkspaceCreationHelper::createGroupedEventWorkspace(groups, 50, 1.0, 1.0);
+
+    // Different bin edges per spectrum forces the ragged (non-shared-bins) path in LoadNexusProcessed
+    ws->setX(0, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 1.0, 2.0}));
+    ws->setX(1, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 2.0, 4.0}));
+
+    AnalysisDataService::Instance().add("testEventRagged", ws);
+
+    SaveNexusProcessed saveAlg;
+    saveAlg.initialize();
+    saveAlg.setPropertyValue("InputWorkspace", "testEventRagged");
+    FileResource file("SaveNexusProcessedTest_event_ragged_index_list.nxs", !clearfiles);
+    saveAlg.setPropertyValue("Filename", file.fullPath());
+    saveAlg.setPropertyValue("WorkspaceIndexList", "1"); // save only 2nd spectrum
+    saveAlg.setProperty("PreserveEvents", true);
+    TS_ASSERT_THROWS_NOTHING(saveAlg.execute());
+    TS_ASSERT(saveAlg.isExecuted());
+
+    LoadNexus loadAlg;
+    loadAlg.initialize();
+    loadAlg.setPropertyValue("Filename", file.fullPath());
+    loadAlg.setPropertyValue("OutputWorkspace", "testEventRaggedReloaded");
+    TS_ASSERT_THROWS_NOTHING(loadAlg.execute());
+    TS_ASSERT(loadAlg.isExecuted());
+
+    auto wsReloaded =
+        std::dynamic_pointer_cast<EventWorkspace>(AnalysisDataService::Instance().retrieve("testEventRaggedReloaded"));
+    TS_ASSERT(wsReloaded);
+    if (wsReloaded) {
+      TS_ASSERT_EQUALS(wsReloaded->getNumberHistograms(), 1);
+      // Verify bin edges from spectrum 1 were saved, not spectrum 0
+      TS_ASSERT_EQUALS(wsReloaded->readX(0), ws->readX(1));
+      // Verify events from spectrum 1 were saved, not spectrum 0
+      TS_ASSERT_EQUALS(wsReloaded->getSpectrum(0).getNumberEvents(), ws->getSpectrum(1).getNumberEvents());
+    }
+
+    AnalysisDataService::Instance().remove("testEventRagged");
+    AnalysisDataService::Instance().remove("testEventRaggedReloaded");
+  }
+
   void test_ragged_x_bins_input_data_bounds() {
     // Fix SEGFAULT when writing ragged data: respect input vector bounds at `putSlab`.
 

--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -819,14 +819,18 @@ public:
   }
 
   void test_event_workspace_ragged_bins_with_workspace_index_list() {
-    std::vector<std::vector<int>> groups(2);
+    std::vector<std::vector<int>> groups(4);
     groups[0].emplace_back(10);
     groups[1].emplace_back(20);
+    groups[2].emplace_back(30);
+    groups[3].emplace_back(40);
     EventWorkspace_sptr ws = WorkspaceCreationHelper::createGroupedEventWorkspace(groups, 50, 1.0, 1.0);
 
     // Different bin edges per spectrum forces the ragged (non-shared-bins) path in LoadNexusProcessed
     ws->setX(0, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 1.0, 2.0}));
     ws->setX(1, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 2.0, 4.0}));
+    ws->setX(2, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 3.0, 6.0}));
+    ws->setX(3, make_cow<Mantid::HistogramData::HistogramX>(std::vector<double>{0.0, 4.0, 8.0}));
 
     AnalysisDataService::Instance().add("testEventRagged", ws);
 
@@ -835,7 +839,7 @@ public:
     saveAlg.setPropertyValue("InputWorkspace", "testEventRagged");
     FileResource file("SaveNexusProcessedTest_event_ragged_index_list.nxs", !clearfiles);
     saveAlg.setPropertyValue("Filename", file.fullPath());
-    saveAlg.setPropertyValue("WorkspaceIndexList", "1"); // save only 2nd spectrum
+    saveAlg.setPropertyValue("WorkspaceIndexList", "1,3"); // save only 2nd and 4th spectra
     saveAlg.setProperty("PreserveEvents", true);
     TS_ASSERT_THROWS_NOTHING(saveAlg.execute());
     TS_ASSERT(saveAlg.isExecuted());
@@ -851,11 +855,13 @@ public:
         std::dynamic_pointer_cast<EventWorkspace>(AnalysisDataService::Instance().retrieve("testEventRaggedReloaded"));
     TS_ASSERT(wsReloaded);
     if (wsReloaded) {
-      TS_ASSERT_EQUALS(wsReloaded->getNumberHistograms(), 1);
-      // Verify bin edges from spectrum 1 were saved, not spectrum 0
+      TS_ASSERT_EQUALS(wsReloaded->getNumberHistograms(), 2);
+      // Verify bin edges from spectra 1 and 3 were saved, not 0 or 2
       TS_ASSERT_EQUALS(wsReloaded->readX(0), ws->readX(1));
-      // Verify events from spectrum 1 were saved, not spectrum 0
+      TS_ASSERT_EQUALS(wsReloaded->readX(1), ws->readX(3));
+      // Verify events from spectra 1 and 3 were saved, not 0 or 2
       TS_ASSERT_EQUALS(wsReloaded->getSpectrum(0).getNumberEvents(), ws->getSpectrum(1).getNumberEvents());
+      TS_ASSERT_EQUALS(wsReloaded->getSpectrum(1).getNumberEvents(), ws->getSpectrum(3).getNumberEvents());
     }
 
     AnalysisDataService::Instance().remove("testEventRagged");

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41266.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41266.rst
@@ -1,0 +1,1 @@
+- In :ref:`algm-SaveNexusProcessed`:ref:`algm-SaveNexusProcessed` the saving for Event Data now correctly uses the ``WorkspaceIndexList`` when one is provided.


### PR DESCRIPTION
### Description of work

See initial discussion of problem here:
https://github.com/mantidproject/mantid/issues/41030#issuecomment-4280245007

I have changed the range of spectra the save acts over to respect the spectrum list provided

Will Close #41030 once #41242 is in, but the issue it addresses is independent of #41029 so I have made this a separate PR

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Try loading 
[ENGINX_371872_371347_bank_1_TOF.nxs.txt](https://github.com/user-attachments/files/26894930/ENGINX_371872_371347_bank_1_TOF.nxs.txt)


(Sorry for the hyperlink casserole)

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
