### PR TITLE
Account for covariance in Wildes efficiency errors

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -15,7 +15,9 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <cmath>
+#include <concepts>
 #include <optional>
+#include <type_traits>
 #include <unsupported/Eigen/AutoDiff>
 
 namespace Mantid::Algorithms {
@@ -72,6 +74,11 @@ MANTID_ALGORITHMS_DLL void addORSOLogForSpinState(const Mantid::API::MatrixWorks
 
 namespace Arithmetic {
 
+template <typename Provider, typename InputArray, typename CovarianceMatrix>
+concept CovarianceMatrixProviderFor =
+    std::invocable<Provider, const InputArray &, const InputArray &> &&
+    std::convertible_to<std::invoke_result_t<Provider, const InputArray &, const InputArray &>, CovarianceMatrix>;
+
 template <size_t N> class ErrorTypeHelper {
 public:
   using DerType = Eigen::Matrix<double, N, 1>;
@@ -113,75 +120,45 @@ public:
 
   template <std::same_as<API::MatrixWorkspace_sptr>... Ts>
   API::MatrixWorkspace_sptr evaluateWorkspaces(const bool outputWorkspaceDistribution, Ts... args) const {
-    return evaluateWorkspacesImpl(outputWorkspaceDistribution, std::forward<Ts>(args)...);
+    return evaluateWorkspacesImpl(outputWorkspaceDistribution, independentCovarianceMatrixProvider,
+                                  std::forward<Ts>(args)...);
   }
 
   template <std::same_as<API::MatrixWorkspace_sptr>... Ts>
   API::MatrixWorkspace_sptr evaluateWorkspaces(Ts... args) const {
-    return evaluateWorkspacesImpl(std::nullopt, std::forward<Ts>(args)...);
+    return evaluateWorkspacesImpl(std::nullopt, independentCovarianceMatrixProvider, std::forward<Ts>(args)...);
   }
 
-  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+  template <typename Provider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+    requires CovarianceMatrixProviderFor<Provider, InputArray, CovarianceMatrix>
   API::MatrixWorkspace_sptr evaluateWorkspacesWithCovariance(const bool outputWorkspaceDistribution,
-                                                             CovarianceMatrixProvider covarianceMatrixProvider,
-                                                             Ts... args) const {
-    return evaluateWorkspacesWithCovarianceImpl(outputWorkspaceDistribution, covarianceMatrixProvider,
-                                                std::forward<Ts>(args)...);
+                                                             Provider covarianceMatrixProvider, Ts... args) const {
+    return evaluateWorkspacesImpl(outputWorkspaceDistribution, covarianceMatrixProvider, std::forward<Ts>(args)...);
   }
 
-  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
-  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovariance(CovarianceMatrixProvider covarianceMatrixProvider,
-                                                             Ts... args) const {
-    return evaluateWorkspacesWithCovarianceImpl(std::nullopt, covarianceMatrixProvider, std::forward<Ts>(args)...);
+  template <typename Provider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+    requires CovarianceMatrixProviderFor<Provider, InputArray, CovarianceMatrix>
+  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovariance(Provider covarianceMatrixProvider, Ts... args) const {
+    return evaluateWorkspacesImpl(std::nullopt, covarianceMatrixProvider, std::forward<Ts>(args)...);
   }
 
   static CovarianceMatrix covarianceMatrixFromErrors(const InputArray &errors) {
+    // Independent inputs have no off-diagonal covariance terms, so their covariance matrix is diagonal with
+    // C_ii = Var(x_i) = sigma_i^2.
     return errors.array().square().matrix().asDiagonal();
   }
 
 private:
   Func computeFunc;
 
-  template <std::same_as<API::MatrixWorkspace_sptr>... Ts>
-  API::MatrixWorkspace_sptr evaluateWorkspacesImpl(std::optional<bool> outputWorkspaceDistribution, Ts... args) const {
-    const auto firstWs = std::get<0>(std::forward_as_tuple(args...));
-    API::MatrixWorkspace_sptr outWs = firstWs->clone();
-
-    if (outWs->id() == "EventWorkspace") {
-      outWs = convertToWorkspace2D(outWs);
-    }
-
-    const size_t numSpec = outWs->getNumberHistograms();
-    const size_t specSize = outWs->blocksize();
-
-    // cppcheck-suppress unreadVariable
-    const bool isThreadSafe = Kernel::threadSafe((*args)..., *outWs);
-    // cppcheck-suppress unreadVariable
-    const bool specOverBins = numSpec > specSize;
-
-    PARALLEL_FOR_IF(isThreadSafe && specOverBins)
-    for (int64_t i = 0; i < static_cast<int64_t>(numSpec); i++) {
-      auto &yOut = outWs->mutableY(i);
-      auto &eOut = outWs->mutableE(i);
-
-      PARALLEL_FOR_IF(isThreadSafe && !specOverBins)
-      for (int64_t j = 0; j < static_cast<int64_t>(specSize); ++j) {
-        const auto result = evaluate(InputArray{args->y(i)[j]...}, InputArray(args->e(i)[j]...));
-        yOut[j] = result.value;
-        eOut[j] = result.error;
-      }
-    }
-
-    if (outputWorkspaceDistribution.has_value()) {
-      outWs->setDistribution(outputWorkspaceDistribution.value());
-    }
-    return outWs;
+  static CovarianceMatrix independentCovarianceMatrixProvider(const InputArray &, const InputArray &errors) {
+    return covarianceMatrixFromErrors(errors);
   }
 
-  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
-  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovarianceImpl(std::optional<bool> outputWorkspaceDistribution,
-                                                                 CovarianceMatrixProvider covarianceMatrixProvider,
-                                                                 Ts... args) const {
+  template <typename Provider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+    requires CovarianceMatrixProviderFor<Provider, InputArray, CovarianceMatrix>
+  API::MatrixWorkspace_sptr evaluateWorkspacesImpl(std::optional<bool> outputWorkspaceDistribution,
+                                                   Provider covarianceMatrixProvider, Ts... args) const {
     const auto firstWs = std::get<0>(std::forward_as_tuple(args...));
     API::MatrixWorkspace_sptr outWs = firstWs->clone();
 
@@ -206,7 +183,7 @@ private:
       for (int64_t j = 0; j < static_cast<int64_t>(specSize); ++j) {
         const InputArray values{args->y(i)[j]...};
         const InputArray errors(args->e(i)[j]...);
-        const auto covariance = covarianceMatrixProvider(values, errors);
+        const CovarianceMatrix covariance = covarianceMatrixProvider(values, errors);
         const auto result = evaluateWithCovariance(values, covariance);
         yOut[j] = result.value;
         eOut[j] = result.error;

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -13,6 +13,8 @@
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidKernel/MultiThreaded.h"
 #include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
 #include <optional>
 #include <unsupported/Eigen/AutoDiff>
 
@@ -83,6 +85,7 @@ public:
   using DerType = Types::DerType;
   using ADScalar = Types::ADScalar;
   using InputArray = Types::InputArray;
+  using CovarianceMatrix = Eigen::Matrix<double, N, N>;
   ErrorPropagation(Func func) : computeFunc(std::move(func)) {}
 
   struct AutoDevResult {
@@ -92,13 +95,20 @@ public:
   };
 
   AutoDevResult evaluate(const InputArray &values, const InputArray &errors) const {
+    return evaluateWithCovariance(values, covarianceMatrixFromErrors(errors));
+  }
+
+  AutoDevResult evaluateWithCovariance(const InputArray &values, const CovarianceMatrix &covariance) const {
     std::array<ADScalar, N> x;
     for (size_t i = 0; i < N; ++i) {
       x[i] = ADScalar(values[i], DerType::Unit(N, i));
     }
     const ADScalar y = computeFunc(x);
     const auto &derivatives = y.derivatives();
-    return {y.value(), std::sqrt((derivatives.array().square() * errors.array().square()).sum()), derivatives};
+    // First-order Taylor propagation with correlated inputs:
+    // Var(f) = J C J^T, where J is the row vector of derivatives df/dx_i and C is the covariance matrix.
+    const double variance = derivatives.dot(covariance * derivatives);
+    return {y.value(), std::sqrt(std::max(variance, 0.0)), derivatives};
   }
 
   template <std::same_as<API::MatrixWorkspace_sptr>... Ts>
@@ -109,6 +119,24 @@ public:
   template <std::same_as<API::MatrixWorkspace_sptr>... Ts>
   API::MatrixWorkspace_sptr evaluateWorkspaces(Ts... args) const {
     return evaluateWorkspacesImpl(std::nullopt, std::forward<Ts>(args)...);
+  }
+
+  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovariance(const bool outputWorkspaceDistribution,
+                                                             CovarianceMatrixProvider covarianceMatrixProvider,
+                                                             Ts... args) const {
+    return evaluateWorkspacesWithCovarianceImpl(outputWorkspaceDistribution, covarianceMatrixProvider,
+                                                std::forward<Ts>(args)...);
+  }
+
+  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovariance(CovarianceMatrixProvider covarianceMatrixProvider,
+                                                             Ts... args) const {
+    return evaluateWorkspacesWithCovarianceImpl(std::nullopt, covarianceMatrixProvider, std::forward<Ts>(args)...);
+  }
+
+  static CovarianceMatrix covarianceMatrixFromErrors(const InputArray &errors) {
+    return errors.array().square().matrix().asDiagonal();
   }
 
 private:
@@ -139,6 +167,47 @@ private:
       PARALLEL_FOR_IF(isThreadSafe && !specOverBins)
       for (int64_t j = 0; j < static_cast<int64_t>(specSize); ++j) {
         const auto result = evaluate(InputArray{args->y(i)[j]...}, InputArray(args->e(i)[j]...));
+        yOut[j] = result.value;
+        eOut[j] = result.error;
+      }
+    }
+
+    if (outputWorkspaceDistribution.has_value()) {
+      outWs->setDistribution(outputWorkspaceDistribution.value());
+    }
+    return outWs;
+  }
+
+  template <typename CovarianceMatrixProvider, std::same_as<API::MatrixWorkspace_sptr>... Ts>
+  API::MatrixWorkspace_sptr evaluateWorkspacesWithCovarianceImpl(std::optional<bool> outputWorkspaceDistribution,
+                                                                 CovarianceMatrixProvider covarianceMatrixProvider,
+                                                                 Ts... args) const {
+    const auto firstWs = std::get<0>(std::forward_as_tuple(args...));
+    API::MatrixWorkspace_sptr outWs = firstWs->clone();
+
+    if (outWs->id() == "EventWorkspace") {
+      outWs = convertToWorkspace2D(outWs);
+    }
+
+    const size_t numSpec = outWs->getNumberHistograms();
+    const size_t specSize = outWs->blocksize();
+
+    // cppcheck-suppress unreadVariable
+    const bool isThreadSafe = Kernel::threadSafe((*args)..., *outWs);
+    // cppcheck-suppress unreadVariable
+    const bool specOverBins = numSpec > specSize;
+
+    PARALLEL_FOR_IF(isThreadSafe && specOverBins)
+    for (int64_t i = 0; i < static_cast<int64_t>(numSpec); i++) {
+      auto &yOut = outWs->mutableY(i);
+      auto &eOut = outWs->mutableE(i);
+
+      PARALLEL_FOR_IF(isThreadSafe && !specOverBins)
+      for (int64_t j = 0; j < static_cast<int64_t>(specSize); ++j) {
+        const InputArray values{args->y(i)[j]...};
+        const InputArray errors(args->e(i)[j]...);
+        const auto covariance = covarianceMatrixProvider(values, errors);
+        const auto result = evaluateWithCovariance(values, covariance);
         yOut[j] = result.value;
         eOut[j] = result.error;
       }

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -14,11 +14,14 @@
 #include "MantidKernel/MultiThreaded.h"
 #include <Eigen/Dense>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <concepts>
 #include <optional>
+#include <tuple>
 #include <type_traits>
 #include <unsupported/Eigen/AutoDiff>
+#include <utility>
 
 namespace Mantid::Algorithms {
 namespace PolarizationCorrectionsHelpers {
@@ -86,6 +89,94 @@ public:
   using ADScalar = Eigen::AutoDiffScalar<DerType>;
   using CovarianceMatrix = Eigen::Matrix<double, N, N>;
 };
+
+template <size_t IndependentVars, size_t DependentVars, typename... DependentFuncs> class CovarianceMatrixProvider {
+public:
+  static_assert(sizeof...(DependentFuncs) == DependentVars, "Number of dependent functions must match DependentVars");
+
+  static constexpr size_t TotalVars = IndependentVars + DependentVars;
+  using IndependentTypes = ErrorTypeHelper<IndependentVars>;
+  using Types = ErrorTypeHelper<TotalVars>;
+  using InputArray = typename Types::InputArray;
+  using CovarianceMatrix = typename Types::CovarianceMatrix;
+  using ADScalar = typename IndependentTypes::ADScalar;
+  using IndependentDerType = typename IndependentTypes::DerType;
+  using FunctionInput = std::array<ADScalar, TotalVars>;
+
+  explicit CovarianceMatrixProvider(DependentFuncs... dependentFuncs)
+      : m_dependentFuncs(std::move(dependentFuncs)...) {}
+
+  CovarianceMatrix operator()(const InputArray &inputValues, const InputArray &inputErrors) const {
+    CovarianceMatrix covariance = inputErrors.array().square().matrix().asDiagonal();
+    const auto functionInputs = makeFunctionInput(inputValues);
+    const auto derivatives = dependentDerivatives(functionInputs, std::make_index_sequence<DependentVars>{});
+
+    for (size_t dep = 0; dep < DependentVars; ++dep) {
+      const size_t depIndex = IndependentVars + dep;
+      for (size_t independent = 0; independent < IndependentVars; ++independent) {
+        const double covarianceWithIndependent =
+            derivatives[dep][independent] * inputErrors[independent] * inputErrors[independent];
+        covariance(independent, depIndex) = covarianceWithIndependent;
+        covariance(depIndex, independent) = covarianceWithIndependent;
+      }
+    }
+
+    // Preserve supplied dependent variances on the diagonal. Only dependent-dependent off-diagonal terms are inferred.
+    for (size_t depA = 0; depA < DependentVars; ++depA) {
+      const size_t depAIndex = IndependentVars + depA;
+      for (size_t depB = depA + 1; depB < DependentVars; ++depB) {
+        const size_t depBIndex = IndependentVars + depB;
+        double covarianceBetweenDependents = 0.0;
+        for (size_t independent = 0; independent < IndependentVars; ++independent) {
+          covarianceBetweenDependents += derivatives[depA][independent] * derivatives[depB][independent] *
+                                         inputErrors[independent] * inputErrors[independent];
+        }
+        covariance(depAIndex, depBIndex) = covarianceBetweenDependents;
+        covariance(depBIndex, depAIndex) = covarianceBetweenDependents;
+      }
+    }
+
+    return covariance;
+  }
+
+private:
+  FunctionInput makeFunctionInput(const InputArray &inputValues) const {
+    FunctionInput functionInputs;
+    for (size_t i = 0; i < IndependentVars; ++i) {
+      functionInputs[i] = ADScalar(inputValues[i], IndependentDerType::Unit(IndependentVars, i));
+    }
+    for (size_t i = IndependentVars; i < TotalVars; ++i) {
+      functionInputs[i] = ADScalar(inputValues[i], IndependentDerType::Zero());
+    }
+    return functionInputs;
+  }
+
+  template <typename Func>
+  ADScalar evaluateDependentFunction(Func const &func, const FunctionInput &functionInputs) const {
+    static_assert(std::invocable<Func, const FunctionInput &>,
+                  "Dependent functions must accept the covariance provider input values");
+    return func(functionInputs);
+  }
+
+  template <size_t... Indices>
+  std::array<IndependentDerType, DependentVars> dependentDerivatives(const FunctionInput &functionInputs,
+                                                                     std::index_sequence<Indices...>) const {
+    return {evaluateDependentFunction(std::get<Indices>(m_dependentFuncs), functionInputs).derivatives()...};
+  }
+
+  std::tuple<DependentFuncs...> m_dependentFuncs;
+};
+
+// The first IndependentVars inputs are treated as independent. The following DependentVars inputs are treated as
+// quantities derived from the independent variables. If dependent variable d_a has derivatives J_ai = dd_a/dx_i, then
+// Cov(x_i, d_a) = J_ai Var(x_i) and Cov(d_a, d_b) = sum_i J_ai J_bi Var(x_i). Dependent functions must express each
+// dependency directly in terms of the independent variables; if one dependent quantity depends on another, inline that
+// dependency into the function. Use the input values' .value() when a fixed bin value is needed.
+template <size_t IndependentVars, size_t DependentVars, typename... DependentFuncs>
+auto makeCovarianceMatrixProvider(DependentFuncs &&...dependentFuncs) {
+  return CovarianceMatrixProvider<IndependentVars, DependentVars, std::decay_t<DependentFuncs>...>(
+      std::forward<DependentFuncs>(dependentFuncs)...);
+}
 
 template <size_t N, typename Func> class ErrorPropagation {
 public:

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -84,6 +84,7 @@ public:
   using DerType = Eigen::Matrix<double, N, 1>;
   using InputArray = DerType;
   using ADScalar = Eigen::AutoDiffScalar<DerType>;
+  using CovarianceMatrix = Eigen::Matrix<double, N, N>;
 };
 
 template <size_t N, typename Func> class ErrorPropagation {
@@ -92,7 +93,7 @@ public:
   using DerType = Types::DerType;
   using ADScalar = Types::ADScalar;
   using InputArray = Types::InputArray;
-  using CovarianceMatrix = Eigen::Matrix<double, N, N>;
+  using CovarianceMatrix = Types::CovarianceMatrix;
   ErrorPropagation(Func func) : computeFunc(std::move(func)) {}
 
   struct AutoDevResult {

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
@@ -58,22 +58,23 @@ constexpr size_t NON_MAG_INTENSITY_VAR_NUM = 4;
 constexpr size_t DERIVED_EFFICIENCY_VAR_INDEX = NON_MAG_INTENSITY_VAR_NUM;
 constexpr size_t EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM = NON_MAG_INTENSITY_VAR_NUM + 1;
 
-auto covarianceMatrixForDerivedEfficiency(
-    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>::InputArray &values,
-    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>::InputArray &errors) {
-  using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>;
+using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>;
+
+// When one efficiency is supplied and the other is solved from phi = (2p - 1)(2a - 1)
+// we need to account for the covariance between the derived efficiency and the non-magnetic intensities
+auto covarianceMatrixForDerivedEfficiency(const Types::InputArray &values, const Types::InputArray &errors) {
   using PhiTypes = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<NON_MAG_INTENSITY_VAR_NUM>;
 
-  Eigen::Matrix<double, EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM, EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM> covariance =
-      Types::InputArray(errors.array().square()).asDiagonal();
+  // Diagonal of the covariance matrix is just the variances of the input intensities
+  Types::CovarianceMatrix covariance = Types::InputArray(errors.array().square()).asDiagonal();
   const auto phiErrorProp = Mantid::Algorithms::Arithmetic::makeErrorPropagation<NON_MAG_INTENSITY_VAR_NUM>(
       [](const auto &x) { return fnPhi(x); });
   const auto phiResult = phiErrorProp.evaluate(PhiTypes::InputArray{{values[0], values[1], values[2], values[3]}},
                                                PhiTypes::InputArray{{errors[0], errors[1], errors[2], errors[3]}});
 
-  // When one efficiency is supplied and the other is solved from phi = (2p - 1)(2a - 1), the supplied efficiency may
-  // have been derived from the same non-magnetic workspaces as phi. The covariance with each intensity is
-  // Cov(I_i, eff) ~= d(eff)/d(I_i) Var(I_i), where d(eff)/d(I_i) = ((eff - 0.5) / phi) d(phi)/d(I_i).
+  // The covariance between the given efficiency and each intensity is Cov(I_i, eff) ~= d(eff)/d(I_i) Var(I_i), derived
+  // from the first order Taylor expansion of the efficiency with respect to the intensities where d(eff)/d(I_i) = ((eff
+  // - 0.5) / phi) d(phi)/d(I_i), derived from rearranging the equation for phi and applying the chain rule
   for (size_t i = 0; i < NON_MAG_INTENSITY_VAR_NUM; ++i) {
     const double covarianceWithDerivedEfficiency = ((values[DERIVED_EFFICIENCY_VAR_INDEX] - 0.5) / phiResult.value) *
                                                    phiResult.derivatives[i] * errors[i] * errors[i];

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
@@ -54,29 +54,31 @@ constexpr auto fnDenominator = [](const auto &x, const auto &fp) {
   return (1 - 2 * fp) * x[4] + (2 * fp - 1) * x[5] - x[6] + x[7];
 };
 
-constexpr size_t DERIVED_EFFICIENCY_VAR_NUM = 5;
+constexpr size_t NON_MAG_INTENSITY_VAR_NUM = 4;
+constexpr size_t DERIVED_EFFICIENCY_VAR_INDEX = NON_MAG_INTENSITY_VAR_NUM;
+constexpr size_t EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM = NON_MAG_INTENSITY_VAR_NUM + 1;
 
 auto covarianceMatrixForDerivedEfficiency(
-    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>::InputArray &values,
-    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>::InputArray &errors) {
-  using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>;
-  using PhiTypes = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<4>;
+    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>::InputArray &values,
+    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>::InputArray &errors) {
+  using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>;
+  using PhiTypes = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<NON_MAG_INTENSITY_VAR_NUM>;
 
-  Eigen::Matrix<double, DERIVED_EFFICIENCY_VAR_NUM, DERIVED_EFFICIENCY_VAR_NUM> covariance =
+  Eigen::Matrix<double, EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM, EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM> covariance =
       Types::InputArray(errors.array().square()).asDiagonal();
-  const auto phiErrorProp =
-      Mantid::Algorithms::Arithmetic::makeErrorPropagation<4>([](const auto &x) { return fnPhi(x); });
+  const auto phiErrorProp = Mantid::Algorithms::Arithmetic::makeErrorPropagation<NON_MAG_INTENSITY_VAR_NUM>(
+      [](const auto &x) { return fnPhi(x); });
   const auto phiResult = phiErrorProp.evaluate(PhiTypes::InputArray{{values[0], values[1], values[2], values[3]}},
                                                PhiTypes::InputArray{{errors[0], errors[1], errors[2], errors[3]}});
 
   // When one efficiency is supplied and the other is solved from phi = (2p - 1)(2a - 1), the supplied efficiency may
   // have been derived from the same non-magnetic workspaces as phi. The covariance with each intensity is
   // Cov(I_i, eff) ~= d(eff)/d(I_i) Var(I_i), where d(eff)/d(I_i) = ((eff - 0.5) / phi) d(phi)/d(I_i).
-  for (size_t i = 0; i < 4; ++i) {
-    const double covarianceWithDerivedEfficiency =
-        ((values[4] - 0.5) / phiResult.value) * phiResult.derivatives[i] * errors[i] * errors[i];
-    covariance(i, 4) = covarianceWithDerivedEfficiency;
-    covariance(4, i) = covarianceWithDerivedEfficiency;
+  for (size_t i = 0; i < NON_MAG_INTENSITY_VAR_NUM; ++i) {
+    const double covarianceWithDerivedEfficiency = ((values[DERIVED_EFFICIENCY_VAR_INDEX] - 0.5) / phiResult.value) *
+                                                   phiResult.derivatives[i] * errors[i] * errors[i];
+    covariance(i, DERIVED_EFFICIENCY_VAR_INDEX) = covarianceWithDerivedEfficiency;
+    covariance(DERIVED_EFFICIENCY_VAR_INDEX, i) = covarianceWithDerivedEfficiency;
   }
   return covariance;
 }
@@ -368,9 +370,9 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
       m_wsP = inWsP->clone();
     } else {
       const MatrixWorkspace_sptr inWsA = getProperty(PropNames::INPUT_A_EFF_WS);
-      constexpr int var_num = DERIVED_EFFICIENCY_VAR_NUM;
+      constexpr size_t var_num = EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM;
       const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
-        const auto TXMO = (2 * x[4]) - 1;
+        const auto TXMO = (2 * x[DERIVED_EFFICIENCY_VAR_INDEX]) - 1;
         return (fnPhi(x) / (2 * TXMO)) + 0.5;
       });
       m_wsP = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
@@ -383,9 +385,9 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
       m_wsA = inWsA->clone();
     } else {
       const MatrixWorkspace_sptr inWsP = getProperty(PropNames::INPUT_P_EFF_WS);
-      constexpr int var_num = DERIVED_EFFICIENCY_VAR_NUM;
+      constexpr size_t var_num = EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM;
       const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
-        const auto TXMO = (2 * x[4]) - 1;
+        const auto TXMO = (2 * x[DERIVED_EFFICIENCY_VAR_INDEX]) - 1;
         return (fnPhi(x) / (2 * TXMO)) + 0.5;
       });
       m_wsA = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
@@ -53,6 +53,33 @@ constexpr auto fnNumerator = [](const auto &x, const auto &fa) {
 constexpr auto fnDenominator = [](const auto &x, const auto &fp) {
   return (1 - 2 * fp) * x[4] + (2 * fp - 1) * x[5] - x[6] + x[7];
 };
+
+constexpr size_t DERIVED_EFFICIENCY_VAR_NUM = 5;
+
+auto covarianceMatrixForDerivedEfficiency(
+    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>::InputArray &values,
+    const Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>::InputArray &errors) {
+  using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<DERIVED_EFFICIENCY_VAR_NUM>;
+  using PhiTypes = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<4>;
+
+  Eigen::Matrix<double, DERIVED_EFFICIENCY_VAR_NUM, DERIVED_EFFICIENCY_VAR_NUM> covariance =
+      Types::InputArray(errors.array().square()).asDiagonal();
+  const auto phiErrorProp =
+      Mantid::Algorithms::Arithmetic::makeErrorPropagation<4>([](const auto &x) { return fnPhi(x); });
+  const auto phiResult = phiErrorProp.evaluate(PhiTypes::InputArray{{values[0], values[1], values[2], values[3]}},
+                                               PhiTypes::InputArray{{errors[0], errors[1], errors[2], errors[3]}});
+
+  // When one efficiency is supplied and the other is solved from phi = (2p - 1)(2a - 1), the supplied efficiency may
+  // have been derived from the same non-magnetic workspaces as phi. The covariance with each intensity is
+  // Cov(I_i, eff) ~= d(eff)/d(I_i) Var(I_i), where d(eff)/d(I_i) = ((eff - 0.5) / phi) d(phi)/d(I_i).
+  for (size_t i = 0; i < 4; ++i) {
+    const double covarianceWithDerivedEfficiency =
+        ((values[4] - 0.5) / phiResult.value) * phiResult.derivatives[i] * errors[i] * errors[i];
+    covariance(i, 4) = covarianceWithDerivedEfficiency;
+    covariance(4, i) = covarianceWithDerivedEfficiency;
+  }
+  return covariance;
+}
 } // namespace
 
 namespace Mantid::Algorithms {
@@ -340,15 +367,14 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
     if (const MatrixWorkspace_sptr inWsP = getProperty(PropNames::INPUT_P_EFF_WS)) {
       m_wsP = inWsP->clone();
     } else {
-      g_log.warning("The analyser efficiency workspace provided has been used to calculate the polarizer efficiency."
-                    "This could lead to inflated errors as the analyser efficiency is a derived quantity.");
       const MatrixWorkspace_sptr inWsA = getProperty(PropNames::INPUT_A_EFF_WS);
-      constexpr int var_num = 5;
+      constexpr int var_num = DERIVED_EFFICIENCY_VAR_NUM;
       const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
         const auto TXMO = (2 * x[4]) - 1;
         return (fnPhi(x) / (2 * TXMO)) + 0.5;
       });
-      m_wsP = errorProp.evaluateWorkspaces(true, ws00, ws01, ws10, ws11, inWsA);
+      m_wsP = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
+                                                         ws11, inWsA);
     }
   }
 
@@ -356,15 +382,14 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
     if (const MatrixWorkspace_sptr inWsA = getProperty(PropNames::INPUT_A_EFF_WS)) {
       m_wsA = inWsA->clone();
     } else {
-      g_log.warning("The polarizer efficiency workspace provided has been used to calculate the analyser efficiency. "
-                    "This could lead to inflated errors as the polarizer efficiency is a derived quantity.");
       const MatrixWorkspace_sptr inWsP = getProperty(PropNames::INPUT_P_EFF_WS);
-      constexpr int var_num = 5;
+      constexpr int var_num = DERIVED_EFFICIENCY_VAR_NUM;
       const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
         const auto TXMO = (2 * x[4]) - 1;
         return (fnPhi(x) / (2 * TXMO)) + 0.5;
       });
-      m_wsA = errorProp.evaluateWorkspaces(true, ws00, ws01, ws10, ws11, inWsP);
+      m_wsA = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
+                                                         ws11, inWsP);
     }
   }
 }

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
@@ -54,34 +54,26 @@ constexpr auto fnDenominator = [](const auto &x, const auto &fp) {
   return (1 - 2 * fp) * x[4] + (2 * fp - 1) * x[5] - x[6] + x[7];
 };
 
-constexpr size_t NON_MAG_INTENSITY_VAR_NUM = 4;
-constexpr size_t DERIVED_EFFICIENCY_VAR_INDEX = NON_MAG_INTENSITY_VAR_NUM;
-constexpr size_t EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM = NON_MAG_INTENSITY_VAR_NUM + 1;
-
-using Types = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM>;
+constexpr size_t INDEPENDENT_INTENSITY_VAR_COUNT = 4;
+constexpr size_t DERIVED_EFFICIENCY_VAR_COUNT = 1;
+constexpr size_t DERIVED_EFFICIENCY_INPUT_INDEX = INDEPENDENT_INTENSITY_VAR_COUNT;
+constexpr size_t EFFICIENCY_FROM_DERIVED_INPUT_VAR_COUNT =
+    INDEPENDENT_INTENSITY_VAR_COUNT + DERIVED_EFFICIENCY_VAR_COUNT;
 
 // When one efficiency is supplied and the other is solved from phi = (2p - 1)(2a - 1)
-// we need to account for the covariance between the derived efficiency and the non-magnetic intensities
-auto covarianceMatrixForDerivedEfficiency(const Types::InputArray &values, const Types::InputArray &errors) {
-  using PhiTypes = Mantid::Algorithms::Arithmetic::ErrorTypeHelper<NON_MAG_INTENSITY_VAR_NUM>;
-
-  // Diagonal of the covariance matrix is just the variances of the input intensities
-  Types::CovarianceMatrix covariance = Types::InputArray(errors.array().square()).asDiagonal();
-  const auto phiErrorProp = Mantid::Algorithms::Arithmetic::makeErrorPropagation<NON_MAG_INTENSITY_VAR_NUM>(
-      [](const auto &x) { return fnPhi(x); });
-  const auto phiResult = phiErrorProp.evaluate(PhiTypes::InputArray{{values[0], values[1], values[2], values[3]}},
-                                               PhiTypes::InputArray{{errors[0], errors[1], errors[2], errors[3]}});
-
-  // The covariance between the given efficiency and each intensity is Cov(I_i, eff) ~= d(eff)/d(I_i) Var(I_i), derived
-  // from the first order Taylor expansion of the efficiency with respect to the intensities where d(eff)/d(I_i) = ((eff
-  // - 0.5) / phi) d(phi)/d(I_i), derived from rearranging the equation for phi and applying the chain rule
-  for (size_t i = 0; i < NON_MAG_INTENSITY_VAR_NUM; ++i) {
-    const double covarianceWithDerivedEfficiency = ((values[DERIVED_EFFICIENCY_VAR_INDEX] - 0.5) / phiResult.value) *
-                                                   phiResult.derivatives[i] * errors[i] * errors[i];
-    covariance(i, DERIVED_EFFICIENCY_VAR_INDEX) = covarianceWithDerivedEfficiency;
-    covariance(DERIVED_EFFICIENCY_VAR_INDEX, i) = covarianceWithDerivedEfficiency;
-  }
-  return covariance;
+// we need to account for the covariance between the derived efficiency and the non-magnetic intensities.
+// We provide the covariance matrix provider with a function to calculate the derived efficiency from the provided
+// intensities so the differential can be calculated. This function includes the unknown value of the efficiency to be
+// calculated, so for each bin we solve for this from the known values.
+auto covarianceMatrixProviderForDerivedEfficiency() {
+  return Mantid::Algorithms::Arithmetic::makeCovarianceMatrixProvider<INDEPENDENT_INTENSITY_VAR_COUNT,
+                                                                      DERIVED_EFFICIENCY_VAR_COUNT>(
+      [](const auto &inputs) {
+        const auto phi = fnPhi(inputs);
+        const double suppliedEfficiency = inputs[DERIVED_EFFICIENCY_INPUT_INDEX].value();
+        const double unknownEfficiency = 0.5 + (1 / (4 * suppliedEfficiency - 2)) * phi.value();
+        return 0.5 + (1 / (4 * unknownEfficiency - 2)) * phi;
+      });
 }
 } // namespace
 
@@ -371,13 +363,13 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
       m_wsP = inWsP->clone();
     } else {
       const MatrixWorkspace_sptr inWsA = getProperty(PropNames::INPUT_A_EFF_WS);
-      constexpr size_t var_num = EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM;
-      const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
-        const auto TXMO = (2 * x[DERIVED_EFFICIENCY_VAR_INDEX]) - 1;
-        return (fnPhi(x) / (2 * TXMO)) + 0.5;
-      });
-      m_wsP = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
-                                                         ws11, inWsA);
+      const auto errorProp =
+          Arithmetic::makeErrorPropagation<EFFICIENCY_FROM_DERIVED_INPUT_VAR_COUNT>([](const auto &inputValues) {
+            const auto suppliedEfficiencyFactor = (2 * inputValues[DERIVED_EFFICIENCY_INPUT_INDEX]) - 1;
+            return (fnPhi(inputValues) / (2 * suppliedEfficiencyFactor)) + 0.5;
+          });
+      m_wsP = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixProviderForDerivedEfficiency(), ws00,
+                                                         ws01, ws10, ws11, inWsA);
     }
   }
 
@@ -386,13 +378,13 @@ void PolarizationEfficienciesWildes::calculatePolarizerAndAnalyserEfficiencies(c
       m_wsA = inWsA->clone();
     } else {
       const MatrixWorkspace_sptr inWsP = getProperty(PropNames::INPUT_P_EFF_WS);
-      constexpr size_t var_num = EFFICIENCY_FROM_DERIVED_INPUT_VAR_NUM;
-      const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
-        const auto TXMO = (2 * x[DERIVED_EFFICIENCY_VAR_INDEX]) - 1;
-        return (fnPhi(x) / (2 * TXMO)) + 0.5;
-      });
-      m_wsA = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
-                                                         ws11, inWsP);
+      const auto errorProp =
+          Arithmetic::makeErrorPropagation<EFFICIENCY_FROM_DERIVED_INPUT_VAR_COUNT>([](const auto &inputValues) {
+            const auto suppliedEfficiencyFactor = (2 * inputValues[DERIVED_EFFICIENCY_INPUT_INDEX]) - 1;
+            return (fnPhi(inputValues) / (2 * suppliedEfficiencyFactor)) + 0.5;
+          });
+      m_wsA = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixProviderForDerivedEfficiency(), ws00,
+                                                         ws01, ws10, ws11, inWsP);
     }
   }
 }

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
@@ -139,6 +139,28 @@ public:
     TS_ASSERT_DELTA(0.126666, result.error, 0.000001);
   }
 
+  void testCovarianceMatrixProvider_generates_covariance_for_multiple_dependent_variables() {
+    constexpr size_t independentVars = 1;
+    constexpr size_t dependentVars = 2;
+    using Types = Arithmetic::ErrorTypeHelper<independentVars + dependentVars>;
+
+    const auto covarianceProvider = Arithmetic::makeCovarianceMatrixProvider<independentVars, dependentVars>(
+        [](const auto &inputs) { return 2.0 * inputs[0]; }, [](const auto &inputs) { return inputs[0] * inputs[0]; });
+
+    const auto covariance =
+        covarianceProvider(Types::InputArray{{3.0, 10.0, 20.0}}, Types::InputArray{{0.1, 0.5, 0.6}});
+
+    TS_ASSERT_DELTA(0.01, covariance(0, 0), 1e-10);
+    TS_ASSERT_DELTA(0.25, covariance(1, 1), 1e-10);
+    TS_ASSERT_DELTA(0.36, covariance(2, 2), 1e-10);
+    TS_ASSERT_DELTA(0.02, covariance(0, 1), 1e-10);
+    TS_ASSERT_DELTA(0.02, covariance(1, 0), 1e-10);
+    TS_ASSERT_DELTA(0.06, covariance(0, 2), 1e-10);
+    TS_ASSERT_DELTA(0.06, covariance(2, 0), 1e-10);
+    TS_ASSERT_DELTA(0.12, covariance(1, 2), 1e-10);
+    TS_ASSERT_DELTA(0.12, covariance(2, 1), 1e-10);
+  }
+
   void testErrorPropagation_workspaces_quad() {
     const size_t vars = 1;
     const double a = 5.0;
@@ -179,16 +201,10 @@ public:
 
     auto wsA = createWorkspace("wsA", {0.0, 1.0, 2.0}, {3.141, 3.141, 3.141}, {0.01, 0.01, 0.01});
     auto wsB = createWorkspace("wsB", {0.0, 1.0, 2.0}, {1.0, 1.0, 1.0}, {0.05, 0.05, 0.05});
-    using ErrorProp = decltype(errorProp);
+    const auto covarianceProvider =
+        Arithmetic::makeCovarianceMatrixProvider<1, 1>([](const auto &inputs) { return 2.0 * inputs[0]; });
 
-    const auto result = errorProp.evaluateWorkspacesWithCovariance(
-        [](const auto &, const auto &errors) {
-          ErrorProp::CovarianceMatrix covariance;
-          const double covarianceTerm = 0.4 * errors[0] * errors[1];
-          covariance << errors[0] * errors[0], covarianceTerm, covarianceTerm, errors[1] * errors[1];
-          return covariance;
-        },
-        wsA, wsB);
+    const auto result = errorProp.evaluateWorkspacesWithCovariance(covarianceProvider, wsA, wsB);
 
     for (size_t i = 0; i < result->size(); i++) {
       TS_ASSERT_DELTA(2.72014, result->y(0)[i], 0.00001);

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
@@ -124,6 +124,20 @@ public:
     TS_ASSERT_DELTA(result.value, 2.72014, 0.00001);
   }
 
+  void testErrorPropagation_uses_covariance_terms() {
+    constexpr size_t vars = 2;
+    using Types = Arithmetic::ErrorTypeHelper<vars>;
+
+    const auto errorProp = Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] + x[1]; });
+    decltype(errorProp)::CovarianceMatrix covariance;
+    covariance << 4.0, 6.0, 6.0, 9.0;
+
+    const auto result = errorProp.evaluateWithCovariance(Types::InputArray{{10.0, 5.0}}, covariance);
+
+    TS_ASSERT_DELTA(15.0, result.value, 1e-10);
+    TS_ASSERT_DELTA(5.0, result.error, 1e-10);
+  }
+
   void testErrorPropagation_workspaces_quad() {
     const size_t vars = 1;
     const double a = 5.0;
@@ -154,6 +168,28 @@ public:
     for (size_t i = 0; i < result->size(); i++) {
       TS_ASSERT_DELTA(2.72014, result->y(0)[i], 0.001);
       TS_ASSERT_DELTA(0.139495, result->e(0)[i], 0.001);
+    }
+  }
+
+  void testErrorPropagation_workspaces_use_covariance_terms() {
+    constexpr size_t vars = 2;
+    const auto errorProp = Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] - x[1]; });
+
+    auto wsA = createWorkspace("wsA", {0.0, 1.0, 2.0}, {3.0, 3.0, 3.0}, {2.0, 2.0, 2.0});
+    auto wsB = createWorkspace("wsB", {0.0, 1.0, 2.0}, {1.0, 1.0, 1.0}, {2.0, 2.0, 2.0});
+    using ErrorProp = decltype(errorProp);
+
+    const auto result = errorProp.evaluateWorkspacesWithCovariance(
+        [](const auto &, const auto &errors) {
+          ErrorProp::CovarianceMatrix covariance;
+          covariance << errors[0] * errors[0], errors[0] * errors[1], errors[0] * errors[1], errors[1] * errors[1];
+          return covariance;
+        },
+        wsA, wsB);
+
+    for (size_t i = 0; i < result->size(); i++) {
+      TS_ASSERT_DELTA(2.0, result->y(0)[i], 1e-10);
+      TS_ASSERT_DELTA(0.0, result->e(0)[i], 1e-10);
     }
   }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
@@ -124,18 +124,19 @@ public:
     TS_ASSERT_DELTA(result.value, 2.72014, 0.00001);
   }
 
-  void testErrorPropagation_uses_covariance_terms() {
+  void testErrorPropagation_uses_covariance_terms_for_non_linear_function() {
     constexpr size_t vars = 2;
     using Types = Arithmetic::ErrorTypeHelper<vars>;
 
-    const auto errorProp = Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] + x[1]; });
+    const auto errorProp =
+        Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] * sin(x[0]) + exp(x[1]); });
     decltype(errorProp)::CovarianceMatrix covariance;
-    covariance << 4.0, 6.0, 6.0, 9.0;
+    covariance << 0.0001, 0.0002, 0.0002, 0.0025;
 
-    const auto result = errorProp.evaluateWithCovariance(Types::InputArray{{10.0, 5.0}}, covariance);
+    const auto result = errorProp.evaluateWithCovariance(Types::InputArray{{3.141, 1.0}}, covariance);
 
-    TS_ASSERT_DELTA(15.0, result.value, 1e-10);
-    TS_ASSERT_DELTA(5.0, result.error, 1e-10);
+    TS_ASSERT_DELTA(2.72014, result.value, 0.00001);
+    TS_ASSERT_DELTA(0.126666, result.error, 0.000001);
   }
 
   void testErrorPropagation_workspaces_quad() {
@@ -173,23 +174,25 @@ public:
 
   void testErrorPropagation_workspaces_use_covariance_terms() {
     constexpr size_t vars = 2;
-    const auto errorProp = Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] - x[1]; });
+    const auto errorProp =
+        Arithmetic::makeErrorPropagation<vars>([](const auto &x) { return x[0] * sin(x[0]) + exp(x[1]); });
 
-    auto wsA = createWorkspace("wsA", {0.0, 1.0, 2.0}, {3.0, 3.0, 3.0}, {2.0, 2.0, 2.0});
-    auto wsB = createWorkspace("wsB", {0.0, 1.0, 2.0}, {1.0, 1.0, 1.0}, {2.0, 2.0, 2.0});
+    auto wsA = createWorkspace("wsA", {0.0, 1.0, 2.0}, {3.141, 3.141, 3.141}, {0.01, 0.01, 0.01});
+    auto wsB = createWorkspace("wsB", {0.0, 1.0, 2.0}, {1.0, 1.0, 1.0}, {0.05, 0.05, 0.05});
     using ErrorProp = decltype(errorProp);
 
     const auto result = errorProp.evaluateWorkspacesWithCovariance(
         [](const auto &, const auto &errors) {
           ErrorProp::CovarianceMatrix covariance;
-          covariance << errors[0] * errors[0], errors[0] * errors[1], errors[0] * errors[1], errors[1] * errors[1];
+          const double covarianceTerm = 0.4 * errors[0] * errors[1];
+          covariance << errors[0] * errors[0], covarianceTerm, covarianceTerm, errors[1] * errors[1];
           return covariance;
         },
         wsA, wsB);
 
     for (size_t i = 0; i < result->size(); i++) {
-      TS_ASSERT_DELTA(2.0, result->y(0)[i], 1e-10);
-      TS_ASSERT_DELTA(0.0, result->e(0)[i], 1e-10);
+      TS_ASSERT_DELTA(2.72014, result->y(0)[i], 0.00001);
+      TS_ASSERT_DELTA(0.126666, result->e(0)[i], 0.000001);
     }
   }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationEfficienciesWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationEfficienciesWildesTest.h
@@ -337,8 +337,8 @@ public:
   void test_all_calculations_are_correct_using_input_P_ws() {
     const std::pair expectedPEfficiency = {0.98, 0.9899494934};
     const std::pair expectedTPMO = {0.96, 1.9798989879};
-    const std::pair expectedAEfficiency = {0.9855226, 1.0315912829};
-    const std::pair expectedTAMO = {0.9710452, 2.0631825648};
+    const std::pair expectedAEfficiency = {0.9855226, 0.9701443732};
+    const std::pair expectedTAMO = {0.9710452, 1.9402887465};
 
     const auto polarizerEffWs = generateFunctionDefinedWorkspace(TestWorkspaceParameters(
         EFF_WS, "name=UserFunction, Formula=x*0 +" + std::to_string(expectedPEfficiency.first)));
@@ -349,8 +349,8 @@ public:
   }
 
   void test_all_calculations_are_correct_using_input_A_ws() {
-    const std::pair expectedPEfficiency = {0.99, 1.0479338884};
-    const std::pair expectedTPMO = {0.98, 2.0958677778};
+    const std::pair expectedPEfficiency = {0.99, 0.9863498081};
+    const std::pair expectedTPMO = {0.98, 1.9726996162};
     const std::pair expectedAEfficiency = {0.975614, 0.9877317447};
     const std::pair expectedTAMO = {0.9512279, 1.9754634895};
 

--- a/Testing/SystemTests/tests/framework/ReflectometryISISCalculatePolEffTest.py
+++ b/Testing/SystemTests/tests/framework/ReflectometryISISCalculatePolEffTest.py
@@ -8,7 +8,6 @@
 from systemtesting import MantidSystemTest
 from abc import abstractmethod, ABCMeta
 from mantid.simpleapi import ReflectometryISISCalculatePolEff, Load
-import platform
 
 
 class ReflectometryISISCalculatePolEffTestBase(MantidSystemTest, metaclass=ABCMeta):
@@ -85,7 +84,7 @@ class ReflectometryISISCalculatePolEffTestBase(MantidSystemTest, metaclass=ABCMe
         ReflectometryISISCalculatePolEff(**args)
 
     def validate(self):
-        self.tolerance = 1e-10
+        self.tolerance = 1e-9
         self.nanEqual = True
         return self._OUTPUT_WS_NAME, self.reference_file
 
@@ -112,10 +111,6 @@ class ReflectometryISISCalculatePolEffAllCorrectionsTest(ReflectometryISISCalcul
     reference_file = "ReflectometryISISCalculatePolEffAllCorrections.nxs"
     all_corrections = True
     include_mag_runs = True
-
-    def skipTests(self):
-        # Numbers are different on ARM architecture so skip test
-        return "arm" in platform.machine()
 
     def __init__(self):
         super(ReflectometryISISCalculatePolEffAllCorrectionsTest, self).__init__()

--- a/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
+++ b/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
@@ -44,8 +44,8 @@ From which you can solve for the polarizer efficiency (:math:`p`) and then solve
 Alternatively, previously calculated polarizer and/or analyser efficiency workspaces can be passed to the ``InputPolarizerEfficiency`` and ``InputAnalyserEfficiency`` properties respectively.
 If workspaces are provided for both then they are used directly as the output polarizer and analyser efficiencies. If only one is provided then it is used to solve for the other efficiency.
 
-Both types of input workspace group should contain four child workspaces. A flipper configuration must be passed to the ``Flippers`` property to identify which child workspaces in the input group(s) correspond to which instrument configurations.
-The ``Flippers`` property takes a string in the form :literal:`'00, 01, 10, 11'`, which would indicate both flippers off, analyzer flipper on, polarizer flipper on, both flippers on. The flipper configuration can be provided in any order that matches the child workspaces in the input group(s).
+A flipper configuration must be passed to the ``Flippers`` property to identify which child workspaces in the input group(s) correspond to which instrument configuration. Each input workspace group should therefore contain an appropriate number of child workspaces, corresponding to the number relevant instrument configurations.
+The ``Flippers`` property takes a string in a form such as :literal:`'00, 01, 10, 11'` (Polarization Analysis (PA)), or :literal:`'0, 1'` Polarized Neutron Reflectivity (PNR). For PA, :literal:`'00, 01, 10, 11'` indicates: flippers off, analyzer flipper on, polarizer flipper on, both flippers on. The flipper configuration can be provided in any order that matches the child workspaces in the input group(s).
 
 
 Error propagation

--- a/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
+++ b/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
@@ -44,6 +44,45 @@ From which you can solve for the polarizer efficiency (:math:`p`) and then solve
 Alternatively, previously calculated polarizer and/or analyser efficiency workspaces can be passed to the ``InputPolarizerEfficiency`` and ``InputAnalyserEfficiency`` properties respectively.
 If workspaces are provided for both then they are used directly as the output polarizer and analyser efficiencies. If only one is provided then it is used to solve for the other efficiency.
 
+Error propagation
+#################
+
+Errors are propagated with a first-order Taylor expansion. For independent input quantities this is equivalent to:
+
+.. math::
+
+   \sigma_f^2 = \sum_i \left(\frac{\partial f}{\partial x_i}\right)^2 \sigma_i^2
+
+When only one of ``InputPolarizerEfficiency`` or ``InputAnalyserEfficiency`` is provided, the missing efficiency is solved from :math:`\phi = (2p-1)(2a-1)`.
+The provided efficiency may itself have been derived from the same non-magnetic transmission workspaces that are used to calculate :math:`\phi`.
+In this case the inputs are correlated, so the algorithm uses the covariance form of first-order error propagation:
+
+.. math::
+
+   \sigma_f^2 = J C J^T
+
+where :math:`J` is the vector of partial derivatives of the calculated output with respect to the apparent inputs and :math:`C` is their covariance matrix for a single wavelength bin.
+For example, when calculating :math:`p` from a provided analyser efficiency :math:`a`, the apparent input vector is:
+
+.. math::
+
+   x = [I^{00}_{1}, I^{01}_{1}, I^{10}_{1}, I^{11}_{1}, a]
+
+The diagonal terms of :math:`C` contain the variances of these quantities. The off-diagonal terms account for the shared dependence of :math:`a` and :math:`\phi` on the non-magnetic intensities:
+
+.. math::
+
+   \mathrm{Cov}(I_i, a) \simeq \frac{\partial a}{\partial I_i}\sigma_{I_i}^2
+
+with:
+
+.. math::
+
+   \frac{\partial a}{\partial I_i} = \frac{a - 0.5}{\phi}\frac{\partial \phi}{\partial I_i}
+
+The same approach is used when calculating :math:`a` from a provided polarizer efficiency :math:`p`.
+The covariance matrix is calculated independently for each wavelength bin and is not stored on the output workspace.
+
 Both types of input workspace group should contain four child workspaces. A flipper configuration must be passed to the ``Flippers`` property to identify which child workspaces in the input group(s) correspond to which instrument configurations.
 The ``Flippers`` property takes a string in the form :literal:`'00, 01, 10, 11'`, which would indicate both flippers off, analyzer flipper on, polarizer flipper on, both flippers on. The flipper configuration can be provided in any order that matches the child workspaces in the input group(s).
 

--- a/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
+++ b/docs/source/algorithms/PolarizationEfficienciesWildes-v1.rst
@@ -44,6 +44,10 @@ From which you can solve for the polarizer efficiency (:math:`p`) and then solve
 Alternatively, previously calculated polarizer and/or analyser efficiency workspaces can be passed to the ``InputPolarizerEfficiency`` and ``InputAnalyserEfficiency`` properties respectively.
 If workspaces are provided for both then they are used directly as the output polarizer and analyser efficiencies. If only one is provided then it is used to solve for the other efficiency.
 
+Both types of input workspace group should contain four child workspaces. A flipper configuration must be passed to the ``Flippers`` property to identify which child workspaces in the input group(s) correspond to which instrument configurations.
+The ``Flippers`` property takes a string in the form :literal:`'00, 01, 10, 11'`, which would indicate both flippers off, analyzer flipper on, polarizer flipper on, both flippers on. The flipper configuration can be provided in any order that matches the child workspaces in the input group(s).
+
+
 Error propagation
 #################
 
@@ -83,8 +87,6 @@ with:
 The same approach is used when calculating :math:`a` from a provided polarizer efficiency :math:`p`.
 The covariance matrix is calculated independently for each wavelength bin and is not stored on the output workspace.
 
-Both types of input workspace group should contain four child workspaces. A flipper configuration must be passed to the ``Flippers`` property to identify which child workspaces in the input group(s) correspond to which instrument configurations.
-The ``Flippers`` property takes a string in the form :literal:`'00, 01, 10, 11'`, which would indicate both flippers off, analyzer flipper on, polarizer flipper on, both flippers on. The flipper configuration can be provided in any order that matches the child workspaces in the input group(s).
 
 Outputs
 #######

--- a/docs/source/release/v6.16.0/Reflectometry/Bugfixes/polarization_efficiencies_wildes_covariance.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/Bugfixes/polarization_efficiencies_wildes_covariance.rst
@@ -1,0 +1,3 @@
+- The :ref:`algm-PolarizationEfficienciesWildes` algorithm now accounts for covariance terms when calculating a
+  polarizer or analyser efficiency from the other supplied efficiency workspace, avoiding overestimated propagated
+  errors when the supplied efficiency is a derived quantity.


### PR DESCRIPTION
### Description of work

This PR extends the functionality currently located in `PolarizationCorrectionHelpers.h`, that allows for effective error propagation by Taylor series expansion when evaluating functions where each variable is a `MatrixWorkspace`.

This is currently only used in `PolarizationEfficienciesWildes`, but has been written in a generalised manner to be reusable.

The previous implementation assumed that all variables (intensities) were independent, but this is not aways the case. 

For example, in `PolarizationEfficienciesWildes` it is possible to provide an single efficiency workspace, which is then used to calculate the other efficiency workspace using `phi = (2p - 1)(2a - 1)`, where `phi` is a function of the provided intensities. As the provided efficiency workspace is also a function of these intensities, these variables are no longer independent.

To handle this, the covariance matrices must be considered.

In addition to the previous interface:
```
  const auto errorPropFp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) { return fnFp(x); });
  m_wsFp = errorPropFp.evaluateWorkspaces(true, ws00, ws01, ws10, ws11);
```

A new interface is now provided for this purpose:
```
      const auto errorProp = Arithmetic::makeErrorPropagation<var_num>([](const auto &x) {
        const auto TXMO = (2 * x[DERIVED_EFFICIENCY_VAR_INDEX]) - 1;
        return (fnPhi(x) / (2 * TXMO)) + 0.5;
      });
      m_wsP = errorProp.evaluateWorkspacesWithCovariance(true, covarianceMatrixForDerivedEfficiency, ws00, ws01, ws10,
                                                         ws11, inWsA);
```

It was my design philosophy with the original design that the implementation detail, Eigen types etc., be hidden from the consumer.

Now, the consumer has to provide a method to calculate the covariance matrix (`covarianceMatrixForDerivedEfficiency`) above. Attempts to abstract any further implementation away ended up with a pretty complicated implementation, albeit nice from the consumer's perspective. It may bring it back in a future PR.

I have also slliiightly increased the tolerance on the `ReflectometryISISCalculatePolEff` system tests to increased reliability and allow us to reenable it on arm.

Closes #39301

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

We expect no calculated y values to change. For the paths that do not consider covariance, we expect the error to remain the same also.

For paths that do consider covariance, we expect a reduction in the error. This is because we previously would expect to overestimate the errors given the codependence of variables and the method used to calculate the errors.

I think the best testing is probably to check the maths and to confirm consistency of the unit/system tests.

If desired, the polarizationEfficienciesWildes algorithm can be tested as here:
https://github.com/mantidproject/mantid/pull/37753

If you want to run with realistic data, suggest looking at the system tests for `ReflectometryISISCalculatePolEff`

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
