### PR TITLE
Fix Windows conda-bld env_logs written to wrong directory

### DIFF
--- a/conda/recipes/archive_env_logs.bat
+++ b/conda/recipes/archive_env_logs.bat
@@ -4,9 +4,9 @@ set build_env_prefix=%1
 set host_env_prefix=%2
 set package_name=%3
 
-if not exist ..\..\env_logs\win-64 mkdir ..\..\env_logs\win-64
+if not exist ..\..\..\env_logs\win-64 mkdir ..\..\..\env_logs\win-64
 :: Just for first package (mantid), archive the base environment
-if %package_name%==mantid call conda list --explicit base > ..\..\env_logs\win-64\base_environment.txt
+if %package_name%==mantid call pixi run -e package-standalone conda list --explicit base > ..\..\..\env_logs\win-64\base_environment.txt 2>&1
 
-call conda list --explicit --prefix %host_env_prefix% > ..\..\env_logs\win-64\%package_name%_host_environment.txt
-call conda list --explicit --prefix %build_env_prefix% > ..\..\env_logs\win-64\%package_name%_build_environment.txt
+call pixi run -e package-standalone conda list --explicit --prefix %host_env_prefix% > ..\..\..\env_logs\win-64\%package_name%_host_environment.txt 2>&1
+call pixi run -e package-standalone conda list --explicit --prefix %build_env_prefix% > ..\..\..\env_logs\win-64\%package_name%_build_environment.txt 2>&1

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -175,8 +175,7 @@ def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, 
     :param log_file: Name of the file to compare, e.g. mantid_build_environment.txt
     :return: URL for build artifact
     """
-    url_base = f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/"
-    return url_base + (f"env_logs/{os_name}/{log_file}" if not os_name == "win-64" else f"bld/env_logs/win-64/{log_file}")
+    return f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/env_logs/{os_name}/{log_file}"
 
 
 def extract_package_versions(url: str, os_name: str) -> Dict[str, str]:


### PR DESCRIPTION
### Description of work                                                                                                                                                                              
The .bat used 2 levels up (..\..) but rattler-build's work directory is 3 levels deep inside conda-bld/, so logs landed in conda-bld/bld/env_logs/ instead of conda-bld/env_logs/. Also update to use pixi run -e package-standalone for consistency with the .sh equivalent, following the migration in #40447. It also reverts PR #41213 because the path update is no longer needed. 


Closes #41244 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Check the env logs are correctly written in this build: https://builds.mantidproject.org/job/build_branch/1573/
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
