### PR TITLE
Added the option to apply an inverted mask to the workspace in the Sliceviewer

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/SliceViewer/New_features/40955.rst
+++ b/docs/source/release/v6.16.0/Workbench/SliceViewer/New_features/40955.rst
@@ -1,0 +1,1 @@
+- Updated the :ref:`SliceViewer <sliceviewer>` to support inverted masking using the rectangular, elliptical and polygonal masking selectors.

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -279,3 +279,6 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
     def apply_masking_clicked(self):
         pass
+
+    def invert_masking_clicked(self, active) -> None:
+        pass

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -74,7 +74,8 @@ class CursorInfoBase(ABC):
 
     @staticmethod
     def consolidate_inverted_table_rows(table_rows):
-        consolidated_rows = CursorInfoBase.create_consolidated_dict(table_rows)
+        unpacked_table_rows = CursorInfoBase.unpack_table_rows(table_rows)
+        consolidated_rows = CursorInfoBase.create_consolidated_dict(unpacked_table_rows)
         new_table_rows = []
         for spec, xvals in consolidated_rows.items():
             starts = set()
@@ -90,7 +91,60 @@ class CursorInfoBase(ABC):
                 if start < stop:
                     new_table_rows.append(TableRow(spec_list=spec, x_min=start, x_max=stop))
 
-        return new_table_rows
+        packed_new_table_rows = CursorInfoBase.pack_table_rows(new_table_rows)
+        return packed_new_table_rows
+
+    @staticmethod
+    def unpack_table_rows(table_rows):
+        unpacked_table_rows = []
+        for row in table_rows:
+            if "-" not in row.spec_list:
+                unpacked_table_rows.append(row)
+                continue
+            start, end = map(int, row.spec_list.split("-", 1))
+            for spec in range(start, end + 1):
+                unpacked_table_rows.append(TableRow(spec_list=str(spec), x_min=row.x_min, x_max=row.x_max))
+        return unpacked_table_rows
+
+    @staticmethod
+    def pack_table_rows(table_rows):
+        packed_table_rows = []
+        packing_summary = {}
+        for row in table_rows:
+            key = (row.x_min, row.x_max)
+            packing_summary.setdefault(key, []).extend([int(row.spec_list)])
+
+        for (x_min, x_max), specs in packing_summary.items():
+            ranges = CursorInfoBase.find_ranges(specs)
+            for spec_list in ranges:
+                packed_table_rows.append(
+                    TableRow(
+                        spec_list=spec_list,
+                        x_min=x_min,
+                        x_max=x_max,
+                    )
+                )
+        return packed_table_rows
+
+    @staticmethod
+    def find_ranges(specs):
+        specs = sorted(set(specs))
+        ranges = []
+        start = prev = specs[0]
+        for spec in specs[1:]:
+            if spec == prev + 1:
+                prev = spec
+                continue
+            if start == prev:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{prev}")
+            start = prev = spec
+        if start == prev:
+            ranges.append(str(start))
+        else:
+            ranges.append(f"{start}-{prev}")
+        return ranges
 
     @property
     def table_rows(self):
@@ -133,15 +187,11 @@ class RectCursorInfoBase(CursorInfoBase, ABC):
         y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
 
         # Mask everything outside selected rectangle
-        rows = []
-        for s in range(spec_min, y_min):
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_max))
-        for s in range(y_min, y_max + 1):
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_data[0]))
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_data[-1], x_max=x_max))
-        for s in range(y_max + 1, spec_max + 1):
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_max))
-        return rows
+        row1 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_min, x_max=x_data[0])
+        row2 = TableRow(spec_list=f"{spec_min}-{y_min}", x_min=x_data[0], x_max=x_data[-1])
+        row3 = TableRow(spec_list=f"{y_max}-{spec_max}", x_min=x_data[0], x_max=x_data[-1])
+        row4 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_data[-1], x_max=x_max)
+        return [row1, row2, row3, row4]
 
 
 class RectCursorInfo(RectCursorInfoBase):
@@ -323,10 +373,8 @@ class PolyCursorInfo(CursorInfoBase):
         y_range = [n / 3 for n in range(y_min * 3, (y_max * 3) + 1)]
 
         # Mask the rectangles above and below the polygon
-        for s in range(spec_min, round(y_range[0]) + 1):
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_axis_min, x_max=x_axis_max))
-        for s in range(round(y_range[-1]), spec_max + 1):
-            rows.append(TableRow(spec_list=f"{s}", x_min=x_axis_min, x_max=x_axis_max))
+        rows.append(TableRow(spec_list=f"{spec_min}-{str(round(y_range[0]))}", x_min=x_axis_min, x_max=x_axis_max))
+        rows.append(TableRow(spec_list=f"{str(round(y_range[-1]))}-{spec_max}", x_min=x_axis_min, x_max=x_axis_max))
 
         # Mask the area around the polygon
         for y in y_range:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -102,16 +102,17 @@ class RectCursorInfo(RectCursorInfoBase):
         row = TableRow(spec_list=f"{y_min}-{y_max}", x_min=x_data[0], x_max=x_data[-1])
         return [row]
 
-
-class RectCursorInvertedInfo(RectCursorInfoBase):
-    def __init__(self, click, release, transpose):
-        super().__init__(click, release, transpose)
-
-    def generate_table_rows(self):
+    def generate_inverted_table_rows(self):
+        x_min, x_max, spec_min, spec_max = self._click.extent
+        spec_min = int(ceil(spec_min))
+        spec_max = self.snap_to_bin_centre((spec_max))
         x_data, y_data = self.get_xy_data()
         y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
-        row = TableRow(spec_list=f"{y_min}-{y_max}", x_min=x_data[0], x_max=x_data[-1])
-        return [row]
+        row1 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_min, x_max=x_data[0])
+        row2 = TableRow(spec_list=f"{spec_min}-{y_min}", x_min=x_data[0], x_max=x_data[-1])
+        row3 = TableRow(spec_list=f"{y_max}-{spec_max}", x_min=x_data[0], x_max=x_data[-1])
+        row4 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_data[-1], x_max=x_max)
+        return [row1, row2, row3, row4]
 
 
 class ElliCursorInfo(RectCursorInfoBase):
@@ -143,6 +144,9 @@ class ElliCursorInfo(RectCursorInfoBase):
     @staticmethod
     def _calc_sqrt_portion(y, a, b, k):
         return sqrt(round((a**2) * (1 - ((y - k) ** 2) / (b**2)), ALLOWABLE_ERROR_SIG_FIGS))
+
+    def generate_inverted_table_rows(self):
+        pass
 
 
 class PolyCursorInfo(CursorInfoBase):
@@ -243,6 +247,9 @@ class PolyCursorInfo(CursorInfoBase):
             return False
         return True
 
+    def generate_inverted_table_rows(self):
+        pass
+
 
 class MaskingModel:
     def __init__(self, ws_name):
@@ -289,7 +296,10 @@ class MaskingModel:
     def generate_mask_table_ws(self, store_in_ads=True):
         table_rows = []
         for info in self._masks:
-            table_rows.extend(info.generate_table_rows())
+            if self._apply_inverted_mask:
+                table_rows.extend(info.generate_inverted_table_rows())
+            else:
+                table_rows.extend(info.generate_table_rows())
         return self.create_table_workspace_from_rows(table_rows, store_in_ads)
 
     def export_selectors(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -103,6 +103,17 @@ class RectCursorInfo(RectCursorInfoBase):
         return [row]
 
 
+class RectCursorInvertedInfo(RectCursorInfoBase):
+    def __init__(self, click, release, transpose):
+        super().__init__(click, release, transpose)
+
+    def generate_table_rows(self):
+        x_data, y_data = self.get_xy_data()
+        y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
+        row = TableRow(spec_list=f"{y_min}-{y_max}", x_min=x_data[0], x_max=x_data[-1])
+        return [row]
+
+
 class ElliCursorInfo(RectCursorInfoBase):
     def __init__(self, click, release, transpose):
         super().__init__(click, release, transpose)
@@ -238,6 +249,7 @@ class MaskingModel:
         self._active_mask = None
         self._masks = []
         self._ws_name = ws_name
+        self._apply_inverted_mask = False
 
     def update_active_mask(self, mask):
         self._active_mask = mask
@@ -293,3 +305,6 @@ class MaskingModel:
         alg.setProperty("MaskingInformation", mask_ws)
         alg.setProperty("InputWorkspaceIndexType", "SpectrumNumber")
         alg.execute()
+
+    def invert_masking_clicked(self, active):
+        self._apply_inverted_mask = active

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -5,7 +5,6 @@ from mantid.api import WorkspaceFactory, AnalysisDataService, AlgorithmManager
 from sys import float_info
 from numpy import inf
 
-# from qtpy.QtWidgets import QMessageBox
 from mantid.kernel import logger
 
 ALLOWABLE_ERROR_SIG_FIGS = 8
@@ -33,20 +32,23 @@ class CursorInfoBase(ABC):
         pass
 
     @staticmethod
-    def consolidate_table_rows(table_rows):
+    def create_consolidated_dict(table_rows):
         @dataclass()
         class XVal:
             start: bool
             val: float
 
-        def sort_fn(e):
-            return e.val
-
         consolidated_rows = {}
         for row in table_rows:
-            if row.spec_list not in consolidated_rows:
-                consolidated_rows[row.spec_list] = []
-            consolidated_rows[row.spec_list].extend([XVal(start=True, val=row.x_min), XVal(start=False, val=row.x_max)])
+            consolidated_rows.setdefault(row.spec_list, []).extend([XVal(start=True, val=row.x_min), XVal(start=False, val=row.x_max)])
+        return consolidated_rows
+
+    @staticmethod
+    def consolidate_table_rows(table_rows):
+        consolidated_rows = CursorInfoBase.create_consolidated_dict(table_rows)
+
+        def sort_fn(e):
+            return e.val
 
         new_table_rows = []
         for row in consolidated_rows.items():
@@ -69,6 +71,26 @@ class CursorInfoBase(ABC):
             x_maxs.append(row[1][-1].val)
             for i in range(len(x_mins)):
                 new_table_rows.append(TableRow(spec_list=row[0], x_min=x_mins[i], x_max=x_maxs[i]))
+        return new_table_rows
+
+    @staticmethod
+    def consolidate_inverted_table_rows(table_rows):
+        consolidated_rows = CursorInfoBase.create_consolidated_dict(table_rows)
+        new_table_rows = []
+        for spec, xvals in consolidated_rows.items():
+            starts = set()
+            stops = set()
+            for val in xvals:
+                if val.start:
+                    starts.add(val.val)
+                else:
+                    stops.add(val.val)
+            starts = sorted(starts)
+            stops = sorted(stops)
+            for start, stop in zip(starts, stops):
+                if start < stop:
+                    new_table_rows.append(TableRow(spec_list=spec, x_min=start, x_max=stop))
+
         return new_table_rows
 
     @property
@@ -112,11 +134,15 @@ class RectCursorInfoBase(CursorInfoBase, ABC):
         y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
 
         # Mask everything outside selected rectangle
-        row1 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_min, x_max=x_data[0])
-        row2 = TableRow(spec_list=f"{spec_min}-{y_min}", x_min=x_data[0], x_max=x_data[-1])
-        row3 = TableRow(spec_list=f"{y_max}-{spec_max}", x_min=x_data[0], x_max=x_data[-1])
-        row4 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_data[-1], x_max=x_max)
-        return [row1, row2, row3, row4]
+        rows = []
+        for s in range(spec_min, y_min):
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_max))
+        for s in range(y_min, y_max + 1):
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_data[0]))
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_data[-1], x_max=x_max))
+        for s in range(y_max + 1, spec_max + 1):
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_min, x_max=x_max))
+        return rows
 
 
 class RectCursorInfo(RectCursorInfoBase):
@@ -298,8 +324,10 @@ class PolyCursorInfo(CursorInfoBase):
         y_range = [n / 3 for n in range(y_min * 3, (y_max * 3) + 1)]
 
         # Mask the rectangles above and below the polygon
-        rows.append(TableRow(spec_list=f"{spec_min}-{str(round(y_range[0]))}", x_min=x_axis_min, x_max=x_axis_max))
-        rows.append(TableRow(spec_list=f"{str(round(y_range[-1]))}-{spec_max}", x_min=x_axis_min, x_max=x_axis_max))
+        for s in range(spec_min, round(y_range[0]) + 1):
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_axis_min, x_max=x_axis_max))
+        for s in range(round(y_range[-1]), spec_max + 1):
+            rows.append(TableRow(spec_list=f"{s}", x_min=x_axis_min, x_max=x_axis_max))
 
         # Mask the area around the polygon
         for y in y_range:
@@ -359,6 +387,8 @@ class MaskingModel:
                 table_rows.extend(info.generate_inverted_table_rows())
             else:
                 table_rows.extend(info.generate_table_rows())
+        if self._apply_inverted_mask and len(self._masks) > 1:
+            table_rows = self._masks[0].consolidate_inverted_table_rows(table_rows)
         return self.create_table_workspace_from_rows(table_rows, store_in_ads)
 
     def export_selectors(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -5,6 +5,9 @@ from mantid.api import WorkspaceFactory, AnalysisDataService, AlgorithmManager
 from sys import float_info
 from numpy import inf
 
+# from qtpy.QtWidgets import QMessageBox
+from mantid.kernel import logger
+
 ALLOWABLE_ERROR_SIG_FIGS = 8
 
 
@@ -374,3 +377,7 @@ class MaskingModel:
 
     def invert_masking_clicked(self, active):
         self._apply_inverted_mask = active
+        if active:
+            logger.warning("Inverted masking is enabled. This will apply the mask around the selected region.")
+        else:
+            logger.notice("Inverted masking disabled.")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -25,6 +25,10 @@ class CursorInfoBase(ABC):
     def generate_table_rows(self):
         pass
 
+    @abstractmethod
+    def generate_inverted_table_rows(self):
+        pass
+
     @staticmethod
     def consolidate_table_rows(table_rows):
         @dataclass()
@@ -91,12 +95,20 @@ class RectCursorInfoBase(CursorInfoBase, ABC):
         x_data = sorted([self._click.data[0], self._release.data[0]])
         return (x_data, y_data) if not self._transpose else (y_data, x_data)
 
-    def get_rows_outside_rect(self):
-        x_min, x_max, spec_min, spec_max = self._click.extent
+    def get_image_axis_boundaries(self, click):
+        x_min, x_max, spec_min, spec_max = click.extent
+        # Round the spec min and max
         spec_min = int(ceil(spec_min))
         spec_max = self.snap_to_bin_centre((spec_max))
+        return x_min, x_max, spec_min, spec_max
+
+    def get_rows_outside_rect(self):
+        # Get the axis limits
+        x_min, x_max, spec_min, spec_max = self.get_image_axis_boundaries(self._click)
         x_data, y_data = self.get_xy_data()
         y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
+
+        # Mask everything outside selected rectangle
         row1 = TableRow(spec_list=f"{spec_min}-{spec_max}", x_min=x_min, x_max=x_data[0])
         row2 = TableRow(spec_list=f"{spec_min}-{y_min}", x_min=x_data[0], x_max=x_data[-1])
         row3 = TableRow(spec_list=f"{y_max}-{spec_max}", x_min=x_data[0], x_max=x_data[-1])
@@ -127,7 +139,7 @@ class ElliCursorInfo(RectCursorInfoBase):
         y_range, a, b, h, k = self._process_elli_parameters(x_data, y_data)
 
         rows = []
-        for index, y in enumerate(y_range):
+        for y in y_range:
             x_min, x_max = self._calc_x_val(y, a, b, h, k)
             x_min = x_min - 10**-ALLOWABLE_ERROR_SIG_FIGS if x_min == x_max else x_min  # slightly adjust min value so x vals are different.
             rows.append(TableRow(spec_list=str(round(y)), x_min=x_min, x_max=x_max))
@@ -159,9 +171,10 @@ class ElliCursorInfo(RectCursorInfoBase):
         y_range, a, b, h, k = self._process_elli_parameters(x_data, y_data)
 
         rows = []
-        for index, y in enumerate(y_range):
+        for y in y_range:
             x_min, x_max = self._calc_x_val(y, a, b, h, k)
-            x_min = x_min - 10**-ALLOWABLE_ERROR_SIG_FIGS if x_min == x_max else x_min  # slightly adjust min value so x vals are different.
+            # slightly adjust min value so x vals are different.
+            x_min = x_min - 10**-ALLOWABLE_ERROR_SIG_FIGS if x_min == x_max else x_min
             rows.append(TableRow(spec_list=str(round(y)), x_min=x_data[0], x_max=x_min))
             rows.append(TableRow(spec_list=str(round(y)), x_min=x_max, x_max=x_data[-1]))
         rows = self.consolidate_table_rows(rows)
@@ -169,8 +182,10 @@ class ElliCursorInfo(RectCursorInfoBase):
 
 
 class PolyCursorInfo(CursorInfoBase):
-    def __init__(self, nodes, transpose):
+    def __init__(self, nodes, transpose, x_limits, y_limits):
         super().__init__(transpose)
+        self._x_limits = x_limits
+        self._y_limits = y_limits
 
         self._lines = self._generate_lines(nodes)
         if not self._check_intersecting_lines():
@@ -267,7 +282,29 @@ class PolyCursorInfo(CursorInfoBase):
         return True
 
     def generate_inverted_table_rows(self):
-        pass
+        rows = []
+
+        # Get the axis limits to mask eveything outside the selected polygon
+        x_axis_min, x_axis_max = self._x_limits
+        spec_min, spec_max = self._y_limits
+        spec_min = int(ceil(spec_min))
+        spec_max = self.snap_to_bin_centre((spec_max))
+        y_min, y_max = self._extract_global_y_limits()
+
+        # inclusive range with 1/3 step for greater resolution
+        y_range = [n / 3 for n in range(y_min * 3, (y_max * 3) + 1)]
+
+        # Mask the rectangles above and below the polygon
+        rows.append(TableRow(spec_list=f"{spec_min}-{str(round(y_range[0]))}", x_min=x_axis_min, x_max=x_axis_max))
+        rows.append(TableRow(spec_list=f"{str(round(y_range[-1]))}-{spec_max}", x_min=x_axis_min, x_max=x_axis_max))
+
+        # Mask the area around the polygon
+        for y in y_range:
+            x_val_pairs = self._calculate_relevant_x_value_pairs(y)
+            for x_min, x_max in x_val_pairs:
+                rows.append(TableRow(spec_list=str(round(y)), x_min=x_axis_min, x_max=x_min))
+                rows.append(TableRow(spec_list=str(round(y)), x_min=x_max, x_max=x_axis_max))
+        return self.consolidate_table_rows(rows)
 
 
 class MaskingModel:
@@ -297,8 +334,8 @@ class MaskingModel:
     def add_elli_cursor_info(self, click, release, transpose):
         self.update_active_mask(ElliCursorInfo(click=click, release=release, transpose=transpose))
 
-    def add_poly_cursor_info(self, nodes, transpose):
-        self.update_active_mask(PolyCursorInfo(nodes=nodes, transpose=transpose))
+    def add_poly_cursor_info(self, nodes, transpose, x_limits, y_limits):
+        self.update_active_mask(PolyCursorInfo(nodes=nodes, transpose=transpose, x_limits=x_limits, y_limits=y_limits))
 
     def create_table_workspace_from_rows(self, table_rows, store_in_ads):
         # create table ws_from rows

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -51,14 +51,14 @@ class CursorInfoBase(ABC):
             return e.val
 
         new_table_rows = []
-        for row in consolidated_rows.items():
-            row[1].sort(key=sort_fn)
-            x_mins = [row[1][0].val]
+        for spec, xvals in consolidated_rows.items():
+            xvals.sort(key=sort_fn)
+            x_mins = [xvals[0].val]
             x_maxs = []
             found_end = False
             x_max = None
-            if len(row[1]) > 2:
-                for val in row[1][1:-1]:
+            if len(xvals) > 2:
+                for val in xvals[1:-1]:
                     if not found_end and not val.start:
                         found_end = True
                         x_max = val.val
@@ -68,9 +68,9 @@ class CursorInfoBase(ABC):
                         x_maxs.append(x_max)
                         x_mins.append(val.val)
                         found_end = False
-            x_maxs.append(row[1][-1].val)
+            x_maxs.append(xvals[-1].val)
             for i in range(len(x_mins)):
-                new_table_rows.append(TableRow(spec_list=row[0], x_min=x_mins[i], x_max=x_maxs[i]))
+                new_table_rows.append(TableRow(spec_list=spec, x_min=x_mins[i], x_max=x_maxs[i]))
         return new_table_rows
 
     @staticmethod

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -91,18 +91,7 @@ class RectCursorInfoBase(CursorInfoBase, ABC):
         x_data = sorted([self._click.data[0], self._release.data[0]])
         return (x_data, y_data) if not self._transpose else (y_data, x_data)
 
-
-class RectCursorInfo(RectCursorInfoBase):
-    def __init__(self, click, release, transpose):
-        super().__init__(click, release, transpose)
-
-    def generate_table_rows(self):
-        x_data, y_data = self.get_xy_data()
-        y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
-        row = TableRow(spec_list=f"{y_min}-{y_max}", x_min=x_data[0], x_max=x_data[-1])
-        return [row]
-
-    def generate_inverted_table_rows(self):
+    def get_rows_outside_rect(self):
         x_min, x_max, spec_min, spec_max = self._click.extent
         spec_min = int(ceil(spec_min))
         spec_max = self.snap_to_bin_centre((spec_max))
@@ -115,21 +104,27 @@ class RectCursorInfo(RectCursorInfoBase):
         return [row1, row2, row3, row4]
 
 
+class RectCursorInfo(RectCursorInfoBase):
+    def __init__(self, click, release, transpose):
+        super().__init__(click, release, transpose)
+
+    def generate_table_rows(self):
+        x_data, y_data = self.get_xy_data()
+        y_min, y_max = self.snap_to_bin_centre(y_data[0]), self.snap_to_bin_centre(y_data[-1])
+        row = TableRow(spec_list=f"{y_min}-{y_max}", x_min=x_data[0], x_max=x_data[-1])
+        return [row]
+
+    def generate_inverted_table_rows(self):
+        return self.get_rows_outside_rect()
+
+
 class ElliCursorInfo(RectCursorInfoBase):
     def __init__(self, click, release, transpose):
         super().__init__(click, release, transpose)
 
     def generate_table_rows(self):
         x_data, y_data = self.get_xy_data()
-        y_min = self.snap_to_bin_centre(y_data[0])
-        y_max = self.snap_to_bin_centre(y_data[1])
-        y_range = [n / 3 for n in range(y_min * 3, (y_max * 3) + 1)]  # inclusive range with 1/3 step for greater resolution
-
-        x_min, x_max = x_data[0], x_data[-1]
-        a = (x_max - x_min) / 2
-        b = (y_max - y_min) / 2
-        h = x_min + a
-        k = y_min + b
+        y_range, a, b, h, k = self._process_elli_parameters(x_data, y_data)
 
         rows = []
         for index, y in enumerate(y_range):
@@ -145,8 +140,32 @@ class ElliCursorInfo(RectCursorInfoBase):
     def _calc_sqrt_portion(y, a, b, k):
         return sqrt(round((a**2) * (1 - ((y - k) ** 2) / (b**2)), ALLOWABLE_ERROR_SIG_FIGS))
 
+    def _process_elli_parameters(self, x_data, y_data):
+        y_min = self.snap_to_bin_centre(y_data[0])
+        y_max = self.snap_to_bin_centre(y_data[1])
+        y_range = [n / 3 for n in range(y_min * 3, (y_max * 3) + 1)]  # inclusive range with 1/3 step for greater resolution
+
+        x_min, x_max = x_data[0], x_data[-1]
+        a = (x_max - x_min) / 2
+        b = (y_max - y_min) / 2
+        h = x_min + a
+        k = y_min + b
+        return y_range, a, b, h, k
+
     def generate_inverted_table_rows(self):
-        pass
+        rect_rows = self.get_rows_outside_rect()
+
+        x_data, y_data = self.get_xy_data()
+        y_range, a, b, h, k = self._process_elli_parameters(x_data, y_data)
+
+        rows = []
+        for index, y in enumerate(y_range):
+            x_min, x_max = self._calc_x_val(y, a, b, h, k)
+            x_min = x_min - 10**-ALLOWABLE_ERROR_SIG_FIGS if x_min == x_max else x_min  # slightly adjust min value so x vals are different.
+            rows.append(TableRow(spec_list=str(round(y)), x_min=x_data[0], x_max=x_min))
+            rows.append(TableRow(spec_list=str(round(y)), x_min=x_max, x_max=x_data[-1]))
+        rows = self.consolidate_table_rows(rows)
+        return rect_rows + rows
 
 
 class PolyCursorInfo(CursorInfoBase):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -5,7 +5,6 @@ from mantid.api import WorkspaceFactory, AnalysisDataService, AlgorithmManager
 from sys import float_info
 from numpy import inf
 
-from mantid.kernel import logger
 
 ALLOWABLE_ERROR_SIG_FIGS = 8
 
@@ -407,7 +406,3 @@ class MaskingModel:
 
     def invert_masking_clicked(self, active):
         self._apply_inverted_mask = active
-        if active:
-            logger.warning("Inverted masking is enabled. This will apply the mask around the selected region.")
-        else:
-            logger.notice("Inverted masking disabled.")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
@@ -229,3 +229,6 @@ class Masking:
     def clear_model(self):
         self._model.clear_active_mask()
         self._model.clear_stored_masks()
+
+    def invert_masking_clicked(self, active):
+        self._model.invert_masking_clicked(active)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
@@ -154,8 +154,10 @@ class PolygonSelectionMasking(SelectionMaskingBase):
         self._clear = False
         self._dataview.mpl_toolbar.set_action_checked(SELECTOR_TO_TOOL_ITEM_TEXT[self.__class__], False, trigger=False)
         nodes = [cursor_info(self._img, node[0], node[1]) for node in eclick]
+        x_limits = self._dataview.ax.get_xlim()
+        y_limits = self._dataview.ax.get_ylim()
         try:
-            self._model.add_poly_cursor_info(nodes=nodes, transpose=self._transpose)
+            self._model.add_poly_cursor_info(nodes=nodes, transpose=self._transpose, x_limits=x_limits, y_limits=y_limits)
         except RuntimeError as e:
             self.clear()
             self._mask_drawn = False

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -621,6 +621,9 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             self.view.data_view.masking.apply_selectors()
             self.replace_workspace(self.model.ws.name(), self.model.ws)
 
+    def invert_masking_clicked(self, active) -> None:
+        self.view.data_view.masking.invert_masking_clicked(active)
+
 
 class SliceViewXAxisEditor(XAxisEditor):
     def __init__(self, canvas, axes, dimensions_changed):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -58,6 +58,9 @@ class SliceViewerBasePresenterShim(SliceViewerBasePresenter):
     def rect_masking_clicked(self, active):
         pass
 
+    def invert_masking_clicked(self, active):
+        pass
+
 
 class SliceViewerBasePresenterTest(unittest.TestCase):
     def setUp(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -90,13 +90,15 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
             self.model.generate_mask_table_ws(store_in_ads=False)
             create_tbl_mock.assert_called_once_with(["test_0", "test_1", "test_2"], False)
 
-    def test_generate_mask_table_ws_inverted(self):
+    @patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows")
+    def test_generate_mask_table_ws_inverted(self, create_tbl_mock):
         mock_masks = [Mock(generate_inverted_table_rows=Mock(return_value=[f"test_{i}"])) for i in range(3)]
+        mock_masks[0].consolidate_inverted_table_rows.return_value = ["consolidated"]
         self.model._masks = mock_masks
         self.model._apply_inverted_mask = True
-        with patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows") as create_tbl_mock:
-            self.model.generate_mask_table_ws(store_in_ads=False)
-            create_tbl_mock.assert_called_once_with(["test_0", "test_1", "test_2"], False)
+        self.model.generate_mask_table_ws(store_in_ads=False)
+        mock_masks[0].consolidate_inverted_table_rows.assert_called_once_with(["test_0", "test_1", "test_2"])
+        create_tbl_mock.assert_called_once_with(["consolidated"], False)
 
     def test_invert_masking_clicked(self):
         with patch("mantidqt.widgets.sliceviewer.models.masking.logger") as logger_mock:
@@ -172,10 +174,28 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="1-10", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="1-1", x_min=-5.2, x_max=5.6),
-            TableRow(spec_list="11-10", x_min=-5.2, x_max=5.6),
-            TableRow(spec_list="1-10", x_min=5.6, x_max=10),
+            TableRow(spec_list="1", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="1", x_min=5.6, x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="2", x_min=5.6, x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="3", x_min=5.6, x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="4", x_min=5.6, x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="5", x_min=5.6, x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="6", x_min=5.6, x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="7", x_min=5.6, x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="8", x_min=5.6, x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="9", x_min=5.6, x_max=10),
+            TableRow(spec_list="10", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="10", x_min=5.6, x_max=10),
+            TableRow(spec_list="11", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="11", x_min=5.6, x_max=10),
         ]
         self._assert_table_rows_delta(actual_rows, expected_table_rows, delta=0.001)
 
@@ -203,10 +223,25 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="1-10", x_min=-0.5, x_max=3),
-            TableRow(spec_list="1-0", x_min=3, x_max=5),
-            TableRow(spec_list="7-10", x_min=3, x_max=5),
-            TableRow(spec_list="1-10", x_min=5, x_max=10),
+            TableRow(spec_list="0", x_min=-0.5, x_max=3),
+            TableRow(spec_list="0", x_min=5, x_max=10),
+            TableRow(spec_list="1", x_min=-0.5, x_max=3),
+            TableRow(spec_list="1", x_min=5, x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=3),
+            TableRow(spec_list="2", x_min=5, x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=3),
+            TableRow(spec_list="3", x_min=5, x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=3),
+            TableRow(spec_list="4", x_min=5, x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=3),
+            TableRow(spec_list="5", x_min=5, x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=3),
+            TableRow(spec_list="6", x_min=5, x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=3),
+            TableRow(spec_list="7", x_min=5, x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=10),
+            TableRow(spec_list="10", x_min=-0.5, x_max=10),
             TableRow(spec_list="0", x_min=3, x_max=3.99999999),
             TableRow(spec_list="0", x_min=4.0, x_max=5),
             TableRow(spec_list="1", x_min=3, x_max=3.4129129536431586),
@@ -259,8 +294,13 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="1-0", x_min=-0.5, x_max=15),
-            TableRow(spec_list="10-15", x_min=-0.5, x_max=15),
+            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=15),
+            TableRow(spec_list="11", x_min=-0.5, x_max=15),
+            TableRow(spec_list="12", x_min=-0.5, x_max=15),
+            TableRow(spec_list="13", x_min=-0.5, x_max=15),
+            TableRow(spec_list="14", x_min=-0.5, x_max=15),
+            TableRow(spec_list="15", x_min=-0.5, x_max=15),
             TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=15),
             TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
@@ -281,8 +321,6 @@ class CursorInfoTest(unittest.TestCase):
             TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=15),
             TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=15),
-            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="10", x_min=float64(0.0), x_max=15),
         ]
         self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -16,6 +16,7 @@ from numpy import float64
 
 class SliceViewerMaskingModelTest(unittest.TestCase):
     TableRow = namedtuple("TableRow", ["spec_list", "x_min", "x_max"])
+    Click = namedtuple("Click", ["data", "extent"], defaults=[None])
 
     def setUp(self):
         self.model = MaskingModel("test_ws_name")
@@ -141,6 +142,192 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
                 ]
             )
             alg_mock.execute.assert_called_once()
+
+    @patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows")
+    def test_poly_generate_mask_table_ws_inverted(self, create_tbl_mock):
+        self.model._masks = [
+            PolyCursorInfo(
+                [self.Click((float64(0), float64(0))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))],
+                False,
+                (-0.5, 10),
+                (1, 10),
+            ),
+            PolyCursorInfo(
+                [self.Click((float64(0), float64(3))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))],
+                False,
+                (-0.5, 10),
+                (1, 10),
+            ),
+            PolyCursorInfo(
+                [
+                    self.Click((float64(8), float64(8))),
+                    self.Click((float64(9), float64(9))),
+                    self.Click((float64(10), float64(8))),
+                    self.Click((float64(8), float64(8))),
+                ],
+                False,
+                (-0.5, 10),
+                (1, 10),
+            ),
+        ]
+        self.model._apply_inverted_mask = True
+        self.model.generate_mask_table_ws(store_in_ads=False)
+        expected_call_args = [
+            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=10),
+            TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=10),
+            TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="3", x_min=float64(1.6666666666666674), x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="4", x_min=float64(3.3333333333333326), x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="5", x_min=float64(8.333333333333334), x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="6", x_min=float64(7.333333333333334), x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="7", x_min=float64(5.333333333333334), x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=float64(8.333333333333334)),
+            TableRow(spec_list="8", x_min=float64(9.666666666666666), x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=float64(8.99999999)),
+            TableRow(spec_list="9", x_min=float64(9.0), x_max=10),
+        ]
+        create_tbl_mock.assert_called_once_with(expected_call_args, False)
+
+    @patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows")
+    def test_elli_generate_mask_table_ws_inverted(self, create_tbl_mock):
+        self.model._masks = [
+            ElliCursorInfo(self.Click(data=(3, 0), extent=(-0.5, 10, 1, 10)), self.Click(data=(5, 7), extent=(-0.5, 10, 1, 10)), False),
+            ElliCursorInfo(self.Click(data=(1, 2), extent=(-0.5, 10, 1, 10)), self.Click(data=(6, 8), extent=(-0.5, 10, 1, 10)), False),
+            ElliCursorInfo(self.Click(data=(9, 9), extent=(-0.5, 10, 1, 10)), self.Click(data=(10, 8), extent=(-0.5, 10, 1, 10)), False),
+        ]
+        self.model._apply_inverted_mask = True
+        self.model.generate_mask_table_ws(store_in_ads=False)
+        expected_call_args = [
+            TableRow(spec_list="0", x_min=-0.5, x_max=3),
+            TableRow(spec_list="0", x_min=3, x_max=3.99999999),
+            TableRow(spec_list="0", x_min=4.0, x_max=5),
+            TableRow(spec_list="0", x_min=5, x_max=10),
+            TableRow(spec_list="1", x_min=-0.5, x_max=3),
+            TableRow(spec_list="1", x_min=3, x_max=3.4129129536431586),
+            TableRow(spec_list="1", x_min=4.587087046356841, x_max=5),
+            TableRow(spec_list="1", x_min=5, x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=1),
+            TableRow(spec_list="2", x_min=1, x_max=3),
+            TableRow(spec_list="2", x_min=3, x_max=3.1481645816238912),
+            TableRow(spec_list="2", x_min=4.851835418376108, x_max=5),
+            TableRow(spec_list="2", x_min=5, x_max=6),
+            TableRow(spec_list="2", x_min=6, x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=1),
+            TableRow(spec_list="3", x_min=1, x_max=1.9286515981489019),
+            TableRow(spec_list="3", x_min=5.071348401851099, x_max=6),
+            TableRow(spec_list="3", x_min=6, x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=1),
+            TableRow(spec_list="4", x_min=1, x_max=1.2604839585303256),
+            TableRow(spec_list="4", x_min=5.739516041469674, x_max=6),
+            TableRow(spec_list="4", x_min=6, x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=1),
+            TableRow(spec_list="5", x_min=1, x_max=1.0154800242300324),
+            TableRow(spec_list="5", x_min=5.984519975769968, x_max=6),
+            TableRow(spec_list="5", x_min=6, x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=1),
+            TableRow(spec_list="6", x_min=1, x_max=1.2604839585303256),
+            TableRow(spec_list="6", x_min=5.739516041469674, x_max=6),
+            TableRow(spec_list="6", x_min=6, x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=1),
+            TableRow(spec_list="7", x_min=1, x_max=1.9286515981489019),
+            TableRow(spec_list="7", x_min=5.071348401851099, x_max=6),
+            TableRow(spec_list="7", x_min=6, x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=1),
+            TableRow(spec_list="8", x_min=1, x_max=3.49999999),
+            TableRow(spec_list="8", x_min=3.5, x_max=6),
+            TableRow(spec_list="8", x_min=6, x_max=9),
+            TableRow(spec_list="8", x_min=9, x_max=9.49999999),
+            TableRow(spec_list="8", x_min=9.5, x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=9),
+            TableRow(spec_list="9", x_min=9, x_max=9.49999999),
+            TableRow(spec_list="9", x_min=9.5, x_max=10),
+            TableRow(spec_list="10", x_min=-0.5, x_max=10),
+        ]
+        create_tbl_mock.assert_called_once_with(expected_call_args, False)
+
+    @patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows")
+    def test_rect_generate_mask_table_ws_inverted(self, create_tbl_mock):
+        self.model._masks = [
+            RectCursorInfo(self.Click(data=(1, 1), extent=(-0.5, 10, 1, 10)), self.Click(data=(1, 3), extent=(-0.5, 10, 1, 10)), False),
+            RectCursorInfo(self.Click(data=(1, 2), extent=(-0.5, 10, 1, 10)), self.Click(data=(2, 4), extent=(-0.5, 10, 1, 10)), False),
+            RectCursorInfo(self.Click(data=(6, 8), extent=(-0.5, 10, 1, 10)), self.Click(data=(6, 7), extent=(-0.5, 10, 1, 10)), False),
+        ]
+        self.model._apply_inverted_mask = True
+        self.model.generate_mask_table_ws(store_in_ads=False)
+        expected_call_args = [
+            TableRow(spec_list="1", x_min=-0.5, x_max=1),
+            TableRow(spec_list="1", x_min=1, x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=1),
+            TableRow(spec_list="2", x_min=1, x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=1),
+            TableRow(spec_list="3", x_min=1, x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=1),
+            TableRow(spec_list="4", x_min=2, x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=6),
+            TableRow(spec_list="7", x_min=6, x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=6),
+            TableRow(spec_list="8", x_min=6, x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=10),
+            TableRow(spec_list="10", x_min=-0.5, x_max=10),
+        ]
+        create_tbl_mock.assert_called_once_with(expected_call_args, False)
+
+    @patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows")
+    def test_mixed_generate_mask_table_ws_inverted(self, create_tbl_mock):
+        self.model._masks = [
+            RectCursorInfo(self.Click(data=(6, 8), extent=(-0.5, 10, 1, 10)), self.Click(data=(6, 7), extent=(-0.5, 10, 1, 10)), False),
+            ElliCursorInfo(self.Click(data=(1, 7), extent=(-0.5, 10, 1, 10)), self.Click(data=(6, 8), extent=(-0.5, 10, 1, 10)), False),
+            PolyCursorInfo(
+                [self.Click((float64(0), float64(0))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))],
+                False,
+                (-0.5, 10),
+                (1, 10),
+            ),
+        ]
+        self.model._apply_inverted_mask = True
+        self.model.generate_mask_table_ws(store_in_ads=False)
+        expected_call_args = [
+            TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=10),
+            TableRow(spec_list="2", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=10),
+            TableRow(spec_list="3", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="3", x_min=float64(5.333333333333333), x_max=10),
+            TableRow(spec_list="4", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="4", x_min=float64(7.333333333333333), x_max=10),
+            TableRow(spec_list="5", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="5", x_min=float64(9.333333333333334), x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="6", x_min=float64(7.333333333333334), x_max=10),
+            TableRow(spec_list="7", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="7", x_min=float64(5.333333333333334), x_max=6),
+            TableRow(spec_list="7", x_min=6, x_max=10),
+            TableRow(spec_list="8", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=3.49999999),
+            TableRow(spec_list="8", x_min=3.5, x_max=6),
+            TableRow(spec_list="8", x_min=6, x_max=10),
+            TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=10),
+            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=10),
+            TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=10),
+        ]
+        create_tbl_mock.assert_called_once_with(expected_call_args, False)
 
 
 class CursorInfoTest(unittest.TestCase):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -90,6 +90,20 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
             self.model.generate_mask_table_ws(store_in_ads=False)
             create_tbl_mock.assert_called_once_with(["test_0", "test_1", "test_2"], False)
 
+    def test_generate_mask_table_ws_inverted(self):
+        mock_masks = [Mock(generate_inverted_table_rows=Mock(return_value=[f"test_{i}"])) for i in range(3)]
+        self.model._masks = mock_masks
+        self.model._apply_inverted_mask = True
+        with patch("mantidqt.widgets.sliceviewer.models.masking.MaskingModel.create_table_workspace_from_rows") as create_tbl_mock:
+            self.model.generate_mask_table_ws(store_in_ads=False)
+            create_tbl_mock.assert_called_once_with(["test_0", "test_1", "test_2"], False)
+
+    def test_invert_masking_clicked(self):
+        self.model.invert_masking_clicked(True)
+        self.assertEqual(self.model._apply_inverted_mask, True)
+        self.model.invert_masking_clicked(False)
+        self.assertEqual(self.model._apply_inverted_mask, False)
+
     def test_export_selectors(self):
         with (
             patch("mantidqt.widgets.sliceviewer.models.masking.AnalysisDataService") as ads_mock,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -59,7 +59,7 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
 
     @patch("mantidqt.widgets.sliceviewer.models.masking.PolyCursorInfo")
     def test_add_poly_cursor_info(self, CursorInfo_mock):
-        kwargs = {"nodes": "nodes", "transpose": "test_transpose"}
+        kwargs = {"nodes": "nodes", "transpose": "test_transpose", "x_limits": "test_x_limits", "y_limits": "test_y_limits"}
         self.model.add_poly_cursor_info(**kwargs)
         CursorInfo_mock.assert_called_once_with(**kwargs)
 
@@ -169,7 +169,10 @@ class CursorInfoTest(unittest.TestCase):
     def test_poly_cursor_info_generate_table_rows(self):
         # Actual alg uses float64. This is important as divide by 0 returns inf rather than an exception.
         cursor_info = PolyCursorInfo(
-            [self.Click((float64(0), float64(0))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))], False
+            [self.Click((float64(0), float64(0))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))],
+            False,
+            (1, 2),
+            (3, 4),
         )
         actual_rows = cursor_info.generate_table_rows()
         expected_table_rows = [
@@ -196,6 +199,8 @@ class CursorInfoTest(unittest.TestCase):
                 self.Click((float64(10), float64(0))),
             ],
             False,
+            (1, 2),
+            (3, 4),
         )
         actual_rows = cursor_info.generate_table_rows()
         expected_table_rows = [
@@ -226,6 +231,8 @@ class CursorInfoTest(unittest.TestCase):
                     self.Click((float64(10), float64(5))),
                 ],
                 False,
+                (1, 2),
+                (3, 4),
             )
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -124,7 +124,7 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
 
 
 class CursorInfoTest(unittest.TestCase):
-    Click = namedtuple("Click", ["data"])
+    Click = namedtuple("Click", ["data", "extent"], defaults=[None])
 
     @staticmethod
     def _set_up_model_test(text, transpose=False, images=None):
@@ -148,6 +148,19 @@ class CursorInfoTest(unittest.TestCase):
         row = cursor_info.generate_table_rows()
         self.assertEqual(row, [TableRow(spec_list="1-11", x_min=-5.2, x_max=5.6)])
 
+    def test_rect_cursor_info_generate_inverted_table_rows(self):
+        cursor_info = RectCursorInfo(
+            self.Click(data=(-5.2, 0.8), extent=(-0.5, 10, 1, 10)), self.Click(data=(5.6, 10.8), extent=(-0.5, 10, 1, 10)), False
+        )
+        actual_rows = cursor_info.generate_inverted_table_rows()
+        expected_table_rows = [
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="1-1", x_min=-5.2, x_max=5.6),
+            TableRow(spec_list="11-10", x_min=-5.2, x_max=5.6),
+            TableRow(spec_list="1-10", x_min=5.6, x_max=10),
+        ]
+        self._assert_table_rows_delta(actual_rows, expected_table_rows, delta=0.001)
+
     def test_elli_cursor_info_generate_table_rows(self):
         cursor_info = ElliCursorInfo(self.Click((-5, 0)), self.Click((5, 10)), False)
         actual_rows = cursor_info.generate_table_rows()
@@ -163,6 +176,35 @@ class CursorInfoTest(unittest.TestCase):
             TableRow(spec_list="8", x_min=-4.229, x_max=4.229),
             TableRow(spec_list="9", x_min=-3.399, x_max=3.399),
             TableRow(spec_list="10", x_min=-1.795, x_max=1.795),
+        ]
+        self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
+
+    def test_elli_cursor_info_generate_inverted_table_rows(self):
+        cursor_info = ElliCursorInfo(
+            self.Click(data=(3, 0), extent=(-0.5, 10, 1, 10)), self.Click(data=(5, 7), extent=(-0.5, 10, 1, 10)), False
+        )
+        actual_rows = cursor_info.generate_inverted_table_rows()
+        expected_table_rows = [
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=3),
+            TableRow(spec_list="1-0", x_min=3, x_max=5),
+            TableRow(spec_list="7-10", x_min=3, x_max=5),
+            TableRow(spec_list="1-10", x_min=5, x_max=10),
+            TableRow(spec_list="0", x_min=3, x_max=3.99999999),
+            TableRow(spec_list="0", x_min=4.0, x_max=5),
+            TableRow(spec_list="1", x_min=3, x_max=3.4129129536431586),
+            TableRow(spec_list="1", x_min=4.587087046356841, x_max=5),
+            TableRow(spec_list="2", x_min=3, x_max=3.1481645816238912),
+            TableRow(spec_list="2", x_min=4.851835418376108, x_max=5),
+            TableRow(spec_list="3", x_min=3, x_max=3.0287581866496893),
+            TableRow(spec_list="3", x_min=4.971241813350311, x_max=5),
+            TableRow(spec_list="4", x_min=3, x_max=3.0287581866496893),
+            TableRow(spec_list="4", x_min=4.971241813350311, x_max=5),
+            TableRow(spec_list="5", x_min=3, x_max=3.1481645816238912),
+            TableRow(spec_list="5", x_min=4.851835418376108, x_max=5),
+            TableRow(spec_list="6", x_min=3, x_max=3.4129129536431586),
+            TableRow(spec_list="6", x_min=4.587087046356841, x_max=5),
+            TableRow(spec_list="7", x_min=3, x_max=3.99999999),
+            TableRow(spec_list="7", x_min=4.0, x_max=5),
         ]
         self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
 
@@ -187,6 +229,42 @@ class CursorInfoTest(unittest.TestCase):
             TableRow(spec_list="8", x_min=0, x_max=4.666),
             TableRow(spec_list="9", x_min=0, x_max=2.666),
             TableRow(spec_list="10", x_min=0, x_max=0.666),
+        ]
+        self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
+
+    def test_poly_cursor_info_generate_inverted_table_rows(self):
+        cursor_info = PolyCursorInfo(
+            [self.Click((float64(0), float64(0))), self.Click((float64(10), float64(5))), self.Click((float64(0), float64(10)))],
+            False,
+            (-0.5, 15),
+            (1, 15),
+        )
+        actual_rows = cursor_info.generate_inverted_table_rows()
+        expected_table_rows = [
+            TableRow(spec_list="1-0", x_min=-0.5, x_max=15),
+            TableRow(spec_list="10-15", x_min=-0.5, x_max=15),
+            TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=15),
+            TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=15),
+            TableRow(spec_list="2", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=15),
+            TableRow(spec_list="3", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="3", x_min=float64(5.333333333333333), x_max=15),
+            TableRow(spec_list="4", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="4", x_min=float64(7.333333333333333), x_max=15),
+            TableRow(spec_list="5", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="5", x_min=float64(9.333333333333334), x_max=15),
+            TableRow(spec_list="6", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="6", x_min=float64(7.333333333333334), x_max=15),
+            TableRow(spec_list="7", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="7", x_min=float64(5.333333333333334), x_max=15),
+            TableRow(spec_list="8", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=15),
+            TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=15),
+            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=15),
         ]
         self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -102,14 +102,10 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         create_tbl_mock.assert_called_once_with(["consolidated"], False)
 
     def test_invert_masking_clicked(self):
-        with patch("mantidqt.widgets.sliceviewer.models.masking.logger") as logger_mock:
-            self.model.invert_masking_clicked(True)
-            self.assertTrue(self.model._apply_inverted_mask)
-            logger_mock.warning.assert_called_once_with("Inverted masking is enabled. This will apply the mask around the selected region.")
-            logger_mock.reset_mock()
-            self.model.invert_masking_clicked(False)
-            self.assertFalse(self.model._apply_inverted_mask)
-            logger_mock.notice.assert_called_once_with("Inverted masking disabled.")
+        self.model.invert_masking_clicked(True)
+        self.assertTrue(self.model._apply_inverted_mask)
+        self.model.invert_masking_clicked(False)
+        self.assertFalse(self.model._apply_inverted_mask)
 
     def test_export_selectors(self):
         with (

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -99,10 +99,14 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
             create_tbl_mock.assert_called_once_with(["test_0", "test_1", "test_2"], False)
 
     def test_invert_masking_clicked(self):
-        self.model.invert_masking_clicked(True)
-        self.assertEqual(self.model._apply_inverted_mask, True)
-        self.model.invert_masking_clicked(False)
-        self.assertEqual(self.model._apply_inverted_mask, False)
+        with patch("mantidqt.widgets.sliceviewer.models.masking.logger") as logger_mock:
+            self.model.invert_masking_clicked(True)
+            self.assertTrue(self.model._apply_inverted_mask)
+            logger_mock.warning.assert_called_once_with("Inverted masking is enabled. This will apply the mask around the selected region.")
+            logger_mock.reset_mock()
+            self.model.invert_masking_clicked(False)
+            self.assertFalse(self.model._apply_inverted_mask)
+            logger_mock.notice.assert_called_once_with("Inverted masking disabled.")
 
     def test_export_selectors(self):
         with (

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -10,7 +10,14 @@ from unittest.mock import patch, Mock, call
 from collections import namedtuple
 from functools import partial
 
-from mantidqt.widgets.sliceviewer.models.masking import MaskingModel, RectCursorInfo, TableRow, ElliCursorInfo, PolyCursorInfo
+from mantidqt.widgets.sliceviewer.models.masking import (
+    MaskingModel,
+    RectCursorInfo,
+    TableRow,
+    ElliCursorInfo,
+    PolyCursorInfo,
+    CursorInfoBase,
+)
 from numpy import float64
 
 
@@ -169,28 +176,18 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         self.model._apply_inverted_mask = True
         self.model.generate_mask_table_ws(store_in_ads=False)
         expected_call_args = [
-            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="0-10", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="10", x_min=float64(0.0), x_max=10),
-            TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=10),
-            TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="3", x_min=float64(1.6666666666666674), x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="4", x_min=float64(3.3333333333333326), x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="5", x_min=float64(8.333333333333334), x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="6", x_min=float64(7.333333333333334), x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="7", x_min=float64(5.333333333333334), x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=float64(8.333333333333334)),
             TableRow(spec_list="8", x_min=float64(9.666666666666666), x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=float64(8.99999999)),
             TableRow(spec_list="9", x_min=float64(9.0), x_max=10),
         ]
@@ -206,50 +203,35 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         self.model._apply_inverted_mask = True
         self.model.generate_mask_table_ws(store_in_ads=False)
         expected_call_args = [
-            TableRow(spec_list="0", x_min=-0.5, x_max=3),
-            TableRow(spec_list="0", x_min=3, x_max=3.99999999),
-            TableRow(spec_list="0", x_min=4.0, x_max=5),
-            TableRow(spec_list="0", x_min=5, x_max=10),
-            TableRow(spec_list="1", x_min=-0.5, x_max=3),
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=1),
+            TableRow(spec_list="1-2", x_min=1, x_max=3),
+            TableRow(spec_list="8-10", x_min=1, x_max=3),
             TableRow(spec_list="1", x_min=3, x_max=3.4129129536431586),
             TableRow(spec_list="1", x_min=4.587087046356841, x_max=5),
-            TableRow(spec_list="1", x_min=5, x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=1),
-            TableRow(spec_list="2", x_min=1, x_max=3),
+            TableRow(spec_list="1-2", x_min=5, x_max=6),
+            TableRow(spec_list="8-10", x_min=5, x_max=6),
+            TableRow(spec_list="1-10", x_min=6, x_max=9),
+            TableRow(spec_list="1-7", x_min=9, x_max=10),
+            TableRow(spec_list="10", x_min=9, x_max=10),
             TableRow(spec_list="2", x_min=3, x_max=3.1481645816238912),
             TableRow(spec_list="2", x_min=4.851835418376108, x_max=5),
-            TableRow(spec_list="2", x_min=5, x_max=6),
-            TableRow(spec_list="2", x_min=6, x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=1),
             TableRow(spec_list="3", x_min=1, x_max=1.9286515981489019),
+            TableRow(spec_list="7", x_min=1, x_max=1.9286515981489019),
             TableRow(spec_list="3", x_min=5.071348401851099, x_max=6),
-            TableRow(spec_list="3", x_min=6, x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=1),
+            TableRow(spec_list="7", x_min=5.071348401851099, x_max=6),
             TableRow(spec_list="4", x_min=1, x_max=1.2604839585303256),
+            TableRow(spec_list="6", x_min=1, x_max=1.2604839585303256),
             TableRow(spec_list="4", x_min=5.739516041469674, x_max=6),
-            TableRow(spec_list="4", x_min=6, x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=1),
+            TableRow(spec_list="6", x_min=5.739516041469674, x_max=6),
             TableRow(spec_list="5", x_min=1, x_max=1.0154800242300324),
             TableRow(spec_list="5", x_min=5.984519975769968, x_max=6),
-            TableRow(spec_list="5", x_min=6, x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=1),
-            TableRow(spec_list="6", x_min=1, x_max=1.2604839585303256),
-            TableRow(spec_list="6", x_min=5.739516041469674, x_max=6),
-            TableRow(spec_list="6", x_min=6, x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=1),
-            TableRow(spec_list="7", x_min=1, x_max=1.9286515981489019),
-            TableRow(spec_list="7", x_min=5.071348401851099, x_max=6),
-            TableRow(spec_list="7", x_min=6, x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=1),
-            TableRow(spec_list="8", x_min=1, x_max=3.49999999),
-            TableRow(spec_list="8", x_min=3.5, x_max=6),
-            TableRow(spec_list="8", x_min=6, x_max=9),
-            TableRow(spec_list="8", x_min=9, x_max=9.49999999),
-            TableRow(spec_list="8", x_min=9.5, x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=9),
-            TableRow(spec_list="9", x_min=9, x_max=9.49999999),
-            TableRow(spec_list="9", x_min=9.5, x_max=10),
-            TableRow(spec_list="10", x_min=-0.5, x_max=10),
+            TableRow(spec_list="8", x_min=3, x_max=3.49999999),
+            TableRow(spec_list="8", x_min=3.5, x_max=5),
+            TableRow(spec_list="8-9", x_min=9, x_max=9.49999999),
+            TableRow(spec_list="8-9", x_min=9.5, x_max=10),
+            TableRow(spec_list="9-10", x_min=3, x_max=5),
+            TableRow(spec_list="0", x_min=3, x_max=3.99999999),
+            TableRow(spec_list="0", x_min=4.0, x_max=5),
         ]
         create_tbl_mock.assert_called_once_with(expected_call_args, False)
 
@@ -263,22 +245,15 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         self.model._apply_inverted_mask = True
         self.model.generate_mask_table_ws(store_in_ads=False)
         expected_call_args = [
-            TableRow(spec_list="1", x_min=-0.5, x_max=1),
-            TableRow(spec_list="1", x_min=1, x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=1),
-            TableRow(spec_list="2", x_min=1, x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=1),
-            TableRow(spec_list="3", x_min=1, x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=1),
-            TableRow(spec_list="4", x_min=2, x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=6),
-            TableRow(spec_list="7", x_min=6, x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=6),
-            TableRow(spec_list="8", x_min=6, x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=10),
-            TableRow(spec_list="10", x_min=-0.5, x_max=10),
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=1),
+            TableRow(spec_list="1-2", x_min=1, x_max=2),
+            TableRow(spec_list="4-10", x_min=1, x_max=2),
+            TableRow(spec_list="1-2", x_min=2, x_max=6),
+            TableRow(spec_list="4-10", x_min=2, x_max=6),
+            TableRow(spec_list="1-2", x_min=6, x_max=10),
+            TableRow(spec_list="4-10", x_min=6, x_max=10),
+            TableRow(spec_list="3", x_min=1, x_max=6),
+            TableRow(spec_list="3", x_min=2, x_max=10),
         ]
         create_tbl_mock.assert_called_once_with(expected_call_args, False)
 
@@ -297,30 +272,21 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         self.model._apply_inverted_mask = True
         self.model.generate_mask_table_ws(store_in_ads=False)
         expected_call_args = [
-            TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="3", x_min=float64(5.333333333333333), x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="0-10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="1", x_min=float64(1.3333333333333333), x_max=6),
+            TableRow(spec_list="1-3", x_min=6, x_max=10),
+            TableRow(spec_list="7-10", x_min=6, x_max=10),
+            TableRow(spec_list="2", x_min=float64(3.3333333333333335), x_max=6),
+            TableRow(spec_list="3", x_min=float64(5.333333333333333), x_max=6),
             TableRow(spec_list="4", x_min=float64(7.333333333333333), x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="5", x_min=float64(9.333333333333334), x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="6", x_min=float64(7.333333333333334), x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="7", x_min=float64(5.333333333333334), x_max=6),
-            TableRow(spec_list="7", x_min=6, x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=3.49999999),
             TableRow(spec_list="8", x_min=3.5, x_max=6),
-            TableRow(spec_list="8", x_min=6, x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=10),
-            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="10", x_min=float64(0.0), x_max=10),
-            TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=6),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=1),
+            TableRow(spec_list="10", x_min=1, x_max=6),
             TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=10),
         ]
         create_tbl_mock.assert_called_once_with(expected_call_args, False)
@@ -357,28 +323,10 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="1", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="1", x_min=5.6, x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="2", x_min=5.6, x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="3", x_min=5.6, x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="4", x_min=5.6, x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="5", x_min=5.6, x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="6", x_min=5.6, x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="7", x_min=5.6, x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="8", x_min=5.6, x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="9", x_min=5.6, x_max=10),
-            TableRow(spec_list="10", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="10", x_min=5.6, x_max=10),
-            TableRow(spec_list="11", x_min=-0.5, x_max=-5.2),
-            TableRow(spec_list="11", x_min=5.6, x_max=10),
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=-5.2),
+            TableRow(spec_list="1-1", x_min=-5.2, x_max=5.6),
+            TableRow(spec_list="11-10", x_min=-5.2, x_max=5.6),
+            TableRow(spec_list="1-10", x_min=5.6, x_max=10),
         ]
         self._assert_table_rows_delta(actual_rows, expected_table_rows, delta=0.001)
 
@@ -406,25 +354,10 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="0", x_min=-0.5, x_max=3),
-            TableRow(spec_list="0", x_min=5, x_max=10),
-            TableRow(spec_list="1", x_min=-0.5, x_max=3),
-            TableRow(spec_list="1", x_min=5, x_max=10),
-            TableRow(spec_list="2", x_min=-0.5, x_max=3),
-            TableRow(spec_list="2", x_min=5, x_max=10),
-            TableRow(spec_list="3", x_min=-0.5, x_max=3),
-            TableRow(spec_list="3", x_min=5, x_max=10),
-            TableRow(spec_list="4", x_min=-0.5, x_max=3),
-            TableRow(spec_list="4", x_min=5, x_max=10),
-            TableRow(spec_list="5", x_min=-0.5, x_max=3),
-            TableRow(spec_list="5", x_min=5, x_max=10),
-            TableRow(spec_list="6", x_min=-0.5, x_max=3),
-            TableRow(spec_list="6", x_min=5, x_max=10),
-            TableRow(spec_list="7", x_min=-0.5, x_max=3),
-            TableRow(spec_list="7", x_min=5, x_max=10),
-            TableRow(spec_list="8", x_min=-0.5, x_max=10),
-            TableRow(spec_list="9", x_min=-0.5, x_max=10),
-            TableRow(spec_list="10", x_min=-0.5, x_max=10),
+            TableRow(spec_list="1-10", x_min=-0.5, x_max=3),
+            TableRow(spec_list="1-0", x_min=3, x_max=5),
+            TableRow(spec_list="7-10", x_min=3, x_max=5),
+            TableRow(spec_list="1-10", x_min=5, x_max=10),
             TableRow(spec_list="0", x_min=3, x_max=3.99999999),
             TableRow(spec_list="0", x_min=4.0, x_max=5),
             TableRow(spec_list="1", x_min=3, x_max=3.4129129536431586),
@@ -477,13 +410,8 @@ class CursorInfoTest(unittest.TestCase):
         )
         actual_rows = cursor_info.generate_inverted_table_rows()
         expected_table_rows = [
-            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
-            TableRow(spec_list="10", x_min=float64(0.0), x_max=15),
-            TableRow(spec_list="11", x_min=-0.5, x_max=15),
-            TableRow(spec_list="12", x_min=-0.5, x_max=15),
-            TableRow(spec_list="13", x_min=-0.5, x_max=15),
-            TableRow(spec_list="14", x_min=-0.5, x_max=15),
-            TableRow(spec_list="15", x_min=-0.5, x_max=15),
+            TableRow(spec_list="1-0", x_min=-0.5, x_max=15),
+            TableRow(spec_list="10-15", x_min=-0.5, x_max=15),
             TableRow(spec_list="0", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="0", x_min=float64(0.6666666666666666), x_max=15),
             TableRow(spec_list="1", x_min=-0.5, x_max=float64(0.0)),
@@ -504,6 +432,8 @@ class CursorInfoTest(unittest.TestCase):
             TableRow(spec_list="8", x_min=float64(3.333333333333332), x_max=15),
             TableRow(spec_list="9", x_min=-0.5, x_max=float64(0.0)),
             TableRow(spec_list="9", x_min=float64(1.3333333333333321), x_max=15),
+            TableRow(spec_list="10", x_min=-0.5, x_max=float64(0.0)),
+            TableRow(spec_list="10", x_min=float64(0.0), x_max=15),
         ]
         self._assert_table_rows_delta(expected_table_rows, actual_rows, delta=0.001)
 
@@ -551,6 +481,47 @@ class CursorInfoTest(unittest.TestCase):
                 (1, 2),
                 (3, 4),
             )
+
+    def test_find_ranges(self):
+        input_specs = [
+            [1, 2, 3, 4, 6, 7, 8, 90, 92, 93, 95],
+            [100],
+            [100, 150],
+            [1, 2],
+        ]
+        expected_ranges = [
+            ["1-4", "6-8", "90", "92-93", "95"],
+            ["100"],
+            ["100", "150"],
+            ["1-2"],
+        ]
+        for spec, ranges in zip(input_specs, expected_ranges):
+            self.assertEqual(CursorInfoBase.find_ranges(spec), ranges)
+
+    def test_pack_unpack_table_rows(self):
+        table_rows = [
+            TableRow(spec_list="1-4", x_min=-0.5, x_max=5),
+            TableRow(spec_list="5", x_min=-0.5, x_max=10),
+            TableRow(spec_list="6-8", x_min=-0.5, x_max=15),
+            TableRow(spec_list="9", x_min=0.5, x_max=8),
+            TableRow(spec_list="10", x_min=2, x_max=5),
+        ]
+        expected_table_rows = [
+            TableRow(spec_list="1", x_min=-0.5, x_max=5),
+            TableRow(spec_list="2", x_min=-0.5, x_max=5),
+            TableRow(spec_list="3", x_min=-0.5, x_max=5),
+            TableRow(spec_list="4", x_min=-0.5, x_max=5),
+            TableRow(spec_list="5", x_min=-0.5, x_max=10),
+            TableRow(spec_list="6", x_min=-0.5, x_max=15),
+            TableRow(spec_list="7", x_min=-0.5, x_max=15),
+            TableRow(spec_list="8", x_min=-0.5, x_max=15),
+            TableRow(spec_list="9", x_min=0.5, x_max=8),
+            TableRow(spec_list="10", x_min=2, x_max=5),
+        ]
+        unpacked_table_rows = CursorInfoBase.unpack_table_rows(table_rows)
+        self._assert_table_rows_delta(expected_table_rows, unpacked_table_rows, delta=0.001)
+        packed_table_rows = CursorInfoBase.pack_table_rows(unpacked_table_rows)
+        self._assert_table_rows_delta(table_rows, packed_table_rows, delta=0.001)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
@@ -266,10 +266,14 @@ class SliceViewerSelectionMaskingTest(unittest.TestCase):
             selector, mocks = self._set_up_selector_test(ToolItemText.POLY_MASKING, images=["test"])
             cursor_info_mock = [Mock() for _ in range(3)]
             cursor_info_fn.side_effect = cursor_info_mock
+            mocks["dataview"].ax.get_xlim.return_value = (0, 10)
+            mocks["dataview"].ax.get_ylim.return_value = (0, 20)
 
             selector._on_selected([self.Click(0, 0), self.Click(5, 5), self.Click(0, 10)])
             mocks["dataview"].mpl_toolbar.set_action_checked.assert_called_once_with(ToolItemText.POLY_MASKING, False, trigger=False)
-            mocks["model"].add_poly_cursor_info.assert_called_with(nodes=cursor_info_mock, transpose=False)
+            mocks["model"].add_poly_cursor_info.assert_called_with(
+                nodes=cursor_info_mock, transpose=False, x_limits=(0, 10), y_limits=(0, 20)
+            )
 
     def test_on_selected_poly_error(self):
         with (
@@ -285,9 +289,13 @@ class SliceViewerSelectionMaskingTest(unittest.TestCase):
             cursor_info_mock = [Mock() for _ in range(3)]
             cursor_info_fn.side_effect = cursor_info_mock
             mocks["model"].add_poly_cursor_info.side_effect = RuntimeError("test")
+            mocks["dataview"].ax.get_xlim.return_value = (0, 20)
+            mocks["dataview"].ax.get_ylim.return_value = (0, 30)
 
             selector._on_selected([self.Click(0, 0), self.Click(5, 5), self.Click(0, 10)])
-            mocks["model"].add_poly_cursor_info.assert_called_with(nodes=cursor_info_mock, transpose=False)
+            mocks["model"].add_poly_cursor_info.assert_called_with(
+                nodes=cursor_info_mock, transpose=False, x_limits=(0, 20), y_limits=(0, 30)
+            )
             selector.clear.assert_called_once()
             selector.disconnect.assert_called_once()
             selector.set_active.assert_called_once_with(False)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -44,7 +44,7 @@ SCALENORM = "SliceViewer/scale_norm"
 POWERSCALE = "SliceViewer/scale_norm_power"
 
 MASK_SHAPE_OPTIONS = [ToolItemText.RECT_MASKING, ToolItemText.ELLI_MASKING, ToolItemText.POLY_MASKING]
-MASK_PROCESS_OPTIONS = [ToolItemText.APPLY_MASKING, ToolItemText.EXPORT_MASKING]
+MASK_PROCESS_OPTIONS = [ToolItemText.APPLY_MASKING, ToolItemText.EXPORT_MASKING, ToolItemText.INVERTED_MASKING]
 MASK_OPTIONS = MASK_SHAPE_OPTIONS + MASK_PROCESS_OPTIONS
 
 
@@ -159,6 +159,7 @@ class SliceViewerDataView(QWidget):
         self.mpl_toolbar.polyMaskingClicked.connect(self.on_poly_masking_clicked)
         self.mpl_toolbar.exportMaskingClicked.connect(self.on_export_masking_clicked)
         self.mpl_toolbar.applyMaskingClicked.connect(self.on_apply_masking_clicked)
+        self.mpl_toolbar.invertMaskingClicked.connect(self.on_invert_masking_clicked)
         self.toolbar_layout.addWidget(self.mpl_toolbar)
 
         # Status bar
@@ -546,6 +547,12 @@ class SliceViewerDataView(QWidget):
         React to apply masking selected
         """
         self.presenter.apply_masking_clicked()
+
+    def on_invert_masking_clicked(self, state):
+        """
+        React to invert masking clicked
+        """
+        self.presenter.invert_masking_clicked(state)
 
     def deactivate_and_disable_tool(self, tool_text):
         """Deactivate a tool as if the control had been pressed and disable the functionality"""

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
@@ -76,3 +76,7 @@ class IDataViewSubscriber(ABC):
     @abstractmethod
     def apply_masking_clicked(self) -> None:
         pass
+
+    @abstractmethod
+    def invert_masking_clicked(self, active) -> None:
+        pass

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
@@ -68,7 +68,9 @@ class SliceViewerNavigationToolbar(MantidNavigationToolbar):
         ),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool(ToolItemText.MASKING, "Toggle masking on/off", "mdi.transition-masked", "maskingClicked", False),
-        MantidNavigationTool(ToolItemText.INVERTED_MASKING, "Toggle inverted masking", "mdi.transition", "invertMaskingClicked", False),
+        MantidNavigationTool(
+            ToolItemText.INVERTED_MASKING, "Toggle inverted masking on/off", "mdi.transition", "invertMaskingClicked", False
+        ),
         MantidNavigationTool(ToolItemText.RECT_MASKING, "Select rectangle mask", "mdi.square-outline", "rectMaskingClicked", False),
         MantidNavigationTool(ToolItemText.ELLI_MASKING, "Select elliptical mask", "mdi.circle-outline", "elliMaskingClicked", False),
         MantidNavigationTool(ToolItemText.POLY_MASKING, "Select polygon mask", "mdi.triangle-outline", "polyMaskingClicked", False),

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
@@ -23,6 +23,7 @@ class ToolItemText:
     SAVE = "Save"
     NONAXISALIGNEDCUTS = "NonAxisAlignedCuts"
     MASKING = "Masking"
+    INVERTED_MASKING = "InvertMasking"
     RECT_MASKING = "RectangleMasking"
     ELLI_MASKING = "EllipticalMasking"
     POLY_MASKING = "PolygonMasking"
@@ -46,6 +47,7 @@ class SliceViewerNavigationToolbar(MantidNavigationToolbar):
     polyMaskingClicked = Signal(bool)
     applyMaskingClicked = Signal(bool)
     exportMaskingClicked = Signal(bool)
+    invertMaskingClicked = Signal(bool)
 
     toolitems = (
         MantidNavigationTool(ToolItemText.HOME, "Reset original view", "mdi.home", "homeClicked", None),
@@ -71,6 +73,7 @@ class SliceViewerNavigationToolbar(MantidNavigationToolbar):
         MantidNavigationTool(ToolItemText.POLY_MASKING, "Select polygon mask", "mdi.triangle-outline", "polyMaskingClicked", False),
         MantidNavigationTool(ToolItemText.APPLY_MASKING, "Apply drawn mask", "mdi.checkbox-marked-outline", "applyMaskingClicked", None),
         MantidNavigationTool(ToolItemText.EXPORT_MASKING, "Export drawn mask to table", "mdi.export", "exportMaskingClicked", None),
+        MantidNavigationTool(ToolItemText.INVERTED_MASKING, "Toggle inverted masking", "mdi.transition", "invertMaskingClicked", False),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool(ToolItemText.SAVE, "Save the figure", "mdi.content-save", "save_figure", None),
     )

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/toolbar.py
@@ -68,12 +68,12 @@ class SliceViewerNavigationToolbar(MantidNavigationToolbar):
         ),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool(ToolItemText.MASKING, "Toggle masking on/off", "mdi.transition-masked", "maskingClicked", False),
+        MantidNavigationTool(ToolItemText.INVERTED_MASKING, "Toggle inverted masking", "mdi.transition", "invertMaskingClicked", False),
         MantidNavigationTool(ToolItemText.RECT_MASKING, "Select rectangle mask", "mdi.square-outline", "rectMaskingClicked", False),
         MantidNavigationTool(ToolItemText.ELLI_MASKING, "Select elliptical mask", "mdi.circle-outline", "elliMaskingClicked", False),
         MantidNavigationTool(ToolItemText.POLY_MASKING, "Select polygon mask", "mdi.triangle-outline", "polyMaskingClicked", False),
         MantidNavigationTool(ToolItemText.APPLY_MASKING, "Apply drawn mask", "mdi.checkbox-marked-outline", "applyMaskingClicked", None),
         MantidNavigationTool(ToolItemText.EXPORT_MASKING, "Export drawn mask to table", "mdi.export", "exportMaskingClicked", None),
-        MantidNavigationTool(ToolItemText.INVERTED_MASKING, "Toggle inverted masking", "mdi.transition", "invertMaskingClicked", False),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool(ToolItemText.SAVE, "Save the figure", "mdi.content-save", "save_figure", None),
     )


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40955. <!-- One line per closed issue. -->
Added a button to invert the mask in the slice viewer.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Launch **workbench** and run the snippet of code from this [PR](https://github.com/mantidproject/mantid/pull/39893).
2) Open Slice Viewer on **out_ws** workspace.
3) Click the `Toggle masking on/off` button. And verify that all masking related options are enabled.
<img width="175" height="48" alt="image" src="https://github.com/user-attachments/assets/db4708fc-a6a8-4b4f-82b1-2db00f697cb9" />

4) Click the `Toggle inverted masking on/off` button.
<img width="214" height="44" alt="image" src="https://github.com/user-attachments/assets/5accb262-0125-4fa3-b0e2-f990cbd16b0d" />

5) Select a rectangular region of the axis.
<img width="925" height="527" alt="image" src="https://github.com/user-attachments/assets/98b6ef46-da27-4261-9ecc-1ac223e08724" />

6) Click the `Export drawn mask to table` button. And verify the data in **out_ws_sv_mask_tbl**.

7) Click `Apply drawn mask` and verify the inverted rectangular mask is applied.
<img width="887" height="512" alt="image" src="https://github.com/user-attachments/assets/9008cb60-c6b1-42a0-ad18-2d4d8cafd2b3" />

8) Repeat the above steps with **ellipse** and **polygonal** selectors. Make sure to rerun the snippet of [code](https://github.com/mantidproject/mantid/pull/39893) between each tests.

9) Verify that the following results are produced with the various masking options.
<img width="864" height="513" alt="image" src="https://github.com/user-attachments/assets/7fbf79e6-14c8-40c8-a23e-6dfac34f0aaa" />





<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
