### PR TITLE
Fix regex escaping of Windows paths in BASISReduction7Test

### DIFF
--- a/Testing/SystemTests/tests/framework/BASISTest.py
+++ b/Testing/SystemTests/tests/framework/BASISTest.py
@@ -18,6 +18,7 @@ from mantid.simpleapi import (
     ReplaceSpecialValues,
 )
 
+import re
 from unittest import mock
 
 
@@ -342,13 +343,13 @@ class BASISReduction7Test(systemtesting.MantidSystemTest, PreppingMixin):
         dnemask = "does_not_exist.xml"
         assert not FileFinder.getFullPath(dnemask)
         assert not os.path.exists(dnemask)
-        with self.assertRaisesRegex(RuntimeError, f"Mask file {dnemask} could not be loaded"):
+        with self.assertRaisesRegex(RuntimeError, f"Mask file {re.escape(dnemask)} could not be loaded"):
             BASISReduction(**def_args, MaskFile=dnemask)
 
         # step 2: run with a file that does exist but is wrong format -- should throw a runtime error
         mask = FileFinder.getFullPath("arg_si.dat")
         assert os.path.exists(mask)
-        with self.assertRaisesRegex(RuntimeError, f"Mask file {mask} is not of the correct format"):
+        with self.assertRaisesRegex(RuntimeError, f"Mask file {re.escape(mask)} is not of the correct format"):
             BASISReduction(**def_args, MaskFile=mask)
 
         # lookup the module object for BASISReduction to patch the lookups to simulate situations where a mask is not found
@@ -361,7 +362,7 @@ class BASISReduction7Test(systemtesting.MantidSystemTest, PreppingMixin):
             mask = os.path.join(tdir, "BASIS_Mask_default_333.xml")
             assert not os.path.exists(mask)
             with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": tdir}):
-                with self.assertRaisesRegex(RuntimeError, f"Mask file {mask} could not be loaded"):
+                with self.assertRaisesRegex(RuntimeError, f"Mask file {re.escape(mask)} could not be loaded"):
                     BASISReduction(**def_args, MaskFile=None)  # run with no mask, set None for clarity
 
         # step 4: run with no mask -- should resort to default, which we set to exist but be unreadable
@@ -371,7 +372,7 @@ class BASISReduction7Test(systemtesting.MantidSystemTest, PreppingMixin):
                 f.write("This is an XML file!")
             assert os.path.exists(mask)
             with mock.patch.dict(mod.__dict__, {"DEFAULT_MASK_GROUP_DIR": tdir}):
-                with self.assertRaisesRegex(RuntimeError, f"An unexpected error occurred when loading mask file {mask}"):
+                with self.assertRaisesRegex(RuntimeError, f"An unexpected error occurred when loading mask file {re.escape(mask)}"):
                     BASISReduction(**def_args, MaskFile=None)
 
         # cleanup


### PR DESCRIPTION
### Description of work

assertRaisesRegex treats its pattern argument as a regex. On Windows, os.path.join produces backslash-separated paths (e.g. C:\Users\...) containing sequences like \U which are invalid regex escapes, causing re.error on the nightly Windows build. Fixed by wrapping all four path variables with re.escape() before passing them as patterns.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Fixes #41286 
 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Run systemtest on a Windows machine and ensures the test pass.

Verify the branch build pass: https://builds.mantidproject.org/job/build_branch/1577

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
