### PR TITLE
Fix to MSVC warning issue in `LoadNexusLogs`

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -223,8 +223,9 @@ std::unique_ptr<Kernel::Property> createTimeSeries(Nexus::File &file, const std:
     // but some older files (wrongly) put this in the first dimension (0) if the rank is 1
     const int64_t item_length = (info.dims.size() > 1 ? info.dims[1] : info.dims[0]);
     try {
-      const std::size_t total_length = static_cast<std::size_t>(
-          std::accumulate(info.dims.cbegin(), info.dims.cend(), 1, std::multiplies<int64_t>()));
+      const std::size_t total_length =
+          std::accumulate(info.dims.cbegin(), info.dims.cend(), std::size_t(1),
+                          [](std::size_t acc, int64_t x) { return acc * static_cast<std::size_t>(x); });
       boost::scoped_array<char> val_array(new char[total_length + 1]);
       file.getData(val_array.get());
       file.closeData();

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -223,8 +223,8 @@ std::unique_ptr<Kernel::Property> createTimeSeries(Nexus::File &file, const std:
     // but some older files (wrongly) put this in the first dimension (0) if the rank is 1
     const int64_t item_length = (info.dims.size() > 1 ? info.dims[1] : info.dims[0]);
     try {
-      const std::size_t total_length =
-          std::accumulate(info.dims.cbegin(), info.dims.cend(), 1, std::multiplies<int64_t>());
+      const std::size_t total_length = static_cast<std::size_t>(
+          std::accumulate(info.dims.cbegin(), info.dims.cend(), 1, std::multiplies<int64_t>()));
       boost::scoped_array<char> val_array(new char[total_length + 1]);
       file.getData(val_array.get());
       file.closeData();


### PR DESCRIPTION
### Description of work

Somehow a compiler warning on MSVC crept into `LoadNexusLogs`.

This should fix it.

### To test:

Make sure the Windows build passes without compiler warnings.

Make sure the `LoadNexusLogs` tests still pass.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
