### PR TITLE
Updated the text color of the notice log messages to provide greater legibility in both light and dark modes

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/41239.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/41239.rst
@@ -1,0 +1,1 @@
+- The text color of the notice log messages in :ref:`Messages Window <WorkbenchMessagesWindow>` has been updated to provide better readability in both light and dark modes.

--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/41239.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/41239.rst
@@ -1,1 +1,1 @@
-- The text color of the notice log messages in :ref:`Messages Window <WorkbenchMessagesWindow>` has been updated to provide better readability in both light and dark modes.
+- The :ref:`Messages Window <WorkbenchMessagesWindow>` now prints logs that are more readable in both light and dark mode at all logging levels.

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -432,7 +432,7 @@ void MessageDisplay::initFormats() {
   textFormat.setForeground(Qt::gray);
   m_formats[Message::Priority::PRIO_INFORMATION] = textFormat;
 
-  textFormat.setForeground(Qt::darkBlue);
+  textFormat.setForeground(QColor::fromRgb(65, 105, 225));
   m_formats[Message::Priority::PRIO_NOTICE] = textFormat;
 }
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41239 . <!-- One line per closed issue. -->
The cleanest way to handle the issue is to update the text color of the notice messages. I decided to use `rgb(65, 105, 225)` after considering various options. The color provides a good tradeoff of legibility in both light and dark mode and is close to the original color.

<img width="1208" height="815" alt="image" src="https://github.com/user-attachments/assets/1fdaea5d-f918-4355-9cd5-cef0a9ce3090" />


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Set system theme/appearance to `light` mode.
2) Launch **workbench**.
3) Right click the messages window and vary the log levels.
<img width="244" height="197" alt="image" src="https://github.com/user-attachments/assets/e848fae3-442d-421a-b382-9a7f64482ca1" />

4) Verify that all levels are readable.
5) Close **workbench**.
6) Set system theme/appearance to `dark` mode.
7) Repeat the above steps and verify readability in `dark` mode. 



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
