### PR TITLE
Resolve Coverity warnings in LoadNGEM

### DIFF
--- a/Framework/DataHandling/src/LoadNGEM.cpp
+++ b/Framework/DataHandling/src/LoadNGEM.cpp
@@ -616,7 +616,7 @@ LoadDataResult LoadNGEM::readDataAsHistograms(double &minToF, double &maxToF, co
   strategy->addFrame(rawFrames, goodFrames, eventCountInFrame, minEventsReq, maxEventsReq, frameEventCounts);
   progress(0.90);
   dataWorkspace = createHistogramWorkspace(std::move(strategy->getBinEdges()), std::move(strategy->getCounts()));
-  return {rawFrames, goodFrames, frameEventCounts, dataWorkspace};
+  return {rawFrames, goodFrames, std::move(frameEventCounts), std::move(dataWorkspace)};
 }
 
 /**


### PR DESCRIPTION
### Description of work

Resolves the following Coverity warnings:

```
** CID 1657914:       Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/home/docker/actions-runner/_work/mantid/mantid/Framework/DataHandling/src/LoadNGEM.cpp: 619           in Mantid::DataHandling::LoadNGEM::readDataAsHistograms(double &, double &, double, int, int, const std::vector<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>, std::allocator<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>> &)()


_____________________________________________________________________________________________
*** CID 1657914:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/home/docker/actions-runner/_work/mantid/mantid/Framework/DataHandling/src/LoadNGEM.cpp: 619             in Mantid::DataHandling::LoadNGEM::readDataAsHistograms(double &, double &, double, int, int, const std::vector<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>, std::allocator<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>> &)()
613                        maxEventsReq, frameEventCounts, totalFilePaths, strategy);
614       }
615       // Add the final frame of events (as they are not followed by a T0 event)
616       strategy->addFrame(rawFrames, goodFrames, eventCountInFrame, minEventsReq, maxEventsReq, frameEventCounts);
617       progress(0.90);
618       dataWorkspace = createHistogramWorkspace(std::move(strategy->getBinEdges()), std::move(strategy->getCounts()));
>>>     CID 1657914:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
>>>     "frameEventCounts" is copied in call to copy constructor for class "std::vector<double, std::allocator<double> >", when it could be moved instead.
619       return {rawFrames, goodFrames, frameEventCounts, dataWorkspace};
620     }
621     
622     /**
623      * @brief Add an event to the relevant histogram.
624      *

** CID 1657913:       Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
```

### To test:

```
from mantid.simpleapi import *

LoadNGEM(Filename='GEM000005_00_000_short', OutputWorkspace='ws', BinWidth=50, MinToF=700, MaxToF=98000, PreserveEvents=False)
```

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
