### PR TITLE
Check for `InternetError` within `FrameworkManager`

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -368,12 +368,14 @@ void FrameworkManagerImpl::updateInstrumentDefinitions() {
     auto algDownloadInstrument = Mantid::API::AlgorithmManager::Instance().create("DownloadInstrument");
     algDownloadInstrument->setAlgStartupLogging(false);
     algDownloadInstrument->executeAsync();
-  } catch (Kernel::Exception::NotFoundError &) {
+  } catch (Kernel::Exception::NotFoundError const &e) {
     g_log.debug() << "DowndloadInstrument algorithm is not available - cannot "
-                     "update instrument definitions.\n";
-  } catch (Kernel::Exception::InternetError &) {
+                     "update instrument definitions. "
+                  << e.what();
+  } catch (Kernel::Exception::InternetError const &e) {
     g_log.debug() << "Unable to connect to the internet - cannot update "
-                     "instrument definitions.\n";
+                     "instrument definitions. "
+                  << e.what();
   }
 }
 
@@ -383,12 +385,14 @@ void FrameworkManagerImpl::checkIfNewerVersionIsAvailable() {
     auto algCheckVersion = Mantid::API::AlgorithmManager::Instance().create("CheckMantidVersion");
     algCheckVersion->setAlgStartupLogging(false);
     algCheckVersion->executeAsync();
-  } catch (Kernel::Exception::NotFoundError &) {
+  } catch (Kernel::Exception::NotFoundError const &e) {
     g_log.debug() << "CheckMantidVersion algorithm is not available - cannot "
-                     "check if a newer version is available.\n";
-  } catch (Kernel::Exception::InternetError &) {
+                     "check if a newer version is available. "
+                  << e.what();
+  } catch (Kernel::Exception::InternetError const &e) {
     g_log.debug() << "Unable to connect to the internet - cannot check if a "
-                     "newer version of Mantid is available.\n";
+                     "newer version of Mantid is available. "
+                  << e.what();
   }
 }
 

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -371,6 +371,9 @@ void FrameworkManagerImpl::updateInstrumentDefinitions() {
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "DowndloadInstrument algorithm is not available - cannot "
                      "update instrument definitions.\n";
+  } catch (Kernel::Exception::InternetError &) {
+    g_log.debug() << "Unable to connect to the internet - cannot update "
+                     "instrument definitions.\n";
   }
 }
 
@@ -383,6 +386,9 @@ void FrameworkManagerImpl::checkIfNewerVersionIsAvailable() {
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "CheckMantidVersion algorithm is not available - cannot "
                      "check if a newer version is available.\n";
+  } catch (Kernel::Exception::InternetError &) {
+    g_log.debug() << "Unable to connect to the internet - cannot check if a "
+                     "newer version of Mantid is available.\n";
   }
 }
 


### PR DESCRIPTION
### Description of work

When users need an updated instrument file, such as a parameters file, they should be downloaded from the Mantid github repository.  The `DownloadInstrument` algorithm handles this.

If the connection happens to drop sometime after the map of URLs being created, but before the files are downloaded, then it can lead to an uncaught error.  This adds a check to protect against this.

The other method to check the Mantid version also could, technically, have the same issue, so a catch was added there too.

Refs: [EWM 16096](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16096)

### To test:

It is almost impossible to reproduce the error as it appears in the ticket.  You would need to perfectly time an internet outage between L92 and L123 of `DownloadInstrument`.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
