### PR TITLE
Fix MultipleFileProperty handling of multi-part extension

### DIFF
--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -272,15 +272,16 @@ void Parser::split() {
                               m_multiFileName.begin(), m_multiFileName.end(), isspace),
                           m_multiFileName.end());
   }
-  // Get the extension, if there is one.
-  const size_t lastDot = m_multiFileName.find_last_of('.');
-  if (lastDot != std::string::npos)
-    m_extString = m_multiFileName.substr(lastDot);
-
   // Get the directory, if there is one.
   const size_t lastSeparator = m_multiFileName.find_last_of("/\\");
   if (lastSeparator != std::string::npos)
     m_dirString = m_multiFileName.substr(0, lastSeparator + 1);
+
+  // Get the extension, if there is one. For multi-part extensions like
+  // ".nxs.h5", keep everything from the first dot in the filename part.
+  const size_t firstDotAfterDir = m_multiFileName.find('.', m_dirString.size());
+  if (firstDotAfterDir != std::string::npos)
+    m_extString = m_multiFileName.substr(firstDotAfterDir);
 
   // If the directory contains an instance of a comma, then the string is
   // a comma separated list of single *full* file names to load.

--- a/Framework/Kernel/test/MultiFileNameParserTest.h
+++ b/Framework/Kernel/test/MultiFileNameParserTest.h
@@ -458,33 +458,33 @@ public:
   void test_complexFileNameString_SNS() {
     Parser parser;
 
-    parser.parse("CNCS10-15, 30:40:2, 50+51+52.nxs");
+    parser.parse("CNCS10-15, 30:40:2, 50+51+52.nxs.h5");
 
     TS_ASSERT_EQUALS(parser.dirString(), "");
     TS_ASSERT_EQUALS(parser.instString(), "CNCS");
     TS_ASSERT_EQUALS(parser.underscoreString(), "");
     TS_ASSERT_EQUALS(parser.runString(), "10-15,30:40:2,50+51+52");
-    TS_ASSERT_EQUALS(parser.extString(), ".nxs");
+    TS_ASSERT_EQUALS(parser.extString(), ".nxs.h5");
 
     std::vector<std::vector<std::string>> filenames = parser.fileNames();
 
-    TS_ASSERT_EQUALS(filenames[0][0], "CNCS_10.nxs");
-    TS_ASSERT_EQUALS(filenames[0][1], "CNCS_11.nxs");
-    TS_ASSERT_EQUALS(filenames[0][2], "CNCS_12.nxs");
-    TS_ASSERT_EQUALS(filenames[0][3], "CNCS_13.nxs");
-    TS_ASSERT_EQUALS(filenames[0][4], "CNCS_14.nxs");
-    TS_ASSERT_EQUALS(filenames[0][5], "CNCS_15.nxs");
+    TS_ASSERT_EQUALS(filenames[0][0], "CNCS_10.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[0][1], "CNCS_11.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[0][2], "CNCS_12.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[0][3], "CNCS_13.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[0][4], "CNCS_14.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[0][5], "CNCS_15.nxs.h5");
 
-    TS_ASSERT_EQUALS(filenames[1][0], "CNCS_30.nxs");
-    TS_ASSERT_EQUALS(filenames[2][0], "CNCS_32.nxs");
-    TS_ASSERT_EQUALS(filenames[3][0], "CNCS_34.nxs");
-    TS_ASSERT_EQUALS(filenames[4][0], "CNCS_36.nxs");
-    TS_ASSERT_EQUALS(filenames[5][0], "CNCS_38.nxs");
-    TS_ASSERT_EQUALS(filenames[6][0], "CNCS_40.nxs");
+    TS_ASSERT_EQUALS(filenames[1][0], "CNCS_30.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[2][0], "CNCS_32.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[3][0], "CNCS_34.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[4][0], "CNCS_36.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[5][0], "CNCS_38.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[6][0], "CNCS_40.nxs.h5");
 
-    TS_ASSERT_EQUALS(filenames[7][0], "CNCS_50.nxs");
-    TS_ASSERT_EQUALS(filenames[7][1], "CNCS_51.nxs");
-    TS_ASSERT_EQUALS(filenames[7][2], "CNCS_52.nxs");
+    TS_ASSERT_EQUALS(filenames[7][0], "CNCS_50.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[7][1], "CNCS_51.nxs.h5");
+    TS_ASSERT_EQUALS(filenames[7][2], "CNCS_52.nxs.h5");
   }
 
   void test_instrument_with_multiple_padding() {


### PR DESCRIPTION
### Description of work

Previously when you included an extension it would only work for something like `.nxs` and would fail when given `.nxs.h5`.

You get the following
```
Traceback (most recent call last):
  File "/home/nxw/src/mantid/Framework/PythonInterface/mantid/simpleapi.py", line 153, in Load
    algm.setProperty("Filename", filename)  # Must be set first
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Invalid value for property Filename (list of str lists) from string "HB2C_7000,7001.nxs.h5": When setting value of property "Slave": File "HB2C_7000,7001.nxs.h5" not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nxw/test_MultipleFileProperty.py", line 10, in <module>
    ws = Load("HB2C_7000,7001.nxs.h5", MetaDataOnly=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nxw/src/mantid/Framework/PythonInterface/mantid/simpleapi.py", line 156, in Load
    raise ValueError(
ValueError: Problem setting "Filename" in Load: Invalid value for property Filename (list of str lists) from string "HB2C_7000,7001.nxs.h5": When setting value of property "Slave": File "HB2C_7000,7001.nxs.h5" not found
If the file has been found but you got this error, you might not have read permissions or the file might be corrupted.
If the file has not been found, you might have forgotten to add its location in the data search directories.
```

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

The following should now work.

```python
ws = Load("HB2C_7000,7001.nxs.h5")
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
