### PR TITLE
Changed restriction on Ei from 1.0 meV to 0.1 meV

### DIFF
--- a/docs/source/release/v6.16.0/Direct_Geometry/General/New_features/41309.rst
+++ b/docs/source/release/v6.16.0/Direct_Geometry/General/New_features/41309.rst
@@ -1,0 +1,1 @@
+- In DGS Planner, the minimal value for the Incident Energy has been lowered from 1.0 to 0.1 meV.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
@@ -210,7 +210,7 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
         self.signaldict["DetZ"] = self.DetZ
         self.validatorS2 = QtGui.QDoubleValidator(-90.0, 90.0, 5, self)
         self.validatorDetZ = QtGui.QDoubleValidator(-999999.0, 999999.0, 5, self)
-        self.validatorEi = QtGui.QDoubleValidator(1.0, 10000.0, 5, self)
+        self.validatorEi = QtGui.QDoubleValidator(0.1, 10000.0, 5, self)
         self.labelS2 = QtWidgets.QLabel("S2")
         self.labelDetZ = QtWidgets.QLabel("DetZ")
         self.labelEi = QtWidgets.QLabel("Incident Energy")


### PR DESCRIPTION
### Description of work

The DGS Planner enforced a restriction on the incident energy of 1.0 meV as a minimum. However, in reality values lower 1.0 meV are used so the restriction was lowered to 0.1 meV.

Closes #41308.

**Report to:** [G. Wood/ISIS]


### To test:

Open the DGS Planner in the Direct menu and try entering values between 0.1 and 1.0 for Incident Energy. 


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
