### PR TITLE
Fix mocked memory units in Rebin tests

### DIFF
--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -117,9 +117,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector2", "z,m,0,0,1"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("BasisVector3", ""));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
-    // make enough bins so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
+    // make enough bins so that product * bytesPerBin exceeds the mock memory limit (26 KiB)
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputExtents", "0,10,0,10,0,10"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "3, 3, 3"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputBins", "11,11,11"));
     Mantid::TestMemory::MockMemory memL(26);
     TS_ASSERT_THROWS_ANYTHING(alg.execute();)
 #endif
@@ -136,9 +136,9 @@ public:
     AnalysisDataService::Instance().addOrReplace("BinMDTest_ws", in_ws);
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "BinMDTest_ws"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AxisAligned", "1"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "x,0,0,3"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "y,0,0,3"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "z,0,0,3"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "x,0,0,11"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "y,0,0,11"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "z,0,0,11"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim3", ""));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "BinMDTest_ws"));
     Mantid::TestMemory::MockMemory memL(26);

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -204,10 +204,10 @@ public:
       Mantid::TestMemory::MockMemory memL(12);
       // bin counts are chosen so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
-                               do_createAlignedTransform("Axis0, 2.0,8.0, 13", "", "", ""), std::runtime_error & e,
+                               do_createAlignedTransform("Axis0, 2.0,8.0, 493", "", "", ""), std::runtime_error & e,
                                strstr(e.what(), "Mock Memory"));
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 2D",
-                               do_createAlignedTransform("Axis0, 2.0,8.0, 6", "Axis1, 2.0,8.0, 8", "", ""),
+                               do_createAlignedTransform("Axis0, 2.0,8.0, 23", "Axis1, 2.0,8.0, 22", "", ""),
                                std::runtime_error & e, strstr(e.what(), "Mock Memory"));
     }
 #endif
@@ -596,11 +596,11 @@ public:
       Mantid::TestMemory::MockMemory memL(12);
       // bin counts are chosen so that product * bytesPerBin exceeds the mock memory limit (12 KiB)
       TSM_ASSERT_THROWS_ASSERT("Excessive memory allocation 1D",
-                               do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "13"),
+                               do_createGeneralTransform(ws, "x,m,1,0,0", "", "", "", VMD(1, 2, 3), "0,10", "493"),
                                std::runtime_error & e, strstr(e.what(), "Mock Memory"));
       TSM_ASSERT_THROWS_ASSERT(
           "Excessive memory allocation 2D",
-          do_createGeneralTransform(ws, "x,m,1,0,0", "y,m,0,1,0", "", "", VMD(1, 2, 3), "0,10,0,10", "6,7"),
+          do_createGeneralTransform(ws, "x,m,1,0,0", "y,m,0,1,0", "", "", VMD(1, 2, 3), "0,10,0,10", "23,22"),
           std::runtime_error & e, strstr(e.what(), "Mock Memory"));
     }
 #endif

--- a/Framework/TestHelpers/src/MockMemory.cpp
+++ b/Framework/TestHelpers/src/MockMemory.cpp
@@ -70,7 +70,7 @@ std::size_t Mantid::Kernel::MemoryStats::availMem() const {
 
 std::string Mantid::Kernel::MemoryStats::checkAvailableMemory(std::size_t const requestedMemory) const {
   if (g_override_availMem.load()) {
-    std::size_t avail = g_value.load();
+    std::size_t avail = g_value.load() * 1024;
     if (requestedMemory > avail) {
       return "Mock Memory Failure";
     } else {


### PR DESCRIPTION
This pulls #41378 into `ornl-next`