### PR TITLE
Match system test flag from jenkins

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -104,11 +104,9 @@ jobs:
         run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
 
       - name: Determine if a PR build
-        run: |
-          echo "ACTION=${{ github.event_name }}"
-          echo "ACTION=${{ github.event.action }}"
-          echo "Telling jenkins scripts this is a PR build"
-          echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' }}
+        # telling jenkins scripts this is a PR build
+        run: echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
 
       - name: Build code
         run: |

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -105,8 +105,8 @@ jobs:
 
       - name: Determine if a PR build
         run: |
+          echo "ACTION=${{ github.event_name }}"
           echo "ACTION=${{ github.event.action }}"
-          #if ${{ github.event.action }}"
           echo "Telling jenkins scripts this is a PR build"
           echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
 

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -103,8 +103,16 @@ jobs:
         # supplying --clean-build or CLEAN_BUILD=true should be added here
         run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
 
+      - name: Determine if a PR build
+        run: |
+          echo "ACTION=${{ github.event.action }}"
+          #if ${{ github.event.action }}"
+          echo "Telling jenkins scripts this is a PR build"
+          echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
+
       - name: Build code
         run: |
+          echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
           cd ${GITHUB_WORKSPACE}
           echo "::add-matcher::.github/matchers/gcc.json"
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $ENABLE_COVERITY $EXTRA_CMAKE_FLAGS


### PR DESCRIPTION
As reported slack, the PR system tests run significantly longer than jenkins. This appears to be because [this logic in `run-tests`](https://github.com/mantidproject/mantid/blob/main/buildconfig/Jenkins/Conda/run-tests#L118-L135) skipping select system tests.

There is no associated issue.

I pulled in #41378 to fix the build. That should be merged first.

### To test:

Look at the runtime of the jenkins and github-actions linux build. There should be the same number of system tests run on them with this change.

*This does not require release notes* because it is a change to CI

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
