### PR TITLE
Property validtor for rebinning parameters to check available memory

### DIFF
--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -34,6 +34,9 @@ using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::CountStandardDeviations;
 
+// this is a simple mock of the availMem function to keep consistent and small values from this function
+std::size_t Mantid::Kernel::MemoryStats::availMem() const { return 12; }
+
 class RebinTest : public CxxTest::TestSuite {
 public:
   double BIN_DELTA;
@@ -131,8 +134,9 @@ public:
     // Logarithmic case
     rebin.initialize();
     start = 1.0;
-    binWidth = std::pow(10.0, 1. / static_cast<double>(numBins)) - 1.;
+    binWidth = 1.0 - std::pow(10.0, 1. / static_cast<double>(numBins + 1));
     end = 10.0;
+    TS_ASSERT_LESS_THAN(binWidth, 0.0); // make sure it is negative, to trigger log binning
     TS_ASSERT_THROWS_ANYTHING(rebin.setProperty("Params", std::vector<double>{start, binWidth, end}));
   }
 

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -118,9 +118,9 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
   }
 
-// NOTE this test will only run on linux, as it requires the availMem patch to work
-#if defined(__linux__) || defined(__gnu_linux__)
+  // NOTE this test will only run on linux, as it requires the availMem patch to work
   void testIsMocked() {
+#if defined(__linux__) || defined(__gnu_linux__)
     constexpr std::size_t newMem{25};
     size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(newMem, mem1);
@@ -131,8 +131,8 @@ public:
     }
     std::size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(newMem, mem2);
-  }
 #endif
+  }
 
   void test_failure_too_much_memory() {
     Mantid::TestMemory::MockMemory memL; // patch the available memory calculator

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -21,6 +21,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidHistogramData/LinearGenerator.h"
+#include "MantidKernel/Memory.h"
 
 #include <numeric>
 
@@ -116,9 +117,28 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
   }
 
+  void test_failure_too_much_memory() {
+    // ensure that rebinning will fail if the number of bins requested is expected to exceed available memory
+    Rebin rebin;
+    // Linear case
+    rebin.initialize();
+    size_t mem = Mantid::Kernel::MemoryStats().availMem();
+    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    double binWidth = 1.0;
+    double start = 1.0;
+    double end = start + static_cast<double>(numBins) * binWidth;
+    TS_ASSERT_THROWS_ANYTHING(rebin.setProperty("Params", std::vector<double>{start, binWidth, end}));
+    // Logarithmic case
+    rebin.initialize();
+    start = 1.0;
+    binWidth = std::pow(10.0, 1. / static_cast<double>(numBins)) - 1.;
+    end = 10.0;
+    TS_ASSERT_THROWS_ANYTHING(rebin.setProperty("Params", std::vector<double>{start, binWidth, end}));
+  }
+
   /* execution tests */
 
-  void testworkspace1D_dist() {
+  void xtestworkspace1D_dist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     test_in1D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
@@ -156,7 +176,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void testworkspace1D_nondist() {
+  void xtestworkspace1D_nondist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
 
@@ -188,7 +208,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void testworkspace1D_logarithmic_binning() {
+  void xtestworkspace1D_logarithmic_binning() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     test_in1D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
@@ -222,7 +242,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void testworkspace2D_dist() {
+  void xtestworkspace2D_dist() {
     Workspace2D_sptr test_in2D = Create2DWorkspace(50, 20);
     test_in2D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in2D", test_in2D);
@@ -329,41 +349,41 @@ public:
     AnalysisDataService::Instance().remove(outName);
   }
 
-  void testEventWorkspace_InPlace_PreserveEvents() { do_test_EventWorkspace(TOF, true, true, true); }
+  void xtestEventWorkspace_InPlace_PreserveEvents() { do_test_EventWorkspace(TOF, true, true, true); }
 
-  void testEventWorkspace_InPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, true, true); }
+  void xtestEventWorkspace_InPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, true, true); }
 
-  void testEventWorkspace_InPlace_PreserveEvents_weightedNoTime() {
+  void xtestEventWorkspace_InPlace_PreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, true, true, true);
   }
 
-  void testEventWorkspace_InPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, true, false, false); }
+  void xtestEventWorkspace_InPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, true, false, false); }
 
-  void testEventWorkspace_InPlace_NoPreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, false, false); }
+  void xtestEventWorkspace_InPlace_NoPreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, false, false); }
 
-  void testEventWorkspace_InPlace_NoPreserveEvents_weightedNoTime() {
+  void xtestEventWorkspace_InPlace_NoPreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, true, false, false);
   }
 
-  void testEventWorkspace_NotInPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, false, false, false); }
+  void xtestEventWorkspace_NotInPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, false, false, false); }
 
-  void testEventWorkspace_NotInPlace_NoPreserveEvents_weighted() {
+  void xtestEventWorkspace_NotInPlace_NoPreserveEvents_weighted() {
     do_test_EventWorkspace(WEIGHTED, false, false, false);
   }
 
-  void testEventWorkspace_NotInPlace_NoPreserveEvents_weightedNoTime() {
+  void xtestEventWorkspace_NotInPlace_NoPreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, false, false, false);
   }
 
-  void testEventWorkspace_NotInPlace_PreserveEvents() { do_test_EventWorkspace(TOF, false, true, true); }
+  void xtestEventWorkspace_NotInPlace_PreserveEvents() { do_test_EventWorkspace(TOF, false, true, true); }
 
-  void testEventWorkspace_NotInPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, false, true, true); }
+  void xtestEventWorkspace_NotInPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, false, true, true); }
 
-  void testEventWorkspace_NotInPlace_PreserveEvents_weightedNoTime() {
+  void xtestEventWorkspace_NotInPlace_PreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, false, true, true);
   }
 
-  void testRebinPointData() {
+  void xtestRebinPointData() {
     Workspace2D_sptr input = Create1DWorkspace(51);
     AnalysisDataService::Instance().add("test_RebinPointDataInput", input);
 
@@ -396,7 +416,7 @@ public:
     AnalysisDataService::Instance().remove("test_RebinPointDataOutput");
   }
 
-  void testMaskedBinsDist() {
+  void xtestMaskedBinsDist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     AnalysisDataService::Instance().add("test_Rebin_mask_dist", test_in1D);
     test_in1D->setDistribution(true);
@@ -446,7 +466,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_masked_ws");
   }
 
-  void testMaskedBinsIntegratedCounts() {
+  void xtestMaskedBinsIntegratedCounts() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(51);
     test_in1D->setDistribution(false);
     AnalysisDataService::Instance().add("test_Rebin_mask_raw", test_in1D);
@@ -500,21 +520,21 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_mask_raw");
   }
 
-  void test_FullBinsOnly_Fixed() {
+  void xtest_FullBinsOnly_Fixed() {
     std::vector<double> xExpected = {0.5, 2.5, 4.5, 6.5};
     std::vector<double> yExpected(3, 8.0);
     std::string params = "2.0";
     do_test_FullBinsOnly(params, yExpected, xExpected);
   }
 
-  void test_FullBinsOnly_Variable() {
+  void xtest_FullBinsOnly_Variable() {
     std::vector<double> xExpected = {0.5, 1.5, 2.5, 3.2, 3.9, 4.6, 6.6};
     std::vector<double> yExpected = {4.0, 4.0, 2.8, 2.8, 2.8, 8.0};
     std::string params = "0.5, 1.0, 3.1, 0.7, 5.0, 2.0, 7.25";
     do_test_FullBinsOnly(params, yExpected, xExpected);
   }
 
-  void test_reverseLogSimple() {
+  void xtest_reverseLogSimple() {
     // Test UseReverseLogarithmic alone
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -544,7 +564,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogDiffStep() {
+  void xtest_reverseLogDiffStep() {
     // Test UseReverseLog with a different step than the usual -1
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -572,7 +592,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogEdgeCase() {
+  void xtest_reverseLogEdgeCase() {
     // Check the case where the parameters given are so that the edges of the bins fall perfectly, and so no padding is
     // needed
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -602,7 +622,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogAgainst() {
+  void xtest_reverseLogAgainst() {
     // Test UseReverseLogarithmic with a linear spacing before it
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -631,7 +651,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogBetween() {
+  void xtest_reverseLogBetween() {
     // Test UseReverseLogarithmic between 2 linear binnings
 
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -663,7 +683,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogFullBinsOnly() {
+  void xtest_reverseLogFullBinsOnly() {
     // Test UseReverseLogarithmic with the FullBinsOnly option checked. It should not change anything from the non
     // checked version.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -695,7 +715,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_reverseLogIncompleteFirstBin() {
+  void xtest_reverseLogIncompleteFirstBin() {
     // Test UseReverseLogarithmic with a first bin that is incomplete, but still bigger than the next one so not merged.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -727,7 +747,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_inversePowerSquareRoot() {
+  void xtest_inversePowerSquareRoot() {
     // Test InversePower in a simple case of square root sum
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -756,7 +776,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_inversePowerHarmonic() {
+  void xtest_inversePowerHarmonic() {
     // Test InversePower in a simple case of harmonic serie
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -785,7 +805,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_inversePowerValidateHarmonic() {
+  void xtest_inversePowerValidateHarmonic() {
     // Test that the validator which forbid creating more than 10000 bins works in a harmonic series case
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -801,7 +821,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void test_inversePowerValidateInverseSquareRoot() {
+  void xtest_inversePowerValidateInverseSquareRoot() {
     // Test that the validator which forbid breating more than 10000 bins works in an inverse square root case
     // We test both because they rely on different formula to compute the expected number of bins.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -822,7 +842,7 @@ public:
   //          TESTS FOR BINNING MODE BEHAVIOR         //
   //__/__/__/__/__/__/__/__/__/__/__/__/__/__/__/__/__//
 
-  void test_failure_bad_binning_modeset() {
+  void xtest_failure_bad_binning_modeset() {
     // ensure failure if bad binning mode is set
     // fast failure because of string list validator
     Rebin rebin;
@@ -831,7 +851,7 @@ public:
         rebin.setProperty("BinningMode", "FunkyCrosswaysBinning")); // this is not a known binning mode
   }
 
-  void test_failure_power_modeset_without_power() {
+  void xtest_failure_power_modeset_without_power() {
     // Test Power binning mode will fail if no power is given
     Rebin rebin;
     rebin.initialize();
@@ -843,7 +863,7 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 35) == "The binning mode was set to 'Power'");
   }
 
-  void test_failure_bad_log_binning_endpoints_modeset() {
+  void xtest_failure_bad_log_binning_endpoints_modeset() {
     // ensure failure with log binning from neg to pos with modeset
     Rebin rebin;
     rebin.initialize();
@@ -889,7 +909,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void test_some_properties_always_unchanged() {
+  void xtest_some_properties_always_unchanged() {
     // these are properties which should not be changed anywhere inside algo
     std::vector<std::string> props{"PreserveEvents", "FullBinsOnly", "IgnoreBinErrors"};
     std::vector<bool> propV{false, true};
@@ -944,7 +964,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void test_all_binning_modes_change_usereverselogarithmic() {
+  void xtest_all_binning_modes_change_usereverselogarithmic() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic", "Power"};
     std::vector<double> steps{1.2, -1.2, -1.2, 1.2};
     std::vector<bool> useRvrsLog{true, true, false, true};
@@ -954,7 +974,7 @@ public:
     }
   }
 
-  void test_reverse_log_doesnt_change_usereverselogarithmic() {
+  void xtest_reverse_log_doesnt_change_usereverselogarithmic() {
     // this additional test ensures the ReverseLog binning mode doesn't
     // accidentally unset the "UseReverseLogarithmic" flag
 
@@ -1037,7 +1057,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void test_all_binning_modes_change_rebin_params() {
+  void xtest_all_binning_modes_change_rebin_params() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic", "Power"};
     std::vector<double> steps{-1.0, 1.0, 1.0, -1.0};
     std::vector<double> goodSteps{1.0, -1.0, -1.0, 1.0};
@@ -1079,7 +1099,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void test_all_binning_modes_change_power() {
+  void xtest_all_binning_modes_change_power() {
     std::vector<std::string> binningModes{"Linear", "Logarithmic", "ReverseLogarithmic"};
     std::vector<double> steps{1.0, -1.0, -1.0};
     for (size_t i = 0; i < binningModes.size(); i++) {
@@ -1087,7 +1107,7 @@ public:
     }
   }
 
-  void test_default_linear_and_modeset_equal_everywhere() {
+  void xtest_default_linear_and_modeset_equal_everywhere() {
     // Check that linear binning mode equals to original behavior
 
     const std::string IN_WKSP("default_modeset_linear_in");
@@ -1142,7 +1162,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void test_default_log_and_modeset_equal_everywhere() {
+  void xtest_default_log_and_modeset_equal_everywhere() {
     // Check that linear binning mode equals to original behavior
 
     const std::string IN_WKSP("default_modeset_log_in");
@@ -1201,7 +1221,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void test_default_reverse_log_and_modeset_equal_everywhere() {
+  void xtest_default_reverse_log_and_modeset_equal_everywhere() {
     // Check that reverse logarithmic binning mode equals original behavior
 
     const std::string IN_WKSP("default_modeset_equal_in");
@@ -1261,7 +1281,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void test_default_power_and_modeset_equal_everywhere() {
+  void xtest_default_power_and_modeset_equal_everywhere() {
     // Test that modeset to power mode equals default behavior
 
     const std::string IN_WKSP("default_modeset_equal_in");
@@ -1389,7 +1409,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP3);
   }
 
-  void test_all_bin_modes_ignore_power() {
+  void xtest_all_bin_modes_ignore_power() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic"};
     std::vector<double> steps{1.0, -1.0, -1.0};
 
@@ -1398,17 +1418,17 @@ public:
     }
   }
 
-  void test_histogram_unsorted_linear() { do_test_unsorted(false, "0.0,4.0,100"); }
+  void xtest_histogram_unsorted_linear() { do_test_unsorted(false, "0.0,4.0,100"); }
 
-  void test_histogram_unsorted_linear2() { do_test_unsorted(false, "4.0"); }
+  void xtest_histogram_unsorted_linear2() { do_test_unsorted(false, "4.0"); }
 
-  void test_histogram_unsorted_varying_step() { do_test_unsorted(true, "0.0,2.0,50,4.0,100"); }
+  void xtest_histogram_unsorted_varying_step() { do_test_unsorted(true, "0.0,2.0,50,4.0,100"); }
 
-  void test_histogram_unsorted_log() { do_test_unsorted(false, "1.0,-1,100"); }
+  void xtest_histogram_unsorted_log() { do_test_unsorted(false, "1.0,-1,100"); }
 
-  void test_histogram_unsorted_reverse_log() { do_test_unsorted(true, "1.0,-1,100", true); }
+  void xtest_histogram_unsorted_reverse_log() { do_test_unsorted(true, "1.0,-1,100", true); }
 
-  void test_histogram_unsorted_power() { do_test_unsorted(true, "1.0,0.5,100", false, 0.5); }
+  void xtest_histogram_unsorted_power() { do_test_unsorted(true, "1.0,0.5,100", false, 0.5); }
 
   void do_test_unsorted(bool expectSorted, std::string params, bool useReverseLogarithmic = false, double power = 0) {
     EventWorkspace_sptr test_in = WorkspaceCreationHelper::createEventWorkspace2(50, 100);
@@ -1427,7 +1447,7 @@ public:
     TS_ASSERT_EQUALS(test_in->getSpectrum(0).isSortedByTof(), expectSorted);
   }
 
-  void test_group_workspace_validation() {
+  void xtest_group_workspace_validation() {
     auto ws1 = Create1DWorkspace(10);
     auto ws2 = Create1DWorkspace(10);
     AnalysisDataService::Instance().add("ws1", ws1);
@@ -1560,7 +1580,7 @@ public:
 
   RebinTestPerformance() { ws = WorkspaceCreationHelper::create2DWorkspaceBinned(5000, 20000); }
 
-  void test_rebin() {
+  void xtest_rebin() {
     Rebin rebin;
     rebin.initialize();
     rebin.setProperty("InputWorkspace", ws);

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -118,6 +118,8 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
   }
 
+// NOTE this test will only run on linux, as it requires the availMem patch to work
+#if defined(__linux__) || defined(__gnu_linux__)
   void testIsMocked() {
     constexpr std::size_t newMem{25};
     size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
@@ -130,15 +132,15 @@ public:
     std::size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(newMem, mem2);
   }
+#endif
 
   void test_failure_too_much_memory() {
     Mantid::TestMemory::MockMemory memL; // patch the available memory calculator
+    size_t numBins = memL.numberOfFloats();
     // ensure that rebinning will fail if the number of bins requested is expected to exceed available memory
     Rebin rebin;
     // Linear case
     rebin.initialize();
-    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = memInKiB * 1024 / sizeof(double) + 1; // one more than can fit in memory
     double binWidth = 1.0;
     double start = 1.0;
     double end = start + static_cast<double>(numBins) * binWidth;

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -138,7 +138,7 @@ public:
 
   /* execution tests */
 
-  void xtestworkspace1D_dist() {
+  void testworkspace1D_dist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     test_in1D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
@@ -176,7 +176,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void xtestworkspace1D_nondist() {
+  void testworkspace1D_nondist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
 
@@ -208,7 +208,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void xtestworkspace1D_logarithmic_binning() {
+  void testworkspace1D_logarithmic_binning() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     test_in1D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in1D", test_in1D);
@@ -242,7 +242,7 @@ public:
     AnalysisDataService::Instance().remove("test_out");
   }
 
-  void xtestworkspace2D_dist() {
+  void testworkspace2D_dist() {
     Workspace2D_sptr test_in2D = Create2DWorkspace(50, 20);
     test_in2D->setDistribution(true);
     AnalysisDataService::Instance().add("test_in2D", test_in2D);
@@ -349,41 +349,41 @@ public:
     AnalysisDataService::Instance().remove(outName);
   }
 
-  void xtestEventWorkspace_InPlace_PreserveEvents() { do_test_EventWorkspace(TOF, true, true, true); }
+  void testEventWorkspace_InPlace_PreserveEvents() { do_test_EventWorkspace(TOF, true, true, true); }
 
-  void xtestEventWorkspace_InPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, true, true); }
+  void testEventWorkspace_InPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, true, true); }
 
-  void xtestEventWorkspace_InPlace_PreserveEvents_weightedNoTime() {
+  void testEventWorkspace_InPlace_PreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, true, true, true);
   }
 
-  void xtestEventWorkspace_InPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, true, false, false); }
+  void testEventWorkspace_InPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, true, false, false); }
 
-  void xtestEventWorkspace_InPlace_NoPreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, false, false); }
+  void testEventWorkspace_InPlace_NoPreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, true, false, false); }
 
-  void xtestEventWorkspace_InPlace_NoPreserveEvents_weightedNoTime() {
+  void testEventWorkspace_InPlace_NoPreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, true, false, false);
   }
 
-  void xtestEventWorkspace_NotInPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, false, false, false); }
+  void testEventWorkspace_NotInPlace_NoPreserveEvents() { do_test_EventWorkspace(TOF, false, false, false); }
 
-  void xtestEventWorkspace_NotInPlace_NoPreserveEvents_weighted() {
+  void testEventWorkspace_NotInPlace_NoPreserveEvents_weighted() {
     do_test_EventWorkspace(WEIGHTED, false, false, false);
   }
 
-  void xtestEventWorkspace_NotInPlace_NoPreserveEvents_weightedNoTime() {
+  void testEventWorkspace_NotInPlace_NoPreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, false, false, false);
   }
 
-  void xtestEventWorkspace_NotInPlace_PreserveEvents() { do_test_EventWorkspace(TOF, false, true, true); }
+  void testEventWorkspace_NotInPlace_PreserveEvents() { do_test_EventWorkspace(TOF, false, true, true); }
 
-  void xtestEventWorkspace_NotInPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, false, true, true); }
+  void testEventWorkspace_NotInPlace_PreserveEvents_weighted() { do_test_EventWorkspace(WEIGHTED, false, true, true); }
 
-  void xtestEventWorkspace_NotInPlace_PreserveEvents_weightedNoTime() {
+  void testEventWorkspace_NotInPlace_PreserveEvents_weightedNoTime() {
     do_test_EventWorkspace(WEIGHTED_NOTIME, false, true, true);
   }
 
-  void xtestRebinPointData() {
+  void testRebinPointData() {
     Workspace2D_sptr input = Create1DWorkspace(51);
     AnalysisDataService::Instance().add("test_RebinPointDataInput", input);
 
@@ -416,7 +416,7 @@ public:
     AnalysisDataService::Instance().remove("test_RebinPointDataOutput");
   }
 
-  void xtestMaskedBinsDist() {
+  void testMaskedBinsDist() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(50);
     AnalysisDataService::Instance().add("test_Rebin_mask_dist", test_in1D);
     test_in1D->setDistribution(true);
@@ -466,7 +466,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_masked_ws");
   }
 
-  void xtestMaskedBinsIntegratedCounts() {
+  void testMaskedBinsIntegratedCounts() {
     Workspace2D_sptr test_in1D = Create1DWorkspace(51);
     test_in1D->setDistribution(false);
     AnalysisDataService::Instance().add("test_Rebin_mask_raw", test_in1D);
@@ -520,21 +520,21 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_mask_raw");
   }
 
-  void xtest_FullBinsOnly_Fixed() {
+  void test_FullBinsOnly_Fixed() {
     std::vector<double> xExpected = {0.5, 2.5, 4.5, 6.5};
     std::vector<double> yExpected(3, 8.0);
     std::string params = "2.0";
     do_test_FullBinsOnly(params, yExpected, xExpected);
   }
 
-  void xtest_FullBinsOnly_Variable() {
+  void test_FullBinsOnly_Variable() {
     std::vector<double> xExpected = {0.5, 1.5, 2.5, 3.2, 3.9, 4.6, 6.6};
     std::vector<double> yExpected = {4.0, 4.0, 2.8, 2.8, 2.8, 8.0};
     std::string params = "0.5, 1.0, 3.1, 0.7, 5.0, 2.0, 7.25";
     do_test_FullBinsOnly(params, yExpected, xExpected);
   }
 
-  void xtest_reverseLogSimple() {
+  void test_reverseLogSimple() {
     // Test UseReverseLogarithmic alone
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -564,7 +564,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogDiffStep() {
+  void test_reverseLogDiffStep() {
     // Test UseReverseLog with a different step than the usual -1
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -592,7 +592,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogEdgeCase() {
+  void test_reverseLogEdgeCase() {
     // Check the case where the parameters given are so that the edges of the bins fall perfectly, and so no padding is
     // needed
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -622,7 +622,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogAgainst() {
+  void test_reverseLogAgainst() {
     // Test UseReverseLogarithmic with a linear spacing before it
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -651,7 +651,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogBetween() {
+  void test_reverseLogBetween() {
     // Test UseReverseLogarithmic between 2 linear binnings
 
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -683,7 +683,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogFullBinsOnly() {
+  void test_reverseLogFullBinsOnly() {
     // Test UseReverseLogarithmic with the FullBinsOnly option checked. It should not change anything from the non
     // checked version.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -715,7 +715,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_reverseLogIncompleteFirstBin() {
+  void test_reverseLogIncompleteFirstBin() {
     // Test UseReverseLogarithmic with a first bin that is incomplete, but still bigger than the next one so not merged.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -747,7 +747,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_inversePowerSquareRoot() {
+  void test_inversePowerSquareRoot() {
     // Test InversePower in a simple case of square root sum
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -776,7 +776,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_inversePowerHarmonic() {
+  void test_inversePowerHarmonic() {
     // Test InversePower in a simple case of harmonic serie
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -805,7 +805,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_inversePowerValidateHarmonic() {
+  void test_inversePowerValidateHarmonic() {
     // Test that the validator which forbid creating more than 10000 bins works in a harmonic series case
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
@@ -821,7 +821,7 @@ public:
     AnalysisDataService::Instance().remove("test_Rebin_revLog");
   }
 
-  void xtest_inversePowerValidateInverseSquareRoot() {
+  void test_inversePowerValidateInverseSquareRoot() {
     // Test that the validator which forbid breating more than 10000 bins works in an inverse square root case
     // We test both because they rely on different formula to compute the expected number of bins.
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
@@ -842,7 +842,7 @@ public:
   //          TESTS FOR BINNING MODE BEHAVIOR         //
   //__/__/__/__/__/__/__/__/__/__/__/__/__/__/__/__/__//
 
-  void xtest_failure_bad_binning_modeset() {
+  void test_failure_bad_binning_modeset() {
     // ensure failure if bad binning mode is set
     // fast failure because of string list validator
     Rebin rebin;
@@ -851,7 +851,7 @@ public:
         rebin.setProperty("BinningMode", "FunkyCrosswaysBinning")); // this is not a known binning mode
   }
 
-  void xtest_failure_power_modeset_without_power() {
+  void test_failure_power_modeset_without_power() {
     // Test Power binning mode will fail if no power is given
     Rebin rebin;
     rebin.initialize();
@@ -863,7 +863,7 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 35) == "The binning mode was set to 'Power'");
   }
 
-  void xtest_failure_bad_log_binning_endpoints_modeset() {
+  void test_failure_bad_log_binning_endpoints_modeset() {
     // ensure failure with log binning from neg to pos with modeset
     Rebin rebin;
     rebin.initialize();
@@ -909,7 +909,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void xtest_some_properties_always_unchanged() {
+  void test_some_properties_always_unchanged() {
     // these are properties which should not be changed anywhere inside algo
     std::vector<std::string> props{"PreserveEvents", "FullBinsOnly", "IgnoreBinErrors"};
     std::vector<bool> propV{false, true};
@@ -964,7 +964,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void xtest_all_binning_modes_change_usereverselogarithmic() {
+  void test_all_binning_modes_change_usereverselogarithmic() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic", "Power"};
     std::vector<double> steps{1.2, -1.2, -1.2, 1.2};
     std::vector<bool> useRvrsLog{true, true, false, true};
@@ -974,7 +974,7 @@ public:
     }
   }
 
-  void xtest_reverse_log_doesnt_change_usereverselogarithmic() {
+  void test_reverse_log_doesnt_change_usereverselogarithmic() {
     // this additional test ensures the ReverseLog binning mode doesn't
     // accidentally unset the "UseReverseLogarithmic" flag
 
@@ -1057,7 +1057,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void xtest_all_binning_modes_change_rebin_params() {
+  void test_all_binning_modes_change_rebin_params() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic", "Power"};
     std::vector<double> steps{-1.0, 1.0, 1.0, -1.0};
     std::vector<double> goodSteps{1.0, -1.0, -1.0, 1.0};
@@ -1099,7 +1099,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP);
   }
 
-  void xtest_all_binning_modes_change_power() {
+  void test_all_binning_modes_change_power() {
     std::vector<std::string> binningModes{"Linear", "Logarithmic", "ReverseLogarithmic"};
     std::vector<double> steps{1.0, -1.0, -1.0};
     for (size_t i = 0; i < binningModes.size(); i++) {
@@ -1107,7 +1107,7 @@ public:
     }
   }
 
-  void xtest_default_linear_and_modeset_equal_everywhere() {
+  void test_default_linear_and_modeset_equal_everywhere() {
     // Check that linear binning mode equals to original behavior
 
     const std::string IN_WKSP("default_modeset_linear_in");
@@ -1162,7 +1162,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void xtest_default_log_and_modeset_equal_everywhere() {
+  void test_default_log_and_modeset_equal_everywhere() {
     // Check that linear binning mode equals to original behavior
 
     const std::string IN_WKSP("default_modeset_log_in");
@@ -1221,7 +1221,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void xtest_default_reverse_log_and_modeset_equal_everywhere() {
+  void test_default_reverse_log_and_modeset_equal_everywhere() {
     // Check that reverse logarithmic binning mode equals original behavior
 
     const std::string IN_WKSP("default_modeset_equal_in");
@@ -1281,7 +1281,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP2);
   }
 
-  void xtest_default_power_and_modeset_equal_everywhere() {
+  void test_default_power_and_modeset_equal_everywhere() {
     // Test that modeset to power mode equals default behavior
 
     const std::string IN_WKSP("default_modeset_equal_in");
@@ -1409,7 +1409,7 @@ public:
     AnalysisDataService::Instance().remove(OUT_WKSP3);
   }
 
-  void xtest_all_bin_modes_ignore_power() {
+  void test_all_bin_modes_ignore_power() {
     std::vector<std::string> binModes{"Linear", "Logarithmic", "ReverseLogarithmic"};
     std::vector<double> steps{1.0, -1.0, -1.0};
 
@@ -1418,17 +1418,17 @@ public:
     }
   }
 
-  void xtest_histogram_unsorted_linear() { do_test_unsorted(false, "0.0,4.0,100"); }
+  void test_histogram_unsorted_linear() { do_test_unsorted(false, "0.0,4.0,100"); }
 
-  void xtest_histogram_unsorted_linear2() { do_test_unsorted(false, "4.0"); }
+  void test_histogram_unsorted_linear2() { do_test_unsorted(false, "4.0"); }
 
-  void xtest_histogram_unsorted_varying_step() { do_test_unsorted(true, "0.0,2.0,50,4.0,100"); }
+  void test_histogram_unsorted_varying_step() { do_test_unsorted(true, "0.0,2.0,50,4.0,100"); }
 
-  void xtest_histogram_unsorted_log() { do_test_unsorted(false, "1.0,-1,100"); }
+  void test_histogram_unsorted_log() { do_test_unsorted(false, "1.0,-1,100"); }
 
-  void xtest_histogram_unsorted_reverse_log() { do_test_unsorted(true, "1.0,-1,100", true); }
+  void test_histogram_unsorted_reverse_log() { do_test_unsorted(true, "1.0,-1,100", true); }
 
-  void xtest_histogram_unsorted_power() { do_test_unsorted(true, "1.0,0.5,100", false, 0.5); }
+  void test_histogram_unsorted_power() { do_test_unsorted(true, "1.0,0.5,100", false, 0.5); }
 
   void do_test_unsorted(bool expectSorted, std::string params, bool useReverseLogarithmic = false, double power = 0) {
     EventWorkspace_sptr test_in = WorkspaceCreationHelper::createEventWorkspace2(50, 100);
@@ -1447,7 +1447,7 @@ public:
     TS_ASSERT_EQUALS(test_in->getSpectrum(0).isSortedByTof(), expectSorted);
   }
 
-  void xtest_group_workspace_validation() {
+  void test_group_workspace_validation() {
     auto ws1 = Create1DWorkspace(10);
     auto ws2 = Create1DWorkspace(10);
     AnalysisDataService::Instance().add("ws1", ws1);
@@ -1580,7 +1580,7 @@ public:
 
   RebinTestPerformance() { ws = WorkspaceCreationHelper::create2DWorkspaceBinned(5000, 20000); }
 
-  void xtest_rebin() {
+  void test_rebin() {
     Rebin rebin;
     rebin.initialize();
     rebin.setProperty("InputWorkspace", ws);

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -122,8 +122,8 @@ public:
     Rebin rebin;
     // Linear case
     rebin.initialize();
-    size_t mem = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem();
+    size_t numBins = memInKiB * 1024 / sizeof(double) + 1; // one more than can fit in memory
     double binWidth = 1.0;
     double start = 1.0;
     double end = start + static_cast<double>(numBins) * binWidth;

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -19,6 +19,7 @@
 #include "MantidAlgorithms/Rebin.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidFrameworkTestHelpers/MockMemory.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/Memory.h"
@@ -33,9 +34,6 @@ using namespace Mantid::Algorithms;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::CountStandardDeviations;
-
-// this is a simple mock of the availMem function to keep consistent and small values from this function
-std::size_t Mantid::Kernel::MemoryStats::availMem() const { return 12; }
 
 class RebinTest : public CxxTest::TestSuite {
 public:
@@ -120,7 +118,21 @@ public:
     TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
   }
 
+  void testIsMocked() {
+    constexpr std::size_t newMem{25};
+    size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
+    TS_ASSERT_LESS_THAN(newMem, mem1);
+    {
+      Mantid::TestMemory::MockMemory memL(newMem);
+      size_t mem = Mantid::Kernel::MemoryStats().availMem();
+      TS_ASSERT_EQUALS(mem, newMem);
+    }
+    std::size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
+    TS_ASSERT_LESS_THAN(newMem, mem2);
+  }
+
   void test_failure_too_much_memory() {
+    Mantid::TestMemory::MockMemory memL; // patch the available memory calculator
     // ensure that rebinning will fail if the number of bins requested is expected to exceed available memory
     Rebin rebin;
     // Linear case

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -55,10 +55,9 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
       size_t numBins = 0;
       // ensure all bin widths are non-zero
       double previousBoundary = value[0];
-      double binWidth, nextBoundary;
       for (size_t i = 1; i < value.size() - 1; i += 2) {
-        binWidth = value[i];
-        nextBoundary = value[i + 1];
+        double binWidth = value[i];
+        double nextBoundary = value[i + 1];
         // first validate the bins and boundaries
         if (binWidth == 0.0) {
           error = "Cannot have a zero bin width";

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -5,7 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/RebinParamsValidator.h"
-#include <memory>
+#include "MantidKernel/Memory.h"
+#include <cmath>
 
 namespace Mantid::Kernel {
 RebinParamsValidator::RebinParamsValidator(bool allowEmpty, bool allowRange)
@@ -18,52 +19,84 @@ IValidator_sptr RebinParamsValidator::clone() const { return std::make_shared<Re
  *  @return A user level description of any problem or "" if there is no problem
  */
 std::string RebinParamsValidator::checkValidity(const std::vector<double> &value) const {
-  // array must not be empty
-  if (value.empty()) {
-    if (m_allowEmpty) // unless allowed in the constructor
-      return "";
-    else
-      return "Enter values for this property";
-  }
+  // Rebin Parameters allow three forms of input:
+  // 1) a single value, the bin width, in which case the bin boundaries will be calculated from the input workspace
+  // 2) a pair of values (a range), the lower and upper limits of the binning
+  // 3) a list of values in the form x1,dx1,x2,dx2,...,xn where the x's are bin boundaries and the dx's are bin widths
 
-  if (m_allowRange && value.size() == 2) {
-    if (value[0] < value[1])
-      return "";
-    else
-      return "When giving a range the second value must be larger than the "
-             "first";
-  }
-
-  // it must have an odd number of values (and be at least 3 elements long)
-  if (value.size() % 2 == 0) {
-    return "The number of bin boundary parameters provided must be odd";
-  }
-
-  // bin widths must not be zero
-  if (value.size() == 1 && value[0] == 0.0) {
-    return "Cannot have a zero bin width";
-  } else {
-    for (size_t i = 1; i < value.size(); i += 2) {
-      if (value[i] == 0.0) {
-        return "Cannot have a zero bin width";
+  std::string error = "";
+  size_t numParams = value.size();
+  switch (numParams) {
+  case 0: {
+    if (!m_allowEmpty) { // unless allowed in the constructor
+      error = "Enter values for this property";
+    }
+  } break;
+  case 1: {
+    if (value[0] == 0.0) {
+      error = "Cannot have a zero bin width";
+    }
+  } break;
+  case 2: {
+    if (m_allowRange) { // if we allow ranges, must be in order
+      if (value[0] >= value[1]) {
+        error = "When giving a range the second value must be larger than the first";
       }
+    } else { // if we don't allow ranges, then this is wrong
+      error = "The number of bin boundary parameters provided must be odd";
     }
+  } break;
+  // three or more parameters must be in the form x1,dx1,x2,dx2,...,xn
+  default: {
+    if (value.size() % 2 == 0) { // even
+      error = "The number of bin boundary parameters provided must be odd";
+    } else { // odd
+      // for checking memory allocation
+      size_t numBins = 0;
+      // ensure all bin widths are non-zero
+      double previousBoundary = value[0];
+      double binWidth, nextBoundary;
+      for (size_t i = 1; i < value.size() - 1; i += 2) {
+        binWidth = value[i];
+        nextBoundary = value[i + 1];
+        // first validate the bins and boundaries
+        if (binWidth == 0.0) {
+          error = "Cannot have a zero bin width";
+          break;
+        } else {
+          if (nextBoundary <= previousBoundary) { // check bin boundaries are in increasing order
+            error = "Bin boundary values must be given in order of increasing value";
+            break;
+          } else if (binWidth < 0.0 &&
+                     previousBoundary <=
+                         0.0) { // if bin width is negative (log binning) check boundaries are positive-definite
+            error = "Bin boundaries must be positive for logarithmic binning";
+            break;
+          }
+        }
+        // the bins and bounds are okay, now check the memory allocation
+        if (binWidth < 0.0) {
+          // logarithmic binning
+          numBins += static_cast<size_t>(std::log(nextBoundary / previousBoundary) / std::log(1. - binWidth));
+        } else {
+          // linear binning
+          numBins += static_cast<size_t>((nextBoundary - previousBoundary) / binWidth);
+        }
+        previousBoundary = nextBoundary;
+      } // end for checking bins/boundaries
+      size_t mem = MemoryStats().availMem();
+      if (numBins > mem / sizeof(double)) {
+        error = "The number of bins requested is expected to exceed available memory. "
+                "This binning requires approximately " +
+                std::to_string(numBins * sizeof(double) / 1'000'000'000) + " GB of memory, but only " +
+                std::to_string(mem / 1'000'000) + " GB is available.";
+      }
+    } // end else odd
+  } // end default case
   }
 
-  // bin boundary values must be in increasing order
-  double previous = value[0];
-  for (size_t i = 2; i < value.size(); i += 2) {
-    if ((value[i - 1] < 0) && (previous <= 0)) {
-      return "Bin boundaries must be positive for logarithmic binning";
-    }
-    if (value[i] <= previous) {
-      return "Bin boundary values must be given in order of increasing value";
-    } else
-      previous = value[i];
-  }
-
-  // All's OK if we get to here
-  return "";
+  // return string, which contains any error messages
+  return error;
 }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -73,7 +73,7 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
             break;
           }
         }
-        // the bins and bounds are okay, now check the memory allocation
+        // the bins and bounds are okay, accumulate memory
         if (binWidth < 0.0) {
           // logarithmic binning
           numBins += static_cast<size_t>(std::log(nextBoundary / previousBoundary) / std::log(1. - binWidth));
@@ -83,12 +83,14 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
         }
         previousBoundary = nextBoundary;
       } // end for checking bins/boundaries
-      size_t mem = MemoryStats().availMem();
-      if (numBins > mem / sizeof(double)) {
+      size_t memInBytes = MemoryStats().availMem() * 1024;
+      size_t binSpaceInBytes = numBins * sizeof(double);
+      if (binSpaceInBytes > memInBytes) {
+        size_t bytesInGB = 1'000'000'000;
         error = "The number of bins requested is expected to exceed available memory. "
                 "This binning requires approximately " +
-                std::to_string(numBins * sizeof(double) / 1'000'000'000) + " GB of memory, but only " +
-                std::to_string(mem / 1'000'000) + " GB is available.";
+                std::to_string(binSpaceInBytes / bytesInGB) + " GB of memory, but only " +
+                std::to_string(memInBytes / bytesInGB) + " GB is available.";
       }
     } // end else odd
   } // end default case

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -83,10 +83,10 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
         }
         previousBoundary = nextBoundary;
       } // end for checking bins/boundaries
-      size_t memInBytes = MemoryStats().availMem() * 1024;
-      size_t binSpaceInBytes = numBins * sizeof(double);
+      double memInBytes = static_cast<double>(MemoryStats().availMem() * 1024);
+      double binSpaceInBytes = static_cast<double>(numBins * sizeof(double));
       if (binSpaceInBytes > memInBytes) {
-        size_t bytesInGB = 1'000'000'000;
+        double bytesInGB = 1e9;
         error = "The number of bins requested is expected to exceed available memory. "
                 "This binning requires approximately " +
                 std::to_string(binSpaceInBytes / bytesInGB) + " GB of memory, but only " +

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -6,15 +6,13 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidFrameworkTestHelpers/MockMemory.h"
 #include "MantidKernel/Memory.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include <cxxtest/TestSuite.h>
 #include <memory>
 
 using namespace Mantid::Kernel;
-
-// this is a simple mock of the availMem function to keep consistent and small values from this function
-std::size_t Mantid::Kernel::MemoryStats::availMem() const { return 12; }
 
 class RebinParamsValidatorTest : public CxxTest::TestSuite {
 public:
@@ -107,7 +105,21 @@ public:
                      "When giving a range the second value must be larger than the first");
   }
 
+  void testIsMocked() {
+    std::size_t memSize = 13;
+    size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
+    TS_ASSERT_LESS_THAN(memSize, mem1);
+    { // scope the mock
+      Mantid::TestMemory::MockMemory memL(memSize);
+      size_t mem = Mantid::Kernel::MemoryStats().availMem();
+      TS_ASSERT_EQUALS(mem, memSize);
+    }
+    size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
+    TS_ASSERT_LESS_THAN(memSize, mem2);
+  }
+
   void testTooManyBins() {
+    Mantid::TestMemory::MockMemory memL;
     size_t mem = Mantid::Kernel::MemoryStats().availMem();
     size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
     std::vector<double> vec(3);
@@ -118,6 +130,7 @@ public:
   }
 
   void testTooManyBinsLog() {
+    Mantid::TestMemory::MockMemory memL;
     size_t mem = Mantid::Kernel::MemoryStats().availMem();
     size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
     std::vector<double> vec(3);
@@ -133,7 +146,8 @@ public:
     // 1. find the number of KiB remaining in memory.
     // 2. calculate the number of bins that would equal that value in *bytes* (i.e. numBins * sizeof(double))
     // 3. make sure that the validator passes, if the bytes of the bins are less than the available memory
-    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem();
+    constexpr std::size_t memInKiB{12};
+    Mantid::TestMemory::MockMemory memL(memInKiB);
     size_t numBins =
         memInKiB / sizeof(double); // the number bins (doubles) that would fit in memory, IF memory were in bytes
     std::vector<double> vec{1., 1., 1. + static_cast<double>(numBins)}; // make sure we have numBins bins

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -105,6 +105,8 @@ public:
                      "When giving a range the second value must be larger than the first");
   }
 
+// NOTE this test will only run on linux, as it requires the availMem patch to work
+#if defined(__linux__) || defined(__gnu_linux__)
   void testIsMocked() {
     std::size_t memSize = 13;
     size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
@@ -117,11 +119,11 @@ public:
     size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(memSize, mem2);
   }
+#endif
 
   void testTooManyBins() {
     Mantid::TestMemory::MockMemory memL;
-    size_t mem = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
+    size_t numBins = memL.numberOfFloats();
     std::vector<double> vec(3);
     vec[0] = 1.0;
     vec[1] = 1.0;
@@ -131,8 +133,7 @@ public:
 
   void testTooManyBinsLog() {
     Mantid::TestMemory::MockMemory memL;
-    size_t mem = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
+    size_t numBins = memL.numberOfFloats();
     std::vector<double> vec(3);
     vec[0] = 1.0;
     vec[1] = 1.0 - std::pow(10.0, 1. / static_cast<double>(numBins)); // make sure we have more than numBins bins
@@ -141,6 +142,8 @@ public:
     TS_ASSERT(!standardValidator.isValid(vec).empty());
   }
 
+// NOTE this test will only run on linux, as it requires the availMem patch to work
+#if defined(__linux__) || defined(__gnu_linux__)
   void testBinsInKiB() {
     // make sure we are calculating the number of bins in KiB correctly
     // 1. find the number of KiB remaining in memory.
@@ -153,6 +156,7 @@ public:
     std::vector<double> vec{1., 1., 1. + static_cast<double>(numBins)}; // make sure we have numBins bins
     TS_ASSERT(standardValidator.isValid(vec).empty());
   }
+#endif
 
 private:
   RebinParamsValidator standardValidator;

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -105,9 +105,9 @@ public:
                      "When giving a range the second value must be larger than the first");
   }
 
-// NOTE this test will only run on linux, as it requires the availMem patch to work
-#if defined(__linux__) || defined(__gnu_linux__)
+  // NOTE this test will only run on linux, as it requires the availMem patch to work
   void testIsMocked() {
+#if defined(__linux__) || defined(__gnu_linux__)
     std::size_t memSize = 13;
     size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(memSize, mem1);
@@ -118,8 +118,8 @@ public:
     }
     size_t mem2 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(memSize, mem2);
-  }
 #endif
+  }
 
   void testTooManyBins() {
     Mantid::TestMemory::MockMemory memL;
@@ -142,9 +142,9 @@ public:
     TS_ASSERT(!standardValidator.isValid(vec).empty());
   }
 
-// NOTE this test will only run on linux, as it requires the availMem patch to work
-#if defined(__linux__) || defined(__gnu_linux__)
+  // NOTE this test will only run on linux, as it requires the availMem patch to work
   void testBinsInKiB() {
+#if defined(__linux__) || defined(__gnu_linux__)
     // make sure we are calculating the number of bins in KiB correctly
     // 1. find the number of KiB remaining in memory.
     // 2. calculate the number of bins that would equal that value in *bytes* (i.e. numBins * sizeof(double))
@@ -155,8 +155,8 @@ public:
         memInKiB / sizeof(double); // the number bins (doubles) that would fit in memory, IF memory were in bytes
     std::vector<double> vec{1., 1., 1. + static_cast<double>(numBins)}; // make sure we have numBins bins
     TS_ASSERT(standardValidator.isValid(vec).empty());
-  }
 #endif
+  }
 
 private:
   RebinParamsValidator standardValidator;

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -106,7 +106,7 @@ public:
 
   void testTooManyBins() {
     size_t mem = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
     std::vector<double> vec(3);
     vec[0] = 1.0;
     vec[1] = 1.0;
@@ -116,12 +116,24 @@ public:
 
   void testTooManyBinsLog() {
     size_t mem = Mantid::Kernel::MemoryStats().availMem();
-    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
     std::vector<double> vec(3);
     vec[0] = 1.0;
     vec[1] = std::pow(10.0, 1. / static_cast<double>(numBins)) - 1.; // make sure we have more than numBins bins
     vec[2] = 10.0;
     TS_ASSERT(!standardValidator.isValid(vec).empty());
+  }
+
+  void testBinsInKiB() {
+    // make sure we are calculating the number of bins in KiB correctly
+    // 1. find the number of KiB remaining in memory.
+    // 2. calculate the number of bins that would equal that value in *bytes* (i.e. numBins * sizeof(double))
+    // 3. make sure that the validator passes, if the bytes of the bins are less than the available memory
+    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem(); // one more than can fit in memory
+    size_t numBins =
+        memInKiB / sizeof(double); // the number bins (doubles) that would fit in memory, IF memory were in bytes
+    std::vector<double> vec{1., 1., 1. + static_cast<double>(numBins)}; // make sure we have numBins bins
+    TS_ASSERT(standardValidator.isValid(vec).empty());
   }
 
 private:

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -13,6 +13,9 @@
 
 using namespace Mantid::Kernel;
 
+// this is a simple mock of the availMem function to keep consistent and small values from this function
+std::size_t Mantid::Kernel::MemoryStats::availMem() const { return 12; }
+
 class RebinParamsValidatorTest : public CxxTest::TestSuite {
 public:
   void testClone() {
@@ -119,8 +122,9 @@ public:
     size_t numBins = mem * 1024 / sizeof(double) + 1; // one more than can fit in memory
     std::vector<double> vec(3);
     vec[0] = 1.0;
-    vec[1] = std::pow(10.0, 1. / static_cast<double>(numBins)) - 1.; // make sure we have more than numBins bins
+    vec[1] = 1.0 - std::pow(10.0, 1. / static_cast<double>(numBins)); // make sure we have more than numBins bins
     vec[2] = 10.0;
+    TS_ASSERT_LESS_THAN(vec[1], 0.0); // make sure it is negative, to trigger log binning
     TS_ASSERT(!standardValidator.isValid(vec).empty());
   }
 
@@ -129,7 +133,7 @@ public:
     // 1. find the number of KiB remaining in memory.
     // 2. calculate the number of bins that would equal that value in *bytes* (i.e. numBins * sizeof(double))
     // 3. make sure that the validator passes, if the bytes of the bins are less than the available memory
-    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem(); // one more than can fit in memory
+    size_t memInKiB = Mantid::Kernel::MemoryStats().availMem();
     size_t numBins =
         memInKiB / sizeof(double); // the number bins (doubles) that would fit in memory, IF memory were in bytes
     std::vector<double> vec{1., 1., 1. + static_cast<double>(numBins)}; // make sure we have numBins bins

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidKernel/Memory.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include <cxxtest/TestSuite.h>
 #include <memory>
@@ -101,6 +102,26 @@ public:
     vec[1] = 0.0;
     TS_ASSERT_EQUALS(allowRangeValidator.isValid(vec),
                      "When giving a range the second value must be larger than the first");
+  }
+
+  void testTooManyBins() {
+    size_t mem = Mantid::Kernel::MemoryStats().availMem();
+    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    std::vector<double> vec(3);
+    vec[0] = 1.0;
+    vec[1] = 1.0;
+    vec[2] = 1.0 + static_cast<double>(numBins); // make sure we have more than numBins bins
+    TS_ASSERT(!standardValidator.isValid(vec).empty());
+  }
+
+  void testTooManyBinsLog() {
+    size_t mem = Mantid::Kernel::MemoryStats().availMem();
+    size_t numBins = mem / sizeof(double) + 1; // one more than can fit in memory
+    std::vector<double> vec(3);
+    vec[0] = 1.0;
+    vec[1] = std::pow(10.0, 1. / static_cast<double>(numBins)) - 1.; // make sure we have more than numBins bins
+    vec[2] = 10.0;
+    TS_ASSERT(!standardValidator.isValid(vec).empty());
   }
 
 private:

--- a/Framework/TestHelpers/CMakeLists.txt
+++ b/Framework/TestHelpers/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_FILES
     src/LoggingCleaner.cpp
     src/MDAlgorithmsTestHelper.cpp
     src/MDEventsTestHelper.cpp
+    src/MockMemory.cpp
     src/MultiDomainFunctionHelper.cpp
     src/MuonGroupingXMLHelper.cpp
     src/MuonWorkspaceCreationHelper.cpp
@@ -42,6 +43,7 @@ set(INC_FILES
     inc/MantidFrameworkTestHelpers/MDAlgorithmsTestHelper.h
     inc/MantidFrameworkTestHelpers/MDEventsTestHelper.h
     inc/MantidFrameworkTestHelpers/MockAlgorithm.h
+    inc/MantidFrameworkTestHelpers/MockMemory.h
     inc/MantidFrameworkTestHelpers/MultiDomainFunctionHelper.h
     inc/MantidFrameworkTestHelpers/MuonGroupingXMLHelper.h
     inc/MantidFrameworkTestHelpers/MuonWorkspaceCreationHelper.h

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -17,16 +17,28 @@ extern "C" void disable_mem_override();
 
 /// @brief Mock the availMem function with RAII.  Construct an operation within a scope for the
 /// availMem function to return a fixed value within that scope.  Will reset on exit.
+/// @note on Windows or other deficient OSes, this will not perform the patch, but will just provide
+/// the numberOfFloats method to return a very large number expected to always exceed available memory
 struct MockMemory {
   /// @brief Patch the available memory while in scope
   /// @param value The amount of available memory, in kiB, that will be reported.  Default 12 kiB.
-  MockMemory(std::size_t value = g_default_value) { enable_mem_override(value); }
+  MockMemory(std::size_t value = g_default_value) : m_value(value) { enable_mem_override(value); }
   ~MockMemory() { disable_mem_override(); }
   // delete copies and moves to fill out rule-of-five
   MockMemory(MockMemory const &) = delete;
   MockMemory(MockMemory &&) = delete;
   MockMemory &operator=(MockMemory const &) = delete;
   MockMemory &operator=(MockMemory &&) = delete;
+  std::size_t numberOfFloats() const {
+#if defined(__linux__) || defined(__gnu_linux__)
+    return static_cast<std::size_t>(static_cast<double>(m_value * 1024) / sizeof(double) + 1);
+#else
+    return static_cast<std::size_t>(1e12); // a very large number, sure to always exhaust memory
+#endif
+  }
+
+private:
+  std::size_t m_value{g_default_value};
 };
 
 } // namespace Mantid::TestMemory

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -22,7 +22,7 @@ extern "C" void disable_mem_override();
 struct MockMemory {
   /// @brief Patch the available memory while in scope
   /// @param value The amount of available memory, in kiB, that will be reported.  Default 12 kiB.
-  MockMemory(std::size_t value = g_default_value) : m_value(value) { enable_mem_override(value); }
+  MockMemory(std::size_t value = g_default_value) : m_value(value) { enable_mem_override(m_value); }
   ~MockMemory() { disable_mem_override(); }
   // delete copies and moves to fill out rule-of-five
   MockMemory(MockMemory const &) = delete;
@@ -33,13 +33,12 @@ struct MockMemory {
   std::size_t numberOfFloats() const {
     return static_cast<std::size_t>(static_cast<double>(m_value * 1024) / sizeof(double) + 1);
   }
-
-private:
-  std::size_t m_value{g_default_value};
 #else
   // a very large number, sure to always exhaust memory
   std::size_t numberOfFloats() const { return static_cast<std::size_t>(1e12); }
 #endif
+private:
+  std::size_t m_value{g_default_value};
 };
 
 } // namespace Mantid::TestMemory

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -29,16 +29,17 @@ struct MockMemory {
   MockMemory(MockMemory &&) = delete;
   MockMemory &operator=(MockMemory const &) = delete;
   MockMemory &operator=(MockMemory &&) = delete;
-  std::size_t numberOfFloats() const {
 #if defined(__linux__) || defined(__gnu_linux__)
+  std::size_t numberOfFloats() const {
     return static_cast<std::size_t>(static_cast<double>(m_value * 1024) / sizeof(double) + 1);
-#else
-    return static_cast<std::size_t>(1e12); // a very large number, sure to always exhaust memory
-#endif
   }
 
 private:
   std::size_t m_value{g_default_value};
+#else
+  // a very large number, sure to always exhaust memory
+  std::size_t numberOfFloats() const { return static_cast<std::size_t>(1e12); }
+#endif
 };
 
 } // namespace Mantid::TestMemory

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -1,4 +1,10 @@
 #pragma once
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX-License-Identifier: GPL-3.0+
 
 #include <cstddef>
 
@@ -10,12 +16,17 @@ extern "C" void enable_mem_override(std::size_t value = g_default_value);
 extern "C" void disable_mem_override();
 
 /// @brief Mock the availMem function with RAII.  Construct an operation within a scope for the
-/// availMem function to return a fixed calue within that scope.  Will reset on exit.
+/// availMem function to return a fixed value within that scope.  Will reset on exit.
 struct MockMemory {
   /// @brief Patch the available memory while in scope
   /// @param value The amount of available memory, in kiB, that will be reported.  Default 12 kiB.
   MockMemory(std::size_t value = g_default_value) { enable_mem_override(value); }
   ~MockMemory() { disable_mem_override(); }
+  // delete copies and moves to fill out rule-of-five
+  MockMemory(MockMemory const &) = delete;
+  MockMemory(MockMemory &&) = delete;
+  MockMemory &operator=(MockMemory const &) = delete;
+  MockMemory &operator=(MockMemory &&) = delete;
 };
 
 } // namespace Mantid::TestMemory

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+
+namespace Mantid::TestMemory {
+
+constexpr std::size_t g_default_value{12};
+
+extern "C" void enable_mem_override(std::size_t value = g_default_value);
+extern "C" void disable_mem_override();
+
+/// @brief Mock the availMem function with RAII.  Construct an operation within a scope for the
+/// availMem function to return a fixed calue within that scope.  Will reset on exit.
+struct MockMemory {
+  /// @brief Patch the available memory while in scope
+  /// @param value The amount of available memory, in kiB, that will be reported.  Default 12 kiB.
+  MockMemory(std::size_t value = g_default_value) { enable_mem_override(value); }
+  ~MockMemory() { disable_mem_override(); }
+};
+
+} // namespace Mantid::TestMemory

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -6,14 +6,14 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "MantidFrameworkTestHelpers/MockMemory.h"
+
+// only define the methods for the patch if using Linux
+#if defined(__linux__) || defined(__gnu_linux__)
+
 #include "MantidKernel/Memory.h"
 
 #include <atomic>
-#if defined(_WIN32) || defined(_WIN64)
-#include <windows.h>
-#else
 #include <dlfcn.h>
-#endif
 #include <stdexcept>
 
 namespace {
@@ -24,47 +24,21 @@ static std::atomic<std::size_t> g_value{Mantid::TestMemory::g_default_value}; //
 static std::once_flag g_init_flag;
 
 static void init_real_availMem() {
+  // NOTE: begin Deep Magic
   // if not set, set the real function for availMem by looking up its mangled name in the symbol list
   std::call_once(g_init_flag, []() {
-  // NOTE: The following is Deep Magic.
-#if defined(_WIN32) || defined(_WIN64) // windows
-    HMODULE hModule = GetModuleHandleA(nullptr);
-    if (hModule) {
-      // char const *const func_name = "?availMem@MemoryStats@Kernel@Mantid@@QEBA_KXZ";
-      char const *const func_name = "Mantid_TestMemory_get_real_availMem";
-      FARPROC proc = GetProcAddress(hModule, func_name);
-      if (proc) {
-        using Getter = void *(*)();
-        try {
-          Getter getter = reinterpret_cast<Getter>(proc);
-          void *raw = getter();
-          g_real_availMem.store(reinterpret_cast<AvailMemFunc>(raw));
-        } catch (...) {
-          throw std::runtime_error("Failed to cast or call the original MemoryStats::availMem");
-        }
-      } else {
-        throw std::runtime_error("Failed to locate the original MemoryStats::availMem");
-      }
-    } else {
-      throw std::runtime_error("Failed to get module handle for MemoryStats::availMem");
-    }
-#else // unix
+    // the mangled name may be found with: nm -D bin/libMantidKernel.so | grep availMem
     char const *const mangled = "_ZNK6Mantid6Kernel11MemoryStats8availMemEv";
-#if defined(__linux__) || defined(__gnu_linux__)
     void *sym = dlsym(RTLD_NEXT, mangled);
-#else // on MacOS or other, should use RLTD_DEFAULT
-    void *sym = dlsym(RTLD_DEFAULT, mangled);
-#endif
-    // try fallback to default if not found
+    // fallback to RTLD_DEFAULT if still not found
     if (!sym) {
       sym = dlsym(RTLD_DEFAULT, mangled);
     }
     if (sym) {
       g_real_availMem.store(reinterpret_cast<AvailMemFunc>(sym));
     }
-#endif // win32 or unix
-    // end deep magic
   });
+  // end Deep Magic
 }
 } // namespace
 
@@ -76,10 +50,10 @@ extern "C" void enable_mem_override(std::size_t value) {
 extern "C" void disable_mem_override() { g_override_availMem.store(false); }
 } // namespace Mantid::TestMemory
 
-// this is a patched availMem which will be used in testing
+// this is a patched availMem which will be used in testing.
 // when g_override_availMem has been set, it will return a fixed value
-// otherwise, it will prepare the real function from symbol lookup, and
-// return the actual memory count
+// otherwise, it will prepare the real function from symbol lookup,
+// and return the actual memory count
 std::size_t Mantid::Kernel::MemoryStats::availMem() const {
   if (g_override_availMem.load()) {
     return g_value;
@@ -93,3 +67,9 @@ std::size_t Mantid::Kernel::MemoryStats::availMem() const {
     }
   }
 }
+#else
+namespace Mantid::TestMemory {
+extern "C" void enable_mem_override(std::size_t value) { UNUSED_ARG(value); }
+extern "C" void disable_mem_override() {}
+} // namespace Mantid::TestMemory
+#endif

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -69,7 +69,7 @@ std::size_t Mantid::Kernel::MemoryStats::availMem() const {
 }
 #else
 namespace Mantid::TestMemory {
-extern "C" void enable_mem_override(std::size_t value) { UNUSED_ARG(value); }
+extern "C" void enable_mem_override(std::size_t value) { (void)value; }
 extern "C" void disable_mem_override() {}
 } // namespace Mantid::TestMemory
 #endif

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -1,27 +1,70 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX-License-Identifier: GPL-3.0+
+
 #include "MantidFrameworkTestHelpers/MockMemory.h"
 #include "MantidKernel/Memory.h"
 
 #include <atomic>
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 #include <stdexcept>
 
 namespace {
 using AvailMemFunc = std::size_t (*)(Mantid::Kernel::MemoryStats const *);
-static std::atomic<bool> g_override_availMem{false}; // flag, whether to use the real or mock availMem
-static AvailMemFunc g_real_availMem(nullptr);        // the real function, looked up from symbol list
+static std::atomic<bool> g_override_availMem{false};       // flag, whether to use the real or mock availMem
+static std::atomic<AvailMemFunc> g_real_availMem(nullptr); // the real function, looked up from symbol list
 static std::atomic<std::size_t> g_value{Mantid::TestMemory::g_default_value}; // the return value of mocked availMem
+static std::once_flag g_init_flag;
 
 static void init_real_availMem() {
   // if not set, set the real function for availMem by looking up its mangled name in the symbol list
-  if (!g_real_availMem) {
-    // NOTE: deep magic begins here
-    char const *mangled = "_ZNK6Mantid6Kernel11MemoryStats8availMemEv";
-    void *sym = dlsym(RTLD_NEXT, mangled);
-    if (sym) {
-      g_real_availMem = reinterpret_cast<AvailMemFunc>(sym);
+  std::call_once(g_init_flag, []() {
+  // NOTE: The following is Deep Magic.
+#if defined(_WIN32) || defined(_WIN64) // windows
+    HMODULE hModule = GetModuleHandleA(nullptr);
+    if (hModule) {
+      // char const *const func_name = "?availMem@MemoryStats@Kernel@Mantid@@QEBA_KXZ";
+      char const *const func_name = "Mantid_TestMemory_get_real_availMem";
+      FARPROC proc = GetProcAddress(hModule, func_name);
+      if (proc) {
+        using Getter = void *(*)();
+        try {
+          Getter getter = reinterpret_cast<Getter>(proc);
+          void *raw = getter();
+          g_real_availMem.store(reinterpret_cast<AvailMemFunc>(raw));
+        } catch (...) {
+          throw std::runtime_error("Failed to cast or call the original MemoryStats::availMem");
+        }
+      } else {
+        throw std::runtime_error("Failed to locate the original MemoryStats::availMem");
+      }
+    } else {
+      throw std::runtime_error("Failed to get module handle for MemoryStats::availMem");
     }
+#else // unix
+    char const *const mangled = "_ZNK6Mantid6Kernel11MemoryStats8availMemEv";
+#if defined(__linux__) || defined(__gnu_linux__)
+    void *sym = dlsym(RTLD_NEXT, mangled);
+#else // on MacOS or other, should use RLTD_DEFAULT
+    void *sym = dlsym(RTLD_DEFAULT, mangled);
+#endif
+    // try fallback to default if not found
+    if (!sym) {
+      sym = dlsym(RTLD_DEFAULT, mangled);
+    }
+    if (sym) {
+      g_real_availMem.store(reinterpret_cast<AvailMemFunc>(sym));
+    }
+#endif // win32 or unix
     // end deep magic
-  }
+  });
 }
 } // namespace
 
@@ -38,12 +81,12 @@ extern "C" void disable_mem_override() { g_override_availMem.store(false); }
 // otherwise, it will prepare the real function from symbol lookup, and
 // return the actual memory count
 std::size_t Mantid::Kernel::MemoryStats::availMem() const {
-  if (g_override_availMem) {
+  if (g_override_availMem.load()) {
     return g_value;
   } else {
     init_real_availMem();
-    if (g_real_availMem) {
-      return g_real_availMem(this);
+    if (g_real_availMem.load()) {
+      return g_real_availMem.load()(this);
     } else {
       // if it cannot be thrown, this can cause opaque testing errors; throw an error here instead
       throw std::runtime_error("Failed to reset the MemoryStats patch by name lookup");

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -1,0 +1,52 @@
+#include "MantidFrameworkTestHelpers/MockMemory.h"
+#include "MantidKernel/Memory.h"
+
+#include <atomic>
+#include <dlfcn.h>
+
+namespace {
+using AvailMemFunc = std::size_t (*)(Mantid::Kernel::MemoryStats const *);
+static std::atomic<bool> g_override_availMem{true}; // flag, whether to use the real or mock availMem
+static AvailMemFunc g_real_availMem(nullptr);       // the real function, looked up from symbol list
+static std::atomic<std::size_t> g_value{Mantid::TestMemory::g_default_value}; // the return value of mocked availMem
+
+static void init_real_availMem() {
+  // prepare the real
+  if (g_real_availMem) {
+    // if the real function has been set, we are done
+    return;
+  } else {
+    // otherwise looked it up by its mangled name in the symbol list and set it
+    char const *mangled = "_ZNK6Mantid6Kernel11MemoryStats8availMemEv";
+    void *sym = dlsym(RTLD_NEXT, mangled);
+    if (sym) {
+      g_real_availMem = reinterpret_cast<AvailMemFunc>(sym);
+    }
+  }
+}
+} // namespace
+
+namespace Mantid::TestMemory {
+extern "C" void enable_mem_override(std::size_t value) {
+  g_value.store(value);
+  g_override_availMem.store(true);
+}
+extern "C" void disable_mem_override() { g_override_availMem.store(false); }
+} // namespace Mantid::TestMemory
+
+// this is a patched availMem which will be used in testing
+// when g_override_availMem has been set, it will return a fixed value
+// otherwise, it will prepare the real function from symbol lookup, and
+// return the actual memory count
+std::size_t Mantid::Kernel::MemoryStats::availMem() const {
+  if (g_override_availMem) {
+    return g_value;
+  } else {
+    init_real_availMem();
+    if (g_real_availMem) {
+      return g_real_availMem(this);
+    } else {
+      return 0;
+    }
+  }
+}

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -3,25 +3,24 @@
 
 #include <atomic>
 #include <dlfcn.h>
+#include <stdexcept>
 
 namespace {
 using AvailMemFunc = std::size_t (*)(Mantid::Kernel::MemoryStats const *);
-static std::atomic<bool> g_override_availMem{true}; // flag, whether to use the real or mock availMem
-static AvailMemFunc g_real_availMem(nullptr);       // the real function, looked up from symbol list
+static std::atomic<bool> g_override_availMem{false}; // flag, whether to use the real or mock availMem
+static AvailMemFunc g_real_availMem(nullptr);        // the real function, looked up from symbol list
 static std::atomic<std::size_t> g_value{Mantid::TestMemory::g_default_value}; // the return value of mocked availMem
 
 static void init_real_availMem() {
-  // prepare the real
-  if (g_real_availMem) {
-    // if the real function has been set, we are done
-    return;
-  } else {
-    // otherwise looked it up by its mangled name in the symbol list and set it
+  // if not set, set the real function for availMem by looking up its mangled name in the symbol list
+  if (!g_real_availMem) {
+    // NOTE: deep magic begins here
     char const *mangled = "_ZNK6Mantid6Kernel11MemoryStats8availMemEv";
     void *sym = dlsym(RTLD_NEXT, mangled);
     if (sym) {
       g_real_availMem = reinterpret_cast<AvailMemFunc>(sym);
     }
+    // end deep magic
   }
 }
 } // namespace
@@ -46,7 +45,8 @@ std::size_t Mantid::Kernel::MemoryStats::availMem() const {
     if (g_real_availMem) {
       return g_real_availMem(this);
     } else {
-      return 0;
+      // if it cannot be thrown, this can cause opaque testing errors; throw an error here instead
+      throw std::runtime_error("Failed to reset the MemoryStats patch by name lookup");
     }
   }
 }


### PR DESCRIPTION
### Description of work

Currently, when `Rebin` is run with linear or logarithmic parameters, it is possible for users to specify binning in such a way that it overruns the system memory and causes a Mantid crash.

As a first step in preventing this, we will check the parameters for how much memory one spectrum would require and ensure it does not exceed the available system memory.  This adds the check inside the `RebinParamsValidator`, so that it is more centralized and fails earlier for any code requiring rebinning parameters.

This also refactors the validator to be a bit more perspicuous, considering the different cases that are allowed for rebinning parameters.

New tests ensure the errors are thrown when necessary.

Refs: [EWM 15806](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15806)

### To test:

The new tests should be convincing.

Note the new test fixture.  On Linux, this will patch the `MemoryStats::availMem()` method to return a fixed value, defaulting to 12 (kiB), which can trigger the error.  This patch can be easily set by instantiated a `MemoryMock` object, which will undo the patch on scope exit.  On Windows or Mac, the patch is not performed, and instead the `MemoryMock` object will return some large number of floats that will almost certainly exceed available RAM on any realistic system.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
