### PR TITLE
Enable PolarizationCorrectionWildes to take a ws group as an input

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -29,6 +29,7 @@ static const std::string FLIPPERS{"Flippers"};
 static const std::string SPIN_STATES{"SpinStates"};
 static const std::string EFFICIENCIES{"Efficiencies"};
 static const std::string INPUT_WS{"InputWorkspaces"};
+static const std::string INPUT_WS_GROUP{"InputWorkspaceGroup"};
 static const std::string OUTPUT_WS{"OutputWorkspace"};
 static const std::string ADD_SPIN_STATE_LOG{"AddSpinStateToLog"};
 } // namespace Prop
@@ -323,8 +324,12 @@ size_t PolarizationCorrectionWildes::WorkspaceMap::size() const noexcept {
  */
 void PolarizationCorrectionWildes::init() {
   declareProperty(std::make_unique<Kernel::ArrayProperty<std::string>>(
-                      Prop::INPUT_WS, "", std::make_shared<API::ADSValidator>(), Kernel::Direction::Input),
+                      Prop::INPUT_WS, "", std::make_shared<API::ADSValidator>(true, true), Kernel::Direction::Input),
                   "A list of workspaces to be corrected corresponding to the "
+                  "flipper configurations.");
+  declareProperty(std::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(
+                      Prop::INPUT_WS_GROUP, "", Kernel::Direction::Input, API::PropertyMode::Optional),
+                  "A group of workspaces to be corrected corresponding to the "
                   "flipper configurations.");
   declareProperty(
       std::make_unique<API::WorkspaceProperty<API::WorkspaceGroup>>(Prop::OUTPUT_WS, "", Kernel::Direction::Output),
@@ -412,15 +417,22 @@ std::map<std::string, std::string> PolarizationCorrectionWildes::validateInputs(
     }
   }
   const std::vector<std::string> inputs = getProperty(Prop::INPUT_WS);
+  const API::WorkspaceGroup_sptr inputsGroup = getProperty(Prop::INPUT_WS_GROUP);
+  if (inputs.empty() && !inputsGroup) {
+    issues[Prop::INPUT_WS] = "At least one of the input workspace properties must be provided.";
+  } else if (!inputs.empty() && inputsGroup) {
+    issues[Prop::INPUT_WS] = "Only one of the input workspace properties can be provided.";
+  }
   const auto flipperConfig = Kernel::SpinStateHelpers::splitSpinStateString(getPropertyValue(Prop::FLIPPERS));
   const auto flipperCount = flipperConfig.size();
-  if (inputs.size() != flipperCount) {
+  const size_t inputsCount = (inputsGroup) ? inputsGroup->getNumberOfEntries() : inputs.size();
+  if (inputsCount != flipperCount) {
     issues[Prop::FLIPPERS] = "The number of flipper configurations (" + std::to_string(flipperCount) +
-                             ") does not match the number of input workspaces (" + std::to_string(inputs.size()) + ")";
+                             ") does not match the number of input workspaces (" + std::to_string(inputsCount) + ")";
   }
   // SpinStates checks.
   const auto spinStates = Kernel::SpinStateHelpers::splitSpinStateString(getPropertyValue(Prop::SPIN_STATES));
-  if (inputs.size() == 1 && !spinStates.empty()) {
+  if (inputsCount == 1 && !spinStates.empty()) {
     issues[Prop::SPIN_STATES] = "Output workspace order cannot be set for direct beam calculations.";
   } else if (!spinStates.empty()) {
     if (flipperConfig.front().size() == 1 && spinStates.size() != 2) {
@@ -883,9 +895,11 @@ PolarizationCorrectionWildes::fullCorrections(const WorkspaceMap &inputs, const 
 PolarizationCorrectionWildes::WorkspaceMap
 PolarizationCorrectionWildes::mapInputsToDirections(const std::vector<std::string> &flippers) {
   const std::vector<std::string> inputNames = getProperty(Prop::INPUT_WS);
+  const API::WorkspaceGroup_sptr inputGroup = getProperty(Prop::INPUT_WS_GROUP);
   WorkspaceMap inputs;
   for (size_t i = 0; i < flippers.size(); ++i) {
-    auto ws = (API::AnalysisDataService::Instance().retrieveWS<API::MatrixWorkspace>(inputNames[i]));
+    auto ws = (inputGroup) ? dynamic_pointer_cast<API::MatrixWorkspace>(inputGroup->getItem(i))
+                           : API::AnalysisDataService::Instance().retrieveWS<API::MatrixWorkspace>(inputNames[i]);
     if (!ws) {
       throw std::runtime_error("One of the input workspaces doesn't seem to be a MatrixWorkspace.");
     }

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -30,6 +30,7 @@ static const std::string FLIPPERS{"Flippers"};
 static const std::string OUTPUT_WILDES_SPIN_STATES{"SpinStatesOutWildes"};
 static const std::string POLARIZATION_ANALYSIS{"PolarizationAnalysis"};
 static const std::string EFFICIENCIES{"Efficiencies"};
+static const std::string INPUT_WORKSPACE{"InputWorkspace"};
 static const std::string INPUT_WORKSPACES{"InputWorkspaces"};
 static const std::string INPUT_WORKSPACE_GROUP{"InputWorkspaceGroup"};
 static const std::string OUTPUT_WORKSPACES{"OutputWorkspace"};
@@ -167,26 +168,30 @@ void PolarizationEfficiencyCor::exec() {
 //----------------------------------------------------------------------------------------------
 void PolarizationEfficiencyCor::execWildes() {
   checkWildesProperties();
-  std::vector<std::string> workspaces = getWorkspaceNameList();
-
-  MatrixWorkspace_sptr efficiencies = getEfficiencies();
   auto alg = createChildAlgorithm("PolarizationCorrectionWildes");
   alg->initialize();
-  alg->setProperty("InputWorkspaces", workspaces);
-  alg->setProperty("Efficiencies", efficiencies);
+  if (!isDefault(Prop::INPUT_WORKSPACES)) {
+    std::vector<std::string> workspaces = getWorkspaceNameList();
+    alg->setProperty(Prop::INPUT_WORKSPACES, workspaces);
+  } else {
+    auto group = getWorkspaceGroup();
+    alg->setProperty(Prop::INPUT_WORKSPACE_GROUP, group);
+  }
+  MatrixWorkspace_sptr efficiencies = getEfficiencies();
+  alg->setProperty(Prop::EFFICIENCIES, efficiencies);
   if (!isDefault(Prop::FLIPPERS)) {
-    alg->setPropertyValue("Flippers", getPropertyValue(Prop::FLIPPERS));
+    alg->setPropertyValue(Prop::FLIPPERS, getPropertyValue(Prop::FLIPPERS));
   }
   if (!isDefault(Prop::ADD_SPIN_STATE_LOG)) {
-    alg->setPropertyValue("AddSpinStateToLog", getPropertyValue(Prop::ADD_SPIN_STATE_LOG));
+    alg->setPropertyValue(Prop::ADD_SPIN_STATE_LOG, getPropertyValue(Prop::ADD_SPIN_STATE_LOG));
   }
   if (!isDefault(Prop::OUTPUT_WILDES_SPIN_STATES)) {
-    alg->setPropertyValue("SpinStates", getPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES));
+    alg->setPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES, getPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES));
   }
   auto out = getPropertyValue(Prop::OUTPUT_WORKSPACES);
-  alg->setPropertyValue("OutputWorkspace", out);
+  alg->setPropertyValue(Prop::OUTPUT_WORKSPACES, out);
   alg->execute();
-  API::WorkspaceGroup_sptr outWS = alg->getProperty("OutputWorkspace");
+  API::WorkspaceGroup_sptr outWS = alg->getProperty(Prop::OUTPUT_WORKSPACES);
   setProperty(Prop::OUTPUT_WORKSPACES, outWS);
 }
 
@@ -197,10 +202,10 @@ void PolarizationEfficiencyCor::execFredrikze() {
   MatrixWorkspace_sptr efficiencies = getEfficiencies();
   auto alg = createChildAlgorithm("PolarizationCorrectionFredrikze");
   alg->initialize();
-  alg->setProperty("InputWorkspace", group);
-  alg->setProperty("Efficiencies", efficiencies);
+  alg->setProperty(Prop::INPUT_WORKSPACE, group);
+  alg->setProperty(Prop::EFFICIENCIES, efficiencies);
   if (!isDefault(Prop::POLARIZATION_ANALYSIS)) {
-    alg->setPropertyValue("PolarizationAnalysis", getPropertyValue(Prop::POLARIZATION_ANALYSIS));
+    alg->setPropertyValue(Prop::POLARIZATION_ANALYSIS, getPropertyValue(Prop::POLARIZATION_ANALYSIS));
   }
   if (!isDefault(Prop::INPUT_FRED_SPIN_STATES)) {
     alg->setPropertyValue("InputSpinStates", getPropertyValue(Prop::INPUT_FRED_SPIN_STATES));
@@ -208,9 +213,9 @@ void PolarizationEfficiencyCor::execFredrikze() {
   if (!isDefault(Prop::OUTPUT_FRED_SPIN_STATES)) {
     alg->setPropertyValue("OutputSpinStates", getPropertyValue(Prop::OUTPUT_FRED_SPIN_STATES));
   }
-  alg->setPropertyValue("OutputWorkspace", getPropertyValue(Prop::OUTPUT_WORKSPACES));
+  alg->setPropertyValue(Prop::OUTPUT_WORKSPACES, getPropertyValue(Prop::OUTPUT_WORKSPACES));
   alg->execute();
-  API::WorkspaceGroup_sptr outWS = alg->getProperty("OutputWorkspace");
+  API::WorkspaceGroup_sptr outWS = alg->getProperty(Prop::OUTPUT_WORKSPACES);
   setProperty(Prop::OUTPUT_WORKSPACES, outWS);
 }
 
@@ -275,18 +280,6 @@ std::vector<std::string> PolarizationEfficiencyCor::getWorkspaceNameList() const
       throw std::invalid_argument(
           "Only Matrix Workspaces can be added in InputWorkspace property list. If the input is a group, "
           "use the InputWorkspaceGroup property");
-    }
-  } else {
-    WorkspaceGroup_sptr group = getProperty(Prop::INPUT_WORKSPACE_GROUP);
-    auto const n = group->size();
-    for (size_t i = 0; i < n; ++i) {
-      auto ws = group->getItem(i);
-      auto const wsName = ws->getName();
-      if (wsName.empty()) {
-        throw std::invalid_argument("Workspace from the input workspace group is not stored in the "
-                                    "Analysis Data Service which is required by the Wildes method.");
-      }
-      wsNames.emplace_back(wsName);
     }
   }
   return wsNames;

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -30,7 +30,6 @@ static const std::string FLIPPERS{"Flippers"};
 static const std::string OUTPUT_WILDES_SPIN_STATES{"SpinStatesOutWildes"};
 static const std::string POLARIZATION_ANALYSIS{"PolarizationAnalysis"};
 static const std::string EFFICIENCIES{"Efficiencies"};
-static const std::string INPUT_WORKSPACE{"InputWorkspace"};
 static const std::string INPUT_WORKSPACES{"InputWorkspaces"};
 static const std::string INPUT_WORKSPACE_GROUP{"InputWorkspaceGroup"};
 static const std::string OUTPUT_WORKSPACES{"OutputWorkspace"};
@@ -180,18 +179,18 @@ void PolarizationEfficiencyCor::execWildes() {
   MatrixWorkspace_sptr efficiencies = getEfficiencies();
   alg->setProperty(Prop::EFFICIENCIES, efficiencies);
   if (!isDefault(Prop::FLIPPERS)) {
-    alg->setPropertyValue(Prop::FLIPPERS, getPropertyValue(Prop::FLIPPERS));
+    alg->setPropertyValue("Flippers", getPropertyValue(Prop::FLIPPERS));
   }
   if (!isDefault(Prop::ADD_SPIN_STATE_LOG)) {
-    alg->setPropertyValue(Prop::ADD_SPIN_STATE_LOG, getPropertyValue(Prop::ADD_SPIN_STATE_LOG));
+    alg->setPropertyValue("AddSpinStateToLog", getPropertyValue(Prop::ADD_SPIN_STATE_LOG));
   }
   if (!isDefault(Prop::OUTPUT_WILDES_SPIN_STATES)) {
-    alg->setPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES, getPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES));
+    alg->setPropertyValue("SpinStates", getPropertyValue(Prop::OUTPUT_WILDES_SPIN_STATES));
   }
   auto out = getPropertyValue(Prop::OUTPUT_WORKSPACES);
-  alg->setPropertyValue(Prop::OUTPUT_WORKSPACES, out);
+  alg->setPropertyValue("OutputWorkspace", out);
   alg->execute();
-  API::WorkspaceGroup_sptr outWS = alg->getProperty(Prop::OUTPUT_WORKSPACES);
+  API::WorkspaceGroup_sptr outWS = alg->getProperty("OutputWorkspace");
   setProperty(Prop::OUTPUT_WORKSPACES, outWS);
 }
 
@@ -202,10 +201,10 @@ void PolarizationEfficiencyCor::execFredrikze() {
   MatrixWorkspace_sptr efficiencies = getEfficiencies();
   auto alg = createChildAlgorithm("PolarizationCorrectionFredrikze");
   alg->initialize();
-  alg->setProperty(Prop::INPUT_WORKSPACE, group);
-  alg->setProperty(Prop::EFFICIENCIES, efficiencies);
+  alg->setProperty("InputWorkspace", group);
+  alg->setProperty("Efficiencies", efficiencies);
   if (!isDefault(Prop::POLARIZATION_ANALYSIS)) {
-    alg->setPropertyValue(Prop::POLARIZATION_ANALYSIS, getPropertyValue(Prop::POLARIZATION_ANALYSIS));
+    alg->setPropertyValue("PolarizationAnalysis", getPropertyValue(Prop::POLARIZATION_ANALYSIS));
   }
   if (!isDefault(Prop::INPUT_FRED_SPIN_STATES)) {
     alg->setPropertyValue("InputSpinStates", getPropertyValue(Prop::INPUT_FRED_SPIN_STATES));
@@ -213,9 +212,9 @@ void PolarizationEfficiencyCor::execFredrikze() {
   if (!isDefault(Prop::OUTPUT_FRED_SPIN_STATES)) {
     alg->setPropertyValue("OutputSpinStates", getPropertyValue(Prop::OUTPUT_FRED_SPIN_STATES));
   }
-  alg->setPropertyValue(Prop::OUTPUT_WORKSPACES, getPropertyValue(Prop::OUTPUT_WORKSPACES));
+  alg->setPropertyValue("OutputWorkspace", getPropertyValue(Prop::OUTPUT_WORKSPACES));
   alg->execute();
-  API::WorkspaceGroup_sptr outWS = alg->getProperty(Prop::OUTPUT_WORKSPACES);
+  API::WorkspaceGroup_sptr outWS = alg->getProperty("OutputWorkspace");
   setProperty(Prop::OUTPUT_WORKSPACES, outWS);
 }
 

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -198,6 +198,19 @@ public:
     fullFourInputsResultsCheck(outputWS, wsList[0], wsList[1], wsList[2], wsList[3], effWS, counts);
   }
 
+  void test_FullCorrections_workspace_group() {
+    constexpr size_t numClones{4};
+    Counts counts{Y_VAL, Y_VAL, Y_VAL};
+
+    auto [wsGroup, wsList] = createWorkspaceGroup(numClones, counts);
+    setWorkspacesTestData(wsList, NHIST);
+
+    auto effWS = efficiencies(DEFAULT_EDGES);
+    WorkspaceGroup_sptr outputWS = runCorrectionWildes(wsGroup, effWS);
+
+    fullFourInputsResultsCheck(outputWS, wsList[0], wsList[1], wsList[2], wsList[3], effWS, counts);
+  }
+
   void test_ThreeInputsWithMissing01FlipperConfiguration() { threeInputsTest("01"); }
 
   void test_ThreeInputsWithMissing10FlipperConfiguration() { threeInputsTest("10"); }
@@ -408,6 +421,26 @@ public:
   }
 
 private:
+  std::unique_ptr<PolarizationCorrectionWildes> createWildesAlg(const Mantid::API::WorkspaceGroup_sptr &inputWorkspaces,
+                                                                Mantid::API::MatrixWorkspace_sptr effWs,
+                                                                const std::string &flippers = "",
+                                                                const std::string &spinStates = "") {
+    auto alg = std::make_unique<PolarizationCorrectionWildes>();
+    alg->setChild(true);
+    alg->setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg->initialize())
+    TS_ASSERT(alg->isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg->setProperty("InputWorkspaceGroup", inputWorkspaces))
+    TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("OutputWorkspace", OUTPUT_WS_NAME))
+    if (!flippers.empty())
+      alg->setProperty("Flippers", flippers);
+    if (!spinStates.empty())
+      alg->setProperty("SpinStates", spinStates);
+    TS_ASSERT_THROWS_NOTHING(alg->setProperty("Efficiencies", effWs))
+    setNonWSProps(*alg, flippers, spinStates, effWs);
+    return alg;
+  }
+
   std::unique_ptr<PolarizationCorrectionWildes> createWildesAlg(const std::vector<std::string> &inputWorkspaces,
                                                                 Mantid::API::MatrixWorkspace_sptr effWs,
                                                                 const std::string &flippers = "",
@@ -417,26 +450,23 @@ private:
     alg->setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg->initialize())
     TS_ASSERT(alg->isInitialized())
-
     if (inputWorkspaces.size() == 1) {
       TS_ASSERT_THROWS_NOTHING(alg->setProperty("InputWorkspaces", inputWorkspaces[0]))
     } else {
       TS_ASSERT_THROWS_NOTHING(alg->setProperty("InputWorkspaces", inputWorkspaces))
     }
-
     TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("OutputWorkspace", OUTPUT_WS_NAME))
-
-    if (!flippers.empty()) {
-      alg->setProperty("Flippers", flippers);
-    }
-
-    if (!spinStates.empty()) {
-      alg->setProperty("SpinStates", spinStates);
-    }
-
-    TS_ASSERT_THROWS_NOTHING(alg->setProperty("Efficiencies", effWs))
-
+    setNonWSProps(*alg, flippers, spinStates, effWs);
     return alg;
+  }
+
+  void setNonWSProps(PolarizationCorrectionWildes &alg, const std::string &flippers, const std::string &spinStates,
+                     Mantid::API::MatrixWorkspace_sptr effWs) {
+    if (!flippers.empty())
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", flippers));
+    if (!spinStates.empty())
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("SpinStates", spinStates));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWs));
   }
 
   Mantid::API::WorkspaceGroup_sptr runAlg(std::unique_ptr<PolarizationCorrectionWildes> alg,
@@ -464,6 +494,15 @@ private:
   }
 
   Mantid::API::WorkspaceGroup_sptr runCorrectionWildes(const std::vector<std::string> &inputWorkspaces,
+                                                       Mantid::API::MatrixWorkspace_sptr effWs,
+                                                       const std::string &flippers = "",
+                                                       const std::string &spinStates = "",
+                                                       const bool expectedToWork = true) {
+    auto alg = createWildesAlg(inputWorkspaces, effWs, flippers, spinStates);
+    return runAlg(std::move(alg), expectedToWork);
+  }
+
+  Mantid::API::WorkspaceGroup_sptr runCorrectionWildes(const Mantid::API::WorkspaceGroup_sptr &inputWorkspaces,
                                                        Mantid::API::MatrixWorkspace_sptr effWs,
                                                        const std::string &flippers = "",
                                                        const std::string &spinStates = "",
@@ -1434,6 +1473,16 @@ private:
     auto baseWorkspace = counts.has_value() ? createWorkspace(2, *counts) : createWorkspace();
 
     return cloneWorkspaces(baseWorkspace, numClones);
+  }
+
+  std::pair<WorkspaceGroup_sptr, std::vector<MatrixWorkspace_sptr>>
+  createWorkspaceGroup(const size_t numClones, const std::optional<Counts> &counts = std::nullopt) {
+    auto wsList = createWorkspaceList(numClones, counts);
+    WorkspaceGroup_sptr group = std::make_shared<WorkspaceGroup>();
+    for (const auto &ws : wsList) {
+      group->addWorkspace(ws);
+    }
+    return {group, wsList};
   }
 
   void setupWorkspacesForIdealCasesTwoInput(const Mantid::API::MatrixWorkspace_sptr &ws) {

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41334.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41334.rst
@@ -1,0 +1,2 @@
+- Algorithm :ref:`algm-PolarizationCorrectionWildes` now accepts an input workspace group as an alternative to a string
+  list of workspace names.

--- a/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41334.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/New_features/41334.rst
@@ -1,2 +1,1 @@
-- Algorithm :ref:`algm-PolarizationCorrectionWildes` now accepts an input workspace group as an alternative to a string
-  list of workspace names.
+- Algorithm :ref:`algm-PolarizationCorrectionWildes` now accepts an input workspace group as an alternative to a string list of workspace names.


### PR DESCRIPTION
### Description of work

This PR enables `PolarizationCorrectionWildes` to take a group workspace. At the moment, it can only take a string of workspaces that looks for in the ADS.

`PolarizationEfficiencyCor`, which calls `PolarizationCorrectionWildes` no longer throws an error if the user attempts to do this.

I've also replaced property strings with the relevant property helpers where appropriate.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
