### PR TITLE
Change signature of `VectorHelper::createAxisFromRebinParams`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -102,7 +102,7 @@ SofQW::setUpOutputWorkspace(const API::MatrixWorkspace &inputWorkspace, const st
   }
   // Create a vector to temporarily hold the vertical ('y') axis and populate
   // that
-  int yLength;
+  size_t yLength;
   if (qbinParams.size() == 1) {
     if (std::isnan(eMin)) {
       inputWorkspace.getXMinMax(eMin, eMax);

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -85,7 +85,7 @@ void InterpolatingRebin::exec() {
   std::vector<double> rb_params = Rebin::rebinParamsFromInput(getProperty("Params"), *inputW, g_log);
   HistogramData::BinEdges XValues_new(0);
   // create new output X axis
-  const int ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, XValues_new.mutableRawData());
+  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, XValues_new.mutableRawData());
 
   const auto nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -135,7 +135,7 @@ void Q1DWeighted::bootstrap(const MatrixWorkspace_const_sptr &inputWS) {
   // Calculate the output binning
   const std::vector<double> binParams = getProperty("OutputBinning");
 
-  m_nQ = static_cast<size_t>(VectorHelper::createAxisFromRebinParams(binParams, m_qBinEdges)) - 1;
+  m_nQ = VectorHelper::createAxisFromRebinParams(binParams, m_qBinEdges) - 1;
 
   m_isMonochromatic = inputWS->getAxis(0)->unit()->unitID() != "Wavelength";
   // number of spectra in the input

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -174,7 +174,7 @@ MatrixWorkspace_sptr Rebin2D::createOutputWorkspace(const MatrixWorkspace_const_
   auto &newY = newYBins.mutableRawData();
   // First create the two sets of bin boundaries
   static_cast<void>(createAxisFromRebinParams(getProperty("Axis1Binning"), newXBins.mutableRawData()));
-  const int newYSize = createAxisFromRebinParams(getProperty("Axis2Binning"), newY);
+  const size_t newYSize = createAxisFromRebinParams(getProperty("Axis2Binning"), newY);
   // and now the workspace
   HistogramData::BinEdges binEdges(newXBins);
   Workspace2D_sptr outputWS;

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -191,9 +191,9 @@ void ResampleX::setOptions(const int numBins, const bool useLogBins, const bool 
 double ResampleX::determineBinning(MantidVec &xValues, const double xmin, const double xmax) {
   xValues.clear(); // clear out the x-values
 
-  int numBoundaries(0);
-  int reqNumBoundaries(m_numBins);
-  int expNumBoundaries(m_numBins);
+  size_t numBoundaries(0);
+  size_t reqNumBoundaries(m_numBins);
+  size_t expNumBoundaries(m_numBins);
   if (m_isDistribution)
     reqNumBoundaries -= 1; // to get the VectorHelper to do the right thing
   else

--- a/Framework/Algorithms/src/SumEventsByLogValue.cpp
+++ b/Framework/Algorithms/src/SumEventsByLogValue.cpp
@@ -372,8 +372,8 @@ template <typename T> void SumEventsByLogValue::createBinnedOutput(const Kernel:
 
   // XValues will be resized in createAxisFromRebinParams()
   std::vector<double> XValues;
-  const int XLength = VectorHelper::createAxisFromRebinParams(m_binningParams, XValues);
-  assert((int)XValues.size() == XLength);
+  const size_t XLength = VectorHelper::createAxisFromRebinParams(m_binningParams, XValues);
+  assert(XValues.size() == XLength);
 
   // Create the output workspace - the factory will give back a Workspace2D
   MatrixWorkspace_sptr outputWorkspace = WorkspaceFactory::Instance().create("Workspace2D", 1, XLength, XLength - 1);

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -313,7 +313,7 @@ void CreateSimulationWorkspace::createGroupingsFromTables(const int *specTable, 
 BinEdges CreateSimulationWorkspace::createBinBoundaries() const {
   const std::vector<double> rbparams = getProperty("BinParams");
   MantidVec newBins;
-  const int numBoundaries = Mantid::Kernel::VectorHelper::createAxisFromRebinParams(rbparams, newBins);
+  const size_t numBoundaries = Mantid::Kernel::VectorHelper::createAxisFromRebinParams(rbparams, newBins);
   if (numBoundaries <= 2) {
     throw std::invalid_argument("Error in BinParams - Gave invalid number of bin boundaries: " +
                                 std::to_string(numBoundaries));

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -25,11 +25,11 @@ namespace Kernel {
     @date 16/12/2008
  */
 namespace VectorHelper {
-int MANTID_KERNEL_DLL createAxisFromRebinParams(const std::vector<double> &params, std::vector<double> &xnew,
-                                                const bool resize_xnew = true, const bool full_bins_only = false,
-                                                const double xMinHint = std::nan(""),
-                                                const double xMaxHint = std::nan(""),
-                                                const bool useReverseLogarithmic = false, const double power = -1);
+
+std::size_t MANTID_KERNEL_DLL createAxisFromRebinParams(
+    const std::vector<double> &params, std::vector<double> &xnew, const bool resize_xnew = true,
+    const bool full_bins_only = false, const double xMinHint = std::nan(""), const double xMaxHint = std::nan(""),
+    const bool useReverseLogarithmic = false, const double power = -1);
 
 void MANTID_KERNEL_DLL rebin(const std::vector<double> &xold, const std::vector<double> &yold,
                              const std::vector<double> &eold, const std::vector<double> &xnew,

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -31,9 +31,12 @@ namespace Mantid::Kernel::VectorHelper {
  *  @param[in] power the power in case of inverse power sum. Must be between 0 and 1 or is ignored.
  *  @return The number of bin boundaries in the new axis
  **/
-int DLLExport createAxisFromRebinParams(const std::vector<double> &params, std::vector<double> &xnew,
-                                        const bool resize_xnew, const bool full_bins_only, const double xMinHint,
-                                        const double xMaxHint, const bool useReverseLogarithmic, const double power) {
+std::size_t DLLExport createAxisFromRebinParams(const std::vector<double> &params, std::vector<double> &xnew,
+                                                const bool resize_xnew, const bool full_bins_only,
+                                                const double xMinHint, const double xMaxHint,
+                                                const bool useReverseLogarithmic, const double power) {
+
+  // correctly expand the parameters
   std::vector<double> tmp;
   const std::vector<double> &fullParams = [&params, &tmp, xMinHint, xMaxHint]() {
     if (params.size() == 1) {
@@ -48,10 +51,10 @@ int DLLExport createAxisFromRebinParams(const std::vector<double> &params, std::
     }
     return params;
   }();
-  int ibound(2), istep(1), inew(1);
+  std::size_t ibound(2), istep(1), inew(1);
   // highest index in params array containing a bin boundary
-  auto ibounds = static_cast<int>(fullParams.size());
-  int isteps = ibounds - 1; // highest index in params array containing a step
+  std::size_t ibounds = fullParams.size();
+  std::size_t isteps = ibounds - 1; // highest index in params array containing a step
 
   // This coefficitent represents the maximum difference between the size of the last bin and all
   // the other bins.

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -76,7 +76,7 @@ public:
     rbParams[2] = 10;
 
     std::vector<double> axis;
-    const int numBoundaries = VectorHelper::createAxisFromRebinParams(rbParams, axis);
+    const size_t numBoundaries = VectorHelper::createAxisFromRebinParams(rbParams, axis);
 
     TS_ASSERT_EQUALS(numBoundaries, 10);
     TS_ASSERT_EQUALS(axis.size(), 10);
@@ -89,7 +89,7 @@ public:
     rbParams[2] = 10;
 
     std::vector<double> axis;
-    const int numBoundaries = VectorHelper::createAxisFromRebinParams(rbParams, axis, false);
+    const size_t numBoundaries = VectorHelper::createAxisFromRebinParams(rbParams, axis, false);
 
     TS_ASSERT_EQUALS(numBoundaries, 10);
     TS_ASSERT_EQUALS(axis.size(), 0);
@@ -129,7 +129,7 @@ public:
     std::vector<double> rbParams = {1, -1, 37};
 
     std::vector<double> axis;
-    VectorHelper::createAxisFromRebinParams(rbParams, axis, true, false, 1, 37, true);
+    VectorHelper::createAxisFromRebinParams(rbParams, axis, true, true, 1, 37, true);
 
     std::vector<double> expectedAxis = {1, 22, 30, 34, 36, 37};
     TS_ASSERT_EQUALS(axis, expectedAxis);

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1187,11 +1187,11 @@ RebinnedOutput_sptr createRebinnedOutputWorkspace() {
   // Set Q ('y') axis binning
   std::vector<double> qbins{0.0, 1.0, 4.0};
   std::vector<double> qaxis;
-  const auto numY = static_cast<int>(VectorHelper::createAxisFromRebinParams(qbins, qaxis));
+  const size_t numY = VectorHelper::createAxisFromRebinParams(qbins, qaxis);
 
   // Initialize the workspace
-  const int numHist = numY - 1;
-  const int numX = 7;
+  const size_t numHist = numY - 1;
+  const size_t numX = 7;
   outputWS->initialize(numHist, numX, numX - 1);
 
   // Set the normal units
@@ -1206,7 +1206,7 @@ RebinnedOutput_sptr createRebinnedOutputWorkspace() {
   auto verticalAxis = std::make_unique<NumericAxis>(numY);
 
   // Now set the axis values
-  for (int i = 0; i < numHist; ++i) {
+  for (size_t i = 0; i < numHist; ++i) {
     outputWS->setBinEdges(i, x1);
     verticalAxis->setValue(i, qaxis[i]);
   }
@@ -1250,9 +1250,9 @@ RebinnedOutput_sptr createRebinnedOutputWorkspace() {
   outputWS->finalize();
 
   // Make errors squared rooted and set sqrd err flag
-  for (int i = 0; i < numHist; ++i) {
+  for (size_t i = 0; i < numHist; ++i) {
     auto &mutableE = outputWS->mutableE(i);
-    for (int j = 0; j < numX - 1; ++j) {
+    for (size_t j = 0; j < numX - 1; ++j) {
       mutableE[j] = std::sqrt(mutableE[j]);
     }
   }


### PR DESCRIPTION
### Description of work

The function `VectorHelper::createAxisFromRebinParams()` returned an `int` representing the total size of the binned axes to be created.

This is better represented by a `size_t`.  This changes the signature and relevant portions with this fix.

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
