### PR TITLE
Add ReflectometryReductionOne v3

### DIFF
--- a/Framework/Reflectometry/CMakeLists.txt
+++ b/Framework/Reflectometry/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC_FILES
     src/ReflectometryBeamStatistics.cpp
     src/ReflectometryMomentumTransfer.cpp
     src/ReflectometryReductionOne2.cpp
+    src/ReflectometryReductionOne3.cpp
     src/ReflectometryReductionOneAuto2.cpp
     src/ReflectometryReductionOneAuto3.cpp
     src/ReflectometryTransformKiKf.cpp
@@ -37,6 +38,7 @@ set(INC_FILES
     inc/MantidReflectometry/ReflectometryBeamStatistics.h
     inc/MantidReflectometry/ReflectometryMomentumTransfer.h
     inc/MantidReflectometry/ReflectometryReductionOne2.h
+    inc/MantidReflectometry/ReflectometryReductionOne3.h
     inc/MantidReflectometry/ReflectometryReductionOneAuto2.h
     inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
     inc/MantidReflectometry/ReflectometryTransformKiKf.h

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne3.h
@@ -1,0 +1,357 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/TaskBasedAlgorithm.h"
+#include "MantidReflectometry/ReflectometryWorkflowBase2.h"
+#include <numeric>
+
+namespace Mantid {
+// Forward declaration
+namespace API {
+class SpectrumInfo;
+}
+namespace Geometry {
+class ReferenceFrame;
+}
+namespace HistogramData {
+class HistogramX;
+class HistogramY;
+class HistogramE;
+} // namespace HistogramData
+namespace Reflectometry {
+
+struct Tasks {
+  struct NormalizeByMonitor {
+    static constexpr const char *name = "TaskNormalizeByMonitor";
+    struct Outputs {
+      static constexpr const char *MonitorCorrectedWorkspace = "MonitorCorrectedWorkspace";
+    };
+  };
+  struct NormalizeByTransmission {
+    static constexpr const char *name = "TaskNormalizeByTransmission";
+    struct Outputs {
+      static constexpr const char *TransmissionCorrectedWorkspace = "TransmissionCorrectedWorkspace";
+      static constexpr const char *TransmissionWorkspace = "TransmissionWorkspace";
+    };
+  };
+  struct NormalizeByAlgorithm {
+    static constexpr const char *name = "TaskNormalizeByAlgorithm";
+    struct Outputs {
+      static constexpr const char *AlgorithmCorrectedWorkspace = "AlgorithmCorrectedWorkspace";
+    };
+  };
+  struct SumDetectorsInQ {
+    static constexpr const char *name = "TaskSumDetectorsInQ";
+    struct Outputs {
+      static constexpr const char *QSummedWorkspace = "QSummedWorkspace";
+    };
+  };
+  struct CropWavelength {
+    static constexpr const char *name = "TaskCropWavelength";
+    struct Outputs {
+      static constexpr const char *CroppedWorkspace = "CroppedWorkspace";
+    };
+  };
+  struct ConvertToQ {
+    static constexpr const char *name = "TaskConvertToQ";
+    struct Outputs {
+      static constexpr const char *ConvertedWorkspaceQ = "ConvertedWorkspaceQ";
+    };
+  };
+  struct ConvertToWavelength {
+    static constexpr const char *name = "TaskConvertToWavelength";
+    struct Outputs {
+      static constexpr const char *ConvertedWorkspaceWavelength = "ConvertedWorkspaceWavelength";
+    };
+  };
+  struct SumDetectors {
+    static constexpr const char *name = "TaskSumDetectors";
+    struct Outputs {
+      static constexpr const char *SummedWorkspace = "SummedWorkspace";
+    };
+  };
+  struct BackgroundSubtraction {
+    static constexpr const char *name = "TaskBackgroundSubtraction";
+    struct Outputs {
+      static constexpr const char *BackgroundSubtractedWorkspace = "BackgroundSubtractedWorkspace";
+    };
+  };
+  struct ExtractROI {
+    static constexpr const char *name = "TaskExtractROI";
+    struct Outputs {
+      static constexpr const char *ExtractedROIWorkspace = "ExtractedROIWorkspace";
+    };
+  };
+};
+
+/** ReflectometryReductionOne3 : Reflectometry reduction of a single input TOF
+ workspace to an IvsQ workspace. Version 3 of the algorithm.
+ */
+class MANTID_REFLECTOMETRY_DLL ReflectometryReductionOne3 : public ReflectometryWorkflowBase2,
+                                                            public TaskBasedAlgorithm<ReflectometryReductionOne3> {
+public:
+  /// Algorithm's name for identification
+  const std::string name() const override { return "ReflectometryReductionOne"; };
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "Reduces a single TOF/Lambda reflectometry run into a mod Q vs I/I0 "
+           "workspace. Performs monitor normalization and transmission "
+           "corrections.";
+  }
+  /// Algorithm's version for identification.
+  int version() const override { return 3; };
+  const std::vector<std::string> seeAlso() const override { return {"ReflectometryReductionOneAuto"}; }
+  /// Algorithm's category for identification.
+  const std::string category() const override { return "Reflectometry"; };
+
+private:
+  /** Overridden Algorithm methods **/
+
+  // Initialize the algorithm
+  void init() override;
+  // Execute the algorithm
+  void exec() override;
+  // Validate inputs
+  std::map<std::string, std::string> validateInputs() override;
+  // Set default names for output workspaces
+  void setDefaultOutputWorkspaceNames();
+  // Performs background subtraction
+  Mantid::API::MatrixWorkspace_sptr backgroundSubtraction(Mantid::API::MatrixWorkspace_sptr detectorWS);
+  // Performs transmission corrections
+  std::pair<Mantid::API::MatrixWorkspace_sptr, Mantid::API::MatrixWorkspace_sptr>
+  transmissionCorrection(const Mantid::API::MatrixWorkspace_sptr &detectorWS);
+  // Performs transmission corrections using alternative correction algorithms
+  Mantid::API::MatrixWorkspace_sptr algorithmicCorrection(const Mantid::API::MatrixWorkspace_sptr &detectorWS);
+  // Performs monitor corrections
+  Mantid::API::MatrixWorkspace_sptr monitorCorrection(Mantid::API::MatrixWorkspace_sptr detectorWS);
+  // convert to momentum transfer
+  bool useDetectorAngleForQConversion(const MatrixWorkspace_sptr &ws) const;
+  Mantid::API::MatrixWorkspace_sptr convertToQ(const Mantid::API::MatrixWorkspace_sptr &inputWS);
+  // Get the twoTheta width of a given detector
+  double getDetectorTwoThetaRange(const size_t spectrumIdx);
+  // Utility function to create name for diagnostic workspaces
+  std::string createDebugWorkspaceName(const std::string &inputName);
+  // Do the reduction by summation in Q
+  Mantid::API::MatrixWorkspace_sptr sumInQ(const API::MatrixWorkspace_sptr &detectorWS);
+  // Do the summation in Q for a single input value
+  void sumInQProcessValue(const int inputIdx, const double twoTheta, const double bTwoTheta,
+                          const HistogramData::HistogramX &inputX, const HistogramData::HistogramY &inputY,
+                          const HistogramData::HistogramE &inputE, const std::vector<size_t> &detectors,
+                          const size_t outSpecIdx, const API::MatrixWorkspace_sptr &IvsLam,
+                          std::vector<double> &outputE);
+  // Share counts to a projected value for summation in Q
+  void sumInQShareCounts(const double inputCounts, const double inputErr, const double bLambda, const double lambdaMin,
+                         const double lambdaMax, const size_t outSpecIdx, const API::MatrixWorkspace_sptr &IvsLam,
+                         std::vector<double> &outputE);
+  void findWavelengthMinMax(const API::MatrixWorkspace_sptr &inputWS);
+  // Construct the output workspace
+  void findIvsLamRange(const API::MatrixWorkspace_sptr &detectorWS, const std::vector<size_t> &detectors,
+                       const double lambdaMin, const double lambdaMax, double &projectedMin, double &projectedMax);
+  // Construct the output workspace
+  Mantid::API::MatrixWorkspace_sptr constructIvsLamWS(const API::MatrixWorkspace_sptr &detectorWS);
+  // Whether summation should be done in Q or the default lambda
+  bool summingInQ() const;
+  // Get projected coordinates onto twoThetaR
+  void getProjectedLambdaRange(const double lambda, const double twoTheta, const double bLambda, const double bTwoTheta,
+                               const std::vector<size_t> &detectors, double &lambdaTop, double &lambdaBot,
+                               const bool outerCorners = true);
+  // Check whether two spectrum maps match
+  void verifySpectrumMaps(const API::MatrixWorkspace_const_sptr &ws1, const API::MatrixWorkspace_const_sptr &ws2);
+  // Find and cache constants
+  void findDetectorGroups();
+  void findTheta0();
+  // initialize algorithm members
+  void initalizeMembers();
+
+  // Accessors for detectors and theta and lambda values
+  const std::vector<std::vector<size_t>> &detectorGroups() const { return m_detectorGroups; };
+  double theta0() { return m_theta0; }
+  double twoThetaR(const std::vector<size_t> &detectors);
+  size_t twoThetaRDetectorIdx(const std::vector<size_t> &detectors);
+  double wavelengthMin() { return m_wavelengthMin; };
+  double wavelengthMax() { return m_wavelengthMax; };
+  size_t findIvsLamRangeMinDetector(const std::vector<size_t> &detectors);
+  size_t findIvsLamRangeMaxDetector(const std::vector<size_t> &detectors);
+  double findIvsLamRangeMin(const Mantid::API::MatrixWorkspace_sptr &detectorWS, const std::vector<size_t> &detectors,
+                            const double lambda);
+  double findIvsLamRangeMax(const Mantid::API::MatrixWorkspace_sptr &detectorWS, const std::vector<size_t> &detectors,
+                            const double lambda);
+
+  API::MatrixWorkspace_sptr m_runWS;
+  const API::SpectrumInfo *m_spectrumInfo;
+  std::shared_ptr<const Mantid::Geometry::ReferenceFrame> m_refFrame;
+  double m_theta0; // horizon angle
+  // groups of spectrum indices of the detectors of interest
+  std::vector<std::vector<size_t>> m_detectorGroups;
+  // Store the min/max wavelength we're interested in. These will be the
+  // input Wavelength min/max if summing in lambda, or the projected
+  // versions of these if summing in Q
+  double m_wavelengthMin;
+  double m_wavelengthMax;
+  // True if partial bins should be included in the summation in Q
+  bool m_partialBins;
+  // When a task sets wavelength min/max, flag this so it is not repeated.
+  bool m_wavelengthMinMaxSet;
+
+  /** Task based Algorithm declarations */
+  class TaskBackgroundSubtraction final : public AlgorithmTask {
+  public:
+    explicit TaskBackgroundSubtraction(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::BackgroundSubtraction::name) {
+      setExpectedOutputs({Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace});
+      setDependantTask(Tasks::ExtractROI::name, Tasks::ExtractROI::Outputs::ExtractedROIWorkspace, "InputWorkspace");
+    }
+    void executeImpl() override;
+  };
+
+  class TaskConvertToWavelength final : public AlgorithmTask {
+  public:
+    explicit TaskConvertToWavelength(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::ConvertToWavelength::name) {
+      setExpectedOutputs({Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength});
+      setDependantTask(Tasks::BackgroundSubtraction::name,
+                       Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace, "InputWorkspace");
+      const auto taskSet = addDependantTaskSet();
+      setDependantTask(Tasks::SumDetectors::name, Tasks::SumDetectors::Outputs::SummedWorkspace, "InputWorkspace",
+                       taskSet);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskNormalizeByMonitor final : public AlgorithmTask {
+  public:
+    explicit TaskNormalizeByMonitor(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::NormalizeByMonitor::name) {
+      setExpectedOutputs({Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace});
+      setDependantTask(Tasks::SumDetectors::name, Tasks::SumDetectors::Outputs::SummedWorkspace, "InputWorkspace");
+      const auto taskSet = addDependantTaskSet();
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace", taskSet);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskNormalizeByTransmission final : public AlgorithmTask {
+  public:
+    explicit TaskNormalizeByTransmission(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::NormalizeByTransmission::name) {
+      setExpectedOutputs({Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace});
+      setDependantTask(Tasks::NormalizeByMonitor::name, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace,
+                       "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace", taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::CropWavelength::name, Tasks::CropWavelength::Outputs::CroppedWorkspace, "InputWorkspace",
+                       taskSet2);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskNormalizeByAlgorithm final : public AlgorithmTask {
+  public:
+    explicit TaskNormalizeByAlgorithm(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::NormalizeByAlgorithm::name) {
+      setExpectedOutputs({Tasks::NormalizeByAlgorithm::Outputs::AlgorithmCorrectedWorkspace});
+      setDependantTask(Tasks::NormalizeByMonitor::name, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace,
+                       "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace", taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::CropWavelength::name, Tasks::CropWavelength::Outputs::CroppedWorkspace, "InputWorkspace",
+                       taskSet2);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskExtractROI final : public AlgorithmTask {
+  public:
+    explicit TaskExtractROI(ReflectometryReductionOne3 *parent) : AlgorithmTask(parent, Tasks::ExtractROI::name) {
+      setExpectedOutputs({Tasks::ExtractROI::Outputs::ExtractedROIWorkspace});
+    }
+    void executeImpl() override;
+  };
+
+  class TaskSumDetectors final : public AlgorithmTask {
+  public:
+    explicit TaskSumDetectors(ReflectometryReductionOne3 *parent) : AlgorithmTask(parent, Tasks::SumDetectors::name) {
+      setExpectedOutputs({Tasks::SumDetectors::Outputs::SummedWorkspace});
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::BackgroundSubtraction::name,
+                       Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace, "InputWorkspace",
+                       taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::ExtractROI::name, Tasks::ExtractROI::Outputs::ExtractedROIWorkspace, "InputWorkspace",
+                       taskSet2);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskSumDetectorsInQ final : public AlgorithmTask {
+  public:
+    explicit TaskSumDetectorsInQ(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::SumDetectorsInQ::name) {
+      setExpectedOutputs({Tasks::SumDetectorsInQ::Outputs::QSummedWorkspace});
+      setDependantTask(Tasks::NormalizeByMonitor::name, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace,
+                       "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::NormalizeByTransmission::name,
+                       Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace, "InputWorkspace",
+                       taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace", taskSet2);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskCropWavelength final : public AlgorithmTask {
+  public:
+    explicit TaskCropWavelength(ReflectometryReductionOne3 *parent)
+        : AlgorithmTask(parent, Tasks::CropWavelength::name) {
+      setExpectedOutputs({Tasks::CropWavelength::Outputs::CroppedWorkspace});
+      setDependantTask(Tasks::NormalizeByMonitor::name, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace,
+                       "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::NormalizeByTransmission::name,
+                       Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace, "InputWorkspace",
+                       taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::SumDetectorsInQ::name, Tasks::SumDetectorsInQ::Outputs::QSummedWorkspace,
+                       "InputWorkspace", taskSet2);
+      const auto taskSet3 = addDependantTaskSet();
+      setDependantTask(Tasks::ConvertToWavelength::name,
+                       Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength, "InputWorkspace", taskSet3);
+    }
+    void executeImpl() override;
+  };
+
+  class TaskConvertToQ final : public AlgorithmTask {
+  public:
+    explicit TaskConvertToQ(ReflectometryReductionOne3 *parent) : AlgorithmTask(parent, Tasks::ConvertToQ::name) {
+      setExpectedOutputs({Tasks::ConvertToQ::Outputs::ConvertedWorkspaceQ});
+      setDependantTask(Tasks::CropWavelength::name, Tasks::CropWavelength::Outputs::CroppedWorkspace, "InputWorkspace");
+      const auto taskSet1 = addDependantTaskSet();
+      setDependantTask(Tasks::NormalizeByTransmission::name,
+                       Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace, "InputWorkspace",
+                       taskSet1);
+      const auto taskSet2 = addDependantTaskSet();
+      setDependantTask(Tasks::NormalizeByAlgorithm::name,
+                       Tasks::NormalizeByAlgorithm::Outputs::AlgorithmCorrectedWorkspace, "InputWorkspace", taskSet2);
+    }
+    void executeImpl() override;
+  };
+
+  std::vector<std::string> constructTaskExecutionOrder() override;
+};
+
+} // namespace Reflectometry
+} // namespace Mantid

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOne3.h
@@ -25,70 +25,6 @@ class HistogramE;
 } // namespace HistogramData
 namespace Reflectometry {
 
-struct Tasks {
-  struct NormalizeByMonitor {
-    static constexpr const char *name = "TaskNormalizeByMonitor";
-    struct Outputs {
-      static constexpr const char *MonitorCorrectedWorkspace = "MonitorCorrectedWorkspace";
-    };
-  };
-  struct NormalizeByTransmission {
-    static constexpr const char *name = "TaskNormalizeByTransmission";
-    struct Outputs {
-      static constexpr const char *TransmissionCorrectedWorkspace = "TransmissionCorrectedWorkspace";
-      static constexpr const char *TransmissionWorkspace = "TransmissionWorkspace";
-    };
-  };
-  struct NormalizeByAlgorithm {
-    static constexpr const char *name = "TaskNormalizeByAlgorithm";
-    struct Outputs {
-      static constexpr const char *AlgorithmCorrectedWorkspace = "AlgorithmCorrectedWorkspace";
-    };
-  };
-  struct SumDetectorsInQ {
-    static constexpr const char *name = "TaskSumDetectorsInQ";
-    struct Outputs {
-      static constexpr const char *QSummedWorkspace = "QSummedWorkspace";
-    };
-  };
-  struct CropWavelength {
-    static constexpr const char *name = "TaskCropWavelength";
-    struct Outputs {
-      static constexpr const char *CroppedWorkspace = "CroppedWorkspace";
-    };
-  };
-  struct ConvertToQ {
-    static constexpr const char *name = "TaskConvertToQ";
-    struct Outputs {
-      static constexpr const char *ConvertedWorkspaceQ = "ConvertedWorkspaceQ";
-    };
-  };
-  struct ConvertToWavelength {
-    static constexpr const char *name = "TaskConvertToWavelength";
-    struct Outputs {
-      static constexpr const char *ConvertedWorkspaceWavelength = "ConvertedWorkspaceWavelength";
-    };
-  };
-  struct SumDetectors {
-    static constexpr const char *name = "TaskSumDetectors";
-    struct Outputs {
-      static constexpr const char *SummedWorkspace = "SummedWorkspace";
-    };
-  };
-  struct BackgroundSubtraction {
-    static constexpr const char *name = "TaskBackgroundSubtraction";
-    struct Outputs {
-      static constexpr const char *BackgroundSubtractedWorkspace = "BackgroundSubtractedWorkspace";
-    };
-  };
-  struct ExtractROI {
-    static constexpr const char *name = "TaskExtractROI";
-    struct Outputs {
-      static constexpr const char *ExtractedROIWorkspace = "ExtractedROIWorkspace";
-    };
-  };
-};
-
 /** ReflectometryReductionOne3 : Reflectometry reduction of a single input TOF
  workspace to an IvsQ workspace. Version 3 of the algorithm.
  */
@@ -181,6 +117,8 @@ private:
                             const double lambda);
   double findIvsLamRangeMax(const Mantid::API::MatrixWorkspace_sptr &detectorWS, const std::vector<size_t> &detectors,
                             const double lambda);
+  void setAlgPropertyValueFromSelf(const std::string &propName, Algorithm_sptr &alg,
+                                   const std::string &algPropName = "");
 
   API::MatrixWorkspace_sptr m_runWS;
   const API::SpectrumInfo *m_spectrumInfo;

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
@@ -20,7 +20,7 @@ namespace Reflectometry {
 /** ReflectometryWorkflowBase2 : base class containing common implementation
  functionality usable by concrete reflectometry workflow algorithms. Version 2.
  */
-class MANTID_REFLECTOMETRY_DLL ReflectometryWorkflowBase2 : public API::DataProcessorAlgorithm {
+class MANTID_REFLECTOMETRY_DLL ReflectometryWorkflowBase2 : virtual public API::DataProcessorAlgorithm {
 protected:
   /// Initialize the analysis properties
   void initAnalysisProperties();
@@ -86,13 +86,18 @@ protected:
   std::string m_processingInstructionsWorkspaceIndex;
   std::string m_processingInstructions;
 
-protected:
   std::string convertToSpectrumNumber(const std::string &workspaceIndex,
                                       const Mantid::API::MatrixWorkspace_const_sptr &ws) const;
   std::string convertProcessingInstructionsToSpectrumNumbers(const std::string &instructions,
                                                              const Mantid::API::MatrixWorkspace_const_sptr &ws) const;
 
   void setWorkspacePropertyFromChild(const Algorithm_sptr &alg, std::string const &propertyName);
+
+  std::vector<std::string>
+  getTaskExecutionOrderFromProperties(const bool summingInQ, const bool reduced, const std::string &IOMonIndexProp,
+                                      const std::string &MonBGWaveMinProp, const std::string &MonBGWaveMaxProp,
+                                      const std::string &firstTransRunProp, const std::string &correctionAlgProp,
+                                      const std::string &subBGProp) const;
 };
 } // namespace Reflectometry
 } // namespace Mantid

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
@@ -17,6 +17,70 @@ using namespace Mantid::Geometry;
 namespace Mantid {
 namespace Reflectometry {
 
+struct Tasks {
+  struct NormalizeByMonitor {
+    static constexpr const char *name = "TaskNormalizeByMonitor";
+    struct Outputs {
+      static constexpr const char *MonitorCorrectedWorkspace = "MonitorCorrectedWorkspace";
+    };
+  };
+  struct NormalizeByTransmission {
+    static constexpr const char *name = "TaskNormalizeByTransmission";
+    struct Outputs {
+      static constexpr const char *TransmissionCorrectedWorkspace = "TransmissionCorrectedWorkspace";
+      static constexpr const char *TransmissionWorkspace = "TransmissionWorkspace";
+    };
+  };
+  struct NormalizeByAlgorithm {
+    static constexpr const char *name = "TaskNormalizeByAlgorithm";
+    struct Outputs {
+      static constexpr const char *AlgorithmCorrectedWorkspace = "AlgorithmCorrectedWorkspace";
+    };
+  };
+  struct SumDetectorsInQ {
+    static constexpr const char *name = "TaskSumDetectorsInQ";
+    struct Outputs {
+      static constexpr const char *QSummedWorkspace = "QSummedWorkspace";
+    };
+  };
+  struct CropWavelength {
+    static constexpr const char *name = "TaskCropWavelength";
+    struct Outputs {
+      static constexpr const char *CroppedWorkspace = "CroppedWorkspace";
+    };
+  };
+  struct ConvertToQ {
+    static constexpr const char *name = "TaskConvertToQ";
+    struct Outputs {
+      static constexpr const char *ConvertedWorkspaceQ = "ConvertedWorkspaceQ";
+    };
+  };
+  struct ConvertToWavelength {
+    static constexpr const char *name = "TaskConvertToWavelength";
+    struct Outputs {
+      static constexpr const char *ConvertedWorkspaceWavelength = "ConvertedWorkspaceWavelength";
+    };
+  };
+  struct SumDetectors {
+    static constexpr const char *name = "TaskSumDetectors";
+    struct Outputs {
+      static constexpr const char *SummedWorkspace = "SummedWorkspace";
+    };
+  };
+  struct BackgroundSubtraction {
+    static constexpr const char *name = "TaskBackgroundSubtraction";
+    struct Outputs {
+      static constexpr const char *BackgroundSubtractedWorkspace = "BackgroundSubtractedWorkspace";
+    };
+  };
+  struct ExtractROI {
+    static constexpr const char *name = "TaskExtractROI";
+    struct Outputs {
+      static constexpr const char *ExtractedROIWorkspace = "ExtractedROIWorkspace";
+    };
+  };
+};
+
 /** ReflectometryWorkflowBase2 : base class containing common implementation
  functionality usable by concrete reflectometry workflow algorithms. Version 2.
  */

--- a/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -41,8 +41,8 @@ namespace {
 std::string const OUTPUT_WORKSPACE_DEFAULT_PREFIX("IvsQ");
 std::string const OUTPUT_WORKSPACE_WAVELENGTH_DEFAULT_PREFIX("IvsLam");
 
-static constexpr double degToRad = M_PI / 180.;
-static constexpr double radToDeg = 180. / M_PI;
+static constexpr double DEG_TO_RAD = M_PI / 180.;
+static constexpr double RAD_TO_DEG = 180. / M_PI;
 
 /** Get the twoTheta angle for the centre of the detector associated with the
  * given spectrum
@@ -337,13 +337,13 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::backgroundSubtraction(MatrixWor
   alg->initialize();
   alg->setProperty("InputWorkspace", detectorWS);
   alg->setProperty("InputWorkspaceIndexType", "SpectrumNumber");
-  alg->setProperty("ProcessingInstructions", getPropertyValue("BackgroundProcessingInstructions"));
-  alg->setProperty("BackgroundCalculationMethod", getPropertyValue("BackgroundCalculationMethod"));
-  alg->setProperty("DegreeOfPolynomial", getPropertyValue("DegreeOfPolynomial"));
-  alg->setProperty("CostFunction", getPropertyValue("CostFunction"));
+  setAlgPropertyValueFromSelf("BackgroundProcessingInstructions", alg, "ProcessingInstructions");
+  setAlgPropertyValueFromSelf("BackgroundCalculationMethod", alg);
+  setAlgPropertyValueFromSelf("DegreeOfPolynomial", alg);
+  setAlgPropertyValueFromSelf("CostFunction", alg);
   // For our case, the peak range is the same as the main processing
   // instructions, and we do the summation separately so don't sum the peak
-  alg->setProperty("PeakRange", getPropertyValue("ProcessingInstructions"));
+  setAlgPropertyValueFromSelf("ProcessingInstructions", alg, "PeakRange");
   alg->setProperty("SumPeak", false);
   alg->execute();
   MatrixWorkspace_sptr corrected = alg->getProperty("OutputWorkspace");
@@ -376,26 +376,26 @@ ReflectometryReductionOne3::transmissionCorrection(const MatrixWorkspace_sptr &d
       transmissionCommands = getPropertyValue("TransmissionProcessingInstructions");
     }
 
-    bool const isDebug = getProperty("Debug");
-    MatrixWorkspace_sptr secondTransmissionWS = getProperty("SecondTransmissionRun");
     auto alg = this->createChildAlgorithm("CreateTransmissionWorkspace");
     alg->initialize();
     alg->setProperty("FirstTransmissionRun", transmissionWS);
+
+    MatrixWorkspace_sptr secondTransmissionWS = getProperty("SecondTransmissionRun");
     alg->setProperty("SecondTransmissionRun", secondTransmissionWS);
-    alg->setPropertyValue("Params", getPropertyValue("Params"));
-    alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
-    alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
-    alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
-    alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
-    alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));
-    alg->setPropertyValue("MonitorBackgroundWavelengthMin", getPropertyValue("MonitorBackgroundWavelengthMin"));
-    alg->setPropertyValue("MonitorBackgroundWavelengthMax", getPropertyValue("MonitorBackgroundWavelengthMax"));
-    alg->setPropertyValue("MonitorIntegrationWavelengthMin", getPropertyValue("MonitorIntegrationWavelengthMin"));
-    alg->setPropertyValue("MonitorIntegrationWavelengthMax", getPropertyValue("MonitorIntegrationWavelengthMax"));
+    setAlgPropertyValueFromSelf("Params", alg);
+    setAlgPropertyValueFromSelf("StartOverlap", alg);
+    setAlgPropertyValueFromSelf("EndOverlap", alg);
+    setAlgPropertyValueFromSelf("ScaleRHSWorkspace", alg);
+    setAlgPropertyValueFromSelf("I0MonitorIndex", alg);
+    setAlgPropertyValueFromSelf("WavelengthMin", alg);
+    setAlgPropertyValueFromSelf("WavelengthMax", alg);
+    setAlgPropertyValueFromSelf("MonitorBackgroundWavelengthMin", alg);
+    setAlgPropertyValueFromSelf("MonitorBackgroundWavelengthMax", alg);
+    setAlgPropertyValueFromSelf("MonitorIntegrationWavelengthMin", alg);
+    setAlgPropertyValueFromSelf("MonitorIntegrationWavelengthMax", alg);
     alg->setProperty("ProcessingInstructions", transmissionCommands);
-    alg->setProperty("NormalizeByIntegratedMonitors", getPropertyValue("NormalizeByIntegratedMonitors"));
-    alg->setProperty("Debug", isDebug);
+    setAlgPropertyValueFromSelf("NormalizeByIntegratedMonitors", alg);
+    setAlgPropertyValueFromSelf("Debug", alg);
     alg->execute();
     transmissionWS = alg->getProperty("OutputWorkspace");
     transmissionWSName = alg->getPropertyValue("OutputWorkspace");
@@ -430,6 +430,13 @@ ReflectometryReductionOne3::transmissionCorrection(const MatrixWorkspace_sptr &d
   return {normalized, transmissionWS};
 }
 
+void ReflectometryReductionOne3::setAlgPropertyValueFromSelf(const std::string &propName, Algorithm_sptr &alg,
+                                                             const std::string &algPropName) {
+  std::string algPropNameToUse = algPropName.empty() ? propName : algPropName;
+  if (alg)
+    alg->setPropertyValue(algPropNameToUse, getPropertyValue(propName));
+}
+
 /**
  * Perform transmission correction using alternative correction algorithms
  * @param detectorWS : workspace in wavelength which is to be normalized by the
@@ -443,10 +450,10 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::algorithmicCorrection(const Mat
   auto corrAlg = createChildAlgorithm(corrAlgName);
   corrAlg->initialize();
   if (corrAlgName == "PolynomialCorrection") {
-    corrAlg->setPropertyValue("Coefficients", getPropertyValue("Polynomial"));
+    setAlgPropertyValueFromSelf("Polynomial", corrAlg, "Coefficients");
   } else if (corrAlgName == "ExponentialCorrection") {
-    corrAlg->setPropertyValue("C0", getPropertyValue("C0"));
-    corrAlg->setPropertyValue("C1", getPropertyValue("C1"));
+    setAlgPropertyValueFromSelf("C0", corrAlg);
+    setAlgPropertyValueFromSelf("C1", corrAlg);
   } else {
     throw std::runtime_error("Unknown correction algorithm: " + corrAlgName);
   }
@@ -518,7 +525,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::convertToQ(const MatrixWorkspac
     // The angle to use in conversion is different for each mode
     double theta = 0.0;
     if (summingInQ())
-      theta = getDetectorTwoTheta(m_spectrumInfo, twoThetaRDetectorIdx(detectorGroups()[0])) * radToDeg / 2.;
+      theta = getDetectorTwoTheta(m_spectrumInfo, twoThetaRDetectorIdx(detectorGroups()[0])) * RAD_TO_DEG / 2.;
     else
       theta = getProperty("ThetaIn");
 
@@ -550,14 +557,8 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::convertToQ(const MatrixWorkspac
  * @return : true if the reduction should sum in Q; false otherwise
  */
 bool ReflectometryReductionOne3::summingInQ() const {
-  bool result = false;
   const std::string summationType = getProperty("SummationType");
-
-  if (summationType == "SumInQ") {
-    result = true;
-  }
-
-  return result;
+  return summationType == "SumInQ";
 }
 
 /**
@@ -625,7 +626,7 @@ void ReflectometryReductionOne3::findTheta0() {
   g_log.debug("theta0: " + std::to_string(theta0()) + " degrees\n");
 
   // Convert to radians
-  m_theta0 *= degToRad;
+  m_theta0 *= DEG_TO_RAD;
 }
 
 /**
@@ -1021,8 +1022,8 @@ void ReflectometryReductionOne3::getProjectedLambdaRange(const double lambda, co
 
   // We cannot project pixels below the horizon angle
   if (twoTheta <= theta0()) {
-    throw std::runtime_error("Cannot process twoTheta=" + std::to_string(twoTheta * radToDeg) +
-                             " as it is below the horizon angle=" + std::to_string(theta0() * radToDeg));
+    throw std::runtime_error("Cannot process twoTheta=" + std::to_string(twoTheta * RAD_TO_DEG) +
+                             " as it is below the horizon angle=" + std::to_string(theta0() * RAD_TO_DEG));
   }
 
   // Get the angle from twoThetaR to this detector
@@ -1046,7 +1047,7 @@ void ReflectometryReductionOne3::getProjectedLambdaRange(const double lambda, co
     lambdaVMax = std::max(lambdaV1, lambdaV2);
   } catch (std::exception &ex) {
     throw std::runtime_error("Failed to project (lambda, twoTheta) = (" + std::to_string(lambda) + "," +
-                             std::to_string(twoTheta * radToDeg) +
+                             std::to_string(twoTheta * RAD_TO_DEG) +
                              ") onto twoThetaR = " + std::to_string(twoThetaRVal) + ": " + ex.what());
   }
 }

--- a/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
@@ -1,0 +1,1161 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidReflectometry/ReflectometryReductionOne3.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidGeometry/Objects/BoundingBox.h"
+#include "MantidHistogramData/LinearGenerator.h"
+#include "MantidIndexing/IndexInfo.h"
+#include "MantidKernel/EnabledWhenProperty.h"
+#include "MantidKernel/MandatoryValidator.h"
+#include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/Strings.h"
+#include "MantidKernel/Unit.h"
+#include "MantidKernel/UnitFactory.h"
+
+#include <algorithm>
+#include <utility>
+
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+using namespace Mantid::Geometry;
+using namespace Mantid::HistogramData;
+using namespace Mantid::Indexing;
+
+namespace Mantid::Reflectometry {
+
+/*Anonomous namespace */
+namespace {
+
+std::string const OUTPUT_WORKSPACE_DEFAULT_PREFIX("IvsQ");
+std::string const OUTPUT_WORKSPACE_WAVELENGTH_DEFAULT_PREFIX("IvsLam");
+
+static constexpr double degToRad = M_PI / 180.;
+static constexpr double radToDeg = 180. / M_PI;
+
+/** Get the twoTheta angle for the centre of the detector associated with the
+ * given spectrum
+ *
+ * @param spectrumInfo : the spectrum info
+ * @param spectrumIdx : the workspace index of the spectrum
+ * @return : the twoTheta angle in radians
+ */
+double getDetectorTwoTheta(const SpectrumInfo *spectrumInfo, const size_t spectrumIdx) {
+  return spectrumInfo->signedTwoTheta(spectrumIdx);
+}
+
+/** Get the start/end of the lambda range for the detector associated
+ * with the given spectrum
+ *
+ * @return : the lambda range
+ */
+double getLambdaRange(const HistogramX &xValues, const int xIdx) {
+  // The lambda range is the bin width from the given index to the next.
+  if (xIdx < 0 || xIdx + 1 >= static_cast<int>(xValues.size())) {
+    throw std::runtime_error("Error accessing X values out of range (index=" + std::to_string(xIdx + 1) +
+                             ", size=" + std::to_string(xValues.size()));
+  }
+
+  double result = xValues[xIdx + 1] - xValues[xIdx];
+  return result;
+}
+
+/** Get the lambda value at the centre of the detector associated
+ * with the given spectrum
+ *
+ * @return : the lambda range
+ */
+double getLambda(const HistogramX &xValues, const int xIdx) {
+  if (xIdx < 0 || xIdx >= static_cast<int>(xValues.size())) {
+    throw std::runtime_error("Error accessing X values out of range (index=" + std::to_string(xIdx) +
+                             ", size=" + std::to_string(xValues.size()));
+  }
+
+  // The centre of the bin is the lower bin edge plus half the width
+  return xValues[xIdx] + getLambdaRange(xValues, xIdx) / 2.0;
+}
+
+/**
+ * Get the topbottom extent of a detector for the given axis
+ *
+ * @param axis [in] : the axis to get the extent for
+ * @param top [in] : if true, get the max extent, or min otherwise
+ * @return : the max/min extent on the given axis
+ */
+double getBoundingBoxExtent(const BoundingBox &boundingBox, const PointingAlong axis, const bool top) {
+
+  double result = 0.0;
+  switch (axis) {
+  case X:
+    result = top ? boundingBox.xMax() : boundingBox.xMin();
+    break;
+  case Y:
+    result = top ? boundingBox.yMax() : boundingBox.yMin();
+    break;
+  case Z:
+    result = top ? boundingBox.zMax() : boundingBox.zMin();
+    break;
+  default:
+    throw std::runtime_error("Axis is not X/Y/Z");
+    break;
+  }
+  return result;
+}
+} // namespace
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(ReflectometryReductionOne3)
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void ReflectometryReductionOne3::init() {
+  initTaskBasedAlgorithm<TaskExtractROI, TaskBackgroundSubtraction, TaskConvertToWavelength, TaskSumDetectors,
+                         TaskNormalizeByMonitor, TaskNormalizeByTransmission, TaskCropWavelength, TaskConvertToQ,
+                         TaskSumDetectorsInQ, TaskNormalizeByAlgorithm>();
+  setMutableInput(true); // The first task, ExtractROI, not mutate the input workspace. This saves a copy.
+
+  // Input workspace
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input),
+                  "Run to reduce.");
+
+  initReductionProperties();
+
+  // ThetaIn
+  declareProperty(std::make_unique<PropertyWithValue<double>>("ThetaIn", Mantid::EMPTY_DBL(), Direction::Input),
+                  "Angle in degrees");
+
+  // Processing instructions
+  declareProperty(std::make_unique<PropertyWithValue<std::string>>("ProcessingInstructions", "",
+                                                                   std::make_shared<MandatoryValidator<std::string>>(),
+                                                                   Direction::Input),
+                  "Grouping pattern on spectrum numbers to yield only "
+                  "the detectors of interest. See GroupDetectors for details.");
+
+  // Minimum wavelength
+  declareProperty(std::make_unique<PropertyWithValue<double>>("WavelengthMin", Mantid::EMPTY_DBL(),
+                                                              std::make_shared<MandatoryValidator<double>>(),
+                                                              Direction::Input),
+                  "Wavelength minimum in angstroms");
+
+  // Maximum wavelength
+  declareProperty(std::make_unique<PropertyWithValue<double>>("WavelengthMax", Mantid::EMPTY_DBL(),
+                                                              std::make_shared<MandatoryValidator<double>>(),
+                                                              Direction::Input),
+                  "Wavelength maximum in angstroms");
+
+  initMonitorProperties();
+  initBackgroundProperties();
+  initTransmissionProperties();
+  initAlgorithmicProperties();
+  initDebugProperties();
+
+  declareProperty(
+      std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "", Direction::Output, PropertyMode::Optional),
+      "Outputs the workspace associated with the last performed task. Typically IvsQ.");
+
+  declareProperty(
+      std::make_unique<WorkspaceProperty<>>("OutputWorkspaceWavelength", "", Direction::Output, PropertyMode::Optional),
+      "Output Workspace IvsLam. Intermediate workspace.");
+  setPropertySettings("OutputWorkspaceWavelength",
+                      std::make_unique<Kernel::EnabledWhenProperty>("Debug", IS_EQUAL_TO, "1"));
+
+  declareProperty(
+      std::make_unique<WorkspaceProperty<>>("OutputWorkspaceQ", "", Direction::Output, PropertyMode::Optional),
+      "Output Workspace IvsQ.");
+  setPropertySettings("OutputWorkspaceQ", std::make_unique<Kernel::EnabledWhenProperty>("Debug", IS_EQUAL_TO, "1"));
+
+  initTransmissionOutputProperties();
+  m_wavelengthMinMaxSet = false;
+}
+
+/** Validate inputs
+ */
+std::map<std::string, std::string> ReflectometryReductionOne3::validateInputs() {
+  std::map<std::string, std::string> results;
+
+  const auto background = validateBackgroundProperties();
+  results.insert(background.begin(), background.end());
+
+  const auto reduction = validateReductionProperties();
+  results.insert(reduction.begin(), reduction.end());
+
+  const auto wavelength = validateWavelengthRanges();
+  results.insert(wavelength.begin(), wavelength.end());
+
+  const auto transmission = validateTransmissionProperties();
+  results.insert(transmission.begin(), transmission.end());
+
+  const std::string summationType = getProperty("SummationType");
+  const std::string reductionType = getProperty("ReductionType");
+  if (summationType == "SumInQ" && reductionType == "DivergentBeam" && (*getProperty("ThetaIn")).isDefault())
+    results["ThetaIn"] = "ThetaIn must be specified for the DivergentBeam case";
+
+  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
+  const auto xUnitID = inputWS->getAxis(0)->unit()->unitID();
+  if ((xUnitID != "Wavelength") && (xUnitID != "TOF"))
+    results["InputWorkspace"] = "InputWorkspace must have units of TOF or Wavelength";
+
+  return results;
+}
+
+// Set default names for output workspaces
+void ReflectometryReductionOne3::setDefaultOutputWorkspaceNames() {
+  bool const isDebug = getProperty("Debug");
+  MatrixWorkspace_sptr ws = getProperty("InputWorkspace");
+  auto const runNumber = getRunNumber(*ws);
+  if (isDefault("OutputWorkspace")) {
+    setPropertyValue("OutputWorkspace", OUTPUT_WORKSPACE_DEFAULT_PREFIX + runNumber);
+  }
+  if (isDebug && isDefault("OutputWorkspaceWavelength")) {
+    setPropertyValue("OutputWorkspaceWavelength", OUTPUT_WORKSPACE_WAVELENGTH_DEFAULT_PREFIX + runNumber);
+  }
+}
+
+std::vector<std::string> ReflectometryReductionOne3::constructTaskExecutionOrder() {
+  const bool reduced = m_runWS->getAxis(0)->unit()->unitID() == "Wavelength";
+  return getTaskExecutionOrderFromProperties(summingInQ(), reduced, "I0MonitorIndex", "MonitorBackgroundWavelengthMin",
+                                             "MonitorBackgroundWavelengthMax", "FirstTransmissionRun",
+                                             "CorrectionAlgorithm", "SubtractBackground");
+}
+
+void ReflectometryReductionOne3::initalizeMembers() {
+  setDefaultOutputWorkspaceNames();
+  m_runWS = getProperty("InputWorkspace");
+
+  // Handle processing instructions conversion from spectra number to workspace
+  // indexes
+  convertProcessingInstructions(m_runWS);
+
+  // Cache the spectrum info and reference frame
+  m_spectrumInfo = &m_runWS->spectrumInfo();
+  auto instrument = m_runWS->getInstrument();
+  m_refFrame = instrument->getReferenceFrame();
+  m_partialBins = getProperty("IncludePartialBins");
+
+  // Find and cache detector groups and theta0
+  // do we need findDetectorGroups - cache is not used anyhere.
+  findDetectorGroups();
+  findTheta0();
+}
+
+/** Execute the algorithm.
+ */
+void ReflectometryReductionOne3::exec() {
+  initalizeMembers();
+  const bool outputDiagnostics = getProperty("Diagnostics");
+  std::string diagWSName = (outputDiagnostics) ? createDebugWorkspaceName(getPropertyValue("InputWorkspace")) : "";
+  execTasks(diagWSName);
+}
+
+/** Get the twoTheta angle range for the top/bottom of the detector associated
+ * with the given spectrum
+ *
+ * @param spectrumIdx : the workspace index of the spectrum
+ * @return : the twoTheta range in radians
+ */
+double ReflectometryReductionOne3::getDetectorTwoThetaRange(const size_t spectrumIdx) {
+
+  double bTwoTheta = 0;
+
+  // Get the sample->detector distance along the beam
+  const V3D detSample = m_spectrumInfo->position(spectrumIdx) - m_spectrumInfo->samplePosition();
+  const double beamOffset = m_refFrame->vecPointingAlongBeam().scalar_prod(detSample);
+  // Get the bounding box for this detector/group
+  BoundingBox boundingBox;
+  auto detector = m_runWS->getDetector(spectrumIdx);
+  detector->getBoundingBox(boundingBox);
+  // Get the top and bottom on the axis pointing up
+  const double top = getBoundingBoxExtent(boundingBox, m_refFrame->pointingUp(), true);
+  const double bottom = getBoundingBoxExtent(boundingBox, m_refFrame->pointingUp(), false);
+  // Calculate the difference in twoTheta between the top and bottom
+  const double twoThetaTop = std::atan(top / beamOffset);
+  const double twoThetaBottom = std::atan(bottom / beamOffset);
+  bTwoTheta = twoThetaTop - twoThetaBottom;
+
+  // We must have non-zero width to project a range
+  if (bTwoTheta < Tolerance) {
+    throw std::runtime_error("Error calculating pixel size.");
+  }
+
+  return bTwoTheta;
+}
+
+/**
+ * Utility function to create a unique workspace name for diagnostic outputs
+ * based on a given input workspace name
+ *
+ * @param inputName [in] : the input name
+ * @return : the output name
+ */
+std::string ReflectometryReductionOne3::createDebugWorkspaceName(const std::string &inputName) {
+  std::string result = inputName;
+  if (summingInQ()) {
+    if (getPropertyValue("ReductionType") == "DivergentBeam")
+      result += "_QSD"; // Q-summed divergent beam
+    else
+      result += "_QSB"; // Q-summed bent (non-flat) sample
+  } else {
+    result += "_LS"; // lambda-summed
+  }
+  return result;
+}
+
+/**
+ * Normalize by monitors
+ *
+ * @param detectorWS :: the detector workspace to normalise, in lambda
+ * @return :: the normalized workspace in lambda
+ */
+MatrixWorkspace_sptr ReflectometryReductionOne3::monitorCorrection(MatrixWorkspace_sptr detectorWS) {
+  MatrixWorkspace_sptr IvsLam;
+  const bool integratedMonitors = getProperty("NormalizeByIntegratedMonitors");
+  int index = getProperty("I0MonitorIndex");
+  if (!m_spectrumInfo->isMonitor(index)) {
+    throw std::invalid_argument("A monitor is expected at spectrum index " + std::to_string(index));
+  }
+  const auto monitorWS = makeMonitorWS(m_runWS, integratedMonitors);
+  if (!integratedMonitors)
+    detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
+  IvsLam = divide(detectorWS, monitorWS);
+  return IvsLam;
+}
+
+MatrixWorkspace_sptr ReflectometryReductionOne3::backgroundSubtraction(MatrixWorkspace_sptr detectorWS) {
+  auto alg = this->createChildAlgorithm("ReflectometryBackgroundSubtraction");
+  alg->initialize();
+  alg->setProperty("InputWorkspace", detectorWS);
+  alg->setProperty("InputWorkspaceIndexType", "SpectrumNumber");
+  alg->setProperty("ProcessingInstructions", getPropertyValue("BackgroundProcessingInstructions"));
+  alg->setProperty("BackgroundCalculationMethod", getPropertyValue("BackgroundCalculationMethod"));
+  alg->setProperty("DegreeOfPolynomial", getPropertyValue("DegreeOfPolynomial"));
+  alg->setProperty("CostFunction", getPropertyValue("CostFunction"));
+  // For our case, the peak range is the same as the main processing
+  // instructions, and we do the summation separately so don't sum the peak
+  alg->setProperty("PeakRange", getPropertyValue("ProcessingInstructions"));
+  alg->setProperty("SumPeak", false);
+  alg->execute();
+  MatrixWorkspace_sptr corrected = alg->getProperty("OutputWorkspace");
+  return corrected;
+}
+
+/** Perform transmission correction by running 'CreateTransmissionWorkspace' on
+ * the input workspace
+ * @param detectorWS :: the input workspace
+ * @param detectorWSReduced:: whether the input detector workspace has been
+ * reduced
+ * @return :: the input workspace normalized by transmission
+ */
+std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr>
+ReflectometryReductionOne3::transmissionCorrection(const MatrixWorkspace_sptr &detectorWS) {
+  MatrixWorkspace_sptr transmissionWS = getProperty("FirstTransmissionRun");
+  auto transmissionWSName = transmissionWS->getName();
+
+  // Reduce the transmission workspace, if not already done (assume that if
+  // the workspace is in wavelength then it has already been reduced)
+  Unit_const_sptr xUnit = transmissionWS->getAxis(0)->unit();
+  if (xUnit->unitID() == "TOF") {
+
+    // If TransmissionProcessingInstructions are not passed then use
+    // passed processing instrucions
+    std::string transmissionCommands = "";
+    if (getPointerToProperty("TransmissionProcessingInstructions")->isDefault()) {
+      transmissionCommands = m_processingInstructions;
+    } else {
+      transmissionCommands = getPropertyValue("TransmissionProcessingInstructions");
+    }
+
+    bool const isDebug = getProperty("Debug");
+    MatrixWorkspace_sptr secondTransmissionWS = getProperty("SecondTransmissionRun");
+    auto alg = this->createChildAlgorithm("CreateTransmissionWorkspace");
+    alg->initialize();
+    alg->setProperty("FirstTransmissionRun", transmissionWS);
+    alg->setProperty("SecondTransmissionRun", secondTransmissionWS);
+    alg->setPropertyValue("Params", getPropertyValue("Params"));
+    alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
+    alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
+    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
+    alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
+    alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));
+    alg->setPropertyValue("MonitorBackgroundWavelengthMin", getPropertyValue("MonitorBackgroundWavelengthMin"));
+    alg->setPropertyValue("MonitorBackgroundWavelengthMax", getPropertyValue("MonitorBackgroundWavelengthMax"));
+    alg->setPropertyValue("MonitorIntegrationWavelengthMin", getPropertyValue("MonitorIntegrationWavelengthMin"));
+    alg->setPropertyValue("MonitorIntegrationWavelengthMax", getPropertyValue("MonitorIntegrationWavelengthMax"));
+    alg->setProperty("ProcessingInstructions", transmissionCommands);
+    alg->setProperty("NormalizeByIntegratedMonitors", getPropertyValue("NormalizeByIntegratedMonitors"));
+    alg->setProperty("Debug", isDebug);
+    alg->execute();
+    transmissionWS = alg->getProperty("OutputWorkspace");
+    transmissionWSName = alg->getPropertyValue("OutputWorkspace");
+
+    // Set interim workspace outputs
+    setWorkspacePropertyFromChild(alg, "OutputWorkspaceFirstTransmission");
+    setWorkspacePropertyFromChild(alg, "OutputWorkspaceSecondTransmission");
+  }
+
+  // Rebin the transmission run to be the same as the input.
+  auto rebinToWorkspaceAlg = this->createChildAlgorithm("RebinToWorkspace");
+  rebinToWorkspaceAlg->initialize();
+  rebinToWorkspaceAlg->setProperty("WorkspaceToMatch", detectorWS);
+  rebinToWorkspaceAlg->setProperty("WorkspaceToRebin", transmissionWS);
+  rebinToWorkspaceAlg->execute();
+  transmissionWS = rebinToWorkspaceAlg->getProperty("OutputWorkspace");
+
+  // If the detector workspace has been reduced (summing in lambda) then the spectrum maps
+  // should match AFTER reducing the transmission workspace
+  if (!summingInQ()) {
+    verifySpectrumMaps(detectorWS, transmissionWS);
+  }
+
+  MatrixWorkspace_sptr normalized = divide(detectorWS, transmissionWS);
+
+  // Set output transmission workspace
+  if (isDefault("OutputWorkspaceTransmission") && !transmissionWSName.empty()) {
+    setPropertyValue("OutputWorkspaceTransmission", transmissionWSName);
+  }
+  setProperty("OutputWorkspaceTransmission", transmissionWS);
+
+  return {normalized, transmissionWS};
+}
+
+/**
+ * Perform transmission correction using alternative correction algorithms
+ * @param detectorWS : workspace in wavelength which is to be normalized by the
+ * results of the transmission corrections.
+ * @return : corrected workspace
+ */
+MatrixWorkspace_sptr ReflectometryReductionOne3::algorithmicCorrection(const MatrixWorkspace_sptr &detectorWS) {
+
+  const std::string corrAlgName = getProperty("CorrectionAlgorithm");
+
+  auto corrAlg = createChildAlgorithm(corrAlgName);
+  corrAlg->initialize();
+  if (corrAlgName == "PolynomialCorrection") {
+    corrAlg->setPropertyValue("Coefficients", getPropertyValue("Polynomial"));
+  } else if (corrAlgName == "ExponentialCorrection") {
+    corrAlg->setPropertyValue("C0", getPropertyValue("C0"));
+    corrAlg->setPropertyValue("C1", getPropertyValue("C1"));
+  } else {
+    throw std::runtime_error("Unknown correction algorithm: " + corrAlgName);
+  }
+
+  corrAlg->setProperty("InputWorkspace", detectorWS);
+  corrAlg->setProperty("Operation", "Divide");
+  corrAlg->execute();
+
+  return corrAlg->getProperty("OutputWorkspace");
+}
+
+/** Returns true if we should use the output workspace's detector position
+ * for the theta angle to use in the conversion to Q */
+bool ReflectometryReductionOne3::useDetectorAngleForQConversion(const MatrixWorkspace_sptr &ws) const {
+  // If summing in Q, the output workspace is constructed such that the angle
+  // of the detector is correct for the conversion to Q
+  if (summingInQ())
+    return false;
+
+  // Otherwise we are summing in lambda. If ThetaIn was not specified then no
+  // correction was requested so assume the detector angle is correct
+  if ((*getProperty("ThetaIn")).isDefault())
+    return true;
+
+  // If there is only one detector (i.e. no summation was required) then we use
+  // the detector angle. This is because the correction is assumed to only be
+  // required when the region of interest is not centred on a pixel other than
+  // the specular pixel, but if we only have one pixel we assume it is the
+  // centre pixel. I'm not sure if we may want to change this in future to
+  // enable overriding it anyway.
+  // Note that when summing in lambda it is not allowed to pass ThetaIn with
+  // multiple groups, so we can assume we only have one group (i.e. one output
+  // spectrum) here.
+  bool const singleDetector = ws->getDetector(0)->nDets() <= 1;
+  if (singleDetector)
+    return true;
+
+  return false;
+}
+
+/** Convert a workspace to Q
+ *
+ * @param inputWS : The input workspace (in wavelength) to convert to Q
+ * @return : output workspace in Q
+ */
+MatrixWorkspace_sptr ReflectometryReductionOne3::convertToQ(const MatrixWorkspace_sptr &inputWS) {
+  MatrixWorkspace_sptr IvsQ;
+  if (useDetectorAngleForQConversion(inputWS)) {
+    // We can just use ConvertUnits, because the detectors are at the correct
+    // position
+    auto convertUnits = this->createChildAlgorithm("ConvertUnits");
+    convertUnits->initialize();
+    convertUnits->setProperty("InputWorkspace", inputWS);
+    convertUnits->setProperty("Target", "MomentumTransfer");
+    convertUnits->setProperty("AlignBins", false);
+    convertUnits->execute();
+    IvsQ = convertUnits->getProperty("OutputWorkspace");
+  } else {
+    // Use RefRoi with the given ThetaIn. This is currently only possible for a
+    // single region of interest (i.e. a single histogram in the summed
+    // workspace) because different regions of interest would be centred around
+    // different angles.
+    if (detectorGroups().size() != 1) {
+      throw std::invalid_argument("Angle correction using ThetaIn can only be done for a single group "
+                                  "in ProcessingInstructions, but the number of groups specified was " +
+                                  std::to_string(inputWS->getNumberHistograms()));
+    }
+
+    // The angle to use in conversion is different for each mode
+    double theta = 0.0;
+    if (summingInQ())
+      theta = getDetectorTwoTheta(m_spectrumInfo, twoThetaRDetectorIdx(detectorGroups()[0])) * radToDeg / 2.;
+    else
+      theta = getProperty("ThetaIn");
+
+    auto refRoi = this->createChildAlgorithm("RefRoi");
+    refRoi->initialize();
+    refRoi->setProperty("InputWorkspace", inputWS);
+    refRoi->setProperty("NXPixel", 1);
+    refRoi->setProperty("NYPixel", 1);
+    refRoi->setProperty("ConvertToQ", true);
+    refRoi->setProperty("SumPixels", false);
+    refRoi->setProperty("ScatteringAngle", theta);
+    refRoi->execute();
+    IvsQ = refRoi->getProperty("OutputWorkspace");
+    // RefRoi outputs as distribution data but ConvertUnits outputs as counts
+    // if the input is counts. For now make this consistent with the original
+    // behaviour using ConvertUnits but we may wish to change this in future.
+    if (!inputWS->isDistribution()) {
+      IvsQ->setYUnitLabel("Counts");
+      IvsQ->setDistribution(false);
+    }
+  }
+  return IvsQ;
+}
+
+/**
+ * Determine whether the reduction should sum along lines of constant
+ * Q or in the default lambda.
+ *
+ * @return : true if the reduction should sum in Q; false otherwise
+ */
+bool ReflectometryReductionOne3::summingInQ() const {
+  bool result = false;
+  const std::string summationType = getProperty("SummationType");
+
+  if (summationType == "SumInQ") {
+    result = true;
+  }
+
+  return result;
+}
+
+/**
+ * Find and cache the indicies of the detectors of interest
+ */
+void ReflectometryReductionOne3::findDetectorGroups() {
+  std::string instructions = m_processingInstructionsWorkspaceIndex;
+
+  m_detectorGroups = Kernel::Strings::parseGroups<size_t>(instructions);
+
+  // Sort the groups by the first spectrum number in the group (to give the same
+  // output order as GroupDetectors)
+  std::sort(m_detectorGroups.begin(), m_detectorGroups.end(),
+            [](const std::vector<size_t> &a, const std::vector<size_t> &b) { return a.front() < b.front(); });
+
+  if (m_detectorGroups.empty()) {
+    throw std::runtime_error("Invalid processing instructions");
+  }
+
+  for (const auto &group : m_detectorGroups) {
+    for (const auto &wsIdx : group) {
+      if (m_spectrumInfo->isMonitor(wsIdx)) {
+        throw std::invalid_argument("A detector is expected at workspace index " + std::to_string(wsIdx) +
+                                    " (Was converted from specnum), found a monitor");
+      }
+      if (wsIdx > m_spectrumInfo->size() - 1) {
+        throw std::runtime_error("ProcessingInstructions contains an out-of-range index: " + std::to_string(wsIdx));
+      }
+    }
+  }
+}
+
+/**
+ * Find and cache the angle theta0 from which lines of constant Q emanate
+ */
+void ReflectometryReductionOne3::findTheta0() {
+  // Only requried if summing in Q
+  if (!summingInQ()) {
+    return;
+  }
+
+  const std::string reductionType = getProperty("ReductionType");
+
+  // For the non-flat sample case theta0 is 0
+  m_theta0 = 0.0;
+
+  if (reductionType == "DivergentBeam") {
+    // theta0 is the horizon angle, which is half the twoTheta angle of the
+    // detector position. This is the angle the detector has been rotated
+    // to, which we can get from ThetaIn
+    const Property *thetaIn = getProperty("ThetaIn");
+    if (!thetaIn->isDefault()) {
+      m_theta0 = getProperty("ThetaIn");
+    } else {
+      /// @todo Currently, ThetaIn must be provided via a property. We could
+      /// calculate its value instead using
+      /// ReflectometryReductionOneAuto2::calculateTheta, which could be moved
+      /// to the base class (ReflectometryWorkflowBase2). Users normally use
+      /// ReflectometryReductionOneAuto2 though, so at the moment it isn't a
+      /// high priority to be able to calculate it here.
+      throw std::runtime_error("The ThetaIn property is required for the DivergentBeam case");
+    }
+  }
+
+  g_log.debug("theta0: " + std::to_string(theta0()) + " degrees\n");
+
+  // Convert to radians
+  m_theta0 *= degToRad;
+}
+
+/**
+ * Get the (arbitrary) reference angle twoThetaR for use for summation
+ * in Q
+ *
+ * @return : the angle twoThetaR in radians
+ * @throws : if the angle could not be found
+ */
+double ReflectometryReductionOne3::twoThetaR(const std::vector<size_t> &detectors) {
+  // Get the twoTheta value for the destinaion pixel that we're projecting onto
+  double twoThetaR = getDetectorTwoTheta(m_spectrumInfo, twoThetaRDetectorIdx(detectors));
+  if (getPropertyValue("ReductionType") == "DivergentBeam") {
+    // The angle that should be used in the final conversion to Q is
+    // (twoThetaR-theta0). However, the angle actually used by ConvertUnits is
+    // twoThetaD/2 where twoThetaD is the detector's twoTheta angle. Since it
+    // is not easy to change what angle ConvertUnits uses, we can compensate by
+    // setting twoThetaR = twoThetaD/2+theta0
+    twoThetaR = twoThetaR / 2.0 + theta0();
+  }
+  return twoThetaR;
+}
+
+/**
+ * Get the spectrum index which defines the twoThetaR reference angle
+ * @return : the spectrum index
+ */
+size_t ReflectometryReductionOne3::twoThetaRDetectorIdx(const std::vector<size_t> &detectors) {
+  // Get the mid-point of the area of interest
+  return detectors.front() + (detectors.back() - detectors.front()) / 2;
+}
+
+void ReflectometryReductionOne3::findWavelengthMinMax(const MatrixWorkspace_sptr &inputWS) {
+
+  // Get the max/min wavelength of region of interest
+  const double lambdaMin = getProperty("WavelengthMin");
+  const double lambdaMax = getProperty("WavelengthMax");
+
+  // If summing in lambda, the min/max wavelength is the same as the input
+  if (!summingInQ()) {
+    m_wavelengthMin = lambdaMin;
+    m_wavelengthMax = lambdaMax;
+    return;
+  }
+
+  // If summing in Q, we need to do a projection the input min/max for each
+  // detector group and take the overall min/max of the projected range
+  const size_t numGroups = detectorGroups().size();
+
+  // Find the projected min/max wavelength for all detector groups
+  bool first = true;
+  for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+    // Get the detectors in this group
+    const auto &detectors = detectorGroups()[groupIdx];
+    double projectedMin = 0;
+    double projectedMax = 0;
+    // Get the projected lambda for this detector group
+    findIvsLamRange(inputWS, detectors, lambdaMin, lambdaMax, projectedMin, projectedMax);
+    // Set the overall min/max
+    if (first) {
+      m_wavelengthMin = projectedMin;
+      m_wavelengthMax = projectedMax;
+      first = false;
+    } else {
+      m_wavelengthMin = std::min(m_wavelengthMin, projectedMin);
+      m_wavelengthMax = std::max(m_wavelengthMax, projectedMax);
+    }
+  }
+}
+
+/** Return the spectrum index of the detector to use in the projection for the
+ * start of the virtual IvsLam range when summing in Q
+ */
+size_t ReflectometryReductionOne3::findIvsLamRangeMinDetector(const std::vector<size_t> &detectors) {
+  // If we're including partial bins, we use the full input range, which means
+  // we project the top left and bottom right corner. For the start of the
+  // range we therefore use the highest theta, i.e. max detector index. If
+  // excluding partial bins we use the bottom left and top right corner so use
+  // the min detector for the start of the range.
+  if (m_partialBins)
+    return detectors.back();
+  else
+    return detectors.front();
+}
+
+/** Return the spectrum index of the detector to use in the projection for the
+ * end of the virtual IvsLam range when summing in Q
+ */
+size_t ReflectometryReductionOne3::findIvsLamRangeMaxDetector(const std::vector<size_t> &detectors) {
+  // If we're including partial bins, we use the full input range, which means
+  // we project the top left and bottom right corner. For the end (max) of the
+  // range we therefore use the lowest theta, i.e. min detector index. If
+  // excluding partial bins we use the bottom left and top right corner so use
+  // the max detector for the end of the range.
+  if (m_partialBins)
+    return detectors.front();
+  else
+    return detectors.back();
+}
+
+double ReflectometryReductionOne3::findIvsLamRangeMin(const MatrixWorkspace_sptr &detectorWS,
+                                                      const std::vector<size_t> &detectors, const double lambda) {
+  double projectedMin = 0.0;
+
+  const size_t spIdx = findIvsLamRangeMinDetector(detectors);
+  const double twoTheta = getDetectorTwoTheta(m_spectrumInfo, spIdx);
+  const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
+
+  // For bLambda, use the average bin size for this spectrum
+  const auto &xValues = detectorWS->x(spIdx);
+  double bLambda = (xValues[xValues.size() - 1] - xValues[0]) / static_cast<int>(xValues.size());
+  double dummy = 0.0;
+  getProjectedLambdaRange(lambda, twoTheta, bLambda, bTwoTheta, detectors, projectedMin, dummy, m_partialBins);
+  return projectedMin;
+}
+
+double ReflectometryReductionOne3::findIvsLamRangeMax(const MatrixWorkspace_sptr &detectorWS,
+                                                      const std::vector<size_t> &detectors, const double lambda) {
+  double projectedMax = 0.0;
+
+  const size_t spIdx = findIvsLamRangeMaxDetector(detectors);
+  const double twoTheta = getDetectorTwoTheta(m_spectrumInfo, spIdx);
+  const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
+
+  // For bLambda, use the average bin size for this spectrum
+  const auto &xValues = detectorWS->x(spIdx);
+  double bLambda = (xValues[xValues.size() - 1] - xValues[0]) / static_cast<int>(xValues.size());
+
+  double dummy = 0.0;
+  getProjectedLambdaRange(lambda, twoTheta, bLambda, bTwoTheta, detectors, dummy, projectedMax, m_partialBins);
+  return projectedMax;
+}
+
+/**
+ * Find the range of the projected lambda range when summing in Q
+ *
+ * @param detectorWS [in] : the workspace containing the values to project
+ * @param detectors [in] : the workspace indices of the detectors of interest
+ * @param lambdaMin [in] : the start of the range to project
+ * @param lambdaMax [in] : the end of the range to project
+ * @param projectedMin [out] : the start of the resulting projected range
+ * @param projectedMax [out] : the end of the resulting projected range
+ */
+void ReflectometryReductionOne3::findIvsLamRange(const MatrixWorkspace_sptr &detectorWS,
+                                                 const std::vector<size_t> &detectors, const double lambdaMin,
+                                                 const double lambdaMax, double &projectedMin, double &projectedMax) {
+
+  // Get the new max and min X values of the projected (virtual) lambda range
+  projectedMin = findIvsLamRangeMin(detectorWS, detectors, lambdaMin);
+  projectedMax = findIvsLamRangeMax(detectorWS, detectors, lambdaMax);
+
+  if (projectedMin > projectedMax) {
+    throw std::runtime_error(
+        "Error projecting lambda range to reference line at twoTheta=" + std::to_string(twoThetaR(detectors)) +
+        "; projected range (" + std::to_string(projectedMin) + "," + std::to_string(projectedMax) + ") is negative.");
+  }
+}
+
+/**
+ * Construct an "empty" output workspace in virtual-lambda for summation in Q.
+ * The workspace will have the same x values as the input workspace but the y
+ * values will all be zero.
+ *
+ * @return : a 1D workspace where y values are all zero
+ */
+MatrixWorkspace_sptr ReflectometryReductionOne3::constructIvsLamWS(const MatrixWorkspace_sptr &detectorWS) {
+
+  // There is one output spectrum for each detector group
+  const size_t numGroups = detectorGroups().size();
+  // Calculate the number of bins based on the min/max wavelength, using
+  // the same bin width as the input workspace
+  const double binWidth =
+      (detectorWS->x(0).back() - detectorWS->x(0).front()) / static_cast<double>(detectorWS->blocksize());
+  const auto numBins = static_cast<int>(std::ceil((wavelengthMax() - wavelengthMin()) / binWidth));
+  // Construct the histogram with these X values. Y and E values are zero.
+  const BinEdges xValues(numBins, LinearGenerator(wavelengthMin(), binWidth));
+  // Create the output workspace
+  MatrixWorkspace_sptr outputWS = WorkspaceFactory::Instance().create(detectorWS, numGroups, numBins, numBins - 1);
+
+  // Loop through each detector group in the input and collate the related list
+  // of spectrum numbers for the output
+  std::vector<SpectrumNumber> spectrumNumbers;
+  for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+    // Get the detectors in this group
+    auto &detectors = detectorGroups()[groupIdx];
+    // Set the x values for this spectrum
+    outputWS->setBinEdges(groupIdx, xValues);
+    // Set the detector ID from the twoThetaR detector.
+    const size_t twoThetaRIdx = twoThetaRDetectorIdx(detectors);
+    auto &outSpec = outputWS->getSpectrum(groupIdx);
+    const detid_t twoThetaRDetID = m_spectrumInfo->detector(twoThetaRIdx).getID();
+    outSpec.clearDetectorIDs();
+    outSpec.addDetectorID(twoThetaRDetID);
+    // Set the spectrum number from the twoThetaR detector
+    spectrumNumbers.emplace_back(detectorWS->indexInfo().spectrumNumber(twoThetaRIdx));
+  }
+  auto indexInf = outputWS->indexInfo();
+  indexInf.setSpectrumNumbers(std::move(spectrumNumbers));
+  outputWS->setIndexInfo(indexInf);
+
+  return outputWS;
+}
+
+/**
+ * Sum counts from the input workspace in lambda along lines of constant Q by
+ * projecting to "virtual lambda" at a reference angle twoThetaR.
+ *
+ * @param detectorWS [in] :: the input workspace in wavelength
+ * @return :: the output workspace in wavelength
+ */
+MatrixWorkspace_sptr ReflectometryReductionOne3::sumInQ(const MatrixWorkspace_sptr &detectorWS) {
+
+  // Construct the output array in virtual lambda
+  MatrixWorkspace_sptr IvsLam = constructIvsLamWS(detectorWS);
+
+  // Loop through each input group (and corresponding output spectrum)
+  const size_t numGroups = detectorGroups().size();
+  for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
+    auto &detectors = detectorGroups()[groupIdx];
+    auto &outputE = IvsLam->dataE(groupIdx);
+
+    // Loop through each spectrum in the detector group
+    for (auto spIdx : detectors) {
+      // Get the angle of this detector and its size in twoTheta
+      const double twoTheta = getDetectorTwoTheta(m_spectrumInfo, spIdx);
+      const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
+
+      // Check X length is Y length + 1
+      const auto &inputX = detectorWS->x(spIdx);
+      const auto &inputY = detectorWS->y(spIdx);
+      const auto &inputE = detectorWS->e(spIdx);
+      if (inputX.size() != inputY.size() + 1) {
+        throw std::runtime_error("Expected input workspace to be histogram data (got X len=" +
+                                 std::to_string(inputX.size()) + ", Y len=" + std::to_string(inputY.size()) + ")");
+      }
+
+      // Create a vector for the projected errors for this spectrum.
+      // (Output Y values can simply be accumulated directly into the output
+      // workspace, but for error values we need to create a separate error
+      // vector for the projected errors from each input spectrum and then
+      // do an overall sum in quadrature.)
+      std::vector<double> projectedE(outputE.size(), 0.0);
+
+      // Process each value in the spectrum
+      const auto ySize = static_cast<int>(inputY.size());
+      for (int inputIdx = 0; inputIdx < ySize; ++inputIdx) {
+        // Do the summation in Q
+        sumInQProcessValue(inputIdx, twoTheta, bTwoTheta, inputX, inputY, inputE, detectors, groupIdx, IvsLam,
+                           projectedE);
+      }
+
+      // Sum errors in quadrature
+      const auto eSize = static_cast<int>(outputE.size());
+      for (int outIdx = 0; outIdx < eSize; ++outIdx) {
+        outputE[outIdx] += projectedE[outIdx] * projectedE[outIdx];
+      }
+    }
+
+    // Take the square root of all the accumulated squared errors for this
+    // detector group. Assumes Gaussian errors
+    double (*rs)(double) = std::sqrt;
+    std::transform(outputE.begin(), outputE.end(), outputE.begin(), rs);
+  }
+
+  return IvsLam;
+}
+
+/**
+ * Share counts from an input value onto the projected output in virtual-lambda
+ *
+ * @param inputIdx [in] :: the index into the input arrays
+ * @param twoTheta [in] :: the value of twotTheta for this spectrum
+ * @param bTwoTheta [in] :: the size of the pixel in twoTheta
+ * @param inputX [in] :: the input spectrum X values
+ * @param inputY [in] :: the input spectrum Y values
+ * @param inputE [in] :: the input spectrum E values
+ * @param detectors [in] :: spectrum indices of the detectors of interest
+ * @param outSpecIdx [in] :: the output spectrum index
+ * @param IvsLam [in,out] :: the output workspace
+ * @param outputE [in,out] :: the projected E values
+ */
+void ReflectometryReductionOne3::sumInQProcessValue(const int inputIdx, const double twoTheta, const double bTwoTheta,
+                                                    const HistogramX &inputX, const HistogramY &inputY,
+                                                    const HistogramE &inputE, const std::vector<size_t> &detectors,
+                                                    const size_t outSpecIdx, const MatrixWorkspace_sptr &IvsLam,
+                                                    std::vector<double> &outputE) {
+
+  // Check whether there are any counts (if not, nothing to share)
+  const double inputCounts = inputY[inputIdx];
+  if (inputCounts <= 0.0 || std::isnan(inputCounts) || std::isinf(inputCounts)) {
+    return;
+  }
+  // Get the bin width and the bin centre
+  const double bLambda = getLambdaRange(inputX, inputIdx);
+  const double lambda = getLambda(inputX, inputIdx);
+  // Project these coordinates onto the virtual-lambda output (at twoThetaR)
+  double lambdaVMin = 0.0;
+  double lambdaVMax = 0.0;
+  getProjectedLambdaRange(lambda, twoTheta, bLambda, bTwoTheta, detectors, lambdaVMin, lambdaVMax);
+  // Share the input counts into the output array
+  sumInQShareCounts(inputCounts, inputE[inputIdx], bLambda, lambdaVMin, lambdaVMax, outSpecIdx, IvsLam, outputE);
+}
+
+/**
+ * Share the given input counts into the output array bins proportionally
+ * according to how much the bins overlap the given lambda range.
+ * outputX.size() must equal outputY.size() + 1
+ *
+ * @param inputCounts [in] :: the input counts to share out
+ * @param inputErr [in] :: the input errors to share out
+ * @param bLambda [in] :: the bin width in lambda
+ * @param lambdaMin [in] :: the start of the range to share counts to
+ * @param lambdaMax [in] :: the end of the range to share counts to
+ * @param outSpecIdx [in] :: the spectrum index to be updated in the output
+ * workspace
+ * @param IvsLam [in,out] :: the output workspace
+ * @param outputE [in,out] :: the projected E values
+ */
+void ReflectometryReductionOne3::sumInQShareCounts(const double inputCounts, const double inputErr,
+                                                   const double bLambda, const double lambdaMin, const double lambdaMax,
+                                                   const size_t outSpecIdx, const MatrixWorkspace_sptr &IvsLam,
+                                                   std::vector<double> &outputE) {
+  // Check that we have histogram data
+  const auto &outputX = IvsLam->dataX(outSpecIdx);
+  auto &outputY = IvsLam->dataY(outSpecIdx);
+  if (outputX.size() != outputY.size() + 1) {
+    throw std::runtime_error("Expected output array to be histogram data (got X len=" + std::to_string(outputX.size()) +
+                             ", Y len=" + std::to_string(outputY.size()) + ")");
+  }
+
+  const double totalWidth = lambdaMax - lambdaMin;
+
+  // Get the first bin edge in the output X array that is within range.
+  // There will probably be some overlap, so start from the bin edge before
+  // this (unless we're already at the first bin edge).
+  auto startIter = std::lower_bound(outputX.begin(), outputX.end(), lambdaMin);
+  if (startIter != outputX.begin()) {
+    --startIter;
+  }
+
+  // Loop through all overlapping output bins. Convert the iterator to an
+  // index because we need to index both the X and Y arrays.
+  const auto xSize = static_cast<int>(outputX.size());
+  for (auto outIdx = startIter - outputX.begin(); outIdx < xSize - 1; ++outIdx) {
+    const double binStart = outputX[outIdx];
+    const double binEnd = outputX[outIdx + 1];
+    if (binStart > lambdaMax) {
+      // No longer in the overlap region so we're finished
+      break;
+    }
+    // Add a share of the input counts to this bin based on the proportion of
+    // overlap.
+    if (totalWidth > Tolerance) {
+      // Share counts out proportionally based on the overlap of this range
+      const double overlapWidth = std::min({bLambda, lambdaMax - binStart, binEnd - lambdaMin});
+      const double fraction = overlapWidth / totalWidth;
+      outputY[outIdx] += inputCounts * fraction;
+      outputE[outIdx] += inputErr * fraction;
+    } else {
+      // Projection to a single value. Put all counts in the overlapping output
+      // bin.
+      outputY[outIdx] += inputCounts;
+      outputE[outIdx] += inputCounts;
+    }
+  }
+}
+
+/**
+ * Project an input pixel onto an arbitrary reference line at twoThetaR. The
+ * projection is done along lines of constant Q, which emanate from theta0. The
+ * top-left and bottom-right corners of the pixel are projected, resulting in an
+ * output range in "virtual" lambda (lambdaV).
+ *
+ * For a description of this projection, see:
+ *   R. Cubitt, T. Saerbeck, R.A. Campbell, R. Barker, P. Gutfreund
+ *   J. Appl. Crystallogr., 48 (6) (2015)
+ *
+ * @param lambda [in] :: the lambda coord of the centre of the pixel to project
+ * @param twoTheta [in] :: the twoTheta coord of the centre of the pixel to
+ *project
+ * @param bLambda [in] :: the pixel size in lambda
+ * @param bTwoTheta [in] :: the pixel size in twoTheta
+ * @param detectors [in] :: spectrum indices of the detectors of interest
+ * @param lambdaVMin [out] :: the projected range start
+ * @param lambdaVMax [out] :: the projected range end
+ * @param outerCorners [in] :: true to project from top-left and bottom-right
+ * corners of the pixel; false to use bottom-left and top-right
+ */
+void ReflectometryReductionOne3::getProjectedLambdaRange(const double lambda, const double twoTheta,
+                                                         const double bLambda, const double bTwoTheta,
+                                                         const std::vector<size_t> &detectors, double &lambdaVMin,
+                                                         double &lambdaVMax, const bool outerCorners) {
+
+  // We cannot project pixels below the horizon angle
+  if (twoTheta <= theta0()) {
+    throw std::runtime_error("Cannot process twoTheta=" + std::to_string(twoTheta * radToDeg) +
+                             " as it is below the horizon angle=" + std::to_string(theta0() * radToDeg));
+  }
+
+  // Get the angle from twoThetaR to this detector
+  const double twoThetaRVal = twoThetaR(detectors);
+  // Get the angle from the horizon to the reference angle
+  const double delta = twoThetaRVal - theta0();
+  // For outer corners use top left, bottom right; otherwise bottom left, top
+  // right
+  const double lambda1 = lambda - bLambda / 2.0;
+  const double lambda2 = lambda + bLambda / 2.0;
+  double twoTheta1 = twoTheta + bTwoTheta / 2.0;
+  double twoTheta2 = twoTheta - bTwoTheta / 2.0;
+  if (!outerCorners)
+    std::swap(twoTheta1, twoTheta2);
+
+  // Calculate the projected wavelength range
+  try {
+    const double lambdaV1 = lambda1 * (std::sin(delta) / std::sin(twoTheta1 - theta0()));
+    const double lambdaV2 = lambda2 * (std::sin(delta) / std::sin(twoTheta2 - theta0()));
+    lambdaVMin = std::min(lambdaV1, lambdaV2);
+    lambdaVMax = std::max(lambdaV1, lambdaV2);
+  } catch (std::exception &ex) {
+    throw std::runtime_error("Failed to project (lambda, twoTheta) = (" + std::to_string(lambda) + "," +
+                             std::to_string(twoTheta * radToDeg) +
+                             ") onto twoThetaR = " + std::to_string(twoThetaRVal) + ": " + ex.what());
+  }
+}
+
+/**
+Check whether the spectra for the given workspaces are the same.
+
+@param ws1 : First workspace to compare
+@param ws2 : Second workspace to compare against
+exception. Otherwise a warning is generated.
+*/
+void ReflectometryReductionOne3::verifySpectrumMaps(const MatrixWorkspace_const_sptr &ws1,
+                                                    const MatrixWorkspace_const_sptr &ws2) {
+
+  bool mismatch = false;
+  // Check that the number of histograms is the same
+  if (ws1->getNumberHistograms() != ws2->getNumberHistograms()) {
+    mismatch = true;
+  }
+  // Check that the spectrum numbers match for each histogram
+  if (!mismatch) {
+    for (size_t i = 0; i < ws1->getNumberHistograms(); ++i) {
+      if (ws1->indexInfo().spectrumNumber(i) != ws2->indexInfo().spectrumNumber(i)) {
+        mismatch = true;
+        break;
+      }
+    }
+  }
+  // Handle if error
+  if (mismatch) {
+    const std::string message = "Spectrum maps between workspaces do NOT match up.";
+    g_log.warning(message);
+  }
+}
+
+void ReflectometryReductionOne3::TaskBackgroundSubtraction::executeImpl() {
+  auto detectorWS = getDependantWorkspace("InputWorkspace");
+  MatrixWorkspace_sptr corrected = m_parent->backgroundSubtraction(detectorWS);
+  outputWorkspace(corrected, Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskConvertToWavelength::executeImpl() {
+  const auto &inputWS = getDependantWorkspace("InputWorkspace");
+  auto result = m_parent->convertToWavelength(inputWS);
+  if (!m_parent->m_wavelengthMinMaxSet) {
+    m_parent->findWavelengthMinMax(result);
+    m_parent->m_wavelengthMinMaxSet = true;
+  }
+  outputWorkspace(result, Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength);
+}
+
+void ReflectometryReductionOne3::TaskNormalizeByMonitor::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  MatrixWorkspace_sptr normalized = m_parent->monitorCorrection(inputWS);
+  outputWorkspace(normalized, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskNormalizeByTransmission::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  auto [transmissionCorrected, transmission] = m_parent->transmissionCorrection(inputWS);
+  outputWorkspace(transmissionCorrected, Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace);
+  outputWorkspace(transmission, Tasks::NormalizeByTransmission::Outputs::TransmissionWorkspace);
+  setSelectedOutput(Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace, true);
+}
+
+void ReflectometryReductionOne3::TaskExtractROI::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  auto extracted = m_parent->makeDetectorWS(inputWS, false, false);
+  outputWorkspace(extracted, Tasks::ExtractROI::Outputs::ExtractedROIWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskSumDetectors::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  auto summed = m_parent->makeDetectorWS(inputWS, false, true);
+  outputWorkspace(summed, Tasks::SumDetectors::Outputs::SummedWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskCropWavelength::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  if (!m_parent->m_wavelengthMinMaxSet) {
+    m_parent->findWavelengthMinMax(inputWS);
+    m_parent->m_wavelengthMinMaxSet = true;
+  }
+  auto cropped = m_parent->cropWavelength(inputWS, true, m_parent->wavelengthMin(), m_parent->wavelengthMax());
+  outputWorkspace(cropped, Tasks::CropWavelength::Outputs::CroppedWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskConvertToQ::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  // Outputs the input workspace to convert to Q (i.e wavelength output workspace)
+  if (!m_parent->isDefault("OutputWorkspaceWavelength") || m_parent->isChild())
+    m_parent->setProperty("OutputWorkspaceWavelength", inputWS);
+  auto converted = m_parent->convertToQ(inputWS);
+  // Outputs the converted workspace
+  if (!m_parent->isDefault("OutputWorkspaceQ") || m_parent->isChild())
+    m_parent->setProperty("OutputWorkspaceQ", converted);
+  outputWorkspace(converted, Tasks::ConvertToQ::Outputs::ConvertedWorkspaceQ);
+}
+
+void ReflectometryReductionOne3::TaskSumDetectorsInQ::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  auto summedInQ = m_parent->sumInQ(inputWS);
+  outputWorkspace(summedInQ, Tasks::SumDetectorsInQ::Outputs::QSummedWorkspace);
+}
+
+void ReflectometryReductionOne3::TaskNormalizeByAlgorithm::executeImpl() {
+  auto inputWS = getDependantWorkspace("InputWorkspace");
+  auto algCorrected = m_parent->algorithmicCorrection(inputWS);
+  outputWorkspace(algCorrected, Tasks::NormalizeByAlgorithm::Outputs::AlgorithmCorrectedWorkspace);
+}
+
+} // namespace Mantid::Reflectometry

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -880,4 +880,67 @@ void ReflectometryWorkflowBase2::setWorkspacePropertyFromChild(const Algorithm_s
   MatrixWorkspace_sptr workspace = alg->getProperty(propertyName);
   setProperty(propertyName, workspace);
 }
+
+std::vector<std::string> ReflectometryWorkflowBase2::getTaskExecutionOrderFromProperties(
+    const bool summingInQ, const bool reduced, const std::string &IOMonIndexProp, const std::string &MonBGWaveMinProp,
+    const std::string &MonBGWaveMaxProp, const std::string &firstTransRunProp, const std::string &correctionAlgProp,
+    const std::string &subBGProp) const {
+  std::vector<std::string> teo;
+  std::string sumDetectorsTask;
+  // Select tasks based upon summation type
+  if (summingInQ) {
+    teo = {
+        "TaskBackgroundSubtraction", "TaskConvertToWavelength", "TaskNormalizeByMonitor", "TaskNormalizeByTransmission",
+        "TaskSumDetectorsInQ",       "TaskCropWavelength",      "TaskConvertToQ"};
+    sumDetectorsTask = "TaskSumDetectorsInQ";
+  } else {
+    teo = {"TaskExtractROI",
+           "TaskBackgroundSubtraction",
+           "TaskSumDetectors",
+           "TaskConvertToWavelength",
+           "TaskNormalizeByMonitor",
+           "TaskCropWavelength",
+           "TaskNormalizeByTransmission",
+           "TaskConvertToQ"};
+    sumDetectorsTask = "TaskSumDetectors";
+  }
+
+  if (reduced) {
+    // Assume already part reduced: lambda workspace already normalized and summed
+    std::erase(teo, "TaskExtractROI");
+    std::erase(teo, "TaskBackgroundSubtraction");
+    std::erase(teo, "TaskNormalizeByMonitor");
+    std::erase(teo, "TaskConvertToWavelength");
+    std::erase(teo, "TaskNormalizeByMonitor");
+    std::erase(teo, "TaskNormalizeByTransmission");
+    std::erase(teo, sumDetectorsTask);
+    return teo;
+  }
+
+  // evaluate necessity of monitor normalization
+  const Property *monProperty = getProperty(IOMonIndexProp);
+  const Property *backgroundMinProperty = getProperty(MonBGWaveMinProp);
+  const Property *backgroundMaxProperty = getProperty(MonBGWaveMaxProp);
+  if (monProperty->isDefault() || backgroundMinProperty->isDefault() || backgroundMaxProperty->isDefault()) {
+    std::erase(teo, "TaskNormalizeByMonitor");
+  }
+
+  // evaluate necessity of transmission/alg normalization
+  const Property *transRun = getProperty(firstTransRunProp);
+  const Property *correctionAlg = getProperty(correctionAlgProp);
+  if (!correctionAlg->isDefault()) {
+    auto it = std::find(teo.begin(), teo.end(), "TaskNormalizeByTransmission");
+    if (it != teo.end()) {
+      *it = "TaskNormalizeByAlgorithm";
+    }
+  } else if (transRun->isDefault()) {
+    std::erase(teo, "TaskNormalizeByTransmission");
+  }
+  // evaluate necessity of background subtraction
+  const Property *subtractBackground = getProperty(subBGProp);
+  if (subtractBackground->isDefault()) {
+    std::erase(teo, "TaskBackgroundSubtraction");
+  }
+  return teo;
+}
 } // namespace Mantid::Reflectometry

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -889,30 +889,34 @@ std::vector<std::string> ReflectometryWorkflowBase2::getTaskExecutionOrderFromPr
   std::string sumDetectorsTask;
   // Select tasks based upon summation type
   if (summingInQ) {
-    teo = {
-        "TaskBackgroundSubtraction", "TaskConvertToWavelength", "TaskNormalizeByMonitor", "TaskNormalizeByTransmission",
-        "TaskSumDetectorsInQ",       "TaskCropWavelength",      "TaskConvertToQ"};
-    sumDetectorsTask = "TaskSumDetectorsInQ";
+    teo = {Tasks::BackgroundSubtraction::name,
+           Tasks::ConvertToWavelength::name,
+           Tasks::NormalizeByMonitor::name,
+           Tasks::NormalizeByTransmission::name,
+           Tasks::SumDetectorsInQ::name,
+           Tasks::CropWavelength::name,
+           Tasks::ConvertToQ::name};
+    sumDetectorsTask = Tasks::SumDetectorsInQ::name;
   } else {
-    teo = {"TaskExtractROI",
-           "TaskBackgroundSubtraction",
-           "TaskSumDetectors",
-           "TaskConvertToWavelength",
-           "TaskNormalizeByMonitor",
-           "TaskCropWavelength",
-           "TaskNormalizeByTransmission",
-           "TaskConvertToQ"};
-    sumDetectorsTask = "TaskSumDetectors";
+    teo = {Tasks::ExtractROI::name,
+           Tasks::BackgroundSubtraction::name,
+           Tasks::SumDetectors::name,
+           Tasks::ConvertToWavelength::name,
+           Tasks::NormalizeByMonitor::name,
+           Tasks::CropWavelength::name,
+           Tasks::NormalizeByTransmission::name,
+           Tasks::ConvertToQ::name};
+    sumDetectorsTask = Tasks::SumDetectors::name;
   }
 
   if (reduced) {
     // Assume already part reduced: lambda workspace already normalized and summed
-    std::erase(teo, "TaskExtractROI");
-    std::erase(teo, "TaskBackgroundSubtraction");
-    std::erase(teo, "TaskNormalizeByMonitor");
-    std::erase(teo, "TaskConvertToWavelength");
-    std::erase(teo, "TaskNormalizeByMonitor");
-    std::erase(teo, "TaskNormalizeByTransmission");
+    std::erase(teo, Tasks::ExtractROI::name);
+    std::erase(teo, Tasks::BackgroundSubtraction::name);
+    std::erase(teo, Tasks::NormalizeByMonitor::name);
+    std::erase(teo, Tasks::ConvertToWavelength::name);
+    std::erase(teo, Tasks::NormalizeByMonitor::name);
+    std::erase(teo, Tasks::NormalizeByTransmission::name);
     std::erase(teo, sumDetectorsTask);
     return teo;
   }
@@ -922,24 +926,24 @@ std::vector<std::string> ReflectometryWorkflowBase2::getTaskExecutionOrderFromPr
   const Property *backgroundMinProperty = getProperty(MonBGWaveMinProp);
   const Property *backgroundMaxProperty = getProperty(MonBGWaveMaxProp);
   if (monProperty->isDefault() || backgroundMinProperty->isDefault() || backgroundMaxProperty->isDefault()) {
-    std::erase(teo, "TaskNormalizeByMonitor");
+    std::erase(teo, Tasks::NormalizeByMonitor::name);
   }
 
   // evaluate necessity of transmission/alg normalization
   const Property *transRun = getProperty(firstTransRunProp);
   const Property *correctionAlg = getProperty(correctionAlgProp);
   if (!correctionAlg->isDefault()) {
-    auto it = std::find(teo.begin(), teo.end(), "TaskNormalizeByTransmission");
+    auto it = std::find(teo.begin(), teo.end(), Tasks::NormalizeByTransmission::name);
     if (it != teo.end()) {
-      *it = "TaskNormalizeByAlgorithm";
+      *it = Tasks::NormalizeByAlgorithm::name;
     }
   } else if (transRun->isDefault()) {
-    std::erase(teo, "TaskNormalizeByTransmission");
+    std::erase(teo, Tasks::NormalizeByTransmission::name);
   }
   // evaluate necessity of background subtraction
   const Property *subtractBackground = getProperty(subBGProp);
   if (subtractBackground->isDefault()) {
-    std::erase(teo, "TaskBackgroundSubtraction");
+    std::erase(teo, Tasks::BackgroundSubtraction::name);
   }
   return teo;
 }

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -231,7 +231,8 @@ Usage
 
    run = Load(Filename='INTER00013460.nxs')
    # Basic reduction with no transmission run
-   IvsQ, IvsLam = ReflectometryReductionOne(InputWorkspace=run,
+   IvsQ, IvsLam = ReflectometryReductionOne(Version = 2,
+                                            InputWorkspace=run,
                                             WavelengthMin=1.0,
                                             WavelengthMax=17.0,
                                             ProcessingInstructions='4',
@@ -265,7 +266,8 @@ Output:
    trans1 = Load(Filename='INTER00013463.nxs')
    trans2 = Load(Filename='INTER00013464.nxs')
    # Basic reduction with two transmission runs
-   IvsQ, IvsLam, TRANS = ReflectometryReductionOne(InputWorkspace=run,
+   IvsQ, IvsLam, TRANS = ReflectometryReductionOne(Version = 2,
+                                                   InputWorkspace=run,
                                                    WavelengthMin=1.0,
                                                    WavelengthMax=17.0,
                                                    ProcessingInstructions='4',

--- a/docs/source/algorithms/ReflectometryReductionOne-v3.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v3.rst
@@ -1,0 +1,152 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm is not meant to be used directly by users. Please see
+:ref:`algm-ReflectometryReductionOneAuto`, which is a facade over this
+algorithm.
+
+Version 3 is a refactor of :ref:`ReflectometryReductionOne version 2
+<algm-ReflectometryReductionOne-v2>` into a task-based algorithm. The reduction
+methodology and output workspaces are intended to be the same as version 2. See
+:ref:`ReflectometryReductionOne version 2 <algm-ReflectometryReductionOne-v2>`
+for the detailed description of the reduction workflow, including conversion to
+wavelength, monitor normalisation, transmission correction, summation in Q, and
+conversion to momentum transfer.
+
+Task Execution Order
+####################
+
+Version 3 exposes the ``TaskExecutionOrder`` property. This property is
+intended for advanced use. If it is left blank, the algorithm dynamically builds
+the task execution order from the input workspace and reduction properties. If
+it is provided, the custom task execution order is used instead.
+
+When ``TaskExecutionOrder`` is blank, the generated order depends on:
+
+* the input workspace X unit. A workspace already in wavelength is treated as
+  partially reduced, so the initial extraction, summation, wavelength conversion,
+  monitor normalisation, and transmission normalisation tasks are skipped;
+* ``SummationType``. ``SumInQ`` uses the Q-summation task after the
+  normalisation steps, while the default wavelength summation uses the detector
+  summation task before wavelength conversion;
+* monitor normalisation properties. ``TaskNormalizeByMonitor`` is included only
+  when ``I0MonitorIndex``, ``MonitorBackgroundWavelengthMin``, and
+  ``MonitorBackgroundWavelengthMax`` are all set;
+* transmission and algorithmic correction properties. ``TaskNormalizeByTransmission``
+  is included when ``FirstTransmissionRun`` is set. If ``CorrectionAlgorithm``
+  is set, ``TaskNormalizeByAlgorithm`` is used instead;
+* ``SubtractBackground``. ``TaskBackgroundSubtraction`` is included only when
+  this property is set.
+
+The available task names are:
+
+* ``TaskExtractROI``
+* ``TaskBackgroundSubtraction``
+* ``TaskSumDetectors``
+* ``TaskConvertToWavelength``
+* ``TaskNormalizeByMonitor``
+* ``TaskNormalizeByTransmission``
+* ``TaskNormalizeByAlgorithm``
+* ``TaskSumDetectorsInQ``
+* ``TaskCropWavelength``
+* ``TaskConvertToQ``
+
+Custom task orders must use valid task names and must include the prerequisite
+tasks needed to satisfy each task's input dependencies. Knowledge of the implementation of the task-based structure
+is therefore required.
+
+For routine reductions, leave ``TaskExecutionOrder`` blank so that the algorithm selects the same
+workflow as version 2 from the supplied properties.
+
+Previous Versions
+-----------------
+
+This is version 3 of the algorithm. For version 2, please see `here
+<ReflectometryReductionOne-v2.html>`_.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+**Example - Reduce a run using the dynamically generated task order**
+
+.. testcode:: ExReflRedOneDynamicTEO
+
+   run = Load(Filename='INTER00013460.nxs')
+   IvsQ, IvsLam = ReflectometryReductionOne(InputWorkspace=run,
+                                            WavelengthMin=1.0,
+                                            WavelengthMax=17.0,
+                                            ProcessingInstructions='4',
+                                            I0MonitorIndex=2,
+                                            MonitorBackgroundWavelengthMin=15.0,
+                                            MonitorBackgroundWavelengthMax=17.0,
+                                            MonitorIntegrationWavelengthMin=4.0,
+                                            MonitorIntegrationWavelengthMax=10.0)
+
+   print("{:.4f}".format(IvsLam.readY(0)[533]))
+   print("{:.4f}".format(IvsLam.readY(0)[534]))
+   print("{:.4f}".format(IvsQ.readY(0)[327]))
+   print("{:.4f}".format(IvsQ.readY(0)[328]))
+
+
+Output:
+
+.. testoutput:: ExReflRedOneDynamicTEO
+
+   0.0003
+   0.0003
+   0.0003
+   0.0003
+
+
+**Example - Reduce a run using a custom task execution order**
+
+.. testcode:: ExReflRedOneCustomTEO
+
+   run = Load(Filename='INTER00013460.nxs')
+   task_order = [
+       "TaskExtractROI",
+       "TaskSumDetectors",
+       "TaskConvertToWavelength",
+       "TaskNormalizeByMonitor",
+       "TaskCropWavelength",
+       "TaskConvertToQ",
+   ]
+   IvsQ, IvsLam = ReflectometryReductionOne(TaskExecutionOrder=task_order,
+                                            InputWorkspace=run,
+                                            WavelengthMin=1.0,
+                                            WavelengthMax=17.0,
+                                            ProcessingInstructions='4',
+                                            I0MonitorIndex=2,
+                                            MonitorBackgroundWavelengthMin=15.0,
+                                            MonitorBackgroundWavelengthMax=17.0,
+                                            MonitorIntegrationWavelengthMin=4.0,
+                                            MonitorIntegrationWavelengthMax=10.0)
+
+   print("{:.4f}".format(IvsLam.readY(0)[533]))
+   print("{:.4f}".format(IvsLam.readY(0)[534]))
+   print("{:.4f}".format(IvsQ.readY(0)[327]))
+   print("{:.4f}".format(IvsQ.readY(0)[328]))
+
+
+Output:
+
+.. testoutput:: ExReflRedOneCustomTEO
+
+   0.0003
+   0.0003
+   0.0003
+   0.0003
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.16.0/Reflectometry/New_features/41325.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/New_features/41325.rst
@@ -1,0 +1,1 @@
+- A new version of :ref:`algm-ReflectometryReductionOne` has been introduced. This version of the algorithm is tasked based, and therefore a new property ``TaskExecutionOrder`` can be specified, enabling advanced users to customise the algorithm workflow.

--- a/docs/source/release/v6.16.0/Reflectometry/New_features/41325.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/New_features/41325.rst
@@ -1,1 +1,1 @@
-- A new version of :ref:`algm-ReflectometryReductionOne` has been introduced. This version of the algorithm is tasked based, and therefore a new property ``TaskExecutionOrder`` can be specified, enabling advanced users to customise the algorithm workflow.
+- A new version of :ref:`algm-ReflectometryReductionOne-v3` has been introduced. This version of the algorithm is tasked based, and therefore a new property ``TaskExecutionOrder`` can be specified, enabling advanced users to customise the algorithm workflow.


### PR DESCRIPTION
### Description of work

This PR introduces a new version of `ReflectometryReductionOne`, version 3.

When run with the same arguments, there should be no difference when compared to the output from v2.

The only external facing change is the new input parameter, `TaskExecutionOrder`.  For more detail on this, see the `TaskBasedAlgorithm` documentation.

### To test:

Run the following scripts and compare IvsQ output (I've called it... `OUTPUT`) for version 3 and version 2 (change parameter at top of script).

**Sum in lambda**
```
from mantid.simpleapi import *

ALGORITHM_VERSION=3 #2
DATA_LOCATION='/Users/mial.lewis/data/PNR/'

Load(Filename=f'{DATA_LOCATION}POLREF00047039.nxs', OutputWorkspace='POLREF00047039')
Load(Filename=f'{DATA_LOCATION}POLREF00047041.nxs', OutputWorkspace='POLREF00047041')

ReflectometryReductionOne(Version=ALGORITHM_VERSION, InputWorkspace='POLREF00047041_1',
                          ThetaIn=0.40000000000000002, ProcessingInstructions='272-288',
                          WavelengthMin=1, WavelengthMax=15, I0MonitorIndex=2, MonitorBackgroundWavelengthMin=15,
                          MonitorBackgroundWavelengthMax=16, MonitorIntegrationWavelengthMin=4, MonitorIntegrationWavelengthMax=10,
                          SubtractBackground=True, BackgroundProcessingInstructions='360-450', FirstTransmissionRun='POLREF00047039',
                          StartOverlap=10, EndOverlap=12, OutputWorkspace='IvsQ_47041', OutputWorkspaceTransmission='TRANS_LAM_47039',
                          Diagnostics=True)
Rebin(InputWorkspace='IvsQ_47041', OutputWorkspace='OUTPUT', Params='0.00584943,-0.0334278,0.0874452', PreserveEvents=False)
```

**Sum in Q**
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ALGORITHM_VERSION=3 #2
DATA_LOCATION='/Users/mial.lewis/data/PNR/'

Load(Filename=f'{DATA_LOCATION}POLREF00047039.nxs', OutputWorkspace='POLREF00047039')
Load(Filename=f'{DATA_LOCATION}POLREF00047041.nxs', OutputWorkspace='POLREF00047041')

ReflectometryReductionOne(Version=ALGORITHM_VERSION, InputWorkspace='POLREF00047041_1',
                          ThetaIn=0.40000000000000002, ProcessingInstructions='272-288',
                          WavelengthMin=1, WavelengthMax=15, I0MonitorIndex=2, MonitorBackgroundWavelengthMin=15,
                          MonitorBackgroundWavelengthMax=16, MonitorIntegrationWavelengthMin=4, MonitorIntegrationWavelengthMax=10,
                          SubtractBackground=True, BackgroundProcessingInstructions='360-450', FirstTransmissionRun='POLREF00047039',
                          StartOverlap=10, EndOverlap=12, OutputWorkspace='IvsQ_47041', OutputWorkspaceTransmission='TRANS_LAM_47039',
                          Diagnostics=True, SummationType="SumInQ", ReductionType="DivergentBeam")
Rebin(InputWorkspace='IvsQ_47041', OutputWorkspace='OUTPUT', Params='0.00584943,-0.0334278,0.0874452', PreserveEvents=False)
```

**Task Execution Order**

Pass into RRO using `TaskExecutionOrder=teo`.

Try removing one of the normalisation steps and observing output, or similar.

For sum in lamba:
```
teo = ["TaskExtractROI", "TaskBackgroundSubtraction", "TaskSumDetectors", "TaskConvertToWavelength",
       "TaskNormalizeByMonitor", "TaskNormalizeByTransmission", "TaskCropWavelength", "TaskConvertToQ"]
```

For sum in q:
```
teo = ["TaskBackgroundSubtraction", "TaskConvertToWavelength",
       "TaskNormalizeByMonitor", "TaskNormalizeByTransmission", "TaskSumDetectorsInQ", "TaskCropWavelength", "TaskConvertToQ"]
```

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
