### PR TITLE
Delete the `mutableRawData` method from `BinEdges`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -89,18 +89,18 @@ SofQW::setUpOutputWorkspace(const API::MatrixWorkspace &inputWorkspace, const st
                             const SofQCommon &emodeProperties) {
   using Kernel::VectorHelper::createAxisFromRebinParams;
   // Create vector to hold the new X axis values
-  std::vector<double> tmp;
+  std::vector<double> xnew;
   double eMin{std::nan("")};
   double eMax{std::nan("")};
   if (ebinParams.empty()) {
-    tmp = inputWorkspace.binEdges(0).rawData();
+    xnew = inputWorkspace.binEdges(0).rawData();
   } else if (ebinParams.size() == 1) {
     inputWorkspace.getXMinMax(eMin, eMax);
-    createAxisFromRebinParams(ebinParams, tmp, true, true, eMin, eMax);
+    createAxisFromRebinParams(ebinParams, xnew, true, true, eMin, eMax);
   } else {
-    createAxisFromRebinParams(ebinParams, tmp);
+    createAxisFromRebinParams(ebinParams, xnew);
   }
-  HistogramData::BinEdges xAxis(std::move(tmp));
+  HistogramData::BinEdges xAxis(std::move(xnew));
   // Create a vector to temporarily hold the vertical ('y') axis and populate
   // that
   size_t yLength;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -89,17 +89,18 @@ SofQW::setUpOutputWorkspace(const API::MatrixWorkspace &inputWorkspace, const st
                             const SofQCommon &emodeProperties) {
   using Kernel::VectorHelper::createAxisFromRebinParams;
   // Create vector to hold the new X axis values
-  HistogramData::BinEdges xAxis(0);
+  std::vector<double> tmp;
   double eMin{std::nan("")};
   double eMax{std::nan("")};
   if (ebinParams.empty()) {
-    xAxis = inputWorkspace.binEdges(0);
+    tmp = inputWorkspace.binEdges(0).rawData();
   } else if (ebinParams.size() == 1) {
     inputWorkspace.getXMinMax(eMin, eMax);
-    createAxisFromRebinParams(ebinParams, xAxis.mutableRawData(), true, true, eMin, eMax);
+    createAxisFromRebinParams(ebinParams, tmp, true, true, eMin, eMax);
   } else {
-    createAxisFromRebinParams(ebinParams, xAxis.mutableRawData());
+    createAxisFromRebinParams(ebinParams, tmp);
   }
+  HistogramData::BinEdges xAxis(std::move(tmp));
   // Create a vector to temporarily hold the vertical ('y') axis and populate
   // that
   size_t yLength;

--- a/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
+++ b/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
@@ -153,10 +153,8 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
     binsFromFile = true;
 
   const auto &oldXEdges = m_inputWS->x(0);
-  BinEdges dBins(oldXEdges.size());
-  BinEdges dPerpBins(oldXEdges.size());
 
-  auto &dPerp = dPerpBins.mutableRawData();
+  std::vector<double> dPerp, dBins;
   std::vector<std::vector<double>> fileXbins;
 
   // First create the output Workspace filled with zeros
@@ -181,14 +179,14 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
     }
 
   } else {
-    static_cast<void>(createAxisFromRebinParams(getProperty("dSpaceBinning"), dBins.mutableRawData()));
+    createAxisFromRebinParams(getProperty("dSpaceBinning"), dBins);
     HistogramData::BinEdges binEdges(dBins);
     dPerpSize = createAxisFromRebinParams(getProperty("dPerpendicularBinning"), dPerp);
     dSize = binEdges.size();
     outputWS = WorkspaceFactory::Instance().create(m_inputWS, dPerpSize - 1, dSize, dSize - 1);
     for (size_t idx = 0; idx < dPerpSize - 1; idx++)
       outputWS->setBinEdges(idx, binEdges);
-    auto abscissa = std::make_unique<BinEdgeAxis>(dBins.mutableRawData());
+    auto abscissa = std::make_unique<BinEdgeAxis>(dBins);
     outputWS->replaceAxis(0, std::move(abscissa));
   }
   addTimer("createWorkspace", startTime, std::chrono::high_resolution_clock::now());
@@ -246,7 +244,7 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
         const auto dp_index = static_cast<size_t>(std::distance(dp_vec.begin(), lowy) - 1);
 
         // find d bin
-        const auto xs = binsFromFile ? fileXbins[dp_index] : dBins.rawData();
+        const auto xs = binsFromFile ? fileXbins[dp_index] : dBins;
         const auto d = calcD(ev.tof(), sin_theta);
         const auto lowx = std::lower_bound(xs.begin(), xs.end(), d);
         if ((lowx == xs.end()) || lowx == xs.begin())

--- a/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
+++ b/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
@@ -152,8 +152,6 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
   if (!beFileName.empty())
     binsFromFile = true;
 
-  const auto &oldXEdges = m_inputWS->x(0);
-
   std::vector<double> dPerp, dBins;
   std::vector<std::vector<double>> fileXbins;
 

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -800,8 +800,7 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
     // NOTE must use a vector instead of a HistogramData::BinEdges here because the latter doesn't allow resizing
     // BinEdges stores HistogramX data, and HistogramX is a type of FixedLengthVector
     std::vector<double> xnew;
-    static_cast<void>(
-        VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew, true, fullBinsOnly));
+    VectorHelper::createAxisFromRebinParams({xmins[i], deltas[i], xmaxs[i]}, xnew, true, fullBinsOnly);
     group2xvector[group] = std::move(xnew); // Register this vector in the map
     group2xstep[group] = deltas[i];
     i++;

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -83,9 +83,10 @@ void InterpolatingRebin::exec() {
 
   // retrieve the properties
   std::vector<double> rb_params = Rebin::rebinParamsFromInput(getProperty("Params"), *inputW, g_log);
-  HistogramData::BinEdges XValues_new(0);
   // create new output X axis
-  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, XValues_new.mutableRawData());
+  std::vector<double> tmp;
+  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, tmp);
+  HistogramData::BinEdges XValues_new(std::move(tmp));
 
   const auto nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -84,9 +84,9 @@ void InterpolatingRebin::exec() {
   // retrieve the properties
   std::vector<double> rb_params = Rebin::rebinParamsFromInput(getProperty("Params"), *inputW, g_log);
   // create new output X axis
-  std::vector<double> xtmp;
-  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, xtmp);
-  HistogramData::BinEdges XValues_new(std::move(xtmp));
+  std::vector<double> xAxisTmp;
+  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, xAxisTmp);
+  HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
   const auto nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -84,9 +84,9 @@ void InterpolatingRebin::exec() {
   // retrieve the properties
   std::vector<double> rb_params = Rebin::rebinParamsFromInput(getProperty("Params"), *inputW, g_log);
   // create new output X axis
-  std::vector<double> tmp;
-  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, tmp);
-  HistogramData::BinEdges XValues_new(std::move(tmp));
+  std::vector<double> xtmp;
+  const std::size_t ntcnew = VectorHelper::createAxisFromRebinParams(rb_params, xtmp);
+  HistogramData::BinEdges XValues_new(std::move(xtmp));
 
   const auto nHists = static_cast<int>(inputW->getNumberHistograms());
   // make output Workspace the same type as the input but with the new axes

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -308,9 +308,9 @@ void Q1D2::exec() {
  */
 API::MatrixWorkspace_sptr Q1D2::setUpOutputWorkspace(const std::vector<double> &binParams) const {
   // Calculate the output binning
-  std::vector<double> tmp;
-  VectorHelper::createAxisFromRebinParams(binParams, tmp);
-  HistogramData::BinEdges XOut(std::move(tmp));
+  std::vector<double> xtmp;
+  VectorHelper::createAxisFromRebinParams(binParams, xtmp);
+  HistogramData::BinEdges XOut(std::move(xtmp));
 
   // Create output workspace. On all but rank 0 this is a temporary workspace.
   Indexing::IndexInfo indexInfo(1);

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -308,9 +308,9 @@ void Q1D2::exec() {
  */
 API::MatrixWorkspace_sptr Q1D2::setUpOutputWorkspace(const std::vector<double> &binParams) const {
   // Calculate the output binning
-  std::vector<double> xtmp;
-  VectorHelper::createAxisFromRebinParams(binParams, xtmp);
-  HistogramData::BinEdges XOut(std::move(xtmp));
+  std::vector<double> xAxisTmp;
+  VectorHelper::createAxisFromRebinParams(binParams, xAxisTmp);
+  HistogramData::BinEdges XOut(std::move(xAxisTmp));
 
   // Create output workspace. On all but rank 0 this is a temporary workspace.
   Indexing::IndexInfo indexInfo(1);

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -308,8 +308,9 @@ void Q1D2::exec() {
  */
 API::MatrixWorkspace_sptr Q1D2::setUpOutputWorkspace(const std::vector<double> &binParams) const {
   // Calculate the output binning
-  HistogramData::BinEdges XOut(0);
-  static_cast<void>(VectorHelper::createAxisFromRebinParams(binParams, XOut.mutableRawData()));
+  std::vector<double> tmp;
+  VectorHelper::createAxisFromRebinParams(binParams, tmp);
+  HistogramData::BinEdges XOut(std::move(tmp));
 
   // Create output workspace. On all but rank 0 this is a temporary workspace.
   Indexing::IndexInfo indexInfo(1);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -304,9 +304,9 @@ void Rebin::exec() {
   inputWS->getXMinMax(xmin, xmax);
 
   // create new output X axis
-  std::vector<double> tmp;
-  VectorHelper::createAxisFromRebinParams(rbParams, tmp, true, fullBinsOnly, xmin, xmax, useReverseLog, power);
-  HistogramData::BinEdges XValues_new(std::move(tmp));
+  std::vector<double> xtmp;
+  VectorHelper::createAxisFromRebinParams(rbParams, xtmp, true, fullBinsOnly, xmin, xmax, useReverseLog, power);
+  HistogramData::BinEdges XValues_new(std::move(xtmp));
 
   // Now, determine if the input workspace is actually an EventWorkspace
   EventWorkspace_const_sptr eventInputWS = std::dynamic_pointer_cast<const EventWorkspace>(inputWS);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -304,9 +304,9 @@ void Rebin::exec() {
   inputWS->getXMinMax(xmin, xmax);
 
   // create new output X axis
-  std::vector<double> xtmp;
-  VectorHelper::createAxisFromRebinParams(rbParams, xtmp, true, fullBinsOnly, xmin, xmax, useReverseLog, power);
-  HistogramData::BinEdges XValues_new(std::move(xtmp));
+  std::vector<double> xAxisTmp;
+  VectorHelper::createAxisFromRebinParams(rbParams, xAxisTmp, true, fullBinsOnly, xmin, xmax, useReverseLog, power);
+  HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
   // Now, determine if the input workspace is actually an EventWorkspace
   EventWorkspace_const_sptr eventInputWS = std::dynamic_pointer_cast<const EventWorkspace>(inputWS);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -303,10 +303,10 @@ void Rebin::exec() {
   double xmax = 0.;
   inputWS->getXMinMax(xmin, xmax);
 
-  HistogramData::BinEdges XValues_new(0);
   // create new output X axis
-  static_cast<void>(VectorHelper::createAxisFromRebinParams(rbParams, XValues_new.mutableRawData(), true, fullBinsOnly,
-                                                            xmin, xmax, useReverseLog, power));
+  std::vector<double> tmp;
+  VectorHelper::createAxisFromRebinParams(rbParams, tmp, true, fullBinsOnly, xmin, xmax, useReverseLog, power);
+  HistogramData::BinEdges XValues_new(std::move(tmp));
 
   // Now, determine if the input workspace is actually an EventWorkspace
   EventWorkspace_const_sptr eventInputWS = std::dynamic_pointer_cast<const EventWorkspace>(inputWS);

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -171,10 +171,12 @@ MatrixWorkspace_sptr Rebin2D::createOutputWorkspace(const MatrixWorkspace_const_
                                                     BinEdges &newYBins, const bool useFractionalArea) const {
   using Kernel::VectorHelper::createAxisFromRebinParams;
 
-  auto &newY = newYBins.mutableRawData();
+  std::vector<double> newX, newY;
   // First create the two sets of bin boundaries
-  static_cast<void>(createAxisFromRebinParams(getProperty("Axis1Binning"), newXBins.mutableRawData()));
+  createAxisFromRebinParams(getProperty("Axis1Binning"), newX);
+  newXBins = BinEdges(std::move(newX));
   const size_t newYSize = createAxisFromRebinParams(getProperty("Axis2Binning"), newY);
+  newYBins = BinEdges(std::move(newY));
   // and now the workspace
   HistogramData::BinEdges binEdges(newXBins);
   Workspace2D_sptr outputWS;
@@ -183,7 +185,7 @@ MatrixWorkspace_sptr Rebin2D::createOutputWorkspace(const MatrixWorkspace_const_
   } else {
     outputWS = create<RebinnedOutput>(*parent, newYSize - 1, binEdges);
   }
-  auto verticalAxis = std::make_unique<BinEdgeAxis>(newY);
+  auto verticalAxis = std::make_unique<BinEdgeAxis>(newYBins.rawData());
   // Meta data
   verticalAxis->unit() = parent->getAxis(1)->unit();
   verticalAxis->title() = parent->getAxis(1)->title();

--- a/Framework/Algorithms/src/RebinByTimeBase.cpp
+++ b/Framework/Algorithms/src/RebinByTimeBase.cpp
@@ -109,7 +109,7 @@ void RebinByTimeBase::exec() {
 
   MantidVecPtr XValues_new;
   // create new X axis, with absolute times in seconds.
-  static_cast<void>(VectorHelper::createAxisFromRebinParams(rebinningParams, XValues_new.access()));
+  VectorHelper::createAxisFromRebinParams(rebinningParams, XValues_new.access());
 
   ConvertToRelativeTime transformToRelativeT(runStartTime);
 

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -17,8 +17,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/VectorHelper.h"
 
-namespace Mantid {
-namespace Algorithms {
+namespace Mantid::Algorithms {
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(RebinRagged)
@@ -316,5 +315,4 @@ void RebinRagged::extend_value(int histnumber, std::vector<double> &array) {
     array.resize(histnumber, array[0]);
   }
 }
-} // namespace Algorithms
-} // namespace Mantid
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -166,9 +166,9 @@ void RebinRagged::exec() {
         auto xmax = xmaxs[hist];
         const auto delta = deltas[hist];
 
-        HistogramData::BinEdges XValues_new(0);
-        static_cast<void>(VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, XValues_new.mutableRawData(),
-                                                                  true, fullBinsOnly));
+        std::vector<double> tmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(tmp));
         EventList &el = eventOutputWS->getSpectrum(hist);
         el.setHistogram(XValues_new);
       }
@@ -191,9 +191,9 @@ void RebinRagged::exec() {
         // Get a const event list reference. eventInputWS->dataY() doesn't work.
         const EventList &el = eventInputWS->getSpectrum(hist);
 
-        HistogramData::BinEdges XValues_new(0);
-        static_cast<void>(VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, XValues_new.mutableRawData(),
-                                                                  true, fullBinsOnly));
+        std::vector<double> tmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(tmp));
 
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
@@ -246,9 +246,9 @@ void RebinRagged::exec() {
       auto xmax = xmaxs[hist];
       const auto delta = deltas[hist];
 
-      HistogramData::BinEdges XValues_new(0);
-      static_cast<void>(VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, XValues_new.mutableRawData(), true,
-                                                                fullBinsOnly));
+      std::vector<double> tmp;
+      VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
+      HistogramData::BinEdges XValues_new(std::move(tmp));
 
       outputWS->setHistogram(hist, HistogramData::rebin(inputWS->histogram(hist), XValues_new));
       prog.report();

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -165,9 +165,9 @@ void RebinRagged::exec() {
         auto xmax = xmaxs[hist];
         const auto delta = deltas[hist];
 
-        std::vector<double> xtmp;
-        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
-        HistogramData::BinEdges XValues_new(std::move(xtmp));
+        std::vector<double> xAxisTmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xAxisTmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
         EventList &el = eventOutputWS->getSpectrum(hist);
         el.setHistogram(XValues_new);
       }
@@ -190,9 +190,9 @@ void RebinRagged::exec() {
         // Get a const event list reference. eventInputWS->dataY() doesn't work.
         const EventList &el = eventInputWS->getSpectrum(hist);
 
-        std::vector<double> xtmp;
-        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
-        HistogramData::BinEdges XValues_new(std::move(xtmp));
+        std::vector<double> xAxisTmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xAxisTmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
@@ -245,9 +245,9 @@ void RebinRagged::exec() {
       auto xmax = xmaxs[hist];
       const auto delta = deltas[hist];
 
-      std::vector<double> xtmp;
-      VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
-      HistogramData::BinEdges XValues_new(std::move(xtmp));
+      std::vector<double> xAxisTmp;
+      VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xAxisTmp, true, fullBinsOnly);
+      HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
       outputWS->setHistogram(hist, HistogramData::rebin(inputWS->histogram(hist), XValues_new));
       prog.report();

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -165,9 +165,9 @@ void RebinRagged::exec() {
         auto xmax = xmaxs[hist];
         const auto delta = deltas[hist];
 
-        std::vector<double> tmp;
-        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
-        HistogramData::BinEdges XValues_new(std::move(tmp));
+        std::vector<double> xtmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(xtmp));
         EventList &el = eventOutputWS->getSpectrum(hist);
         el.setHistogram(XValues_new);
       }
@@ -190,9 +190,9 @@ void RebinRagged::exec() {
         // Get a const event list reference. eventInputWS->dataY() doesn't work.
         const EventList &el = eventInputWS->getSpectrum(hist);
 
-        std::vector<double> tmp;
-        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
-        HistogramData::BinEdges XValues_new(std::move(tmp));
+        std::vector<double> xtmp;
+        VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
+        HistogramData::BinEdges XValues_new(std::move(xtmp));
 
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
@@ -245,9 +245,9 @@ void RebinRagged::exec() {
       auto xmax = xmaxs[hist];
       const auto delta = deltas[hist];
 
-      std::vector<double> tmp;
-      VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, tmp, true, fullBinsOnly);
-      HistogramData::BinEdges XValues_new(std::move(tmp));
+      std::vector<double> xtmp;
+      VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, xtmp, true, fullBinsOnly);
+      HistogramData::BinEdges XValues_new(std::move(xtmp));
 
       outputWS->setHistogram(hist, HistogramData::rebin(inputWS->histogram(hist), XValues_new));
       prog.report();

--- a/Framework/Algorithms/src/Regroup.cpp
+++ b/Framework/Algorithms/src/Regroup.cpp
@@ -65,9 +65,9 @@ void Regroup::exec() {
   auto &XValues_old = inputW->x(0);
   std::vector<int> xoldIndex; // indeces of new x in XValues_old
   // create new output X axis
-  std::vector<double> tmp;
-  int ntcnew = newAxis(rb_params, XValues_old.rawData(), tmp, xoldIndex);
-  HistogramData::BinEdges XValues_new(std::move(tmp));
+  std::vector<double> xtmp;
+  int ntcnew = newAxis(rb_params, XValues_old.rawData(), xtmp, xoldIndex);
+  HistogramData::BinEdges XValues_new(std::move(xtmp));
 
   // make output Workspace the same type is the input, but with new length of
   // signal array

--- a/Framework/Algorithms/src/Regroup.cpp
+++ b/Framework/Algorithms/src/Regroup.cpp
@@ -62,11 +62,12 @@ void Regroup::exec() {
   const bool dist = inputW->isDistribution();
 
   const auto histnumber = static_cast<int>(inputW->getNumberHistograms());
-  HistogramData::BinEdges XValues_new(0);
   auto &XValues_old = inputW->x(0);
   std::vector<int> xoldIndex; // indeces of new x in XValues_old
   // create new output X axis
-  int ntcnew = newAxis(rb_params, XValues_old.rawData(), XValues_new.mutableRawData(), xoldIndex);
+  std::vector<double> tmp;
+  int ntcnew = newAxis(rb_params, XValues_old.rawData(), tmp, xoldIndex);
+  HistogramData::BinEdges XValues_new(std::move(tmp));
 
   // make output Workspace the same type is the input, but with new length of
   // signal array

--- a/Framework/Algorithms/src/Regroup.cpp
+++ b/Framework/Algorithms/src/Regroup.cpp
@@ -65,9 +65,9 @@ void Regroup::exec() {
   auto &XValues_old = inputW->x(0);
   std::vector<int> xoldIndex; // indeces of new x in XValues_old
   // create new output X axis
-  std::vector<double> xtmp;
-  int ntcnew = newAxis(rb_params, XValues_old.rawData(), xtmp, xoldIndex);
-  HistogramData::BinEdges XValues_new(std::move(xtmp));
+  std::vector<double> xAxisTmp;
+  int ntcnew = newAxis(rb_params, XValues_old.rawData(), xAxisTmp, xoldIndex);
+  HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
   // make output Workspace the same type is the input, but with new length of
   // signal array

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -324,9 +324,9 @@ void ResampleX::exec() {
 
       if (common_limits) {
         // get the delta from the first since they are all the same
-        std::vector<double> xtmp;
-        const double delta = this->determineBinning(xtmp, xmins[0], xmaxs[0]);
-        BinEdges xValues(std::move(xtmp));
+        std::vector<double> xAxisTmp;
+        const double delta = this->determineBinning(xAxisTmp, xmins[0], xmaxs[0]);
+        BinEdges xValues(std::move(xAxisTmp));
         g_log.debug() << "delta = " << delta << "\n";
         outputEventWS->setAllX(xValues);
       } else {
@@ -337,9 +337,9 @@ void ResampleX::exec() {
         PARALLEL_FOR_IF(Kernel::threadSafe(*inputEventWS, *outputWS))
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
           PARALLEL_START_INTERRUPT_REGION
-          std::vector<double> xtmp;
-          const double delta = this->determineBinning(xtmp, xmins[wkspIndex], xmaxs[wkspIndex]);
-          BinEdges xValues(std::move(xtmp));
+          std::vector<double> xAxisTmp;
+          const double delta = this->determineBinning(xAxisTmp, xmins[wkspIndex], xmaxs[wkspIndex]);
+          BinEdges xValues(std::move(xAxisTmp));
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";
           outputEventWS->setHistogram(wkspIndex, xValues);

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -324,9 +324,9 @@ void ResampleX::exec() {
 
       if (common_limits) {
         // get the delta from the first since they are all the same
-        std::vector<double> tmp;
-        const double delta = this->determineBinning(tmp, xmins[0], xmaxs[0]);
-        BinEdges xValues(std::move(tmp));
+        std::vector<double> xtmp;
+        const double delta = this->determineBinning(xtmp, xmins[0], xmaxs[0]);
+        BinEdges xValues(std::move(xtmp));
         g_log.debug() << "delta = " << delta << "\n";
         outputEventWS->setAllX(xValues);
       } else {
@@ -337,9 +337,9 @@ void ResampleX::exec() {
         PARALLEL_FOR_IF(Kernel::threadSafe(*inputEventWS, *outputWS))
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
           PARALLEL_START_INTERRUPT_REGION
-          std::vector<double> tmp;
-          const double delta = this->determineBinning(tmp, xmins[wkspIndex], xmaxs[wkspIndex]);
-          BinEdges xValues(std::move(tmp));
+          std::vector<double> xtmp;
+          const double delta = this->determineBinning(xtmp, xmins[wkspIndex], xmaxs[wkspIndex]);
+          BinEdges xValues(std::move(xtmp));
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";
           outputEventWS->setHistogram(wkspIndex, xValues);

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -324,8 +324,9 @@ void ResampleX::exec() {
 
       if (common_limits) {
         // get the delta from the first since they are all the same
-        BinEdges xValues(0);
-        const double delta = this->determineBinning(xValues.mutableRawData(), xmins[0], xmaxs[0]);
+        std::vector<double> tmp;
+        const double delta = this->determineBinning(tmp, xmins[0], xmaxs[0]);
+        BinEdges xValues(std::move(tmp));
         g_log.debug() << "delta = " << delta << "\n";
         outputEventWS->setAllX(xValues);
       } else {
@@ -336,8 +337,9 @@ void ResampleX::exec() {
         PARALLEL_FOR_IF(Kernel::threadSafe(*inputEventWS, *outputWS))
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
           PARALLEL_START_INTERRUPT_REGION
-          BinEdges xValues(0);
-          const double delta = this->determineBinning(xValues.mutableRawData(), xmins[wkspIndex], xmaxs[wkspIndex]);
+          std::vector<double> tmp;
+          const double delta = this->determineBinning(tmp, xmins[wkspIndex], xmaxs[wkspIndex]);
+          BinEdges xValues(std::move(tmp));
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";
           outputEventWS->setHistogram(wkspIndex, xValues);

--- a/Framework/Algorithms/test/CalculatePolynomialBackgroundTest.h
+++ b/Framework/Algorithms/test/CalculatePolynomialBackgroundTest.h
@@ -174,13 +174,13 @@ public:
     const double xMax{5000.0};
     const double xStep{10.0};
     const auto nBins = static_cast<size_t>((xMax - xMin) / xStep);
-    HistogramData::BinEdges edges(nBins + 1);
+    std::vector<double> bins(nBins + 1);
     {
-      auto &bins = edges.mutableRawData();
       for (size_t i = 0; i < bins.size(); ++i) {
         bins[i] = xMin + xStep * static_cast<double>(i);
       }
     }
+    HistogramData::BinEdges edges(std::move(bins));
     HistogramData::Counts counts(nBins);
     {
       auto &ys = counts.mutableRawData();

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -673,9 +673,10 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
 
   // always use the first histogram x-values for initialization
   double const binWidth = linearBins ? x_delta[0] : -1. * std::abs(x_delta[0]);
-  std::vector<double> xtmp;
-  Kernel::VectorHelper::createAxisFromRebinParams({x_min[0], binWidth, x_max[0]}, xtmp, resize_xnew, full_bins_only);
-  HistogramData::BinEdges XValues(std::move(xtmp));
+  std::vector<double> xAxisTmp;
+  Kernel::VectorHelper::createAxisFromRebinParams({x_min[0], binWidth, x_max[0]}, xAxisTmp, resize_xnew,
+                                                  full_bins_only);
+  HistogramData::BinEdges XValues(std::move(xAxisTmp));
   wksp->initialize(num_hist, HistogramData::Histogram(XValues, HistogramData::Counts(XValues.size() - 1, 0.0)));
 
   if (raggedBins) {

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -673,9 +673,9 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
 
   // always use the first histogram x-values for initialization
   double const binWidth = linearBins ? x_delta[0] : -1. * std::abs(x_delta[0]);
-  std::vector<double> tmp;
-  Kernel::VectorHelper::createAxisFromRebinParams({x_min[0], binWidth, x_max[0]}, tmp, resize_xnew, full_bins_only);
-  HistogramData::BinEdges XValues(std::move(tmp));
+  std::vector<double> xtmp;
+  Kernel::VectorHelper::createAxisFromRebinParams({x_min[0], binWidth, x_max[0]}, xtmp, resize_xnew, full_bins_only);
+  HistogramData::BinEdges XValues(std::move(xtmp));
   wksp->initialize(num_hist, HistogramData::Histogram(XValues, HistogramData::Counts(XValues.size() - 1, 0.0)));
 
   if (raggedBins) {
@@ -688,15 +688,11 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
       x_max.resize(num_hist, x_max[0]);
 
     for (size_t i = 1; i < num_hist; ++i) {
-      std::vector<double> tmpragged;
-      if (linearBins) {
-        const std::vector<double> params{x_min[i], x_delta[i], x_max[i]};
-        Kernel::VectorHelper::createAxisFromRebinParams(params, tmpragged, resize_xnew, full_bins_only);
-      } else {
-        const std::vector<double> params{x_min[i], -1. * std::abs(x_delta[i]), x_max[i]};
-        Kernel::VectorHelper::createAxisFromRebinParams(params, tmpragged, resize_xnew, full_bins_only);
-      }
-      HistogramData::BinEdges XValues_new(std::move(tmpragged));
+      double const binWidth = linearBins ? x_delta[i] : -1. * std::abs(x_delta[i]);
+      std::vector<double> const params{x_min[i], binWidth, x_max[i]};
+      std::vector<double> xtmpragged;
+      Kernel::VectorHelper::createAxisFromRebinParams(params, xtmpragged, resize_xnew, full_bins_only);
+      HistogramData::BinEdges XValues_new(std::move(xtmpragged));
       wksp->setHistogram(i, HistogramData::Histogram(XValues_new, HistogramData::Counts(XValues_new.size() - 1, 0.0)));
     }
   }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -672,14 +672,9 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
   constexpr bool full_bins_only{false};
 
   // always use the first histogram x-values for initialization
+  double const binWidth = linearBins ? x_delta[0] : -1. * std::abs(x_delta[0]);
   std::vector<double> tmp;
-  if (linearBins) {
-    const std::vector<double> params{x_min[0], x_delta[0], x_max[0]};
-    Kernel::VectorHelper::createAxisFromRebinParams(params, tmp, resize_xnew, full_bins_only);
-  } else {
-    const std::vector<double> params{x_min[0], -1. * std::abs(x_delta[0]), x_max[0]};
-    Kernel::VectorHelper::createAxisFromRebinParams(params, tmp, resize_xnew, full_bins_only);
-  }
+  Kernel::VectorHelper::createAxisFromRebinParams({x_min[0], binWidth, x_max[0]}, tmp, resize_xnew, full_bins_only);
   HistogramData::BinEdges XValues(std::move(tmp));
   wksp->initialize(num_hist, HistogramData::Histogram(XValues, HistogramData::Counts(XValues.size() - 1, 0.0)));
 

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -672,16 +672,15 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
   constexpr bool full_bins_only{false};
 
   // always use the first histogram x-values for initialization
-  HistogramData::BinEdges XValues(0);
+  std::vector<double> tmp;
   if (linearBins) {
     const std::vector<double> params{x_min[0], x_delta[0], x_max[0]};
-    UNUSED_ARG(
-        Kernel::VectorHelper::createAxisFromRebinParams(params, XValues.mutableRawData(), resize_xnew, full_bins_only));
+    Kernel::VectorHelper::createAxisFromRebinParams(params, tmp, resize_xnew, full_bins_only);
   } else {
     const std::vector<double> params{x_min[0], -1. * std::abs(x_delta[0]), x_max[0]};
-    UNUSED_ARG(
-        Kernel::VectorHelper::createAxisFromRebinParams(params, XValues.mutableRawData(), resize_xnew, full_bins_only));
+    Kernel::VectorHelper::createAxisFromRebinParams(params, tmp, resize_xnew, full_bins_only);
   }
+  HistogramData::BinEdges XValues(std::move(tmp));
   wksp->initialize(num_hist, HistogramData::Histogram(XValues, HistogramData::Counts(XValues.size() - 1, 0.0)));
 
   if (raggedBins) {
@@ -694,17 +693,15 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
       x_max.resize(num_hist, x_max[0]);
 
     for (size_t i = 1; i < num_hist; ++i) {
-      HistogramData::BinEdges XValues_new(0);
-
+      std::vector<double> tmpragged;
       if (linearBins) {
         const std::vector<double> params{x_min[i], x_delta[i], x_max[i]};
-        Kernel::VectorHelper::createAxisFromRebinParams(params, XValues_new.mutableRawData(), resize_xnew,
-                                                        full_bins_only);
+        Kernel::VectorHelper::createAxisFromRebinParams(params, tmpragged, resize_xnew, full_bins_only);
       } else {
         const std::vector<double> params{x_min[i], -1. * std::abs(x_delta[i]), x_max[i]};
-        Kernel::VectorHelper::createAxisFromRebinParams(params, XValues_new.mutableRawData(), resize_xnew,
-                                                        full_bins_only);
+        Kernel::VectorHelper::createAxisFromRebinParams(params, tmpragged, resize_xnew, full_bins_only);
       }
+      HistogramData::BinEdges XValues_new(std::move(tmpragged));
       wksp->setHistogram(i, HistogramData::Histogram(XValues_new, HistogramData::Counts(XValues_new.size() - 1, 0.0)));
     }
   }

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -688,8 +688,8 @@ void AlignAndFocusPowderSlim::initializeOutputWorkspace(const MatrixWorkspace_sp
       x_max.resize(num_hist, x_max[0]);
 
     for (size_t i = 1; i < num_hist; ++i) {
-      double const binWidth = linearBins ? x_delta[i] : -1. * std::abs(x_delta[i]);
-      std::vector<double> const params{x_min[i], binWidth, x_max[i]};
+      double const raggedBinWidth = linearBins ? x_delta[i] : -1. * std::abs(x_delta[i]);
+      std::vector<double> const params{x_min[i], raggedBinWidth, x_max[i]};
       std::vector<double> xtmpragged;
       Kernel::VectorHelper::createAxisFromRebinParams(params, xtmpragged, resize_xnew, full_bins_only);
       HistogramData::BinEdges XValues_new(std::move(xtmpragged));

--- a/Framework/DataHandling/src/CompressEvents.cpp
+++ b/Framework/DataHandling/src/CompressEvents.cpp
@@ -124,8 +124,8 @@ void CompressEvents::exec() {
     double tof_min_fixed;
     double tof_max_fixed;
     inputWS->getEventXMinMax(tof_min_fixed, tof_max_fixed);
-    Mantid::Kernel::VectorHelper::createAxisFromRebinParams(
-        {tof_min_fixed, toleranceTof, (tof_max_fixed + std::abs(toleranceTof))}, *histogram_bin_edges, true, true);
+    std::vector<double> const params{tof_min_fixed, toleranceTof, tof_max_fixed + std::abs(toleranceTof)};
+    Mantid::Kernel::VectorHelper::createAxisFromRebinParams(params, *histogram_bin_edges, true, true);
     num_edges = histogram_bin_edges->size();
   }
 

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -501,8 +501,8 @@ void LoadBankFromDiskTask::run() {
 
     // make a vector of logorithmic bins
     auto histogram_bin_edges = std::make_shared<std::vector<double>>();
-    Mantid::Kernel::VectorHelper::createAxisFromRebinParams({tof_min_fixed, delta, (tof_max_fixed + std::abs(delta))},
-                                                            *histogram_bin_edges);
+    std::vector<double> const params{tof_min_fixed, delta, tof_max_fixed + std::abs(delta)};
+    Mantid::Kernel::VectorHelper::createAxisFromRebinParams(params, *histogram_bin_edges);
 
     // create the tasks
     std::shared_ptr<Task> newTask1 = std::make_shared<ProcessBankCompressed>(

--- a/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
+++ b/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
@@ -71,9 +71,9 @@ public:
     std::vector<Mantid::API::MatrixWorkspace_sptr> wksps;
     std::map<size_t, std::vector<Mantid::detid_t>> det_in_group; // empty signifies all into one group
     // create a two workspaces for output
-    std::vector<double> tmp;
-    Mantid::Kernel::VectorHelper::createAxisFromRebinParams({0, 6000, 12000}, tmp, true, false);
-    Mantid::HistogramData::BinEdges XValues(std::move(tmp));
+    std::vector<double> xtmp;
+    Mantid::Kernel::VectorHelper::createAxisFromRebinParams({0, 6000, 12000}, xtmp, true, false);
+    Mantid::HistogramData::BinEdges XValues(std::move(xtmp));
     // create pulse_times vector. 10ms pulses, 100Hz.
     std::shared_ptr<std::vector<Mantid::Types::Core::DateAndTime>> pulse_times =
         std::make_shared<std::vector<Mantid::Types::Core::DateAndTime>>();

--- a/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
+++ b/Framework/DataHandling/test/ProcessBankSplitFullTimeTaskTest.h
@@ -71,8 +71,9 @@ public:
     std::vector<Mantid::API::MatrixWorkspace_sptr> wksps;
     std::map<size_t, std::vector<Mantid::detid_t>> det_in_group; // empty signifies all into one group
     // create a two workspaces for output
-    Mantid::HistogramData::BinEdges XValues(0);
-    Mantid::Kernel::VectorHelper::createAxisFromRebinParams({0, 6000, 12000}, XValues.mutableRawData(), true, false);
+    std::vector<double> tmp;
+    Mantid::Kernel::VectorHelper::createAxisFromRebinParams({0, 6000, 12000}, tmp, true, false);
+    Mantid::HistogramData::BinEdges XValues(std::move(tmp));
     // create pulse_times vector. 10ms pulses, 100Hz.
     std::shared_ptr<std::vector<Mantid::Types::Core::DateAndTime>> pulse_times =
         std::make_shared<std::vector<Mantid::Types::Core::DateAndTime>>();

--- a/Framework/HistogramData/inc/MantidHistogramData/BinEdges.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/BinEdges.h
@@ -49,6 +49,10 @@ public:
   BinEdges &operator=(BinEdges &&) & = default;
 
   explicit BinEdges(const Points &points);
+
+  /// Deleted. Would return pointer to the internal data.
+  /// This inherits from FixedLengthVector and so should not allow for length modifications.
+  std::vector<double> &mutableRawData() = delete;
 };
 
 } // namespace HistogramData

--- a/Framework/HistogramData/test/XValidationTest.h
+++ b/Framework/HistogramData/test/XValidationTest.h
@@ -46,8 +46,7 @@ public:
   void test_works_for_BinEdges() {
     BinEdges data{1.0, 2.0};
     TS_ASSERT(isValid(data));
-    data.mutableRawData()[1] = data[0];
-    TS_ASSERT(!isValid(data));
+    TS_ASSERT_THROWS((BinEdges{1.0, 1.0}), std::runtime_error &);
   }
 
   void test_works_for_Points() {


### PR DESCRIPTION
### Description of work

The class `BinEdges` inherits from objects of type `HistogramX`, which in turn inherits from `FixedLengthVector`.

Objects of this type are not supposed to change in size.  For whatever reason, `FixedLengthVector` exposes its internal data anyway, with this method:
```c++
protected:
  /** Returns a reference to the underlying vector.
   *
   * Note that this is not available in the public interface, since that would
   * allow for length modifications, which we need to prevent. */
  std::vector<double> &mutableRawData() { return m_data; }
```
It's a great warning, but it goes unheeded, especially due to the convoluted inheritance trees that utilize this.

One place in particular where this was unheeded was within `BinEdges`.  Despite technically supposed to be of fixed length and not have its internal data messed with, multiple places in the code formed `BinEdges` objects by constructing them with length `0` and then passing the mutable raw data to some other function, which changed their lengths.

As part of PR #41326, I noted this pattern can cause heap corruptions.  Therefore, in this PR I have deleted this method in `BinEdges` and edited the parts of the code that were using it, so that they more properly construct a vector first and then init the `BinEdges` from it.

### To test:

This is a refactor.  Make sure all code compiles.

This does not need release notes because it is an internal refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
