### PR TITLE
GroupingWorkspace output property for LoadWANDSCD and HB3AAdjustSampleNormTest

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -185,7 +185,7 @@ void ConvertHFIRSCDtoMDE::exec() {
     azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
     twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
     if (expInfo.run().hasProperty("detectorID")) {
-      detectorID = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<int>> *>(expInfo.getLog("detector_id"))))();
+      detectorID = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<int>> *>(expInfo.getLog("detectorID"))))();
     } else {
       // backwards compatibility if sample-log is not present
       detectorID.assign(azimuthal.size(), 0);

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -168,6 +168,7 @@ void ConvertHFIRSCDtoMDE::exec() {
   std::string instrument = expInfo.getInstrument()->getName();
 
   std::vector<double> twotheta, azimuthal;
+  std::vector<int> detectorID; // detector ID for each (twotheta, azimuthal), most useful when detector grouping done
   if (instrument == "HB3A" && !expInfo.run().hasProperty("azimuthal")) { // HB3A Load MD
     const auto &di = expInfo.detectorInfo();
     for (size_t x = 0; x < 512; x++) {
@@ -176,12 +177,19 @@ void ConvertHFIRSCDtoMDE::exec() {
         if (!di.isMonitor(n)) {
           twotheta.push_back(di.twoTheta(n));
           azimuthal.push_back(di.azimuthal(n));
+          detectorID.push_back(static_cast<int>(n));
         }
       }
     }
   } else { // HB2C LoadWAND or HB3A HB3AAdjustSampleNorm
     azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
     twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
+    if (expInfo.run().hasProperty("detector_id")) {
+      detectorID = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<int>> *>(expInfo.getLog("detector_id"))))();
+    } else {
+      // backwards compatibility if sample-log is not present
+      detectorID.assign(azimuthal.size(), 0);
+    }
   }
 
   auto outputWS = DataObjects::MDEventFactory::CreateMDWorkspace(3, "MDEvent");
@@ -240,12 +248,14 @@ void ConvertHFIRSCDtoMDE::exec() {
     for (size_t m = 0; m < azimuthal.size(); m++) {
       size_t idx = n * azimuthal.size() + m;
       coord_t signal = static_cast<coord_t>(inputWS->getSignalAt(idx));
+      auto detectno = static_cast<uint16_t>(detectorID[m]);
       if (signal > 0.f && std::isfinite(signal)) {
         Eigen::Vector3f q_sample = goniometer * q_lab_pre[m];
         if (lorentz) {
           factor = lorentz_pre[m];
         }
-        inserter.insertMDEvent(signal * factor, signal * factor * factor, 0, goniometerIndex, 0, q_sample.data());
+        inserter.insertMDEvent(signal * factor, signal * factor * factor, 0, goniometerIndex, detectno,
+                               q_sample.data());
       }
     }
   }

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -177,14 +177,14 @@ void ConvertHFIRSCDtoMDE::exec() {
         if (!di.isMonitor(n)) {
           twotheta.push_back(di.twoTheta(n));
           azimuthal.push_back(di.azimuthal(n));
-          detectorID.push_back(static_cast<int>(n));
+          detectorID.push_back(static_cast<int>(1 + n)); // detector ID's start at 1 in HB3A
         }
       }
     }
   } else { // HB2C LoadWAND or HB3A HB3AAdjustSampleNorm
     azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
     twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
-    if (expInfo.run().hasProperty("detector_id")) {
+    if (expInfo.run().hasProperty("detectorID")) {
       detectorID = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<int>> *>(expInfo.getLog("detector_id"))))();
     } else {
       // backwards compatibility if sample-log is not present
@@ -248,13 +248,12 @@ void ConvertHFIRSCDtoMDE::exec() {
     for (size_t m = 0; m < azimuthal.size(); m++) {
       size_t idx = n * azimuthal.size() + m;
       coord_t signal = static_cast<coord_t>(inputWS->getSignalAt(idx));
-      auto detectno = static_cast<uint16_t>(detectorID[m]);
       if (signal > 0.f && std::isfinite(signal)) {
         Eigen::Vector3f q_sample = goniometer * q_lab_pre[m];
         if (lorentz) {
           factor = lorentz_pre[m];
         }
-        inserter.insertMDEvent(signal * factor, signal * factor * factor, 0, goniometerIndex, detectno,
+        inserter.insertMDEvent(signal * factor, signal * factor * factor, 0, goniometerIndex, detectorID[m],
                                q_sample.data());
       }
     }

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -203,7 +203,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         self.declareProperty(
             WorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
-            doc="Optional: output Workspace2D mapping every detector's workspace index to its group ID. "
+            doc="Optional: output GroupingWorkspace mapping every detector's workspace index to its group ID. "
             "Only produced when Grouping is '2x2' or '4x4'.",
         )
         self.setPropertyGroup("Grouping", "Grouping")
@@ -473,10 +473,11 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             # Create the grouping workspace, if so required.
             if create_grouping_ws:
                 detector_ids_per_group = groups.reshape(-1, groups.shape[2])
-                # Use Workspace2D instead of GroupingWorkspace: building the detector-ID-to-workspace-index
-                # map in GroupingWorkspace is prohibitively slow for HB3A's ~786k detectors. Since HB3A
-                # detector IDs start at 1, workspace_index = det_id - 1, so dataY can be written directly.
-                grouping_workspace = WorkspaceFactory.create("Workspace2D", _tmp_ws.getNumberHistograms(), 1, 1)
+                # WorkspaceFactory.create is used directly rather than CreateGroupingWorkspace to avoid
+                # building the detector-ID-to-workspace-index map (detID_to_WI), which is prohibitively
+                # slow for HB3A's ~786k detectors. Since HB3A detector IDs start at 1,
+                # workspace_index = det_id - 1, so dataY can be written directly.
+                grouping_workspace = WorkspaceFactory.create("GroupingWorkspace", _tmp_ws.getNumberHistograms(), 1, 1)
                 for i, det_ids in enumerate(detector_ids_per_group):
                     group_id = float(i + 1)
                     for det_id in det_ids:

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (
     AlgorithmFactory,
+    CreateGroupingWorkspace,
     FileAction,
     FileProperty,
     IMDHistoWorkspace,
@@ -195,6 +196,12 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         self.declareProperty(
             "Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels (shared by input and normalization)"
         )
+
+        self.declareProperty(
+            WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output),
+            doc="Output MDWorkspace in Q-space, name is prefix if multiple input files were provided.",
+        )
+
         self.declareProperty(
             GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
             doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
@@ -202,10 +209,9 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         )
         self.setPropertyGroup("Grouping", "Grouping")
         self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
-
-        self.declareProperty(
-            WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output),
-            doc="Output MDWorkspace in Q-space, name is prefix if multiple input files were provided.",
+        self.setPropertySettings(
+            "OutputGroupingWorkspace",
+            EnabledWhenProperty("Grouping", PropertyCriterion.IsNotEqualTo, "None"),
         )
 
     def validateInputs(self):
@@ -246,8 +252,11 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                 issues["Wavelength"] = "Wavelength should be greater than zero"
 
         # OutputGroupingWorkspace requires grouping to be active
-        if self.getProperty("Grouping").value == "None" and not self.getProperty("OutputGroupingWorkspace").isDefault:
-            issues["OutputGroupingWorkspace"] = "OutputGroupingWorkspace can only be produced when Grouping is '2x2' or '4x4'"
+        if self.getProperty("Grouping").value == "None" and self.getPropertyValue("OutputGroupingWorkspace") != "":
+            grp_ws_name = self.getPropertyValue("OutputGroupingWorkspace")
+            issues["OutputGroupingWorkspace"] = (
+                f"OutputGroupingWorkspace '{grp_ws_name}' can only be produced when Grouping is '2x2' or '4x4'"
+            )
 
         return issues
 
@@ -277,10 +286,6 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         else:
             grouping = 2 if grouping == "2x2" else 4
 
-        # Determine whether to produce a GroupingWorkspace alongside the main output
-        create_grouping_ws = grouping != 1 and not self.getProperty("OutputGroupingWorkspace").isDefault
-        grouping_ws = None
-
         out_ws = self.getPropertyValue("OutputWorkspace")
         out_ws_name = out_ws
 
@@ -289,8 +294,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             vanws, _ = self.__regroup_and_move(vanws, grouping, height, distance)
 
         has_multiple = len(datafiles) > 1
-        first_file = True
-
+        first_iteration = True
         for in_file in datafiles:
             if load_files:
                 scan = LoadMD(in_file, LoadHistory=False, OutputWorkspace="__scan")
@@ -303,13 +307,13 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
             self.log().information("Detector adjustments '({},{})m'".format(height, distance))
 
-            # It's only necessary to create the grouping workspace in the first iteration of the datafiles loop
-            scan, ws_grouping = self.__regroup_and_move(
-                scan, grouping, height, distance, create_grouping_ws=(create_grouping_ws and first_file)
-            )
-            first_file = False
-            if ws_grouping is not None:
-                grouping_ws = ws_grouping
+            if first_iteration:
+                create_grouping_ws = grouping > 1 and not self.getProperty("OutputGroupingWorkspace").isDefault
+                scan, grouping_ws = self.__regroup_and_move(scan, grouping, height, distance, create_grouping_ws=create_grouping_ws)
+                first_iteration = False
+            else:
+                # no need to recreate the grouping workspace in later iterations
+                scan, _ = self.__regroup_and_move(scan, grouping, height, distance)
 
             prog.report()
             self.log().information("Processing '{}'".format(in_file))
@@ -383,46 +387,79 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             self.setProperty("OutputGroupingWorkspace", grouping_ws)
 
     def __regroup_and_move(self, scan, grouping, height, distance, create_grouping_ws=False):
-        ws = scan.name()
+        output_workspace_name = scan.name()  # the input workspace will be modified or replaced
 
-        array = mtd[ws].getSignalArray().copy()
+        array = mtd[output_workspace_name].getSignalArray().copy()
+        groups = None  # stores detector groupings
+        if grouping > 1:
+            # Layout of the detector IDs
+            #     1,      2,..,   512
+            #   513,    514,..,  1024
+            # ..
+            # 785921, 785922,..,786432
+            idmap = np.arange(1, 512 * 512 * 3 + 1).reshape((512 * 3, 512))  # reproduces the layout of detector IDs
+            if grouping == 2:
+                array = array[0::2, 0::2] + array[1::2, 0::2] + array[0::2, 1::2] + array[1::2, 1::2]
+                # groups[0, 0] = [1, 2, 513, 514]  the very first group of detectors
+                groups = np.stack([idmap[0::2, 0::2], idmap[0::2, 1::2], idmap[1::2, 0::2], idmap[1::2, 1::2]], axis=2)
+            elif grouping == 4:
+                array = (
+                    array[0::4, 0::4]
+                    + array[1::4, 0::4]
+                    + array[2::4, 0::4]
+                    + array[3::4, 0::4]
+                    + array[0::4, 1::4]
+                    + array[1::4, 1::4]
+                    + array[2::4, 1::4]
+                    + array[3::4, 1::4]
+                    + array[0::4, 2::4]
+                    + array[1::4, 2::4]
+                    + array[2::4, 2::4]
+                    + array[3::4, 2::4]
+                    + array[0::4, 3::4]
+                    + array[1::4, 3::4]
+                    + array[2::4, 3::4]
+                    + array[3::4, 3::4]
+                )
+                # groups[0, 0] = [1, 2, 3, 4, 513, 514, 515, 516, 1025, 1026, 1027, 1028, 1537, 1538, 1539, 1540]
+                groups = np.stack(
+                    [
+                        idmap[0::4, 0::4],
+                        idmap[1::4, 0::4],
+                        idmap[2::4, 0::4],
+                        idmap[3::4, 0::4],
+                        idmap[0::4, 1::4],
+                        idmap[1::4, 1::4],
+                        idmap[2::4, 1::4],
+                        idmap[3::4, 1::4],
+                        idmap[0::4, 2::4],
+                        idmap[1::4, 2::4],
+                        idmap[2::4, 2::4],
+                        idmap[3::4, 2::4],
+                        idmap[0::4, 3::4],
+                        idmap[1::4, 3::4],
+                        idmap[2::4, 3::4],
+                        idmap[3::4, 3::4],
+                    ],
+                    axis=2,
+                )
 
-        if grouping == 2:
-            array = array[0::2, 0::2] + array[1::2, 0::2] + array[0::2, 1::2] + array[1::2, 1::2]
-        elif grouping == 4:
-            array = (
-                array[0::4, 0::4]
-                + array[1::4, 0::4]
-                + array[2::4, 0::4]
-                + array[3::4, 0::4]
-                + array[0::4, 1::4]
-                + array[1::4, 1::4]
-                + array[2::4, 1::4]
-                + array[3::4, 1::4]
-                + array[0::4, 2::4]
-                + array[1::4, 2::4]
-                + array[2::4, 2::4]
-                + array[3::4, 2::4]
-                + array[0::4, 3::4]
-                + array[1::4, 3::4]
-                + array[2::4, 3::4]
-                + array[3::4, 3::4]
-            )
+        y_dim, x_dim, number_of_runs = array.shape  # y_dim, x_dim effective dimensions after grouping
+        array = array.T  # shape == (number_of_runs, x_dim, y_dim)
 
-        y_dim, x_dim, number_of_runs = array.shape
-        array = array.T
-
-        run = mtd[ws].getExperimentInfo(0).run()
+        # Create a temporary Workspace2D with the HB3A instrument geometry, using the detector
+        # translation and two-theta values from the scan to correctly position the instrument components.
+        # This workspace serves as a carrier for computing per-detector angles and IDs via ConvertToMD.
+        _tmp_ws = CreateSimulationWorkspace(Instrument="HB3A", BinParams="0,1,2", UnitX="TOF", SetErrors=True)
+        run = mtd[output_workspace_name].getExperimentInfo(0).run()
         det_trans = run.getProperty("det_trans").timeAverageValue()
         two_theta = run.getProperty("2theta").timeAverageValue()
-        logs = run.getLogData()
-
-        _tmp_ws = CreateSimulationWorkspace(Instrument="HB3A", BinParams="0,1,2", UnitX="TOF", SetErrors=True)
         AddSampleLog(Workspace=_tmp_ws, LogName="det_trans", LogText=str(det_trans), LogType="Number Series", NumberType="Double")
         AddSampleLog(Workspace=_tmp_ws, LogName="2theta", LogText=str(two_theta), LogType="Number Series", NumberType="Double")
         LoadInstrument(Workspace=_tmp_ws, RewriteSpectraMap=True, InstrumentName="HB3A")
         self.__move_components(_tmp_ws, height, distance)
 
+        grouping_workspace = None
         if grouping > 1:
             CreateMDHistoWorkspace(
                 SignalInput=array,
@@ -434,83 +471,64 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                 Units="bin,bin,number",
                 OutputWorkspace="__scan_grouped",
             )
-            detector_list = ""
-            for x in range(0, 512, grouping):
-                for y in range(0, 512 * 3, grouping):
-                    spectra_list = []
-                    for j in range(grouping):
-                        for i in range(grouping):
-                            spectra_list.append(str(x + i + (y + j) * 512))
-                    detector_list += "," + "+".join(spectra_list)
-            _ungrouped_tmp_ws = _tmp_ws
-            _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
-            grouping_ws = self._build_grouping_ws(_ungrouped_tmp_ws, grouping) if create_grouping_ws else None
-            DeleteWorkspace(_ungrouped_tmp_ws, EnableLogging=False)
-        else:
-            grouping_ws = None
+            # Create the grouping workspace, if so required
+            if create_grouping_ws:
+                detector_ids_per_group = groups.reshape(-1, groups.shape[2])
+                # grouping_pattern = '1+2+513+514, 3+4+515+516,..'
+                grouping_pattern = ",".join("+".join(str(idx) for idx in row) for row in detector_ids_per_group)
+                grouping_workspace = CreateGroupingWorkspace(
+                    InputWorkspace=_tmp_ws,
+                    CustomGroupingString=grouping_pattern,
+                    OutputWorkspace=self.getProperty("OutputGroupingWorkspace"),
+                    EnableLogging=False,
+                )
+            # Group spectra
+            workspace_indexes = groups - 1  # for the HB3A instrument, detector IDs start at 1, not 0
+            workspace_indexes = workspace_indexes.reshape(-1, workspace_indexes.shape[2])
+            # grouping_pattern = '0+1+512+513, 2+3+514+515,..'
+            grouping_pattern = ",".join("+".join(str(idx) for idx in row) for row in workspace_indexes)
+            _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=grouping_pattern, OutputWorkspace=_tmp_ws, EnableLogging=False)
 
+        # Convert Workspace2D to IMDEventWorkspace
         _tmp_ws = Rebin(InputWorkspace=_tmp_ws, Params="0,1,2", EnableLogging=False)
         _tmp_ws = ConvertToMD(
             InputWorkspace=_tmp_ws, dEAnalysisMode="Elastic", EnableLogging=False, PreprocDetectorsWS="_PreprocessedDetectorsWS"
         )
 
+        # Copy all original scan logs into _tmp_ws, overwriting the scalar "det_trans" and "2theta" logs
+        # added earlier with the full time-series logs from the input scan workspace
         run = _tmp_ws.getExperimentInfo(0).run()
-        for log in logs:
+        scan_logs = mtd[output_workspace_name].getExperimentInfo(0).run().getLogData()
+        for log in scan_logs:
             run[log.name] = log
+
+        # Collect twotheta, azimuthal, and detector ID's from the _PreprocessedDetectorsWS table
         run["twotheta"] = np.array(mtd["_PreprocessedDetectorsWS"].column(2)).reshape(y_dim, x_dim).T.flatten().tolist()
         run["azimuthal"] = np.array(mtd["_PreprocessedDetectorsWS"].column(3)).reshape(y_dim, x_dim).T.flatten().tolist()
-        # Store pixel ID. If grouping, follow Mantid convention by storing the first detector-pixel ID for each group
-        run["detectorID"] = np.array(mtd["_PreprocessedDetectorsWS"].column(4)).reshape(y_dim, x_dim).T.flatten().tolist()
+        # Store detector ID's. If grouping, follow Mantid convention by storing the first ID in each group
+        # The sequence of detector ID's follows an ascending order along the X-dimension first
+        first_detid = np.array(mtd["_PreprocessedDetectorsWS"].column(4))  # 1, 3, 5,..,1025, 1027,.. for 2x2 grouping
+        # sample-log "detectorID" stores ID's in ordering of ascending along the Y-dimension first,
+        # replicating the ordering in which "twotheta" and "azimuthal" are stored
+        run["detectorID"] = first_detid.reshape(y_dim, x_dim).T.flatten().tolist()  # 1, 1025, 2029,..,3,.. for 2x2
+
+        # transfer the UB matrix from the original scan data into _tmp_ws
         CopySample(scan, _tmp_ws, CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
 
-        donor_workspace = "__scan_grouped" if grouping > 1 else ws
-        mtd[donor_workspace].copyExperimentInfos(_tmp_ws)
+        # transfer the experiment info from _tmp_ws to the output workspace
+        if grouping > 1:
+            mtd["__scan_grouped"].copyExperimentInfos(_tmp_ws)
+            # replace the input scan workspace with the grouped workspace
+            DeleteWorkspace(scan)
+            RenameWorkspace("__scan_grouped", OutputWorkspace=output_workspace_name)
+        else:
+            mtd[output_workspace_name].copyExperimentInfos(_tmp_ws)
 
+        # clean up temporary workspaces
         DeleteWorkspace(_tmp_ws, EnableLogging=False)
         DeleteWorkspace("_PreprocessedDetectorsWS", EnableLogging=False)
 
-        if grouping > 1:
-            DeleteWorkspace(scan)
-            RenameWorkspace("__scan_grouped", OutputWorkspace=ws)
-
-        return mtd[ws], grouping_ws
-
-    def _build_grouping_ws(self, instrument_ws, grouping: int):
-        """
-        Build a GroupingWorkspace from an ungrouped HB3A instrument workspace.
-
-        Each detector ID (spectrum index) is mapped to a 1-indexed group ID that
-        matches the order in which groups appear in the ``GroupingPattern`` used by
-        ``GroupDetectors``. For the HB3A detector array (512 columns × 1536 rows across
-        3 banks), the spectrum at column ``x`` and row ``y`` has index ``x + y*512``
-        and belongs to group
-        ``(x // grouping) * ((512 * 3) // grouping) + (y // grouping) + 1``.
-
-        The returned workspace is NOT stored in the ADS; ``PyExec`` publishes it
-        via ``setProperty("OutputGroupingWorkspace", ...)``.
-
-        :param instrument_ws: Ungrouped workspace supplying the HB3A instrument geometry.
-        :param grouping: Pixel-grouping factor (2 for 2×2, 4 for 4×4).
-        :returns: Populated GroupingWorkspace.
-        """
-        # Initialise an empty GroupingWorkspace (all Y = 0) from the instrument
-        createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
-        createGrp_alg.setProperty("InputWorkspace", instrument_ws)
-        createGrp_alg.setProperty("OutputWorkspace", "__hb3a_grouping_ws")
-        createGrp_alg.execute()
-        grouping_ws = createGrp_alg.getProperty("OutputWorkspace").value
-
-        # Assign 1-indexed group IDs to every detector
-        y_groups = (512 * 3) // grouping
-        for x in range(0, 512, grouping):
-            x_idx = x // grouping
-            for y in range(0, 512 * 3, grouping):
-                group_id = float(x_idx * y_groups + y // grouping + 1)
-                for j in range(grouping):
-                    for i in range(grouping):
-                        grouping_ws.setValue(x + i + (y + j) * 512, group_id)
-
-        return grouping_ws
+        return mtd[output_workspace_name], grouping_workspace
 
     def __normalization(self, data, vanadium, load_files):
         if vanadium:

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -14,9 +14,9 @@ from mantid.api import (
     Progress,
     PropertyMode,
     MultipleFileProperty,
+    WorkspaceFactory,
     WorkspaceProperty,
 )
-from mantid.dataobjects import GroupingWorkspaceProperty
 from mantid.kernel import (
     Direction,
     EnabledWhenProperty,
@@ -202,8 +202,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         )
 
         self.declareProperty(
-            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
-            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
+            WorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output Workspace2D mapping every detector's workspace index to its group ID. "
             "Only produced when Grouping is '2x2' or '4x4'.",
         )
         self.setPropertyGroup("Grouping", "Grouping")
@@ -473,17 +473,15 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             # Create the grouping workspace, if so required.
             if create_grouping_ws:
                 detector_ids_per_group = groups.reshape(-1, groups.shape[2])
-                createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
-                createGrp_alg.setProperty("InputWorkspace", _tmp_ws)
-                createGrp_alg.setProperty("OutputWorkspace", "__hb3a_grouping_ws")
-                createGrp_alg.execute()
-                grouping_workspace = createGrp_alg.getProperty("OutputWorkspace").value
-                # Calling `CreateGroupingWorkspace` while feeding the detID-to-groupID mapping to option
-                # `CustomGroupingString` executes much slower than calling `setValue()` for every detector ID
+                # Use Workspace2D instead of GroupingWorkspace: building the detector-ID-to-workspace-index
+                # map in GroupingWorkspace is prohibitively slow for HB3A's ~786k detectors. Since HB3A
+                # detector IDs start at 1, workspace_index = det_id - 1, so dataY can be written directly.
+                grouping_workspace = WorkspaceFactory.create("Workspace2D", _tmp_ws.getNumberHistograms(), 1, 1)
                 for i, det_ids in enumerate(detector_ids_per_group):
                     group_id = float(i + 1)
                     for det_id in det_ids:
-                        grouping_workspace.setValue(int(det_id), group_id)
+                        grouping_workspace.dataY(int(det_id) - 1)[0] = group_id
+                        grouping_workspace.getSpectrum(int(det_id) - 1).setDetectorID(int(det_id))
 
             # Group spectra
             workspace_indexes = groups - 1  # for the HB3A instrument, detector IDs start at 1, not 0

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -513,7 +513,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         first_detid = np.array(mtd["_PreprocessedDetectorsWS"].column(4))  # 1, 3, 5,..,1025, 1027,.. for 2x2 grouping
         # sample-log "detectorID" stores ID's in ordering of ascending along the Y-dimension first,
         # replicating the ordering in which "twotheta" and "azimuthal" are stored
-        run["detectorID"] = first_detid.reshape(y_dim, x_dim).T.flatten().tolist()  # 1, 1025, 2029,..,3,.. for 2x2
+        run["detectorID"] = first_detid.reshape(y_dim, x_dim).T.flatten().tolist()  # 1, 1025, 2049,..,3,.. for 2x2
 
         # transfer the UB matrix from the original scan data into _tmp_ws
         CopySample(scan, _tmp_ws, CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -16,6 +16,7 @@ from mantid.api import (
     MultipleFileProperty,
     WorkspaceProperty,
 )
+from mantid.dataobjects import GroupingWorkspaceProperty
 from mantid.kernel import (
     Direction,
     EnabledWhenProperty,
@@ -194,6 +195,13 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         self.declareProperty(
             "Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels (shared by input and normalization)"
         )
+        self.declareProperty(
+            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
+            "Only produced when Grouping is '2x2' or '4x4'.",
+        )
+        self.setPropertyGroup("Grouping", "Grouping")
+        self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
 
         self.declareProperty(
             WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output),
@@ -237,6 +245,10 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             if wavelength.value <= 0.0:
                 issues["Wavelength"] = "Wavelength should be greater than zero"
 
+        # OutputGroupingWorkspace requires grouping to be active
+        if self.getProperty("Grouping").value == "None" and not self.getProperty("OutputGroupingWorkspace").isDefault:
+            issues["OutputGroupingWorkspace"] = "OutputGroupingWorkspace can only be produced when Grouping is '2x2' or '4x4'"
+
         return issues
 
     def PyExec(self):
@@ -265,14 +277,19 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         else:
             grouping = 2 if grouping == "2x2" else 4
 
+        # Determine whether to produce a GroupingWorkspace alongside the main output
+        create_grouping_ws = grouping != 1 and not self.getProperty("OutputGroupingWorkspace").isDefault
+        grouping_ws = None
+
         out_ws = self.getPropertyValue("OutputWorkspace")
         out_ws_name = out_ws
 
         if load_van:
             vanws = LoadMD(vanadiumfile, StoreInADS=True)
-            vanws = self.__regroup_and_move(vanws, grouping, height, distance)
+            vanws, _ = self.__regroup_and_move(vanws, grouping, height, distance)
 
         has_multiple = len(datafiles) > 1
+        first_file = True
 
         for in_file in datafiles:
             if load_files:
@@ -286,7 +303,13 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
             self.log().information("Detector adjustments '({},{})m'".format(height, distance))
 
-            scan = self.__regroup_and_move(scan, grouping, height, distance)
+            # It's only necessary to create the grouping workspace in the first iteration of the datafiles loop
+            scan, ws_grouping = self.__regroup_and_move(
+                scan, grouping, height, distance, create_grouping_ws=(create_grouping_ws and first_file)
+            )
+            first_file = False
+            if ws_grouping is not None:
+                grouping_ws = ws_grouping
 
             prog.report()
             self.log().information("Processing '{}'".format(in_file))
@@ -356,8 +379,10 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             DeleteWorkspace(vanws)
 
         self.setProperty("OutputWorkspace", out_ws_name)
+        if grouping_ws is not None:
+            self.setProperty("OutputGroupingWorkspace", grouping_ws)
 
-    def __regroup_and_move(self, scan, grouping, height, distance):
+    def __regroup_and_move(self, scan, grouping, height, distance, create_grouping_ws=False):
         ws = scan.name()
 
         array = mtd[ws].getSignalArray().copy()
@@ -417,7 +442,12 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                         for i in range(grouping):
                             spectra_list.append(str(x + i + (y + j) * 512))
                     detector_list += "," + "+".join(spectra_list)
+            _ungrouped_tmp_ws = _tmp_ws
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
+            grouping_ws = self._build_grouping_ws(_ungrouped_tmp_ws, grouping) if create_grouping_ws else None
+            DeleteWorkspace(_ungrouped_tmp_ws, EnableLogging=False)
+        else:
+            grouping_ws = None
 
         _tmp_ws = Rebin(InputWorkspace=_tmp_ws, Params="0,1,2", EnableLogging=False)
         _tmp_ws = ConvertToMD(
@@ -429,6 +459,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             run[log.name] = log
         run["twotheta"] = np.array(mtd["_PreprocessedDetectorsWS"].column(2)).reshape(y_dim, x_dim).T.flatten().tolist()
         run["azimuthal"] = np.array(mtd["_PreprocessedDetectorsWS"].column(3)).reshape(y_dim, x_dim).T.flatten().tolist()
+        # Store pixel ID. If grouping, follow Mantid convention by storing the first detector-pixel ID for each group
+        run["detectorID"] = np.array(mtd["_PreprocessedDetectorsWS"].column(4)).reshape(y_dim, x_dim).T.flatten().tolist()
         CopySample(scan, _tmp_ws, CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
 
         donor_workspace = "__scan_grouped" if grouping > 1 else ws
@@ -441,7 +473,44 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             DeleteWorkspace(scan)
             RenameWorkspace("__scan_grouped", OutputWorkspace=ws)
 
-        return mtd[ws]
+        return mtd[ws], grouping_ws
+
+    def _build_grouping_ws(self, instrument_ws, grouping: int):
+        """
+        Build a GroupingWorkspace from an ungrouped HB3A instrument workspace.
+
+        Each detector ID (spectrum index) is mapped to a 1-indexed group ID that
+        matches the order in which groups appear in the ``GroupingPattern`` used by
+        ``GroupDetectors``. For the HB3A detector array (512 columns × 1536 rows across
+        3 banks), the spectrum at column ``x`` and row ``y`` has index ``x + y*512``
+        and belongs to group
+        ``(x // grouping) * ((512 * 3) // grouping) + (y // grouping) + 1``.
+
+        The returned workspace is NOT stored in the ADS; ``PyExec`` publishes it
+        via ``setProperty("OutputGroupingWorkspace", ...)``.
+
+        :param instrument_ws: Ungrouped workspace supplying the HB3A instrument geometry.
+        :param grouping: Pixel-grouping factor (2 for 2×2, 4 for 4×4).
+        :returns: Populated GroupingWorkspace.
+        """
+        # Initialise an empty GroupingWorkspace (all Y = 0) from the instrument
+        createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
+        createGrp_alg.setProperty("InputWorkspace", instrument_ws)
+        createGrp_alg.setProperty("OutputWorkspace", "__hb3a_grouping_ws")
+        createGrp_alg.execute()
+        grouping_ws = createGrp_alg.getProperty("OutputWorkspace").value
+
+        # Assign 1-indexed group IDs to every detector
+        y_groups = (512 * 3) // grouping
+        for x in range(0, 512, grouping):
+            x_idx = x // grouping
+            for y in range(0, 512 * 3, grouping):
+                group_id = float(x_idx * y_groups + y // grouping + 1)
+                for j in range(grouping):
+                    for i in range(grouping):
+                        grouping_ws.setValue(x + i + (y + j) * 512, group_id)
+
+        return grouping_ws
 
     def __normalization(self, data, vanadium, load_files):
         if vanadium:

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (
     AlgorithmFactory,
-    CreateGroupingWorkspace,
     FileAction,
     FileProperty,
     IMDHistoWorkspace,
@@ -471,17 +470,21 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                 Units="bin,bin,number",
                 OutputWorkspace="__scan_grouped",
             )
-            # Create the grouping workspace, if so required
+            # Create the grouping workspace, if so required.
             if create_grouping_ws:
                 detector_ids_per_group = groups.reshape(-1, groups.shape[2])
-                # grouping_pattern = '1+2+513+514, 3+4+515+516,..'
-                grouping_pattern = ",".join("+".join(str(idx) for idx in row) for row in detector_ids_per_group)
-                grouping_workspace = CreateGroupingWorkspace(
-                    InputWorkspace=_tmp_ws,
-                    CustomGroupingString=grouping_pattern,
-                    OutputWorkspace=self.getProperty("OutputGroupingWorkspace"),
-                    EnableLogging=False,
-                )
+                createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
+                createGrp_alg.setProperty("InputWorkspace", _tmp_ws)
+                createGrp_alg.setProperty("OutputWorkspace", "__hb3a_grouping_ws")
+                createGrp_alg.execute()
+                grouping_workspace = createGrp_alg.getProperty("OutputWorkspace").value
+                # Calling `CreateGroupingWorkspace` while feeding the detID-to-groupID mapping to option
+                # `CustomGroupingString` executes much slower than calling `setValue()` for every detector ID
+                for i, det_ids in enumerate(detector_ids_per_group):
+                    group_id = float(i + 1)
+                    for det_id in det_ids:
+                        grouping_workspace.setValue(int(det_id), group_id)
+
             # Group spectra
             workspace_indexes = groups - 1  # for the HB3A instrument, detector IDs start at 1, not 0
             workspace_indexes = workspace_indexes.reshape(-1, workspace_indexes.shape[2])

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -20,10 +20,10 @@ from mantid.api import (
     Progress,
     PropertyMode,
     PythonAlgorithm,
+    WorkspaceFactory,
     WorkspaceProperty,
     mtd,
 )
-from mantid.dataobjects import GroupingWorkspaceProperty
 from mantid.kernel import (
     Direction,
     Property,
@@ -112,8 +112,8 @@ class LoadWANDSCD(PythonAlgorithm):
         )
 
         self.declareProperty(
-            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
-            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
+            WorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output Workspace2D mapping every detector's workspace index to its group ID. "
             "Only produced when Grouping is '2x2' or '4x4'.",
         )
         self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
@@ -442,37 +442,36 @@ class LoadWANDSCD(PythonAlgorithm):
 
     def _build_grouping_ws(self, instrument_ws, grouping: int):
         """
-        Build a GroupingWorkspace from an ungrouped instrument workspace.
+        Build a Workspace2D from an ungrouped instrument workspace mapping workspace indices to group IDs.
 
-        Each detector ID is mapped to a 1-indexed group ID that matches the
+        Each workspace index is mapped to a 1-indexed group ID that matches the
         order in which groups appear in the ``GroupingPattern`` used by
         ``GroupDetectors``. For the WAND detector array (480×8 rows, 512 columns),
-        detector ``y + x*512`` belongs to group
+        workspace index ``y + x*512`` belongs to group
         ``(x // grouping) * (512 // grouping) + (y // grouping) + 1``.
+
+        A ``Workspace2D`` is used instead of a ``GroupingWorkspace`` for performance reasons.
+        ``GroupingWorkspace`` inherits from ``SpecialWorkspace2D``, which maintains a
+        detector-ID-to-workspace-index map (``detID_to_WI``) built by iterating over every
+        spectrum and querying the instrument geometry. For the WAND array (~2 million detectors)
+        this takes tens of seconds. Because WAND detector IDs map one-to-one onto workspace
+        indices, the map is unnecessary: group IDs can be written directly via ``dataY(wi)``
+        without any detector lookup.
 
         The returned workspace is NOT stored in the ADS; ``PyExec`` publishes it
         via ``setProperty("OutputGroupingWorkspace", ...)``.
 
-        :param instrument_ws: Ungrouped workspace supplying the instrument geometry.
+        :param instrument_ws: Ungrouped workspace supplying the number of histograms.
         :param grouping: Pixel-grouping factor (2 for 2×2, 4 for 4×4).
-        :returns: Populated GroupingWorkspace.
+        :returns: Populated Workspace2D.
         """
-        # Initialise an empty GroupingWorkspace (all Y = 0) from the instrument
-        createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
-        createGrp_alg.setProperty("InputWorkspace", instrument_ws)
-        createGrp_alg.setProperty("OutputWorkspace", "__wand_grouping_ws")
-        createGrp_alg.execute()
-        grouping_ws = createGrp_alg.getProperty("OutputWorkspace").value
-
-        # Assign 1-indexed group IDs to every detector
-        y_groups = 512 // grouping
-        for x in range(0, 480 * 8, grouping):
-            x_idx = x // grouping
-            for y in range(0, 512, grouping):
-                group_id = float(x_idx * y_groups + y // grouping + 1)
-                for j in range(grouping):
-                    for i in range(grouping):
-                        grouping_ws.setValue(y + i + (x + j) * 512, group_id)
+        grouping_ws = WorkspaceFactory.create("Workspace2D", instrument_ws.getNumberHistograms(), 1, 1)
+        # For WAND, the correspondence between detector ID and workspace index is one-to-one
+        nHist = instrument_ws.getNumberHistograms()
+        wi = np.arange(nHist)
+        group_ids = (wi // 512 // grouping) * (512 // grouping) + (wi % 512 // grouping) + 1.0
+        for i in range(nHist):
+            grouping_ws.dataY(i)[0] = group_ids[i]
 
         return grouping_ws
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -176,7 +176,7 @@ class LoadWANDSCD(PythonAlgorithm):
 
         # setup output
         self.setProperty("OutputWorkspace", data)
-        if grouping_ws is not None:
+        if create_grouping_ws:
             self.setProperty("OutputGroupingWorkspace", grouping_ws)
         # cleanup
         DeleteWorkspace(data)
@@ -369,6 +369,7 @@ class LoadWANDSCD(PythonAlgorithm):
 
         SetUB(_tmp_ws, UB=UB, EnableLogging=False)
 
+        grouping_ws = None
         if grouping > 1:
             detector_list = ""
             for x in range(0, 480 * 8, grouping):
@@ -378,12 +379,9 @@ class LoadWANDSCD(PythonAlgorithm):
                         for i in range(grouping):
                             spectra_list.append(str(y + i + (x + j) * 512))
                     detector_list += "," + "+".join(spectra_list)
-            _ungrouped_tmp_ws = _tmp_ws
+            if create_grouping_ws:
+                grouping_ws = self._build_grouping_ws(_tmp_ws, grouping)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
-            grouping_ws = self._build_grouping_ws(_ungrouped_tmp_ws, grouping) if create_grouping_ws else None
-            DeleteWorkspace(_ungrouped_tmp_ws, EnableLogging=False)
-        else:
-            grouping_ws = None
 
         progress.report("Adding logs")
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import re
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 import h5py
@@ -23,6 +23,7 @@ from mantid.api import (
     WorkspaceProperty,
     mtd,
 )
+from mantid.dataobjects import GroupingWorkspaceProperty
 from mantid.kernel import (
     Direction,
     Property,
@@ -97,6 +98,12 @@ class LoadWANDSCD(PythonAlgorithm):
         self.declareProperty(
             "Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels (shared by input and normalization)"
         )
+        self.declareProperty(
+            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
+            "Only produced when Grouping is '2x2' or '4x4'.",
+        )
+        self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
 
         # apply goniometer tilt
         self.declareProperty(
@@ -126,14 +133,20 @@ class LoadWANDSCD(PythonAlgorithm):
         if (va_useIPTS and va_noRunNumber) or (va_noIPTS and va_useRunNumber):
             issues["VanadiumIPTS"] = "VanadiumIPTS and VanadiumRunNumber must be specified together"
 
+        # case 3: OutputGroupingWorkspace requires Grouping to be set
+        if self.getProperty("Grouping").value == "None" and not self.getProperty("OutputGroupingWorkspace").isDefault:
+            issues["OutputGroupingWorkspace"] = "OutputGroupingWorkspace can only be produced when Grouping is '2x2' or '4x4'"
+
         return issues
 
     def PyExec(self):
         # Process input data
         # get the list of input filenames
         runs = self.get_intput_filenames()
+        # determine whether to produce a GroupingWorkspace alongside the main output
+        create_grouping_ws = self.getProperty("Grouping").value != "None" and not self.getProperty("OutputGroupingWorkspace").isDefault
         # load and group
-        data = self.load_and_group(runs)
+        data, grouping_ws = self.load_and_group(runs, create_grouping_ws=create_grouping_ws)
 
         # check if normalization need to be performed
         # NOTE: the normalization will be skipped if no information regarding Vanadium is provided
@@ -152,7 +165,7 @@ class LoadWANDSCD(PythonAlgorithm):
                 # try to load from memory
                 norm = self.getProperty("VanadiumWorkspace").value
             else:
-                norm = self.load_and_group([van_filename])
+                norm, _ = self.load_and_group([van_filename])
             # normalize
             data = self.normalize(data, norm, self.getProperty("NormalizedBy").value.lower())
             # cleanup
@@ -162,6 +175,8 @@ class LoadWANDSCD(PythonAlgorithm):
 
         # setup output
         self.setProperty("OutputWorkspace", data)
+        if grouping_ws is not None:
+            self.setProperty("OutputGroupingWorkspace", grouping_ws)
         # cleanup
         DeleteWorkspace(data)
 
@@ -211,7 +226,7 @@ class LoadWANDSCD(PythonAlgorithm):
             va_filename = None
         return va_filename
 
-    def load_and_group(self, runs: List[str]) -> IMDHistoWorkspace:  # noqa: C901
+    def load_and_group(self, runs: List[str], create_grouping_ws: bool = False) -> Tuple[IMDHistoWorkspace, Optional[object]]:  # noqa: C901
         """
         Loads and groups data from the provided list of run files.
 
@@ -221,7 +236,10 @@ class LoadWANDSCD(PythonAlgorithm):
         workspace.
 
         :param runs: A list of file paths to the run files to be loaded and grouped.
-        :returns: An MDHistoWorkspace containing the grouped data and associated metadata.
+        :param create_grouping_ws: When True and grouping is applied, also build a
+            GroupingWorkspace mapping every detector ID to its 1-indexed group ID.
+        :returns: A tuple ``(outWS, grouping_ws)`` where ``grouping_ws`` is ``None``
+            when ``create_grouping_ws`` is False or no grouping was requested.
         """
         # grouping config
         grouping = self.getProperty("Grouping").value
@@ -359,7 +377,12 @@ class LoadWANDSCD(PythonAlgorithm):
                         for i in range(grouping):
                             spectra_list.append(str(y + i + (x + j) * 512))
                     detector_list += "," + "+".join(spectra_list)
+            _ungrouped_tmp_ws = _tmp_ws
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
+            grouping_ws = self._build_grouping_ws(_ungrouped_tmp_ws, grouping) if create_grouping_ws else None
+            DeleteWorkspace(_ungrouped_tmp_ws, EnableLogging=False)
+        else:
+            grouping_ws = None
 
         progress.report("Adding logs")
 
@@ -372,6 +395,7 @@ class LoadWANDSCD(PythonAlgorithm):
         preprocWS = mtd["__PreprocessedDetectorsWS"]
         twotheta = preprocWS.column(2)
         azimuthal = preprocWS.column(3)
+        detectorID = preprocWS.column(4)
 
         outWS.copyExperimentInfos(_tmp_ws)
         DeleteWorkspace(_tmp_ws, EnableLogging=False)
@@ -396,6 +420,8 @@ class LoadWANDSCD(PythonAlgorithm):
         # Log the detector/group orientations with respect to the sample's position
         run.addProperty("twotheta", twotheta, True)
         run.addProperty("azimuthal", azimuthal, True)
+        # Store pixel ID. If grouping, follow Mantid convention by storing the first detector-pixel ID for each group
+        run.addProperty("detectorID", detectorID, True)
 
         # Add SE logs to the output workspace
         for log_name, log_values in SE_logs.items():
@@ -413,7 +439,43 @@ class LoadWANDSCD(PythonAlgorithm):
         setGoniometer_alg.setProperty("Average", False)
         setGoniometer_alg.execute()
 
-        return outWS
+        return outWS, grouping_ws
+
+    def _build_grouping_ws(self, instrument_ws, grouping: int):
+        """
+        Build a GroupingWorkspace from an ungrouped instrument workspace.
+
+        Each detector ID is mapped to a 1-indexed group ID that matches the
+        order in which groups appear in the ``GroupingPattern`` used by
+        ``GroupDetectors``. For the WAND detector array (480×8 rows, 512 columns),
+        detector ``y + x*512`` belongs to group
+        ``(x // grouping) * (512 // grouping) + (y // grouping) + 1``.
+
+        The returned workspace is NOT stored in the ADS; ``PyExec`` publishes it
+        via ``setProperty("OutputGroupingWorkspace", ...)``.
+
+        :param instrument_ws: Ungrouped workspace supplying the instrument geometry.
+        :param grouping: Pixel-grouping factor (2 for 2×2, 4 for 4×4).
+        :returns: Populated GroupingWorkspace.
+        """
+        # Initialise an empty GroupingWorkspace (all Y = 0) from the instrument
+        createGrp_alg = self.createChildAlgorithm("CreateGroupingWorkspace", enableLogging=False)
+        createGrp_alg.setProperty("InputWorkspace", instrument_ws)
+        createGrp_alg.setProperty("OutputWorkspace", "__wand_grouping_ws")
+        createGrp_alg.execute()
+        grouping_ws = createGrp_alg.getProperty("OutputWorkspace").value
+
+        # Assign 1-indexed group IDs to every detector
+        y_groups = 512 // grouping
+        for x in range(0, 480 * 8, grouping):
+            x_idx = x // grouping
+            for y in range(0, 512, grouping):
+                group_id = float(x_idx * y_groups + y // grouping + 1)
+                for j in range(grouping):
+                    for i in range(grouping):
+                        grouping_ws.setValue(y + i + (x + j) * 512, group_id)
+
+        return grouping_ws
 
     def normalize(
         self,

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -113,7 +113,7 @@ class LoadWANDSCD(PythonAlgorithm):
 
         self.declareProperty(
             WorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
-            doc="Optional: output Workspace2D mapping every detector's workspace index to its group ID. "
+            doc="Optional: output GroupingWorkspace mapping every detector's workspace index to its group ID. "
             "Only produced when Grouping is '2x2' or '4x4'.",
         )
         self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
@@ -442,7 +442,7 @@ class LoadWANDSCD(PythonAlgorithm):
 
     def _build_grouping_ws(self, instrument_ws, grouping: int):
         """
-        Build a Workspace2D from an ungrouped instrument workspace mapping workspace indices to group IDs.
+        Build a GroupingWorkspace from an ungrouped instrument workspace mapping workspace indices to group IDs.
 
         Each workspace index is mapped to a 1-indexed group ID that matches the
         order in which groups appear in the ``GroupingPattern`` used by
@@ -450,22 +450,14 @@ class LoadWANDSCD(PythonAlgorithm):
         workspace index ``y + x*512`` belongs to group
         ``(x // grouping) * (512 // grouping) + (y // grouping) + 1``.
 
-        A ``Workspace2D`` is used instead of a ``GroupingWorkspace`` for performance reasons.
-        ``GroupingWorkspace`` inherits from ``SpecialWorkspace2D``, which maintains a
-        detector-ID-to-workspace-index map (``detID_to_WI``) built by iterating over every
-        spectrum and querying the instrument geometry. For the WAND array (~2 million detectors)
-        this takes tens of seconds. Because WAND detector IDs map one-to-one onto workspace
-        indices, the map is unnecessary: group IDs can be written directly via ``dataY(wi)``
-        without any detector lookup.
-
         The returned workspace is NOT stored in the ADS; ``PyExec`` publishes it
         via ``setProperty("OutputGroupingWorkspace", ...)``.
 
         :param instrument_ws: Ungrouped workspace supplying the number of histograms.
         :param grouping: Pixel-grouping factor (2 for 2×2, 4 for 4×4).
-        :returns: Populated Workspace2D.
+        :returns: Populated GroupingWorkspace.
         """
-        grouping_ws = WorkspaceFactory.create("Workspace2D", instrument_ws.getNumberHistograms(), 1, 1)
+        grouping_ws = WorkspaceFactory.create("GroupingWorkspace", instrument_ws.getNumberHistograms(), 1, 1)
         # For WAND, the correspondence between detector ID and workspace index is one-to-one
         nHist = instrument_ws.getNumberHistograms()
         wi = np.arange(nHist)

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -98,12 +98,6 @@ class LoadWANDSCD(PythonAlgorithm):
         self.declareProperty(
             "Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels (shared by input and normalization)"
         )
-        self.declareProperty(
-            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
-            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
-            "Only produced when Grouping is '2x2' or '4x4'.",
-        )
-        self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
 
         # apply goniometer tilt
         self.declareProperty(
@@ -116,6 +110,13 @@ class LoadWANDSCD(PythonAlgorithm):
         self.declareProperty(
             WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output), "Output Workspace"
         )
+
+        self.declareProperty(
+            GroupingWorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output GroupingWorkspace mapping every detector ID to its group ID. "
+            "Only produced when Grouping is '2x2' or '4x4'.",
+        )
+        self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
 
     def validateInputs(self):
         issues = dict()

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -238,7 +238,7 @@ class LoadWANDSCD(PythonAlgorithm):
 
         :param runs: A list of file paths to the run files to be loaded and grouped.
         :param create_grouping_ws: When True and grouping is applied, also build a
-            GroupingWorkspace mapping every detector ID to its 1-indexed group ID.
+            Workspace2D mapping every detector ID to its 1-indexed group ID.
         :returns: A tuple ``(outWS, grouping_ws)`` where ``grouping_ws`` is ``None``
             when ``create_grouping_ws`` is False or no grouping was requested.
         """
@@ -472,6 +472,7 @@ class LoadWANDSCD(PythonAlgorithm):
         group_ids = (wi // 512 // grouping) * (512 // grouping) + (wi % 512 // grouping) + 1.0
         for i in range(nHist):
             grouping_ws.dataY(i)[0] = group_ids[i]
+            grouping_ws.getSpectrum(i).setDetectorID(i)
 
         return grouping_ws
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -114,8 +114,12 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
 
     def testDetectorGrouping(self):
         data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="None")
-        data_2x2 = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="2x2")
-        data_4x4 = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="4x4")
+        data_2x2 = HB3AAdjustSampleNorm(
+            "HB3A_data.nxs", OutputWorkspace="data_2x2", OutputType="Detector", NormaliseBy="None", Grouping="2x2"
+        )
+        data_4x4 = HB3AAdjustSampleNorm(
+            "HB3A_data.nxs", OutputWorkspace="data_4x4", OutputType="Detector", NormaliseBy="None", Grouping="4x4"
+        )
 
         ref_sum = data.getSignalArray().sum()
         self.assertAlmostEqual(ref_sum, data_2x2.getSignalArray().sum())
@@ -167,38 +171,9 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         )
 
         # Check specific values for the first four entries of each detectorID log.
-        # The HB3A instrument (HB3A_Definition_20190926_3.xml) has three 512×512 banks:
-        #   Bank 1: idstart=1,      idstepbyrow=512  → detID = 1      + x + y*512
-        #   Bank 2: idstart=262145, idstepbyrow=512  → detID = 262145 + x + y*512
-        #   Bank 3: idstart=524289, idstepbyrow=512  → detID = 524289 + x + y*512
-        # CreateSimulationWorkspace + RewriteSpectraMap=True assigns spectrum k (0-based)
-        # to the kth detector in sorted ID order, so spectrum k maps to detector k+1.
-        # The reshape(y_dim, x_dim).T.flatten() transform maps:
-        #   flat2[c*y_dim + r] = flat_column[r*x_dim + c]
-        #
-        # Ungrouped (y_dim=1536, x_dim=512): flat_column[k] = k+1
-        #   i=0: flat[0]    = 1    (bank1, x=0, y=0)
-        #   i=1: flat[512]  = 513  (bank1, x=0, y=1)
-        #   i=2: flat[1024] = 1025 (bank1, x=0, y=2)
-        #   i=3: flat[1536] = 1537 (bank1, x=0, y=3)
-        np.testing.assert_array_equal(ids[:4], [1, 513, 1025, 1537], err_msg="First four ungrouped detectorIDs are incorrect")
-
-        # 2x2 (y_dim=768, x_dim=256): group at (x_idx, y_idx) has first spectrum 2*x_idx + 1024*y_idx
-        #   → detID = 2*x_idx + 1024*y_idx + 1
-        #   flat2 index i → k = r*256 + c (r = i % 768, c = i // 768):
-        #   i=0: k=0,   x_idx=0, y_idx=0   → 1      (bank1, x=0, y=0)
-        #   i=1: k=256, x_idx=0, y_idx=256  → 262145 (bank2, x=0, y=0 — first pixel of bank 2)
-        #   i=2: k=512, x_idx=0, y_idx=512  → 524289 (bank3, x=0, y=0 — first pixel of bank 3)
-        #   i=3: k=768, x_idx=1, y_idx=0    → 3      (bank1, x=2, y=0)
-        np.testing.assert_array_equal(ids_2x2[:4], [1, 262145, 524289, 3], err_msg="First four 2x2 detectorIDs are incorrect")
-
-        # 4x4 (y_dim=384, x_dim=128): group at (x_idx, y_idx) has first spectrum 4*x_idx + 2048*y_idx
-        #   → detID = 4*x_idx + 2048*y_idx + 1
-        #   i=0: k=0,   x_idx=0, y_idx=0   → 1      (bank1, x=0, y=0)
-        #   i=1: k=128, x_idx=0, y_idx=128  → 262145 (bank2, x=0, y=0)
-        #   i=2: k=256, x_idx=0, y_idx=256  → 524289 (bank3, x=0, y=0)
-        #   i=3: k=384, x_idx=1, y_idx=0    → 5      (bank1, x=4, y=0)
-        np.testing.assert_array_equal(ids_4x4[:4], [1, 262145, 524289, 5], err_msg="First four 4x4 detectorIDs are incorrect")
+        np.testing.assert_array_equal(ids[:4], [1, 513, 1025, 1537])
+        np.testing.assert_array_equal(ids_2x2[:4], [1, 1025, 2049, 3073])
+        np.testing.assert_array_equal(ids_4x4[:4], [1, 2049, 4097, 6145])
 
     def testOutputGroupingWorkspace(self):
 
@@ -213,7 +188,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
                 OutputGroupingWorkspace="__hb3a_grp_fail",
             )
 
-        # --- 2x2: workspace is produced with correct type and size ---
+        # --- 2x2:
         HB3AAdjustSampleNorm(
             "HB3A_data.nxs",
             OutputType="Detector",
@@ -222,29 +197,16 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
             OutputWorkspace="__hb3a_out_2x2",
             OutputGroupingWorkspace="__hb3a_grp_2x2",
         )
-        self.assertTrue(mtd.doesExist("__hb3a_grp_2x2"), "OutputGroupingWorkspace should be stored in the ADS")
         grp_2x2 = mtd["__hb3a_grp_2x2"]
         self.assertIsInstance(grp_2x2, GroupingWorkspace)
-        # One spectrum per ungrouped detector: 512 columns × 1536 rows (3 × 512 banks)
-        self.assertEqual(grp_2x2.getNumberHistograms(), 512 * 1536)
+        # One spectrum per pixel detector. HB3A has three 512x512 detector panels
+        self.assertEqual(grp_2x2.getNumberHistograms(), 512 * 512 * 3)
+        # check the group ID of the first spectra:
+        group_ids = grp_2x2.extractY().astype(int).flatten()  # 1, 1, 2, 2, 3, 3,..
+        self.assertListEqual(group_ids[0:6].tolist(), [1, 1, 2, 2, 3, 3])  # first row along X
+        self.assertListEqual(group_ids[512:518].tolist(), [1, 1, 2, 2, 3, 3])  # second row
 
-        # Group 1: x in [0,1], y in [0,1]
-        #   x_idx=0, y_idx=0, y_groups = 1536//2 = 768  →  group_id = 0*768 + 0 + 1 = 1
-        #   Spectrum indices: x+i + (y+j)*512, i,j ∈ {0,1}  →  0, 1, 512, 513
-        for i in range(2):
-            for j in range(2):
-                spec = i + j * 512
-                self.assertAlmostEqual(grp_2x2.readY(spec)[0], 1.0, msg=f"Spectrum {spec} should belong to group 1 (2x2)")
-
-        # Group 2: x in [0,1], y in [2,3]
-        #   x_idx=0, y_idx=1  →  group_id = 0*768 + 1 + 1 = 2
-        #   Spectrum indices: i + (2+j)*512, i,j ∈ {0,1}  →  1024, 1025, 1536, 1537
-        for i in range(2):
-            for j in range(2):
-                spec = i + (2 + j) * 512
-                self.assertAlmostEqual(grp_2x2.readY(spec)[0], 2.0, msg=f"Spectrum {spec} should belong to group 2 (2x2)")
-
-        # --- 4x4: workspace is produced with correct type and size ---
+        # --- 4x4:
         HB3AAdjustSampleNorm(
             "HB3A_data.nxs",
             OutputType="Detector",
@@ -256,23 +218,12 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         self.assertTrue(mtd.doesExist("__hb3a_grp_4x4"), "OutputGroupingWorkspace should be stored in the ADS")
         grp_4x4 = mtd["__hb3a_grp_4x4"]
         self.assertIsInstance(grp_4x4, GroupingWorkspace)
-        self.assertEqual(grp_4x4.getNumberHistograms(), 512 * 1536)
-
-        # Group 1: x in [0,3], y in [0,3]
-        #   x_idx=0, y_idx=0, y_groups = 1536//4 = 384  →  group_id = 0*384 + 0 + 1 = 1
-        #   Spectrum indices: i + j*512, i,j ∈ {0,1,2,3}
-        for i in range(4):
-            for j in range(4):
-                spec = i + j * 512
-                self.assertAlmostEqual(grp_4x4.readY(spec)[0], 1.0, msg=f"Spectrum {spec} should belong to group 1 (4x4)")
-
-        # Group 2: x in [0,3], y in [4,7]
-        #   x_idx=0, y_idx=1  →  group_id = 0*384 + 1 + 1 = 2
-        #   Spectrum indices: i + (4+j)*512, i,j ∈ {0,1,2,3}
-        for i in range(4):
-            for j in range(4):
-                spec = i + (4 + j) * 512
-                self.assertAlmostEqual(grp_4x4.readY(spec)[0], 2.0, msg=f"Spectrum {spec} should belong to group 2 (4x4)")
+        self.assertEqual(grp_4x4.getNumberHistograms(), 512 * 512 * 3)
+        group_ids = grp_4x4.extractY().astype(int).flatten()  # 1, 1, 1, 1, 2, 2, 2, 2,..
+        self.assertListEqual(group_ids[0:8].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # first row along X
+        self.assertListEqual(group_ids[512:520].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # second row
+        self.assertListEqual(group_ids[1024:1032].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # third row
+        self.assertListEqual(group_ids[1536:1544].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # fourth row
 
         DeleteWorkspace("__hb3a_out_2x2", "__hb3a_grp_2x2", "__hb3a_out_4x4", "__hb3a_grp_4x4")
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
-from mantid.dataobjects import GroupingWorkspace
+from mantid.dataobjects import Workspace2D
 from mantid.simpleapi import (
     CreateMDHistoWorkspace,
     DeleteWorkspace,
@@ -210,13 +210,17 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
             OutputGroupingWorkspace="__hb3a_grp_2x2",
         )
         grp_2x2 = mtd["__hb3a_grp_2x2"]
-        self.assertIsInstance(grp_2x2, GroupingWorkspace)
+        self.assertIsInstance(grp_2x2, Workspace2D)
         # One spectrum per pixel detector. HB3A has three 512x512 detector panels
         self.assertEqual(grp_2x2.getNumberHistograms(), 512 * 512 * 3)
         # check the group ID of the first spectra:
         group_ids = grp_2x2.extractY().astype(int).flatten()  # 1, 1, 2, 2, 3, 3,..
         self.assertListEqual(group_ids[0:6].tolist(), [1, 1, 2, 2, 3, 3])  # first row along X
         self.assertListEqual(group_ids[512:518].tolist(), [1, 1, 2, 2, 3, 3])  # second row
+        # detector ID stored
+        histogram_count = grp_2x2.getNumberHistograms()
+        self.assertEqual(grp_2x2.getSpectrum(0).getDetectorIDs()[0], 1)
+        self.assertEqual(grp_2x2.getSpectrum(histogram_count - 1).getDetectorIDs()[0], histogram_count)
 
         # --- 4x4:
         HB3AAdjustSampleNorm(
@@ -229,14 +233,19 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         )
         self.assertTrue(mtd.doesExist("__hb3a_grp_4x4"), "OutputGroupingWorkspace should be stored in the ADS")
         grp_4x4 = mtd["__hb3a_grp_4x4"]
-        self.assertIsInstance(grp_4x4, GroupingWorkspace)
+        self.assertIsInstance(grp_4x4, Workspace2D)
         self.assertEqual(grp_4x4.getNumberHistograms(), 512 * 512 * 3)
         group_ids = grp_4x4.extractY().astype(int).flatten()  # 1, 1, 1, 1, 2, 2, 2, 2,..
         self.assertListEqual(group_ids[0:8].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # first row along X
         self.assertListEqual(group_ids[512:520].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # second row
         self.assertListEqual(group_ids[1024:1032].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # third row
         self.assertListEqual(group_ids[1536:1544].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # fourth row
+        # detector ID stored
+        histogram_count = grp_4x4.getNumberHistograms()
+        self.assertEqual(grp_4x4.getSpectrum(0).getDetectorIDs()[0], 1)
+        self.assertEqual(grp_4x4.getSpectrum(histogram_count - 1).getDetectorIDs()[0], histogram_count)
 
+        # clean up
         DeleteWorkspaces(["__hb3a_out_2x2", "__hb3a_grp_2x2", "__hb3a_out_4x4", "__hb3a_grp_4x4"])
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -7,7 +7,16 @@
 import unittest
 import numpy as np
 from mantid.dataobjects import GroupingWorkspace
-from mantid.simpleapi import CreateMDHistoWorkspace, DeleteWorkspace, HB3AAdjustSampleNorm, LoadMD, SliceMDHisto, AddSampleLog, mtd
+from mantid.simpleapi import (
+    CreateMDHistoWorkspace,
+    DeleteWorkspace,
+    DeleteWorkspaces,
+    HB3AAdjustSampleNorm,
+    LoadMD,
+    SliceMDHisto,
+    AddSampleLog,
+    mtd,
+)
 
 
 class HB3AAdjustSampleNormTest(unittest.TestCase):
@@ -41,7 +50,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         # Verify detector adjustment
         self.__checkAdjustments(orig_pos, new_pos, height_adj, dist_adj)
 
-        DeleteWorkspace(orig, result)
+        DeleteWorkspaces([orig, result])
 
     def testDoNotAdjustDetector(self):
         # Ensure detector position does not change when no offsets are given
@@ -53,7 +62,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         # Verify detector adjustment
         self.__checkAdjustments(orig_pos, new_pos, 0.0, 0.0)
 
-        DeleteWorkspace(orig, result)
+        DeleteWorkspaces([orig, result])
 
     def testInputFail(self):
         signal = range(0, 1000)
@@ -175,6 +184,9 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         np.testing.assert_array_equal(ids_2x2[:4], [1, 1025, 2049, 3073])
         np.testing.assert_array_equal(ids_4x4[:4], [1, 2049, 4097, 6145])
 
+        # clean up
+        DeleteWorkspaces([data, data_2x2, data_4x4])
+
     def testOutputGroupingWorkspace(self):
 
         # --- Validation: OutputGroupingWorkspace requires Grouping != 'None' ---
@@ -225,7 +237,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         self.assertListEqual(group_ids[1024:1032].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # third row
         self.assertListEqual(group_ids[1536:1544].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # fourth row
 
-        DeleteWorkspace("__hb3a_out_2x2", "__hb3a_grp_2x2", "__hb3a_out_4x4", "__hb3a_grp_4x4")
+        DeleteWorkspaces(["__hb3a_out_2x2", "__hb3a_grp_2x2", "__hb3a_out_4x4", "__hb3a_grp_4x4"])
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
-from mantid.dataobjects import Workspace2D
+from mantid.dataobjects import GroupingWorkspace
 from mantid.simpleapi import (
     CreateMDHistoWorkspace,
     DeleteWorkspace,
@@ -210,7 +210,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
             OutputGroupingWorkspace="__hb3a_grp_2x2",
         )
         grp_2x2 = mtd["__hb3a_grp_2x2"]
-        self.assertIsInstance(grp_2x2, Workspace2D)
+        self.assertIsInstance(grp_2x2, GroupingWorkspace)
         # One spectrum per pixel detector. HB3A has three 512x512 detector panels
         self.assertEqual(grp_2x2.getNumberHistograms(), 512 * 512 * 3)
         # check the group ID of the first spectra:
@@ -233,7 +233,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         )
         self.assertTrue(mtd.doesExist("__hb3a_grp_4x4"), "OutputGroupingWorkspace should be stored in the ADS")
         grp_4x4 = mtd["__hb3a_grp_4x4"]
-        self.assertIsInstance(grp_4x4, Workspace2D)
+        self.assertIsInstance(grp_4x4, GroupingWorkspace)
         self.assertEqual(grp_4x4.getNumberHistograms(), 512 * 512 * 3)
         group_ids = grp_4x4.extractY().astype(int).flatten()  # 1, 1, 1, 1, 2, 2, 2, 2,..
         self.assertListEqual(group_ids[0:8].tolist(), [1, 1, 1, 1, 2, 2, 2, 2])  # first row along X

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -6,7 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
-from mantid.simpleapi import CreateMDHistoWorkspace, DeleteWorkspace, HB3AAdjustSampleNorm, LoadMD, SliceMDHisto, AddSampleLog
+from mantid.dataobjects import GroupingWorkspace
+from mantid.simpleapi import CreateMDHistoWorkspace, DeleteWorkspace, HB3AAdjustSampleNorm, LoadMD, SliceMDHisto, AddSampleLog, mtd
 
 
 class HB3AAdjustSampleNormTest(unittest.TestCase):
@@ -123,6 +124,157 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         ref_shape = data.getSignalArray().shape
         self.assertEqual(ref_shape, tuple([2 * val if i < 2 else val for i, val in enumerate(data_2x2.getSignalArray().shape)]))
         self.assertEqual(ref_shape, tuple([4 * val if i < 2 else val for i, val in enumerate(data_4x4.getSignalArray().shape)]))
+
+        # --- detectorID log checks ---
+        run = data.getExperimentInfo(0).run()
+        run_2x2 = data_2x2.getExperimentInfo(0).run()
+        run_4x4 = data_4x4.getExperimentInfo(0).run()
+
+        # Log must exist for all grouping modes
+        for r, label in [(run, "ungrouped"), (run_2x2, "2x2"), (run_4x4, "4x4")]:
+            self.assertTrue(r.hasProperty("detectorID"), f"detectorID log missing for {label}")
+
+        ids = np.array(run.getProperty("detectorID").value, dtype=int)
+        ids_2x2 = np.array(run_2x2.getProperty("detectorID").value, dtype=int)
+        ids_4x4 = np.array(run_4x4.getProperty("detectorID").value, dtype=int)
+
+        # One entry per detector / grouped pixel (y_dim * x_dim)
+        self.assertEqual(len(ids), 1536 * 512)
+        self.assertEqual(len(ids_2x2), 768 * 256)
+        self.assertEqual(len(ids_4x4), 384 * 128)
+
+        # All IDs must be unique within each grouping
+        self.assertEqual(len(np.unique(ids)), len(ids), "ungrouped detectorIDs should all be unique")
+        self.assertEqual(len(np.unique(ids_2x2)), len(ids_2x2), "2x2 detectorIDs should all be unique")
+        self.assertEqual(len(np.unique(ids_4x4)), len(ids_4x4), "4x4 detectorIDs should all be unique")
+
+        # Each grouped ID must be a valid single-pixel ID (group leader is a real detector)
+        ungrouped_set = set(ids.tolist())
+        self.assertTrue(
+            set(ids_2x2.tolist()).issubset(ungrouped_set),
+            "Every 2x2 group-leader ID should also appear in the ungrouped detectorID list",
+        )
+        self.assertTrue(
+            set(ids_4x4.tolist()).issubset(ungrouped_set),
+            "Every 4x4 group-leader ID should also appear in the ungrouped detectorID list",
+        )
+
+        # 4x4 group leaders must also be 2x2 group leaders (coarser grouping is a subset of finer)
+        grouped_2x2_set = set(ids_2x2.tolist())
+        self.assertTrue(
+            set(ids_4x4.tolist()).issubset(grouped_2x2_set),
+            "Every 4x4 group-leader ID should also be a 2x2 group-leader ID",
+        )
+
+        # Check specific values for the first four entries of each detectorID log.
+        # The HB3A instrument (HB3A_Definition_20190926_3.xml) has three 512×512 banks:
+        #   Bank 1: idstart=1,      idstepbyrow=512  → detID = 1      + x + y*512
+        #   Bank 2: idstart=262145, idstepbyrow=512  → detID = 262145 + x + y*512
+        #   Bank 3: idstart=524289, idstepbyrow=512  → detID = 524289 + x + y*512
+        # CreateSimulationWorkspace + RewriteSpectraMap=True assigns spectrum k (0-based)
+        # to the kth detector in sorted ID order, so spectrum k maps to detector k+1.
+        # The reshape(y_dim, x_dim).T.flatten() transform maps:
+        #   flat2[c*y_dim + r] = flat_column[r*x_dim + c]
+        #
+        # Ungrouped (y_dim=1536, x_dim=512): flat_column[k] = k+1
+        #   i=0: flat[0]    = 1    (bank1, x=0, y=0)
+        #   i=1: flat[512]  = 513  (bank1, x=0, y=1)
+        #   i=2: flat[1024] = 1025 (bank1, x=0, y=2)
+        #   i=3: flat[1536] = 1537 (bank1, x=0, y=3)
+        np.testing.assert_array_equal(ids[:4], [1, 513, 1025, 1537], err_msg="First four ungrouped detectorIDs are incorrect")
+
+        # 2x2 (y_dim=768, x_dim=256): group at (x_idx, y_idx) has first spectrum 2*x_idx + 1024*y_idx
+        #   → detID = 2*x_idx + 1024*y_idx + 1
+        #   flat2 index i → k = r*256 + c (r = i % 768, c = i // 768):
+        #   i=0: k=0,   x_idx=0, y_idx=0   → 1      (bank1, x=0, y=0)
+        #   i=1: k=256, x_idx=0, y_idx=256  → 262145 (bank2, x=0, y=0 — first pixel of bank 2)
+        #   i=2: k=512, x_idx=0, y_idx=512  → 524289 (bank3, x=0, y=0 — first pixel of bank 3)
+        #   i=3: k=768, x_idx=1, y_idx=0    → 3      (bank1, x=2, y=0)
+        np.testing.assert_array_equal(ids_2x2[:4], [1, 262145, 524289, 3], err_msg="First four 2x2 detectorIDs are incorrect")
+
+        # 4x4 (y_dim=384, x_dim=128): group at (x_idx, y_idx) has first spectrum 4*x_idx + 2048*y_idx
+        #   → detID = 4*x_idx + 2048*y_idx + 1
+        #   i=0: k=0,   x_idx=0, y_idx=0   → 1      (bank1, x=0, y=0)
+        #   i=1: k=128, x_idx=0, y_idx=128  → 262145 (bank2, x=0, y=0)
+        #   i=2: k=256, x_idx=0, y_idx=256  → 524289 (bank3, x=0, y=0)
+        #   i=3: k=384, x_idx=1, y_idx=0    → 5      (bank1, x=4, y=0)
+        np.testing.assert_array_equal(ids_4x4[:4], [1, 262145, 524289, 5], err_msg="First four 4x4 detectorIDs are incorrect")
+
+    def testOutputGroupingWorkspace(self):
+
+        # --- Validation: OutputGroupingWorkspace requires Grouping != 'None' ---
+        with self.assertRaisesRegex(RuntimeError, "OutputGroupingWorkspace"):
+            HB3AAdjustSampleNorm(
+                "HB3A_data.nxs",
+                OutputType="Detector",
+                NormaliseBy="None",
+                Grouping="None",
+                OutputWorkspace="__hb3a_out_fail",
+                OutputGroupingWorkspace="__hb3a_grp_fail",
+            )
+
+        # --- 2x2: workspace is produced with correct type and size ---
+        HB3AAdjustSampleNorm(
+            "HB3A_data.nxs",
+            OutputType="Detector",
+            NormaliseBy="None",
+            Grouping="2x2",
+            OutputWorkspace="__hb3a_out_2x2",
+            OutputGroupingWorkspace="__hb3a_grp_2x2",
+        )
+        self.assertTrue(mtd.doesExist("__hb3a_grp_2x2"), "OutputGroupingWorkspace should be stored in the ADS")
+        grp_2x2 = mtd["__hb3a_grp_2x2"]
+        self.assertIsInstance(grp_2x2, GroupingWorkspace)
+        # One spectrum per ungrouped detector: 512 columns × 1536 rows (3 × 512 banks)
+        self.assertEqual(grp_2x2.getNumberHistograms(), 512 * 1536)
+
+        # Group 1: x in [0,1], y in [0,1]
+        #   x_idx=0, y_idx=0, y_groups = 1536//2 = 768  →  group_id = 0*768 + 0 + 1 = 1
+        #   Spectrum indices: x+i + (y+j)*512, i,j ∈ {0,1}  →  0, 1, 512, 513
+        for i in range(2):
+            for j in range(2):
+                spec = i + j * 512
+                self.assertAlmostEqual(grp_2x2.readY(spec)[0], 1.0, msg=f"Spectrum {spec} should belong to group 1 (2x2)")
+
+        # Group 2: x in [0,1], y in [2,3]
+        #   x_idx=0, y_idx=1  →  group_id = 0*768 + 1 + 1 = 2
+        #   Spectrum indices: i + (2+j)*512, i,j ∈ {0,1}  →  1024, 1025, 1536, 1537
+        for i in range(2):
+            for j in range(2):
+                spec = i + (2 + j) * 512
+                self.assertAlmostEqual(grp_2x2.readY(spec)[0], 2.0, msg=f"Spectrum {spec} should belong to group 2 (2x2)")
+
+        # --- 4x4: workspace is produced with correct type and size ---
+        HB3AAdjustSampleNorm(
+            "HB3A_data.nxs",
+            OutputType="Detector",
+            NormaliseBy="None",
+            Grouping="4x4",
+            OutputWorkspace="__hb3a_out_4x4",
+            OutputGroupingWorkspace="__hb3a_grp_4x4",
+        )
+        self.assertTrue(mtd.doesExist("__hb3a_grp_4x4"), "OutputGroupingWorkspace should be stored in the ADS")
+        grp_4x4 = mtd["__hb3a_grp_4x4"]
+        self.assertIsInstance(grp_4x4, GroupingWorkspace)
+        self.assertEqual(grp_4x4.getNumberHistograms(), 512 * 1536)
+
+        # Group 1: x in [0,3], y in [0,3]
+        #   x_idx=0, y_idx=0, y_groups = 1536//4 = 384  →  group_id = 0*384 + 0 + 1 = 1
+        #   Spectrum indices: i + j*512, i,j ∈ {0,1,2,3}
+        for i in range(4):
+            for j in range(4):
+                spec = i + j * 512
+                self.assertAlmostEqual(grp_4x4.readY(spec)[0], 1.0, msg=f"Spectrum {spec} should belong to group 1 (4x4)")
+
+        # Group 2: x in [0,3], y in [4,7]
+        #   x_idx=0, y_idx=1  →  group_id = 0*384 + 1 + 1 = 2
+        #   Spectrum indices: i + (4+j)*512, i,j ∈ {0,1,2,3}
+        for i in range(4):
+            for j in range(4):
+                spec = i + (4 + j) * 512
+                self.assertAlmostEqual(grp_4x4.readY(spec)[0], 2.0, msg=f"Spectrum {spec} should belong to group 2 (4x4)")
+
+        DeleteWorkspace("__hb3a_out_2x2", "__hb3a_grp_2x2", "__hb3a_out_4x4", "__hb3a_grp_4x4")
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from mantid.dataobjects import GroupingWorkspace
 from mantid.simpleapi import LoadWANDSCD
 import unittest
 import numpy as np
@@ -92,6 +93,15 @@ class LoadWANDTest(unittest.TestCase):
         self.assertAlmostEqual(run.getGoniometer(1).getEulerAngles("YXZ")[2], -4.4)  # sgu from HB2C_7001
         self.assertAlmostEqual(run.getGoniometer(0).getEulerAngles("YXZ")[1], 4.6995)  # sgl from HB2C_7000
         self.assertAlmostEqual(run.getGoniometer(1).getEulerAngles("YXZ")[1], 4.6995)  # sgl from HB2C_7001
+
+        # check detectorID log: length must match twotheta/azimuthal, values must be non-negative
+        twotheta = run.getProperty("twotheta").value
+        azimuthal = run.getProperty("azimuthal").value
+        detectorID = run.getProperty("detectorID").value
+        self.assertEqual(len(detectorID), len(twotheta))
+        self.assertEqual(len(detectorID), len(azimuthal))
+        self.assertTrue(all(d >= 0 for d in detectorID))
+
         LoadWANDTest_ws.delete()
 
 
@@ -123,6 +133,81 @@ class LoadWANDGrouping(unittest.TestCase):
         LoadWANDTest_ws.delete()
         LoadWANDTest_ws_2x2.delete()
         LoadWANDTest_ws_4x4.delete()
+
+
+class LoadWANDGroupingWorkspace(unittest.TestCase):
+    # Full detector grid dimensions for WAND (HB2C)
+    N_ROWS = 480 * 8  # 3840
+    N_COLS = 512
+
+    def test_grouping_workspace_2x2(self):
+        grouping = 2
+        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2", OutputGroupingWorkspace="grp_ws_2x2")
+
+        # Type check
+        self.assertIsInstance(grp_ws, GroupingWorkspace)
+
+        # Total number of groups must equal (N_ROWS // g) * (N_COLS // g)
+        expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
+        self.assertEqual(grp_ws.getTotalGroups(), expected_groups)
+
+        # Every detector lies in a valid group (1 .. expected_groups)
+        self.assertEqual(grp_ws.getNumberHistograms(), self.N_ROWS * self.N_COLS)
+        y_values = grp_ws.extractY().flatten()
+        self.assertEqual(int(y_values.min()), 1)
+        self.assertEqual(int(y_values.max()), expected_groups)
+
+        # Spot-check: detector 0  → pixel (x=0, y=0) → group 1
+        self.assertEqual(int(grp_ws.getValue(0)), 1)
+        # Spot-check: detector 1  → pixel (x=0, y=1) → group 1  (same 2×2 block as detector 0)
+        self.assertEqual(int(grp_ws.getValue(1)), 1)
+        # Spot-check: detector 2  → pixel (x=0, y=2) → group 2  (next 2×2 block along y)
+        self.assertEqual(int(grp_ws.getValue(2)), 2)
+        # Spot-check: detector 512 → pixel (x=1, y=0) → shares 2×2 block with detector 0 → group 1
+        self.assertEqual(int(grp_ws.getValue(512)), 1)
+        # Spot-check: detector 1024 → pixel (x=2, y=0) → first group of x_idx=1 row → group (512//2)+1 = 257
+        self.assertEqual(int(grp_ws.getValue(1024)), (self.N_COLS // grouping) + 1)
+
+        # detectorID log must have one entry per group (same length as twotheta/azimuthal)
+        run = ws.getExperimentInfo(0).run()
+        detectorID = run.getProperty("detectorID").value
+        twotheta = run.getProperty("twotheta").value
+        self.assertEqual(len(detectorID), expected_groups)
+        self.assertEqual(len(detectorID), len(twotheta))
+        # each stored detector ID must be a valid key in the GroupingWorkspace
+        self.assertTrue(all(grp_ws.getValue(int(d)) >= 1 for d in detectorID))
+
+        ws.delete()
+        grp_ws.delete()
+
+    def test_grouping_workspace_4x4(self):
+        grouping = 4
+        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="4x4", OutputGroupingWorkspace="grp_ws_4x4")
+
+        self.assertIsInstance(grp_ws, GroupingWorkspace)
+        expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
+        self.assertEqual(grp_ws.getTotalGroups(), expected_groups)
+
+        # Group size: each group spans g×g = 16 detectors
+        group_size = grouping * grouping
+        ids_in_first_group = grp_ws.getDetectorIDsOfGroup(1)
+        self.assertEqual(len(ids_in_first_group), group_size)
+
+        ws.delete()
+        grp_ws.delete()
+
+    def test_no_grouping_workspace_without_output_property(self):
+        """OutputGroupingWorkspace must NOT be produced when the property is not set."""
+        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2")
+        self.assertIsNone(grp_ws)
+        ws.delete()
+
+    def test_validation_rejects_grouping_ws_without_grouping(self):
+        """Requesting OutputGroupingWorkspace while Grouping='None' must raise."""
+        import mantid.simpleapi as sapi
+
+        with self.assertRaises(Exception):
+            sapi.LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="None", OutputGroupingWorkspace="should_fail")
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,7 +4,6 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import IMDHistoWorkspace
 from mantid.dataobjects import GroupingWorkspace
 from mantid.simpleapi import LoadWANDSCD
 import unittest
@@ -123,27 +122,16 @@ class LoadWANDApplyGoniometerTiltTest(unittest.TestCase):
 
 
 class LoadWANDGrouping(unittest.TestCase):
-    def test(self):
-        LoadWANDTest_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping=None)
-        LoadWANDTest_ws_2x2 = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2")
-        LoadWANDTest_ws_4x4 = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="4x4")
-
-        self.assertEqual(LoadWANDTest_ws.getSignalArray().sum(), LoadWANDTest_ws_2x2.getSignalArray().sum())
-        self.assertEqual(LoadWANDTest_ws.getSignalArray().sum(), LoadWANDTest_ws_4x4.getSignalArray().sum())
-
-        LoadWANDTest_ws.delete()
-        LoadWANDTest_ws_2x2.delete()
-        LoadWANDTest_ws_4x4.delete()
-
-
-class LoadWANDGroupingWorkspace(unittest.TestCase):
     # Full detector grid dimensions for WAND (HB2C)
     N_ROWS = 480 * 8  # 3840
     N_COLS = 512
+    TOTAL_COUNTS = 128049  # number of events in file "HB2C_475936.nxs.h5"
 
     def test_grouping_workspace_2x2(self):
         grouping = 2
         ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2", OutputWorkspace="ws_2x2", OutputGroupingWorkspace="grp_ws_2x2")
+
+        self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
 
         # Type check
         self.assertIsInstance(grp_ws, GroupingWorkspace)
@@ -185,6 +173,8 @@ class LoadWANDGroupingWorkspace(unittest.TestCase):
         grouping = 4
         ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="4x4", OutputGroupingWorkspace="grp_ws_4x4")
 
+        self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
+
         self.assertIsInstance(grp_ws, GroupingWorkspace)
         expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
         self.assertEqual(grp_ws.getTotalGroups(), expected_groups)
@@ -194,16 +184,6 @@ class LoadWANDGroupingWorkspace(unittest.TestCase):
         ids_in_first_group = grp_ws.getDetectorIDsOfGroup(1)
         self.assertEqual(len(ids_in_first_group), group_size)
 
-        ws.delete()
-        grp_ws.delete()
-
-    def test_simpleapi_wrapper_assigns_workspace_names(self):
-        """simpleapi uses LHS variable names for output workspace properties."""
-        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2")
-        self.assertEqual(ws.name(), "ws")
-        self.assertIsInstance(ws, IMDHistoWorkspace)
-        self.assertEqual(grp_ws.name(), "grp_ws")
-        self.assertIsInstance(grp_ws, GroupingWorkspace)
         ws.delete()
         grp_ws.delete()
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from mantid.api import IMDHistoWorkspace
 from mantid.dataobjects import GroupingWorkspace
 from mantid.simpleapi import LoadWANDSCD
 import unittest
@@ -142,7 +143,7 @@ class LoadWANDGroupingWorkspace(unittest.TestCase):
 
     def test_grouping_workspace_2x2(self):
         grouping = 2
-        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2", OutputGroupingWorkspace="grp_ws_2x2")
+        ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2", OutputWorkspace="ws_2x2", OutputGroupingWorkspace="grp_ws_2x2")
 
         # Type check
         self.assertIsInstance(grp_ws, GroupingWorkspace)
@@ -196,18 +197,20 @@ class LoadWANDGroupingWorkspace(unittest.TestCase):
         ws.delete()
         grp_ws.delete()
 
-    def test_no_grouping_workspace_without_output_property(self):
-        """OutputGroupingWorkspace must NOT be produced when the property is not set."""
+    def test_simpleapi_wrapper_assigns_workspace_names(self):
+        """simpleapi uses LHS variable names for output workspace properties."""
         ws, grp_ws = LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="2x2")
-        self.assertIsNone(grp_ws)
+        self.assertEqual(ws.name(), "ws")
+        self.assertIsInstance(ws, IMDHistoWorkspace)
+        self.assertEqual(grp_ws.name(), "grp_ws")
+        self.assertIsInstance(grp_ws, GroupingWorkspace)
         ws.delete()
+        grp_ws.delete()
 
     def test_validation_rejects_grouping_ws_without_grouping(self):
         """Requesting OutputGroupingWorkspace while Grouping='None' must raise."""
-        import mantid.simpleapi as sapi
-
         with self.assertRaises(Exception):
-            sapi.LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="None", OutputGroupingWorkspace="should_fail")
+            LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="None", OutputGroupingWorkspace="should_fail")
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.dataobjects import Workspace2D
+from mantid.dataobjects import GroupingWorkspace
 from mantid.simpleapi import LoadWANDSCD
 import unittest
 import numpy as np
@@ -134,7 +134,7 @@ class LoadWANDGrouping(unittest.TestCase):
         self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
 
         # Type check
-        self.assertIsInstance(grp_ws, Workspace2D)
+        self.assertIsInstance(grp_ws, GroupingWorkspace)
 
         # Total number of groups must equal (N_ROWS // g) * (N_COLS // g)
         expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
@@ -179,7 +179,7 @@ class LoadWANDGrouping(unittest.TestCase):
 
         self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
 
-        self.assertIsInstance(grp_ws, Workspace2D)
+        self.assertIsInstance(grp_ws, GroupingWorkspace)
         expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
         y_values = grp_ws.extractY().flatten()
         self.assertEqual(int(y_values.max()), expected_groups)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -142,7 +142,8 @@ class LoadWANDGrouping(unittest.TestCase):
         self.assertEqual(int(y_values.max()), expected_groups)
 
         # Every workspace index lies in a valid group (1 .. expected_groups)
-        self.assertEqual(grp_ws.getNumberHistograms(), self.N_ROWS * self.N_COLS)
+        histogram_count = grp_ws.getNumberHistograms()
+        self.assertEqual(histogram_count, self.N_ROWS * self.N_COLS)
         self.assertEqual(int(y_values.min()), 1)
 
         # Spot-check: workspace index 0  → pixel (x=0, y=0) → group 1
@@ -155,6 +156,10 @@ class LoadWANDGrouping(unittest.TestCase):
         self.assertEqual(int(grp_ws.readY(512)[0]), 1)
         # Spot-check: workspace index 1024 → pixel (x=2, y=0) → first group of x_idx=1 row → group (512//2)+1 = 257
         self.assertEqual(int(grp_ws.readY(1024)[0]), (self.N_COLS // grouping) + 1)
+
+        # detector ID stored
+        self.assertEqual(grp_ws.getSpectrum(0).getDetectorIDs()[0], 0)
+        self.assertEqual(grp_ws.getSpectrum(histogram_count - 1).getDetectorIDs()[0], histogram_count - 1)
 
         # detectorID log must have one entry per group (same length as twotheta/azimuthal)
         run = ws.getExperimentInfo(0).run()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.dataobjects import GroupingWorkspace
+from mantid.dataobjects import Workspace2D
 from mantid.simpleapi import LoadWANDSCD
 import unittest
 import numpy as np
@@ -134,28 +134,27 @@ class LoadWANDGrouping(unittest.TestCase):
         self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
 
         # Type check
-        self.assertIsInstance(grp_ws, GroupingWorkspace)
+        self.assertIsInstance(grp_ws, Workspace2D)
 
         # Total number of groups must equal (N_ROWS // g) * (N_COLS // g)
         expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
-        self.assertEqual(grp_ws.getTotalGroups(), expected_groups)
-
-        # Every detector lies in a valid group (1 .. expected_groups)
-        self.assertEqual(grp_ws.getNumberHistograms(), self.N_ROWS * self.N_COLS)
         y_values = grp_ws.extractY().flatten()
-        self.assertEqual(int(y_values.min()), 1)
         self.assertEqual(int(y_values.max()), expected_groups)
 
-        # Spot-check: detector 0  → pixel (x=0, y=0) → group 1
-        self.assertEqual(int(grp_ws.getValue(0)), 1)
-        # Spot-check: detector 1  → pixel (x=0, y=1) → group 1  (same 2×2 block as detector 0)
-        self.assertEqual(int(grp_ws.getValue(1)), 1)
-        # Spot-check: detector 2  → pixel (x=0, y=2) → group 2  (next 2×2 block along y)
-        self.assertEqual(int(grp_ws.getValue(2)), 2)
-        # Spot-check: detector 512 → pixel (x=1, y=0) → shares 2×2 block with detector 0 → group 1
-        self.assertEqual(int(grp_ws.getValue(512)), 1)
-        # Spot-check: detector 1024 → pixel (x=2, y=0) → first group of x_idx=1 row → group (512//2)+1 = 257
-        self.assertEqual(int(grp_ws.getValue(1024)), (self.N_COLS // grouping) + 1)
+        # Every workspace index lies in a valid group (1 .. expected_groups)
+        self.assertEqual(grp_ws.getNumberHistograms(), self.N_ROWS * self.N_COLS)
+        self.assertEqual(int(y_values.min()), 1)
+
+        # Spot-check: workspace index 0  → pixel (x=0, y=0) → group 1
+        self.assertEqual(int(grp_ws.readY(0)[0]), 1)
+        # Spot-check: workspace index 1  → pixel (x=0, y=1) → group 1  (same 2×2 block as index 0)
+        self.assertEqual(int(grp_ws.readY(1)[0]), 1)
+        # Spot-check: workspace index 2  → pixel (x=0, y=2) → group 2  (next 2×2 block along y)
+        self.assertEqual(int(grp_ws.readY(2)[0]), 2)
+        # Spot-check: workspace index 512 → pixel (x=1, y=0) → shares 2×2 block with index 0 → group 1
+        self.assertEqual(int(grp_ws.readY(512)[0]), 1)
+        # Spot-check: workspace index 1024 → pixel (x=2, y=0) → first group of x_idx=1 row → group (512//2)+1 = 257
+        self.assertEqual(int(grp_ws.readY(1024)[0]), (self.N_COLS // grouping) + 1)
 
         # detectorID log must have one entry per group (same length as twotheta/azimuthal)
         run = ws.getExperimentInfo(0).run()
@@ -163,8 +162,8 @@ class LoadWANDGrouping(unittest.TestCase):
         twotheta = run.getProperty("twotheta").value
         self.assertEqual(len(detectorID), expected_groups)
         self.assertEqual(len(detectorID), len(twotheta))
-        # each stored detector ID must be a valid key in the GroupingWorkspace
-        self.assertTrue(all(grp_ws.getValue(int(d)) >= 1 for d in detectorID))
+        # each stored detector ID maps to a valid group (det_id == workspace index for WAND)
+        self.assertTrue(all(grp_ws.readY(int(d))[0] >= 1 for d in detectorID))
 
         ws.delete()
         grp_ws.delete()
@@ -175,14 +174,15 @@ class LoadWANDGrouping(unittest.TestCase):
 
         self.assertEqual(ws.getSignalArray().sum(), self.TOTAL_COUNTS)
 
-        self.assertIsInstance(grp_ws, GroupingWorkspace)
+        self.assertIsInstance(grp_ws, Workspace2D)
         expected_groups = (self.N_ROWS // grouping) * (self.N_COLS // grouping)
-        self.assertEqual(grp_ws.getTotalGroups(), expected_groups)
+        y_values = grp_ws.extractY().flatten()
+        self.assertEqual(int(y_values.max()), expected_groups)
 
         # Group size: each group spans g×g = 16 detectors
         group_size = grouping * grouping
-        ids_in_first_group = grp_ws.getDetectorIDsOfGroup(1)
-        self.assertEqual(len(ids_in_first_group), group_size)
+        indices_in_first_group = np.where(y_values == 1.0)[0]
+        self.assertEqual(len(indices_in_first_group), group_size)
 
         ws.delete()
         grp_ws.delete()

--- a/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
+++ b/docs/source/algorithms/CreateGroupingWorkspace-v1.rst
@@ -30,9 +30,11 @@ the number of groups specified, detectors will be left ungrouped in
 the event that the number of detectors does not divide equally into
 the number of groups.
 
-If both the ``CustomGroupingString`` and ``ComponentName`` property are
+If both ``CustomGroupingString`` and ``ComponentName`` properties are
 given, then the detectors for the given component will be grouped using
-this grouping string. The syntax of the ``CustomGroupingString`` is the
+this grouping string.
+Passing ``CustomGroupingString`` alone will result in no grouping.
+The syntax of the ``CustomGroupingString`` is the
 same as used in the :ref:`GroupDetectors <algm-GroupDetectors>` algorithm,
 and is explained below:
 

--- a/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
+++ b/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
@@ -46,6 +46,15 @@ Grouping
 A grouping option is available group pixels by either 2x2 or 4x4 which reduces memory
 usage and improves the performance of subsequent reduction steps. The default is the original detetor pixelation.
 
+When ``OutputGroupingWorkspace`` is specified alongside a ``2x2`` or ``4x4`` grouping, the algorithm
+produces an additional ``Workspace2D`` with one spectrum per detector. The Y value of each spectrum
+holds the 1-indexed group ID that the corresponding detector belongs to. Since HB3A detector IDs
+start at 1 and map directly to workspace indices (``workspace_index = det_id - 1``), the group ID
+for detector ``d`` can be read as ``grouping_ws.readY(d - 1)[0]``. A ``Workspace2D`` is used instead
+of a ``GroupingWorkspace`` for performance reasons: constructing a ``GroupingWorkspace`` from the
+HB3A instrument requires building the detector-ID-to-workspace-index map, which takes tens of
+seconds for the ~786k detectors across HB3A's three 512×512 panels.
+
 See :ref:`HB3AIntegratePeaks <algm-HB3AIntegratePeaks>` for complete examples of the HB3A workflow.
 
 .. categories::

--- a/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
+++ b/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
@@ -44,16 +44,7 @@ Grouping
 --------
 
 A grouping option is available group pixels by either 2x2 or 4x4 which reduces memory
-usage and improves the performance of subsequent reduction steps. The default is the original detetor pixelation.
-
-When ``OutputGroupingWorkspace`` is specified alongside a ``2x2`` or ``4x4`` grouping, the algorithm
-produces an additional ``Workspace2D`` with one spectrum per detector. The Y value of each spectrum
-holds the 1-indexed group ID that the corresponding detector belongs to. Since HB3A detector IDs
-start at 1 and map directly to workspace indices (``workspace_index = det_id - 1``), the group ID
-for detector ``d`` can be read as ``grouping_ws.readY(d - 1)[0]``. A ``Workspace2D`` is used instead
-of a ``GroupingWorkspace`` for performance reasons: constructing a ``GroupingWorkspace`` from the
-HB3A instrument requires building the detector-ID-to-workspace-index map, which takes tens of
-seconds for the ~786k detectors across HB3A's three 512×512 panels.
+usage and improves the performance of subsequent reduction steps. The default is the original detector pixelation.
 
 See :ref:`HB3AIntegratePeaks <algm-HB3AIntegratePeaks>` for complete examples of the HB3A workflow.
 

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -40,15 +40,6 @@ usage and speed up the later reduction steps.
 In most cases you will not see a difference in reduced data with 4x4 pixel grouping.
 Also, both input data and the Vanadium data will share the same grouping scheme.
 
-When ``OutputGroupingWorkspace`` is specified alongside a ``2x2`` or ``4x4`` grouping, the algorithm
-produces an additional ``Workspace2D`` with one spectrum per detector. The Y value of each spectrum
-holds the 1-indexed group ID that the corresponding detector belongs to. Since WAND detector IDs map
-directly to workspace indices, the group ID for detector ``d`` can be read as
-``grouping_ws.readY(d)[0]``. A ``Workspace2D`` is used instead of a ``GroupingWorkspace`` for
-performance reasons: constructing a ``GroupingWorkspace`` from the WAND instrument requires building
-the detector-ID-to-workspace-index map, which takes tens of seconds for the ~2 million detectors in
-the WAND array.
-
 The loaded workspace is designed to be the input to
 :ref:`algm-ConvertWANDSCDtoQ`.
 

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -40,6 +40,15 @@ usage and speed up the later reduction steps.
 In most cases you will not see a difference in reduced data with 4x4 pixel grouping.
 Also, both input data and the Vanadium data will share the same grouping scheme.
 
+When ``OutputGroupingWorkspace`` is specified alongside a ``2x2`` or ``4x4`` grouping, the algorithm
+produces an additional ``Workspace2D`` with one spectrum per detector. The Y value of each spectrum
+holds the 1-indexed group ID that the corresponding detector belongs to. Since WAND detector IDs map
+directly to workspace indices, the group ID for detector ``d`` can be read as
+``grouping_ws.readY(d)[0]``. A ``Workspace2D`` is used instead of a ``GroupingWorkspace`` for
+performance reasons: constructing a ``GroupingWorkspace`` from the WAND instrument requires building
+the detector-ID-to-workspace-index map, which takes tens of seconds for the ~2 million detectors in
+the WAND array.
+
 The loaded workspace is designed to be the input to
 :ref:`algm-ConvertWANDSCDtoQ`.
 

--- a/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
@@ -1,0 +1,6 @@
+- :ref:`algm-HB3AAdjustSampleNorm` now supports an optional ``OutputGroupingWorkspace`` property
+  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
+  when ``Grouping`` is set to ``2x2`` or ``4x4``.
+- :ref:`algm-LoadWANDSCD` now supports an optional ``OutputGroupingWorkspace`` property
+  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
+  when ``Grouping`` is set to ``2x2`` or ``4x4``.

--- a/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
@@ -1,6 +1,6 @@
 - :ref:`algm-HB3AAdjustSampleNorm` now supports an optional ``OutputGroupingWorkspace`` property
-  that produces a ``Workspace2D`` mapping each ungrouped detector to its pixel group
+  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
   when ``Grouping`` is set to ``2x2`` or ``4x4``.
 - :ref:`algm-LoadWANDSCD` now supports an optional ``OutputGroupingWorkspace`` property
-  that produces a ``Workspace2D`` mapping each ungrouped detector to its pixel group
+  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
   when ``Grouping`` is set to ``2x2`` or ``4x4``.

--- a/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Single_Crystal/New_features/41375.rst
@@ -1,6 +1,6 @@
 - :ref:`algm-HB3AAdjustSampleNorm` now supports an optional ``OutputGroupingWorkspace`` property
-  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
+  that produces a ``Workspace2D`` mapping each ungrouped detector to its pixel group
   when ``Grouping`` is set to ``2x2`` or ``4x4``.
 - :ref:`algm-LoadWANDSCD` now supports an optional ``OutputGroupingWorkspace`` property
-  that produces a ``GroupingWorkspace`` mapping each ungrouped detector to its pixel group
+  that produces a ``Workspace2D`` mapping each ungrouped detector to its pixel group
   when ``Grouping`` is set to ``2x2`` or ``4x4``.


### PR DESCRIPTION
### Description of work

This PR adds an optional `OutputGroupingWorkspace` property to two single-crystal diffraction loading algorithms — LoadWANDSCD (HB2C/WAND) and HB3AAdjustSampleNorm (HB3A).

When detector pixel grouping (2x2 or 4x4) is applied, the new property optionally produces a GroupingWorkspace that maps every ungrouped detector ID to its 1-indexed group ID. This workspace enables downstream algorithms to trace which physical detector pixels contributed to each grouped signal bin. Requesting `OutputGroupingWorkspace` while `Grouping` is set to `None` is explicitly rejected with a validation error.

Companion to PR #41376  
Implements [EWM 13116](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13116)

### To test:
Run [manual_test_pr41375.py](https://github.com/user-attachments/files/27736423/manual_test_pr41375.py) in the workbench and verify the contents of `TableWorkspace review_OutputGroupingWorkspace_summary` 

<img width="1600"  alt="manual_test_output" src="https://github.com/user-attachments/assets/35ed5660-c49f-41a4-aa03-ab0048b33ac6" />




<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
