### PR TITLE
Fix for exception when dragging TableWorkspace onto colour fill plot

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/40733.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/40733.rst
@@ -1,0 +1,1 @@
+- When attempting to over plot a Table Workspace onto a colour fill plot, a warning will now be raised instead of an exception.

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -42,7 +42,8 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
         except KeyError:
             # Handle the case where the workspace name does not exist
             mantid.kernel.logger.warning(f"Workspace '{name}' does not exist.")
-            result = False
+            has_multiple_bins.append(False)
+            continue
 
         if isinstance(ws, WorkspaceGroup):
             result = all(_validate_workspaces(ws.getNames()))
@@ -53,16 +54,18 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
                     mantid.kernel.logger.warning(f"Cannot overplot '{name}', it does not have multiple bins.")
             except RuntimeError:
                 # blocksize() implementation in Workspace2D and EventWorkspace can throw an error if histograms are not equal
+                result = False
                 for i in range(ws.getNumberHistograms()):
                     if ws.y(i).size() > 1:
                         result = True
                         break
+                if not result:
+                    mantid.kernel.logger.warning(f"Cannot overplot '{name}', it does not have multiple bins.")
         else:
             mantid.kernel.logger.warning(f"Workspace '{name}' is neither a MatrixWorkspace or WorkspaceGroup.")
             result = False
 
-        if result is not None:
-            has_multiple_bins.append(result)
+        has_multiple_bins.append(result)
 
     return has_multiple_bins
 

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -43,17 +43,23 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
             # Handle the case where the workspace name does not exist
             mantid.kernel.logger.warning(f"Workspace '{name}' does not exist.")
             result = False
+
         if isinstance(ws, WorkspaceGroup):
             result = all(_validate_workspaces(ws.getNames()))
         elif isinstance(ws, MatrixWorkspace):
             try:
                 result = ws.blocksize() > 1
+                if not result:
+                    mantid.kernel.logger.warning(f"Cannot overplot '{name}', it does not have multiple bins.")
             except RuntimeError:
                 # blocksize() implementation in Workspace2D and EventWorkspace can throw an error if histograms are not equal
                 for i in range(ws.getNumberHistograms()):
                     if ws.y(i).size() > 1:
                         result = True
                         break
+        else:
+            mantid.kernel.logger.warning(f"Workspace '{name}' is neither a MatrixWorkspace or WorkspaceGroup.")
+            result = False
 
         if result is not None:
             has_multiple_bins.append(result)
@@ -165,7 +171,6 @@ class FigureWindow(QMainWindow, ObservingView):
         if len(names) == 0:
             return
         if not all(_validate_workspaces(names)):
-            mantid.kernel.logger.warning("To overplot, workspace(s) must have multiple bins")
             return
         # local import to avoid circular import with FigureManager
         from mantidqt.plotting.functions import pcolormesh, plot_from_names, plot_surface, plot_wireframe, plot_contour

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -11,7 +11,7 @@ import unittest
 import matplotlib
 from mantid import plots  # noqa: F401  # need mantid projection
 from unittest.mock import Mock, patch
-from mantid.simpleapi import CreateWorkspace
+from mantid.simpleapi import CreateWorkspace, CreateEmptyTableWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figurewindow import FigureWindow, _validate_workspaces
 
@@ -57,6 +57,11 @@ class Test(unittest.TestCase):
             self.assertEqual(result, [False, False])
         except KeyError:
             self.fail("KeyError was raised for non-existent workspaces.")
+
+    def test_validate_workspaces_returns_false_on_non_matrix_workspace(self):
+        _ = CreateEmptyTableWorkspace(OutputWorkspace="table_ws")
+        result = _validate_workspaces(["table_ws"])
+        self.assertEqual(result, [False])
 
     def _drop_workspace(self, ws_name: str):
         ax = self.fig.get_axes()[1]

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -29,6 +29,7 @@ class Test(unittest.TestCase):
 
         cls.ws = CreateWorkspace(DataX=[0, 3], DataY=[3, 0], DataE=[1, 1], NSpec=1, OutputWorkspace="ws")
         cls.single_bin_ws = CreateWorkspace(DataX=[0], DataY=[0], DataE=[1], NSpec=1, OutputWorkspace="single_bin_ws")
+        cls.table_ws = CreateEmptyTableWorkspace(OutputWorkspace="table_ws")
 
     @classmethod
     def setUp(cls):
@@ -41,6 +42,7 @@ class Test(unittest.TestCase):
     def tearDownClass(cls):
         cls.ws.delete()
         cls.single_bin_ws.delete()
+        cls.table_ws.delete()
         cls.show_patch.stop()
 
     def test_drag_and_drop_adds_plot_to_correct_axes(self):
@@ -59,7 +61,6 @@ class Test(unittest.TestCase):
             self.fail("KeyError was raised for non-existent workspaces.")
 
     def test_validate_workspaces_returns_false_on_non_matrix_workspace(self):
-        _ = CreateEmptyTableWorkspace(OutputWorkspace="table_ws")
         result = _validate_workspaces(["table_ws"])
         self.assertEqual(result, [False])
 


### PR DESCRIPTION
### Description of work

Added validation to the figure window to check that workspaces dropped onto plots can be overplot.

Closes #40733

### To test:

See #40733 for instructions.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
