### PR TITLE
Fix error bar settings being silently ignored when plotting a spectrum with errors

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -557,7 +557,7 @@ def _do_single_plot(ax, workspaces, errors, set_title, nums, kw, plot_kwargs, lo
             plot_fn = ax.errorbar if errors else ax.plot
             if isinstance(ws, MatrixWorkspace):
                 plot_type = ws.getPlotType()
-                _plot_kwargs = get_plot_specific_properties(ws, plot_type, plot_kwargs)
+                _plot_kwargs = get_plot_specific_properties(ws, plot_type, plot_kwargs, errors=errors)
                 if "errorbar" in plot_type or errors:
                     plot_fn = ax.errorbar
 

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -286,13 +286,14 @@ def convert_color_to_hex(color):
         return colors.rgb2hex(rgb)
 
 
-def get_plot_specific_properties(ws, plot_type, plot_kwargs):
+def get_plot_specific_properties(ws, plot_type, plot_kwargs, errors=False):
     """
     Set plot specific properties from the workspace
     :param ws:
-    :param ax:
-    :param errors:
+    :param plot_type:
     :param plot_kwargs:
+    :param errors: If True, errorbar kwargs (capsize, capthick, etc.) will not be stripped even for
+                   non-errorbar workspace types. This is needed when errors=True is passed to plot().
     """
 
     if plot_type in ["errorbar_x", "errorbar_y", "errorbar_xy"]:
@@ -315,9 +316,10 @@ def get_plot_specific_properties(ws, plot_type, plot_kwargs):
             plot_kwargs["markersize"] = (
                 marker_size if marker_size != 6 else float(ConfigService.getString("plots.markerworkspace.MarkerSize"))
             )
-        plot_kwargs.pop("capsize", None)
-        plot_kwargs.pop("capthick", None)
-        plot_kwargs.pop("errorevery", None)
-        plot_kwargs.pop("elinewidth", None)
+        if not errors:
+            plot_kwargs.pop("capsize", None)
+            plot_kwargs.pop("capthick", None)
+            plot_kwargs.pop("errorevery", None)
+            plot_kwargs.pop("elinewidth", None)
 
     return plot_kwargs

--- a/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 
 from mantid.api import AnalysisDataService
 from mantid.simpleapi import CreateSampleWorkspace
-from mantid.plots.utility import col_num, legend_set_draggable, row_num
+from mantid.plots.utility import col_num, get_plot_specific_properties, legend_set_draggable, row_num
 from matplotlib.legend import Legend
 from unittest.mock import create_autospec
 
@@ -69,6 +69,22 @@ class UtilityTest(unittest.TestCase):
         expected_col_nums = [0, 1, None]
         for axis, col_number in zip(self.fig.get_axes(), expected_col_nums):
             self.assertEqual(col_num(axis), col_number)
+
+    def test_get_plot_specific_properties_preserves_errorbar_kwargs_when_errors_true(self):
+        plot_kwargs = {"capsize": 4.0, "capthick": 1.0, "errorevery": 1, "elinewidth": 1.0}
+        result = get_plot_specific_properties(self.workspace, "plot", plot_kwargs, errors=True)
+        self.assertAlmostEqual(result["capsize"], 4.0)
+        self.assertAlmostEqual(result["capthick"], 1.0)
+        self.assertEqual(result["errorevery"], 1)
+        self.assertAlmostEqual(result["elinewidth"], 1.0)
+
+    def test_get_plot_specific_properties_removes_errorbar_kwargs_when_errors_false(self):
+        plot_kwargs = {"capsize": 4.0, "capthick": 1.0, "errorevery": 1, "elinewidth": 1.0}
+        result = get_plot_specific_properties(self.workspace, "plot", plot_kwargs, errors=False)
+        self.assertNotIn("capsize", result)
+        self.assertNotIn("capthick", result)
+        self.assertNotIn("errorevery", result)
+        self.assertNotIn("elinewidth", result)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -306,6 +306,21 @@ class FunctionsTest(unittest.TestCase):
         layout_engine = fig.get_layout_engine()
         self.assertIsInstance(layout_engine, ConstrainedLayoutEngine)
 
+    def test_capsize_setting_applied_when_plotting_spectrum_with_errors(self):
+        original_capsize = config["plots.errorbar.Capsize"]
+        try:
+            config["plots.errorbar.Capsize"] = "4.0"
+            fig = plot([self._test_ws], wksp_indices=[1], errors=True)
+            ax = fig.get_axes()[0]
+            containers = ax.containers
+            self.assertTrue(len(containers) > 0, "Expected at least one ErrorbarContainer")
+            caps = containers[0][1]
+            # With capsize=4.0 the cap lines are drawn with a positive marker size
+            self.assertTrue(len(caps) > 0, "Cap lines should be created when capsize > 0")
+            self.assertGreater(caps[0].get_markersize(), 0.0)
+        finally:
+            config["plots.errorbar.Capsize"] = original_capsize
+
     # ------------- Failure tests -------------
     def test_that_manage_workspace_names_raises_on_mix_of_workspaces_and_names(self):
         ws = ["some_workspace", self._test_ws]

--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/39460.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/39460.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where error bar settings (CapSize, Cap Thickness, Width, Error Every) from :menuselection:`File --> Settings --> Plots --> Error Bars` were not applied when plotting a spectrum with errors.


### PR DESCRIPTION
### Description of work

Fix error bar settings (CapSize, Cap Thickness, Width, Error Every) from File > Settings > Plots > Error Bars being silently ignored when plotting a spectrum with errors. The errors bar were removed previously if the plot type is not error-related. This PR preserves error parameters when the errors are enabled for a plot.

Closes #39460 

---

### To test:

1. Open Mantid Workbench.
2. Go to **File > Settings > Plots**, scroll to the **Error Bars** section and set **CapSize** to `4`. Click **Apply**.
3. Load any workspace (e.g. run `CreateSampleWorkspace()` in the Script Editor).
4. Right-click the workspace → **Plot > Spectrum with errors**.
5. Verify the error bar caps are now visible (before the fix, caps were invisible because capsize defaulted to 0).
6. Repeat steps 2–5 for **Cap Thickness**, **Width**, and **Error Every** to confirm all four settings are applied.
7. Plot a plain **Spectrum** (without errors) and confirm it is unaffected.



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
