### PR TITLE
Updated the ORSO helper test file to remove the validation check that requires a database call

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -246,15 +246,11 @@ class MantidORSODatasetTest(unittest.TestCase):
 
     @mock.patch("mantid.utils.reflectometry.orso_helper.logger.error")
     def test_create_mandatory_header_raises_error(self, mock_logger):
-        model_def = ["air | Ni 100 | SiO2 0.5 | 02", "air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
+        model_def = ["air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
         for model in model_def:
             MantidORSODataset(None, None, None, None, None, None, None, model=model, validate=True)
         mock_logger.assert_has_calls(
             [
-                mock.call(
-                    "The provided model description 'air | Ni 100 | SiO2 0.5 | 02' contains an error. "
-                    "Please check that the string follows the correct ORSO format."
-                ),
                 mock.call(
                     "The provided model description 'air | 25 [ Si 7 | Fe 7 ] | Si' contains an error. "
                     "Please check that the string follows the correct ORSO format."


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41367 . <!-- One line per closed issue. -->

The test that contained a typo in $\text{O}_2$ where O was replaced with 0 is removed. This gets past the regex check and requires a database call. 

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
Follow the following instructions to verify that the other two options are ValueErrors raised from this [file](https://github.com/reflectivity/orsopy/blob/main/orsopy/utils/chemical_formula.py).
1) Temporarily update `_create_mandatory_header` to log the type of the error.

<img width="1082" height="601" alt="image" src="https://github.com/user-attachments/assets/b922a208-f392-4325-8ad5-9af8fc174808" />

2) Build Mantid and launch **workbench**.
3) Run the following lines of code to create a workspace
```
ws = CreateSampleWorkspace(XUnit="MomentumTransfer", NumBanks=1, BankPixelWidth=1)
AddSampleLog(Workspace=ws, LogName='rb_proposal', LogText='1234', LogType='Number')
```
4) Open the `ISIS Reflectometry` interface and navigate to the `Save` tab.
5) Select the **ws** workspace.
6) Select **ORSO Ascii (*.ort)**.
7) Enter `air | 25 [ Si 7 | Fe 7 ] | Si` into the model description textbox.
8) Click **Save**.
9) Verify that a `ValueError` is raised.
<img width="394" height="46" alt="Screenshot 2026-05-07 at 5 14 57 pm" src="https://github.com/user-attachments/assets/fa32d04c-9321-4f2c-82e4-f1117f62978c" />

10) Click ok and enter `Si | SiO2 0.5 | wat:er` into the model description textbox.
11) Click **Save**.
12) Verify that a `ValueError` is raised again.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
