### PR TITLE
Fix Coverity warning in TranslateSampleShape

### DIFF
--- a/Framework/DataHandling/src/TranslateSampleShape.cpp
+++ b/Framework/DataHandling/src/TranslateSampleShape.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright © 2025 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright ï¿½ 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -232,6 +232,12 @@ void TranslateSampleShape::exec() {
   } else {
     // CSG shapes need to translate XML definition, then use this to set a new shape
     auto csgShape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+
+    // add a explicit check that csgShape is not null before dereferencing
+    // (this should already be the case anyway)
+    if (!csgShape) {
+      throw std::runtime_error("Input sample does not have a valid CSG shape!");
+    }
 
     // get shape xml
     const std::string &origXML = csgShape->getShapeXML();


### PR DESCRIPTION
### Description of work

```
_____________________________________________________________________________________________
*** CID 1657895:         Null pointer dereferences  (NULL_RETURNS)
/home/docker/actions-runner/_work/mantid/mantid/Framework/DataHandling/src/TranslateSampleShape.cpp: 237             in Mantid::DataHandling::TranslateSampleShape::exec()()
231         meshShape->translate(V3D(dx, dy, dz));
232       } else {
233         // CSG shapes need to translate XML definition, then use this to set a new shape
234         auto csgShape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
235     
236         // get shape xml
>>>     CID 1657895:         Null pointer dereferences  (NULL_RETURNS)
>>>     Attempting to access the managed object of an empty smart pointer "csgShape".
237         const std::string &origXML = csgShape->getShapeXML();
238     
239         // translate xml def
240         std::string translatedXML = translateCSG(origXML, dx, dy, dz);
241     
242         // remove type tag, if there is one
```

I don't think it is possible to reach dereferencing a null `csgShape` because to reach that point requires `checkIsValidShape` (L220) to be `true` and for `meshShape` to be `false`. For `checkIsValidShape` to return `true` without setting `meshShape = true`, `checkIsValidShape` must exit through the `return true` on L257 explicitly validating that `csgShape` is not null.

An additional check has been added to appease coverity and defend against accidentally breaking this in future.


### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
