### PR TITLE
Investigate POLDIDataAnalysisTest failing on OSX

### DIFF
--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -35,6 +35,11 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 
+namespace {
+// The logger object
+Mantid::Kernel::Logger g_log("PoldiFitPeaks2D");
+} // namespace
+
 namespace Mantid::Poldi {
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(PoldiFitPeaks2D)
@@ -266,7 +271,7 @@ PoldiFitPeaks2D::getNormalizedPeakCollection(const PoldiPeakCollection_sptr &pea
   for (size_t i = 0; i < peakCollection->peakCount(); ++i) {
     PoldiPeak_sptr peak = peakCollection->peak(i);
     double calculatedIntensity = m_timeTransformer->calculatedTotalIntensity(peak->d());
-
+    g_log.notice() << "peak index: " << i << " , calc intenisty: " << calculatedIntensity << "\n";
     PoldiPeak_sptr normalizedPeak = peak->clonePeak();
     normalizedPeak->setIntensity(peak->intensity() / calculatedIntensity);
     normalizedPeakCollection->addPeak(normalizedPeak);


### PR DESCRIPTION
### Description of work

I do not have a mac, so this way I can test it on the CI, apologies for the inefficient use of resources, I will use this branch to also fix the issue once I find it

Closes #41307

From my experience in nans in fits, the problem is usually the starting conditions of the fit rather than the fit itself, so seeing if the issue is in the peak normalisation before the fit 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
