### PR TITLE
Rattler build changes

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
-# This script expects to be in a POSIX environment. Uses rattler to build the suite of
+# This script expects to be in a POSIX environment. Uses the pixi
+# ``rattler-builder`` feature environment to build the suite of
 # mantid packages. You must pass flags to specify which packages to build. If building
 # a package dependent on another one it will either install a locally built package
 # (if present from a previous build step) or build and produce that package too.
@@ -17,11 +18,11 @@
 #                 outputs are placed in $WORKSPACE/conda-bld
 #
 # Possible flags:
-#   --build-mantid-developer: build the mantid-developer metapackage using conda-build
-#   --build-mantid: build the mantid package using conda-build
-#   --build-qt: build the qt package using conda-build (this will implicitly build mantid)
+#   --build-mantid-developer: build the mantid-developer metapackage using rattler-build
+#   --build-mantid: build the mantid package using rattler-build
+#   --build-qt: build the qt package using rattler-build (this will implicitly build mantid)
 #   --build-docs: build the HTML/Qthelp documentation
-#   --build-workbench: build the workbench package using conda-build (this will implicitly build qt and mantid)
+#   --build-workbench: build the workbench package using rattler-build (this will implicitly build qt and mantid)
 #   --git-tag: specify a tag for a release or nightly version
 #   --platform: target architecture, e.g. linux-64
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -89,6 +90,10 @@ done
 # install pixi if not already installed
 install_pixi
 
+# Activate the pixi environment backed by the rattler-builder feature so the
+# build tools can be used directly below.
+eval "$(pixi shell-hook -e rattler-builder --frozen --change-ps1 false)"
+
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE
 if [[ -d conda-recipes ]]; then
@@ -106,7 +111,7 @@ if [[ -n "$GIT_TAG" ]]; then
 fi
 
 # Set the version to inject into the recipe file
-export MANTID_VERSION=$(pixi run -e rattler-builder --frozen versioningit $REPO_ROOT_DIR)
+export MANTID_VERSION=$(versioningit $REPO_ROOT_DIR)
 
 # Set locale to avoid problems building the docs
 # See https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do
@@ -118,7 +123,7 @@ export LC_ALL=C
 # copy the source to a working folder.
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld
 if [[ -d $CONDA_BLD_PATH ]]; then
-    pixi run -e rattler-builder --frozen rattler-index fs $CONDA_BLD_PATH
+    rattler-index fs $CONDA_BLD_PATH
 fi
 cd $RECIPES_DIR
 
@@ -137,19 +142,19 @@ pixi list -e rattler-builder --frozen
 
 # Run conda build.
 if [[ $ENABLE_BUILD_MANTID_DEVELOPER == true ]]; then
-    pixi run -e rattler-builder --frozen rattler-build build -r ./mantid-developer/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c neutrons $EXTRA_BUILD_OPTIONS
+    rattler-build build -r ./mantid-developer/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c neutrons $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_MANTID == true ]]; then
-    pixi run -e rattler-builder --frozen rattler-build build --experimental -r ./mantid/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    rattler-build build --experimental -r ./mantid/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_QT == true ]]; then
-    pixi run -e rattler-builder --frozen rattler-build build -r ./mantidqt/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    rattler-build build -r ./mantidqt/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_DOCS == true ]]; then
-    pixi run -e rattler-builder --frozen rattler-build build -r ./mantiddocs/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c conda-forge -c neutrons -c mantid $EXTRA_BUILD_OPTIONS
+    rattler-build build -r ./mantiddocs/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c conda-forge -c neutrons -c mantid $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
-    pixi run -e rattler-builder --frozen rattler-build build -r ./mantidworkbench/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    rattler-build build -r ./mantidworkbench/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
 
 # elapsed time with second resolution

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -90,10 +90,6 @@ done
 # install pixi if not already installed
 install_pixi
 
-# Activate the pixi environment backed by the rattler-builder feature so the
-# build tools can be used directly below.
-eval "$(pixi shell -e rattler-builder --frozen --change-ps1 false)"
-
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE
 if [[ -d conda-recipes ]]; then
@@ -111,7 +107,7 @@ if [[ -n "$GIT_TAG" ]]; then
 fi
 
 # Set the version to inject into the recipe file
-export MANTID_VERSION=$(versioningit $REPO_ROOT_DIR)
+export MANTID_VERSION=$(pixi run -e rattler-builder --frozen versioningit $REPO_ROOT_DIR)
 
 # Set locale to avoid problems building the docs
 # See https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do
@@ -123,7 +119,7 @@ export LC_ALL=C
 # copy the source to a working folder.
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld
 if [[ -d $CONDA_BLD_PATH ]]; then
-    rattler-index fs $CONDA_BLD_PATH
+    pixi run -e rattler-builder --frozen rattler-index fs $CONDA_BLD_PATH
 fi
 cd $RECIPES_DIR
 
@@ -142,21 +138,20 @@ pixi list -e rattler-builder --frozen
 
 # Run conda build.
 if [[ $ENABLE_BUILD_MANTID_DEVELOPER == true ]]; then
-    rattler-build build -r ./mantid-developer/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c neutrons $EXTRA_BUILD_OPTIONS
+    pixi run -e rattler-builder --frozen rattler-build build -r ./mantid-developer/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c neutrons $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_MANTID == true ]]; then
-    rattler-build build --experimental -r ./mantid/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    pixi run -e rattler-builder --frozen rattler-build build --experimental -r ./mantid/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_QT == true ]]; then
-    rattler-build build -r ./mantidqt/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    pixi run -e rattler-builder --frozen rattler-build build -r ./mantidqt/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_DOCS == true ]]; then
-    rattler-build build -r ./mantiddocs/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c conda-forge -c neutrons -c mantid $EXTRA_BUILD_OPTIONS
+    pixi run -e rattler-builder --frozen rattler-build build -r ./mantiddocs/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH -c conda-forge -c neutrons -c mantid $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
-    rattler-build build -r ./mantidworkbench/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
+    pixi run -e rattler-builder --frozen rattler-build build -r ./mantidworkbench/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
-exit # leave pixi shell
 
 # elapsed time with second resolution
 end_time=$(date +%s)

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -92,7 +92,7 @@ install_pixi
 
 # Activate the pixi environment backed by the rattler-builder feature so the
 # build tools can be used directly below.
-eval "$(pixi shell-hook -e rattler-builder --frozen --change-ps1 false)"
+eval "$(pixi shell -e rattler-builder --frozen --change-ps1 false)"
 
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE
@@ -156,6 +156,7 @@ fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
     rattler-build build -r ./mantidworkbench/ -m ./conda_build_config.yaml --output-dir $CONDA_BLD_PATH $EXTRA_BUILD_OPTIONS
 fi
+exit # leave pixi shell
 
 # elapsed time with second resolution
 end_time=$(date +%s)

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -193,7 +193,7 @@ This is useful if you need to change a pinned version of one of Mantid's depende
         pixi shell -e rattler-builder --frozen
         MANTID_VERSION=$(versioningit ../../) rattler-build build -r ./mantid-developer -m ./conda_build_config.yaml --output-dir=/home/me/tmp/rattler
 
-    This will build a local version of ``mantid-developer`` with your changes and place it in the directory ``/home/me/tmp/rattler``. **This must be outside of the buildtree** because rattler will recursively copy everything.
+   This will build a local version of ``mantid-developer`` with your changes and place it in the directory ``/home/me/tmp/rattler``. **This must be outside of the buildtree** because rattler will recursively copy everything.
 5. Index the new packages
 
    .. code-block:: sh

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -49,7 +49,9 @@ Conda requires `recipes <conda-recipes-docs_>`_ as input for producing packages.
 The recipes are stored in the `main codebase <mantid-conda-recipes_>`_ so that
 they can evolve as the code develops. The packages are built as part of the
 `CI pipeline <ci-pipeline_>`_ using a `script <package-conda_>`_ to encapsulate
-the steps.
+the steps. That script installs pixi if needed, activates the environment backed
+by the ``rattler-builder`` feature from ``pixi.toml``, and runs ``rattler-build``
+from there.
 
 To build the packages locally it is recommended that you use a separate
 clone of the repository as the build copies the repository content to a temporary
@@ -181,16 +183,17 @@ Building a custom ``mantid-developer`` environment
 
 This is useful if you need to change a pinned version of one of Mantid's dependencies and test the change locally.
 
-1. One can create a new environment specifically for building the package (with ``rattler-build``, and ``versioningit``), but the build itself happens in a separate sandbox which makes this unneccesary.
+1. The required tooling lives in the pixi environment backed by the ``rattler-builder`` feature.
 2. Make your changes to the conda recipe files.
 3. Change directory to ``mantid/conda/recipes``
-4. With ``mantid_dev_builder`` active, run
+4. Activate the environment and run
 
    .. code-block:: sh
 
-       MANTID_VERSION=$(versioningit ../../) rattler-build build -r ./mantid-developer -m ./conda_build_config.yaml --output-dir=/home/me/tmp/rattler
+        pixi shell -e rattler-builder --frozen
+        MANTID_VERSION=$(versioningit ../../) rattler-build build -r ./mantid-developer -m ./conda_build_config.yaml --output-dir=/home/me/tmp/rattler
 
-   This will build a local version of ``mantid-developer`` with your changes and place it in the directory ``/home/me/tmp/rattler``. **This must be outside of the buildtree** because rattler will recursively copy everything.
+    This will build a local version of ``mantid-developer`` with your changes and place it in the directory ``/home/me/tmp/rattler``. **This must be outside of the buildtree** because rattler will recursively copy everything.
 5. Index the new packages
 
    .. code-block:: sh

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -13,6 +14,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://prefix.dev/skill-forge/noarch/agent-skill-rattler-build-0.0.2-h4616a5c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -285,7 +287,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
@@ -341,7 +342,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quasielasticbayes-0.3.0-py312hfc6b132_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/quickbayes-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rattler-build-0.51.0-he64ecbb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rattler-index-0.27.21-h58ba7e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -437,6 +437,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://prefix.dev/skill-forge/noarch/agent-skill-rattler-build-0.0.2-h4616a5c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.5-py312h9f8c436_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -704,7 +705,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/quasielasticbayes-0.3.0-py312h24809d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/quickbayes-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rapidjson-1.1.0.post20240409-ha1acc90_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rattler-build-0.51.0-h8d80559_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rattler-index-0.27.21-hcb0414c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
@@ -773,6 +773,7 @@ environments:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/skill-forge/noarch/agent-skill-rattler-build-0.0.2-h4616a5c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -1025,7 +1026,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/quasielasticbayes-0.3.0-py312h7e22eef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/quickbayes-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rapidjson-1.1.0.post20240409-he0c23c2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rattler-build-0.51.0-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rattler-index-0.27.21-h91801bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -1112,6 +1112,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1142,6 +1143,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1216,6 +1218,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1311,6 +1314,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1525,6 +1529,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1764,6 +1769,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1896,6 +1902,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1906,6 +1913,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/neutrons/
     - url: https://conda.anaconda.org/mantid/
+    - url: https://prefix.dev/skill-forge/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -2053,6 +2061,14 @@ packages:
   license_family: LGPL
   size: 631452
   timestamp: 1758743294412
+- conda: https://prefix.dev/skill-forge/noarch/agent-skill-rattler-build-0.0.2-h4616a5c_0.conda
+  sha256: b26de75458c1ad2e1c32aca859372419eadf9ca3d9812c1d460a3c25934814db
+  md5: 3e31d14d8f52b4645f8044d6478566bc
+  constrains:
+  - rattler-build >=0.35.0
+  license: BSD-3-Clause
+  size: 15647
+  timestamp: 1775331030684
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
   sha256: 7842ddc678e77868ba7b92a726b437575b23aaec293bca0d40826f1026d90e27
   md5: 18fd895e0e775622906cdabfc3cf0fb4

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,12 @@
 [workspace]
 name = "mantid"
 authors = ["Pete Peterson <petersonpf@ornl.gov>"]
-channels = ["conda-forge", "neutrons", "mantid"]
+channels = [
+  "conda-forge",
+  "neutrons",
+  "mantid",
+  "https://prefix.dev/skill-forge",
+]
 # when editing local copy of mantid-developer, will need to temporarily remove
 # the platforms that you aren't working on
 platforms = ["linux-64", "win-64", "osx-arm64"]
@@ -114,7 +119,6 @@ qtconsole = ">5.5.0"
 qtpy = ">=2.4,!=2.4.2"
 quasielasticbayes = "==0.3.0"
 quickbayes = "==1.0.2"
-rattler-build = "==0.51.0"
 rattler-index = ">=0.27.4,<0.28"
 requests = ">=2.32.4"
 scipy = ">=1.16.0,<1.17"
@@ -130,6 +134,7 @@ graphviz = ">=2.47.0"
 mantid-sphinx-theme = ">=0.1.0,<1"
 myst-parser = ">=5.0.0,<6"
 sphinx = ">=9.0,<10"
+agent-skill-rattler-build = ">=0.0.2,<0.0.3"
 
 [target.linux-64.dependencies]
 gxx_linux-64 = "13.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,7 +29,7 @@ docs-migration = { features = ["docs-migration"], no-default-feature = true }
 
 [feature.rattler-builder.dependencies]
 rattler-build = "==0.51.0"
-versioningit = ">=3.3.0,<4"
+versioningit = ">=2.1"
 rattler-index = ">=0.27.6,<0.28"
 
 [feature.rattler-builder.target.linux-64.dependencies]

--- a/tools/dependencies/pixi_dependency_updater.py
+++ b/tools/dependencies/pixi_dependency_updater.py
@@ -109,6 +109,7 @@ def get_pixi_mantid_dev_pins() -> DependencyPins:
     manifest_data = {}
     dependency_headers = (
         ("dependencies", "all"),
+        ("feature.rattler-builder.dependencies", "all"),  # for building packages
         ("target.linux-64.dependencies", "linux"),
         ("target.win-64.dependencies", "win"),
         ("target.osx-arm64.dependencies", "osx"),
@@ -126,6 +127,12 @@ def get_pixi_mantid_dev_pins() -> DependencyPins:
                 elif isinstance(version, dict):
                     version_and_build = f"{version['version']} {version['build']}"
                     pin_map[package] |= {os_name: version_and_build}
+
+    # skills are only available in pixi
+    IGNORE_LIST = ["agent-skill-rattler-build"]
+    for ignore in IGNORE_LIST:
+        if ignore in pin_map:
+            del pin_map[ignore]
 
     return pin_map
 
@@ -168,6 +175,15 @@ def _run_pixi_command(command: List[str]):
     elif process.returncode != 0:
         print(f'Tried to run "{" ".join(command)}" but encountered a problem:')
         print(process.stderr)
+
+
+def _file_has_changes(filename: Path) -> bool:
+    process = run(["git", "status", "--porcelain", filename], text=True, capture_output=True)
+    if process.stderr:  # something went wrong
+        raise RuntimeError(process.stderr)
+
+    # any sort of status is a change of some sort
+    return bool(process.stdout)
 
 
 def _compare_version_numbers(conda_version: str, pixi_version: str):
@@ -281,7 +297,10 @@ def main(argv: Sequence[str] = None) -> int:
         command = ["pixi", "install"]
         print("Invoking pixi environment to update pixi.lock")
         _run_pixi_command(command)
-        return EXIT_CODE_ERROR
+        if _file_has_changes(PIXI_LOCK):
+            return EXIT_CODE_ERROR
+        else:
+            return EXIT_CODE_SUCCESS
 
     return EXIT_CODE_SUCCESS
 


### PR DESCRIPTION
There are 3-ish changes in this PR that are, unfortantely, related. With some extra effor they could be split up.

Use `ratter-build` from the "rattler-builder" environment/feature. This reduces what is in the default pixi environment by one package. This exposed that the rattler-builder environment was pinning a different version of versioningit. 

Modify local `pixi-deps` pre-commit hook to check the rattler-builder feature for dependencies. This is what discovered the versioningit issue. Also fixed a bug where the hook would return "failure" when it ran `pixi install` to update the `pixi.lock` file but no changes happened. This occurs normally when a pin is modified (increasing the minimum pin), and the lockfile is already using a version that meets the pin.

Add a [pixi skill](https://pixi.prefix.dev/dev/integration/extensions/pixi_skills/), [agent-skill-rattler-build](https://prefix.dev/channels/skill-forge/packages/agent-skill-rattler-build). This allows for adding an agents file files (example)
```sh
pixi skills manage --backend opencode --scope local
```
to manage "local" skills for the opencode backend. This was used to give advice and more thourough suggestion on the mpi package monobuild (#40997). 

There is no associated issue.

### To test:

Follow the instructions in the developer docs for building a conda package. They should work still. This does not need the `brach_build` job because the package building on linux is a sufficient test that `rattler-build` is still found.

To testing the changes to the `pixi-deps` hook, look at the pinned versions of packages and increase a minimum pin for something that still includes the version that is in `pixi.lock`. If the `pixi.toml` is not changed, it will not run `pixi install` and the new logic will not be tested.

*This does not require release notes* because it is changing packaging scripts and a pre-commit hook.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
