### PR TITLE
Fix new coverity warnings.

### DIFF
--- a/Framework/API/inc/MantidAPI/TaskBasedAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/TaskBasedAlgorithm.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "AnalysisDataService.h"
@@ -67,7 +68,7 @@ protected:
     void setExpectedOutputs(const std::vector<std::string> &expectedOutputs) { m_expectedOutputs = expectedOutputs; }
     const std::string &name() const { return m_name; }
     void initAsFirstTask(std::shared_ptr<MatrixWorkspace> inputWS) {
-      addDependantTaskOutput("InputWorkspace", inputWS, 0);
+      addDependantTaskOutput("InputWorkspace", std::move(inputWS), 0);
       m_firstTaskFlag = true;
     }
     void setTaskExecutionOrder(const std::vector<std::string> *taskExecutionOrder) {
@@ -80,7 +81,7 @@ protected:
     T *m_parent;
     void outputWorkspace(std::shared_ptr<MatrixWorkspace> ws, const std::string &outputName) {
       setSelectedOutput(outputName);
-      m_parent->m_algorithmTaskOutputs[m_name][outputName] = ws;
+      m_parent->m_algorithmTaskOutputs[m_name][outputName] = std::move(ws);
     }
 
     std::shared_ptr<MatrixWorkspace> getDependantWorkspace(const std::string &outputAlias) {
@@ -213,12 +214,14 @@ protected:
           missingTasksAll.insert(missingTasksAll.cend(), missingTasks.cbegin(), missingTasks.cend());
         }
       }
-      return (m_fulfilledDependantTaskSets.empty() ? missingTasksAll : std::vector<std::string>{});
+      if (m_fulfilledDependantTaskSets.empty())
+        return missingTasksAll;
+      return {};
     }
 
     void addDependantTaskOutput(const std::string &outputName, std::shared_ptr<MatrixWorkspace> ws,
                                 const size_t taskSetIndex) {
-      m_dependantOutputs[taskSetIndex][outputName] = ws;
+      m_dependantOutputs[taskSetIndex][outputName] = std::move(ws);
     }
   };
 
@@ -234,8 +237,8 @@ protected:
       Workspace_sptr clone = cloneAlg->getProperty("OutputWorkspace");
       inputWS = std::dynamic_pointer_cast<MatrixWorkspace>(clone);
     }
-    tasks[0]->initAsFirstTask(inputWS);
-    m_stagedAlgorithmTasks = tasks;
+    tasks[0]->initAsFirstTask(std::move(inputWS));
+    m_stagedAlgorithmTasks = std::move(tasks);
   }
 
   void configureAlgorithmTasks() {
@@ -251,7 +254,7 @@ protected:
         tasksToStage[index] = task;
       }
     }
-    stageAlgorithmTasks(tasksToStage);
+    stageAlgorithmTasks(std::move(tasksToStage));
   }
 
   void validateTaskExecutionOrder() {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1554,9 +1554,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
     const size_t output_iws = iws - m_startWorkspaceIndex;
 
     for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-      IPeakFunction_sptr peak_function = std::move(peak_functions[output_iws][ipeak]);
-      IBackgroundFunction_sptr bkgd_function = std::move(bkgd_functions[output_iws][ipeak]);
-      if (!peak_function || !bkgd_function)
+      if (!peak_functions[output_iws][ipeak] || !bkgd_functions[output_iws][ipeak])
         continue;
 
       // use domain and function to calculate
@@ -1572,8 +1570,8 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
       CompositeFunction_sptr comp_func = std::make_shared<API::CompositeFunction>();
-      comp_func->addFunction(std::move(peak_function));
-      comp_func->addFunction(std::move(bkgd_function));
+      comp_func->addFunction(std::move(peak_functions[output_iws][ipeak]));
+      comp_func->addFunction(std::move(bkgd_functions[output_iws][ipeak]));
       comp_func->function(domain, values);
 
       // copy over the values

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1542,8 +1542,8 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
       const std::pair<double, double> peakwindow = m_getPeakFitWindow(iws, ipeak);
       peak_function->setMatrixWorkspace(m_inputMatrixWS, iws, peakwindow.first, peakwindow.second);
 
-      peak_functions[output_iws][ipeak] = peak_function;
-      bkgd_functions[output_iws][ipeak] = bkgd_function;
+      peak_functions[output_iws][ipeak] = std::move(peak_function);
+      bkgd_functions[output_iws][ipeak] = std::move(bkgd_function);
     }
   }
 

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1554,8 +1554,8 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
     const size_t output_iws = iws - m_startWorkspaceIndex;
 
     for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-      const IPeakFunction_sptr &peak_function = peak_functions[output_iws][ipeak];
-      const IBackgroundFunction_sptr &bkgd_function = bkgd_functions[output_iws][ipeak];
+      IPeakFunction_sptr peak_function = std::move(peak_functions[output_iws][ipeak]);
+      IBackgroundFunction_sptr bkgd_function = std::move(bkgd_functions[output_iws][ipeak]);
       if (!peak_function || !bkgd_function)
         continue;
 
@@ -1572,8 +1572,8 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
       FunctionDomain1DVector domain(start_x_iter, stop_x_iter);
       FunctionValues values(domain);
       CompositeFunction_sptr comp_func = std::make_shared<API::CompositeFunction>();
-      comp_func->addFunction(peak_function);
-      comp_func->addFunction(bkgd_function);
+      comp_func->addFunction(std::move(peak_function));
+      comp_func->addFunction(std::move(bkgd_function));
       comp_func->function(domain, values);
 
       // copy over the values
@@ -2122,8 +2122,8 @@ void FitPeaks::processOutputs(std::vector<std::shared_ptr<FitPeaksAlgorithm::Pea
  * @return :: total number of counts in the histogram
  */
 double FitPeaks::numberCounts(size_t iws) {
-  const auto hist_y = m_inputMatrixWS->histogram(iws).y();
-  const auto &vec_y = hist_y.rawData();
+  const Histogram histogram = m_inputMatrixWS->histogram(iws);
+  const auto &vec_y = histogram.y().rawData();
   double total = std::accumulate(vec_y.begin(), vec_y.end(), 0.);
   return total;
 }
@@ -2168,8 +2168,8 @@ size_t FitPeaks::histRangeToDataPointCount(size_t iws, const std::pair<double, d
  */
 void FitPeaks::histRangeToIndexBounds(size_t iws, const std::pair<double, double> &range, size_t &left_index,
                                       size_t &right_index) {
-  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
-  const auto &orig_x = hist_x;
+  const Histogram histogram = m_inputMatrixWS->histogram(iws);
+  const auto &orig_x = histogram.x();
   rangeToIndexBounds(orig_x, range.first, range.second, left_index, right_index);
 
   // handle an invalid range case. For the histogram point data, make sure the number of data points is non-zero as
@@ -2201,14 +2201,14 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
   size_t num_elements_x = right_index - left_index;
 
   vec_x.resize(num_elements_x);
-  const auto hist_x = m_inputMatrixWS->histogram(iws).x();
-  const auto &orig_x = hist_x;
+  const Histogram histogram = m_inputMatrixWS->histogram(iws);
+  const auto &orig_x = histogram.x();
   std::copy(orig_x.begin() + left_index, orig_x.begin() + right_index, vec_x.begin());
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
 
-  const std::vector<double> orig_y = m_inputMatrixWS->histogram(iws).y().rawData();
-  const std::vector<double> orig_e = m_inputMatrixWS->histogram(iws).e().rawData();
+  const auto &orig_y = histogram.y().rawData();
+  const auto &orig_e = histogram.e().rawData();
   vec_y.resize(num_datapoints);
   vec_e.resize(num_datapoints);
   std::copy(orig_y.begin() + left_index, orig_y.begin() + left_index + num_datapoints, vec_y.begin());

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -140,6 +140,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
   MatrixWorkspace_sptr inputWS = getProperty(PropertyNames::INPUT_WKSP);
   std::vector<double> rbParams = getProperty(PropertyNames::PARAMS);
   std::vector<double> validParams;
+  bool paramsWereReset = false;
   if (inputWS == nullptr) {
     // The workspace could exist, but not be a MatrixWorkspace, e.g. it might be
     // a group workspace. In that case we don't want a validation error for the
@@ -154,7 +155,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
       // if the binmode has been set, force the rebin params to be consistent
       if (binMode != BinningMode::DEFAULT) {
         setProperty(PropertyNames::PARAMS, validParams);
-        rbParams = validParams;
+        paramsWereReset = true;
       }
     } catch (std::exception &err) {
       helpMessages[PropertyNames::PARAMS] = err.what();
@@ -205,7 +206,8 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     }
   } else {
     try {
-      VectorHelper::validateRebinParameters(rbParams, static_cast<bool>(power));
+      const auto &paramsToValidate = paramsWereReset ? validParams : rbParams;
+      VectorHelper::validateRebinParameters(paramsToValidate, static_cast<bool>(power));
     } catch (std::exception &err) {
       helpMessages[PropertyNames::PARAMS] = err.what();
     }

--- a/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
@@ -328,7 +328,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::monitorCorrection(MatrixWorkspa
   const auto monitorWS = makeMonitorWS(m_runWS, integratedMonitors);
   if (!integratedMonitors)
     detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
-  IvsLam = divide(detectorWS, monitorWS);
+  IvsLam = divide(std::move(detectorWS), monitorWS);
   return IvsLam;
 }
 
@@ -1085,8 +1085,8 @@ void ReflectometryReductionOne3::verifySpectrumMaps(const MatrixWorkspace_const_
 
 void ReflectometryReductionOne3::TaskBackgroundSubtraction::executeImpl() {
   auto detectorWS = getDependantWorkspace("InputWorkspace");
-  MatrixWorkspace_sptr corrected = m_parent->backgroundSubtraction(detectorWS);
-  outputWorkspace(corrected, Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace);
+  MatrixWorkspace_sptr corrected = m_parent->backgroundSubtraction(std::move(detectorWS));
+  outputWorkspace(std::move(corrected), Tasks::BackgroundSubtraction::Outputs::BackgroundSubtractedWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskConvertToWavelength::executeImpl() {
@@ -1096,33 +1096,34 @@ void ReflectometryReductionOne3::TaskConvertToWavelength::executeImpl() {
     m_parent->findWavelengthMinMax(result);
     m_parent->m_wavelengthMinMaxSet = true;
   }
-  outputWorkspace(result, Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength);
+  outputWorkspace(std::move(result), Tasks::ConvertToWavelength::Outputs::ConvertedWorkspaceWavelength);
 }
 
 void ReflectometryReductionOne3::TaskNormalizeByMonitor::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
-  MatrixWorkspace_sptr normalized = m_parent->monitorCorrection(inputWS);
-  outputWorkspace(normalized, Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace);
+  MatrixWorkspace_sptr normalized = m_parent->monitorCorrection(std::move(inputWS));
+  outputWorkspace(std::move(normalized), Tasks::NormalizeByMonitor::Outputs::MonitorCorrectedWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskNormalizeByTransmission::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
   auto [transmissionCorrected, transmission] = m_parent->transmissionCorrection(inputWS);
-  outputWorkspace(transmissionCorrected, Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace);
-  outputWorkspace(transmission, Tasks::NormalizeByTransmission::Outputs::TransmissionWorkspace);
+  outputWorkspace(std::move(transmissionCorrected),
+                  Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace);
+  outputWorkspace(std::move(transmission), Tasks::NormalizeByTransmission::Outputs::TransmissionWorkspace);
   setSelectedOutput(Tasks::NormalizeByTransmission::Outputs::TransmissionCorrectedWorkspace, true);
 }
 
 void ReflectometryReductionOne3::TaskExtractROI::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
-  auto extracted = m_parent->makeDetectorWS(inputWS, false, false);
-  outputWorkspace(extracted, Tasks::ExtractROI::Outputs::ExtractedROIWorkspace);
+  auto extracted = m_parent->makeDetectorWS(std::move(inputWS), false, false);
+  outputWorkspace(std::move(extracted), Tasks::ExtractROI::Outputs::ExtractedROIWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskSumDetectors::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
-  auto summed = m_parent->makeDetectorWS(inputWS, false, true);
-  outputWorkspace(summed, Tasks::SumDetectors::Outputs::SummedWorkspace);
+  auto summed = m_parent->makeDetectorWS(std::move(inputWS), false, true);
+  outputWorkspace(std::move(summed), Tasks::SumDetectors::Outputs::SummedWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskCropWavelength::executeImpl() {
@@ -1132,7 +1133,7 @@ void ReflectometryReductionOne3::TaskCropWavelength::executeImpl() {
     m_parent->m_wavelengthMinMaxSet = true;
   }
   auto cropped = m_parent->cropWavelength(inputWS, true, m_parent->wavelengthMin(), m_parent->wavelengthMax());
-  outputWorkspace(cropped, Tasks::CropWavelength::Outputs::CroppedWorkspace);
+  outputWorkspace(std::move(cropped), Tasks::CropWavelength::Outputs::CroppedWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskConvertToQ::executeImpl() {
@@ -1140,23 +1141,23 @@ void ReflectometryReductionOne3::TaskConvertToQ::executeImpl() {
   // Outputs the input workspace to convert to Q (i.e wavelength output workspace)
   if (!m_parent->isDefault("OutputWorkspaceWavelength") || m_parent->isChild())
     m_parent->setProperty("OutputWorkspaceWavelength", inputWS);
-  auto converted = m_parent->convertToQ(inputWS);
+  auto converted = m_parent->convertToQ(std::move(inputWS));
   // Outputs the converted workspace
   if (!m_parent->isDefault("OutputWorkspaceQ") || m_parent->isChild())
     m_parent->setProperty("OutputWorkspaceQ", converted);
-  outputWorkspace(converted, Tasks::ConvertToQ::Outputs::ConvertedWorkspaceQ);
+  outputWorkspace(std::move(converted), Tasks::ConvertToQ::Outputs::ConvertedWorkspaceQ);
 }
 
 void ReflectometryReductionOne3::TaskSumDetectorsInQ::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
   auto summedInQ = m_parent->sumInQ(inputWS);
-  outputWorkspace(summedInQ, Tasks::SumDetectorsInQ::Outputs::QSummedWorkspace);
+  outputWorkspace(std::move(summedInQ), Tasks::SumDetectorsInQ::Outputs::QSummedWorkspace);
 }
 
 void ReflectometryReductionOne3::TaskNormalizeByAlgorithm::executeImpl() {
   auto inputWS = getDependantWorkspace("InputWorkspace");
   auto algCorrected = m_parent->algorithmicCorrection(inputWS);
-  outputWorkspace(algCorrected, Tasks::NormalizeByAlgorithm::Outputs::AlgorithmCorrectedWorkspace);
+  outputWorkspace(std::move(algCorrected), Tasks::NormalizeByAlgorithm::Outputs::AlgorithmCorrectedWorkspace);
 }
 
 } // namespace Mantid::Reflectometry

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionPresenter.cpp
@@ -10,6 +10,8 @@
 #include <MantidQtWidgets/Spectroscopy/InterfaceUtils.h>
 #include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 
+#include <utility>
+
 namespace {
 Mantid::Kernel::Logger g_log("ContainerSubtraction");
 }
@@ -34,8 +36,8 @@ void ContainerSubtractionPresenter::handleValidation(IUserInputValidator *valida
   m_view->validate(validator);
   if (auto sampleWS = m_model->sampleWS(), canWS = m_model->canWS(); sampleWS && canWS) {
     // Check Sample is of same type as container
-    const auto containerType = canWS->YUnit();
-    const auto sampleType = sampleWS->YUnit();
+    const auto &containerType = canWS->YUnit();
+    const auto &sampleType = sampleWS->YUnit();
 
     g_log.debug() << "Sample Y-Unit is: " << sampleType << '\n';
     g_log.debug() << "Container Y-Unit is: " << containerType << '\n';
@@ -100,7 +102,7 @@ std::string ContainerSubtractionPresenter::createOutputName() {
   for (const auto &qSuffix : InterfaceUtils::getSampleWSSuffixes("ContainerSubtraction")) {
     auto suffix = qSuffix.toStdString();
     if (sampleName.ends_with(suffix)) {
-      sampleNameSuffix = suffix;
+      sampleNameSuffix = std::move(suffix);
       break;
     }
   }


### PR DESCRIPTION
### Description of work

Summary of coverity warnings fixed:

 - Fixed Coverity copy/move performance defects across 32 reported CIDs.
  - TaskBasedAlgorithm.h: moved task workspace/vector ownership at final transfer points, covering task staging/output CIDs 1659495, 1659491, 1659488, 1659485, 1659484, 1659483, 1659482.
  - ReflectometryReductionOne3.cpp: moved workspace shared_ptrs after last use in task execution/helper paths, covering CIDs 1659499, 1659498, 1659494, 1659493, 1659492, 1659490, 1659489, 1659486, 1659480, 1659479,
    1659478, 1659477, 1659475, 1659473, 1659469, 1659468.
  - ContainerSubtractionPresenter.cpp: avoided copied Y-unit strings and moved suffix assignment after last use, covering CIDs 1659497, 1659481, 1659487.
  - FitPeaks.cpp: moved cloned peak/background function pointers at final transfer, avoided unnecessary histogram data copies, and moved temporary functions into composite functions, covering CIDs 1659496, 1659476,
    1659474, 1659471, 1659470.
  - Rebin.cpp: removed the validParams to rbParams vector copy while preserving validation behavior via a paramsWereReset flag, covering CID 1659472.


### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
