### PR TITLE
Fix error on switching to peak adding mode

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -997,7 +997,8 @@ class FullInstrumentViewWindow(QMainWindow):
     @_skip_if_closing
     def clear_lineplot_overlays(self) -> None:
         for line in self._lineplot_overlays:
-            line.remove()
+            if line in self._detector_spectrum_axes.lines:
+                line.remove()
         self._lineplot_overlays.clear()
         for text in self._detector_spectrum_axes.texts:
             text.remove()

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -117,6 +117,7 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         self._view._detector_spectrum_axes.texts = [mock_text]
         self.assertEqual(0, len(self._view._lineplot_overlays))
         self._view._lineplot_overlays.append(mock_line)
+        self._view._detector_spectrum_axes.lines = [mock_line]
         self._view.clear_lineplot_overlays()
         mock_line.remove.assert_called_once()
         self.assertEqual(0, len(self._view._lineplot_overlays))


### PR DESCRIPTION
Fixes an error in the new Instrument View. To reproduce:

Open the new IV, overlay a peaks workspace, select a pixel with a peak so you get a vertical peak line in the lineplot at the bottom. Switch to peak adding mode, should be no error.


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
