### PR TITLE
Version 2 of PEARLTransfit algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -159,6 +159,7 @@ set(PYTHON_PLUGINS
     algorithms/PeakMatching.py
     algorithms/PearlMCAbsorption.py
     algorithms/PEARLTransfit.py
+    algorithms/PEARLTransfit2.py
     algorithms/PelicanReduction.py
     algorithms/PelicanCrystalProcessing.py
     algorithms/PoldiAutoCorrelation6.py

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -103,7 +103,7 @@ class PEARLTransfit(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty(
             MultipleFileProperty("Files", extensions=[".raw", ".s0x", ".nxs"]),
-            doc="Files or run numbers for calibration runs (numors). Must be detector scans.",
+            doc="File paths or comma separated run numbers for target runs (numors). Must be detector scans.",
         )
 
         self.declareProperty(
@@ -122,10 +122,12 @@ class PEARLTransfit(PythonAlgorithm):
         )
 
         self.declareProperty(
-            ITableWorkspaceProperty(name="FitParametersTable", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional),
+            ITableWorkspaceProperty(
+                name="InputCalibrationParameters", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional
+            ),
             doc="Table with fit parameters for 'PEARLTransVoigt' function: 'Position', 'LorentzianFWHM', 'GaussianFWHM', 'Amplitude', 'Bg0'"
             "'Bg1', 'Bg2'. The calculated temperature is added in non-calibration runs. This property is mandatory when calibration"
-            " is set to False. If a 'FitParametersTable' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will "
+            " is set to False. If a 'InputCalibrationParameters' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will "
             " be used for background estimation",
         )
 
@@ -159,12 +161,12 @@ class PEARLTransfit(PythonAlgorithm):
     def validateInputs(self):
         issues = dict()
         is_calib = self.getProperty("Calibration").value
-        fit_table = self.getProperty("FitParametersTable").value
+        fit_table = self.getProperty("InputCalibrationParameters").value
         if not (is_calib or fit_table):
-            issues["FitParametersTable"] = "FitParametersTable is missing."
+            issues["InputCalibrationParameters"] = "InputCalibrationParameters is missing."
         elif fit_table:
             if "Name" not in fit_table.getColumnNames():
-                issues["FitParametersTable"] = "'Name' column for parameter names is missing in FitParametersTable."
+                issues["InputCalibrationParameters"] = "'Name' column for parameter names is missing in InputCalibrationParameters."
             else:
                 parameters = fit_table.column("Name")
                 missing = []
@@ -172,9 +174,9 @@ class PEARLTransfit(PythonAlgorithm):
                 fit_params = FIT_TABLE_PARAMS if not is_calib else FIT_TABLE_PARAMS[-3:]
                 for param in fit_params:
                     if param not in parameters:
-                        missing.append(f"Parameter {param} missing from FitParametersTable.")
+                        missing.append(f"Parameter {param} missing from InputCalibrationParameters.")
                 if missing:
-                    issues["FitParametersTable"] = "\n".join(missing)
+                    issues["InputCalibrationParameters"] = "\n".join(missing)
         return issues
 
     def setup_property_rules(self):
@@ -194,7 +196,7 @@ class PEARLTransfit(PythonAlgorithm):
         self.is_calib = self.getProperty("Calibration").value
 
         ref_temp = self.getProperty("ReferenceTemp").value
-        fit_table = self.getProperty("FitParametersTable").value
+        fit_table = self.getProperty("InputCalibrationParameters").value
         estimate_background = self.getProperty("EstimateBackground").value or not fit_table
 
         ws = self._load_and_average_monitors_from_files(files)

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -93,7 +93,7 @@ class PEARLTransfit(PythonAlgorithm):
 
     def summary(self):
         return (
-            "Reads high-energy neutron resonances from the downstream monitor data on the PEARL instrument,"
+            " Version 2 of PEARLTransfit. Reads high-energy neutron resonances from the downstream monitor data on the PEARL instrument,"
             " then fits a Voigt function to them to determine the sample temperature. A calibration must be run for"
             " each sample pressure. Can be used on a single file, or multiple files, in which case workspaces"
             " are summed and the average taken."

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -4,87 +4,83 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-# -----------------------------------------------------------------------
-# Transfit v2 - translated from Fortran77 to Python/Mantid
-# Original Author: Christopher J Ridley
-# Last updated: 2nd October 2020
-#
-# Program fits a Voigt function to PEARL transmission data, using the doppler broadening
-# of the gaussian component to determine the sample temperature
-#
-#
-# References:
-# 'Temperature measurement in a Paris-Edinburgh cell by neutron resonance spectroscopy' - Journal Of Applied Physics 98,
-# 064905 (2005)
-# 'Remote determination of sample temperature by neutron resonance spectroscopy' - Nuclear Instruments and Methods in
-# Physics Research A 547 (2005) 601-615
-# -----------------------------------------------------------------------
-from mantid.kernel import Direction, StringListValidator, EnabledWhenProperty, PropertyCriterion, LogicOperator
-from mantid.api import PythonAlgorithm, MultipleFileProperty, AlgorithmFactory, AnalysisDataService as ADS
+"""
+Transfit v2 - translated from Fortran77 to Python/Mantid
+Original Author: Christopher J Ridley
+Last updated: 2nd October 2020
+
+Program fits a Voigt function to PEARL transmission data, using the doppler broadening
+of the gaussian component to determine the sample temperature
+
+
+- References:
+    - 'Temperature measurement in a Paris-Edinburgh cell by neutron resonance spectroscopy' - Journal Of Applied Physics 98,
+       064905 (2005).'
+    - 'Remote determination of sample temperature by neutron resonance spectroscopy' - Nuclear Instruments and Methods in
+       Physics Research A 547 (2005) 601-615.'
+"""
+
+from mantid.kernel import Direction, StringListValidator, EnabledWhenProperty, PropertyCriterion
+from mantid.api import (
+    PythonAlgorithm,
+    MultipleFileProperty,
+    AlgorithmFactory,
+    ITableWorkspaceProperty,
+    ITableWorkspace,
+    WorkspaceFactory,
+    PropertyMode,
+    MatrixWorkspaceProperty,
+)
 from scipy import constants
 import numpy as np
 from mantid.fitfunctions import FunctionWrapper
-from typing import Sequence
+from typing import Sequence, TYPE_CHECKING, Union
+from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from mantid.api import MatrixWorkspace, IFunction1D
+
+"""
+ Resonance constants broadly consistent with those reported from
+ 'Neutron cross sections Vol 1, Resonance Parameters'
+ S.F. Mughabghab and D.I. Garber
+ June 1973, BNL report 325
+ Mass in atomic units, En in eV, temperatures in K, gamma factors in eV
+"""
+RES_PARAMS = {
+    #       (mass,  En,  TD,  TwogG,  Gg,  startE,  endE)
+    "Hf01": (177.0, 1.098, 252.0, 0.00192, 0.0662, 0.6, 1.7),
+    "Hf02": (177.0, 2.388, 252.0, 0.009, 0.0608, 2.0, 2.7),
+    "Ta10": (181.0, 10.44, 240.0, 0.00335, 0.0069, 9.6, 11.4),
+    "Irp6": (191.0, 0.6528, 420.0, 0.000547, 0.072, 0.1, 0.9),
+    "Iro5": (191.0, 5.36, 420.0, 0.006, 0.082, 4.9, 6.3),
+    "Iro9": (191.0, 9.3, 420.0, 0.0031, 0.082, 8.7, 9.85),
+}
+TABLE_COLUMN_NAME = ["Name", "Value", "Error"]
+TABLE_COLUMN_TYPES = ["str", *["float"] * 2]
+FIT_TABLE_PARAMS = ["Position", "LorentzianFWHM", "GaussianFWHM", "Amplitude", "Bg0", "Bg1", "Bg2"]
+eV_TO_meV: float = 1000.0
+
+
+@dataclass(frozen=True)
+class FoilParameters:
+    Foil: str = "Hf01"
+    Mass: float = 177.0
+    En: float = 1.098
+    TD: float = 252.0
+    TwogG: float = 0.00192
+    Gg: float = 0.0662
+    StartE: float = 2.0
+    EndE: float = 2.7
 
 
 class PEARLTransfit(PythonAlgorithm):
-    # Resonance constants broadly consistent with those reported from
-    # 'Neutron cross sections Vol 1, Resonance Parameters'
-    # S.F. Mughabghab and D.I. Garber
-    # June 1973, BNL report 325
-    # Mass in atomic units, En in eV, temperatures in K, gamma factors in eV
-    res_params_dict = {
-        # Hf01
-        "Hf01_Mass": 177.0,
-        "Hf01_En": 1.098,
-        "Hf01_TD": 252.0,
-        "Hf01_TwogG": 0.00192,
-        "Hf01_Gg": 0.0662,
-        "Hf01_startE": 0.6,
-        "Hf01_endE": 1.7,
-        # Hf02
-        "Hf02_Mass": 177.0,
-        "Hf02_En": 2.388,
-        "Hf02_TD": 252.0,
-        "Hf02_TwogG": 0.009,
-        "Hf02_Gg": 0.0608,
-        "Hf02_startE": 2.0,
-        "Hf02_endE": 2.7,
-        # Ta10
-        "Ta10_Mass": 181.0,
-        "Ta10_En": 10.44,
-        "Ta10_TD": 240.0,
-        "Ta10_TwogG": 0.00335,
-        "Ta10_Gg": 0.0069,
-        "Ta10_startE": 9.6,
-        "Ta10_endE": 11.4,
-        # Irp6
-        "Irp6_Mass": 191.0,
-        "Irp6_En": 0.6528,
-        "Irp6_TD": 420.0,
-        "Irp6_TwogG": 0.000547,
-        "Irp6_Gg": 0.072,
-        "Irp6_startE": 0.1,
-        "Irp6_endE": 0.9,
-        # Iro5
-        "Iro5_Mass": 191.0,
-        "Iro5_En": 5.36,
-        "Iro5_TD": 420.0,
-        "Iro5_TwogG": 0.006,
-        "Iro5_Gg": 0.082,
-        "Iro5_startE": 4.9,
-        "Iro5_endE": 6.3,
-        # Iro9
-        "Iro9_Mass": 191.0,
-        "Iro9_En": 9.3,
-        "Iro9_TD": 420.0,
-        "Iro9_TwogG": 0.0031,
-        "Iro9_Gg": 0.082,
-        "Iro9_startE": 8.7,
-        "Iro9_endE": 9.85,
-    }
-    DEFAULT_PEAK_AMP = 1.6
-    eV_TO_meV = 1000.0
+    x_range: tuple[float, float] = (100, 19990)
+    trans_monitor_index: int = 3
+    res_params: FoilParameters = None
+    default_peak_amplitude: float = 1.6
+    is_calib: bool = True
+    gauss_fwhm_ref_temp: float = 0.0
 
     def version(self):
         return 2
@@ -106,8 +102,9 @@ class PEARLTransfit(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty(
             MultipleFileProperty("Files", extensions=[".raw", ".s0x", ".nxs"]),
-            doc="Files of calibration runs (numors). Must be detector scans.",
+            doc="Files of calibration runs (numors). Must be detector scans",
         )
+
         self.declareProperty(
             name="FoilType",
             defaultValue="Hf01",
@@ -115,20 +112,22 @@ class PEARLTransfit(PythonAlgorithm):
             direction=Direction.Input,
             doc="Type of foil included with the sample",
         )
-        self.declareProperty(name="Ediv", defaultValue=0.0025, direction=Direction.Input, doc="Energy bin-width in eV")
-        self.declareProperty(name="ReferenceTemp", defaultValue="290", direction=Direction.Input, doc="Enter reference temperature in K")
+
         self.declareProperty(
             name="Calibration",
             defaultValue=False,
             direction=Direction.Input,
             doc="Calibration flag, default is False in which case temperature measured",
         )
+
         self.declareProperty(
-            name="Debug",
-            defaultValue=False,
-            direction=Direction.Input,
-            doc="True/False - provides more verbose output of procedure for debugging purposes",
+            ITableWorkspaceProperty(name="FitParametersTable", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional),
+            doc="Table with fit parameters for 'PEARLTransVoigt' function: 'Position', 'LorentzianFWHM', 'GaussianFWHM', 'Amplitude', 'Bg0'"
+            "'Bg1', 'Bg2'. Mandatory when calibration is set to False. "
+            "If a 'FitParametersTable' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will be used for background estimation",
         )
+
+        self.declareProperty(name="ReferenceTemp", defaultValue="290", direction=Direction.Input, doc="Enter reference temperature in K")
 
         self.declareProperty(
             name="EstimateBackground",
@@ -137,165 +136,271 @@ class PEARLTransfit(PythonAlgorithm):
             doc="Estimate background parameters from data.",
         )
         self.declareProperty(
-            name="Bg0guessFraction",
-            defaultValue=0.84,
+            name="CreateDebugTable",
+            defaultValue=False,
             direction=Direction.Input,
-            doc="Starting guess for constant term of polynomial background is calculated as Bg0guessScaleFactor*y0 where"
-            "y0 is the intensity in the first bin of the data to be fitted.",
+            doc="Create an output table withdebug parameters in non calibration runs",
         )
+
         self.declareProperty(
-            name="Bg1guess",
-            defaultValue=0.0173252,
+            name="Output",
+            defaultValue="",
             direction=Direction.Input,
-            doc="Starting guess for linear term of polynomial background.",
+            doc="Output basename on ADS. If empty, `S_fit` will be the basenamefor calibration runs and `T_fit` for non-calibration",
         )
-        self.declareProperty(
-            name="Bg2guess",
-            defaultValue=0.0000004,
-            direction=Direction.Input,
-            doc="Starting guess for quadratic term of polynomial background.",
-        )
-        self.declareProperty(
-            name="RebinInEnergy",
-            defaultValue=True,
-            direction=Direction.Input,
-            doc="Estimate background parameters from data.",
-        )
-        # disable properties
-        is_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsNotDefault)
-        is_not_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsDefault)
-        self.setPropertySettings("Debug", is_not_cal)
-        self.setPropertySettings("EstimateBackground", is_cal)
-        is_bg_estimated = EnabledWhenProperty("EstimateBackground", PropertyCriterion.IsNotDefault)
-        enable_user_bg = EnabledWhenProperty(is_bg_estimated, is_cal, LogicOperator.And)
-        for prop in ["Bg0guessFraction", "Bg1guess", "Bg2guess"]:
-            self.setPropertySettings(prop, enable_user_bg)
-        enable_Ediv = EnabledWhenProperty("RebinInEnergy", PropertyCriterion.IsDefault)
-        self.setPropertySettings("Ediv", enable_Ediv)
+
+        self.setup_property_rules()
 
     def validateInputs(self):
         issues = dict()
         is_calib = self.getProperty("Calibration").value
-        if not is_calib and not ADS.doesExist("S_fit_Parameters"):
-            issues["Calibration"] = "No S_fit_Parameters workspace exists, please fit a calibration run."
+        fit_table = self.getProperty("FitParametersTable").value
+        if not (is_calib or fit_table):
+            issues["FitParametersTable"] = "FitParametersTable is missing."
+        elif fit_table:
+            if "Name" not in fit_table.getColumnNames():
+                issues["FitParametersTable"] = "'Name' column for parameter names is missing in FitParametersTable."
+            else:
+                parameters = fit_table.column("Name")
+                missing = []
+                # we only need bg info from table if it is a calibration run
+                fit_params = FIT_TABLE_PARAMS if not is_calib else FIT_TABLE_PARAMS[-3:]
+                for param in fit_params:
+                    if param not in parameters:
+                        missing.append(f"Parameter {param} missing from FitParametersTable.")
+                if missing:
+                    issues["FitParametersTable"] = "\n".join(missing)
         return issues
 
+    def setup_property_rules(self):
+        is_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsNotDefault)
+        is_not_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsDefault)
+
+        self.setPropertySettings("EstimateBackground", is_cal)
+        self.setPropertySettings("CreateDebugTable", is_not_cal)
+
     def PyExec(self):
-        # ----------------------------------------------------------
-        # Imports resonance parameters from ResParam dictionary depending on the selected foil type.
-        # ----------------------------------------------------------
         files = self.get_file_list(self.getProperty("Files").value)
+
+        # Imports resonance parameters from ResParam dictionary depending on the selected foil type.
         foil_type = self.getProperty("FoilType").value
-        is_calib = self.getProperty("Calibration").value
+        self.res_params = FoilParameters(foil_type, *RES_PARAMS[foil_type])
+        self.is_calib = self.getProperty("Calibration").value
+
         ref_temp = float(self.getProperty("ReferenceTemp").value)
-        is_debug = self.getProperty("Debug").value
-        estimate_background = self.getProperty("EstimateBackground").value
+        fit_table = self.getProperty("FitParametersTable").value
+        estimate_background = self.getProperty("EstimateBackground").value or not fit_table
 
-        ws = self.load_and_average_moinitor_from_files(files, foil_type)
-        if self.getProperty("RebinInEnergy").value:
-            # Rebin with constant width has similar effect to normalising raw data by bin-width
-            # so hack here is to pre-scale intensities by inverse (i.e. multiply by bin-width)
-            # this means that Rebin is effectively performing a mean rather than sum
-            ws.setDistribution(True)
-            self.exec_child_alg("ConvertFromDistribution", Workspace=ws)
-            bin_width = self.eV_TO_meV * float(self.getProperty("Ediv").value)  # meV
-            ws = self.exec_child_alg("Rebin", InputWorkspace=ws, Params=f"{bin_width}", FullBinsOnly=True)
-
+        ws = self._load_and_average_monitors_from_files(files)
         # Define the gaussian width at the reference temperature
-        energy = self.res_params_dict[foil_type + "_En"]
-        mass = self.res_params_dict[foil_type + "_Mass"]
-        gauss_fwhm_ref_temp = self.eV_TO_meV * np.sqrt(4 * energy * constants.k * ref_temp * mass / (constants.e * (1 + mass) ** 2))
+        self.gauss_fwhm_ref_temp = eV_TO_meV * np.sqrt(
+            4 * self.res_params.En * constants.k * ref_temp * self.res_params.Mass / (constants.e * (1 + self.res_params.Mass) ** 2)
+        )
 
+        func = self._prepare_fit_func(ws, fit_table, estimate_background)
+        fit_res = self._fit(ws, func)
+        debug_table = self._create_debug_info(fit_res, ws, func["GaussianFWHM"]) if not self.is_calib else None
+
+        self._prepare_outputs(fit_res["OutputWorkspace"], fit_res["OutputTable"], debug_table)
+
+    def _prepare_fit_func(self, ws: "MatrixWorkspace", fit_table: ITableWorkspace, estimate_background: bool) -> "IFunction1D":
         # make initial function with constraints
         func = FunctionWrapper("PEARLTransVoigt")
         func.constrain("LorentzianFWHM>1")
-        func.constrain(f"GaussianFWHM>{gauss_fwhm_ref_temp}")
+        func.constrain(f"GaussianFWHM>{self.gauss_fwhm_ref_temp}")
 
         # set initial parameters
-        if is_calib:
+        if self.is_calib:
             # use tabulated values (note energies are in eV)
-            out_ws_name = "S_fit"
-            func["Amplitude"] = self.DEFAULT_PEAK_AMP
-            two_gGamma = self.res_params_dict[foil_type + "_TwogG"]
-            gamma_g = self.res_params_dict[foil_type + "_Gg"]
-            func["LorentzianFWHM"] = self.eV_TO_meV * (0.5 * two_gGamma + gamma_g)
-            func["GaussianFWHM"] = gauss_fwhm_ref_temp
-            func["Position"] = energy * self.eV_TO_meV  # take peak position starting guess from tabulated value
+            func["Amplitude"] = self.default_peak_amplitude
+            func["LorentzianFWHM"] = eV_TO_meV * (0.5 * self.res_params.TwogG + self.res_params.Gg)
+            func["GaussianFWHM"] = self.gauss_fwhm_ref_temp
+            func["Position"] = eV_TO_meV * self.res_params.En  # take peak position starting guess from tabulated value
             bg_pars = np.zeros(3)
             if estimate_background:
                 bg_pars[:2] = self.estimate_linear_background(ws.readX(0), ws.readY(0))
             else:
-                bg_pars[0] = self.getProperty("Bg0guessFraction").value * ws.readY(0)[0]
-                bg_pars[1] = self.getProperty("Bg1guess").value
-                bg_pars[2] = self.getProperty("Bg2guess").value
-            for ipar, par in enumerate(bg_pars):
-                func[f"Bg{ipar}"] = par
+                param_names = fit_table.column(0)
+                bg_pars[0] = fit_table.row(param_names.index("Bg0"))["Value"]
+                bg_pars[1] = fit_table.row(param_names.index("Bg1"))["Value"]
+                bg_pars[2] = fit_table.row(param_names.index("Bg2"))["Value"]
+            for i_par, par in enumerate(bg_pars):
+                func[f"Bg{i_par}"] = par
         else:
-            out_ws_name = "T_fit"
             # retrieve parameters from previous calibration
-            calib_param_table = ADS.retrieve("S_fit_Parameters")
-            for ipar in range(func.nParams()):
-                row = calib_param_table.row(ipar)
+            for i_par in range(func.nParams()):
+                row = fit_table.row(i_par)
                 func[row["Name"]] = row["Value"]
 
+        return func
+
+    def _prepare_outputs(self, ws: "MatrixWorkspace", table: ITableWorkspace, debug_table: Union[ITableWorkspace, None]):
+        if self.getProperty("Output").isDefault:
+            self.setPropertyValue("Output", "S_fit" if self.is_calib else "T_fit")
+
+        out_name = self.getPropertyValue("Output")
+        prop_names = ["OutputWorkspace", "OutputFitParameters", "OutputDebugTable"]
+        prop_callers = [MatrixWorkspaceProperty, ITableWorkspaceProperty, ITableWorkspaceProperty]
+        docs = ["Fitted Calibration Run.", "Fitted Calibration Parameters.", "Debug Parameters table."]
+        suffixes = ["_Workspace", "_Parameters", "_DebugParameters"]
+        data_items = [ws, table, debug_table]
+
+        p_len = len(prop_names)
+        props_len = p_len if debug_table else p_len - 1
+        for idx in range(props_len):
+            self.declareProperty(prop_callers[idx](name=prop_names[idx], defaultValue="", direction=Direction.Output), doc=docs[idx])
+            self.setPropertyValue(prop_names[idx], f"{out_name}{suffixes[idx]}")
+            self.setProperty(prop_names[idx], data_items[idx])
+
+    def _fit(self, ws: "MatrixWorkspace", func: "IFunction1D"):
         fit_kwargs = {
             "InputWorkspace": ws,
             "MaxIterations": 200,
             "CreateOutput": True,
-            "Output": out_ws_name,
+            "Output": "fit_out",
             "IgnoreInvalidData": True,
             "StepSizeMethod": "Sqrt epsilon",
         }
-        if is_calib:
+
+        if self.is_calib:
             # perform initial fit keeping Gaussian width constant
             func.fix("GaussianFWHM")
-            fit_res = self.exec_fit(Function=func.fun, **fit_kwargs)
+            fit_res = self._exec_fit(Function=func.fun, **fit_kwargs)
             func = fit_res["Function"]
             func.untie("GaussianFWHM")
         else:
             func.fix("LorentzianFWHM")
-        fit_res = self.exec_fit(Function=func.fun, **fit_kwargs)
+
+        # Execute fit
+        fit_res = self._exec_fit(Function=func.fun, **fit_kwargs)
 
         if fit_res["OutputStatus"] != "success":
             self.log().warning(f"Fit failed with status: {fit_res['OutputStatus']}")
+        return fit_res
 
-        if not is_calib:
-            # calculate effective temperature using fitted widths
-            # get instrument contribution to Gausssian width in calibration
-            if func["GaussianFWHM"] > gauss_fwhm_ref_temp:
-                # get fwhm d width of resolution (add in quadrature for convolution of Gaussians)
-                gauss_fwhm_inst = np.sqrt(func["GaussianFWHM"] ** 2 - gauss_fwhm_ref_temp**2)
-            else:
-                gauss_fwhm_inst = 0  # shouldn't be the case due to calibration fit constraint
-            final_func = fit_res["Function"]
-            fwhm = np.sqrt(final_func["GaussianFWHM"] ** 2 - gauss_fwhm_inst**2)
-            fwhm_err = final_func.fun.getError("GaussianFWHM")
-            energy = final_func["Position"]
-            energy_err = final_func.fun.getError("Position")
-            # get element from correlation matrix (called normalised covar in mantid)
-            irow = final_func.fun.getParameterIndex("Position")
-            corr = fit_res["OutputNormalisedCovarianceMatrix"].row(irow)["GaussianFWHM"]
-            temp_eff, temp_eff_err = self.calc_effective_temp_and_error(fwhm, fwhm_err, energy, energy_err, corr, mass)
-            # calculate sample temp using ideal gas formulation
-            temp_debye = self.res_params_dict[foil_type + "_TD"]  # Debye temp.
-            temp_sample, temp_sample_err = self.calc_sample_temp_and_error_from_effective(temp_eff, temp_eff_err, temp_debye)
+    def _exec_child_alg(self, alg_name: str, **kwargs):
+        alg = self.createChildAlgorithm(alg_name, enableLogging=False)
+        alg.setAlwaysStoreInADS(False)
+        alg.initialize()
+        alg.setProperties(kwargs)
+        alg.execute()
+        out_props = tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
+        return out_props[0] if len(out_props) == 1 else out_props
 
-            # print info
-            self.log().information(f"Sample temperature is: {temp_sample:.2f} +/- {temp_sample_err:.2f} K")
-            if is_debug:
-                self.log().information("-----------------------------")
-                self.log().information(f"The Debye temperature is {temp_debye:.2f} K")
-                self.log().information(f"The effective temperature is: {temp_eff:.2f} +/- {temp_eff_err:.2f} K")
-                self.log().information(f"Fitted in range {ws.readX(0)[0]:.2f} < Energy (meV) < {ws.readX(0)[-1]:.2f}")
-                self.log().information(f"Gaussian width at this reference temperature is: {gauss_fwhm_ref_temp:.2f} meV")
-                self.log().information(f"Lorentzian FWHM is fixed: {final_func['LorentzianFWHM']:.2f} meV")
-                self.log().information(f"Gaussian FWHM is fitted as: {final_func['GaussianFWHM']:.2f} meV")
-                self.log().information(f"Instrumental contribution is: {gauss_fwhm_inst:.2f} meV")
-                self.log().information(f"Temperature contribution is: {fwhm:.2f} meV")
-                self.log().information("-----------------------------")
+    def _exec_fit(self, **kwargs):
+        alg = self.createChildAlgorithm("Fit", enableLogging=False)
+        alg.setAlwaysStoreInADS(False)
+        alg.initialize()
+        alg.setProperties(kwargs)
+        alg.execute()
+        return {
+            "Function": FunctionWrapper(alg.getProperty("Function").value),
+            "OutputWorkspace": alg.getProperty("OutputWorkspace").value,
+            "OutputTable": alg.getProperty("OutputParameters").value,
+            "OutputStatus": alg.getProperty("OutputStatus").value,
+            "OutputNormalisedCovarianceMatrix": alg.getProperty("OutputNormalisedCovarianceMatrix").value,
+        }
 
-        # clean up ADS
-        self.exec_child_alg("DeleteWorkspace", Workspace=fit_res["OutputNormalisedCovarianceMatrix"])
+    def _load_monitor_from_single_file(self, filepath: str):
+        """
+        Imports raw monitor data; extracts monitor spectrum and crops it.  Normalise by current and convert units to energy.
+        :param filepath: file with raw data
+        :return: workspace
+        """
+        ws, *_ = self._exec_child_alg("Load", Filename=filepath)
+        ws = self._exec_child_alg("ExtractSingleSpectrum", InputWorkspace=ws, WorkspaceIndex=self.trans_monitor_index)
+        ws = self._exec_child_alg("CropWorkspace", InputWorkspace=ws, XMin=self.x_range[0], XMax=self.x_range[1])
+        ws = self._exec_child_alg("NormaliseByCurrent", InputWorkspace=ws)
+        ws = self._exec_child_alg("ConvertUnits", InputWorkspace=ws, Target="Energy")
+        return ws
+
+    def _load_and_average_monitors_from_files(self, filepaths: Sequence[str]):
+        ws = self._load_monitor_from_single_file(filepaths[0])
+        for filepath in filepaths[1:]:
+            ws = ws + self._load_monitor_from_single_file(filepath)
+        if len(filepaths) > 1:
+            ws = ws / len(filepaths)
+        # crop
+        x_start = eV_TO_meV * self.res_params.StartE
+        x_end = eV_TO_meV * self.res_params.EndE
+        ws = self._exec_child_alg("CropWorkspaceRagged", InputWorkspace=ws, XMin=x_start, XMax=x_end)
+        ws.setDistribution(True)
+        return ws
+
+    def _create_debug_info(self, fit_res: dict[str, any], ws: "MatrixWorkspace", gauss_fwhm: float):
+        # calculate effective temperature using fitted widths
+        # get instrument contribution to Gausssian width in calibration
+        if gauss_fwhm > self.gauss_fwhm_ref_temp:
+            # get fwhm d width of resolution (add in quadrature for convolution of Gaussians)
+            gauss_fwhm_inst = np.sqrt(gauss_fwhm**2 - self.gauss_fwhm_ref_temp**2)
+        else:
+            gauss_fwhm_inst = 0  # shouldn't be the case due to calibration fit constraint
+        final_func = fit_res["Function"]
+        fwhm = np.sqrt(final_func["GaussianFWHM"] ** 2 - gauss_fwhm_inst**2)
+        fwhm_err = final_func.fun.getError("GaussianFWHM")
+        energy = final_func["Position"]
+        energy_err = final_func.fun.getError("Position")
+        # get element from correlation matrix (called normalised covar in mantid)
+        irow = final_func.fun.getParameterIndex("Position")
+        corr = fit_res["OutputNormalisedCovarianceMatrix"].row(irow)["GaussianFWHM"]
+        temp_eff, temp_eff_err = self._calc_effective_temp_and_error(fwhm, fwhm_err, energy, energy_err, corr, self.res_params.Mass)
+        # calculate sample temp using ideal gas formulation
+        temp_debye = self.res_params.TD  # Debye temp.
+        temp_sample, temp_sample_err = self._calc_sample_temp_and_error_from_effective(temp_eff, temp_eff_err, temp_debye)
+        self.log().information(f"Sample temperature is: {temp_sample:.2f} +/- {temp_sample_err:.2f} K")
+
+        debug_table = None
+        if self.getProperty("CreateDebugTable").value:
+            # Generate Debug Table
+            debug_params = {
+                "Debye Temp. (K)": temp_debye,
+                "Eff. Temp. (K)}": (temp_eff, temp_eff_err),
+                "Fit. Min. (meV)": ws.readX(0)[0],
+                "Fit. Max. (meV)": ws.readX(0)[-1],
+                "Gaussian Width at Reference Temp (meV)": self.gauss_fwhm_ref_temp,
+                "Instrumental contribution (meV)": gauss_fwhm_inst,
+                "Temperature Contribution (meV)": fwhm,
+                "Sample Temperature (K)": (temp_sample, temp_sample_err),
+            }
+            debug_table = self.generate_table(debug_params)
+        return debug_table
+
+    def _calc_effective_temp_and_error(
+        self, fwhm: float, fwhm_err: float, energy: float, energy_err: float, correlation: float, mass: float
+    ) -> tuple[float, float]:
+        const = ((1 / eV_TO_meV) * constants.e * ((1 + mass) ** 2)) / (4 * constants.k * mass)
+        temp = const * (fwhm**2) / energy
+        # propagate errors
+        dtemp_by_dfwhm = 2 * fwhm / energy
+        dtemp_by_denergy = -((fwhm / energy) ** 2)
+        # calc. term due to covariance
+        # corr = 100*cij/sqrt(cii*cjj); cii = error_i^2
+        covar = (correlation * fwhm_err * energy_err) / 100
+        covar_term = 2 * dtemp_by_dfwhm * dtemp_by_denergy * covar
+        temp_err = const * np.sqrt((dtemp_by_dfwhm * fwhm_err) ** 2 + (dtemp_by_denergy * energy_err) ** 2 + covar_term)
+        return temp, temp_err
+
+    def _calc_sample_temp_and_error_from_effective(self, temp_eff: float, temp_eff_err: float, temp_debye: float) -> tuple[float, float]:
+        if 8 * temp_eff < 3 * temp_debye:
+            self.log().warning("The effective temperature is currently too far below the Debye temperature to give an accurate measure.")
+            return temp_eff, temp_eff_err
+        # use free gas formulation
+        log_term = np.log((8 * temp_eff + 3 * temp_debye) / (8 * temp_eff - 3 * temp_debye))
+        temp_sample = 3 * temp_debye / (4 * log_term)
+        # calculate error using derivative
+        temp_sample_err = abs((36 * temp_debye**2) / ((9 * temp_debye**2 - 64 * temp_eff**2) * log_term**2)) * temp_eff_err
+        return temp_sample, temp_sample_err
+
+    @staticmethod
+    def estimate_linear_background(x: np.ndarray, y: np.ndarray, nbg: int = 3) -> tuple[float, float]:
+        if len(y) < 2 * nbg:
+            # not expected as trying to fit a function with 7 parameters
+            return 2 * (0.0,)
+        dy = y[:nbg].mean() - y[-nbg:].mean()
+        dx = x[:nbg].mean() - x[-nbg:].mean()
+        gradient = dy / dx
+        slope = y[:nbg].mean() - gradient * x[:nbg].mean()
+        return gradient, slope
 
     @staticmethod
     def get_file_list(input_files):
@@ -309,86 +414,18 @@ class PEARLTransfit(PythonAlgorithm):
                 file_list.extend(files)
         return file_list
 
-    def exec_child_alg(self, alg_name: str, **kwargs):
-        alg = self.createChildAlgorithm(alg_name, enableLogging=False)
-        alg.setAlwaysStoreInADS(False)
-        alg.initialize()
-        alg.setProperties(kwargs)
-        alg.execute()
-        out_props = tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
-        return out_props[0] if len(out_props) == 1 else out_props
-
-    def exec_fit(self, **kwargs):
-        alg = self.createChildAlgorithm("Fit", enableLogging=False)
-        alg.setAlwaysStoreInADS(True)
-        alg.initialize()
-        alg.setProperties(kwargs)
-        alg.execute()
-        return {
-            "Function": FunctionWrapper(alg.getProperty("Function").value),
-            "OutputStatus": alg.getProperty("OutputStatus").value,
-            "OutputNormalisedCovarianceMatrix": ADS.retrieve(alg.getPropertyValue("OutputNormalisedCovarianceMatrix")),
-        }
-
-    def calc_effective_temp_and_error(
-        self, fwhm: float, fwhm_err: float, energy: float, energy_err: float, correlation: float, mass: float
-    ) -> tuple[float, float]:
-        const = ((1 / self.eV_TO_meV) * constants.e * ((1 + mass) ** 2)) / (4 * constants.k * mass)
-        temp = const * (fwhm**2) / energy
-        # propagate errors
-        dtemp_by_dfwhm = 2 * fwhm / energy
-        dtemp_by_denergy = -((fwhm / energy) ** 2)
-        # calc. term due to covariance
-        # corr = 100*cij/sqrt(cii*cjj); cii = error_i^2
-        covar = (correlation * fwhm_err * energy_err) / 100
-        covar_term = 2 * dtemp_by_dfwhm * dtemp_by_denergy * covar
-        temp_err = const * np.sqrt((dtemp_by_dfwhm * fwhm_err) ** 2 + (dtemp_by_denergy * energy_err) ** 2 + covar_term)
-        return temp, temp_err
-
-    def calc_sample_temp_and_error_from_effective(self, temp_eff: float, temp_eff_err: float, temp_debye: float) -> tuple[float, float]:
-        if 8 * temp_eff < 3 * temp_debye:
-            self.log().warning("The effective temperature is currently too far below the Debye temperature to give an accurate measure.")
-            return temp_eff, temp_eff_err
-        # use free gas formulation
-        log_term = np.log((8 * temp_eff + 3 * temp_debye) / (8 * temp_eff - 3 * temp_debye))
-        temp_sample = 3 * temp_debye / (4 * log_term)
-        # calculate error using derivative
-        temp_sample_err = abs((36 * temp_debye**2) / ((9 * temp_debye**2 - 64 * temp_eff**2) * log_term**2)) * temp_eff_err
-        return temp_sample, temp_sample_err
-
-    # ----------------------------------------------------------
-    # Define function for importing raw monitor data, summing, normalising, converting units, and cropping
-    # ----------------------------------------------------------
-    def _load_monitor_from_single_file(self, filepath: str):
-        ws, *_ = self.exec_child_alg("Load", Filename=filepath)
-        ws = self.exec_child_alg("ExtractSingleSpectrum", InputWorkspace=ws, WorkspaceIndex=3)
-        ws = self.exec_child_alg("CropWorkspace", InputWorkspace=ws, XMin=100, XMax=19990)
-        ws = self.exec_child_alg("NormaliseByCurrent", InputWorkspace=ws)
-        ws = self.exec_child_alg("ConvertUnits", InputWorkspace=ws, Target="Energy")
-        return ws
-
-    def load_and_average_moinitor_from_files(self, filepaths: Sequence[str], foil_type: str):
-        ws = self._load_monitor_from_single_file(filepaths[0])
-        for filepath in filepaths[1:]:
-            ws = ws + self._load_monitor_from_single_file(filepath)
-        if len(filepaths) > 1:
-            ws = ws / len(filepaths)
-        # crop
-        xstart = self.eV_TO_meV * self.res_params_dict[foil_type + "_startE"]
-        xend = self.eV_TO_meV * self.res_params_dict[foil_type + "_endE"]
-        ws = self.exec_child_alg("CropWorkspaceRagged", InputWorkspace=ws, XMin=xstart, XMax=xend)
-        return ws
-
     @staticmethod
-    def estimate_linear_background(x: np.ndarray, y: np.ndarray, nbg: int = 3) -> tuple[float, float]:
-        if len(y) < 2 * nbg:
-            # not expected as trying to fit a function with 7 parameters
-            return 2 * [0.0]
-        dy = y[:nbg].mean() - y[-nbg:].mean()
-        dx = x[:nbg].mean() - x[-nbg:].mean()
-        gradient = dy / dx
-        slope = y[:nbg].mean() - gradient * x[:nbg].mean()
-        return gradient, slope
+    def generate_table(params_dict: dict[str, any]) -> ITableWorkspace:
+        table = WorkspaceFactory.Instance().createTable()
+        for n, t in zip(TABLE_COLUMN_NAME, TABLE_COLUMN_TYPES):
+            table.addColumn(name=n, type=t)
+        for k, v in params_dict.items():
+            if isinstance(v, tuple):
+                d = {"Name": k, "Value": v[0], "Error": v[1]}
+            else:
+                d = {"Name": k, "Value": v, "Error": 0}
+            table.addRow(d)
+        return table
 
 
 AlgorithmFactory.subscribe(PEARLTransfit)

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -127,7 +127,7 @@ class PEARLTransfit(PythonAlgorithm):
             "If a 'FitParametersTable' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will be used for background estimation",
         )
 
-        self.declareProperty(name="ReferenceTemp", defaultValue="290", direction=Direction.Input, doc="Enter reference temperature in K")
+        self.declareProperty(name="ReferenceTemp", defaultValue=290.0, direction=Direction.Input, doc="Enter reference temperature in K")
 
         self.declareProperty(
             name="EstimateBackground",
@@ -139,7 +139,7 @@ class PEARLTransfit(PythonAlgorithm):
             name="CreateDebugTable",
             defaultValue=False,
             direction=Direction.Input,
-            doc="Create an output table withdebug parameters in non calibration runs",
+            doc="Create an output table with debug parameters in non calibration runs",
         )
 
         self.declareProperty(
@@ -187,7 +187,7 @@ class PEARLTransfit(PythonAlgorithm):
         self.res_params = FoilParameters(foil_type, *RES_PARAMS[foil_type])
         self.is_calib = self.getProperty("Calibration").value
 
-        ref_temp = float(self.getProperty("ReferenceTemp").value)
+        ref_temp = self.getProperty("ReferenceTemp").value
         fit_table = self.getProperty("FitParametersTable").value
         estimate_background = self.getProperty("EstimateBackground").value or not fit_table
 
@@ -328,13 +328,13 @@ class PEARLTransfit(PythonAlgorithm):
         return ws
 
     def _create_debug_info(self, fit_res: dict[str, any], ws: "MatrixWorkspace", gauss_fwhm: float):
-        # calculate effective temperature using fitted widths
-        # get instrument contribution to Gausssian width in calibration
-        if gauss_fwhm > self.gauss_fwhm_ref_temp:
-            # get fwhm d width of resolution (add in quadrature for convolution of Gaussians)
-            gauss_fwhm_inst = np.sqrt(gauss_fwhm**2 - self.gauss_fwhm_ref_temp**2)
-        else:
-            gauss_fwhm_inst = 0  # shouldn't be the case due to calibration fit constraint
+        """
+        Calculates effective temperature using fitted widths
+        Get instrument contribution to Gausssian width in calibration
+        """
+
+        # get fwhm d width of resolution (add in quadrature for convolution of Gaussians), 0 shouldn't be the case due to fit constraint
+        gauss_fwhm_inst = np.sqrt(gauss_fwhm**2 - self.gauss_fwhm_ref_temp**2) if gauss_fwhm > self.gauss_fwhm_ref_temp else 0.0
         final_func = fit_res["Function"]
         fwhm = np.sqrt(final_func["GaussianFWHM"] ** 2 - gauss_fwhm_inst**2)
         fwhm_err = final_func.fun.getError("GaussianFWHM")
@@ -354,7 +354,7 @@ class PEARLTransfit(PythonAlgorithm):
             # Generate Debug Table
             debug_params = {
                 "Debye Temp. (K)": temp_debye,
-                "Eff. Temp. (K)}": (temp_eff, temp_eff_err),
+                "Eff. Temp. (K)": (temp_eff, temp_eff_err),
                 "Fit. Min. (meV)": ws.readX(0)[0],
                 "Fit. Max. (meV)": ws.readX(0)[-1],
                 "Gaussian Width at Reference Temp (meV)": self.gauss_fwhm_ref_temp,

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -34,7 +34,7 @@ from mantid.api import (
 from scipy import constants
 import numpy as np
 from mantid.fitfunctions import FunctionWrapper
-from typing import Sequence, TYPE_CHECKING, Union
+from typing import Sequence, TYPE_CHECKING
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
@@ -64,14 +64,14 @@ eV_TO_meV: float = 1000.0
 
 @dataclass(frozen=True)
 class FoilParameters:
-    Foil: str = "Hf01"
-    Mass: float = 177.0
-    En: float = 1.098
-    TD: float = 252.0
-    TwogG: float = 0.00192
-    Gg: float = 0.0662
-    StartE: float = 2.0
-    EndE: float = 2.7
+    Foil: str
+    Mass: float
+    En: float
+    TD: float
+    TwogG: float
+    Gg: float
+    StartE: float
+    EndE: float
 
 
 class PEARLTransfit(PythonAlgorithm):
@@ -94,7 +94,7 @@ class PEARLTransfit(PythonAlgorithm):
     def summary(self):
         return (
             "Reads high-energy neutron resonances from the downstream monitor data on the PEARL instrument,"
-            "then fits a Voigt function to them to determine the sample temperature. A calibration must be run for"
+            " then fits a Voigt function to them to determine the sample temperature. A calibration must be run for"
             " each sample pressure. Can be used on a single file, or multiple files, in which case workspaces"
             " are summed and the average taken."
         )
@@ -234,7 +234,7 @@ class PEARLTransfit(PythonAlgorithm):
 
         return func
 
-    def _prepare_outputs(self, ws: "MatrixWorkspace", table: ITableWorkspace, debug_table: Union[ITableWorkspace, None]):
+    def _prepare_outputs(self, ws: "MatrixWorkspace", table: ITableWorkspace, debug_table: ITableWorkspace | None):
         if self.getProperty("Output").isDefault:
             self.setPropertyValue("Output", "S_fit" if self.is_calib else "T_fit")
 

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -1,0 +1,394 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# -----------------------------------------------------------------------
+# Transfit v2 - translated from Fortran77 to Python/Mantid
+# Original Author: Christopher J Ridley
+# Last updated: 2nd October 2020
+#
+# Program fits a Voigt function to PEARL transmission data, using the doppler broadening
+# of the gaussian component to determine the sample temperature
+#
+#
+# References:
+# 'Temperature measurement in a Paris-Edinburgh cell by neutron resonance spectroscopy' - Journal Of Applied Physics 98,
+# 064905 (2005)
+# 'Remote determination of sample temperature by neutron resonance spectroscopy' - Nuclear Instruments and Methods in
+# Physics Research A 547 (2005) 601-615
+# -----------------------------------------------------------------------
+from mantid.kernel import Direction, StringListValidator, EnabledWhenProperty, PropertyCriterion, LogicOperator
+from mantid.api import PythonAlgorithm, MultipleFileProperty, AlgorithmFactory, AnalysisDataService as ADS
+from scipy import constants
+import numpy as np
+from mantid.fitfunctions import FunctionWrapper
+from typing import Sequence
+
+
+class PEARLTransfit(PythonAlgorithm):
+    # Resonance constants broadly consistent with those reported from
+    # 'Neutron cross sections Vol 1, Resonance Parameters'
+    # S.F. Mughabghab and D.I. Garber
+    # June 1973, BNL report 325
+    # Mass in atomic units, En in eV, temperatures in K, gamma factors in eV
+    res_params_dict = {
+        # Hf01
+        "Hf01_Mass": 177.0,
+        "Hf01_En": 1.098,
+        "Hf01_TD": 252.0,
+        "Hf01_TwogG": 0.00192,
+        "Hf01_Gg": 0.0662,
+        "Hf01_startE": 0.6,
+        "Hf01_endE": 1.7,
+        # Hf02
+        "Hf02_Mass": 177.0,
+        "Hf02_En": 2.388,
+        "Hf02_TD": 252.0,
+        "Hf02_TwogG": 0.009,
+        "Hf02_Gg": 0.0608,
+        "Hf02_startE": 2.0,
+        "Hf02_endE": 2.7,
+        # Ta10
+        "Ta10_Mass": 181.0,
+        "Ta10_En": 10.44,
+        "Ta10_TD": 240.0,
+        "Ta10_TwogG": 0.00335,
+        "Ta10_Gg": 0.0069,
+        "Ta10_startE": 9.6,
+        "Ta10_endE": 11.4,
+        # Irp6
+        "Irp6_Mass": 191.0,
+        "Irp6_En": 0.6528,
+        "Irp6_TD": 420.0,
+        "Irp6_TwogG": 0.000547,
+        "Irp6_Gg": 0.072,
+        "Irp6_startE": 0.1,
+        "Irp6_endE": 0.9,
+        # Iro5
+        "Iro5_Mass": 191.0,
+        "Iro5_En": 5.36,
+        "Iro5_TD": 420.0,
+        "Iro5_TwogG": 0.006,
+        "Iro5_Gg": 0.082,
+        "Iro5_startE": 4.9,
+        "Iro5_endE": 6.3,
+        # Iro9
+        "Iro9_Mass": 191.0,
+        "Iro9_En": 9.3,
+        "Iro9_TD": 420.0,
+        "Iro9_TwogG": 0.0031,
+        "Iro9_Gg": 0.082,
+        "Iro9_startE": 8.7,
+        "Iro9_endE": 9.85,
+    }
+    DEFAULT_PEAK_AMP = 1.6
+    eV_TO_meV = 1000.0
+
+    def version(self):
+        return 2
+
+    def name(self):
+        return "PEARLTransfit"
+
+    def category(self):
+        return "Diffraction\\Fitting"
+
+    def summary(self):
+        return (
+            "Reads high-energy neutron resonances from the downstream monitor data on the PEARL instrument,"
+            "then fits a Voigt function to them to determine the sample temperature. A calibration must be run for"
+            " each sample pressure. Can be used on a single file, or multiple files, in which case workspaces"
+            " are summed and the average taken."
+        )
+
+    def PyInit(self):
+        self.declareProperty(
+            MultipleFileProperty("Files", extensions=[".raw", ".s0x", ".nxs"]),
+            doc="Files of calibration runs (numors). Must be detector scans.",
+        )
+        self.declareProperty(
+            name="FoilType",
+            defaultValue="Hf01",
+            validator=StringListValidator(["Hf01", "Hf02", "Ta10", "Irp6", "Iro5", "Iro9"]),
+            direction=Direction.Input,
+            doc="Type of foil included with the sample",
+        )
+        self.declareProperty(name="Ediv", defaultValue=0.0025, direction=Direction.Input, doc="Energy bin-width in eV")
+        self.declareProperty(name="ReferenceTemp", defaultValue="290", direction=Direction.Input, doc="Enter reference temperature in K")
+        self.declareProperty(
+            name="Calibration",
+            defaultValue=False,
+            direction=Direction.Input,
+            doc="Calibration flag, default is False in which case temperature measured",
+        )
+        self.declareProperty(
+            name="Debug",
+            defaultValue=False,
+            direction=Direction.Input,
+            doc="True/False - provides more verbose output of procedure for debugging purposes",
+        )
+
+        self.declareProperty(
+            name="EstimateBackground",
+            defaultValue=True,
+            direction=Direction.Input,
+            doc="Estimate background parameters from data.",
+        )
+        self.declareProperty(
+            name="Bg0guessFraction",
+            defaultValue=0.84,
+            direction=Direction.Input,
+            doc="Starting guess for constant term of polynomial background is calculated as Bg0guessScaleFactor*y0 where"
+            "y0 is the intensity in the first bin of the data to be fitted.",
+        )
+        self.declareProperty(
+            name="Bg1guess",
+            defaultValue=0.0173252,
+            direction=Direction.Input,
+            doc="Starting guess for linear term of polynomial background.",
+        )
+        self.declareProperty(
+            name="Bg2guess",
+            defaultValue=0.0000004,
+            direction=Direction.Input,
+            doc="Starting guess for quadratic term of polynomial background.",
+        )
+        self.declareProperty(
+            name="RebinInEnergy",
+            defaultValue=True,
+            direction=Direction.Input,
+            doc="Estimate background parameters from data.",
+        )
+        # disable properties
+        is_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsNotDefault)
+        is_not_cal = EnabledWhenProperty("Calibration", PropertyCriterion.IsDefault)
+        self.setPropertySettings("Debug", is_not_cal)
+        self.setPropertySettings("EstimateBackground", is_cal)
+        is_bg_estimated = EnabledWhenProperty("EstimateBackground", PropertyCriterion.IsNotDefault)
+        enable_user_bg = EnabledWhenProperty(is_bg_estimated, is_cal, LogicOperator.And)
+        for prop in ["Bg0guessFraction", "Bg1guess", "Bg2guess"]:
+            self.setPropertySettings(prop, enable_user_bg)
+        enable_Ediv = EnabledWhenProperty("RebinInEnergy", PropertyCriterion.IsDefault)
+        self.setPropertySettings("Ediv", enable_Ediv)
+
+    def validateInputs(self):
+        issues = dict()
+        is_calib = self.getProperty("Calibration").value
+        if not is_calib and not ADS.doesExist("S_fit_Parameters"):
+            issues["Calibration"] = "No S_fit_Parameters workspace exists, please fit a calibration run."
+        return issues
+
+    def PyExec(self):
+        # ----------------------------------------------------------
+        # Imports resonance parameters from ResParam dictionary depending on the selected foil type.
+        # ----------------------------------------------------------
+        files = self.get_file_list(self.getProperty("Files").value)
+        foil_type = self.getProperty("FoilType").value
+        is_calib = self.getProperty("Calibration").value
+        ref_temp = float(self.getProperty("ReferenceTemp").value)
+        is_debug = self.getProperty("Debug").value
+        estimate_background = self.getProperty("EstimateBackground").value
+
+        ws = self.load_and_average_moinitor_from_files(files, foil_type)
+        if self.getProperty("RebinInEnergy").value:
+            # Rebin with constant width has similar effect to normalising raw data by bin-width
+            # so hack here is to pre-scale intensities by inverse (i.e. multiply by bin-width)
+            # this means that Rebin is effectively performing a mean rather than sum
+            ws.setDistribution(True)
+            self.exec_child_alg("ConvertFromDistribution", Workspace=ws)
+            bin_width = self.eV_TO_meV * float(self.getProperty("Ediv").value)  # meV
+            ws = self.exec_child_alg("Rebin", InputWorkspace=ws, Params=f"{bin_width}", FullBinsOnly=True)
+
+        # Define the gaussian width at the reference temperature
+        energy = self.res_params_dict[foil_type + "_En"]
+        mass = self.res_params_dict[foil_type + "_Mass"]
+        gauss_fwhm_ref_temp = self.eV_TO_meV * np.sqrt(4 * energy * constants.k * ref_temp * mass / (constants.e * (1 + mass) ** 2))
+
+        # make initial function with constraints
+        func = FunctionWrapper("PEARLTransVoigt")
+        func.constrain("LorentzianFWHM>1")
+        func.constrain(f"GaussianFWHM>{gauss_fwhm_ref_temp}")
+
+        # set initial parameters
+        if is_calib:
+            # use tabulated values (note energies are in eV)
+            out_ws_name = "S_fit"
+            func["Amplitude"] = self.DEFAULT_PEAK_AMP
+            two_gGamma = self.res_params_dict[foil_type + "_TwogG"]
+            gamma_g = self.res_params_dict[foil_type + "_Gg"]
+            func["LorentzianFWHM"] = self.eV_TO_meV * (0.5 * two_gGamma + gamma_g)
+            func["GaussianFWHM"] = gauss_fwhm_ref_temp
+            func["Position"] = energy * self.eV_TO_meV  # take peak position starting guess from tabulated value
+            bg_pars = np.zeros(3)
+            if estimate_background:
+                bg_pars[:2] = self.estimate_linear_background(ws.readX(0), ws.readY(0))
+            else:
+                bg_pars[0] = self.getProperty("Bg0guessFraction").value * ws.readY(0)[0]
+                bg_pars[1] = self.getProperty("Bg1guess").value
+                bg_pars[2] = self.getProperty("Bg2guess").value
+            for ipar, par in enumerate(bg_pars):
+                func[f"Bg{ipar}"] = par
+        else:
+            out_ws_name = "T_fit"
+            # retrieve parameters from previous calibration
+            calib_param_table = ADS.retrieve("S_fit_Parameters")
+            for ipar in range(func.nParams()):
+                row = calib_param_table.row(ipar)
+                func[row["Name"]] = row["Value"]
+
+        fit_kwargs = {
+            "InputWorkspace": ws,
+            "MaxIterations": 200,
+            "CreateOutput": True,
+            "Output": out_ws_name,
+            "IgnoreInvalidData": True,
+            "StepSizeMethod": "Sqrt epsilon",
+        }
+        if is_calib:
+            # perform initial fit keeping Gaussian width constant
+            func.fix("GaussianFWHM")
+            fit_res = self.exec_fit(Function=func.fun, **fit_kwargs)
+            func = fit_res["Function"]
+            func.untie("GaussianFWHM")
+        else:
+            func.fix("LorentzianFWHM")
+        fit_res = self.exec_fit(Function=func.fun, **fit_kwargs)
+
+        if fit_res["OutputStatus"] != "success":
+            self.log().warning(f"Fit failed with status: {fit_res['OutputStatus']}")
+
+        if not is_calib:
+            # calculate effective temperature using fitted widths
+            # get instrument contribution to Gausssian width in calibration
+            if func["GaussianFWHM"] > gauss_fwhm_ref_temp:
+                # get fwhm d width of resolution (add in quadrature for convolution of Gaussians)
+                gauss_fwhm_inst = np.sqrt(func["GaussianFWHM"] ** 2 - gauss_fwhm_ref_temp**2)
+            else:
+                gauss_fwhm_inst = 0  # shouldn't be the case due to calibration fit constraint
+            final_func = fit_res["Function"]
+            fwhm = np.sqrt(final_func["GaussianFWHM"] ** 2 - gauss_fwhm_inst**2)
+            fwhm_err = final_func.fun.getError("GaussianFWHM")
+            energy = final_func["Position"]
+            energy_err = final_func.fun.getError("Position")
+            # get element from correlation matrix (called normalised covar in mantid)
+            irow = final_func.fun.getParameterIndex("Position")
+            corr = fit_res["OutputNormalisedCovarianceMatrix"].row(irow)["GaussianFWHM"]
+            temp_eff, temp_eff_err = self.calc_effective_temp_and_error(fwhm, fwhm_err, energy, energy_err, corr, mass)
+            # calculate sample temp using ideal gas formulation
+            temp_debye = self.res_params_dict[foil_type + "_TD"]  # Debye temp.
+            temp_sample, temp_sample_err = self.calc_sample_temp_and_error_from_effective(temp_eff, temp_eff_err, temp_debye)
+
+            # print info
+            self.log().information(f"Sample temperature is: {temp_sample:.2f} +/- {temp_sample_err:.2f} K")
+            if is_debug:
+                self.log().information("-----------------------------")
+                self.log().information(f"The Debye temperature is {temp_debye:.2f} K")
+                self.log().information(f"The effective temperature is: {temp_eff:.2f} +/- {temp_eff_err:.2f} K")
+                self.log().information(f"Fitted in range {ws.readX(0)[0]:.2f} < Energy (meV) < {ws.readX(0)[-1]:.2f}")
+                self.log().information(f"Gaussian width at this reference temperature is: {gauss_fwhm_ref_temp:.2f} meV")
+                self.log().information(f"Lorentzian FWHM is fixed: {final_func['LorentzianFWHM']:.2f} meV")
+                self.log().information(f"Gaussian FWHM is fitted as: {final_func['GaussianFWHM']:.2f} meV")
+                self.log().information(f"Instrumental contribution is: {gauss_fwhm_inst:.2f} meV")
+                self.log().information(f"Temperature contribution is: {fwhm:.2f} meV")
+                self.log().information("-----------------------------")
+
+        # clean up ADS
+        self.exec_child_alg("DeleteWorkspace", Workspace=fit_res["OutputNormalisedCovarianceMatrix"])
+
+    @staticmethod
+    def get_file_list(input_files):
+        # MultipleFileProperty returns a list of list(s) of files, or a list containing a single (string) file
+        # Condense into one list of file(s) in either case
+        file_list = []
+        for files in input_files:
+            if isinstance(files, str):
+                file_list.append(files)
+            else:
+                file_list.extend(files)
+        return file_list
+
+    def exec_child_alg(self, alg_name: str, **kwargs):
+        alg = self.createChildAlgorithm(alg_name, enableLogging=False)
+        alg.setAlwaysStoreInADS(False)
+        alg.initialize()
+        alg.setProperties(kwargs)
+        alg.execute()
+        out_props = tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
+        return out_props[0] if len(out_props) == 1 else out_props
+
+    def exec_fit(self, **kwargs):
+        alg = self.createChildAlgorithm("Fit", enableLogging=False)
+        alg.setAlwaysStoreInADS(True)
+        alg.initialize()
+        alg.setProperties(kwargs)
+        alg.execute()
+        return {
+            "Function": FunctionWrapper(alg.getProperty("Function").value),
+            "OutputStatus": alg.getProperty("OutputStatus").value,
+            "OutputNormalisedCovarianceMatrix": ADS.retrieve(alg.getPropertyValue("OutputNormalisedCovarianceMatrix")),
+        }
+
+    def calc_effective_temp_and_error(
+        self, fwhm: float, fwhm_err: float, energy: float, energy_err: float, correlation: float, mass: float
+    ) -> tuple[float, float]:
+        const = ((1 / self.eV_TO_meV) * constants.e * ((1 + mass) ** 2)) / (4 * constants.k * mass)
+        temp = const * (fwhm**2) / energy
+        # propagate errors
+        dtemp_by_dfwhm = 2 * fwhm / energy
+        dtemp_by_denergy = -((fwhm / energy) ** 2)
+        # calc. term due to covariance
+        # corr = 100*cij/sqrt(cii*cjj); cii = error_i^2
+        covar = (correlation * fwhm_err * energy_err) / 100
+        covar_term = 2 * dtemp_by_dfwhm * dtemp_by_denergy * covar
+        temp_err = const * np.sqrt((dtemp_by_dfwhm * fwhm_err) ** 2 + (dtemp_by_denergy * energy_err) ** 2 + covar_term)
+        return temp, temp_err
+
+    def calc_sample_temp_and_error_from_effective(self, temp_eff: float, temp_eff_err: float, temp_debye: float) -> tuple[float, float]:
+        if 8 * temp_eff < 3 * temp_debye:
+            self.log().warning("The effective temperature is currently too far below the Debye temperature to give an accurate measure.")
+            return temp_eff, temp_eff_err
+        # use free gas formulation
+        log_term = np.log((8 * temp_eff + 3 * temp_debye) / (8 * temp_eff - 3 * temp_debye))
+        temp_sample = 3 * temp_debye / (4 * log_term)
+        # calculate error using derivative
+        temp_sample_err = abs((36 * temp_debye**2) / ((9 * temp_debye**2 - 64 * temp_eff**2) * log_term**2)) * temp_eff_err
+        return temp_sample, temp_sample_err
+
+    # ----------------------------------------------------------
+    # Define function for importing raw monitor data, summing, normalising, converting units, and cropping
+    # ----------------------------------------------------------
+    def _load_monitor_from_single_file(self, filepath: str):
+        ws, *_ = self.exec_child_alg("Load", Filename=filepath)
+        ws = self.exec_child_alg("ExtractSingleSpectrum", InputWorkspace=ws, WorkspaceIndex=3)
+        ws = self.exec_child_alg("CropWorkspace", InputWorkspace=ws, XMin=100, XMax=19990)
+        ws = self.exec_child_alg("NormaliseByCurrent", InputWorkspace=ws)
+        ws = self.exec_child_alg("ConvertUnits", InputWorkspace=ws, Target="Energy")
+        return ws
+
+    def load_and_average_moinitor_from_files(self, filepaths: Sequence[str], foil_type: str):
+        ws = self._load_monitor_from_single_file(filepaths[0])
+        for filepath in filepaths[1:]:
+            ws = ws + self._load_monitor_from_single_file(filepath)
+        if len(filepaths) > 1:
+            ws = ws / len(filepaths)
+        # crop
+        xstart = self.eV_TO_meV * self.res_params_dict[foil_type + "_startE"]
+        xend = self.eV_TO_meV * self.res_params_dict[foil_type + "_endE"]
+        ws = self.exec_child_alg("CropWorkspaceRagged", InputWorkspace=ws, XMin=xstart, XMax=xend)
+        return ws
+
+    @staticmethod
+    def estimate_linear_background(x: np.ndarray, y: np.ndarray, nbg: int = 3) -> tuple[float, float]:
+        if len(y) < 2 * nbg:
+            # not expected as trying to fit a function with 7 parameters
+            return 2 * [0.0]
+        dy = y[:nbg].mean() - y[-nbg:].mean()
+        dx = x[:nbg].mean() - x[-nbg:].mean()
+        gradient = dy / dx
+        slope = y[:nbg].mean() - gradient * x[:nbg].mean()
+        return gradient, slope
+
+
+AlgorithmFactory.subscribe(PEARLTransfit)

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -81,6 +81,7 @@ class PEARLTransfit(PythonAlgorithm):
     default_peak_amplitude: float = 1.6
     is_calib: bool = True
     gauss_fwhm_ref_temp: float = 0.0
+    run_numbers: list[str] = None
 
     def version(self):
         return 2
@@ -102,7 +103,7 @@ class PEARLTransfit(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty(
             MultipleFileProperty("Files", extensions=[".raw", ".s0x", ".nxs"]),
-            doc="Files of calibration runs (numors). Must be detector scans",
+            doc="Files or run numbers for calibration runs (numors). Must be detector scans.",
         )
 
         self.declareProperty(
@@ -123,8 +124,9 @@ class PEARLTransfit(PythonAlgorithm):
         self.declareProperty(
             ITableWorkspaceProperty(name="FitParametersTable", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional),
             doc="Table with fit parameters for 'PEARLTransVoigt' function: 'Position', 'LorentzianFWHM', 'GaussianFWHM', 'Amplitude', 'Bg0'"
-            "'Bg1', 'Bg2'. Mandatory when calibration is set to False. "
-            "If a 'FitParametersTable' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will be used for background estimation",
+            "'Bg1', 'Bg2'. The calculated temperature is added in non-calibration runs. This property is mandatory when calibration"
+            " is set to False. If a 'FitParametersTable' is used in calibration runs: 'Bg0', 'Bg1' and 'Bg2' will "
+            " be used for background estimation",
         )
 
         self.declareProperty(name="ReferenceTemp", defaultValue=290.0, direction=Direction.Input, doc="Enter reference temperature in K")
@@ -135,6 +137,7 @@ class PEARLTransfit(PythonAlgorithm):
             direction=Direction.Input,
             doc="Estimate background parameters from data.",
         )
+
         self.declareProperty(
             name="CreateDebugTable",
             defaultValue=False,
@@ -146,7 +149,9 @@ class PEARLTransfit(PythonAlgorithm):
             name="Output",
             defaultValue="",
             direction=Direction.Input,
-            doc="Output basename on ADS. If empty, `S_fit` will be the basename for calibration runs and `T_fit` for non-calibration",
+            doc="Output basename on ADS. If empty, `S_fit` will be the basename for calibration runs and `T_fit` for non-calibration, "
+            "adding"
+            " the foil type and run numbers as suffixes.",
         )
 
         self.setup_property_rules()
@@ -181,6 +186,7 @@ class PEARLTransfit(PythonAlgorithm):
 
     def PyExec(self):
         files = self.get_file_list(self.getProperty("Files").value)
+        self.run_numbers = []
 
         # Imports resonance parameters from ResParam dictionary depending on the selected foil type.
         foil_type = self.getProperty("FoilType").value
@@ -230,14 +236,21 @@ class PEARLTransfit(PythonAlgorithm):
             # retrieve parameters from previous calibration
             for i_par in range(func.nParams()):
                 row = fit_table.row(i_par)
-                func[row["Name"]] = row["Value"]
+                if (name := row["Name"]) in FIT_TABLE_PARAMS:
+                    func[name] = row["Value"]
 
         return func
 
+    def _create_output_basename(self):
+        run_numbers = ""
+        if self.run_numbers:
+            run_numbers = f"_{self.run_numbers[0]}" if len(self.run_numbers) == 1 else f"_{self.run_numbers[0]}_{self.run_numbers[-1]}"
+        suffix = f"_{self.res_params.Foil}{run_numbers}"
+        self.setPropertyValue("Output", "S_fit" + suffix if self.is_calib else "T_fit" + suffix)
+
     def _prepare_outputs(self, ws: "MatrixWorkspace", table: ITableWorkspace, debug_table: ITableWorkspace | None):
         if self.getProperty("Output").isDefault:
-            self.setPropertyValue("Output", "S_fit" if self.is_calib else "T_fit")
-
+            self._create_output_basename()
         out_name = self.getPropertyValue("Output")
         prop_names = ["OutputWorkspace", "OutputFitParameters", "OutputDebugTable"]
         prop_callers = [MatrixWorkspaceProperty, ITableWorkspaceProperty, ITableWorkspaceProperty]
@@ -248,7 +261,8 @@ class PEARLTransfit(PythonAlgorithm):
         p_len = len(prop_names)
         props_len = p_len if debug_table else p_len - 1
         for idx in range(props_len):
-            self.declareProperty(prop_callers[idx](name=prop_names[idx], defaultValue="", direction=Direction.Output), doc=docs[idx])
+            if not self.existsProperty(propName := prop_names[idx]):
+                self.declareProperty(prop_callers[idx](name=propName, defaultValue="", direction=Direction.Output), doc=docs[idx])
             self.setPropertyValue(prop_names[idx], f"{out_name}{suffixes[idx]}")
             self.setProperty(prop_names[idx], data_items[idx])
 
@@ -312,6 +326,9 @@ class PEARLTransfit(PythonAlgorithm):
         ws = self._exec_child_alg("CropWorkspace", InputWorkspace=ws, XMin=self.x_range[0], XMax=self.x_range[1])
         ws = self._exec_child_alg("NormaliseByCurrent", InputWorkspace=ws)
         ws = self._exec_child_alg("ConvertUnits", InputWorkspace=ws, Target="Energy")
+
+        if (runno := ws.getRunNumber()) and str(runno) not in self.run_numbers:
+            self.run_numbers.append(str(runno))
         return ws
 
     def _load_and_average_monitors_from_files(self, filepaths: Sequence[str]):
@@ -348,6 +365,7 @@ class PEARLTransfit(PythonAlgorithm):
         temp_debye = self.res_params.TD  # Debye temp.
         temp_sample, temp_sample_err = self._calc_sample_temp_and_error_from_effective(temp_eff, temp_eff_err, temp_debye)
         self.log().information(f"Sample temperature is: {temp_sample:.2f} +/- {temp_sample_err:.2f} K")
+        fit_res["OutputTable"].addRow({"Name": "Sample Temperature", "Value": temp_sample, "Error": temp_sample_err})
 
         debug_table = None
         if self.getProperty("CreateDebugTable").value:

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit2.py
@@ -146,7 +146,7 @@ class PEARLTransfit(PythonAlgorithm):
             name="Output",
             defaultValue="",
             direction=Direction.Input,
-            doc="Output basename on ADS. If empty, `S_fit` will be the basenamefor calibration runs and `T_fit` for non-calibration",
+            doc="Output basename on ADS. If empty, `S_fit` will be the basename for calibration runs and `T_fit` for non-calibration",
         )
 
         self.setup_property_rules()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -163,6 +163,7 @@ set(TEST_PY_FILES
     VesuvioThicknessTest.py
     VesuvioTOFFitTest.py
     PEARLTransfitTest.py
+    PEARLTransfitV2Test.py
     PoldiCreatePeaksFromFileTest.py
     LoadCIFTest.py
     SaveYDATest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -15,7 +15,7 @@ class PEARLTransfitTest(unittest.TestCase):
 
     def test_calibration_run_single_run(self):
         # Test that the calibration run produces the correct workspaces for a single run
-        PEARLTransfit(Files="PEARL00112777", Calibration=True)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=True)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_fit_parameters("S_fit", cost=0.72751, peak_cen=1096.79, peak_cen_err=0.20729)
         # assert number energy bins
@@ -23,40 +23,42 @@ class PEARLTransfitTest(unittest.TestCase):
 
     def test_calibration_run_single_run_no_rebin(self):
         # Test that the calibration run produces the correct workspaces for a single run
-        PEARLTransfit(Files="PEARL00112777", Calibration=True, RebinInEnergy=False)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=True, RebinInEnergy=False)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20719)
         self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 509)
 
     def test_calibration_run_single_run_backgorund_params_provided(self):
         # Provide very bad background params and show fit doesn't converge (would do if parameters estimated)
-        PEARLTransfit(Files="PEARL00112777", Calibration=True, EstimateBackground=False, Bg0guessFraction=0.0, Bg1guess=-1.0, Bg2guess=1.0)
+        PEARLTransfit(
+            Version=1, Files="PEARL00112777", Calibration=True, EstimateBackground=False, Bg0guessFraction=0.0, Bg1guess=-1.0, Bg2guess=1.0
+        )
         self._assert_output_workspaces_exist("S_fit")
         self._assert_fit_parameters("S_fit", cost=0.72751, peak_cen=1096.79, peak_cen_err=0.20729)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs
-        PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
+        PEARLTransfit(Version=1, Files="PEARL00073987-00073990", Calibration=True)
         self._assert_output_workspaces_exist("S_fit")
 
     def test_measure_run_single_run(self):
         # Test that the measurement run produces the correct workspaces for a single run
-        PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        PEARLTransfit(Files="PEARL00112777", Calibration=False)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=True)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=False)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_output_workspaces_exist("T_fit")
 
     def test_measure_run_multi_run(self):
         # Test that the measurement run produces the correct workspaces for multiple runs
-        PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
-        PEARLTransfit(Files="PEARL00073987-00073990", Calibration=False)
+        PEARLTransfit(Version=1, Files="PEARL00073987-00073990", Calibration=True)
+        PEARLTransfit(Version=1, Files="PEARL00073987-00073990", Calibration=False)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_output_workspaces_exist("T_fit")
 
     def test_algorithm_cancels_if_no_calib(self):
         # Test that the algorithm is aborted if run in measurement mode without a calibration file
         with self.assertRaisesRegex(RuntimeError, "No S_fit_Parameters workspace exists, please fit a calibration run."):
-            PEARLTransfit(Files="PEARL00073987", Calibration=False)
+            PEARLTransfit(Version=1, Files="PEARL00073987", Calibration=False)
         self.assertFalse(ADS.doesExist("T_fit_Parameters"))
         self.assertFalse(ADS.doesExist("T_fit_Workspace"))
         self.assertFalse(ADS.doesExist("S_fit_Parameters"))
@@ -64,19 +66,19 @@ class PEARLTransfitTest(unittest.TestCase):
 
     def test_calibration_run_single_run_with_nexus_file(self):
         # Test that the calibration run produces the correct workspaces for a single run
-        PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
+        PEARLTransfit(Version=1, Files="PEARL00112777.nxs", Calibration=True)
         self._assert_output_workspaces_exist("S_fit")
 
     def test_calibration_run_non_default_foil_no_rebin(self):
         # Test with non default resonance, note default Ediv not suitable so using RebinInEnergy=False
-        PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02", RebinInEnergy=False)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=True, FoilType="Hf02", RebinInEnergy=False)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_fit_parameters("S_fit", cost=0.89391, peak_cen=2380.03, peak_cen_err=0.31927)
         self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 96)
 
     def test_calibration_run_non_default_foil_non_default_Ediv(self):
         # Test with non default resonance, note default Ediv not suitable
-        PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02", Ediv=0.01)
+        PEARLTransfit(Version=1, Files="PEARL00112777", Calibration=True, FoilType="Hf02", Ediv=0.01)
         self._assert_output_workspaces_exist("S_fit")
         self._assert_fit_parameters("S_fit", cost=0.74853, peak_cen=2380.03, peak_cen_err=0.32064)
         self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 70)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
@@ -1,0 +1,120 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from plugins.algorithms.PEARLTransfit2 import PEARLTransfit as _PEARLTransfit
+from mantid.simpleapi import PEARLTransfit
+from mantid.api import AnalysisDataService as ADS
+import numpy as np
+
+
+class PEARLTransfitV2Test(unittest.TestCase):
+    def tearDown(self):
+        ADS.clear()
+
+    def test_calibration_run_single_run(self):
+        # Test that the calibration run produces the correct workspaces for a single run
+        PEARLTransfit(Files="PEARL00112777", Calibration=True)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
+        # assert number energy bins
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 509)
+
+    def test_custom_output_name_and_history(self):
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, Output="Test")
+        self._assert_output_workspaces_exist("Test")
+        self.assertFalse(ADS.retrieve("Test_Workspace").getHistory().empty())
+
+    def test_lhs_output(self):
+        out = PEARLTransfit(Files="PEARL00112777", Calibration=True, Output="Test")
+        self.assertEqual(out[0].name(), "Test_Workspace")
+        self.assertEqual(out[1].name(), "Test_Parameters")
+
+    def test_validation_error_for_wrong_table_format_in_calibration(self):
+        params_dict = {"Bg0": 0.0, "Bg1": -1.0, "Bg3": 1.0}
+        table = _PEARLTransfit.generate_table(params_dict)
+        err_msg = "Parameter Bg2 missing from FitParametersTable."
+        with self.assertRaisesRegex(RuntimeError, err_msg):
+            PEARLTransfit(Files="PEARL00112777", Calibration=True, FitParametersTable=table)
+
+    def test_validation_error_if_missing_params_table_in_non_calibration_call(self):
+        err_msg = "FitParametersTable is missing."
+        with self.assertRaisesRegex(RuntimeError, err_msg):
+            PEARLTransfit(Files="PEARL00112777", Calibration=False)
+
+    def test_calibration_run_single_run_background_table_provided(self):
+        params_dict = {"Bg0": 0.0, "Bg1": -1.0, "Bg2": 1.0}
+        table = _PEARLTransfit.generate_table(params_dict)
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, FitParametersTable=table)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
+
+    def test_calibration_run_multi_run(self):
+        # Test that the calibration run produces the correct workspaces for multiple runs
+        PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
+        self._assert_output_workspaces_exist("S_fit")
+
+    def test_measure_run_single_run(self):
+        # Test that the measurement run produces the correct workspaces for a single run
+        PEARLTransfit(Files="PEARL00112777", Calibration=True)
+        PEARLTransfit(Files="PEARL00112777", FitParametersTable=ADS.retrieve("S_fit_Parameters"), Calibration=False)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("T_fit")
+
+    def test_measure_run_multi_run(self):
+        # Test that the measurement run produces the correct workspaces for multiple runs
+        PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
+        PEARLTransfit(Files="PEARL00073987-00073990", FitParametersTable=ADS.retrieve("S_fit_Parameters"), Calibration=False)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("T_fit")
+
+    def test_calibration_run_single_run_with_nexus_file(self):
+        # Test that the calibration run produces the correct workspaces for a single run
+        PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
+        self._assert_output_workspaces_exist("S_fit")
+
+    def test_calibration_run_non_default_foil_no_rebin(self):
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02")
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=0.89391, peak_cen=2380.03, peak_cen_err=0.31927)
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 96)
+
+    def test_debug_info_output_as_a_table(self):
+        debug_params = {
+            "Debye Temp. (K)": 252.0,
+            "Eff. Temp. (K)}": 290.3199,
+            "Fit. Min. (meV)": 600.1015,
+            "Fit. Max. (meV)": 1700.2284,
+            "Gaussian Width at Reference Temp (meV)": 24.7618,
+            "Instrumental contribution (meV)": 0.04525,
+            "Temperature Contribution (meV)": 24.76185,
+            "Sample Temperature (K)": 279.7596,
+        }
+
+        out_calib = PEARLTransfit(Files="PEARL00112777", Calibration=True)
+        PEARLTransfit(Files="PEARL00112777", Calibration=False, FitParametersTable=out_calib[1], CreateDebugTable=True)
+
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("T_fit")
+        self.assertTrue(ADS.doesExist("T_fit_DebugParameters"))
+
+        table = ADS.retrieve("T_fit_DebugParameters")
+        self.assertEqual(table.column("Name"), list(debug_params.keys()))
+        np.testing.assert_almost_equal(table.column("Value"), list(debug_params.values()), 4)
+
+    def _assert_fit_parameters(self, ws_prefix, cost, peak_cen, peak_cen_err, frac_delta=1e-4):
+        param_table = ADS.retrieve(f"{ws_prefix}_Parameters")
+        self.assertAlmostEqual(param_table.column("Value")[-1], cost, delta=frac_delta * cost)
+        self.assertAlmostEqual(param_table.column("Value")[0], peak_cen, delta=frac_delta * peak_cen)
+        self.assertAlmostEqual(param_table.column("Error")[0], peak_cen_err, delta=frac_delta * peak_cen)
+
+    def _assert_output_workspaces_exist(self, basename):
+        for suffix in ["_Parameters", "_Workspace"]:
+            self.assertTrue(ADS.doesExist(f"{basename}{suffix}"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
@@ -12,16 +12,19 @@ import numpy as np
 
 
 class PEARLTransfitV2Test(unittest.TestCase):
+    test_calib_output_name = "S_fit_Hf01_112777"
+    test_temp_output_name = "T_fit_Hf01_112777"
+
     def tearDown(self):
         ADS.clear()
 
     def test_calibration_run_single_run(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
+        self._assert_output_workspaces_exist(self.test_calib_output_name)
+        self._assert_fit_parameters(self.test_calib_output_name, cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
         # assert number energy bins
-        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 509)
+        self.assertEqual(ADS.retrieve(f"{self.test_calib_output_name}_Workspace").blocksize(), 509)
 
     def test_custom_output_name_and_history(self):
         PEARLTransfit(Files="PEARL00112777", Calibration=True, Output="Test")
@@ -49,38 +52,42 @@ class PEARLTransfitV2Test(unittest.TestCase):
         params_dict = {"Bg0": 0.0, "Bg1": -1.0, "Bg2": 1.0}
         table = _PEARLTransfit.generate_table(params_dict)
         PEARLTransfit(Files="PEARL00112777", Calibration=True, FitParametersTable=table)
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
+        self._assert_output_workspaces_exist(self.test_calib_output_name)
+        self._assert_fit_parameters(self.test_calib_output_name, cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
-        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("S_fit_Hf01_73987_73990")
 
     def test_measure_run_single_run(self):
         # Test that the measurement run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        PEARLTransfit(Files="PEARL00112777", FitParametersTable=ADS.retrieve("S_fit_Parameters"), Calibration=False)
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_output_workspaces_exist("T_fit")
+        PEARLTransfit(
+            Files="PEARL00112777", FitParametersTable=ADS.retrieve(f"{self.test_calib_output_name}_Parameters"), Calibration=False
+        )
+        self._assert_output_workspaces_exist(self.test_calib_output_name)
+        self._assert_output_workspaces_exist(self.test_temp_output_name)
 
     def test_measure_run_multi_run(self):
         # Test that the measurement run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
-        PEARLTransfit(Files="PEARL00073987-00073990", FitParametersTable=ADS.retrieve("S_fit_Parameters"), Calibration=False)
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_output_workspaces_exist("T_fit")
+        PEARLTransfit(
+            Files="PEARL00073987-00073990", FitParametersTable=ADS.retrieve("S_fit_Hf01_73987_73990_Parameters"), Calibration=False
+        )
+        self._assert_output_workspaces_exist("S_fit_Hf01_73987_73990")
+        self._assert_output_workspaces_exist("T_fit_Hf01_73987_73990")
 
     def test_calibration_run_single_run_with_nexus_file(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
-        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist(self.test_calib_output_name)
 
     def test_calibration_run_non_default_foil_no_rebin(self):
         PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02")
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_fit_parameters("S_fit", cost=0.89391, peak_cen=2380.03, peak_cen_err=0.31927)
-        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 96)
+        self._assert_output_workspaces_exist("S_fit_Hf02_112777")
+        self._assert_fit_parameters("S_fit_Hf02_112777", cost=0.89391, peak_cen=2380.03, peak_cen_err=0.31927)
+        self.assertEqual(ADS.retrieve("S_fit_Hf02_112777_Workspace").blocksize(), 96)
 
     def test_debug_info_output_as_a_table(self):
         debug_params = {
@@ -97,11 +104,11 @@ class PEARLTransfitV2Test(unittest.TestCase):
         out_calib = PEARLTransfit(Files="PEARL00112777", Calibration=True)
         PEARLTransfit(Files="PEARL00112777", Calibration=False, FitParametersTable=out_calib[1], CreateDebugTable=True)
 
-        self._assert_output_workspaces_exist("S_fit")
-        self._assert_output_workspaces_exist("T_fit")
-        self.assertTrue(ADS.doesExist("T_fit_DebugParameters"))
+        self._assert_output_workspaces_exist(self.test_calib_output_name)
+        self._assert_output_workspaces_exist(self.test_temp_output_name)
+        self.assertTrue(ADS.doesExist(f"{self.test_temp_output_name}_DebugParameters"))
 
-        table = ADS.retrieve("T_fit_DebugParameters")
+        table = ADS.retrieve(f"{self.test_temp_output_name}_DebugParameters")
         self.assertEqual(table.column("Name"), list(debug_params.keys()))
         np.testing.assert_almost_equal(table.column("Value"), list(debug_params.values()), 4)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
@@ -85,7 +85,7 @@ class PEARLTransfitV2Test(unittest.TestCase):
     def test_debug_info_output_as_a_table(self):
         debug_params = {
             "Debye Temp. (K)": 252.0,
-            "Eff. Temp. (K)}": 290.3199,
+            "Eff. Temp. (K)": 290.3199,
             "Fit. Min. (meV)": 600.1015,
             "Fit. Max. (meV)": 1700.2284,
             "Gaussian Width at Reference Temp (meV)": 24.7618,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitV2Test.py
@@ -39,19 +39,19 @@ class PEARLTransfitV2Test(unittest.TestCase):
     def test_validation_error_for_wrong_table_format_in_calibration(self):
         params_dict = {"Bg0": 0.0, "Bg1": -1.0, "Bg3": 1.0}
         table = _PEARLTransfit.generate_table(params_dict)
-        err_msg = "Parameter Bg2 missing from FitParametersTable."
+        err_msg = "Parameter Bg2 missing from InputCalibrationParameters."
         with self.assertRaisesRegex(RuntimeError, err_msg):
-            PEARLTransfit(Files="PEARL00112777", Calibration=True, FitParametersTable=table)
+            PEARLTransfit(Files="PEARL00112777", Calibration=True, InputCalibrationParameters=table)
 
     def test_validation_error_if_missing_params_table_in_non_calibration_call(self):
-        err_msg = "FitParametersTable is missing."
+        err_msg = "InputCalibrationParameters is missing."
         with self.assertRaisesRegex(RuntimeError, err_msg):
             PEARLTransfit(Files="PEARL00112777", Calibration=False)
 
     def test_calibration_run_single_run_background_table_provided(self):
         params_dict = {"Bg0": 0.0, "Bg1": -1.0, "Bg2": 1.0}
         table = _PEARLTransfit.generate_table(params_dict)
-        PEARLTransfit(Files="PEARL00112777", Calibration=True, FitParametersTable=table)
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, InputCalibrationParameters=table)
         self._assert_output_workspaces_exist(self.test_calib_output_name)
         self._assert_fit_parameters(self.test_calib_output_name, cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20729)
 
@@ -64,7 +64,7 @@ class PEARLTransfitV2Test(unittest.TestCase):
         # Test that the measurement run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
         PEARLTransfit(
-            Files="PEARL00112777", FitParametersTable=ADS.retrieve(f"{self.test_calib_output_name}_Parameters"), Calibration=False
+            Files="PEARL00112777", InputCalibrationParameters=ADS.retrieve(f"{self.test_calib_output_name}_Parameters"), Calibration=False
         )
         self._assert_output_workspaces_exist(self.test_calib_output_name)
         self._assert_output_workspaces_exist(self.test_temp_output_name)
@@ -73,7 +73,7 @@ class PEARLTransfitV2Test(unittest.TestCase):
         # Test that the measurement run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
         PEARLTransfit(
-            Files="PEARL00073987-00073990", FitParametersTable=ADS.retrieve("S_fit_Hf01_73987_73990_Parameters"), Calibration=False
+            Files="PEARL00073987-00073990", InputCalibrationParameters=ADS.retrieve("S_fit_Hf01_73987_73990_Parameters"), Calibration=False
         )
         self._assert_output_workspaces_exist("S_fit_Hf01_73987_73990")
         self._assert_output_workspaces_exist("T_fit_Hf01_73987_73990")
@@ -102,7 +102,7 @@ class PEARLTransfitV2Test(unittest.TestCase):
         }
 
         out_calib = PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        PEARLTransfit(Files="PEARL00112777", Calibration=False, FitParametersTable=out_calib[1], CreateDebugTable=True)
+        PEARLTransfit(Files="PEARL00112777", Calibration=False, InputCalibrationParameters=out_calib[1], CreateDebugTable=True)
 
         self._assert_output_workspaces_exist(self.test_calib_output_name)
         self._assert_output_workspaces_exist(self.test_temp_output_name)

--- a/docs/source/algorithms/PEARLTransfit-v2.rst
+++ b/docs/source/algorithms/PEARLTransfit-v2.rst
@@ -24,7 +24,7 @@ the temperature. Note that a recalibration is required for each given sample pre
 
 Version 2
 ---------
-For version 1 of this algorithm, see :ref:`PEARLTransfit-v1. <algm-PEARLTransfit-v1>`.
+For version 1 of this algorithm, see :ref:`PEARLTransfit-v1 <algm-PEARLTransfit-v1>`.
 
 In version 2 of this algorithm:
     - The Output Workspace and Fit Parameters Table are created as output properties and not directly extracted from the fit, this preserves workspace history.

--- a/docs/source/algorithms/PEARLTransfit-v2.rst
+++ b/docs/source/algorithms/PEARLTransfit-v2.rst
@@ -33,8 +33,28 @@ In version 2 of this algorithm:
     - There is no rebin in constant energy.
     - In non-calibration fits, a debug table with information about sample temperature can be output if `CreateDebugTable` is set to `True`.
 
-See usage script below.
 
+If no `FitParametersTable` is provided on a calibration run, the background parameters will be estimated from the data.
+This generates an output with the suffix `_Parameters` on the ADS containing, among others, background estimation parameters.
+This table can be used on successive calls to input background parameters. If custom background parameters need to be provided in a calibration run,
+a table workspace with the appropriate parameters can be created from the following script.
+
+.. code:: python
+
+    def create_fit_parameters_table(bg0, bg1, bg2, name="FitParametersTable"):
+        table = CreateEmptyTableWorkspace(OutputWorkspace=name)
+
+        table.addColumn("str","Name")
+        table.addColumn("float","Value")
+
+        for idx, bg in enumerate([bg0, bg1, bg2]):
+            table.addRow({"Name":f"Bg{idx}", "Value": bg})
+        return table
+
+    table = create_fit_parameters_table(10, 0.01, 0.000004)
+    cal_ws, params_table = PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=True, FitParametersTable=table, Output='pearl_cal')
+
+See script below for usage.
 
 .. testcode:: PEARLTransfitV2Example
 

--- a/docs/source/algorithms/PEARLTransfit-v2.rst
+++ b/docs/source/algorithms/PEARLTransfit-v2.rst
@@ -27,21 +27,21 @@ Version 2
 For version 1 of this algorithm, see :ref:`PEARLTransfit-v1 <algm-PEARLTransfit-v1>`.
 
 In version 2 of this algorithm:
-    - The Output Workspace and Fit Parameters Table are created as output properties and not directly extracted from the fit, this preserves workspace history.
+    - The Output Workspace and Parameters Table are created as output properties and not directly extracted from the fit, this preserves workspace history.
     - The `Output` property is a string that sets the basename for outputs in the ADS.
-    - There are no inputs for background parameter estimation, these can be provided in the `FitParametersTable`.
+    - There are no inputs for background parameter estimation, these can be provided in the `InputCalibrationParameters`.
     - There is no rebin in constant energy.
-    - In non-calibration fits, a debug table with information about sample temperature can be output if `CreateDebugTable` is set to `True`.
+    - In non-calibration fits, a debug table with information about sample temperature can be output if `CreateDebugTable` is set to `True`. The output table also contains the computed sample temperature.
 
 
-If no `FitParametersTable` is provided on a calibration run, the background parameters will be estimated from the data.
+If no `InputCalibrationParameters` is provided on a calibration run, the background parameters will be estimated from the data.
 This generates an output with the suffix `_Parameters` on the ADS containing, among others, background estimation parameters.
 This table can be used on successive calls to input background parameters. If custom background parameters need to be provided in a calibration run,
 a table workspace with the appropriate parameters can be created from the following script.
 
 .. code:: python
 
-    def create_fit_parameters_table(bg0, bg1, bg2, name="FitParametersTable"):
+    def create_input_calibration_table(bg0, bg1, bg2, name="InputCalibrationParameters"):
         table = CreateEmptyTableWorkspace(OutputWorkspace=name)
 
         table.addColumn("str","Name")
@@ -51,8 +51,8 @@ a table workspace with the appropriate parameters can be created from the follow
             table.addRow({"Name":f"Bg{idx}", "Value": bg})
         return table
 
-    table = create_fit_parameters_table(10, 0.01, 0.000004)
-    cal_ws, params_table = PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=True, FitParametersTable=table, Output='pearl_cal')
+    table = create_input_calibration_table(10, 0.01, 0.000004)
+    cal_ws, params_table = PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=True, InputCalibrationParameters=table, Output='pearl_cal')
 
 See script below for usage.
 
@@ -64,7 +64,7 @@ See script below for usage.
     cal_ws, params_table = PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=True, EstimateBackground=True, Output='pearl_cal')
 
     # Using results from calibration
-    non_cal_ws, params_table, debug_table= PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=False, FitParametersTable=params_table, CreateDebugTable=True)
+    non_cal_ws, params_table, debug_table= PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=False, InputCalibrationParameters=params_table, CreateDebugTable=True)
 
     # Debug table contains temperature and fitting information.
     row_temp_debug = debug_table.row(debug_table.rowCount()-1)

--- a/docs/source/algorithms/PEARLTransfit-v2.rst
+++ b/docs/source/algorithms/PEARLTransfit-v2.rst
@@ -67,13 +67,17 @@ See script below for usage.
     non_cal_ws, params_table, debug_table= PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=False, FitParametersTable=params_table, CreateDebugTable=True)
 
     # Debug table contains temperature and fitting information.
-    row_temp = debug_table.row(debug_table.rowCount()-1)
-    print(f"Sample Temperature (K) {row_temp['Value']:.3f} +- {row_temp['Error']:.3f}")
+    row_temp_debug = debug_table.row(debug_table.rowCount()-1)
+    print(f"Sample Temperature (K) {row_temp_debug['Value']:.3f} +- {row_temp_debug['Error']:.3f}")
+    # Fit Parameters table also includes calculated temperature
+    row_temp_fit_table = params_table.row(params_table.rowCount()-1)
+    print(f"Sample Temperature (K) {row_temp_fit_table['Value']:.3f} +- {row_temp_fit_table['Error']:.3f}")
 
 Output:
 
 .. testoutput:: PEARLTransfitV2Example
 
+   Sample Temperature (K) 279.760 +- 14.717
    Sample Temperature (K) 279.760 +- 14.717
 
 References

--- a/docs/source/algorithms/PEARLTransfit-v2.rst
+++ b/docs/source/algorithms/PEARLTransfit-v2.rst
@@ -1,0 +1,67 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+PEARL high-pressure, high-temperature measurements rely on the use neutron transmission data to determine the sample
+temperature. Typically Hf foil is included with the sample, though others can be used, provided they have well
+characterised resonances. Transfit is an algorithm which reads high-energy neutron resonances from the downstream
+monitor data on the PEARL instrument. It fits a Voigt function to them to determine the sample temperature. It is
+broadly similar to the Fortran77 version originally implemented on PEARL through OpenGenie. As currently coded – this is
+only appropriate for use on the PEARL instrument.
+
+Full details of how the temperature information is extracted from the peak shape parameters, can be found in the
+references below. Essentially, there are two components contributing to the peak shape, the Gaussian and Lorentzian.
+First, the calibration run must be performed to fit the instrument contributions to the line-shape, and account for any
+other effects to the line-shape at a given sample pressure. After this, only the Gaussian component is fitted to extract
+the temperature. Note that a recalibration is required for each given sample pressure.
+
+Version 2
+---------
+For version 1 of this algorithm, see :ref:`PEARLTransfit-v1. <algm-PEARLTransfit-v1>`.
+
+In version 2 of this algorithm:
+    - The Output Workspace and Fit Parameters Table are created as output properties and not directly extracted from the fit, this preserves workspace history.
+    - The `Output` property is a string that sets the basename for outputs in the ADS.
+    - There are no inputs for background parameter estimation, these can be provided in the `FitParametersTable`.
+    - There is no rebin in constant energy.
+    - In non-calibration fits, a debug table with information about sample temperature can be output if `CreateDebugTable` is set to `True`.
+
+See usage script below.
+
+
+.. testcode:: PEARLTransfitV2Example
+
+    from mantid.simpleapi import *
+
+    # Calibration
+    cal_ws, params_table = PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=True, EstimateBackground=True, Output='pearl_cal')
+
+    # Using results from calibration
+    non_cal_ws, params_table, debug_table= PEARLTransfit(Files='PEARL00112777', FoilType="Hf01", Calibration=False, FitParametersTable=params_table, CreateDebugTable=True)
+
+    # Debug table contains temperature and fitting information.
+    row_temp = debug_table.row(debug_table.rowCount()-1)
+    print(f"Sample Temperature (K) {row_temp['Value']:.3f} +- {row_temp['Error']:.3f}")
+
+Output:
+
+.. testoutput:: PEARLTransfitV2Example
+
+   Sample Temperature (K) 279.760 +- 14.717
+
+References
+----------
+
+‘Temperature measurement in a Paris-Edinburgh cell by neutron resonance spectroscopy' - Journal Of Applied Physics 98, 064905 (2005)
+'Remote determination of sample temperature by neutron resonance spectroscopy' - Nuclear Instruments and Methods in Physics Research A 547 (2005) 601-615
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.16.0/Diffraction/Powder/New_features/39151.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Powder/New_features/39151.rst
@@ -1,0 +1,1 @@
+- Version 2 of :ref:`PEARLTransfit <algm-PEARLTransfit-v2>` algorithm, with improvements in input/output properties management.


### PR DESCRIPTION
### Description of work
As outlined in #39151, this new version tries to improve in/out handling, while making other fixes:
In version 2 of this algorithm:
    - The Output Workspace and Fit Parameters Table are created as output properties and not directly extracted from the fit, this preserves workspace history.
    - The `Output` property is a string that sets the basename for outputs in the ADS.
    - There are no inputs for background parameter estimation, these can be provided in the `FitParametersTable`.
    - There is no rebin in constant energy.
    - In non-calibration fits, a debug table with information about sample temperature can be output if `CreateDebugTable` is set to `True`.

One proposed feature on #39151 was to add sequential fitting. I've discussed with Richard, and we've agreed since 6.16 is around the corner and the sequential fitting workflow is not really specified yet and would be more workflow breaking than this iteration, this will need further communication with scientist to get a better picture of what's required, or how that fits in a calibration workflow. It should be done as part of a separate issue. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39151. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- You can use the testcode example in the docs to start testing the new features. Try to test different input conditions. 
- Build docs and check everything is ok. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

**Added release notes**

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
