### PR TITLE
Validate `Rebin` parameters for memory overflow

### DIFF
--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -19,6 +19,7 @@
 #include "MantidKernel/EnumeratedString.h"
 #include "MantidKernel/EnumeratedStringProperty.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/Memory.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
@@ -129,14 +130,16 @@ std::map<std::string, std::string> Rebin::validateInputs() {
 
   // determing the binning mode, if present, or use default setting
   BINMODE binMode;
-  if (existsProperty(PropertyNames::BINMODE))
+  if (existsProperty(PropertyNames::BINMODE)) {
     binMode = getPropertyValue(PropertyNames::BINMODE);
-  else
+  } else {
     binMode = "Default";
+  }
 
   // validate the rebin params, and outside default mode, reset them
   MatrixWorkspace_sptr inputWS = getProperty(PropertyNames::INPUT_WKSP);
   std::vector<double> rbParams = getProperty(PropertyNames::PARAMS);
+  std::vector<double> validParams;
   if (inputWS == nullptr) {
     // The workspace could exist, but not be a MatrixWorkspace, e.g. it might be
     // a group workspace. In that case we don't want a validation error for the
@@ -147,7 +150,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     }
   } else {
     try {
-      std::vector<double> validParams = rebinParamsFromInput(rbParams, *inputWS, g_log, binMode);
+      validParams = rebinParamsFromInput(rbParams, *inputWS, g_log, binMode);
       // if the binmode has been set, force the rebin params to be consistent
       if (binMode != BinningMode::DEFAULT) {
         setProperty(PropertyNames::PARAMS, validParams);
@@ -169,55 +172,45 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     }
   }
 
-  // perform checks on the power property, if valid
+  // validate power property, if present
+  double power = 0.0;
   if (existsProperty(PropertyNames::POWER)) {
-    // ensure that the power property is set if using power binning
     if (isDefault(PropertyNames::POWER) && binMode == BinningMode::POWER) {
       std::string msg = "The binning mode was set to 'Power', but no power was given.";
       helpMessages[PropertyNames::POWER] = msg;
       helpMessages[PropertyNames::BINMODE] = msg;
       return helpMessages;
     }
-    // if the power is set, perform checks
-    else if (!isDefault(PropertyNames::POWER)) {
-      // power is only available in Default and Power binning modes
-      if (binMode != BinningMode::DEFAULT && binMode != BinningMode::POWER) {
-        g_log.information() << "Discarding input power for incompatible binning mode.";
-        setProperty(PropertyNames::POWER, 0.0);
-      } else { // power is a property, is not default, and binning mode is power of default
-        const double power = getProperty(PropertyNames::POWER);
+    if (binMode != BinningMode::DEFAULT && binMode != BinningMode::POWER) {
+      g_log.information() << "Discarding input power for incompatible binning mode.";
+      setProperty(PropertyNames::POWER, 0.0);
+    } else {
+      power = getProperty(PropertyNames::POWER);
+    }
+  }
+  // estimate the number of bins needed and compare to available memory
+  if (inputWS && !validParams.empty()) {
+    size_t numBins = VectorHelper::estimateNumberOfBins(validParams, power);
+    if (power != 0. && numBins > 10'001) { // this number of bins should only be considered an issue for power binning
+      helpMessages[PropertyNames::POWER] = "This binning is expected to give " + std::to_string(numBins) + " bins.";
+    } else { // otherwise compare against available memory
+      size_t numSpec = inputWS->getNumberHistograms();
+      std::size_t binSpaceInBytes = 2 * numSpec * numBins * sizeof(double); // memory required in bytes
+      std::string memMsg = MemoryStats().checkAvailableMemory(binSpaceInBytes);
+      if (!memMsg.empty()) {
+        memMsg = "This binning is expected to create " + std::to_string(numBins * numSpec) + " bins. " + memMsg +
+                 " Consider grouping spectra before rebinning, or using a coarser binning.";
+        helpMessages[PropertyNames::PARAMS] = memMsg;
+      }
+    }
+  } else {
+    try {
+      VectorHelper::validateRebinParameters(rbParams, static_cast<bool>(power));
+    } catch (std::exception &err) {
+      helpMessages[PropertyNames::PARAMS] = err.what();
+    }
+  }
 
-        // attempt to roughly guess how many bins these parameters imply
-        double roughEstimate = 0;
-
-        // Five significant places of the Euler-Mascheroni constant is probably more than enough for our needs
-        double eulerMascheroni = 0.57721;
-
-        // Params is checked by the validator first, so we can assume it is in a correct format
-        for (size_t i = 0; i < rbParams.size() - 2; i += 2) {
-          double upperLimit = rbParams[i + 2];
-          double lowerLimit = rbParams[i];
-          double factor = rbParams[i + 1];
-
-          // in default mode, give error if try to mix power and log binning
-          // because of prior validation, we can assume this will only happen in default mode
-          if (factor <= 0) {
-            helpMessages[PropertyNames::PARAMS] = "Provided width value cannot be negative for inverse power binning.";
-            return helpMessages;
-          }
-          if (power == 1) {
-            roughEstimate += std::exp((upperLimit - lowerLimit) / factor - eulerMascheroni);
-          } else {
-            roughEstimate += std::pow(((upperLimit - lowerLimit) / factor) * (1 - power) + 1, 1 / (1 - power));
-          }
-        } // end for i in rbParams.size()
-        // Prevent the user form creating too many bins
-        if (roughEstimate > 10000) {
-          helpMessages[PropertyNames::POWER] = "This binning is expected to give more than 10000 bins.";
-        }
-      } // end else
-    } // end else if
-  } // end if property power exists
   return helpMessages;
 }
 

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -37,23 +37,15 @@ using Mantid::HistogramData::CountStandardDeviations;
 
 class RebinTest : public CxxTest::TestSuite {
 public:
-  double BIN_DELTA;
-  int NUMPIXELS, NUMBINS;
-
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static RebinTest *createSuite() { return new RebinTest(); }
   static void destroySuite(RebinTest *suite) { delete suite; }
 
-  RebinTest() {
-    BIN_DELTA = 2.0;
-    NUMPIXELS = 20;
-    NUMBINS = 50;
-  }
-
   /* some basic validation tests */
 
   void test_make_three_params_default() {
+    std::cout << "Test make three params default" << std::endl;
     const std::string IN_WKSP("creates_three_params_in");
     const std::string OUT_WKSP("creates_three_params_out");
 
@@ -83,6 +75,7 @@ public:
   }
 
   void test_failure_bad_log_binning_endpoints() {
+    std::cout << "Test failure bad log binning endpoints" << std::endl;
     // ensure that rebinning will fail if log binning from negative to positive
     // this fails fast, due to the rebin param property validator
     Rebin rebin;
@@ -92,6 +85,7 @@ public:
   }
 
   void test_failure_bad_rebin_params() {
+    std::cout << "Test failure bad rebin params" << std::endl;
     // ensure that rebinning will fail if log binning from negative to positive
     // this fails fast, due to the rebin param property validator
     Rebin rebin;
@@ -108,6 +102,7 @@ public:
   }
 
   void test_failure_mixed_power_and_log() {
+    std::cout << "Test failure mixed power and log" << std::endl;
     Rebin rebin;
     rebin.initialize();
     rebin.setProperty("Params", std::vector<double>{1.0, -1.0, 10.0});
@@ -115,12 +110,13 @@ public:
     auto errmsgs = rebin.validateInputs();
     auto errmsg = errmsgs.find("Params");
     TS_ASSERT(errmsg != errmsgs.end());
-    TS_ASSERT(errmsg->second.substr(0, 20) == "Provided width value");
+    TS_ASSERT(strstr(errmsg->second.c_str(), "Bin width was -1"));
   }
 
   // NOTE this test will only run on linux, as it requires the availMem patch to work
   void testIsMocked() {
 #if defined(__linux__) || defined(__gnu_linux__)
+    std::cout << "Test the memory patch is working" << std::endl;
     constexpr std::size_t newMem{25};
     size_t mem1 = Mantid::Kernel::MemoryStats().availMem();
     TS_ASSERT_LESS_THAN(newMem, mem1);
@@ -135,6 +131,7 @@ public:
   }
 
   void test_failure_too_much_memory() {
+    std::cout << "Test failure too much memory on the rebin params" << std::endl;
     Mantid::TestMemory::MockMemory memL; // patch the available memory calculator
     size_t numBins = memL.numberOfFloats();
     // ensure that rebinning will fail if the number of bins requested is expected to exceed available memory
@@ -152,6 +149,38 @@ public:
     end = 10.0;
     TS_ASSERT_LESS_THAN(binWidth, 0.0); // make sure it is negative, to trigger log binning
     TS_ASSERT_THROWS_ANYTHING(rebin.setProperty("Params", std::vector<double>{start, binWidth, end}));
+  }
+
+  // NOTE this test will only run on linux, as it requires the availMem patch to work
+  void test_failure_too_much_memory_ws() {
+#if defined(__linux__) || defined(__gnu_linux__)
+    std::cout << "Test failure too much memory with a workspace" << std::endl;
+    Mantid::TestMemory::MockMemory memL; // patch the available memory calculator
+    size_t numFloats = memL.numberOfFloats();
+    size_t numSpec = 10;
+    size_t numBins = numFloats / numSpec / 2;
+    // ensure that rebinning will fail if the number of bins requested is expected to exceed available memory
+    Rebin rebin;
+    rebin.initialize();
+    Workspace2D_sptr ws = createWorkspace<Workspace2D>(numSpec, 2, 1);
+    rebin.setProperty("InputWorkspace", ws);
+    rebin.setPropertyValue("OutputWorkspace", "test_out");
+    double binWidth = 1.0;
+    double start = 1.0;
+    double end = start + static_cast<double>(numBins) * binWidth + 1;
+    // this binning is valid on a single spectrum
+    TS_ASSERT_THROWS_NOTHING(rebin.setProperty("Params", std::vector<double>{start, binWidth, end}));
+    // but will fail on the workspace with ten spectra
+    auto errmsgs = rebin.validateInputs();
+    auto errmsg = errmsgs.find("Params");
+    TS_ASSERT(errmsg != errmsgs.end());
+    TS_ASSERT_DIFFERS(errmsg->second.find("This binning is expected to create"), std::string::npos);
+    // this same binning is fine with fewer spectra
+    Workspace2D_sptr ws2 = createWorkspace<Workspace2D>(numSpec - 1, 2, 1);
+    rebin.setProperty("InputWorkspace", ws2);
+    errmsgs = rebin.validateInputs();
+    TS_ASSERT(errmsgs.empty());
+#endif
   }
 
   /* execution tests */
@@ -825,6 +854,7 @@ public:
 
   void test_inversePowerValidateHarmonic() {
     // Test that the validator which forbid creating more than 10000 bins works in a harmonic series case
+    std::cout << "Testing failure with inverse power harmonic series with modeset" << std::endl;
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
     AnalysisDataService::Instance().add("test_Rebin_revLog", test_1D);
@@ -842,6 +872,7 @@ public:
   void test_inversePowerValidateInverseSquareRoot() {
     // Test that the validator which forbid breating more than 10000 bins works in an inverse square root case
     // We test both because they rely on different formula to compute the expected number of bins.
+    std::cout << "Testing failure with inverse power square root series with modeset" << std::endl;
     Workspace2D_sptr test_1D = Create1DWorkspace(51);
     test_1D->setDistribution(false);
     AnalysisDataService::Instance().add("test_Rebin_revLog", test_1D);
@@ -883,6 +914,7 @@ public:
 
   void test_failure_bad_log_binning_endpoints_modeset() {
     // ensure failure with log binning from neg to pos with modeset
+    std::cout << "Testing failure with log binning from negative to positive with modeset" << std::endl;
     Rebin rebin;
     rebin.initialize();
     auto ws1 = Create1DWorkspace(10);
@@ -899,9 +931,9 @@ public:
     AnalysisDataService::Instance().remove("ws1");
   }
 
-  void do_test_property_unchanged(
-      // check that certain properties are unchanged by the execution of the algo
-      std::string property, bool propValue, std::string binMode, double step, double power) {
+  void do_test_property_unchanged(std::string property, bool propValue, std::string binMode, double step,
+                                  double power) {
+    // check that certain properties are unchanged by the execution of the algo
 
     const std::string IN_WKSP("properties_unchanged_in");
     const std::string OUT_WKSP("properties_unchanged_out");

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/Memory.h"
+#include "MantidKernel/VectorHelper.h"
 #include <cmath>
 
 namespace Mantid::Kernel {
@@ -50,48 +51,16 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
   default: {
     if (value.size() % 2 == 0) { // even
       error = "The number of bin boundary parameters provided must be odd";
-    } else { // odd
-      // for checking memory allocation
-      size_t numBins = 0;
-      // ensure all bin widths are non-zero
-      double previousBoundary = value[0];
-      for (size_t i = 1; i < value.size() - 1; i += 2) {
-        double binWidth = value[i];
-        double nextBoundary = value[i + 1];
-        // first validate the bins and boundaries
-        if (binWidth == 0.0) {
-          error = "Cannot have a zero bin width";
-          break;
-        } else {
-          if (nextBoundary <= previousBoundary) { // check bin boundaries are in increasing order
-            error = "Bin boundary values must be given in order of increasing value";
-            break;
-          } else if (binWidth < 0.0 &&
-                     previousBoundary <=
-                         0.0) { // if bin width is negative (log binning) check boundaries are positive-definite
-            error = "Bin boundaries must be positive for logarithmic binning";
-            break;
-          }
-        }
-        // the bins and bounds are okay, accumulate memory
-        if (binWidth < 0.0) {
-          // logarithmic binning
-          numBins += static_cast<size_t>(std::log(nextBoundary / previousBoundary) / std::log(1. - binWidth));
-        } else {
-          // linear binning
-          numBins += static_cast<size_t>((nextBoundary - previousBoundary) / binWidth);
-        }
-        previousBoundary = nextBoundary;
-      } // end for checking bins/boundaries
-      double memInBytes = static_cast<double>(MemoryStats().availMem() * 1024);
-      double binSpaceInBytes = static_cast<double>(numBins * sizeof(double));
-      if (binSpaceInBytes > memInBytes) {
-        double bytesInGB = 1e9;
-        error = "The number of bins requested is expected to exceed available memory. "
-                "This binning requires approximately " +
-                std::to_string(binSpaceInBytes / bytesInGB) + " GB of memory, but only " +
-                std::to_string(memInBytes / bytesInGB) + " GB is available.";
+    } else {                   // odd
+      std::size_t numBins = 0; // defensively init to 0
+      try {
+        numBins = VectorHelper::estimateNumberOfBins(value);
+      } catch (std::runtime_error &e) {
+        error = e.what();
+        break;
       }
+      std::size_t binSpaceInBytes = numBins * sizeof(double);
+      error = MemoryStats().checkAvailableMemory(binSpaceInBytes);
     } // end else odd
   } // end default case
   }

--- a/Framework/Kernel/test/RebinParamsValidatorTest.h
+++ b/Framework/Kernel/test/RebinParamsValidatorTest.h
@@ -44,13 +44,8 @@ public:
   }
 
   void testFailOutOfOrder() {
-    std::vector<double> vec(5);
-    vec[0] = 1.0;
-    vec[1] = 0.1;
-    vec[2] = 2.0;
-    vec[3] = 0.2;
-    vec[4] = 1.5;
-    TS_ASSERT_EQUALS(standardValidator.isValid(vec), "Bin boundary values must be given in order of increasing value");
+    std::vector<double> vec = {1.0, 0.1, 2.0, 0.2, 1.5};
+    TS_ASSERT(standardValidator.isValid(vec).find("Bin boundary values") != std::string::npos);
   }
 
   void testFailZeroBin_only() {

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41320.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41320.rst
@@ -1,0 +1,1 @@
+- The `Rebin` algorithm will now throw an error if the number of bins requested is expected to exceed available memory.


### PR DESCRIPTION
### Description of work

It is very easy to specify parameters to `Rebin` that overwhelm any reasonable amount of RAM.  Mantid will still attempt to create any specified rebinned axes, which can result in Mantid crashes as it exhausts available resources.

Prior work in PR #41296 created a validator on the property, to ensure the rebinning parameters are not so high as to exhaust available memory with a single spectrum.

However, even if rebin parameters are fine for a single spectrum, for a workspace with thousands or even millions of spectra, the `Rebin` operation could still cause memory-related crashes.

This PR adds a fuller check to `Rebin::validateInputs`, which will check if memory would be exhausted with the rebinning in every spectrum of the workspace.

To prevent code duplication, prior PRs added new functions to `VectorHelper` to validate binning parameters for compatibility, and to pre-estimate the number of bins required.  These were used in this PR to significantly reduce the amount of code.

Refs: [EWM 15806](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15806)

PRs:
- #41296 
- #41326 
- #41330 
- #41338 

### To test:

Check the tests.

Build workbench from this branch and run (do NOT run this in main)
``` python
numSpec = 300_000 # number of spectra in corelli
ws = CreateWorkspace([1]*numSpec, [1]*numSpec, NSpec=numSpec)
rebinned = Rebin(ws, "0.5,1,17000.5", BinningMode="Linear")
```
This should report an error, alerting the user to the fact that this requires over 40GB of RAM, rather than attempting to perform the rebin operation.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
