### PR TITLE
Throw error if rebinning a backwards range

### DIFF
--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -79,6 +79,14 @@ int DLLExport createAxisFromRebinParams(const std::vector<double> &params, std::
     bool isReverseLogBin = isLogBin && useReverseLogarithmic;
     double alpha = std::fabs(fullParams[istep]);
 
+    // make sure parameters are specified in strictly increasing order
+    if (fullParams[ibound - 2] >= fullParams[ibound]) {
+      std::stringstream msg;
+      msg << "createAxisFromRebinParams: in the " << ((ibound) / 2) << "th range, "
+          << "the left edge is not smaller than right edge: " << fullParams[ibound - 2] << " vs " << fullParams[ibound];
+      throw std::runtime_error(msg.str());
+    }
+
     if (isReverseLogBin && xcurr == fullParams[ibound - 2]) {
       // we are starting a new bin, but since it is a rev log, xcurr needs to be at its end
       xcurr = fullParams[ibound];

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -213,6 +213,14 @@ public:
     TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(params, axis), const std::runtime_error &);
   }
 
+  void test_CreateAxisFromRebinParams_throwsRangeBackwards() {
+    const std::vector<double> goodParams = {1.0, 1.0, 5.0};
+    const std::vector<double> badParams = {5.0, 1.0, 1.0}; // backwards
+    std::vector<double> axis;
+    TS_ASSERT_THROWS_NOTHING(VectorHelper::createAxisFromRebinParams(goodParams, axis));
+    TS_ASSERT_THROWS(VectorHelper::createAxisFromRebinParams(badParams, axis), const std::runtime_error &);
+  }
+
   void test_CreateAxisFromRebinParams_xMinXMaxHints() {
     const std::vector<double> rbParams = {1.0};
     std::vector<double> axis;

--- a/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
@@ -171,14 +171,24 @@ class RebinRaggedTest(unittest.TestCase):
 
     def test_hist_workspace_fullBinsOnly(self):
         # numpy 1.7 (on rhel7) doesn't have np.full
-        xmins = np.full((200,), 50.0)
+        nbanks = 1
+        npixels = 4
+        nspec = nbanks * npixels * npixels
+        xmins = np.full((nspec,), 50.0)
         xmins[11] = 3000.0
-        xmaxs = np.full((200,), 650.0)
-        xmaxs[12] = 5000.0
-        deltas = np.full(200, -2.0)
-        deltas[13] = 100.0
+        xmaxs = np.full((nspec,), 650.0)
+        xmaxs[11] = 5000.0
+        deltas = np.full(nspec, -2.0)
+        deltas[11] = 100.0
 
-        inputWs = api.CreateSampleWorkspace(OutputWorkspace="RebinRagged_hist", WorkspaceType="Histogram", BinWidth=75, XMin=50)
+        inputWs = api.CreateSampleWorkspace(
+            OutputWorkspace="RebinRagged_hist",
+            WorkspaceType="Histogram",
+            NumBanks=nbanks,
+            BankPixelWidth=npixels,
+            BinWidth=75,
+            XMin=50,
+        )
 
         notFullBinsOnlyWs = api.RebinRagged(
             InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", XMin=xmins, XMax=xmaxs, Delta=deltas, FullBinsOnly=False

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41330.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41330.rst
@@ -1,0 +1,1 @@
+- Rebinning operations (such as in ``Rebin`` or ``RebinRagged``) that specify a range with a start and end value that are not in the correct order (start < end) will now throw an exception instead of silently producing incorrect results. This is to prevent users from accidentally specifying invalid rebinning parameters and getting unexpected outputs.


### PR DESCRIPTION
### Description of work

If users try to perform a rebinning operation using parameters with bin edges in *decreasing* order, this should represent an error.  

As the code worked previously, the rebinning operation inside `VectorHelper::createAxisFromRebinParams()` would not actually perform any binning and just place the two end points; because *all* bin axes are sorted, this silently skated by without errors.

As an example, consider asking for binning with parameters `"10, 2, 2"`.  This does *not* produce bins at `{10, 8, 6, 4, 2}`, but instead just `{10, 2}`.  Then, when sorted, it becomes `{2, 10}`.  This is almost certainly not what any user intends.

There was one place in the unit tests inadvertently revealing this bug, within `RebinRaggedTest::test_hist_workspace_fullBinsOnly()`.  When this test was first created, it was based off of the earlier test `test_hist_workspace()` that uses similar setup.   _That_ test used  linear binning with parameters so that `xmin` < `xmax` in all cases, whereas the full bin test was producing a range "from" 3000 to 650.  Such a range will now throw an error.  The test still fulfills its purpose with this change.

Refs: [EWM 15806](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15806)
Related PRs:
- #38550
- #41296 
- #41320
- #41326

### To test:

This is a refactor, but make sure this change makes sense.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
