### PR TITLE
Remove hidden table of contents from docs pages

### DIFF
--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -4,8 +4,6 @@
 Work flows algorithm profiling
 ==============================
 
-.. contents:: Contents
-   :local:
 
 .. figure:: images/MantidProfiler.png
    :alt: Example output after rendering

--- a/dev-docs/source/Architecture.rst
+++ b/dev-docs/source/Architecture.rst
@@ -2,8 +2,6 @@
 Architecture
 ============
 
-.. contents::
-   :local:
 
 Summary
 -------

--- a/dev-docs/source/AutomatedBuildProcess.rst
+++ b/dev-docs/source/AutomatedBuildProcess.rst
@@ -2,8 +2,6 @@
 The Automated Build Process
 ===========================
 
-.. contents:: Contents
-   :local:
 
 Summary
 ^^^^^^^

--- a/dev-docs/source/BuildingWithCMake.rst
+++ b/dev-docs/source/BuildingWithCMake.rst
@@ -4,8 +4,6 @@
 Building with CMake
 ===================
 
-.. contents::
-  :local:
 
 CMake is the build system for the entirety of Mantid (Framework, MantidQt and MantidWorkbench). It is used to generate native build files for your platform, which can be Makefiles (for use with make, nmake or jom) for command line builds or project/solution files for an IDE (e.g. Visual Studio, Eclipse, Qt Creator, XCode).
 For a "how is it used version" of this guide, see the `build script <https://github.com/mantidproject/mantid/blob/main/buildconfig/Jenkins/Conda/build>`_ used on the build servers.

--- a/dev-docs/source/CodeCoverage.rst
+++ b/dev-docs/source/CodeCoverage.rst
@@ -2,9 +2,6 @@
 Generating code coverage
 ========================
 
-.. contents::
-    :local:
-
 
 C++
 ====

--- a/dev-docs/source/CondaPackageManager.rst
+++ b/dev-docs/source/CondaPackageManager.rst
@@ -4,8 +4,6 @@
 Conda Package Manager
 =====================
 
-.. contents::
-   :local:
 
 Mantid uses `conda <https://docs.conda.io/en/latest/>`_ as its package management system. This document gives a
 developer overview on how we use the conda package manager, including tips on how to debug dependency issues, and

--- a/dev-docs/source/DataFilesForTesting.rst
+++ b/dev-docs/source/DataFilesForTesting.rst
@@ -4,8 +4,6 @@
 Data Files for Testing
 ======================
 
-.. contents::
-  :local:
 
 Summary
 #######

--- a/dev-docs/source/DebuggingUnitTests.rst
+++ b/dev-docs/source/DebuggingUnitTests.rst
@@ -1,8 +1,6 @@
 Debugging Unit Tests
 ====================
 
-.. contents::
-  :local:
 
 Using gdb
 ---------

--- a/dev-docs/source/DesignDocumentGuides.rst
+++ b/dev-docs/source/DesignDocumentGuides.rst
@@ -4,8 +4,6 @@
 Design Document Guidelines
 ==========================
 
-.. contents::
-  :local:
 
 A good design document minimises unexpected complications by addressing
 them before the code is written. A document will provide you, your

--- a/dev-docs/source/DeveloperAccounts.rst
+++ b/dev-docs/source/DeveloperAccounts.rst
@@ -4,8 +4,6 @@
 Developer Accounts
 ==================
 
-.. contents::
-  :local:
 
 Unique Profiles
 ---------------

--- a/dev-docs/source/DynamicProperties.rst
+++ b/dev-docs/source/DynamicProperties.rst
@@ -4,8 +4,6 @@
 Dynamic dialog properties
 =========================
 
-.. contents::
-  :local:
 
 Overview
 --------

--- a/dev-docs/source/Eclipse.rst
+++ b/dev-docs/source/Eclipse.rst
@@ -4,8 +4,6 @@
 Eclipse on Ubuntu
 =================
 
-.. contents::
-	:local:
 
 Prerequisites
 ################

--- a/dev-docs/source/EnumeratedString.rst
+++ b/dev-docs/source/EnumeratedString.rst
@@ -3,8 +3,6 @@
 EnumeratedString
 ==================
 
-.. contents::
-  :local:
 
 Why EnumeratedString?
 -----------------------

--- a/dev-docs/source/EventWorkspaceDev.rst
+++ b/dev-docs/source/EventWorkspaceDev.rst
@@ -4,8 +4,6 @@
 Event Workspace Development
 ===========================
 
-.. contents::
-  :local:
 
 The following information will be useful to you if you want to write an
 :py:obj:`algorithm <mantid.api.Algorithm>` that is :py:obj:`EventWorkspace <mantid.dataobjects.EventWorkspace>` aware.

--- a/dev-docs/source/FlowchartCreation.rst
+++ b/dev-docs/source/FlowchartCreation.rst
@@ -4,9 +4,6 @@
 Flowchart Creation
 ==================
 
-.. contents::
-  :local:
-
 
 The flowchart diagrams are created by writing ``graphviz`` .dot files that describe the diagram in plain text, and placing them into ``docs/source/diagrams``. These can then be rendered in documentation by using the diagram directive in an .rst file:
 

--- a/dev-docs/source/GitConfig.rst
+++ b/dev-docs/source/GitConfig.rst
@@ -4,8 +4,6 @@
 Mantid Git Config
 =================
 
-.. contents:: Contents
-   :local:
 
 Summary
 -------

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -4,8 +4,6 @@
 Mantid Git Workflow
 ===================
 
-.. contents:: Contents
-   :local:
 
 Summary
 -------

--- a/dev-docs/source/ISISSANSReductionBackend.rst
+++ b/dev-docs/source/ISISSANSReductionBackend.rst
@@ -4,10 +4,6 @@
 ISIS SANS Reduction Back-end
 ============================
 
-.. contents::
-  :local:
-
-
 
 What is calculated in a SANS reduction?
 #######################################

--- a/dev-docs/source/IndexProperty.rst
+++ b/dev-docs/source/IndexProperty.rst
@@ -3,8 +3,6 @@
 Index Property
 ==============
 
-.. contents::
-  :local:
 
 Why IndexProperty?
 ------------------

--- a/dev-docs/source/InstrumentViewer.rst
+++ b/dev-docs/source/InstrumentViewer.rst
@@ -4,8 +4,6 @@
 Instrument Viewer Widget
 ========================
 
-.. contents::
-  :local:
 
 Overview
 --------

--- a/dev-docs/source/IssueTracking.rst
+++ b/dev-docs/source/IssueTracking.rst
@@ -8,8 +8,6 @@ Mantid uses GitHub issues to track new feature and bugfix
 development. The issue tracker can be found at `GitHub
 <https://github.com/mantidproject/mantid/issues>`_
 
-.. contents:: Contents
-    :local:
 
 Workflow
 ^^^^^^^^

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -4,8 +4,6 @@
 Jenkins Configuration
 =====================
 
-.. contents::
-  :local:
 
 Summary
 #######

--- a/dev-docs/source/LoadAlgorithmHook.rst
+++ b/dev-docs/source/LoadAlgorithmHook.rst
@@ -2,8 +2,6 @@
 Load Algorithm Hook
 ===================
 
-.. contents::
-  :local:
 
 The Load Algorithm
 ##################

--- a/dev-docs/source/LocalMantidBuildWithPixi.rst
+++ b/dev-docs/source/LocalMantidBuildWithPixi.rst
@@ -4,8 +4,6 @@
 Using Local Mantid Build in Other Projects with Pixi
 ====================================================
 
-.. contents::
-  :local:
 
 Overview
 ########

--- a/dev-docs/source/Logging.rst
+++ b/dev-docs/source/Logging.rst
@@ -4,8 +4,6 @@
 Logging
 =======
 
-.. contents::
-  :local:
 
 Overview
 --------

--- a/dev-docs/source/MVPDesign.rst
+++ b/dev-docs/source/MVPDesign.rst
@@ -4,8 +4,6 @@
 MVP Design
 =====================
 
-.. contents::
-   :local:
 
 Summary
 #######

--- a/dev-docs/source/MatplotlibInCpp.rst
+++ b/dev-docs/source/MatplotlibInCpp.rst
@@ -4,9 +4,6 @@
 Matplotlib in C++
 =================
 
-.. contents::
-  :local:
-
 
 Overview
 --------

--- a/dev-docs/source/NewStarterC++.rst
+++ b/dev-docs/source/NewStarterC++.rst
@@ -4,8 +4,6 @@
 New Starter C++
 =====================
 
-.. contents::
-   :local:
 
 -------------
 Prerequisites

--- a/dev-docs/source/NewStarterPython.rst
+++ b/dev-docs/source/NewStarterPython.rst
@@ -4,8 +4,6 @@
 New Starter Python
 ==================
 
-.. contents::
-   :local:
 
 -------------
 Prerequisites

--- a/dev-docs/source/ObtainingABenchmarkForMantidFitting.rst
+++ b/dev-docs/source/ObtainingABenchmarkForMantidFitting.rst
@@ -3,8 +3,6 @@
 Obtaining a Benchmark for Mantid Fitting
 ========================================
 
-.. contents::
-  :local:
 
 There are several scenarios in which obtaining a benchmark for the accuracy and runtime of Mantid minimizers might be useful:
 

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -4,8 +4,6 @@
 Packaging
 =========
 
-.. contents::
-  :local:
 
 This page gives an overview of the different packaging mechanisms used to deliver
 Mantid to users.

--- a/dev-docs/source/PatchReleaseChecklist.rst
+++ b/dev-docs/source/PatchReleaseChecklist.rst
@@ -4,8 +4,6 @@
 Patch Release Checklist
 =======================
 
-.. contents::
-  :local:
 
 These are the steps involved in performing a Mantid patch release. To
 perform a full release see :ref:`ReleaseChecklist`.

--- a/dev-docs/source/ProfilingOverview.rst
+++ b/dev-docs/source/ProfilingOverview.rst
@@ -4,8 +4,6 @@
 Profiling Overview
 ==================
 
-.. contents::
-   :local:
 
 Profiling can mean a few different things, so here are the current ways!
 Many of these work only on certain platforms and this document will note the limitations.

--- a/dev-docs/source/PythonVSCppAlgorithms.rst
+++ b/dev-docs/source/PythonVSCppAlgorithms.rst
@@ -4,8 +4,6 @@
 Python vs C++ Algorithms
 ========================
 
-.. contents::
-  :local:
 
 Overview
 --------

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -4,8 +4,6 @@
 Release Checklist
 =================
 
-.. contents::
-  :local:
 
 These are the steps involved in performing a full Mantid release. To
 request or perform a patch release look at the

--- a/dev-docs/source/RunningSanitizers.rst
+++ b/dev-docs/source/RunningSanitizers.rst
@@ -4,8 +4,6 @@
 Running Sanitizers
 ##################
 
-.. contents::
-   :local:
 
 Overview
 =========

--- a/dev-docs/source/RunningTheUnitTests.rst
+++ b/dev-docs/source/RunningTheUnitTests.rst
@@ -4,8 +4,6 @@
 Running the Unit Tests
 ======================
 
-.. contents::
-  :local:
 
 Overview
 ########

--- a/dev-docs/source/SampleLogsDev.rst
+++ b/dev-docs/source/SampleLogsDev.rst
@@ -4,8 +4,6 @@
 Sample Logs
 ============
 
-.. contents::
-  :local:
 
 The following information will be useful to you if you want to write an
 :py:obj:`algorithm <mantid.api.Algorithm>` that manipulates sample log data.

--- a/dev-docs/source/Standards/AdditionalPythonCode.rst
+++ b/dev-docs/source/Standards/AdditionalPythonCode.rst
@@ -4,8 +4,6 @@
 Additional Python code
 ======================
 
-.. contents::
-  :local:
 
 Overview
 ########

--- a/dev-docs/source/Standards/AlgorithmDocumentation.rst
+++ b/dev-docs/source/Standards/AlgorithmDocumentation.rst
@@ -4,8 +4,6 @@
 Algorithm Documentation
 =======================
 
-.. contents::
-  :local:
 
 Summary
 =======

--- a/dev-docs/source/Standards/AlgorithmUsageExamples.rst
+++ b/dev-docs/source/Standards/AlgorithmUsageExamples.rst
@@ -4,8 +4,6 @@
 Algorithm Usage Examples
 ========================
 
-.. contents::
-  :local:
 
 Introduction
 ============

--- a/dev-docs/source/Standards/CPPStandards.rst
+++ b/dev-docs/source/Standards/CPPStandards.rst
@@ -4,8 +4,6 @@
 C++ Coding Standards
 ====================
 
-.. contents:: Contents
-   :local:
 
 References
 ^^^^^^^^^^

--- a/dev-docs/source/Standards/DeprecateAlgorithm.rst
+++ b/dev-docs/source/Standards/DeprecateAlgorithm.rst
@@ -4,8 +4,6 @@
 Deprecating an Algorithm
 ========================
 
-.. contents::
-  :local:
 
 When the lifetime of an algorithm reaches its limit, it is good practice to signal developers and users of this
 fact. This signal gives them time to make arrangements for their scripts, either to stop using the algorithm or

--- a/dev-docs/source/Standards/DocumentationGuideForDevs.rst
+++ b/dev-docs/source/Standards/DocumentationGuideForDevs.rst
@@ -4,8 +4,6 @@
 Documentation Guide for Devs
 ============================
 
-.. contents::
-  :local:
 
 This page gives an overview of the documentation process for mantid.
 

--- a/dev-docs/source/Standards/GUIStandards.rst
+++ b/dev-docs/source/Standards/GUIStandards.rst
@@ -4,8 +4,6 @@
 GUI Standards
 #############
 
-.. contents:: Contents
-    :local:
 
 **********************
 Prerequisite Knowledge

--- a/dev-docs/source/Standards/InterfaceDocumentation.rst
+++ b/dev-docs/source/Standards/InterfaceDocumentation.rst
@@ -4,8 +4,6 @@
 Interface Documentation
 =======================
 
-.. contents::
-  :local:
 
 Summary
 =======

--- a/dev-docs/source/Standards/Libraries.rst
+++ b/dev-docs/source/Standards/Libraries.rst
@@ -4,8 +4,6 @@
 Libraries
 =========
 
-.. contents:: Contents
-   :local:
 
 Summary
 ^^^^^^^

--- a/dev-docs/source/Standards/MantidStandards.rst
+++ b/dev-docs/source/Standards/MantidStandards.rst
@@ -7,8 +7,6 @@ Mantid Standards
 These standards relate specifically to the implementation of the
 Mantid framework and the workbench application.
 
-.. contents:: Contents
-   :local:
 
 General Notes on Naming
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/dev-docs/source/Standards/PythonStandards.rst
+++ b/dev-docs/source/Standards/PythonStandards.rst
@@ -2,8 +2,6 @@
 Python Coding Standards
 =======================
 
-.. contents:: Contents
-   :local:
 
 Style
 ^^^^^

--- a/dev-docs/source/Standards/ReleaseNotesGuide.rst
+++ b/dev-docs/source/Standards/ReleaseNotesGuide.rst
@@ -4,8 +4,6 @@
 Release Notes Guide
 ===================
 
-.. contents::
-  :local:
 
 This page gives an overview of the release note process for Mantid.
 

--- a/dev-docs/source/Standards/RenameAlgorithm.rst
+++ b/dev-docs/source/Standards/RenameAlgorithm.rst
@@ -4,8 +4,6 @@
 Renaming an Algorithm
 =====================
 
-.. contents::
-  :local:
 
 Sometime developers will run into situations where the capability of the algorithm grows
 beyond its original designated name, therefore a renaming of the algorithm is necessary

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -4,8 +4,6 @@
 System Tests
 ============
 
-.. contents::
-  :local:
 
 Overview
 ########

--- a/dev-docs/source/Testing/Direct/ALFViewTests.rst
+++ b/dev-docs/source/Testing/Direct/ALFViewTests.rst
@@ -3,8 +3,6 @@
 ALFView GUI Testing
 ===================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/Direct/MSliceTestGuide.rst
+++ b/dev-docs/source/Testing/Direct/MSliceTestGuide.rst
@@ -6,8 +6,6 @@
 MSlice Testing
 ===================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/Documentation/DocumentationTest.rst
+++ b/dev-docs/source/Testing/Documentation/DocumentationTest.rst
@@ -3,8 +3,6 @@
 Documentation Testing
 ===============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/ElementalAnalysis/ElementalAnalysisTests.rst
+++ b/dev-docs/source/Testing/ElementalAnalysis/ElementalAnalysisTests.rst
@@ -3,8 +3,6 @@
 Elemental Analysis GUI Testing
 ==============================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
+++ b/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
@@ -3,8 +3,6 @@
 Engineering Diffraction Testing
 =================================
 
-.. contents:: Table of Contents
-    :local:
 
 Preamble
 ^^^^^^^^^

--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
@@ -3,8 +3,6 @@
 Error Reporter Testing
 ======================
 
-.. contents::
-  :local:
 
 Error Reporter test
 -------------------

--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.rst
@@ -3,8 +3,6 @@
 Project Recovery Testing
 =========================
 
-.. contents::
-  :local:
 
 Project Recovery test
 ---------------------

--- a/dev-docs/source/Testing/General/SampleTransmissionCalculatorTestGuide.rst
+++ b/dev-docs/source/Testing/General/SampleTransmissionCalculatorTestGuide.rst
@@ -3,8 +3,6 @@
 Sample Transmission Calculator Testing
 ======================================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/Indirect/DataReductionTests.rst
+++ b/dev-docs/source/Testing/Indirect/DataReductionTests.rst
@@ -3,8 +3,6 @@
 Indirect Data Reduction Testing
 ===============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/Indirect/DiffractionTests.rst
+++ b/dev-docs/source/Testing/Indirect/DiffractionTests.rst
@@ -1,8 +1,6 @@
 Indirect Diffraction Testing
 ============================
 
-.. contents::
-   :local:
 
 Diffraction
 -----------

--- a/dev-docs/source/Testing/Inelastic/BayesFittingTests.rst
+++ b/dev-docs/source/Testing/Inelastic/BayesFittingTests.rst
@@ -3,8 +3,6 @@
 Inelastic Bayes Fitting Testing
 ===============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/Inelastic/CorrectionsTests.rst
+++ b/dev-docs/source/Testing/Inelastic/CorrectionsTests.rst
@@ -1,8 +1,6 @@
 Inelastic Corrections Testing
 =============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
+++ b/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
@@ -1,8 +1,6 @@
 Inelastic Data Processor Testing
 ================================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/Inelastic/QENSFittingTests.rst
+++ b/dev-docs/source/Testing/Inelastic/QENSFittingTests.rst
@@ -3,8 +3,6 @@
 Inelastic QENS Fitting Testing
 ==============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/Testing/LiveData/LiveDataPacketPlayback.rst
+++ b/dev-docs/source/Testing/LiveData/LiveDataPacketPlayback.rst
@@ -3,8 +3,6 @@
 Working With Real Instruments
 =============================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/LiveData/LiveDataTests.rst
+++ b/dev-docs/source/Testing/LiveData/LiveDataTests.rst
@@ -3,8 +3,6 @@
 Live Data Testing
 =================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
@@ -3,8 +3,6 @@
 Muon Interfaces Unscripted Testing
 ==================================
 
-.. contents:: Table of Contents
-    :local:
 
 Preamble
 ^^^^^^^^^

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_ALC.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_ALC.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: ALC
 ============================
 
-.. contents:: Table of Contents
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_ARGUS.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_ARGUS.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: ARGUS
 ==============================
 
-.. contents:: Table of Contents
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_MUSR.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_MUSR.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: MUSR
 =============================
 
-.. contents:: Table of Contents
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_PSI.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_PSI.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: PSI
 ============================
 
-.. contents:: Table of Contents
-    :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_EMU.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_EMU.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: EMU
 ============================
 
-.. contents:: Table of Contents
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: FDA (Frequency Domain Analysis)
 ========================================================
 
-.. contents:: Table of Contents
-    :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
@@ -3,8 +3,6 @@
 Muon Unscripted Testing: HIFI
 =============================
 
-.. contents:: Table of Contents
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -3,8 +3,6 @@
 Reflectometry GUI Testing
 =========================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -3,8 +3,6 @@
 SANS GUI Testing
 ================
 
-.. contents::
-   :local:
 
 Data reduction
 --------------

--- a/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
+++ b/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
@@ -6,8 +6,6 @@
 SliceViewer Testing
 ===================
 
-.. contents::
-   :local:
 
 Introduction
 ------------

--- a/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
+++ b/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
@@ -3,8 +3,6 @@
 Filter Events Interface Testing
 ===============================
 
-.. contents::
-   :local:
 
 *Prerequisites*
 

--- a/dev-docs/source/TestingUtilities.rst
+++ b/dev-docs/source/TestingUtilities.rst
@@ -4,8 +4,6 @@
 Testing Utilities
 =================
 
-.. contents::
-  :local:
 
 Summary
 #######

--- a/dev-docs/source/Timers.rst
+++ b/dev-docs/source/Timers.rst
@@ -3,8 +3,6 @@ Mantid Timers
 
 This page provides an introduction to measuring execution time of the Mantid C++ code.
 
-.. contents:: Context
-   :local:
 
 Wall-clock timers
 ------------------------

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -9,8 +9,6 @@ Tools Overview
 
    AlgorithmProfiler
 
-.. contents:: Contents
-   :local:
 
 .. _class_maker_py:
 

--- a/dev-docs/source/UnitTestGoodPractice.rst
+++ b/dev-docs/source/UnitTestGoodPractice.rst
@@ -4,8 +4,6 @@
 Unit Test Good Practice
 =======================
 
-.. contents::
-  :local:
 
 General Guidance
 ################

--- a/dev-docs/source/UserSupport.rst
+++ b/dev-docs/source/UserSupport.rst
@@ -4,8 +4,6 @@
 User Support
 ============
 
-.. contents::
-  :local:
 
 Introduction
 ------------

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -4,8 +4,6 @@
 Windows Subsystem for Linux (WSL2)
 ==================================
 
-.. contents::
-  :local:
 
 The Windows Subsystem for Linux lets developers run a Linux environment directly on Windows, unmodified, without the overhead of a traditional virtual machine or dualboot setup.
 

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -3,9 +3,6 @@
 Writing An Algorithm
 ====================
 
-.. contents::
-   :local:
-
 
 Introduction
 ############

--- a/dev-docs/source/WritingCustomConvertToMDTransformation.rst
+++ b/dev-docs/source/WritingCustomConvertToMDTransformation.rst
@@ -3,8 +3,6 @@
 Writing a Custom ConvertToMD Transformation
 ===========================================
 
-.. contents::
-  :local:
 
 Introduction
 ############

--- a/dev-docs/source/WritingPerformanceTests.rst
+++ b/dev-docs/source/WritingPerformanceTests.rst
@@ -4,8 +4,6 @@
 Writing Performance Tests
 =========================
 
-.. contents::
-  :local:
 
 Overview
 ########

--- a/docs/source/concepts/CaChannel.rst
+++ b/docs/source/concepts/CaChannel.rst
@@ -3,8 +3,6 @@
 CaChannel
 =========
 
-.. contents:: Table of Contents
-  :local:
 
 Summary
 -------

--- a/docs/source/concepts/CrystalField.rst
+++ b/docs/source/concepts/CrystalField.rst
@@ -3,9 +3,6 @@
 Crystal Field Theory
 ====================
 
-.. contents:: Table of Contents
-  :local:
-
 
 Introduction
 ------------

--- a/docs/source/interfaces/diffraction/Engineering Diffraction.rst
+++ b/docs/source/interfaces/diffraction/Engineering Diffraction.rst
@@ -3,8 +3,6 @@
 Engineering Diffraction
 =========================
 
-.. contents:: Table of Contents
-    :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/diffraction/HFIR Single Crystal Reduction.rst
+++ b/docs/source/interfaces/diffraction/HFIR Single Crystal Reduction.rst
@@ -3,8 +3,6 @@
 HFIR Single Crystal Reduction Interface
 =======================================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/direct/ALFView.rst
+++ b/docs/source/interfaces/direct/ALFView.rst
@@ -7,8 +7,6 @@ ALFView
    :align: right
    :height: 400px
 
-.. contents:: Table of Contents
-  :local:
 
 .. |export| image:: /images/icons/download.png
 .. |externalplot| image:: /images/icons/open-in-new.png

--- a/docs/source/interfaces/direct/DGS Planner.rst
+++ b/docs/source/interfaces/direct/DGS Planner.rst
@@ -3,8 +3,6 @@
 DGS Planner
 ===========
 
-.. contents:: Table of Contents
-  :local:
 
 .. figure:: /images/DGSPlanner.png
    :alt: DGSPlanner.png

--- a/docs/source/interfaces/direct/MSlice.rst
+++ b/docs/source/interfaces/direct/MSlice.rst
@@ -3,8 +3,6 @@
 MSlice
 ========
 
-.. contents:: Table of Contents
-  :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/direct/PyChop.rst
+++ b/docs/source/interfaces/direct/PyChop.rst
@@ -3,8 +3,6 @@
 PyChop
 ======
 
-.. contents:: Table of Contents
-  :local:
 
 .. figure:: /images/PyChopGui.png
    :alt: PyChopGui.png

--- a/docs/source/interfaces/general/Fit Script Generator.rst
+++ b/docs/source/interfaces/general/Fit Script Generator.rst
@@ -7,8 +7,6 @@ Fit Script Generator
    :align: right
    :height: 400px
 
-.. contents:: Table of Contents
-  :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/general/Sample Transmission Calculator.rst
+++ b/docs/source/interfaces/general/Sample Transmission Calculator.rst
@@ -3,8 +3,6 @@
 Sample Transmission Calculator
 ==============================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/general/Step Scan Analysis.rst
+++ b/docs/source/interfaces/general/Step Scan Analysis.rst
@@ -1,8 +1,6 @@
 Step Scan Analysis
 ==================
 
-.. contents:: Table of Contents
-  :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/indirect/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Reduction.rst
@@ -3,8 +3,6 @@
 Indirect Data Reduction
 =======================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/indirect/Indirect Diffraction.rst
+++ b/docs/source/interfaces/indirect/Indirect Diffraction.rst
@@ -3,8 +3,6 @@
 Indirect Diffraction
 ====================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/indirect/Indirect Settings.rst
+++ b/docs/source/interfaces/indirect/Indirect Settings.rst
@@ -3,8 +3,6 @@
 Indirect Settings
 =================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/indirect/Indirect Simulation.rst
+++ b/docs/source/interfaces/indirect/Indirect Simulation.rst
@@ -3,8 +3,6 @@
 Indirect Simulation
 ===================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/indirect/Indirect Tools.rst
+++ b/docs/source/interfaces/indirect/Indirect Tools.rst
@@ -1,8 +1,6 @@
 Indirect Tools
 ==============
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Bayes Fitting.rst
@@ -3,8 +3,6 @@
 Inelastic Bayes Fitting
 =======================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/inelastic/Inelastic Corrections.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Corrections.rst
@@ -3,8 +3,6 @@
 Inelastic Corrections
 =====================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/inelastic/Inelastic Data Processor.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Data Processor.rst
@@ -3,8 +3,6 @@
 Inelastic Data Processor
 ========================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/isis_sans/Beam Centre Tab.rst
+++ b/docs/source/interfaces/isis_sans/Beam Centre Tab.rst
@@ -3,8 +3,6 @@
 Beam centre tab
 ---------------
 
-.. contents:: Table of Contents
-  :local:
 
 .. image::  /images/ISISSansInterface/beam_centre_page.png
    :align: right

--- a/docs/source/interfaces/isis_sans/Diagnostic Tab.rst
+++ b/docs/source/interfaces/isis_sans/Diagnostic Tab.rst
@@ -7,8 +7,6 @@ Diagnostic tab
    :align: right
    :width: 800px
 
-.. contents:: Table of Contents
-  :local:
 
 .. _Diagnostic:
 

--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -3,8 +3,6 @@
 Runs Tab
 ========
 
-.. contents:: Table of Contents
-  :local:
 
 The *Runs* tab is where the majority of processing takes place. You can select
 your user file, batch file or manually enter data sets for reduction in the

--- a/docs/source/interfaces/isis_sans/Settings Tab.rst
+++ b/docs/source/interfaces/isis_sans/Settings Tab.rst
@@ -2,8 +2,6 @@
 
 Settings
 ========
-.. contents:: Table of Contents
-  :local:
 
 .. _Settings:
 

--- a/docs/source/interfaces/isis_sans/User File Format.rst
+++ b/docs/source/interfaces/isis_sans/User File Format.rst
@@ -4,8 +4,6 @@
 User File Format
 ================
 
-.. contents:: Table of Contents
-  :local:
 
 Instrument Selection
 --------------------

--- a/docs/source/interfaces/muon/Feature Flags.rst
+++ b/docs/source/interfaces/muon/Feature Flags.rst
@@ -3,8 +3,6 @@
 Muon Feature Flags
 ==================
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/muon/Frequency Domain Analysis.rst
+++ b/docs/source/interfaces/muon/Frequency Domain Analysis.rst
@@ -7,8 +7,6 @@ Frequency Domain Analysis
    :align: right
    :height: 400px
 
-.. contents:: Table of Contents
-  :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/muon/Muon ALC.rst
+++ b/docs/source/interfaces/muon/Muon ALC.rst
@@ -3,8 +3,6 @@
 Muon ALC
 ========
 
-.. contents:: Table of Contents
-  :local:
 
 Overview
 --------

--- a/docs/source/interfaces/muon/Muon Analysis.rst
+++ b/docs/source/interfaces/muon/Muon Analysis.rst
@@ -7,8 +7,6 @@ Muon Analysis
    :align: right
    :height: 400px
 
-.. contents:: Table of Contents
-  :local:
 
 Interface Overview
 ------------------

--- a/docs/source/interfaces/muon/Muon Elemental Analysis.rst
+++ b/docs/source/interfaces/muon/Muon Elemental Analysis.rst
@@ -3,8 +3,6 @@
 Muon Elemental Analysis
 =======================
 
-.. contents:: Table of Contents
-  :local:
 
 Interface overview
 ------------------

--- a/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
@@ -5,8 +5,6 @@
 ISIS Reflectometry Interface
 ============================
 
-.. contents:: Table of Contents
-  :local:
 
 .. |process| image:: /images/icons/sigma.png
 .. |pause| image:: /images/icons/pause.png

--- a/docs/source/interfaces/utility/Filter Events.rst
+++ b/docs/source/interfaces/utility/Filter Events.rst
@@ -4,8 +4,6 @@
 Filter Events Interface
 =======================
 
-.. contents:: Table of Contents
-  :local:
 
 Description
 -----------

--- a/docs/source/interfaces/utility/QE Coverage.rst
+++ b/docs/source/interfaces/utility/QE Coverage.rst
@@ -3,8 +3,6 @@
 QE Coverage
 ===========
 
-.. contents:: Table of Contents
-  :local:
 
 .. figure:: /images/QECoverage.png
    :alt: QECoverage.png

--- a/docs/source/plotting/1DPlotsHelp.rst
+++ b/docs/source/plotting/1DPlotsHelp.rst
@@ -24,8 +24,6 @@ Basic 1D and Tiled Plots
 |
 |
 
-.. contents:: Basic 1D and Tiled Plots - Table of contents
-    :local:
 
 Single 1D Plots
 ===============

--- a/docs/source/plotting/3DPlotsHelp.rst
+++ b/docs/source/plotting/3DPlotsHelp.rst
@@ -24,8 +24,6 @@
 |
 |
 
-.. contents:: 3D Plots Surface and Wireframe - Table of contents
-    :local:
 
 Surface Plots
 =============

--- a/docs/source/plotting/ColorfillPlotsHelp.rst
+++ b/docs/source/plotting/ColorfillPlotsHelp.rst
@@ -21,8 +21,6 @@ Colorfill and Contour Plots
 |
 |
 
-.. contents:: Colorfill and Contour Plots - Table of contents
-    :local:
 
 Colorfill Plots
 ===============

--- a/docs/source/plotting/MeshPlotHelp.rst
+++ b/docs/source/plotting/MeshPlotHelp.rst
@@ -15,9 +15,6 @@
 |
 |
 
-.. contents:: 3D Mesh Plots - Table of contents
-    :local:
-
 
 Here the mesh is plotted as a Poly3DCollection `Polygon <https://matplotlib.org/stable/users/explain/toolkits/mplot3d.html#polygon-plots>`_.
 

--- a/docs/source/plotting/WaterfallPlotsHelp.rst
+++ b/docs/source/plotting/WaterfallPlotsHelp.rst
@@ -24,8 +24,6 @@ Waterfall Plots
 |
 |
 
-.. contents:: Waterfall Plots - Table of contents
-    :local:
 
 |
 |

--- a/docs/source/plotting/index.rst
+++ b/docs/source/plotting/index.rst
@@ -29,9 +29,6 @@ Matplotlib in Mantid
 * :ref:`3D_Plots`
 * :ref:`Mesh_Plots`
 
-.. contents:: Table of contents
-    :local:
-
 
 Introduction
 ------------

--- a/docs/source/techniques/ApplyingCorrections.rst
+++ b/docs/source/techniques/ApplyingCorrections.rst
@@ -4,8 +4,6 @@
 Applying Corrections
 ====================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/BinMDCoordinateTransformations.rst
+++ b/docs/source/techniques/BinMDCoordinateTransformations.rst
@@ -3,8 +3,6 @@
 BinMD Coordinate Transformations
 ================================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/CreateBackToBackParameters.rst
+++ b/docs/source/techniques/CreateBackToBackParameters.rst
@@ -3,8 +3,6 @@
 Create Back To Back Parameters
 ==============================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/CreateIkedaCarpenterParameters.rst
+++ b/docs/source/techniques/CreateIkedaCarpenterParameters.rst
@@ -3,8 +3,6 @@
 Create Ikeda Carpenter Parameters
 =================================
 
-.. contents:: Table of Contents
-  :local:
 
 Example of how a parameter can be determined on a beamline
 ----------------------------------------------------------

--- a/docs/source/techniques/CreateIkedaCarpenterParametersFullprof.rst
+++ b/docs/source/techniques/CreateIkedaCarpenterParametersFullprof.rst
@@ -3,8 +3,6 @@
 Create Ikeda Carpenter Parameters Fullprof
 ==========================================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/CreateIkedaCarpenterParametersGSAS.rst
+++ b/docs/source/techniques/CreateIkedaCarpenterParametersGSAS.rst
@@ -3,8 +3,6 @@
 Create Ikeda Carpenter Parameters GSAS
 ======================================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/CrystalField.rst
+++ b/docs/source/techniques/CrystalField.rst
@@ -8,8 +8,6 @@ Mantid supports the calculation and fitting of inelastic neutron scattering (INS
 
 This page contains specific worked examples. The data files can be found `here <https://github.com/mducle/cf_examples/raw/master/cf_examples_data.zip>`_. Please download and unzip this into a folder which is on your Mantid path (set using the "Manage User Directories" menu item).
 
-.. contents:: Table of contents
-    :local:
 
 Fitting INS spectrum
 ====================

--- a/docs/source/techniques/DirectILL.rst
+++ b/docs/source/techniques/DirectILL.rst
@@ -4,8 +4,6 @@
 Data reduction for ILL's direct geometry instruments
 ====================================================
 
-.. contents:: Table of contents
-    :local:
 
 There are seven workflow algorithms supporting data reduction at ILL's time-of-flight instruments. These algorithms are:
 

--- a/docs/source/techniques/ISISPowder-GEM-v1.rst
+++ b/docs/source/techniques/ISISPowder-GEM-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts - GEM Reference
 ================================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _creating_gem_object-isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-HRPD-v1.rst
+++ b/docs/source/techniques/ISISPowder-HRPD-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts - HRPD Reference
 ==================================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _creating_hrpd_object-isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-Index-v1.rst
+++ b/docs/source/techniques/ISISPowder-Index-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts
 ================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _script_param_overview_isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-OSIRIS-v1.rst
+++ b/docs/source/techniques/ISISPowder-OSIRIS-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts - OSIRIS Reference
 =====================================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _creating_osiris_object_isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-Pearl-v1.rst
+++ b/docs/source/techniques/ISISPowder-Pearl-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts - PEARL Reference
 =====================================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _creating_pearl_object-isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts - POLARIS Reference
 =====================================================
 
-.. contents:: Table of Contents
-    :local:
 
 .. _creating_polaris_object_isis-powder-diffraction-ref:
 

--- a/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
+++ b/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
@@ -4,9 +4,6 @@
 ISIS Powder Diffraction Scripts - SampleDetails Reference
 =========================================================
 
-.. contents:: Table of Contents
-    :local:
-
 
 Introduction
 ------------

--- a/docs/source/techniques/ISISPowder-Tutorials.rst
+++ b/docs/source/techniques/ISISPowder-Tutorials.rst
@@ -4,8 +4,6 @@
 ISIS Powder - Tutorials
 ==============================
 
-.. contents:: Table of Contents
-    :local:
 
 Introduction
 -------------

--- a/docs/source/techniques/ISISPowder-Workflows-v1.rst
+++ b/docs/source/techniques/ISISPowder-Workflows-v1.rst
@@ -4,8 +4,6 @@
 ISIS Powder Diffraction Scripts Workflow Diagrams
 ==================================================
 
-.. contents:: Table of Contents
-    :local:
 
 Methods
 -------

--- a/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
+++ b/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
@@ -4,8 +4,6 @@
 ISIS Single Crystal Diffraction Reduction Scripts
 =================================================
 
-.. contents:: Table of Contents
-    :local:
 
 Introduction
 ------------

--- a/docs/source/techniques/PolarisedDiffractionILL.rst
+++ b/docs/source/techniques/PolarisedDiffractionILL.rst
@@ -4,8 +4,6 @@
 Data reduction for D7 instrument at the ILL
 ===========================================
 
-.. contents:: Table of contents
-    :local:
 
 There are three workflow algorithms supporting data reduction at ILL's D7 polarised diffraction and spectroscopy instrument. These algorithms are:
 

--- a/docs/source/techniques/ReflectometryILL.rst
+++ b/docs/source/techniques/ReflectometryILL.rst
@@ -4,8 +4,6 @@
 Data reduction for reflectometry instruments at the ILL
 =======================================================
 
-.. contents:: Table of contents
-    :local:
 
 There is one algorithm providing the entry point and steering the reduction workflow for both FIGARO and D17:
 

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -4,8 +4,6 @@
 SANS TOML Files
 ===============
 
-.. contents:: Table of Contents
-    :local:
 
 General Notes
 =============

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -3,8 +3,6 @@
 Scripting SANS Reductions
 =========================
 
-.. contents:: Table of Contents
-  :local:
 
 Introduction
 ------------

--- a/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
+++ b/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
@@ -13,8 +13,6 @@ Formatting Plots with the User Interface
 * :ref:`Colorfill_Plots`
 * :ref:`3D_Plots`
 
-.. contents:: Table of contents
-    :local:
 
 |
 |

--- a/docs/source/tutorials/muon_GUI_course/basics_of_data_reductions.rst
+++ b/docs/source/tutorials/muon_GUI_course/basics_of_data_reductions.rst
@@ -16,8 +16,6 @@ This section explains:
 * how to set the detector calibration factor, :math:`{\alpha}`
 * how to group data
 
-.. contents:: Table of Contents
-  :local:
 
 The concept of |tzero| and |tgood|
 ==================================

--- a/docs/source/tutorials/muon_GUI_course/data_fitting.rst
+++ b/docs/source/tutorials/muon_GUI_course/data_fitting.rst
@@ -4,8 +4,6 @@
 Data Fitting
 ============
 
-.. contents:: Table of Contents
-  :local:
 
 Fit Function
 ============

--- a/docs/source/tutorials/muon_GUI_course/other_mantid_functions.rst
+++ b/docs/source/tutorials/muon_GUI_course/other_mantid_functions.rst
@@ -12,8 +12,6 @@ This section allows the user to:
 * Learn how to read/export data.
 * Learn how to overlay data/change plot style.
 
-.. contents:: Table of Contents
-  :local:
 
 Workspaces
 ==========

--- a/docs/source/tutorials/muon_GUI_course/the_tabs_fitting.rst
+++ b/docs/source/tutorials/muon_GUI_course/the_tabs_fitting.rst
@@ -6,8 +6,6 @@ The Tabs - Fitting
 
 .. index:: The Tabs - Fitting
 
-.. contents:: Table of Contents
-  :local:
 
 Fitting
 =======

--- a/docs/source/tutorials/muon_GUI_course/the_tabs_grouping.rst
+++ b/docs/source/tutorials/muon_GUI_course/the_tabs_grouping.rst
@@ -6,8 +6,6 @@ The Tabs - Grouping
 
 .. index:: The Tabs - Grouping
 
-.. contents:: Table of Contents
-  :local:
 
 Grouping
 ========

--- a/docs/source/tutorials/muon_GUI_course/the_tabs_home.rst
+++ b/docs/source/tutorials/muon_GUI_course/the_tabs_home.rst
@@ -6,8 +6,6 @@ The Tabs - Home
 
 .. index:: The Tabs - Home
 
-.. contents:: Table of Contents
-  :local:
 
 Home
 ====

--- a/docs/source/tutorials/muon_GUI_course/the_tabs_results.rst
+++ b/docs/source/tutorials/muon_GUI_course/the_tabs_results.rst
@@ -6,8 +6,6 @@ The Tabs - Results
 
 .. index:: The Tabs - Results
 
-.. contents:: Table of Contents
-  :local:
 
 Results
 =======

--- a/docs/source/tutorials/python_in_mantid/algorithms_and_workspaces/07_pim_ex_1.rst
+++ b/docs/source/tutorials/python_in_mantid/algorithms_and_workspaces/07_pim_ex_1.rst
@@ -6,8 +6,6 @@ Python in Mantid: Exercise 1
 
 The aim of this exercise is to show some simple examples of data exploration
 
-.. contents:: Table of contents
-    :local:
 
 A - ISIS Data
 =============

--- a/docs/source/tutorials/python_in_mantid/further_alg_ws/02_scripting_workspaces.rst
+++ b/docs/source/tutorials/python_in_mantid/further_alg_ws/02_scripting_workspaces.rst
@@ -9,10 +9,6 @@ The :ref:`Workspaces Toolbox<WorkbenchWorkspaceToolbox>` is used to store and ma
 
 Below are some examples of how to control workspaces with a script.
 
-.. contents:: Table of contents
-    :local:
-
-
 
 Relevant Algorithms
 ===================

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -6,9 +6,6 @@ Formatting Plots with a script
 
 **Sometimes the easiest way to find out how to control part of a plot with Matplotlib is to search online for their** `documentation <https://matplotlib.org/3.2.1/index.html>`_ **! Below are some useful commands and a handful of links**
 
-.. contents:: Table of contents
-    :local:
-
 
 General
 =======

--- a/docs/source/tutorials/python_in_mantid/plotting/03_pim_ex_3.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/03_pim_ex_3.rst
@@ -4,8 +4,6 @@
 Python in Mantid: Exercise 3
 ============================
 
-.. contents:: Table of contents
-    :local:
 
 A - Direct Matplotlib with SNS Data
 ===================================

--- a/docs/source/tutorials/python_in_mantid/script_generation/04_pim_ex_2.rst
+++ b/docs/source/tutorials/python_in_mantid/script_generation/04_pim_ex_2.rst
@@ -10,10 +10,6 @@ Perform a set of algorithms by pointing and clicking within Mantid
 Use the history window to generate a script based upon the executed algorithms
 Use the dialog functions to make the script more general for future runs.
 
-.. contents:: Table of contents
-    :local:
-
-
 
 A - Processing ISIS Data
 ========================


### PR DESCRIPTION
Near the top of various documentation pages there is some extra whitespace associated with
```rst
.. contents::
   :local:
```
This is because the table of contents is hidden. By removing these two lines from files, the whitespace goes away. Some example pages are
* [Engineering Diffraction Testing](https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html),
* [MSlice Testing](https://developer.mantidproject.org/Testing/Direct/MSliceTestGuide.html)
* [Design Document Guidelines](https://developer.mantidproject.org/DesignDocumentGuides.html)

There is no associated issue.

### To test:

Build the docs and dev-docs and look for the whitespace being gone.

*This does not require release notes* because it removes bonus whitespace from near the top of some doc pages.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
