### PR TITLE
Migrate coverity job to github-actions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - coverity

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,6 +3,11 @@ name: Coverity
 on:
   pull_request: # TODO DELETEME
   workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
   schedule:
     - cron: 0 6 * * *
 
@@ -14,7 +19,10 @@ concurrency:
 jobs:
   build:
     runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
       - self-hosted
+      - Linux
+      - X64
       - coverity
 
     env:
@@ -74,6 +82,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           echo "::add-matcher::.github/matchers/gcc.json"
           pixi run --frozen ${COVERITY_DIR}/cov-build --dir cov-int cmake --build .
+          echo "::remove-matcher owner=gcc-problem-matcher::"
 
       - name: Prepare result
         run: |
@@ -88,9 +97,9 @@ jobs:
             echo "${REPORT_FILE} does not exist with nonzero size"
             exit 1
           fi
-          curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="${REPORT_FILE}" https://scan.coverity.com/projects/335/builds/init > response
+          curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=${{ secrets.COVERITY_TOKEN }} -d file_name="${REPORT_FILE}" https://scan.coverity.com/projects/335/builds/init > response
           cat response
           upload_url=$(jq -r '.url' response)
           build_id=$(jq -r '.build_id' response)
           curl -f -X PUT --header "Content-Type: application/json" --upload-file mantid.tgz $upload_url
-          curl -f -X PUT -d token=$COVERITY_TOKEN https://scan.coverity.com/projects/335/builds/$build_id/enqueue
+          curl -f -X PUT -d token=${{ secrets.COVERITY_TOKEN }} https://scan.coverity.com/projects/335/builds/$build_id/enqueue

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,6 +25,7 @@ jobs:
       ENABLE_DOC_TESTS: false
       ENABLE_DEV_DOCS: false
       ENABLE_COVERITY: true
+      REPORT_FILE: "mantid.tar.gz"
 
     steps:
       - name: Print shell environment vars (debug)
@@ -54,8 +55,8 @@ jobs:
           echo "$HOME/.pixi/bin" >> $GITHUB_PATH
 
       - name: Clean build tree
-        # supplying --clean-build or CLEAN_BUILD=true should be added here
-        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+        # supplying --clean-build deletes the build tree so everything is compiled
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} --clean-build
 
       - name: Configure coverity
         run: |
@@ -74,12 +75,20 @@ jobs:
           echo "::add-matcher::.github/matchers/gcc.json"
           pixi run --frozen ${COVERITY_DIR}/cov-build --dir cov-int cmake --build .
 
+      - name: Prepare result
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          tar czvf ${REPORT_FILE} cov-int
+          ls -lah ${REPORT_FILE}
+
       - name: Upload result
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          tar czvf mantid.tar.gz cov-int
-
-          curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="mantid.tgz" https://scan.coverity.com/projects/335/builds/init > response
+          if [ ! -s ${REPORT_FILE} ]; then
+            echo "${REPORT_FILE} does not exist with nonzero size"
+            exit 1
+          fi
+          curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="${REPORT_FILE}" https://scan.coverity.com/projects/335/builds/init > response
           cat response
           upload_url=$(jq -r '.url' response)
           build_id=$(jq -r '.build_id' response)

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,87 @@
+name: Coverity
+
+on:
+  pull_request: # TODO DELETEME
+  workflow_dispatch:
+  schedule:
+    - cron: 0 6 * * *
+
+# cancel previous job if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - coverity
+
+    env:
+      CMAKE_PRESET: linux-64-ci
+      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
+      ENABLE_BUILD_CODE: true
+      ENABLE_DOCS: false
+      ENABLE_DOC_TESTS: false
+      ENABLE_DEV_DOCS: false
+      ENABLE_COVERITY: true
+
+    steps:
+      - name: Print shell environment vars (debug)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          env -0 | while IFS='' read -d '' line ; do printf '%s\t: %s\n' "${line%%=*}" "${line#*=}" | expand -t 30 | sed ':a;N;$!ba;s/\n/ /g'; done | LC_COLLATE=C sort -b
+      #
+      # If this workflow was triggered manually,
+      # print a sorted list of all shell environment variables
+      #
+
+
+      # in jenkins
+      # $WORKSPACE/buildconfig/Jenkins/Conda/conda-buildscript $WORKSPACE linux-64-ci --enable-coverity --clean-build
+
+      - uses: actions/checkout@v6
+        with:
+          # Needed to fetch the tags for versioningit
+          fetch-depth: 100
+          fetch-tags: true
+
+      - name: Install pixi
+        run: |
+          source ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/pixi-utils
+          install_pixi
+          # Add pixi to path for use in other steps
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+
+      - name: Clean build tree
+        # supplying --clean-build or CLEAN_BUILD=true should be added here
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+
+      - name: Configure coverity
+        run: |
+          pixi run --frozen ${COVERITY_DIR}/cov-configure --template --comptype prefix --compiler ccache
+          pixi run --frozen ${COVERITY_DIR}/cov-configure --template --comptype g++ --compiler x86_64-conda-linux-gnu-c++
+          pixi run --frozen ${COVERITY_DIR}/cov-configure --template --comptype gcc --compiler x86_64-conda-linux-gnu-cc
+
+      - name: Configure cmake
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          pixi run --frozen cmake --preset=${CMAKE_PRESET} -DMPI_BUILD=ON ${GITHUB_WORKSPACE}
+
+      - name: Build code
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo "::add-matcher::.github/matchers/gcc.json"
+          pixi run --frozen ${COVERITY_DIR}/cov-build --dir cov-int cmake --build .
+
+      - name: Upload result
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          tar czvf mantid.tar.gz cov-int
+
+          curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="mantid.tgz" https://scan.coverity.com/projects/335/builds/init > response
+          cat response
+          upload_url=$(jq -r '.url' response)
+          build_id=$(jq -r '.build_id' response)
+          curl -f -X PUT --header "Content-Type: application/json" --upload-file mantid.tgz $upload_url
+          curl -f -X PUT -d token=$COVERITY_TOKEN https://scan.coverity.com/projects/335/builds/$build_id/enqueue

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,7 +1,9 @@
 name: Coverity
 
 on:
-  pull_request: # TODO DELETEME
+  pull_request:
+    paths: # when editing workflow
+      - '.github/workflows/coverity.yml'
   workflow_dispatch:
     inputs:
       RUNNER_LABEL:
@@ -28,11 +30,6 @@ jobs:
     env:
       CMAKE_PRESET: linux-64-ci
       EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
-      ENABLE_BUILD_CODE: true
-      ENABLE_DOCS: false
-      ENABLE_DOC_TESTS: false
-      ENABLE_DEV_DOCS: false
-      ENABLE_COVERITY: true
       REPORT_FILE: "mantid.tar.gz"
 
     steps:
@@ -44,10 +41,6 @@ jobs:
       # If this workflow was triggered manually,
       # print a sorted list of all shell environment variables
       #
-
-
-      # in jenkins
-      # $WORKSPACE/buildconfig/Jenkins/Conda/conda-buildscript $WORKSPACE linux-64-ci --enable-coverity --clean-build
 
       - uses: actions/checkout@v6
         with:
@@ -75,7 +68,7 @@ jobs:
       - name: Configure cmake
         run: |
           cd ${GITHUB_WORKSPACE}
-          pixi run --frozen cmake --preset=${CMAKE_PRESET} -DMPI_BUILD=ON ${GITHUB_WORKSPACE}
+          pixi run --frozen cmake --preset=${CMAKE_PRESET} ${EXTRA_CMAKE_FLAGS} -DMPI_BUILD=ON ${GITHUB_WORKSPACE}
 
       - name: Build code
         run: |

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
   schedule:
-    - cron: 0 6 * * *
+    - cron: 42 3 */2 * *
 
 # cancel previous job if a new commit is pushed
 concurrency:
@@ -89,14 +89,17 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           tar czvf ${REPORT_FILE} cov-int
           ls -lah ${REPORT_FILE}
-
-      - name: Upload result
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
+          # verify the report is non-empty
           if [ ! -s ${REPORT_FILE} ]; then
             echo "${REPORT_FILE} does not exist with nonzero size"
             exit 1
           fi
+
+      - name: Upload result
+        # only run on schedule or workflow_dispatch when the secret is available
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
           curl --fail-with-body -X POST -d version=${{ github.ref }} -d email=mantidproject@gmail.com -d token=${{ secrets.COVERITY_TOKEN }} -d file_name="${REPORT_FILE}" https://scan.coverity.com/projects/335/builds/init > response
           cat response
           upload_url=$(jq -r '.url' response)

--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -12,8 +12,7 @@
 #   6. ENABLE_UNIT_TESTS: whether or not to build the unit tests target
 #   7. ENABLE_SYSTEM_TESTS: whether or not to build the system test data
 #   8. ENABLE_DOC_TESTS: whether or not to build the test data for doc tests
-#   9. ENABLE_COVERITY: enables the coverity scan static analysis
-#   10. EXTRA_CMAKE_FLAGS: Extra flags to pass directly to cmake, enclose in "".
+#   9. EXTRA_CMAKE_FLAGS: Extra flags to pass directly to cmake, enclose in "".
 
 WORKSPACE=$1
 CMAKE_PRESET=$2
@@ -23,8 +22,7 @@ ENABLE_BUILD_CODE=$5
 ENABLE_UNIT_TESTS=$6
 ENABLE_SYSTEM_TESTS=$7
 ENABLE_DOC_TESTS=$8
-ENABLE_COVERITY=$9
-EXTRA_CMAKE_FLAGS=${10}
+EXTRA_CMAKE_FLAGS=${9}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_MIRROR="$("${SCRIPT_DIR}/../data_mirrors")"
 
@@ -58,22 +56,6 @@ cd $WORKSPACE/build
 BUILD_OPTIONS=""
 if [ ! -f build.ninja ]; then
     BUILD_OPTIONS="-j20 --config Release"
-fi
-
-if [[ $ENABLE_COVERITY == true ]]; then
-    conda install -y jq curl
-
-    ${COVERITY_DIR}/cov-build --dir cov-int cmake --build . $BUILD_OPTIONS
-    tar czvf mantid.tgz cov-int
-
-    curl --fail-with-body -X POST -d version=$GIT_COMMIT -d email=mantidproject@gmail.com -d token=$COVERITY_TOKEN -d file_name="mantid.tgz" https://scan.coverity.com/projects/335/builds/init > response
-    cat response
-    upload_url=$(jq -r '.url' response)
-    build_id=$(jq -r '.build_id' response)
-    curl -f -X PUT --header 'Content-Type: application/json' --upload-file mantid.tgz $upload_url
-    curl -f -X PUT -d token=$COVERITY_TOKEN https://scan.coverity.com/projects/335/builds/$build_id/enqueue
-
-    exit 0
 fi
 
 if [[ $ENABLE_BUILD_CODE == true ]]; then

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -20,7 +20,6 @@
 #   --enable-docs: Build the docs
 #   --enable-dev-docs: Build the developer docs
 #   --enable-doctests: Run the documentation tests
-#   --enable-coverity: Run coverity and submit results; ignores all other options and does not run unit tests
 #   --clean-build: Clear the build folder and build from scratch
 #
 # Possible parameters:
@@ -58,7 +57,6 @@ ENABLE_SYSTEM_TESTS=false
 ENABLE_DOCS=false
 ENABLE_DOC_TESTS=false
 ENABLE_DEV_DOCS=false
-ENABLE_COVERITY=false
 CLEAN_BUILD=false
 EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 
@@ -89,10 +87,6 @@ do
             ENABLE_DOC_TESTS=true
             ;;
         --enable-dev-docs) ENABLE_DEV_DOCS=true ;;
-        --enable-coverity)
-            ENABLE_COVERITY=true
-            ENABLE_UNIT_TESTS=false
-	    ;;
         --clean-build) CLEAN_BUILD=true ;;
         --extra-cmake-flags)
             EXTRA_CMAKE_FLAGS="$2"
@@ -151,7 +145,7 @@ fi
 set -o pipefail
 
 # Run the script that handles the build
-pixi run --frozen bash -ex $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
+pixi run --frozen bash -ex $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS "$EXTRA_CMAKE_FLAGS" | tee $BUILD_DIR/test_logs/build_$OSTYPE.log
 
 # Return to original behaviour.
 set +o pipefail


### PR DESCRIPTION
Migrate the [coverity jenkins job](https://builds.mantidproject.org/job/coverity_build_and_submit/) to github actions. The jenkins job used to run
```sh
$WORKSPACE/buildconfig/Jenkins/Conda/conda-buildscript $WORKSPACE linux-64-ci --enable-coverity --clean-build
```
which ran `buildconfig/Jenkins/Conda/build` with arguments to denote that is was running coverity.


Refs #39497 

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

*This does not require release notes* because it is migrating a buildscript from jenkins to github-actions.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
