### PR TITLE
Refactor VectorHelper to be more clear, pre-calculate memory requirement

### DIFF
--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -797,10 +797,12 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
   // Iterate over all groups to create the new X vectors
   size_t i = 0;
   for (auto group : groups) {
-    HistogramData::BinEdges xnew(0);
-    static_cast<void>(VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew.mutableRawData(),
-                                                              true, fullBinsOnly));
-    group2xvector[group] = xnew; // Register this vector in the map
+    // NOTE must use a vector instead of a HistogramData::BinEdges here because the latter doesn't allow resizing
+    // BinEdges stores HistogramX data, and HistogramX is a type of FixedLengthVector
+    std::vector<double> xnew;
+    static_cast<void>(
+        VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew, true, fullBinsOnly));
+    group2xvector[group] = std::move(xnew); // Register this vector in the map
     group2xstep[group] = deltas[i];
     i++;
   }

--- a/Framework/Kernel/inc/MantidKernel/Memory.h
+++ b/Framework/Kernel/inc/MantidKernel/Memory.h
@@ -42,7 +42,7 @@ public:
   std::size_t getCurrentRSS() const;
   std::size_t getPeakRSS() const;
   double getFreeRatio() const;
-  std::string checkAvailableMemory(std::size_t const requestedMemory) const;
+  std::string checkAvailableMemory(std::size_t const requestedMemoryBytes) const;
 
 private:
   void process_mem_system(size_t &sys_avail, size_t &sys_total);

--- a/Framework/Kernel/inc/MantidKernel/Memory.h
+++ b/Framework/Kernel/inc/MantidKernel/Memory.h
@@ -42,6 +42,7 @@ public:
   std::size_t getCurrentRSS() const;
   std::size_t getPeakRSS() const;
   double getFreeRatio() const;
+  std::string checkAvailableMemory(std::size_t const requestedMemory) const;
 
 private:
   void process_mem_system(size_t &sys_avail, size_t &sys_total);

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -26,6 +26,10 @@ namespace Kernel {
  */
 namespace VectorHelper {
 
+void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &, bool const = false);
+
+std::size_t MANTID_KERNEL_DLL estimateNumberOfBins(std::vector<double> const &params, double const power = -1);
+
 std::size_t MANTID_KERNEL_DLL createAxisFromRebinParams(
     const std::vector<double> &params, std::vector<double> &xnew, const bool resize_xnew = true,
     const bool full_bins_only = false, const double xMinHint = std::nan(""), const double xMaxHint = std::nan(""),

--- a/Framework/Kernel/src/Memory.cpp
+++ b/Framework/Kernel/src/Memory.cpp
@@ -565,7 +565,7 @@ size_t MemoryStats::getCurrentRSS() const {
 }
 
 /** @brief Check if there is enough space in memory to hold the requested amount of memory.
- * @param requestedMemory :: The amount of memory that is being requested, in bytes.
+ * @param requestedMemoryBytes :: The amount of memory that is being requested, in bytes.
  * @return error string if the requested memory would exceed the available memory; else empty string
  */
 std::string MemoryStats::checkAvailableMemory(std::size_t const requestedMemoryBytes) const {

--- a/Framework/Kernel/src/Memory.cpp
+++ b/Framework/Kernel/src/Memory.cpp
@@ -564,6 +564,25 @@ size_t MemoryStats::getCurrentRSS() const {
 #endif
 }
 
+/** @brief Check if there is enough space in memory to hold the requested amount of memory.
+ * @param requestedMemory :: The amount of memory that is being requested, in bytes.
+ * @return error string if the requested memory would exceed the available memory; else empty string
+ */
+std::string MemoryStats::checkAvailableMemory(std::size_t const requestedMemory) const {
+  std::string errorString;
+  const auto availableMemory = this->availMem() * 1024; // Convert from KiB to bytes
+  if (requestedMemory > availableMemory) {
+    double constexpr byesToGB = 1e9;
+    double requestedGB = static_cast<double>(requestedMemory) / byesToGB;
+    double availableGB = static_cast<double>(availableMemory) / byesToGB;
+    errorString = "The number of bins requested is expected to exceed available memory. "
+                  "This binning requires approximately " +
+                  std::to_string(requestedGB) + " GB of memory, but only " + std::to_string(availableGB) +
+                  " GB is available.";
+  }
+  return errorString;
+}
+
 // -------------------------- concrete instantiations
 template DLLExport string memToString<uint32_t>(const uint32_t);
 template DLLExport string memToString<uint64_t>(const uint64_t);

--- a/Framework/Kernel/src/Memory.cpp
+++ b/Framework/Kernel/src/Memory.cpp
@@ -572,9 +572,9 @@ std::string MemoryStats::checkAvailableMemory(std::size_t const requestedMemory)
   std::string errorString;
   const auto availableMemory = this->availMem() * 1024; // Convert from KiB to bytes
   if (requestedMemory > availableMemory) {
-    double constexpr byesToGB = 1e9;
-    double requestedGB = static_cast<double>(requestedMemory) / byesToGB;
-    double availableGB = static_cast<double>(availableMemory) / byesToGB;
+    double constexpr bytesToGB = 1e9;
+    double requestedGB = static_cast<double>(requestedMemory) / bytesToGB;
+    double availableGB = static_cast<double>(availableMemory) / bytesToGB;
     errorString = "The number of bins requested is expected to exceed available memory. "
                   "This binning requires approximately " +
                   std::to_string(requestedGB) + " GB of memory, but only " + std::to_string(availableGB) +

--- a/Framework/Kernel/src/Memory.cpp
+++ b/Framework/Kernel/src/Memory.cpp
@@ -568,17 +568,15 @@ size_t MemoryStats::getCurrentRSS() const {
  * @param requestedMemory :: The amount of memory that is being requested, in bytes.
  * @return error string if the requested memory would exceed the available memory; else empty string
  */
-std::string MemoryStats::checkAvailableMemory(std::size_t const requestedMemory) const {
+std::string MemoryStats::checkAvailableMemory(std::size_t const requestedMemoryBytes) const {
   std::string errorString;
   const auto availableMemory = this->availMem() * 1024; // Convert from KiB to bytes
-  if (requestedMemory > availableMemory) {
+  if (requestedMemoryBytes > availableMemory) {
     double constexpr bytesToGB = 1e9;
-    double requestedGB = static_cast<double>(requestedMemory) / bytesToGB;
+    double requestedGB = static_cast<double>(requestedMemoryBytes) / bytesToGB;
     double availableGB = static_cast<double>(availableMemory) / bytesToGB;
-    errorString = "The number of bins requested is expected to exceed available memory. "
-                  "This binning requires approximately " +
-                  std::to_string(requestedGB) + " GB of memory, but only " + std::to_string(availableGB) +
-                  " GB is available.";
+    errorString = "Requested " + std::to_string(requestedGB) + " GB of memory, but only " +
+                  std::to_string(availableGB) + " GB is available.";
   }
   return errorString;
 }

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -17,11 +17,14 @@ using std::size_t;
 
 namespace {
 // edge checks
+struct EdgeCheck { // for polymorphic access to functors
+  virtual bool operator()(double, double, double) const = 0;
+};
 
 // Standard check, for linear, log, and power
-struct standardEdgeCheck {
-  standardEdgeCheck(double lastBinCoef) : m_lastBinCoef(lastBinCoef) {}
-  bool operator()(double xcurr, double xs, double rightEdge) const {
+struct StandardEdgeCheck : EdgeCheck {
+  StandardEdgeCheck(double lastBinCoef) : m_lastBinCoef(lastBinCoef) {}
+  bool operator()(double xcurr, double xs, double rightEdge) const override {
     return xcurr + (1. + m_lastBinCoef) * xs <= rightEdge;
   }
 
@@ -29,45 +32,44 @@ private:
   double m_lastBinCoef;
 };
 // Reverse log check, for reverse log only
-struct reverseLogEdgeCheck {
-  bool operator()(double xcurr, double xs, double leftEdge) const { return xcurr + 2. * xs >= leftEdge; }
+struct ReverseLogEdgeCheck : EdgeCheck {
+  bool operator()(double xcurr, double xs, double leftEdge) const override { return xcurr + 2. * xs >= leftEdge; }
 };
 
-// bin width functions
+// bin width functionss
+struct BinWidth { // for polymorphic access to functors
+  virtual double operator()(double, double) const = 0;
+};
 
 // Linear bin width is just the alpha parameter
-struct linearBinWidth {
-  double operator()(double xcurr, double alpha) const {
-    (void)xcurr;
-    return alpha;
-  }
+struct LinearBinWidth : BinWidth {
+  double operator()([[maybe_unused]] double xcurr, double alpha) const override { return alpha; }
 };
 // Log bin width is current position times the alpha parameter
-struct logBinWidth {
-  double operator()(double xcurr, double alpha) const { return xcurr * alpha; }
+struct LogBinWidth : BinWidth {
+  double operator()(double xcurr, double alpha) const override { return xcurr * alpha; }
 };
 
 // REVERSE LOGARITHMIC
 // we go through a reverse log bin by starting from its end, and working our way back to the beginning
-// this way we can define the bins in a reccuring way, and with a more obvious closeness with the usual log.
-struct reverseLogBinWidth {
-  reverseLogBinWidth(double leftEdge, double rightEdge) : m_leftEdge(leftEdge), m_rightEdge(rightEdge) {}
-  double operator()(double xcurr, double alpha) const { return (xcurr - m_rightEdge - m_leftEdge) * alpha; }
+// this way we can define the bins in a recurring way, and with a more obvious closeness with the usual log.
+struct ReverseLogBinWidth : BinWidth {
+  ReverseLogBinWidth(double leftEdge, double rightEdge) : m_leftEdge(leftEdge), m_rightEdge(rightEdge) {}
+  double operator()(double xcurr, double alpha) const override { return (xcurr - m_rightEdge - m_leftEdge) * alpha; }
 
 private:
   double m_leftEdge;
   double m_rightEdge;
 };
-// Power bin width is the alpha parameter divided by the curren index to the power
-struct powerBinWidth {
-  powerBinWidth(std::size_t &currDiv, double power) : m_currDiv(currDiv), m_power(power) {}
-  double operator()(double xcurr, double alpha) {
-    (void)xcurr;
-    return alpha * std::pow(m_currDiv++, -m_power);
+// Power bin width is the alpha parameter divided by the current index to the power
+struct PowerBinWidth : BinWidth {
+  PowerBinWidth(std::size_t &currDiv, double power) : m_currDiv(&currDiv), m_power(power) {}
+  double operator()([[maybe_unused]] double xcurr, double alpha) const override {
+    return alpha * std::pow((*m_currDiv)++, -m_power);
   }
 
 private:
-  std::size_t &m_currDiv;
+  std::size_t *m_currDiv; // make a pointer so operator() can be const; the pointed-to changes, but not the pointer
   double m_power;
 };
 } // namespace
@@ -104,16 +106,16 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
   }
   std::vector<double> const &fullParams = params.size() == 1 ? tmp : params;
 
-  // if resize_new is true, do a first run to determine the needed number of bins
+  // if resize_xnew is true, do a first run to determine the needed number of bins
   if (resize_xnew) {
     std::vector<double> xnewTemp;
     size_t neededSize = createAxisFromRebinParams(fullParams, xnewTemp, /*resize_new*/ false, full_bins_only, xMinHint,
                                                   xMaxHint, useReverseLogarithmic, power);
-    // NOTE memory overflow error could occur here
+    /* NOTE memory overflow check could occur here */
     xnew.reserve(neededSize);
   }
 
-  // This coefficitent represents the maximum difference between the size of the last bin and all
+  // This coefficient represents the maximum difference between the size of the last bin and all
   // the other bins.
   // For full_bin_only, we want it so that last bin couldn't be smaller than the previous bin
   double const lastBinCoef = full_bins_only ? 1.0 : 0.25;
@@ -136,28 +138,33 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
     double rightEdge = fullParams[i + 1];
     double alpha = std::fabs(binParam);
 
-    // determine the binning mode for this range
-    std::function<double(double, double)> binWidth = nullptr;
-    std::function<bool(double, double, double)> edgeCheck = standardEdgeCheck(lastBinCoef);
+    // functions for calculating bin width and checking if within range
+    std::unique_ptr<BinWidth> binWidth(nullptr);
+    std::unique_ptr<EdgeCheck> edgeCheck(nullptr);
     if (binParam < 0.0 && useReverseLogarithmic) {
       // REVERSE LOGARITHMIC
-      binWidth = reverseLogBinWidth(leftEdge, rightEdge);
-      edgeCheck = reverseLogEdgeCheck();
+      binWidth.reset(new ReverseLogBinWidth{leftEdge, rightEdge});
+      edgeCheck.reset(new ReverseLogEdgeCheck);
+      // for reverse log, we start at the right edge and work back to left; to use the same loop, swap the edges
+      // the final edge will be added after the loop, fullParams[i+1]
       xcurr = rightEdge;
       std::swap(leftEdge, rightEdge);
     } else if (binParam < 0.0) {
       // LOGARITHMIC
-      binWidth = logBinWidth();
+      binWidth.reset(new LogBinWidth);
+      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
     } else if (isPower) {
       // POWER
-      binWidth = powerBinWidth(currDiv, power);
+      binWidth.reset(new PowerBinWidth{currDiv, power});
+      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
     } else {
       // LINEAR
-      binWidth = linearBinWidth();
+      binWidth.reset(new LinearBinWidth);
+      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
     }
 
-    double xs = binWidth(xcurr, alpha);
-    while (edgeCheck(xcurr, xs, rightEdge) || !std::isfinite(xs)) { // let errors fall through
+    double xs = (*binWidth)(xcurr, alpha);
+    while ((*edgeCheck)(xcurr, xs, rightEdge) || !std::isfinite(xs)) { // let errors fall through
       if (xs == 0.0) {
         // Someone gave a 0-sized step! What a dope.
         throw std::runtime_error("Invalid binning step provided! Can't create binning axis.");
@@ -170,7 +177,7 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
       }
       inew++;
       // prepare for next step
-      xs = binWidth(xcurr, alpha);
+      xs = (*binWidth)(xcurr, alpha);
     }
 
     // handle last edge specially, depending on if full_bins_only is set
@@ -189,7 +196,10 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
     // prepare for next range
     leftEdge = xcurr;
   }
-  std::sort(xnew.begin(), xnew.end());
+  // if using reverse log, some bins were added in wrong order; so sort them
+  if (useReverseLogarithmic) {
+    std::sort(xnew.begin(), xnew.end());
+  }
   return inew;
 }
 

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -190,10 +190,13 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
   if (resize_xnew) {
     // call to estimateNumberOfBins will also validate the parameters
     size_t neededSize = estimateNumberOfBins(fullParams, power);
-    /* detect potential memory overflows */
-    std::string memError = MemoryStats().checkAvailableMemory(neededSize * sizeof(double));
-    if (!memError.empty()) {
-      throw std::runtime_error(memError);
+    /* detect potential memory overflows
+     *  TODO find a way to check against actual available system memory
+     *  NOTE use of MemoryStats.availMem() was considered, but introduces large overhead into this hot path
+     */
+    if (neededSize >= xnew.max_size()) {
+      throw std::runtime_error(
+          "createAxisFromRebinParams: The number of bins requested exceeds the maximum storable by the output vector.");
     }
     xnew.reserve(neededSize);
     xnew.push_back(xcurr);

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -15,6 +15,63 @@
 
 using std::size_t;
 
+namespace {
+// edge checks
+
+// Standard check, for linear, log, and power
+struct standardEdgeCheck {
+  standardEdgeCheck(double lastBinCoef) : m_lastBinCoef(lastBinCoef) {}
+  bool operator()(double xcurr, double xs, double rightEdge) const {
+    return xcurr + (1. + m_lastBinCoef) * xs <= rightEdge;
+  }
+
+private:
+  double m_lastBinCoef;
+};
+// Reverse log check, for reverse log only
+struct reverseLogEdgeCheck {
+  bool operator()(double xcurr, double xs, double leftEdge) const { return xcurr + 2. * xs >= leftEdge; }
+};
+
+// bin width functions
+
+// Linear bin width is just the alpha parameter
+struct linearBinWidth {
+  double operator()(double xcurr, double alpha) const {
+    (void)xcurr;
+    return alpha;
+  }
+};
+// Log bin width is current position times the alpha parameter
+struct logBinWidth {
+  double operator()(double xcurr, double alpha) const { return xcurr * alpha; }
+};
+
+// REVERSE LOGARITHMIC
+// we go through a reverse log bin by starting from its end, and working our way back to the beginning
+// this way we can define the bins in a reccuring way, and with a more obvious closeness with the usual log.
+struct reverseLogBinWidth {
+  reverseLogBinWidth(double leftEdge, double rightEdge) : m_leftEdge(leftEdge), m_rightEdge(rightEdge) {}
+  double operator()(double xcurr, double alpha) const { return (xcurr - m_rightEdge - m_leftEdge) * alpha; }
+
+private:
+  double m_leftEdge;
+  double m_rightEdge;
+};
+// Power bin width is the alpha parameter divided by the curren index to the power
+struct powerBinWidth {
+  powerBinWidth(std::size_t &currDiv, double power) : m_currDiv(currDiv), m_power(power) {}
+  double operator()(double xcurr, double alpha) {
+    (void)xcurr;
+    return alpha * std::pow(m_currDiv++, -m_power);
+  }
+
+private:
+  std::size_t &m_currDiv;
+  double m_power;
+};
+} // namespace
+
 namespace Mantid::Kernel::VectorHelper {
 
 /** Creates a new output X array given a 'standard' set of rebinning parameters.
@@ -38,115 +95,99 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
 
   // correctly expand the parameters
   std::vector<double> tmp;
-  const std::vector<double> &fullParams = [&params, &tmp, xMinHint, xMaxHint]() {
-    if (params.size() == 1) {
-      if (std::isnan(xMinHint) || std::isnan(xMaxHint)) {
-        throw std::runtime_error("createAxisFromRebinParams: xMinHint and "
-                                 "xMaxHint must be supplied if params "
-                                 "contains only the bin width.");
-      }
-      tmp.resize(3);
-      tmp = {xMinHint, params.front(), xMaxHint};
-      return tmp;
+  if (params.size() == 1) {
+    if (std::isnan(xMinHint) || std::isnan(xMaxHint)) {
+      throw std::runtime_error(
+          "createAxisFromRebinParams: xMinHint and xMaxHint must be supplied if params contains only the bin width.");
     }
-    return params;
-  }();
-  std::size_t ibound(2), istep(1), inew(1);
-  // highest index in params array containing a bin boundary
-  std::size_t ibounds = fullParams.size();
-  std::size_t isteps = ibounds - 1; // highest index in params array containing a step
+    tmp = {xMinHint, params.front(), xMaxHint};
+  }
+  std::vector<double> const &fullParams = params.size() == 1 ? tmp : params;
+
+  // if resize_new is true, do a first run to determine the needed number of bins
+  if (resize_xnew) {
+    std::vector<double> xnewTemp;
+    size_t neededSize = createAxisFromRebinParams(fullParams, xnewTemp, /*resize_new*/ false, full_bins_only, xMinHint,
+                                                  xMaxHint, useReverseLogarithmic, power);
+    // NOTE memory overflow error could occur here
+    xnew.reserve(neededSize);
+  }
 
   // This coefficitent represents the maximum difference between the size of the last bin and all
   // the other bins.
-  double lastBinCoef(0.25);
+  // For full_bin_only, we want it so that last bin couldn't be smaller than the previous bin
+  double const lastBinCoef = full_bins_only ? 1.0 : 0.25;
 
-  if (full_bins_only) {
-    // For full_bin_only, we want it so that last bin couldn't be smaller than the previous bin
-    lastBinCoef = 1.0;
+  double xcurr = fullParams[0];
+  xnew.clear();
+  if (resize_xnew) {
+    xnew.push_back(xcurr);
   }
 
-  double xs = 0;
-  double xcurr = fullParams[0];
-
-  xnew.clear();
-  if (resize_xnew)
-    xnew.emplace_back(xcurr);
-
-  int currDiv = 1;
+  std::size_t currDiv = 1;
 
   bool isPower = power > 0 && power <= 1;
 
-  while ((ibound <= ibounds) && (istep <= isteps)) {
-    // if step is negative then it is logarithmic step
-    bool isLogBin = (fullParams[istep] < 0.0);
-    bool isReverseLogBin = isLogBin && useReverseLogarithmic;
-    double alpha = std::fabs(fullParams[istep]);
+  // for each range specified, fill in the axis with correct bin edges
+  std::size_t inew = 1; // we start with 1, the leftmost edge
+  double leftEdge = fullParams[0];
+  for (std::size_t i = 1; i <= fullParams.size() - 1; i += 2) {
+    double binParam = fullParams[i];
+    double rightEdge = fullParams[i + 1];
+    double alpha = std::fabs(binParam);
 
-    // make sure parameters are specified in strictly increasing order
-    if (fullParams[ibound - 2] >= fullParams[ibound]) {
-      std::stringstream msg;
-      msg << "createAxisFromRebinParams: in the " << ((ibound) / 2) << "th range, "
-          << "the left edge is not smaller than right edge: " << fullParams[ibound - 2] << " vs " << fullParams[ibound];
-      throw std::runtime_error(msg.str());
-    }
-
-    if (isReverseLogBin && xcurr == fullParams[ibound - 2]) {
-      // we are starting a new bin, but since it is a rev log, xcurr needs to be at its end
-      xcurr = fullParams[ibound];
-    }
-    if (!isPower) {
-      if (!isLogBin)
-        xs = fullParams[istep];
-      else {
-        if (useReverseLogarithmic) {
-          // we go through a reverse log bin by starting from its end, and working our way back to the beginning
-          // this way we can define the bins in a reccuring way, and with a more obvious closeness with the usual log.
-          double x0 = fullParams[ibound - 2];
-          double step = x0 + fullParams[ibound] - xcurr;
-
-          xs = -step * alpha;
-
-        } else
-          xs = xcurr * fabs(fullParams[istep]);
-      }
+    // determine the binning mode for this range
+    std::function<double(double, double)> binWidth = nullptr;
+    std::function<bool(double, double, double)> edgeCheck = standardEdgeCheck(lastBinCoef);
+    if (binParam < 0.0 && useReverseLogarithmic) {
+      // REVERSE LOGARITHMIC
+      binWidth = reverseLogBinWidth(leftEdge, rightEdge);
+      edgeCheck = reverseLogEdgeCheck();
+      xcurr = rightEdge;
+      std::swap(leftEdge, rightEdge);
+    } else if (binParam < 0.0) {
+      // LOGARITHMIC
+      binWidth = logBinWidth();
+    } else if (isPower) {
+      // POWER
+      binWidth = powerBinWidth(currDiv, power);
     } else {
-      xs = fullParams[istep] * std::pow(currDiv, -power);
-      ++currDiv;
+      // LINEAR
+      binWidth = linearBinWidth();
     }
 
-    if (fabs(xs) == 0.0) {
-      // Someone gave a 0-sized step! What a dope.
-      throw std::runtime_error("Invalid binning step provided! Can't create binning axis.");
-    } else if (!std::isfinite(xs)) {
-      throw std::runtime_error("An infinite or NaN value was found in the binning parameters.");
-    }
-
-    if ((!isReverseLogBin && xcurr + xs * (1.0 + lastBinCoef) <= fullParams[ibound]) ||
-        (isReverseLogBin && xcurr + 2 * xs >= fullParams[ibound - 2])) {
-      // If we can still fit current bin _plus_ specified portion of a last bin, continue
-      xcurr += xs;
-
-    } else {
-      // If this is the start of the last bin, finish this range
-      if (!isReverseLogBin) {
-        if (full_bins_only)
-          // For full_bins_only, finish the range by adding one more full bin, so that last bin is not bigger than the
-          // previous one
-          xcurr += xs;
-        else
-          // For non full_bins_only, finish by adding as much as is left from the range
-          xcurr = fullParams[ibound];
-      } else {
-        // we have finished this range, because its starting time has already been added, so we jump back to the last
-        // value of the bin and resume normal behaviour
-        xcurr = fullParams[ibound];
+    double xs = binWidth(xcurr, alpha);
+    while (edgeCheck(xcurr, xs, rightEdge) || !std::isfinite(xs)) { // let errors fall through
+      if (xs == 0.0) {
+        // Someone gave a 0-sized step! What a dope.
+        throw std::runtime_error("Invalid binning step provided! Can't create binning axis.");
+      } else if (!std::isfinite(xs)) {
+        throw std::runtime_error("An infinite or NaN value was found in the binning parameters.");
       }
-      istep += 2;
-      ibound += 2;
+      xcurr = xcurr + xs;
+      if (resize_xnew) {
+        xnew.emplace_back(xcurr);
+      }
+      inew++;
+      // prepare for next step
+      xs = binWidth(xcurr, alpha);
     }
-    if (resize_xnew)
+
+    // handle last edge specially, depending on if full_bins_only is set
+    if (!useReverseLogarithmic && full_bins_only) {
+      // For full_bins_only, we want to add one more full bin, so that last bin is not bigger than the previous one
+      xcurr = xcurr + xs;
+    } else {
+      // For non full_bins_only, finish by adding as much as is left from the range
+      // NOTE for reverse log, the left edge was already added, so we can instead jump to the right edge of this range
+      xcurr = fullParams[i + 1];
+    }
+    if (resize_xnew) {
       xnew.emplace_back(xcurr);
+    }
     inew++;
+    // prepare for next range
+    leftEdge = xcurr;
   }
   std::sort(xnew.begin(), xnew.end());
   return inew;

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -19,6 +19,7 @@ namespace {
 // edge checks
 struct EdgeCheck { // for polymorphic access to functors
   virtual bool operator()(double, double, double) const = 0;
+  virtual ~EdgeCheck() = default;
 };
 
 // Standard check, for linear, log, and power
@@ -39,6 +40,7 @@ struct ReverseLogEdgeCheck : EdgeCheck {
 // bin width functionss
 struct BinWidth { // for polymorphic access to functors
   virtual double operator()(double, double) const = 0;
+  virtual ~BinWidth() = default;
 };
 
 // Linear bin width is just the alpha parameter

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -38,7 +38,7 @@ struct ReverseLogEdgeCheck : EdgeCheck {
   bool operator()(double xcurr, double xs, double leftEdge) const override { return xcurr + 2. * xs >= leftEdge; }
 };
 
-// bin width functionss
+// bin width functions
 struct BinWidth { // for polymorphic access to functors
   virtual double operator()(double, double) const = 0;
   virtual ~BinWidth() = default;
@@ -72,7 +72,7 @@ struct PowerBinWidth : BinWidth {
   }
 
 private:
-  std::size_t *m_currDiv; // make a pointer so operator() can be const; the pointed-to changes, but not the pointer
+  std::size_t *const m_currDiv; // the pointed-to changes, but not the pointer
   double m_power;
 };
 } // namespace
@@ -109,14 +109,14 @@ void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &params
   }
 }
 
-/** Returns a size_t with the estimated size, in bytes, that would be needed
+/** Returns a size_t with the estimated number of bins that would be needed for a rebinning operation
  * @param params Rebin parameters in form [x_1, delta_1,x_2, ... ,x_n-1,delta_n-1,x_n]
  * @param power the power in case of inverse power sum. Must be between 0 and 1 or is ignored.
  */
 std::size_t MANTID_KERNEL_DLL estimateNumberOfBins(std::vector<double> const &params, double const power) {
   bool isPower = power > 0 && power <= 1;
   validateRebinParameters(params, isPower);
-  double numBins = 0.;
+  double numBins = 1.; // always start with 1 left edge / fencepost
   double previousEdge = params[0];
   for (size_t i = 1; i < params.size() - 1; i += 2) {
     double binWidth = params[i];
@@ -188,6 +188,7 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
   double xcurr = fullParams[0];
   xnew.clear();
   if (resize_xnew) {
+    // call to estimateNumberOfBins will also validate the parameters
     size_t neededSize = estimateNumberOfBins(fullParams, power);
     /* detect potential memory overflows */
     std::string memError = MemoryStats().checkAvailableMemory(neededSize * sizeof(double));
@@ -197,6 +198,7 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
     xnew.reserve(neededSize);
     xnew.push_back(xcurr);
   } else {
+    // validate the parameters, but don't calculate needed size
     validateRebinParameters(fullParams, isPower);
   }
 

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <stdexcept>
 
+#include "MantidKernel/Memory.h"
 #include "MantidKernel/VectorHelper.h"
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
@@ -78,6 +79,74 @@ private:
 
 namespace Mantid::Kernel::VectorHelper {
 
+/** Validate rebinning parameters, throwing an error if any assumptions are invalidated */
+void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &params, bool const isPower) {
+  size_t numParams = params.size();
+  if (numParams < 3 || numParams % 2 != 1) {
+    throw std::runtime_error("validateRebinParameters: Invalid number of rebin parameters (" +
+                             std::to_string(numParams) + ")! Must be odd number of parameters, 3 or more.");
+  }
+  double previousEdge = params[0];
+  for (size_t i = 1; i < numParams - 1; i += 2) {
+    double binWidth = params[i];
+    double nextEdge = params[i + 1];
+    if (previousEdge >= nextEdge) {
+      throw std::runtime_error(
+          "validateRebinParameters: Bin boundary values must be given in order of increasing value! " +
+          std::to_string(previousEdge) + " >= " + std::to_string(nextEdge));
+    } else if (binWidth == 0) {
+      throw std::runtime_error("validateRebinParameters: Bin width cannot be zero!  Found in range " +
+                               std::to_string(previousEdge) + " to " + std::to_string(nextEdge));
+    } else if (binWidth < 0 && previousEdge <= 0) {
+      throw std::runtime_error("Bin boundaries must be positive for logarithmic binning. Got " +
+                               std::to_string(previousEdge) + " to " + std::to_string(nextEdge));
+    } else if (binWidth < 0 && isPower) {
+      throw std::runtime_error(
+          "validateRebinParameters: Cannot use power binning with negative bin width!  Bin width was " +
+          std::to_string(binWidth));
+    }
+    previousEdge = nextEdge;
+  }
+}
+
+/** Returns a size_t with the estimated size, in bytes, that would be needed
+ * @param params Rebin parameters in form [x_1, delta_1,x_2, ... ,x_n-1,delta_n-1,x_n]
+ * @param power the power in case of inverse power sum. Must be between 0 and 1 or is ignored.
+ */
+std::size_t MANTID_KERNEL_DLL estimateNumberOfBins(std::vector<double> const &params, double const power) {
+  bool isPower = power > 0 && power <= 1;
+  validateRebinParameters(params, isPower);
+  double numBins = 0.;
+  double previousEdge = params[0];
+  for (size_t i = 1; i < params.size() - 1; i += 2) {
+    double binWidth = params[i];
+    double nextEdge = params[i + 1];
+    if (binWidth < 0) {
+      // LOGARITHMIC BINNING
+      // NOTE log or reverse log should have approximately the same number of bins here
+      numBins += std::ceil(std::log(nextEdge / previousEdge) / std::log(1. - binWidth));
+    } else if (isPower) {
+      // POWER BINNING
+      // formulas taken from Rebin::validateInputs
+      if (power == 1) {
+        double constexpr eulerMascheroni = 0.5772156649; // Euler-Mascheroni constant
+        numBins += std::exp((nextEdge - previousEdge) / binWidth - eulerMascheroni);
+      } else {
+        numBins += std::pow(((nextEdge - previousEdge) / binWidth) * (1 - power) + 1, 1 / (1 - power));
+      }
+    } else if (binWidth > 0) {
+      // LINEAR BINNING
+      numBins += std::ceil((nextEdge - previousEdge) / binWidth);
+    }
+    previousEdge = nextEdge;
+  }
+  if (numBins >= static_cast<double>(std::numeric_limits<std::size_t>::max())) {
+    throw std::runtime_error(
+        "estimateNumberOfBins: The number of bins requested exceeds the maximum storable by size_t.");
+  }
+  return static_cast<size_t>(numBins);
+}
+
 /** Creates a new output X array given a 'standard' set of rebinning parameters.
  *  @param[in]  params Rebin parameters input [x_1, delta_1,x_2, ...
  *,x_n-1,delta_n-1,x_n]
@@ -108,29 +177,30 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
   }
   std::vector<double> const &fullParams = params.size() == 1 ? tmp : params;
 
-  // if resize_xnew is true, do a first run to determine the needed number of bins
-  if (resize_xnew) {
-    std::vector<double> xnewTemp;
-    size_t neededSize = createAxisFromRebinParams(fullParams, xnewTemp, /*resize_new*/ false, full_bins_only, xMinHint,
-                                                  xMaxHint, useReverseLogarithmic, power);
-    /* NOTE memory overflow check could occur here */
-    xnew.reserve(neededSize);
-  }
-
   // This coefficient represents the maximum difference between the size of the last bin and all
   // the other bins.
   // For full_bin_only, we want it so that last bin couldn't be smaller than the previous bin
   double const lastBinCoef = full_bins_only ? 1.0 : 0.25;
+  // whether to use power binning
+  bool isPower = power > 0 && power <= 1;
 
+  // if resize_xnew is true, prepare the vector
   double xcurr = fullParams[0];
   xnew.clear();
   if (resize_xnew) {
+    size_t neededSize = estimateNumberOfBins(fullParams, power);
+    /* detect potential memory overflows */
+    std::string memError = MemoryStats().checkAvailableMemory(neededSize * sizeof(double));
+    if (!memError.empty()) {
+      throw std::runtime_error(memError);
+    }
+    xnew.reserve(neededSize);
     xnew.push_back(xcurr);
+  } else {
+    validateRebinParameters(fullParams, isPower);
   }
 
   std::size_t currDiv = 1;
-
-  bool isPower = power > 0 && power <= 1;
 
   // for each range specified, fill in the axis with correct bin edges
   std::size_t inew = 1; // we start with 1, the leftmost edge
@@ -140,35 +210,29 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
     double rightEdge = fullParams[i + 1];
     double alpha = std::fabs(binParam);
 
-    if (leftEdge >= rightEdge) {
-      throw std::runtime_error("createAxisFromRebinParams: in the " + std::to_string((i + 1) / 2) +
-                               "th range, the left edge is not smaller than right edge: " + std::to_string(leftEdge) +
-                               " vs " + std::to_string(rightEdge));
-    }
-
     // functions for calculating bin width and checking if within range
     std::unique_ptr<BinWidth> binWidth(nullptr);
     std::unique_ptr<EdgeCheck> edgeCheck(nullptr);
     if (binParam < 0.0 && useReverseLogarithmic) {
       // REVERSE LOGARITHMIC
-      binWidth.reset(new ReverseLogBinWidth{leftEdge, rightEdge});
-      edgeCheck.reset(new ReverseLogEdgeCheck);
+      binWidth = std::make_unique<ReverseLogBinWidth>(leftEdge, rightEdge);
+      edgeCheck = std::make_unique<ReverseLogEdgeCheck>();
       // for reverse log, we start at the right edge and work back to left; to use the same loop, swap the edges
       // the final edge will be added after the loop, fullParams[i+1]
       xcurr = rightEdge;
       std::swap(leftEdge, rightEdge);
     } else if (binParam < 0.0) {
       // LOGARITHMIC
-      binWidth.reset(new LogBinWidth);
-      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
+      binWidth = std::make_unique<LogBinWidth>();
+      edgeCheck = std::make_unique<StandardEdgeCheck>(lastBinCoef);
     } else if (isPower) {
       // POWER
-      binWidth.reset(new PowerBinWidth{currDiv, power});
-      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
+      binWidth = std::make_unique<PowerBinWidth>(currDiv, power);
+      edgeCheck = std::make_unique<StandardEdgeCheck>(lastBinCoef);
     } else {
       // LINEAR
-      binWidth.reset(new LinearBinWidth);
-      edgeCheck.reset(new StandardEdgeCheck{lastBinCoef});
+      binWidth = std::make_unique<LinearBinWidth>();
+      edgeCheck = std::make_unique<StandardEdgeCheck>(lastBinCoef);
     }
 
     double xs = (*binWidth)(xcurr, alpha);
@@ -181,7 +245,7 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
       }
       xcurr = xcurr + xs;
       if (resize_xnew) {
-        xnew.emplace_back(xcurr);
+        xnew.push_back(xcurr);
       }
       inew++;
       // prepare for next step
@@ -198,7 +262,7 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
       xcurr = fullParams[i + 1];
     }
     if (resize_xnew) {
-      xnew.emplace_back(xcurr);
+      xnew.push_back(xcurr);
     }
     inew++;
     // prepare for next range

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -18,7 +18,9 @@ using std::size_t;
 
 namespace {
 // edge checks
+/// @brief  When creating a new axis, check if the next bin would go to close to the edge, and if so, stop
 struct EdgeCheck { // for polymorphic access to functors
+  /// Ensure the next bin will not go too close to the right edge of this range
   virtual bool operator()(double, double, double) const = 0;
   virtual ~EdgeCheck() = default;
 };
@@ -39,7 +41,9 @@ struct ReverseLogEdgeCheck : EdgeCheck {
 };
 
 // bin width functions
+/// @brief When creating a new axis, calculate the width of the next bin, and return it
 struct BinWidth { // for polymorphic access to functors
+  /// the width of the next bin to add to the axis, given the current position and the alpha parameter
   virtual double operator()(double, double) const = 0;
   virtual ~BinWidth() = default;
 };
@@ -80,7 +84,7 @@ private:
 namespace Mantid::Kernel::VectorHelper {
 
 /** Validate rebinning parameters, throwing an error if any assumptions are invalidated */
-void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &params, bool const isPower) {
+void validateRebinParameters(std::vector<double> const &params, bool const isPower) {
   size_t numParams = params.size();
   if (numParams < 3 || numParams % 2 != 1) {
     throw std::runtime_error("validateRebinParameters: Invalid number of rebin parameters (" +
@@ -88,8 +92,8 @@ void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &params
   }
   double previousEdge = params[0];
   for (size_t i = 1; i < numParams - 1; i += 2) {
-    double binWidth = params[i];
-    double nextEdge = params[i + 1];
+    double const binWidth = params[i];
+    double const nextEdge = params[i + 1];
     if (previousEdge >= nextEdge) {
       throw std::runtime_error(
           "validateRebinParameters: Bin boundary values must be given in order of increasing value! " +
@@ -113,14 +117,14 @@ void MANTID_KERNEL_DLL validateRebinParameters(std::vector<double> const &params
  * @param params Rebin parameters in form [x_1, delta_1,x_2, ... ,x_n-1,delta_n-1,x_n]
  * @param power the power in case of inverse power sum. Must be between 0 and 1 or is ignored.
  */
-std::size_t MANTID_KERNEL_DLL estimateNumberOfBins(std::vector<double> const &params, double const power) {
-  bool isPower = power > 0 && power <= 1;
+std::size_t estimateNumberOfBins(std::vector<double> const &params, double const power) {
+  bool const isPower = power > 0 && power <= 1;
   validateRebinParameters(params, isPower);
   double numBins = 1.; // always start with 1 left edge / fencepost
   double previousEdge = params[0];
   for (size_t i = 1; i < params.size() - 1; i += 2) {
-    double binWidth = params[i];
-    double nextEdge = params[i + 1];
+    double const binWidth = params[i];
+    double const nextEdge = params[i + 1];
     if (binWidth < 0) {
       // LOGARITHMIC BINNING
       // NOTE log or reverse log should have approximately the same number of bins here
@@ -161,10 +165,9 @@ std::size_t MANTID_KERNEL_DLL estimateNumberOfBins(std::vector<double> const &pa
  *  @param[in] power the power in case of inverse power sum. Must be between 0 and 1 or is ignored.
  *  @return The number of bin boundaries in the new axis
  **/
-std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &params, std::vector<double> &xnew,
-                                                const bool resize_xnew, const bool full_bins_only,
-                                                const double xMinHint, const double xMaxHint,
-                                                const bool useReverseLogarithmic, const double power) {
+std::size_t createAxisFromRebinParams(const std::vector<double> &params, std::vector<double> &xnew,
+                                      const bool resize_xnew, const bool full_bins_only, const double xMinHint,
+                                      const double xMaxHint, const bool useReverseLogarithmic, const double power) {
 
   // correctly expand the parameters
   std::vector<double> tmp;

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -138,6 +138,12 @@ std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &param
     double rightEdge = fullParams[i + 1];
     double alpha = std::fabs(binParam);
 
+    if (leftEdge >= rightEdge) {
+      throw std::runtime_error("createAxisFromRebinParams: in the " + std::to_string((i + 1) / 2) +
+                               "th range, the left edge is not smaller than right edge: " + std::to_string(leftEdge) +
+                               " vs " + std::to_string(rightEdge));
+    }
+
     // functions for calculating bin width and checking if within range
     std::unique_ptr<BinWidth> binWidth(nullptr);
     std::unique_ptr<EdgeCheck> edgeCheck(nullptr);

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -69,6 +69,99 @@ public:
     TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromCenters(m_test_bins, 0.8), 2);
   }
 
+  void test_validateRebinParameters() {
+    // fails if not enough parameters
+    std::vector<double> rbParams = {1};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    rbParams = {1, 2};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    // fail if more than three, but not odd parameters
+    rbParams = {1, 2, 3, 4};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    // fail backwards parameters
+    rbParams = {1, 1, 3, 1, 2};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    // fail zero step
+    rbParams = {1, 1, 4, 0, 7};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    // fail log binning with negative step
+    rbParams = {-5, 1, -2, -1, 10};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams), std::runtime_error &);
+    // fail powerBinning with negative step
+    rbParams = {5, 1, 10, -0.5, 100};
+    TS_ASSERT_THROWS(VectorHelper::validateRebinParameters(rbParams, true), std::runtime_error &);
+    // good bins are good
+    rbParams = {1, 1, 10};
+    TS_ASSERT_THROWS_NOTHING(VectorHelper::validateRebinParameters(rbParams));
+  }
+
+  void test_estimateNumberOfBins_fails() {
+    // fails if not enough parameters
+    std::vector<double> rbParams = {1};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    rbParams = {1, 2};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    // fail if more than three, but not odd parameters
+    rbParams = {1, 2, 3, 4};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    // fail backwards parameters
+    rbParams = {1, 1, 3, 1, 2};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    // fail zero step
+    rbParams = {1, 1, 4, 0, 7};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    // fail log binning with negative step
+    rbParams = {-5, 1, -2, -1, 10};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams), std::runtime_error &);
+    // fail powerBinning with negative step
+    rbParams = {5, 1, 10, -0.5, 100};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams, 0.5), std::runtime_error &);
+    // fail excessive number of bins
+    rbParams = {1, 1, 100};
+    TS_ASSERT_THROWS(VectorHelper::estimateNumberOfBins(rbParams, 1.0), std::runtime_error &);
+  }
+
+  void test_estimateNumberOfBins_linear() {
+    std::vector<double> rbParams(3);
+    rbParams[0] = 1.;
+    rbParams[1] = 1.;
+    rbParams[2] = 10.;
+
+    const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
+    const size_t expectedFootprint = static_cast<size_t>((rbParams[2] - rbParams[0]) / rbParams[1]);
+    TS_ASSERT_EQUALS(memFootprint, expectedFootprint);
+  }
+
+  void test_estimateNumberOfBins_log() {
+    std::vector<double> rbParams(3);
+    rbParams[0] = 1.;
+    rbParams[1] = -0.5;
+    rbParams[2] = 10.;
+
+    const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
+    const size_t expectedFootprint =
+        static_cast<size_t>(std::ceil(std::log(rbParams[2] / rbParams[0]) / std::log(1. - rbParams[1])));
+    TS_ASSERT_EQUALS(memFootprint, expectedFootprint);
+  }
+
+  void test_estimateNumberOfBins_multistep() {
+    std::vector<double> rbParams = {1, 1, 10, -0.5, 100};
+
+    const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
+    const size_t expectedFootprintStep1 = static_cast<size_t>((rbParams[2] - rbParams[0]) / rbParams[1]);
+    const size_t expectedFootprintStep2 =
+        static_cast<size_t>(std::ceil(std::log(rbParams[4] / rbParams[2]) / std::log(1. - rbParams[3])));
+    TS_ASSERT_EQUALS(memFootprint, expectedFootprintStep1 + expectedFootprintStep2);
+  }
+
+  void test_CreateAxisFromRebinParams_FailsTooLarge() {
+    double power = 1.0;
+    std::vector<double> rbParams = {1, 1, 100}; // this creates an astronomical number of bins
+    std::vector<double> axis;
+    TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(rbParams, axis, true, false, 0, 0, false, power),
+                     std::runtime_error &);
+  }
+
   void test_CreateAxisFromRebinParams_Gives_Expected_Number_Bins() {
     std::vector<double> rbParams(3);
     rbParams[0] = 1;

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -128,7 +128,7 @@ public:
     rbParams[2] = 10.;
 
     const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
-    const size_t expectedFootprint = static_cast<size_t>((rbParams[2] - rbParams[0]) / rbParams[1]);
+    const size_t expectedFootprint = static_cast<size_t>(1 + (rbParams[2] - rbParams[0]) / rbParams[1]);
     TS_ASSERT_EQUALS(memFootprint, expectedFootprint);
   }
 
@@ -140,7 +140,7 @@ public:
 
     const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
     const size_t expectedFootprint =
-        static_cast<size_t>(std::ceil(std::log(rbParams[2] / rbParams[0]) / std::log(1. - rbParams[1])));
+        static_cast<size_t>(1 + std::ceil(std::log(rbParams[2] / rbParams[0]) / std::log(1. - rbParams[1])));
     TS_ASSERT_EQUALS(memFootprint, expectedFootprint);
   }
 
@@ -150,7 +150,7 @@ public:
     const size_t memFootprint = VectorHelper::estimateNumberOfBins(rbParams);
     const size_t expectedFootprintStep1 = static_cast<size_t>((rbParams[2] - rbParams[0]) / rbParams[1]);
     const size_t expectedFootprintStep2 =
-        static_cast<size_t>(std::ceil(std::log(rbParams[4] / rbParams[2]) / std::log(1. - rbParams[3])));
+        static_cast<size_t>(1 + std::ceil(std::log(rbParams[4] / rbParams[2]) / std::log(1. - rbParams[3])));
     TS_ASSERT_EQUALS(memFootprint, expectedFootprintStep1 + expectedFootprintStep2);
   }
 


### PR DESCRIPTION
### Description of work

The function `VectorHelper::createAxisFromRebinParams()` is used throughout Mantid, by any algorithm needed to rebin an axis.

As it was written, it was fairly hard to read, due to fairly opaque nested `if`/`else` blocks that made it difficult to figure out under which situation a block would execute.

This refactors the function to assign functors on a simple, un-nested `if`/`else`, with a common loop calling the functors and resulting in the correct behavior in each case.  The functors are assigned with polymorphism through pointers; this pattern avoids some of the overhead in `std::function`.

For more readability, two additional functions were added.  One validates the rebin parameters, throwing errors if any important assumptions are violated.  The other estimates the number of bins for each set given range of rebin parameters.  This estimate is not perfect, but is sufficient for reserving the size of the new axis, preventing reallocations of the vector ( $O(N)$ ).  The functions run through each set of parameters, but this is usually 1, sometimes as high as 3 or 5; whereas the length of a rebinned axis could be thousands of doubles.  The pre-calculation is therefore worth this slight overhead, to avoid reallocations.

It would be possible to add, within this pre-calculation, a check on needed memory overhead.

Refs: [EWM 15806](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15806)
PRs:
- #41296 
- #41320 
- #41330

### To test:

This is a pure refactor, on a highly and widely used function within Mantid.   All unit and system tests should pass, and be sufficient to demonstrate correct behavior.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
