### PR TITLE
Fix flaky FitPeaks segfault

### DIFF
--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1189,21 +1189,44 @@ void IFunction::setMatrixWorkspace(std::shared_ptr<const API::MatrixWorkspace> w
     Geometry::IDetector const *detectorPtr = nullptr;
     size_t numDetectors = workspace->getSpectrum(wi).getDetectorIDs().size();
     if (numDetectors > 1) {
-      // If several detectors are on this workspace index, just use the ID of
-      // the first detector
       // Note JZ oct 2011 - I'm not sure why the code uses the first detector
       // and not the group. Ask Roman.
-      auto firstDetectorId = *workspace->getSpectrum(wi).getDetectorIDs().begin();
-
+      // Use the first detector ID that is actually present in the instrument;
+      // a spectrum may reference detector IDs that are absent from the
+      // instrument definition, in which case getDetector() throws.
       const auto &detectorInfo = workspace->detectorInfo();
-      const auto detectorIndex = detectorInfo.indexOf(firstDetectorId);
-      const auto &detector = detectorInfo.detector(detectorIndex);
-      detectorPtr = &detector;
+      const auto &specDef = workspace->spectrumInfo().spectrumDefinition(wi);
+      for (size_t k = 0; k < specDef.size(); ++k) {
+        try {
+          // detector() throws NotFoundError if the ID is absent from the instrument
+          detectorPtr = &detectorInfo.detector(specDef[k].first);
+          break;
+        } catch (const Kernel::Exception::NotFoundError &) {
+          // This detector is not present in the instrument; try the next one
+        }
+      }
+      if (!detectorPtr) {
+        g_log.information() << "MatrixWorkspace has not been set for index: " << std::to_string(wi)
+                            << " as none of the detector ids can be found on the instrument\n";
+        return;
+      }
     } else {
       // Get the detector (single) at this workspace index
       const auto &spectrumInfo = workspace->spectrumInfo();
-      const auto &detector = spectrumInfo.detector(wi);
-      detectorPtr = &detector;
+      if (!spectrumInfo.hasDetectors(wi)) {
+        g_log.information() << "MatrixWorkspace has not been set for index: " << std::to_string(wi)
+                            << " as no detector ids can be found for this workspace on the instrument\n";
+        return;
+      }
+      try {
+        detectorPtr = &spectrumInfo.detector(wi);
+      } catch (const Kernel::Exception::NotFoundError &) {
+        // hasDetectors() does not validate IDs against the instrument;
+        // the detector ID exists in the spectrum but not in the instrument.
+        g_log.information() << "MatrixWorkspace has not been set for index: " << std::to_string(wi)
+                            << " as the detector id for this workspace can't be found on the instrument\n";
+        return;
+      }
     }
 
     for (size_t i = 0; i < nParams(); i++) {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1002,7 +1002,13 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
   const auto &specInfo = m_inputMatrixWS->spectrumInfo();
   for (size_t wi = m_startWorkspaceIndex; wi <= m_stopWorkspaceIndex; ++wi) {
     if (specInfo.hasDetectors(wi))
+      continue;
+    try {
       static_cast<void>(specInfo.detector(wi));
+    } catch (const Exception::NotFoundError &) {
+      // Leave this spectrum uncached; setMatrixWorkspace() will handle
+      // missing IDs via its normal fallback path.
+    }
   }
 
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1226,10 +1226,12 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     try {
       if (wi > 0 && samePeakCrossSpectrum) {
         size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
-        std::shared_ptr<const Geometry::Detector> pdetector =
-            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
-        std::shared_ptr<const Geometry::Detector> cdetector =
-            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+        std::shared_ptr<const Geometry::Detector> pdetector;
+        std::shared_ptr<const Geometry::Detector> cdetector;
+        PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+          pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
+          cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+        }
 
         // If they do have detector ID
         if (pdetector && cdetector) {
@@ -1269,7 +1271,9 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     peakfunction->setCentre(expected_peak_pos);
 
     std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
-    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
+    PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+      peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
+    }
     // reset value of parameters that were fixed (but are now free to vary)
     for (const auto &[ipar, value] : keep_values) {
       peakfunction->setParameter(ipar, value);
@@ -1534,7 +1538,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
         bkgd_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, num_peakfunc_params + iparam));
       // use domain and function to calcualte
       // get the range of start and stop to construct a function domain
-      const auto &vec_x = m_fittedPeakWS->points(iws);
+      const auto vec_x = m_fittedPeakWS->points(iws);
       std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
       auto start_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.first);
       auto stop_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.second);
@@ -1542,7 +1546,9 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
       if (start_x_iter == stop_x_iter)
         throw std::runtime_error("Range size is zero in calculateFittedPeaks");
 
-      peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
+      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+        peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
+      }
 
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
@@ -1567,7 +1573,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
 double FitPeaks::calculateSignalToSigmaRatio(const size_t &iws, const std::pair<double, double> &peakWindow,
                                              const API::IPeakFunction_sptr &peakFunction) {
-  const auto &vecX = m_inputMatrixWS->points(iws);
+  const auto vecX = m_inputMatrixWS->points(iws);
   auto startX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.first);
   auto stopX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.second);
 
@@ -2352,7 +2358,9 @@ void FitPeaks::writeFitResult(size_t wi, const std::vector<double> &expected_pos
         peak_function->setParameter(iparam, fit_result->getParameterValue(ipeak, iparam));
 
       const std::pair<double, double> peak_window = m_getPeakFitWindow(wi, ipeak);
-      peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
+      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+        peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
+      }
 
       // set the effective peak parameters
       m_fittedParamTable->cell<double>(row_index, 2) = peak_function->centre();

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1512,9 +1512,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
   // Configure the peak functions before entering the parallel region. Some peak
   // functions use setMatrixWorkspace() to initialise detector/workspace-derived
-  // state. Doing that concurrently may cause issues
-  // evaluating the function later, when this requires that each function has
-  // already been configured for the correct workspace index and fit range.
+  // state.
   std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
                                                               std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
   std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1226,10 +1226,12 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     try {
       if (wi > 0 && samePeakCrossSpectrum) {
         size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
-        std::shared_ptr<const Geometry::Detector> pdetector =
-            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
-        std::shared_ptr<const Geometry::Detector> cdetector =
-            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+        std::shared_ptr<const Geometry::Detector> pdetector;
+        std::shared_ptr<const Geometry::Detector> cdetector;
+        PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+          pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
+          cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+        }
 
         // If they do have detector ID
         if (pdetector && cdetector) {
@@ -1269,7 +1271,9 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     peakfunction->setCentre(expected_peak_pos);
 
     std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
-    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
+    PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+      peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
+    }
     // reset value of parameters that were fixed (but are now free to vary)
     for (const auto &[ipar, value] : keep_values) {
       peakfunction->setParameter(ipar, value);
@@ -1510,65 +1514,41 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
   const size_t num_peakfunc_params = m_peakFunction->nParams();
   const size_t num_bkgdfunc_params = m_bkgdFunction->nParams();
 
-  // Configure the peak functions before entering the parallel region. Some peak
-  // functions use setMatrixWorkspace() to initialise detector/workspace-derived
-  // state. Doing that concurrently may cause issues
-  // evaluating the function later, when this requires that each function has
-  // already been configured for the correct workspace index and fit range.
-  std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
-                                                              std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
-  std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(
-      m_numSpectraToFit, std::vector<IBackgroundFunction_sptr>(m_numPeaksToFit));
-
-  for (size_t iws = m_startWorkspaceIndex; iws <= m_stopWorkspaceIndex; ++iws) {
-    const size_t output_iws = iws - m_startWorkspaceIndex;
-    const std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> &fit_result_i = fit_results[output_iws];
+  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
+  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
+    PARALLEL_START_INTERRUPT_REGION
+    std::size_t iws = static_cast<std::size_t>(iiws);
+    // get a copy of peak function and background function
+    IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
+    IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
+    std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> fit_result_i = fit_results[iws - m_startWorkspaceIndex];
     // FIXME - This is a just a pure check
     if (!fit_result_i)
       throw std::runtime_error("There is something wroing with PeakFitResult vector!");
 
     for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
+      // get and set the peak function parameters
       const double chi2 = fit_result_i->getCost(ipeak);
       if (chi2 > 10.e10)
         continue;
-
-      IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
-      IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
 
       for (size_t iparam = 0; iparam < num_peakfunc_params; ++iparam)
         peak_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, iparam));
       for (size_t iparam = 0; iparam < num_bkgdfunc_params; ++iparam)
         bkgd_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, num_peakfunc_params + iparam));
-
-      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
-      peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
-
-      peak_functions[output_iws][ipeak] = peak_function;
-      bkgd_functions[output_iws][ipeak] = bkgd_function;
-    }
-  }
-
-  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
-  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
-    PARALLEL_START_INTERRUPT_REGION
-    const std::size_t iws = static_cast<std::size_t>(iiws);
-    const size_t output_iws = iws - m_startWorkspaceIndex;
-
-    for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-      const IPeakFunction_sptr &peak_function = peak_functions[output_iws][ipeak];
-      const IBackgroundFunction_sptr &bkgd_function = bkgd_functions[output_iws][ipeak];
-      if (!peak_function || !bkgd_function)
-        continue;
-
-      // use domain and function to calculate
+      // use domain and function to calcualte
       // get the range of start and stop to construct a function domain
       const auto vec_x = m_fittedPeakWS->points(iws);
-      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
+      std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
       auto start_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.first);
       auto stop_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.second);
 
       if (start_x_iter == stop_x_iter)
         throw std::runtime_error("Range size is zero in calculateFittedPeaks");
+
+      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+        peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
+      }
 
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
@@ -2169,8 +2149,7 @@ size_t FitPeaks::histRangeToDataPointCount(size_t iws, const std::pair<double, d
  */
 void FitPeaks::histRangeToIndexBounds(size_t iws, const std::pair<double, double> &range, size_t &left_index,
                                       size_t &right_index) {
-  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
-  const auto &orig_x = hist_x;
+  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
   rangeToIndexBounds(orig_x, range.first, range.second, left_index, right_index);
 
   // handle an invalid range case. For the histogram point data, make sure the number of data points is non-zero as
@@ -2202,8 +2181,7 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   size_t num_elements_x = right_index - left_index;
 
   vec_x.resize(num_elements_x);
-  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
-  const auto &orig_x = hist_x;
+  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
   std::copy(orig_x.begin() + left_index, orig_x.begin() + right_index, vec_x.begin());
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
@@ -2380,7 +2358,9 @@ void FitPeaks::writeFitResult(size_t wi, const std::vector<double> &expected_pos
         peak_function->setParameter(iparam, fit_result->getParameterValue(ipeak, iparam));
 
       const std::pair<double, double> peak_window = m_getPeakFitWindow(wi, ipeak);
-      peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
+      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+        peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
+      }
 
       // set the effective peak parameters
       m_fittedParamTable->cell<double>(row_index, 2) = peak_function->centre();

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -34,7 +34,6 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/StartsWithValidator.h"
 #include "MantidKernel/VectorHelper.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/trim.hpp"
@@ -1651,7 +1650,8 @@ bool FitPeaks::fitBackground(const size_t &ws_index, const std::pair<double, dou
   constexpr size_t MIN_POINTS{10}; // TODO explain why 10
 
   // find out how to fit background
-  const auto &points = m_inputMatrixWS->histogram(ws_index).points();
+  const auto histogram = m_inputMatrixWS->histogram(ws_index);
+  const auto &points = histogram.points();
   size_t start_index = findXIndex(points.rawData(), fit_window.first);
   size_t expected_peak_index = findXIndex(points.rawData(), expected_peak_pos, start_index);
   size_t stop_index = findXIndex(points.rawData(), fit_window.second, expected_peak_index);
@@ -2097,7 +2097,8 @@ void FitPeaks::processOutputs(std::vector<std::shared_ptr<FitPeaksAlgorithm::Pea
  * @return :: total number of counts in the histogram
  */
 double FitPeaks::numberCounts(size_t iws) {
-  const std::vector<double> &vec_y = m_inputMatrixWS->histogram(iws).y().rawData();
+  const auto hist_y = m_inputMatrixWS->histogram(iws).y();
+  const auto &vec_y = hist_y.rawData();
   double total = std::accumulate(vec_y.begin(), vec_y.end(), 0.);
   return total;
 }
@@ -2133,8 +2134,6 @@ size_t FitPeaks::histRangeToDataPointCount(size_t iws, const std::pair<double, d
   return number_dp;
 }
 
-GNU_DIAG_OFF("dangling-reference")
-
 //----------------------------------------------------------------------------------------------
 /** Convert a histogram range to vector index boundaries
  * @param iws :: histogram index in workspace
@@ -2144,7 +2143,7 @@ GNU_DIAG_OFF("dangling-reference")
  */
 void FitPeaks::histRangeToIndexBounds(size_t iws, const std::pair<double, double> &range, size_t &left_index,
                                       size_t &right_index) {
-  const auto &orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
   rangeToIndexBounds(orig_x, range.first, range.second, left_index, right_index);
 
   // handle an invalid range case. For the histogram point data, make sure the number of data points is non-zero as
@@ -2176,7 +2175,7 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   size_t num_elements_x = right_index - left_index;
 
   vec_x.resize(num_elements_x);
-  const auto &orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
   std::copy(orig_x.begin() + left_index, orig_x.begin() + right_index, vec_x.begin());
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
@@ -2188,8 +2187,6 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   std::copy(orig_y.begin() + left_index, orig_y.begin() + left_index + num_datapoints, vec_y.begin());
   std::copy(orig_e.begin() + left_index, orig_e.begin() + left_index + num_datapoints, vec_e.begin());
 }
-
-GNU_DIAG_ON("dangling-reference")
 
 //----------------------------------------------------------------------------------------------
 /** Calculate signal-to-noise ratio in a histogram range

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1240,9 +1240,16 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
         std::shared_ptr<const Geometry::Detector> pdetector;
         std::shared_ptr<const Geometry::Detector> cdetector;
         PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-          size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
-          pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
-          cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+          // getDetector() throws NotFoundError for detector IDs that exist in
+          // the spectrum mapping but not in the instrument. Catch inside the
+          // critical section
+          try {
+            size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
+            pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
+            cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
+          } catch (const Exception::NotFoundError &) {
+            // leave pdetector/cdetector null; handled by the null check below
+          }
         }
 
         // If they do have detector ID

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1002,13 +1002,7 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
   const auto &specInfo = m_inputMatrixWS->spectrumInfo();
   for (size_t wi = m_startWorkspaceIndex; wi <= m_stopWorkspaceIndex; ++wi) {
     if (specInfo.hasDetectors(wi))
-      continue;
-    try {
       static_cast<void>(specInfo.detector(wi));
-    } catch (const Exception::NotFoundError &) {
-      // Leave this spectrum uncached; setMatrixWorkspace() will handle
-      // missing IDs via its normal fallback path.
-    }
   }
 
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1226,20 +1226,11 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     // spectrum that last successfully fitted this peak.
     try {
       if (wi > 0 && samePeakCrossSpectrum) {
-        std::shared_ptr<const Geometry::Detector> pdetector;
-        std::shared_ptr<const Geometry::Detector> cdetector;
-        PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-          // getDetector() throws NotFoundError for detector IDs that exist in
-          // the spectrum mapping but not in the instrument. Catch inside the
-          // critical section
-          try {
-            size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
-            pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
-            cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
-          } catch (const Exception::NotFoundError &) {
-            // leave pdetector/cdetector null; handled by the null check below
-          }
-        }
+        size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
+        std::shared_ptr<const Geometry::Detector> pdetector =
+            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
+        std::shared_ptr<const Geometry::Detector> cdetector =
+            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
 
         // If they do have detector ID
         if (pdetector && cdetector) {
@@ -1279,9 +1270,7 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     peakfunction->setCentre(expected_peak_pos);
 
     std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
-    PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-      peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
-    }
+    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
     // reset value of parameters that were fixed (but are now free to vary)
     for (const auto &[ipar, value] : keep_values) {
       peakfunction->setParameter(ipar, value);
@@ -1522,41 +1511,65 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
   const size_t num_peakfunc_params = m_peakFunction->nParams();
   const size_t num_bkgdfunc_params = m_bkgdFunction->nParams();
 
-  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
-  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
-    PARALLEL_START_INTERRUPT_REGION
-    std::size_t iws = static_cast<std::size_t>(iiws);
-    // get a copy of peak function and background function
-    IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
-    IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
-    std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> fit_result_i = fit_results[iws - m_startWorkspaceIndex];
+  // Configure the peak functions before entering the parallel region. Some peak
+  // functions use setMatrixWorkspace() to initialise detector/workspace-derived
+  // state. Doing that concurrently may cause issues
+  // evaluating the function later, when this requires that each function has
+  // already been configured for the correct workspace index and fit range.
+  std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
+                                                              std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
+  std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(
+      m_numSpectraToFit, std::vector<IBackgroundFunction_sptr>(m_numPeaksToFit));
+
+  for (size_t iws = m_startWorkspaceIndex; iws <= m_stopWorkspaceIndex; ++iws) {
+    const size_t output_iws = iws - m_startWorkspaceIndex;
+    const std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> &fit_result_i = fit_results[output_iws];
     // FIXME - This is a just a pure check
     if (!fit_result_i)
       throw std::runtime_error("There is something wroing with PeakFitResult vector!");
 
     for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-      // get and set the peak function parameters
       const double chi2 = fit_result_i->getCost(ipeak);
       if (chi2 > 10.e10)
         continue;
+
+      IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
+      IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
 
       for (size_t iparam = 0; iparam < num_peakfunc_params; ++iparam)
         peak_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, iparam));
       for (size_t iparam = 0; iparam < num_bkgdfunc_params; ++iparam)
         bkgd_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, num_peakfunc_params + iparam));
-      // use domain and function to calcualte
+
+      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
+      peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
+
+      peak_functions[output_iws][ipeak] = peak_function;
+      bkgd_functions[output_iws][ipeak] = bkgd_function;
+    }
+  }
+
+  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
+  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
+    PARALLEL_START_INTERRUPT_REGION
+    const std::size_t iws = static_cast<std::size_t>(iiws);
+    const size_t output_iws = iws - m_startWorkspaceIndex;
+
+    for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
+      const IPeakFunction_sptr &peak_function = peak_functions[output_iws][ipeak];
+      const IBackgroundFunction_sptr &bkgd_function = bkgd_functions[output_iws][ipeak];
+      if (!peak_function || !bkgd_function)
+        continue;
+
+      // use domain and function to calculate
       // get the range of start and stop to construct a function domain
       const auto vec_x = m_fittedPeakWS->points(iws);
-      std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
+      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
       auto start_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.first);
       auto stop_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.second);
 
       if (start_x_iter == stop_x_iter)
         throw std::runtime_error("Range size is zero in calculateFittedPeaks");
-
-      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-        peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
-      }
 
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
@@ -2157,7 +2170,8 @@ size_t FitPeaks::histRangeToDataPointCount(size_t iws, const std::pair<double, d
  */
 void FitPeaks::histRangeToIndexBounds(size_t iws, const std::pair<double, double> &range, size_t &left_index,
                                       size_t &right_index) {
-  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
+  const auto &orig_x = hist_x;
   rangeToIndexBounds(orig_x, range.first, range.second, left_index, right_index);
 
   // handle an invalid range case. For the histogram point data, make sure the number of data points is non-zero as
@@ -2189,7 +2203,8 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   size_t num_elements_x = right_index - left_index;
 
   vec_x.resize(num_elements_x);
-  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
+  const auto &orig_x = hist_x;
   std::copy(orig_x.begin() + left_index, orig_x.begin() + right_index, vec_x.begin());
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
@@ -2366,9 +2381,7 @@ void FitPeaks::writeFitResult(size_t wi, const std::vector<double> &expected_pos
         peak_function->setParameter(iparam, fit_result->getParameterValue(ipeak, iparam));
 
       const std::pair<double, double> peak_window = m_getPeakFitWindow(wi, ipeak);
-      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-        peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
-      }
+      peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
 
       // set the effective peak parameters
       m_fittedParamTable->cell<double>(row_index, 2) = peak_function->centre();

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -16,6 +16,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/FunctionProperty.h"
 #include "MantidAPI/MultiDomainFunction.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAlgorithms/FindPeakBackground.h"
@@ -992,6 +993,17 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
 
   std::shared_ptr<FitPeaksAlgorithm::PeakFitPreCheckResult> pre_check_result =
       std::make_shared<FitPeaksAlgorithm::PeakFitPreCheckResult>();
+
+  // Set the SpectrumInfo/DetectorInfo cache. DetectorInfo::getDetector
+  // lazily writes a shared_ptr<IDetector> slot on first access and is not
+  // thread-safe across different indices. Accessing every spectrum index outside the loop
+  // ensures all subsequent concurrent accesses (including those from inside
+  // the Fit child algorithm) are safe reads of already-populated slots.
+  const auto &specInfo = m_inputMatrixWS->spectrumInfo();
+  for (size_t wi = m_startWorkspaceIndex; wi <= m_stopWorkspaceIndex; ++wi) {
+    if (specInfo.hasDetectors(wi))
+      static_cast<void>(specInfo.detector(wi));
+  }
 
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )
   for (int ithread = 0; ithread < nThreads; ithread++) {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1237,10 +1237,10 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     // spectrum that last successfully fitted this peak.
     try {
       if (wi > 0 && samePeakCrossSpectrum) {
-        size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
         std::shared_ptr<const Geometry::Detector> pdetector;
         std::shared_ptr<const Geometry::Detector> cdetector;
         PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
+          size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
           pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
           cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
         }

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -994,17 +994,6 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
   std::shared_ptr<FitPeaksAlgorithm::PeakFitPreCheckResult> pre_check_result =
       std::make_shared<FitPeaksAlgorithm::PeakFitPreCheckResult>();
 
-  // Set the SpectrumInfo/DetectorInfo cache. DetectorInfo::getDetector
-  // lazily writes a shared_ptr<IDetector> slot on first access and is not
-  // thread-safe across different indices. Accessing every spectrum index outside the loop
-  // ensures all subsequent concurrent accesses (including those from inside
-  // the Fit child algorithm) are safe reads of already-populated slots.
-  const auto &specInfo = m_inputMatrixWS->spectrumInfo();
-  for (size_t wi = m_startWorkspaceIndex; wi <= m_stopWorkspaceIndex; ++wi) {
-    if (specInfo.hasDetectors(wi))
-      static_cast<void>(specInfo.detector(wi));
-  }
-
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )
   for (int ithread = 0; ithread < nThreads; ithread++) {
     PARALLEL_START_INTERRUPT_REGION

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1512,7 +1512,9 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
   // Configure the peak functions before entering the parallel region. Some peak
   // functions use setMatrixWorkspace() to initialise detector/workspace-derived
-  // state.
+  // state. Doing that concurrently may cause issues
+  // evaluating the function later, when this requires that each function has
+  // already been configured for the correct workspace index and fit range.
   std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
                                                               std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
   std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1226,12 +1226,10 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     try {
       if (wi > 0 && samePeakCrossSpectrum) {
         size_t lastGoodWi = lastGoodPeakSpectra[peak_index];
-        std::shared_ptr<const Geometry::Detector> pdetector;
-        std::shared_ptr<const Geometry::Detector> cdetector;
-        PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-          pdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
-          cdetector = std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
-        }
+        std::shared_ptr<const Geometry::Detector> pdetector =
+            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(lastGoodWi));
+        std::shared_ptr<const Geometry::Detector> cdetector =
+            std::dynamic_pointer_cast<const Geometry::Detector>(m_inputMatrixWS->getDetector(wi));
 
         // If they do have detector ID
         if (pdetector && cdetector) {
@@ -1271,9 +1269,7 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
     peakfunction->setCentre(expected_peak_pos);
 
     std::pair<double, double> peak_window_i = m_getPeakFitWindow(wi, peak_index);
-    PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-      peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
-    }
+    peakfunction->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window_i.first, peak_window_i.second);
     // reset value of parameters that were fixed (but are now free to vary)
     for (const auto &[ipar, value] : keep_values) {
       peakfunction->setParameter(ipar, value);
@@ -1514,41 +1510,65 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
   const size_t num_peakfunc_params = m_peakFunction->nParams();
   const size_t num_bkgdfunc_params = m_bkgdFunction->nParams();
 
-  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
-  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
-    PARALLEL_START_INTERRUPT_REGION
-    std::size_t iws = static_cast<std::size_t>(iiws);
-    // get a copy of peak function and background function
-    IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
-    IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
-    std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> fit_result_i = fit_results[iws - m_startWorkspaceIndex];
+  // Configure the peak functions before entering the parallel region. Some peak
+  // functions use setMatrixWorkspace() to initialise detector/workspace-derived
+  // state. Doing that concurrently may cause issues
+  // evaluating the function later, when this requires that each function has
+  // already been configured for the correct workspace index and fit range.
+  std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
+                                                              std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
+  std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(
+      m_numSpectraToFit, std::vector<IBackgroundFunction_sptr>(m_numPeaksToFit));
+
+  for (size_t iws = m_startWorkspaceIndex; iws <= m_stopWorkspaceIndex; ++iws) {
+    const size_t output_iws = iws - m_startWorkspaceIndex;
+    const std::shared_ptr<FitPeaksAlgorithm::PeakFitResult> &fit_result_i = fit_results[output_iws];
     // FIXME - This is a just a pure check
     if (!fit_result_i)
       throw std::runtime_error("There is something wroing with PeakFitResult vector!");
 
     for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-      // get and set the peak function parameters
       const double chi2 = fit_result_i->getCost(ipeak);
       if (chi2 > 10.e10)
         continue;
+
+      IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
+      IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
 
       for (size_t iparam = 0; iparam < num_peakfunc_params; ++iparam)
         peak_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, iparam));
       for (size_t iparam = 0; iparam < num_bkgdfunc_params; ++iparam)
         bkgd_function->setParameter(iparam, fit_result_i->getParameterValue(ipeak, num_peakfunc_params + iparam));
-      // use domain and function to calcualte
+
+      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
+      peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
+
+      peak_functions[output_iws][ipeak] = peak_function;
+      bkgd_functions[output_iws][ipeak] = bkgd_function;
+    }
+  }
+
+  PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
+  for (int64_t iiws = m_startWorkspaceIndex; iiws <= static_cast<int64_t>(m_stopWorkspaceIndex); ++iiws) {
+    PARALLEL_START_INTERRUPT_REGION
+    const std::size_t iws = static_cast<std::size_t>(iiws);
+    const size_t output_iws = iws - m_startWorkspaceIndex;
+
+    for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
+      const IPeakFunction_sptr &peak_function = peak_functions[output_iws][ipeak];
+      const IBackgroundFunction_sptr &bkgd_function = bkgd_functions[output_iws][ipeak];
+      if (!peak_function || !bkgd_function)
+        continue;
+
+      // use domain and function to calculate
       // get the range of start and stop to construct a function domain
       const auto vec_x = m_fittedPeakWS->points(iws);
-      std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
+      const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
       auto start_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.first);
       auto stop_x_iter = std::lower_bound(vec_x.begin(), vec_x.end(), peakwindow.second);
 
       if (start_x_iter == stop_x_iter)
         throw std::runtime_error("Range size is zero in calculateFittedPeaks");
-
-      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-        peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
-      }
 
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
@@ -2149,7 +2169,8 @@ size_t FitPeaks::histRangeToDataPointCount(size_t iws, const std::pair<double, d
  */
 void FitPeaks::histRangeToIndexBounds(size_t iws, const std::pair<double, double> &range, size_t &left_index,
                                       size_t &right_index) {
-  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
+  const auto &orig_x = hist_x;
   rangeToIndexBounds(orig_x, range.first, range.second, left_index, right_index);
 
   // handle an invalid range case. For the histogram point data, make sure the number of data points is non-zero as
@@ -2181,7 +2202,8 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   size_t num_elements_x = right_index - left_index;
 
   vec_x.resize(num_elements_x);
-  const auto orig_x = m_inputMatrixWS->histogram(iws).x();
+  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
+  const auto &orig_x = hist_x;
   std::copy(orig_x.begin() + left_index, orig_x.begin() + right_index, vec_x.begin());
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
@@ -2358,9 +2380,7 @@ void FitPeaks::writeFitResult(size_t wi, const std::vector<double> &expected_pos
         peak_function->setParameter(iparam, fit_result->getParameterValue(ipeak, iparam));
 
       const std::pair<double, double> peak_window = m_getPeakFitWindow(wi, ipeak);
-      PARALLEL_CRITICAL(FitPeaks_DetectorInfoAccess) {
-        peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
-      }
+      peak_function->setMatrixWorkspace(m_inputMatrixWS, wi, peak_window.first, peak_window.second);
 
       // set the effective peak parameters
       m_fittedParamTable->cell<double>(row_index, 2) = peak_function->centre();

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1513,9 +1513,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
   // Configure the peak functions before entering the parallel region. Some peak
   // functions use setMatrixWorkspace() to initialise detector/workspace-derived
-  // state. Doing that concurrently may cause issues
-  // evaluating the function later, when this requires that each function has
-  // already been configured for the correct workspace index and fit range.
+  // state.
   std::vector<std::vector<IPeakFunction_sptr>> peak_functions(m_numSpectraToFit,
                                                               std::vector<IPeakFunction_sptr>(m_numPeaksToFit));
   std::vector<std::vector<IBackgroundFunction_sptr>> bkgd_functions(

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -962,7 +962,7 @@ public:
 
     fitpeaks.setProperty("RawPeakParameters", true);
     fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS_oFE");
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setPropertyValue("OutputParameterFitErrorsWorkspace", "FitErrorsWS"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setPropertyValue("OutputParameterFitErrorsWorkspace", "FitErrorsWS_oFE"));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
 
@@ -993,7 +993,7 @@ public:
       return;
     TS_ASSERT_EQUALS(param_ws->rowCount(), 6);
     API::ITableWorkspace_sptr error_table =
-        std::dynamic_pointer_cast<API::ITableWorkspace>(AnalysisDataService::Instance().retrieve("FitErrorsWS"));
+        std::dynamic_pointer_cast<API::ITableWorkspace>(AnalysisDataService::Instance().retrieve("FitErrorsWS_oFE"));
     TS_ASSERT(error_table);
     if (!error_table)
       return;
@@ -1013,7 +1013,7 @@ public:
     AnalysisDataService::Instance().remove("PeakPositionsWS_oFE");
     AnalysisDataService::Instance().remove("FittedPeaksWS_oFE");
     AnalysisDataService::Instance().remove("PeakParametersWS_oFE");
-    AnalysisDataService::Instance().remove("FitErrorsWS");
+    AnalysisDataService::Instance().remove("FitErrorsWS_oFE");
   }
 
   //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -20,7 +20,6 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/UnitFactory.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 using Mantid::Algorithms::FitPeaks;
 
@@ -35,17 +34,12 @@ using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::CountStandardDeviations;
 using Mantid::HistogramData::Points;
 
-GNU_DIAG_OFF("dangling-reference")
-
 namespace {
 /// static Logger definition
 Logger g_log("FitPeaksTest");
 } // namespace
 
 class FitPeaksTest : public CxxTest::TestSuite {
-private:
-  std::string m_inputWorkspaceName{"FitPeaksTest_workspace"};
-
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -79,7 +73,7 @@ public:
   void test_singlePeaksPartialSpectra() {
     g_log.notice() << "TEST SINGLE PEAKS PARTIAL SPECTRA";
     // Generate input workspace
-    const std::string data_ws_name("Test1Data");
+    const std::string data_ws_name("FitPeaksTest_ws_singlePeaksPartialSpectra");
     generateTestDataGaussian(data_ws_name);
 
     // Generate peak and background parameters
@@ -105,24 +99,28 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 1));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakFunction", "Gaussian"));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name))
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3");
+    const std::string peak_pos_ws_name("PeakPositionsWS_singlePeaksPartialSpectra");
+    const std::string peak_param_ws_name("PeakParametersWS_singlePeaksPartialSpectra");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_singlePeaksPartialSpectra");
+
+    fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name);
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name);
+    fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name);
     fitpeaks.setProperty("MaxFitIterations", 200);
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // about the parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 2 spectra
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 2);
@@ -130,12 +128,13 @@ public:
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
 
@@ -149,7 +148,7 @@ public:
   void test_singlePeaksPartialSpectrum2() {
     g_log.notice() << "TEST SINGLE PEAKS PARTIAL SPECTRA";
     // Generate input workspace
-    const std::string data_ws_name("Test1Data");
+    const std::string data_ws_name("FitPeaksTest_ws_singlePeaksPartialSpectrum2");
     generateTestDataGaussian(data_ws_name);
 
     // Generate peak and background parameters
@@ -177,22 +176,26 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3");
+    const std::string peak_pos_ws_name("PeakPositionsWS_singlePeaksPartialSpectrum2");
+    const std::string peak_param_ws_name("PeakParametersWS_singlePeaksPartialSpectrum2");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_singlePeaksPartialSpectrum2");
+
+    fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name);
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name);
+    fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name);
     fitpeaks.setProperty("MaxFitIterations", 200);
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // about the parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 2 spectra
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
@@ -200,12 +203,13 @@ public:
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
 
@@ -219,13 +223,15 @@ public:
   void test_multiPeaksMultiSpectra() {
     g_log.notice() << "TEST MULTIPLE PEAKS MULTI SPECTRA";
 
+    const std::string data_ws_name("FitPeaksTest_ws_mPmS");
+
     // set up parameters with starting value
     std::vector<string> peakparnames;
     std::vector<double> peakparvalues;
     createGaussParameters(peakparnames, peakparvalues);
 
     // Generate input workspace
-    generateTestDataGaussian(m_inputWorkspaceName);
+    generateTestDataGaussian(data_ws_name);
 
     // initialize algorithm to test
     FitPeaks fitpeaks;
@@ -234,7 +240,7 @@ public:
     fitpeaks.setRethrows(true);
     TS_ASSERT(fitpeaks.isInitialized());
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 2));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0, 10.0"));
@@ -244,9 +250,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakParameterValues", peakparvalues));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS");
+    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS_mPmS");
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS_mPmS");
+    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS_mPmS");
     fitpeaks.setProperty("ConstrainPeakPositions", false);
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
@@ -257,29 +263,29 @@ public:
       return;
 
     // get fitted peak data
-    API::MatrixWorkspace_sptr main_out_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS"));
+    API::MatrixWorkspace_sptr main_out_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakPositionsWS_mPmS"));
     TS_ASSERT(main_out_ws);
     TS_ASSERT_EQUALS(main_out_ws->getNumberHistograms(), 3);
 
     API::MatrixWorkspace_sptr plot_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS"));
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS_mPmS"));
     TS_ASSERT(plot_ws);
     TS_ASSERT_EQUALS(plot_ws->getNumberHistograms(), 3);
 
-    API::ITableWorkspace_sptr param_ws =
-        std::dynamic_pointer_cast<API::ITableWorkspace>(AnalysisDataService::Instance().retrieve("PeakParametersWS"));
+    API::ITableWorkspace_sptr param_ws = std::dynamic_pointer_cast<API::ITableWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakParametersWS_mPmS"));
     TS_ASSERT(param_ws);
     TS_ASSERT_EQUALS(param_ws->rowCount(), 6);
 
     // check values: fitted peak positions
     // spectrum 1
-    const auto &fitted_positions_0 = main_out_ws->histogram(0).y();
+    const auto fitted_positions_0 = main_out_ws->histogram(0).y();
     TS_ASSERT_EQUALS(fitted_positions_0.size(), 2); // with 2 peaks to fit
     TS_ASSERT_DELTA(fitted_positions_0[0], 5.0, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-6);
     // spectrum 3
-    const auto &fitted_positions_2 = main_out_ws->histogram(2).y();
+    const auto fitted_positions_2 = main_out_ws->histogram(2).y();
     TS_ASSERT_EQUALS(fitted_positions_2.size(), 2); // with 2 peaks to fit
     TS_ASSERT_DELTA(fitted_positions_2[0], 5.03, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_2[1], 10.02, 1.E-6);
@@ -296,17 +302,17 @@ public:
     TS_ASSERT_DELTA(ws1peak1_width, 0.12, 1E-6);
 
     // check the fitted peak workspace
-    API::MatrixWorkspace_sptr data_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
-        API::AnalysisDataService::Instance().retrieve(m_inputWorkspaceName));
-    TS_ASSERT_EQUALS(plot_ws->histogram(0).x().size(), data_ws->histogram(0).x().size());
-    TS_ASSERT_DELTA(plot_ws->histogram(0).x().front(), data_ws->histogram(0).x().front(), 1E-10);
-    TS_ASSERT_DELTA(plot_ws->histogram(0).x().back(), data_ws->histogram(0).x().back(), 1E-10);
+    API::MatrixWorkspace_sptr input_data_ws =
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(API::AnalysisDataService::Instance().retrieve(data_ws_name));
+    TS_ASSERT_EQUALS(plot_ws->histogram(0).x().size(), input_data_ws->histogram(0).x().size());
+    TS_ASSERT_DELTA(plot_ws->histogram(0).x().front(), input_data_ws->histogram(0).x().front(), 1E-10);
+    TS_ASSERT_DELTA(plot_ws->histogram(0).x().back(), input_data_ws->histogram(0).x().back(), 1E-10);
 
     // clean up
-    AnalysisDataService::Instance().remove(m_inputWorkspaceName);
-    AnalysisDataService::Instance().remove("PeakPositionsWS");
-    AnalysisDataService::Instance().remove("FittedPeaksWS");
-    AnalysisDataService::Instance().remove("PeakParametersWS");
+    AnalysisDataService::Instance().remove(data_ws_name);
+    AnalysisDataService::Instance().remove("PeakPositionsWS_mPmS");
+    AnalysisDataService::Instance().remove("FittedPeaksWS_mPmS");
+    AnalysisDataService::Instance().remove("PeakParametersWS_mPmS");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -316,13 +322,15 @@ public:
   void test_effectivePeakParameters() {
     g_log.notice() << "TEST EFFECTIVE PEAK PARAMS";
 
+    const std::string data_ws_name("FitPeaksTest_ws_ePP");
+
     // set up parameters with starting value
     std::vector<string> peakparnames;
     std::vector<double> peakparvalues;
     createGaussParameters(peakparnames, peakparvalues);
 
     // Generate input workspace
-    generateTestDataGaussian(m_inputWorkspaceName);
+    generateTestDataGaussian(data_ws_name);
 
     // initialize algorithm to test
     FitPeaks fitpeaks;
@@ -331,7 +339,7 @@ public:
     fitpeaks.setRethrows(true);
     TS_ASSERT(fitpeaks.isInitialized());
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 2));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0, 10.0"));
@@ -342,9 +350,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("RawPeakParameters", false));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS");
+    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS_ePP");
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS_ePP");
+    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS_ePP");
     fitpeaks.setProperty("ConstrainPeakPositions", false);
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
@@ -355,29 +363,29 @@ public:
       return;
 
     // get fitted peak data
-    API::MatrixWorkspace_sptr main_out_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS"));
+    API::MatrixWorkspace_sptr main_out_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakPositionsWS_ePP"));
     TS_ASSERT(main_out_ws);
     TS_ASSERT_EQUALS(main_out_ws->getNumberHistograms(), 3);
 
     API::MatrixWorkspace_sptr plot_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS"));
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS_ePP"));
     TS_ASSERT(plot_ws);
     TS_ASSERT_EQUALS(plot_ws->getNumberHistograms(), 3);
 
-    API::ITableWorkspace_sptr param_ws =
-        std::dynamic_pointer_cast<API::ITableWorkspace>(AnalysisDataService::Instance().retrieve("PeakParametersWS"));
+    API::ITableWorkspace_sptr param_ws = std::dynamic_pointer_cast<API::ITableWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakParametersWS_ePP"));
     TS_ASSERT(param_ws);
     TS_ASSERT_EQUALS(param_ws->rowCount(), 6);
 
     // check values: fitted peak positions
     // spectrum 1
-    const auto &fitted_positions_0 = main_out_ws->histogram(0).y();
+    const auto fitted_positions_0 = main_out_ws->histogram(0).y();
     TS_ASSERT_EQUALS(fitted_positions_0.size(), 2); // with 2 peaks to fit
     TS_ASSERT_DELTA(fitted_positions_0[0], 5.0, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-6);
     // spectrum 3
-    const auto &fitted_positions_2 = main_out_ws->histogram(2).y();
+    const auto fitted_positions_2 = main_out_ws->histogram(2).y();
     TS_ASSERT_EQUALS(fitted_positions_2.size(), 2); // with 2 peaks to fit
     TS_ASSERT_DELTA(fitted_positions_2[0], 5.03, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_2[1], 10.02, 1.E-6);
@@ -395,17 +403,17 @@ public:
     TS_ASSERT_DELTA(ws1peak1_width, 0.12 * 2.3548, 1E-4);
 
     // check the fitted peak workspace
-    API::MatrixWorkspace_sptr data_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
-        API::AnalysisDataService::Instance().retrieve(m_inputWorkspaceName));
-    TS_ASSERT_EQUALS(plot_ws->histogram(0).x().size(), data_ws->histogram(0).x().size());
-    TS_ASSERT_DELTA(plot_ws->histogram(0).x().front(), data_ws->histogram(0).x().front(), 1E-10);
-    TS_ASSERT_DELTA(plot_ws->histogram(0).x().back(), data_ws->histogram(0).x().back(), 1E-10);
+    API::MatrixWorkspace_sptr input_data_ws =
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(API::AnalysisDataService::Instance().retrieve(data_ws_name));
+    TS_ASSERT_EQUALS(plot_ws->histogram(0).x().size(), input_data_ws->histogram(0).x().size());
+    TS_ASSERT_DELTA(plot_ws->histogram(0).x().front(), input_data_ws->histogram(0).x().front(), 1E-10);
+    TS_ASSERT_DELTA(plot_ws->histogram(0).x().back(), input_data_ws->histogram(0).x().back(), 1E-10);
 
     // clean up
-    AnalysisDataService::Instance().remove(m_inputWorkspaceName);
-    AnalysisDataService::Instance().remove("PeakPositionsWS");
-    AnalysisDataService::Instance().remove("FittedPeaksWS");
-    AnalysisDataService::Instance().remove("PeakParametersWS");
+    AnalysisDataService::Instance().remove(data_ws_name);
+    AnalysisDataService::Instance().remove("PeakPositionsWS_ePP");
+    AnalysisDataService::Instance().remove("FittedPeaksWS_ePP");
+    AnalysisDataService::Instance().remove("PeakParametersWS_ePP");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -418,7 +426,7 @@ public:
   void test_NoSignaleWorkspace2D() {
     g_log.notice() << "TEST NO SIGNAL WORKSPACE 2D";
     // load file to workspace
-    std::string input_ws_name("PG3_733");
+    std::string input_ws_name("PG3_733_NoSignalWorkspace2D");
 
     // Start by loading our NXS file
     auto loader = Mantid::API::AlgorithmManager::Instance().create("LoadNexus");
@@ -445,8 +453,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(fit_peaks_alg.setProperty("HighBackground", true));
     TS_ASSERT_THROWS_NOTHING(fit_peaks_alg.setProperty("PeakWidthPercent", 0.016)); // typical powgen's
 
-    std::string peak_pos_ws_name("PG3_733_peak_positions");
-    std::string peak_param_ws_name("PG3_733_peak_params");
+    std::string peak_pos_ws_name("PG3_733_NoSignalWorkspace2D_peak_positions");
+    std::string peak_param_ws_name("PG3_733_NoSignalWorkspace2D_peak_params");
     fit_peaks_alg.setProperty("OutputWorkspace", peak_pos_ws_name);
     fit_peaks_alg.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name);
 
@@ -479,10 +487,10 @@ public:
       return;
 
     // clean up
-    AnalysisDataService::Instance().remove("PG3_733");
-    AnalysisDataService::Instance().remove("PG3_733_EventNumbers");
+    AnalysisDataService::Instance().remove(input_ws_name);
+    AnalysisDataService::Instance().remove(input_ws_name + "_EventNumbers");
     AnalysisDataService::Instance().remove(peak_pos_ws_name);
-    AnalysisDataService::Instance().remove("PG3_733_peak_params");
+    AnalysisDataService::Instance().remove(peak_param_ws_name);
 
     return;
   }
@@ -494,7 +502,7 @@ public:
   void test_HighBackgroundPeaks() {
     g_log.notice() << "TEST HIGH BACKGROUND";
     // load file to workspace
-    std::string input_ws_name("PG3_733");
+    std::string input_ws_name("PG3_733_HighBackgroundPeaks");
 
     // Start by loading our NXS file
     auto loader = Mantid::API::AlgorithmManager::Instance().create("LoadNexus");
@@ -521,9 +529,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(fit_peaks_alg.setProperty("HighBackground", true));
     TS_ASSERT_THROWS_NOTHING(fit_peaks_alg.setProperty("PeakWidthPercent", 0.016)); // typical powgen's
 
-    std::string output_ws_name("PG3_733_stripped");
-    std::string peak_pos_ws_name("PG3_733_peak_positions");
-    std::string peak_param_ws_name("PG3_733_peak_params");
+    std::string output_ws_name("PG3_733_HighBackgroundPeaks_stripped");
+    std::string peak_pos_ws_name("PG3_733_HighBackgroundPeaks_peak_positions");
+    std::string peak_param_ws_name("PG3_733_HighBackgroundPeaks_peak_params");
     fit_peaks_alg.setProperty("OutputWorkspace", peak_pos_ws_name);
     fit_peaks_alg.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name);
     fit_peaks_alg.setProperty("FittedPeaksWorkspace", output_ws_name);
@@ -564,6 +572,7 @@ public:
 
     // Clean up
     AnalysisDataService::Instance().remove(input_ws_name);
+    AnalysisDataService::Instance().remove(input_ws_name + "_EventNumbers");
     AnalysisDataService::Instance().remove(output_ws_name);
     AnalysisDataService::Instance().remove(peak_pos_ws_name);
     AnalysisDataService::Instance().remove(peak_param_ws_name);
@@ -580,7 +589,7 @@ public:
   void test_singlePeakMultiSpectraBackToBackExp() {
     g_log.notice() << "TEST SINGLE PEAK MULTI SPECTRA BACK TO BACK";
     // Generate input workspace
-    std::string input_ws_name = generateTestDataBackToBackExponential();
+    std::string input_ws_name = generateTestDataBackToBackExponential("diamond_3peaks_singlePeakMultiSpectraB2B");
     // Specify output workspaces names
     std::string peak_pos_ws_name("PeakPositionsB2BsPmS");
     std::string param_ws_name("PeakParametersB2BsPmS");
@@ -681,7 +690,7 @@ public:
   void test_multiPeaksMultiSpectraBackToBackExp() {
     g_log.notice() << "TEST MULTIPEAKS MULTI SPECTRA BACK TO BACK";
     // Generate input workspace
-    std::string input_ws_name = generateTestDataBackToBackExponential();
+    std::string input_ws_name = generateTestDataBackToBackExponential("diamond_3peaks_multiPeaksMultiSpectraB2B");
     API::MatrixWorkspace_sptr input_ws =
         std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(input_ws_name));
 
@@ -809,7 +818,8 @@ public:
     g_log.notice() << "TEST MULTI PEAKS SPECTRA BACK TO BACK WITH PARAM XML";
 
     // Generate input workspace
-    std::string input_ws_name = generateTestDataBackToBackExponential();
+    std::string input_ws_name =
+        generateTestDataBackToBackExponential("diamond_3peaks_multiPeaksMultiSpectraB2BParamXml");
 
     // Load VULCAN_Parameters.xml
     auto pLoaderPF = AlgorithmManager::Instance().create("LoadParameterFile");
@@ -822,9 +832,9 @@ public:
         std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(input_ws_name));
 
     // Specify output workspaces names
-    std::string peak_pos_ws_name("PeakPositionsB2BmPmS");
-    std::string param_ws_name("PeakParametersB2BmPmS");
-    std::string model_ws_name("ModelB2BmPmS");
+    std::string peak_pos_ws_name("PeakPositionsB2BmPmSParamXml");
+    std::string param_ws_name("PeakParametersB2BmPmSParamXml");
+    std::string model_ws_name("ModelB2BmPmSParamXml");
 
     size_t min_ws_index = 7;
     size_t max_ws_index = 15;
@@ -918,13 +928,16 @@ public:
    */
   void test_outputFitError() {
     g_log.notice() << "TEST OUTPUT FIT ERROR";
+
+    const std::string data_ws_name("FitPeaksTest_ws_oFE");
+
     // set up parameters with starting value
     std::vector<string> peakparnames;
     std::vector<double> peakparvalues;
     createGaussParameters(peakparnames, peakparvalues);
 
     // Generate input workspace
-    generateTestDataGaussian(m_inputWorkspaceName);
+    generateTestDataGaussian(data_ws_name);
 
     // initialize algorithm to test
     FitPeaks fitpeaks;
@@ -933,7 +946,7 @@ public:
     fitpeaks.setRethrows(true);
     TS_ASSERT(fitpeaks.isInitialized());
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 2));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0, 10.0"));
@@ -944,11 +957,11 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("ConstrainPeakPositions", true));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS");
+    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS_oFE");
+    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS_oFE");
 
     fitpeaks.setProperty("RawPeakParameters", true);
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS");
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS_oFE");
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setPropertyValue("OutputParameterFitErrorsWorkspace", "FitErrorsWS"));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
@@ -959,22 +972,22 @@ public:
       return;
 
     // get fitted peak data
-    API::MatrixWorkspace_sptr main_out_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS"));
+    API::MatrixWorkspace_sptr main_out_ws = std::dynamic_pointer_cast<API::MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakPositionsWS_oFE"));
     TS_ASSERT(main_out_ws);
     if (!main_out_ws)
       return;
     TS_ASSERT_EQUALS(main_out_ws->getNumberHistograms(), 3);
 
     API::MatrixWorkspace_sptr plot_ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS"));
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("FittedPeaksWS_oFE"));
     TS_ASSERT(plot_ws);
     if (!plot_ws)
       return;
     TS_ASSERT_EQUALS(plot_ws->getNumberHistograms(), 3);
 
-    API::ITableWorkspace_sptr param_ws =
-        std::dynamic_pointer_cast<API::ITableWorkspace>(AnalysisDataService::Instance().retrieve("PeakParametersWS"));
+    API::ITableWorkspace_sptr param_ws = std::dynamic_pointer_cast<API::ITableWorkspace>(
+        AnalysisDataService::Instance().retrieve("PeakParametersWS_oFE"));
     TS_ASSERT(param_ws);
     if (!param_ws)
       return;
@@ -996,10 +1009,10 @@ public:
     }
 
     // clean up
-    AnalysisDataService::Instance().remove(m_inputWorkspaceName);
-    AnalysisDataService::Instance().remove("PeakPositionsWS");
-    AnalysisDataService::Instance().remove("FittedPeaksWS");
-    AnalysisDataService::Instance().remove("PeakParametersWS");
+    AnalysisDataService::Instance().remove(data_ws_name);
+    AnalysisDataService::Instance().remove("PeakPositionsWS_oFE");
+    AnalysisDataService::Instance().remove("FittedPeaksWS_oFE");
+    AnalysisDataService::Instance().remove("PeakParametersWS_oFE");
     AnalysisDataService::Instance().remove("FitErrorsWS");
   }
 
@@ -1041,22 +1054,26 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3");
+    const std::string peak_pos_ws_name("PeakPositionsWS_notEnoughPeakDataPoints");
+    const std::string peak_param_ws_name("PeakParametersWS_notEnoughPeakDataPoints");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_notEnoughPeakDataPoints");
+
+    fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name);
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name);
+    fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name);
     fitpeaks.setProperty("MaxFitIterations", 200);
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
@@ -1064,12 +1081,13 @@ public:
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
@@ -1106,40 +1124,45 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         fitpeaks.setProperty("MinimumPeakTotalCount", 60.)); // higher than ~55, the total count in the peak window
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_lowPeakTotalCount");
+    const std::string peak_param_ws_name("PeakParametersWS_lowPeakTotalCount");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_lowPeakTotalCount");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 input spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 1 input peak
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
       // 1 peak fitted
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
       // when the "minimum peak window count" check fails on an individual peak, FitPeaks sets the peak position to -4.
       TS_ASSERT_DELTA(fitted_positions_0[0], -4, 0);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean input workspaces
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
@@ -1176,29 +1199,33 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         fitpeaks.setProperty("MinimumPeakTotalCount", 500.)); // higher than ~320, the total count in the spectrum
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_lowSpectrumTotalCount");
+    const std::string peak_param_ws_name("PeakParametersWS_lowSpectrumTotalCount");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_lowSpectrumTotalCount");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 input spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 2 input peaks
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 2);
       // 2 peaks fitting results
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 2);
       // when the "minimum peak window count" check fails on the whole spectrum, FitPeaks sets all peak position in the
       // spectrum to -1.
@@ -1206,12 +1233,13 @@ public:
       TS_ASSERT_DELTA(fitted_positions_0[1], -1, 0);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean input workspaces
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
@@ -1243,39 +1271,46 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumPeakHeight", 3.)); // higher than ~2, the input peak height
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_lowPeakObservedHeight");
+    const std::string peak_param_ws_name("PeakParametersWS_lowPeakObservedHeight");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_lowPeakObservedHeight");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 input spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 1 input peak
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
       // 1 peak fitted
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
 
       // If the estimated peak height is below the threshold, FitPeaks sets the peak position to -4.
       TS_ASSERT_DELTA(fitted_positions_0[0], -4, 0);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
+
+    // clean input workspace
+    API::AnalysisDataService::Instance().remove(data_ws_name);
   }
 
   //----------------------------------------------------------------------------------------------
@@ -1312,39 +1347,46 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumPeakHeight", 3.)); // higher than ~2, the input peak height
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_lowPeakFittedHeight");
+    const std::string peak_param_ws_name("PeakParametersWS_lowPeakFittedHeight");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_lowPeakFittedHeight");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 input spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 1 input peak
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
       // 1 peak fitted
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
 
       // If the "minimum peak height" check fails after fitting, the peak position is set to -3.
       TS_ASSERT_DELTA(fitted_positions_0[0], -3, 0);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
+
+    // clean input workspace
+    API::AnalysisDataService::Instance().remove(data_ws_name);
   }
 
   //----------------------------------------------------------------------------------------------
@@ -1372,7 +1414,7 @@ public:
     });
 
     // set error values; the exact values don't matter for this test.
-    const auto &yvals = WS->histogram(0).y();
+    const auto yvals = WS->histogram(0).y();
     std::transform(yvals.cbegin(), yvals.cend(), WS->mutableE(0).begin(), [](const double y) { return 0.2 * sqrt(y); });
 
     // set workspace name
@@ -1400,29 +1442,33 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumSignalToNoiseRatio", 50.));
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_signalToNoiseRatio");
+    const std::string peak_param_ws_name("PeakParametersWS_signalToNoiseRatio");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_signalToNoiseRatio");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 2 peaks
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 2);
 
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 2); // with 2 peaks to fit
 
       // When the "signal-to-noise" check fails, FitPeaks sets the peak position to -4.
@@ -1430,12 +1476,13 @@ public:
       TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-2);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
@@ -1465,7 +1512,7 @@ public:
     });
 
     // set error values to 2*sqrt(y)
-    const auto &yvals = WS->histogram(0).y();
+    const auto yvals = WS->histogram(0).y();
     std::transform(yvals.cbegin(), yvals.cend(), WS->mutableE(0).begin(), [](const double y) { return 0.2 * sqrt(y); });
 
     // set workspace name
@@ -1474,9 +1521,9 @@ public:
 
     // create peak-center and fit-window workspaces for the 2 peaks generated above (at X=5 and X=10)
     std::vector<int> peak_index_vec{0, 1};
-    const std::string peak_center_ws_name = genPeakCenterWorkspace(peak_index_vec, "peakcenter_s2nr", 1 /*spectra*/);
+    const std::string peak_center_ws_name = genPeakCenterWorkspace(peak_index_vec, "peakcenter_s2ns", 1 /*spectra*/);
     const std::string fit_window_ws_name =
-        genFitWindowWorkspace(peak_index_vec, "peakwindow_s2nr", 1 /*spectra*/, 1.0 /*fit window halfwidth*/);
+        genFitWindowWorkspace(peak_index_vec, "peakwindow_s2ns", 1 /*spectra*/, 1.0 /*fit window halfwidth*/);
 
     // initialize FitPeaks
     FitPeaks fitpeaks;
@@ -1493,29 +1540,33 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumSignalToSigmaRatio", 25.));
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    const std::string peak_pos_ws_name("PeakPositionsWS_signalToSigmaRatio");
+    const std::string peak_param_ws_name("PeakParametersWS_signalToSigmaRatio");
+    const std::string fitted_peaks_ws_name("FittedPeaksWS_signalToSigmaRatio");
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", peak_pos_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", peak_param_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", fitted_peaks_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
     if (fitpeaks.isExecuted()) {
       // check output workspaces
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
-      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_pos_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(peak_param_ws_name));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist(fitted_peaks_ws_name));
 
       // retrieve fitted parameters
       API::MatrixWorkspace_sptr peak_params_ws =
-          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(peak_pos_ws_name));
       TS_ASSERT(peak_params_ws);
       // 1 spectrum
       TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
       // 2 peaks
       TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 2);
 
-      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      const auto fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 2); // with 2 peaks to fit
 
       // When the "signal-to-sigma" check fails, FitPeaks sets the peak position to -4.
@@ -1523,12 +1574,13 @@ public:
       TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-2);
 
       // clean algorithm-generated workspaces
-      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
-      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
-      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+      API::AnalysisDataService::Instance().remove(peak_pos_ws_name);
+      API::AnalysisDataService::Instance().remove(peak_param_ws_name);
+      API::AnalysisDataService::Instance().remove(fitted_peaks_ws_name);
     }
 
     // clean
+    API::AnalysisDataService::Instance().remove(data_ws_name);
     API::AnalysisDataService::Instance().remove(peak_center_ws_name);
     API::AnalysisDataService::Instance().remove(fit_window_ws_name);
   }
@@ -1562,14 +1614,15 @@ public:
     // When CopyLastGoodPeakParameters=false, the wider peak at x=5 cannot
     // inherit sigma~0.1 from the right-hand neighbour; instead it must be
     // estimated independently from the data.
-    generateTestDataGaussian(m_inputWorkspaceName);
+    const std::string data_ws_name("FitPeaksTest_ws_multiPeaksMultiSpectra_noCopyLastGoodPeakParameters");
+    generateTestDataGaussian(data_ws_name);
 
     FitPeaks fitpeaks;
     fitpeaks.initialize();
     fitpeaks.setRethrows(true);
     TS_ASSERT(fitpeaks.isInitialized());
 
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 2));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0, 10.0"));
@@ -1595,12 +1648,12 @@ public:
     TS_ASSERT_EQUALS(main_out_ws->getNumberHistograms(), 3);
 
     // Fitted peak positions must be correct regardless of how parameters are seeded.
-    const auto &fitted_positions_0 = main_out_ws->histogram(0).y();
+    const auto fitted_positions_0 = main_out_ws->histogram(0).y();
     TS_ASSERT_EQUALS(fitted_positions_0.size(), 2);
     TS_ASSERT_DELTA(fitted_positions_0[0], 5.0, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-6);
 
-    const auto &fitted_positions_2 = main_out_ws->histogram(2).y();
+    const auto fitted_positions_2 = main_out_ws->histogram(2).y();
     TS_ASSERT_EQUALS(fitted_positions_2.size(), 2);
     TS_ASSERT_DELTA(fitted_positions_2[0], 5.03, 1.E-6);
     TS_ASSERT_DELTA(fitted_positions_2[1], 10.02, 1.E-6);
@@ -1619,7 +1672,7 @@ public:
     TS_ASSERT_DELTA(param_ws->cell<double>(1, 4), 0.1, 0.02);
 
     // clean up
-    AnalysisDataService::Instance().remove(m_inputWorkspaceName);
+    AnalysisDataService::Instance().remove(data_ws_name);
     AnalysisDataService::Instance().remove("PeakPositionsWS_noCopy");
     AnalysisDataService::Instance().remove("FittedPeaksWS_noCopy");
     AnalysisDataService::Instance().remove("PeakParametersWS_noCopy");
@@ -1731,7 +1784,7 @@ public:
                      [](const double x) { return 2.0 * exp(-0.5 * pow((x - 5) / 0.15, 2)) + 1; });
     }
 
-    const auto &yvals = WS->histogram(0).y();
+    const auto yvals = WS->histogram(0).y();
     std::transform(yvals.cbegin(), yvals.cend(), WS->mutableE(0).begin(), [](const double y) { return 0.2 * sqrt(y); });
 
     if (num_specs > 1) {
@@ -1745,7 +1798,7 @@ public:
                        [](const double x) { return 4.0 * exp(-0.5 * pow((x - 5.01) / 0.17, 2)) + 1; });
       }
 
-      const auto &yvals1 = WS->histogram(1).y();
+      const auto yvals1 = WS->histogram(1).y();
       std::transform(yvals1.cbegin(), yvals1.cend(), WS->mutableE(1).begin(),
                      [](const double y) { return 0.2 * sqrt(y); });
     }
@@ -1760,7 +1813,7 @@ public:
         std::transform(xvals2.cbegin(), xvals2.cend(), WS->mutableY(2).begin(),
                        [](const double x) { return 3.0 * exp(-0.5 * pow((x - 5.03) / 0.19, 2)) + 1; });
       }
-      const auto &yvals2 = WS->histogram(2).y();
+      const auto yvals2 = WS->histogram(2).y();
       std::transform(yvals2.cbegin(), yvals2.cend(), WS->mutableE(2).begin(),
                      [](const double y) { return 0.2 * sqrt(y); });
     }
@@ -1787,23 +1840,24 @@ public:
   /** Generate a workspace contains peaks with profile as back to back
    * exponenential convoluted
    * by Gaussian
+   * @param workspace_name :: name of workspace to be created
    */
-  std::string generateTestDataBackToBackExponential() {
+  std::string generateTestDataBackToBackExponential(const std::string &workspace_name) {
     DataHandling::LoadNexusProcessed loader;
     loader.initialize();
 
     loader.setProperty("Filename", "vulcan_diamond.nxs");
-    loader.setProperty("OutputWorkspace", "diamond_3peaks");
+    loader.setProperty("OutputWorkspace", workspace_name);
 
     loader.execute();
 
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("diamond_3peaks"));
+    TS_ASSERT(AnalysisDataService::Instance().doesExist(workspace_name));
 
     API::MatrixWorkspace_sptr ws =
-        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("diamond_3peaks"));
+        std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve(workspace_name));
     TS_ASSERT(ws);
 
-    return "diamond_3peaks";
+    return workspace_name;
   }
 
   //----------------------------------------------------------------------------------------------

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -436,7 +436,14 @@ const Geometry::IDetector &DetectorInfo::getDetector(const size_t index) const {
   auto thread = static_cast<size_t>(PARALLEL_THREAD_NUMBER);
   if (m_lastIndex[thread] != index) {
     m_lastIndex[thread] = index;
-    m_lastDetector[thread] = m_instrument->getDetector((*m_detectorIDs)[index]);
+    try {
+      m_lastDetector[thread] = m_instrument->getDetector((*m_detectorIDs)[index]);
+    } catch (...) {
+      // Reset so a future call for this index retries rather than returning
+      // whatever stale pointer m_lastDetector holds from a previous access.
+      m_lastIndex[thread] = -1;
+      throw;
+    }
   }
 
   return *m_lastDetector[thread];

--- a/Testing/SystemTests/tests/framework/EnginXScriptTest.py
+++ b/Testing/SystemTests/tests/framework/EnginXScriptTest.py
@@ -238,7 +238,7 @@ class FocusTexture30(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(diff_consts[UnitParams.difa], -13.2, delta=1)
         self.assertAlmostEqual(diff_consts[UnitParams.tzero], -28.2, delta=2)
         # compare TOF workspaces
-        self.tolerance = 1e-6
+        self.tolerance = 1e-5
         self.disableChecking.extend(["Instrument"])  # don't check
         return self._ws_foc.name(), "299080_engggui_focusing_output_ws_Texture30.nxs"
 


### PR DESCRIPTION
### Description of work

Following the merge of #41167 it appears the segfault that disappeared from the CI after I rebased is just flaky rather than fixed. This segfault does not appear when the tests are run locally so my best guess is it is something to do with asynchronous test execution and some shared references (It is not, it is multithreading and OS-dependent). 

To fix this I have just tried to go through and give everything a unique name

UPDATE: The issue was the `setMatrixWorkspace` was being called on the same `m_inputMatrixWS` within the parallel loop causing the ref count for the shared pointer created by `getDetector` to get messed up with the concurrent accesses. I have kept the individual naming in the tests as it won't hurt and the other attempts I made to protect against dangling pointers

(trace from @jclarkeSTFC )
```
#0  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=this@entry=0x31)
    at /home/james/mantid/.pixi/envs/default/lib/gcc/x86_64-conda-linux-gnu/13.4.0/include/c++/bits/shared_ptr_base.h:337
#1  0x00007ffff55587ea in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fff6d43b6a8,
    __in_chrg=<optimized out>)
    at /home/james/mantid/.pixi/envs/default/lib/gcc/x86_64-conda-linux-gnu/13.4.0/include/c++/bits/shared_ptr_base.h:1071
#2  std::__shared_ptr<Mantid::Geometry::IDetector const, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (
    this=0x7fff6d43b6a0, __in_chrg=<optimized out>)
    at /home/james/mantid/.pixi/envs/default/lib/gcc/x86_64-conda-linux-gnu/13.4.0/include/c++/bits/shared_ptr_base.h:1524
#3  std::__shared_ptr<Mantid::Geometry::IDetector const, (__gnu_cxx::_Lock_policy)2>::operator= (this=0x5555569b9bd0,
    __r=...)
    at /home/james/mantid/.pixi/envs/default/lib/gcc/x86_64-conda-linux-gnu/13.4.0/include/c++/bits/shared_ptr_base.h:1620
#4  0x00007ffff5578e03 in std::shared_ptr<Mantid::Geometry::IDetector const>::operator= (__r=..., this=<optimized out>)
    at /home/james/mantid/.pixi/envs/default/lib/gcc/x86_64-conda-linux-gnu/13.4.0/include/c++/bits/shared_ptr.h:438
#5  Mantid::Geometry::DetectorInfo::getDetector (this=this@entry=0x55555692abe0, index=index@entry=1)
    at /home/james/mantid/Framework/Geometry/src/Instrument/DetectorInfo.cpp:439
#6  0x00007ffff5578e67 in Mantid::Geometry::DetectorInfo::getDetectorPtr (this=0x55555692abe0, index=1)
    at /home/james/mantid/Framework/Geometry/src/Instrument/DetectorInfo.cpp:448
#7  0x00007ffff5a33916 in Mantid::API::SpectrumInfo::getDetector (this=0x5555569c72b0, index=index@entry=1)
    at /home/james/mantid/Framework/API/src/SpectrumInfo.cpp:342
#8  0x00007ffff5a33b14 in Mantid::API::SpectrumInfo::detector (this=<optimized out>, index=index@entry=1)
    at /home/james/mantid/Framework/API/src/SpectrumInfo.cpp:318
#9  0x00007ffff59a3036 in Mantid::API::IFunction::setMatrixWorkspace (this=0x7fff68002d18, workspace=..., wi=1,
    startX=<optimized out>, endX=<optimized out>) at /home/james/mantid/Framework/API/src/IFunction.cpp:1205
```

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

CI should run without seg fault and also local linux builds

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
