### PR TITLE
Validate `BinMD` and `SlicingAlgorithm` for memory overflow

### DIFF
--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -291,6 +291,10 @@ void SlicingAlgorithm::processGeneralTransformProperties() {
   m_transformScaling.clear();
 
   // Create the dimensions based on the strings from the user
+  m_binDimensions.clear();
+  m_bases.clear();
+  m_binningScaling.clear();
+  m_transformScaling.clear();
   for (char dimChar : dimChars) {
     std::string propName = "BasisVector0";
     propName[11] = dimChar;
@@ -530,6 +534,8 @@ void SlicingAlgorithm::createAlignedTransform() {
                              "exist in the MDEventWorkspace.");
 
   // Create the dimensions based on the strings from the user
+  m_binDimensions.clear();
+  m_dimensionToBinFrom.clear();
   for (size_t i = 0; i < numDims; i++) {
     std::string propName = "AlignedDim0";
     propName[10] = dimChars[i];

--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/EnabledWhenProperty.h"
+#include "MantidKernel/Memory.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/VisibleWhenProperty.h"
 
@@ -305,6 +306,15 @@ void SlicingAlgorithm::processGeneralTransformProperties() {
   if (m_outD == 0)
     throw std::runtime_error("No output dimensions were found in the MDEventWorkspace. Cannot bin!");
 
+  // ensure we are not asking for more total output bins than can fit into memory
+  std::size_t totalBins = std::accumulate(m_numBins.cbegin(), m_numBins.cend(), 0);
+  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * sizeof(double));
+  if (!memStr.empty()) {
+    memStr = "You requested a total of " + std::to_string(totalBins) + " bins. " + memStr +
+             " Please reduce the number of bins or output dimensions.";
+    throw std::runtime_error(memStr);
+  }
+
   // Get the Translation parameter
   std::vector<double> translVector;
   try {
@@ -476,8 +486,8 @@ void SlicingAlgorithm::makeAlignedDimensionFromString(const std::string &str) {
     // Copy the dimension name, ID and units
     IMDDimension_const_sptr inputDim = m_inWS->getDimension(dim_index);
     const auto &frame = inputDim->getMDFrame();
-    m_binDimensions.emplace_back(MDHistoDimension_sptr(
-        new MDHistoDimension(inputDim->getName(), inputDim->getDimensionId(), frame, min, max, numBins)));
+    m_binDimensions.emplace_back(
+        new MDHistoDimension(inputDim->getName(), inputDim->getDimensionId(), frame, min, max, numBins));
 
     // Add the index from which we're binning to the vector
     this->m_dimensionToBinFrom.emplace_back(dim_index);
@@ -523,6 +533,17 @@ void SlicingAlgorithm::createAlignedTransform() {
 
   // Number of output binning dimensions found
   m_outD = m_binDimensions.size();
+
+  // ensure we are not asking for more total output bins than can fit into memory
+  std::size_t totalBins = std::accumulate(
+      m_binDimensions.cbegin(), m_binDimensions.cend(), 0,
+      [](std::size_t sum, const std::shared_ptr<MDHistoDimension> &dim) { return sum + dim->getNBins(); });
+  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * sizeof(double));
+  if (!memStr.empty()) {
+    memStr = "You requested a total of " + std::to_string(totalBins) + " bins. " + memStr +
+             " Please reduce the number of bins or output dimensions.";
+    throw std::runtime_error(memStr);
+  }
 
   // Now we build the coordinate transformation object
   m_translation = VMD(inD);
@@ -639,10 +660,11 @@ void SlicingAlgorithm::createTransform() {
 
   // Create the coordinate transformation
   m_transform = nullptr;
-  if (m_axisAligned)
+  if (m_axisAligned) {
     this->createAlignedTransform();
-  else
+  } else {
     this->createGeneralTransform();
+  }
 
   // Finalize, for binnign MDHistoWorkspace
   if (m_originalWS) {

--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -307,8 +307,13 @@ void SlicingAlgorithm::processGeneralTransformProperties() {
     throw std::runtime_error("No output dimensions were found in the MDEventWorkspace. Cannot bin!");
 
   // ensure we are not asking for more total output bins than can fit into memory
-  std::size_t totalBins = std::accumulate(m_numBins.cbegin(), m_numBins.cend(), 0);
-  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * sizeof(double));
+  // the total number of bins in an N-D workspace is the product (not sum) of bins per dimension
+  std::size_t totalBins =
+      std::accumulate(m_numBins.cbegin(), m_numBins.cend(), std::size_t(1),
+                      [](std::size_t acc, int val) -> std::size_t { return acc * static_cast<std::size_t>(val); });
+  // MDHistoWorkspace allocates signal, error squared, and numEvents (each a double) plus a bool mask per bin
+  constexpr std::size_t bytesPerBin = 3 * sizeof(double) + sizeof(bool);
+  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * bytesPerBin);
   if (!memStr.empty()) {
     memStr = "You requested a total of " + std::to_string(totalBins) + " bins. " + memStr +
              " Please reduce the number of bins or output dimensions.";
@@ -535,10 +540,15 @@ void SlicingAlgorithm::createAlignedTransform() {
   m_outD = m_binDimensions.size();
 
   // ensure we are not asking for more total output bins than can fit into memory
-  std::size_t totalBins = std::accumulate(
-      m_binDimensions.cbegin(), m_binDimensions.cend(), 0,
-      [](std::size_t sum, const std::shared_ptr<MDHistoDimension> &dim) { return sum + dim->getNBins(); });
-  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * sizeof(double));
+  // the total number of bins in an N-D workspace is the product (not sum) of bins per dimension
+  std::size_t totalBins =
+      std::accumulate(m_binDimensions.cbegin(), m_binDimensions.cend(), std::size_t(1),
+                      [](std::size_t acc, const std::shared_ptr<MDHistoDimension> &dim) -> std::size_t {
+                        return acc * dim->getNBins();
+                      });
+  // MDHistoWorkspace allocates signal, error squared, and numEvents (each a double) plus a bool mask per bin
+  constexpr std::size_t bytesPerBin = 3 * sizeof(double) + sizeof(bool);
+  std::string memStr = Kernel::MemoryStats().checkAvailableMemory(totalBins * bytesPerBin);
   if (!memStr.empty()) {
     memStr = "You requested a total of " + std::to_string(totalBins) + " bins. " + memStr +
              " Please reduce the number of bins or output dimensions.";

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -101,7 +101,9 @@ public:
     TS_ASSERT(alg.isInitialized())
   }
 
+  /// This test should only run on Linux, as it requires the memory patch
   void test_fail_too_much_memory_general() {
+#if defined(__linux__) || defined(__gnu_linux__)
     BinMD alg;
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -120,9 +122,12 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "4,4,5"));
     Mantid::TestMemory::MockMemory memL(12);
     TS_ASSERT_THROWS_ANYTHING(alg.execute();)
+#endif
   }
 
+  /// This test should only run on Linux, as it requires the memory patch
   void test_fail_too_much_memory_aligned() {
+#if defined(__linux__) || defined(__gnu_linux__)
     BinMD alg;
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -138,6 +143,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
     Mantid::TestMemory::MockMemory memL(12);
     TS_ASSERT_THROWS_ANYTHING(alg.execute();)
+#endif
   }
 
   /** Test the algo

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -117,10 +117,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector2", "z,m,0,0,1"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector3", ""));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
-    // make so many bins it will crash
+    // make enough bins so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputExtents", "0,10,0,10,0,10"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "4,4,5"));
-    Mantid::TestMemory::MockMemory memL(12);
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "3, 3, 3"));
+    Mantid::TestMemory::MockMemory memL(26);
     TS_ASSERT_THROWS_ANYTHING(alg.execute();)
 #endif
   }
@@ -136,12 +136,12 @@ public:
     AnalysisDataService::Instance().addOrReplace("BinMDTest_ws", in_ws);
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "BinMDTest_ws"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AxisAligned", "1"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "x,0,0,4"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "y,0,0,4"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "z,0,0,5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "x,0,0,3"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "y,0,0,3"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "z,0,0,3"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim3", ""));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
-    Mantid::TestMemory::MockMemory memL(12);
+    Mantid::TestMemory::MockMemory memL(26);
     TS_ASSERT_THROWS_ANYTHING(alg.execute();)
 #endif
   }

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -14,6 +14,7 @@
 #include "MantidAPI/ImplicitFunctionParameterParserFactory.h"
 #include "MantidAPI/ImplicitFunctionParser.h"
 #include "MantidFrameworkTestHelpers/MDEventsTestHelper.h"
+#include "MantidFrameworkTestHelpers/MockMemory.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
@@ -98,6 +99,45 @@ public:
     BinMD alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_fail_too_much_memory_general() {
+    BinMD alg;
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    auto in_ws = createSimple3DWorkspace();
+    AnalysisDataService::Instance().addOrReplace("BinMDTest_ws", in_ws);
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "BinMDTest_ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AxisAligned", "0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector0", "x,m,1,0,0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector1", "y,m,0,1,0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector2", "z,m,0,0,1"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector3", ""));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
+    // make so many bins it will crash
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputExtents", "0,10,0,10,0,10"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "4,4,5"));
+    Mantid::TestMemory::MockMemory memL(12);
+    TS_ASSERT_THROWS_ANYTHING(alg.execute();)
+  }
+
+  void test_fail_too_much_memory_aligned() {
+    BinMD alg;
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    auto in_ws = createSimple3DWorkspace();
+    AnalysisDataService::Instance().addOrReplace("BinMDTest_ws", in_ws);
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "BinMDTest_ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AxisAligned", "1"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "x,0,0,4"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "y,0,0,4"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "z,0,0,5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim3", ""));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
+    Mantid::TestMemory::MockMemory memL(12);
+    TS_ASSERT_THROWS_ANYTHING(alg.execute();)
   }
 
   /** Test the algo

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidFrameworkTestHelpers/MDEventsTestHelper.h"
+#include "MantidFrameworkTestHelpers/MockMemory.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/QSample.h"
@@ -197,6 +198,15 @@ public:
     TSM_ASSERT_THROWS_ANYTHING("Dimension name not found",
                                do_createAlignedTransform("NotAnAxis, 2.0,8.0, 3", "", "", ""));
     TSM_ASSERT_THROWS_ANYTHING("0 bins is bad", do_createAlignedTransform("Axis0, 2.0,8.0, 0", "", "", ""));
+    {
+      Mantid::TestMemory::MockMemory memL(12);
+      TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
+                               do_createAlignedTransform("Axis0, 2.0,8.0, 13", "", "", ""), std::runtime_error & e,
+                               strstr(e.what(), "Mock Memory"));
+      TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 2D",
+                               do_createAlignedTransform("Axis0, 2.0,8.0, 6", "Axis1, 2.0,8.0, 8", "", ""),
+                               std::runtime_error & e, strstr(e.what(), "Mock Memory"));
+    }
   }
 
   void test_createAlignedTransform() {
@@ -571,6 +581,20 @@ public:
     TSM_ASSERT_THROWS_ANYTHING(
         "Bad # of dimensions in the OutputBins",
         do_createGeneralTransform(ws, "x,m,1,0,0, 10.0, 10", "", "", "", VMD(1, 2, 3), "0,10", "5,5"));
+
+    TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D no mock",
+                             do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "600000000"),
+                             std::runtime_error & e, strstr(e.what(), "Requested Memory"));
+    {
+      Mantid::TestMemory::MockMemory memL(12);
+      TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
+                               do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "13"),
+                               std::runtime_error & e, strstr(e.what(), "Mock Memory"));
+      TSM_ASSERT_THROWS_ASSERT(
+          "Excessive memory allocation 2D",
+          do_createGeneralTransform(ws, "x,m,1,0,0", "y,m,0,1,0", "", "", VMD(1, 2, 3), "0,10,0,10", "6,7"),
+          std::runtime_error & e, strstr(e.what(), "Mock Memory"));
+    }
   }
 
   void test_createGeneralTransform_3D_to_3D() {

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -198,6 +198,8 @@ public:
     TSM_ASSERT_THROWS_ANYTHING("Dimension name not found",
                                do_createAlignedTransform("NotAnAxis, 2.0,8.0, 3", "", "", ""));
     TSM_ASSERT_THROWS_ANYTHING("0 bins is bad", do_createAlignedTransform("Axis0, 2.0,8.0, 0", "", "", ""));
+    // the below requires the memory patch and should only run on Linux
+#if defined(__linux__) || defined(__gnu_linux__)
     {
       Mantid::TestMemory::MockMemory memL(12);
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
@@ -207,6 +209,7 @@ public:
                                do_createAlignedTransform("Axis0, 2.0,8.0, 6", "Axis1, 2.0,8.0, 8", "", ""),
                                std::runtime_error & e, strstr(e.what(), "Mock Memory"));
     }
+#endif
   }
 
   void test_createAlignedTransform() {
@@ -585,6 +588,8 @@ public:
     TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D no mock",
                              do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "600000000"),
                              std::runtime_error & e, strstr(e.what(), "Requested Memory"));
+    // the below requires the memory patch and should only run on Linux
+#if defined(__linux__) || defined(__gnu_linux__)
     {
       Mantid::TestMemory::MockMemory memL(12);
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
@@ -595,6 +600,7 @@ public:
           do_createGeneralTransform(ws, "x,m,1,0,0", "y,m,0,1,0", "", "", VMD(1, 2, 3), "0,10,0,10", "6,7"),
           std::runtime_error & e, strstr(e.what(), "Mock Memory"));
     }
+#endif
   }
 
   void test_createGeneralTransform_3D_to_3D() {

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -202,6 +202,7 @@ public:
 #if defined(__linux__) || defined(__gnu_linux__)
     {
       Mantid::TestMemory::MockMemory memL(12);
+      // bin counts are chosen so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
                                do_createAlignedTransform("Axis0, 2.0,8.0, 13", "", "", ""), std::runtime_error & e,
                                strstr(e.what(), "Mock Memory"));
@@ -586,12 +587,14 @@ public:
         do_createGeneralTransform(ws, "x,m,1,0,0, 10.0, 10", "", "", "", VMD(1, 2, 3), "0,10", "5,5"));
 
     TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D no mock",
-                             do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "600000000"),
+                             do_createGeneralTransform(ws, "x,m,1,0,0", "x,m,0,1,0", "x,m,0,0,1", "", VMD(1, 2, 3),
+                                                       "0,10,0,10,0,10", "1000000,1000000,1000000"),
                              std::runtime_error & e, strstr(e.what(), "Requested Memory"));
     // the below requires the memory patch and should only run on Linux
 #if defined(__linux__) || defined(__gnu_linux__)
     {
       Mantid::TestMemory::MockMemory memL(12);
+      // bin counts are chosen so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
                                do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "13"),
                                std::runtime_error & e, strstr(e.what(), "Mock Memory"));

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MockMemory.h
@@ -11,6 +11,9 @@
 namespace Mantid::TestMemory {
 
 constexpr std::size_t g_default_value{12};
+/// Fallback bin count on non-Linux platforms where the memory mock is unavailable;
+/// large enough to reliably exhaust any real system's available memory.
+constexpr std::size_t g_fallback_bin_count{static_cast<std::size_t>(1e12)};
 
 extern "C" void enable_mem_override(std::size_t value = g_default_value);
 extern "C" void disable_mem_override();
@@ -35,7 +38,7 @@ struct MockMemory {
   }
 #else
   // a very large number, sure to always exhaust memory
-  std::size_t numberOfFloats() const { return static_cast<std::size_t>(1e12); }
+  std::size_t numberOfFloats() const { return g_fallback_bin_count; }
 #endif
 private:
   std::size_t m_value{g_default_value};

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -79,8 +79,10 @@ std::string Mantid::Kernel::MemoryStats::checkAvailableMemory(std::size_t const 
   } else {
     init_real_availMem();
     if (g_real_availMem.load()) {
-      if (requestedMemory > g_real_availMem.load()(this)) {
-        return "Requested Memory Failure";
+      // requestedMemory is in bytes, availMem is in KiB, so multiply
+      std::size_t avail = g_real_availMem.load()(this) * 1024;
+      if (requestedMemory > avail) {
+        return "Requested Memory Failure " + std::to_string(requestedMemory) + " > " + std::to_string(avail);
       } else {
         return "";
       }

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -56,7 +56,7 @@ extern "C" void disable_mem_override() { g_override_availMem.store(false); }
 // and return the actual memory count
 std::size_t Mantid::Kernel::MemoryStats::availMem() const {
   if (g_override_availMem.load()) {
-    return g_value;
+    return g_value.load();
   } else {
     init_real_availMem();
     if (g_real_availMem.load()) {
@@ -67,6 +67,30 @@ std::size_t Mantid::Kernel::MemoryStats::availMem() const {
     }
   }
 }
+
+std::string Mantid::Kernel::MemoryStats::checkAvailableMemory(std::size_t const requestedMemory) const {
+  if (g_override_availMem.load()) {
+    std::size_t avail = g_value.load();
+    if (requestedMemory > avail) {
+      return "Mock Memory Failure";
+    } else {
+      return "";
+    }
+  } else {
+    init_real_availMem();
+    if (g_real_availMem.load()) {
+      if (requestedMemory > g_real_availMem.load()(this)) {
+        return "Requested Memory Failure";
+      } else {
+        return "";
+      }
+    } else {
+      // if it cannot be thrown, this can cause opaque testing errors; throw an error here instead
+      throw std::runtime_error("Failed to reset the MemoryStats patch by name lookup");
+    }
+  }
+}
+
 #else
 namespace Mantid::TestMemory {
 extern "C" void enable_mem_override(std::size_t value) { (void)value; }

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41343.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41343.rst
@@ -1,1 +1,1 @@
-- The algorithm `BinMD` will throw an error if the total number of bins requested is larger than the available memory. This is done by calling `Kernel::MemoryStats::checkAvailableMemory` with the total number of bins multiplied by the size of a double (the type used to store the signal in the output workspace).
+- The algorithm `BinMD` will throw an error if the total number of bins requested is larger than the available memory.

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41343.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41343.rst
@@ -1,0 +1,1 @@
+- The algorithm `BinMD` will throw an error if the total number of bins requested is larger than the available memory. This is done by calling `Kernel::MemoryStats::checkAvailableMemory` with the total number of bins multiplied by the size of a double (the type used to store the signal in the output workspace).


### PR DESCRIPTION
### Description of work

This adds a check inside `SlicingAlgorithms`, the parent for both `BinMD` and `SliceMD`, to that it checks the total amount of memory being requested in a binning operation, and throws an error if this is expected to exhaust available system memory.

Refs: [EWM 15806](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15806)
Related PRs:
- #41296 
- #41320 
- #41330 
- #41326 

### To test:

Try using `BinMD` and asking for a very large number of bins.

Build and try running this script:
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

outws = CreateMDWorkspace(
    Dimensions=2,
    Extents=[0,10,0,10],
    Names="x,y",
    Units="m,m",
)

# GOOD
rebinned = BinMD(outws, AxisAligned=True, AlignedDim0="x,-10,10,1000", AlignedDim1="y,-10,10,1000")
# BAD
rebinned = BinMD(outws, AxisAligned=True, AlignedDim0="x,-10,10,100000", AlignedDim1="y,-10,10,100000")

#GOOD
rebinned = BinMD(outws,
    AxisAligned=False,
    BasisVector0="x,m,1,0",
    BasisVector1="y,m,0,1",
    OutputExtents="0,10,0,10",
    OutputBins="1000,1000"
)
#BAD
rebinned = BinMD(outws,
    AxisAligned=False,
    BasisVector0="x,m,1,0",
    BasisVector1="y,m,0,1",
    OutputExtents="0,10,0,10",
    OutputBins="100000,100000"
)
```

Also, try running from the dialog menu.  Check the box to "Keep Open" and run with too many bins.  Keep running, and verify the number of bins requested is the same each time you run.  This checks against a separate bug fixed in this PR.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
