### PR TITLE
Fixed problem with Writing an Algorithm documentation

### DIFF
--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -139,7 +139,7 @@ They all have a couple of features in common:
   The whole string appears in the user docs and python help.
 
 An optional :ref:`validator <Properties Validators>` or :ref:`directional argument <Properties Directions>` (input, output or both) can also be appended.
-The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the `properties <https://docs.mantidproject.org/nightly/api/python/mantid/kernel/Property.html>` page.
+The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the `properties <mantid:mantid.kernel.Property>` page.
 
 Validation of inputs
 --------------------
@@ -187,7 +187,7 @@ All of them eventually call the `API::Algorithm::executeInternal() <https://gith
 * run the ``exec()`` method
 * add history to the Workspace annotating the parameters that the algorithm was called with
 
-Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with `AnalysisDataService <https://docs.mantidproject.org/nightly/api/python/mantid/api/AnalysisDataServiceImpl.html#mantid.api.AnalysisDataServiceImpl>`.
+Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with `AnalysisDataService <mantid:mantid.api.AnalysisDataServiceImpl>`.
 
 
 Fetching properties

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -139,7 +139,7 @@ They all have a couple of features in common:
   The whole string appears in the user docs and python help.
 
 An optional :ref:`validator <Properties Validators>` or :ref:`directional argument <Properties Directions>` (input, output or both) can also be appended.
-The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`properties <Properties>` page.
+The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`properties <mantid:Properties>` page.
 
 Validation of inputs
 --------------------
@@ -187,7 +187,7 @@ All of them eventually call the `API::Algorithm::executeInternal() <https://gith
 * run the ``exec()`` method
 * add history to the Workspace annotating the parameters that the algorithm was called with
 
-Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`AnalysisDataService <Analysis Data Service>`.
+Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`AnalysisDataService <mantid:Analysis Data Service>`.
 
 
 Fetching properties

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -139,7 +139,7 @@ They all have a couple of features in common:
   The whole string appears in the user docs and python help.
 
 An optional :ref:`validator <Properties Validators>` or :ref:`directional argument <Properties Directions>` (input, output or both) can also be appended.
-The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`properties <mantid:Properties>` page.
+The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`mantid:properties <Properties>` page.
 
 Validation of inputs
 --------------------
@@ -187,7 +187,7 @@ All of them eventually call the `API::Algorithm::executeInternal() <https://gith
 * run the ``exec()`` method
 * add history to the Workspace annotating the parameters that the algorithm was called with
 
-Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`AnalysisDataService <mantid:Analysis Data Service>`.
+Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`mantid:AnalysisDataService <Analysis Data Service>`.
 
 
 Fetching properties

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -139,7 +139,7 @@ They all have a couple of features in common:
   The whole string appears in the user docs and python help.
 
 An optional :ref:`validator <Properties Validators>` or :ref:`directional argument <Properties Directions>` (input, output or both) can also be appended.
-The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the `properties <mantid:mantid.kernel.Property>` page.
+The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`properties <mantid:mantid.kernel.Property>` page.
 
 Validation of inputs
 --------------------
@@ -187,7 +187,7 @@ All of them eventually call the `API::Algorithm::executeInternal() <https://gith
 * run the ``exec()`` method
 * add history to the Workspace annotating the parameters that the algorithm was called with
 
-Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with `AnalysisDataService <mantid:mantid.api.AnalysisDataServiceImpl>`.
+Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`AnalysisDataService <mantid:mantid.api.AnalysisDataServiceImpl>`.
 
 
 Fetching properties

--- a/dev-docs/source/WritingAnAlgorithm.rst
+++ b/dev-docs/source/WritingAnAlgorithm.rst
@@ -139,7 +139,7 @@ They all have a couple of features in common:
   The whole string appears in the user docs and python help.
 
 An optional :ref:`validator <Properties Validators>` or :ref:`directional argument <Properties Directions>` (input, output or both) can also be appended.
-The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the :ref:`mantid:properties <Properties>` page.
+The syntax for other property types (``WorkspaceProperty`` and ``ArrayProperty``) is more complex - see the `properties <https://docs.mantidproject.org/nightly/api/python/mantid/kernel/Property.html>` page.
 
 Validation of inputs
 --------------------
@@ -187,7 +187,7 @@ All of them eventually call the `API::Algorithm::executeInternal() <https://gith
 * run the ``exec()`` method
 * add history to the Workspace annotating the parameters that the algorithm was called with
 
-Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with :ref:`mantid:AnalysisDataService <Analysis Data Service>`.
+Additionally, the algorithm framework also handles things like sync/async calling, exception handling, and interaction with `AnalysisDataService <https://docs.mantidproject.org/nightly/api/python/mantid/api/AnalysisDataServiceImpl.html#mantid.api.AnalysisDataServiceImpl>`.
 
 
 Fetching properties


### PR DESCRIPTION
### Description of work

The CI pipeline for linux docs build started failing with Sphinx warnings on the Writing an Algorithm page. This page used two incorrect references for documentation pages that this PR corrects.

Closes #41284.

### To test:

Check that CI pipeline works for linux docs build.


  *This does not require release notes* because it was caused by changes to the documentation structure and was never visible to the user due to the CI pipeline failures.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
