### PR TITLE
Do not validate memory if preserving events

### DIFF
--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -193,7 +193,8 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     size_t numBins = VectorHelper::estimateNumberOfBins(validParams, power);
     if (power != 0. && numBins > 10'001) { // this number of bins should only be considered an issue for power binning
       helpMessages[PropertyNames::POWER] = "This binning is expected to give " + std::to_string(numBins) + " bins.";
-    } else { // otherwise compare against available memory
+    } else if (!(std::dynamic_pointer_cast<const EventWorkspace>(inputWS) &&
+                 static_cast<bool>(getProperty(PropertyNames::PRSRV_EVENTS)))) {
       size_t numSpec = inputWS->getNumberHistograms();
       std::size_t binSpaceInBytes = 2 * numSpec * numBins * sizeof(double); // memory required in bytes
       std::string memMsg = MemoryStats().checkAvailableMemory(binSpaceInBytes);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -138,6 +138,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
 
   // validate the rebin params, and outside default mode, reset them
   MatrixWorkspace_sptr inputWS = getProperty(PropertyNames::INPUT_WKSP);
+  const auto eventInputWS = std::dynamic_pointer_cast<const EventWorkspace>(inputWS);
   std::vector<double> rbParams = getProperty(PropertyNames::PARAMS);
   std::vector<double> validParams;
   if (inputWS == nullptr) {
@@ -191,10 +192,10 @@ std::map<std::string, std::string> Rebin::validateInputs() {
   // estimate the number of bins needed and compare to available memory
   if (inputWS && !validParams.empty()) {
     size_t numBins = VectorHelper::estimateNumberOfBins(validParams, power);
+    const bool preserveEvents = static_cast<bool>(getProperty(PropertyNames::PRSRV_EVENTS));
     if (power != 0. && numBins > 10'001) { // this number of bins should only be considered an issue for power binning
       helpMessages[PropertyNames::POWER] = "This binning is expected to give " + std::to_string(numBins) + " bins.";
-    } else if (!(std::dynamic_pointer_cast<const EventWorkspace>(inputWS) &&
-                 static_cast<bool>(getProperty(PropertyNames::PRSRV_EVENTS)))) {
+    } else if (!(eventInputWS && preserveEvents)) {
       size_t numSpec = inputWS->getNumberHistograms();
       std::size_t binSpaceInBytes = 2 * numSpec * numBins * sizeof(double); // memory required in bytes
       std::string memMsg = MemoryStats().checkAvailableMemory(binSpaceInBytes);

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -196,7 +196,8 @@ public:
     rebin.setProperty("InputWorkspace", ws);
     rebin.setPropertyValue("OutputWorkspace", "test_out");
     rebin.setProperty("PreserveEvents", true);
-    TS_ASSERT_THROWS_NOTHING(rebin.setProperty("Params", std::vector<double>{1.0, 1.0, 1.0 + numBins}));
+    TS_ASSERT_THROWS_NOTHING(
+        rebin.setProperty("Params", std::vector<double>{1.0, 1.0, 1.0 + static_cast<double>(numBins)}));
 
     auto errmsgs = rebin.validateInputs();
     TS_ASSERT(errmsgs.empty());

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -183,6 +183,32 @@ public:
 #endif
   }
 
+  void test_event_workspace_preserve_events_does_not_use_histogram_memory_check() {
+#if defined(__linux__) || defined(__gnu_linux__)
+    std::cout << "Test event workspace PreserveEvents skips histogram memory check" << std::endl;
+    Mantid::TestMemory::MockMemory memL; // patch the available memory calculator
+    size_t numSpec = 10;
+    size_t numBins = memL.numberOfFloats() / numSpec;
+    EventWorkspace_sptr ws = WorkspaceCreationHelper::createEventWorkspace2(static_cast<int>(numSpec), 2);
+
+    Rebin rebin;
+    rebin.initialize();
+    rebin.setProperty("InputWorkspace", ws);
+    rebin.setPropertyValue("OutputWorkspace", "test_out");
+    rebin.setProperty("PreserveEvents", true);
+    TS_ASSERT_THROWS_NOTHING(rebin.setProperty("Params", std::vector<double>{1.0, 1.0, 1.0 + numBins}));
+
+    auto errmsgs = rebin.validateInputs();
+    TS_ASSERT(errmsgs.empty());
+
+    rebin.setProperty("PreserveEvents", false);
+    errmsgs = rebin.validateInputs();
+    auto errmsg = errmsgs.find("Params");
+    TS_ASSERT(errmsg != errmsgs.end());
+    TS_ASSERT_DIFFERS(errmsg->second.find("This binning is expected to create"), std::string::npos);
+#endif
+  }
+
   /* execution tests */
 
   void testworkspace1D_dist() {


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Following: https://github.com/mantidproject/mantid/pull/41320, we now estimate how much memory a rebin will consume, then validate that the host system has enough memory available to facilitate the rebin.

This however was not taking into account the different behaviour when preserving, and not preserving events. When preserving events, a full histogram is not immediately created, only the x axis is changed whilst actual rebinning is deferred until data access.

Because of this, on large event workspaces during system tests we are seeing validation errors where we were previously not seeing failures.

As such, this PR disables the validation if the workspace is an event workspace, and `PreserveEvents=True`.

### To test:

See tests pass, especially new unit test on linux CI

At the moment I haven't run the system tests as we are down to half the runners due to the split CI, and we also not guarentee we get a runner that is sufficiently low on memory for the test to fail. I suggest we just wait for the nightly...

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
