### PR TITLE
Use previous version of VULCAN instrument in unit test

### DIFF
--- a/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
+++ b/Framework/DataHandling/test/AlignAndFocusPowderSlimTest.h
@@ -40,6 +40,7 @@ using Mantid::DataObjects::TableWorkspace_sptr;
 namespace {
 // used in most tests
 const std::string VULCAN_218062("VULCAN_218062.nxs.h5");
+const std::string VULCAN_INSTRUMENT("VULCAN_Definition_2022-05-15.xml");
 
 // place where the disabled tests at the bottom are
 // test_exec1GB, test_exec10GB, test_exec18GB
@@ -83,7 +84,7 @@ public:
     // CreateGroupingWorkspace(InstrumentName="VULCAN", GroupDetectorsBy="bank", OutputWorkspace="groups")
     auto gen = AlgorithmManager::Instance().createUnmanaged("CreateGroupingWorkspace");
     gen->initialize();
-    gen->setProperty("InstrumentName", "VULCAN");
+    gen->setProperty("InstrumentFilename", VULCAN_INSTRUMENT);
     gen->setProperty("GroupDetectorsBy", "bank");
     gen->setProperty("OutputWorkspace", "bank_groups");
     gen->execute();
@@ -1066,7 +1067,7 @@ public:
     // load VULCAN instrument
     auto load = AlgorithmManager::Instance().createUnmanaged("LoadEmptyInstrument");
     load->initialize();
-    load->setProperty("InstrumentName", "VULCAN");
+    load->setProperty("Filename", VULCAN_INSTRUMENT);
     load->setProperty("OutputWorkspace", "instrument");
     load->execute();
 
@@ -1113,7 +1114,7 @@ public:
     // load VULCAN instrument
     auto load = AlgorithmManager::Instance().createUnmanaged("LoadEmptyInstrument");
     load->initialize();
-    load->setProperty("InstrumentName", "VULCAN");
+    load->setProperty("Filename", VULCAN_INSTRUMENT);
     load->setProperty("OutputWorkspace", "instrument");
     load->execute();
 


### PR DESCRIPTION
For some reason, when #41243 was created it didn't run the unit tests so it got merged and broke `AlignAndFocusPowderSlimTest` because the latest IDF has more banks. This changes the tests to use the IDF they were written with.

There is no associated issue.

### To test:

You can see the unit tests pass now, or run the broken one yourself
```sh
ninja DataHandlingTest && ctest -R DataHandlingTest_AlignAndFocusPowderSlimTest --output-on-failure
```

*This does not require release notes* because it is fixing a broken unit test.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
