### PR TITLE
Prevent some crashes when importing custom python plugins

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -18,7 +18,6 @@ import importlib.util
 from importlib.machinery import SourceFileLoader
 from . import logger, Logger, config
 
-
 # String that separates paths (should be in the ConfigService)
 PATH_SEPARATOR = ";"
 
@@ -48,6 +47,8 @@ class PluginLoader(object):
         self._logger.debug("Loading python plugin %s" % pathname)
         loader = SourceFileLoader(name, pathname)
         spec = importlib.util.spec_from_loader(name, loader)
+        if name == "__main__":
+            raise RuntimeError
         module = importlib.util.module_from_spec(spec)
         loader.exec_module(module)
         # It's better to let import handle editing sys.modules, but this code used to call
@@ -103,6 +104,9 @@ def find_plugins(top_dir):
     all_plugins = []
     algs = []
     for root, dirs, files in _os.walk(top_dir):
+        if _os.path.basename(_os.path.normpath(root)).startswith("."):
+            dirs.clear()
+            files.clear()
         for f in files:
             if f.endswith(PluginLoader.extension):
                 filename = _os.path.join(root, f)
@@ -128,7 +132,7 @@ def load(path):
     all files in each are loaded in turn
 
     @return A list of the loaded modules. Note this
-    will not included modules that will have attempted to be
+    will not include modules that will have attempted to be
     reloaded but had not been changed
     """
     if PATH_SEPARATOR in path:
@@ -160,7 +164,7 @@ def load_from_list(paths):
     for p in paths:
         try:
             loaded += load(p)
-        except RuntimeError:
+        except (RuntimeError, ImportError):
             continue
 
     return loaded
@@ -226,7 +230,7 @@ def sync_attrs(source, attrs, clients):
     """
     Syncs the attribute definitions between the
     given list from the source module & list of client modules such
-    that the function defintions point to the same
+    that the function definitions point to the same
     one
     @param source :: A dictionary containing the real attribute definitions
     @param attrs :: The list of attributes to change in the client modules
@@ -234,10 +238,13 @@ def sync_attrs(source, attrs, clients):
                       should be taken from source
     """
     for func_name in attrs:
-        attr = source[func_name]
-        for plugin in clients:
-            if plugin.__name__ != func_name and hasattr(plugin, func_name):
-                setattr(plugin, func_name, attr)
+        try:
+            attr = source[func_name]
+            for plugin in clients:
+                if plugin.__name__ != func_name and hasattr(plugin, func_name):
+                    setattr(plugin, func_name, attr)
+        except (RuntimeError, ImportError):
+            continue
 
 
 # ======================================================================================================================

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -85,7 +85,11 @@ def specialization_exists(name):
 
     :param name: The name of a possible new function
     """
-    return name in __SPECIALIZED_FUNCTIONS__
+    import builtins
+
+    protected = dir(builtins)
+    protected.append("logger")
+    return name in __SPECIALIZED_FUNCTIONS__ + protected
 
 
 def extract_progress_kwargs(kwargs):

--- a/docs/source/release/v6.16.0/Framework/Python/Bugfixes/35479.rst
+++ b/docs/source/release/v6.16.0/Framework/Python/Bugfixes/35479.rst
@@ -1,0 +1,1 @@
+- Loading :ref:`Python extensions<04_loading_extensions_on_startup>` does not allow to import hidden folders or Python files with protected names to avoid crashing Mantid on startup.


### PR DESCRIPTION
### Description of work

Tries to put a closed sticker on #35479

Mantid can import custom python plugins on startup if a directory is set from `Manage User Directories -> Python Script Directories -> Python Extensions`. If a folder is set, Mantid will scan on simpleapi startup all files on that folder (and its subfolders), and import modules for every python file it finds. To avoid circular dependencies, it first creates a fake function with the name of that module that throws if called . Later this is translated and resynchronize to those modules which are actually mantid functions or algorithms by comparing with the registered ones. 

The problem is that when importing modules from every python files, it executes all code in the files (except if name == "__main__" part), this creates quite a few vulnerabilities that can crash mantid when setting the wrong folder as startup. 

The repository with which I've been testing this is the one producing the crash in #35479 (vesuvio repo). 

- There is one file on this repo named `globals.py`, the mockup funciton in simpleapi will convert, thinking is an algorithm, this to a fake function call `globals()`, globals is a builtin python function, that is later used when translating the algorithms, this crashes Mantid. I've added the restriction that the imported modules cant be builtins (there is also another file named logger... )
- If there are hidden folders (like virtual environments .venv  or .pixi), these are all scanned and modules tried to be imported, including all python packages contained in those folders. I have added another constraint to avoid importing hidden folders. 
- When importing a module, it does not execute the code under (if name==__main__) clause, except if the file is named `__main__` ..., then it does. 

Furthermore, there is nothing much preventing mantid crashing when a python file that is imported has the `exit()` statement. it is clear users using this feature should know better, but I'm just wondering if we shouldn't be more strict about what can be imported, actually the plugin_finder function  has a helper (contains_algorithm) that scans the file looking for algorithm signatures (`algorithmFactory.subscribe`), but this is not currently used. 



<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Try to add vesuvio or mslice repos as mantid extensions, even though it will fail to import most of the modules, mantid shouldn't crash. Just errors registered on logger.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
