### PR TITLE
Expose InstrumentDataService to python

### DIFF
--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -18,6 +18,7 @@ set(EXPORT_FILES
     src/Exports/AlgorithmFactoryObserver.cpp
     src/Exports/AlgorithmManager.cpp
     src/Exports/AnalysisDataService.cpp
+    src/Exports/InstrumentDataService.cpp
     src/Exports/FileProperty.cpp
     src/Exports/InstrumentFileFinder.cpp
     src/Exports/MultipleFileProperty.cpp

--- a/Framework/PythonInterface/mantid/api/_aliases.py
+++ b/Framework/PythonInterface/mantid/api/_aliases.py
@@ -18,6 +18,7 @@ from mantid.api import (
     FileLoaderRegistryImpl,
     FrameworkManagerImpl,
     FunctionFactoryImpl,
+    InstrumentDataServiceImpl,
     WorkspaceFactoryImpl,
 )
 from mantid.kernel._aliases import lazy_instance_access
@@ -34,6 +35,7 @@ from mantid.kernel._aliases import lazy_instance_access
 # If you see a segfault late in a python process related to the GIL
 # it is likely an exit handler is missing.
 AnalysisDataService = lazy_instance_access(AnalysisDataServiceImpl, key_as_str=True)
+InstrumentDataService = lazy_instance_access(InstrumentDataServiceImpl, key_as_str=True)
 AlgorithmFactory = lazy_instance_access(AlgorithmFactoryImpl)
 AlgorithmManager = lazy_instance_access(AlgorithmManagerImpl)
 FileFinder = lazy_instance_access(FileFinderImpl)

--- a/Framework/PythonInterface/mantid/api/src/Exports/InstrumentDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/InstrumentDataService.cpp
@@ -7,6 +7,7 @@
 
 #include "MantidAPI/InstrumentDataService.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidKernel/Exception.h"
 #include "MantidPythonInterface/core/DataServiceExporter.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 
@@ -28,7 +29,7 @@ Mantid::Geometry::Instrument_sptr retrieveOrKeyError(const InstrumentDataService
   // Instrument. So we have to reimplement the same logic here, but returning a shared pointer instead.
   try {
     return self.retrieve(name);
-  } catch (Mantid::Kernel::Exception::NotFoundError &) {
+  } catch (const Mantid::Kernel::Exception::NotFoundError &) {
     const std::string err = "'" + name + "' does not exist.";
     PyErr_SetString(PyExc_KeyError, err.c_str());
     throw boost::python::error_already_set();

--- a/Framework/PythonInterface/mantid/api/src/Exports/InstrumentDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/InstrumentDataService.cpp
@@ -1,0 +1,56 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAPI/InstrumentDataService.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidPythonInterface/core/DataServiceExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/return_value_policy.hpp>
+
+using namespace Mantid::API;
+using namespace Mantid::PythonInterface;
+using namespace boost::python;
+
+GET_POINTER_SPECIALIZATION(InstrumentDataServiceImpl)
+
+namespace {
+
+InstrumentDataServiceImpl &instance() { return InstrumentDataService::Instance(); }
+
+Mantid::Geometry::Instrument_sptr retrieveOrKeyError(const InstrumentDataServiceImpl &self, const std::string &name) {
+  // Can't use DataServiceExporter::retrieveOrKeyError here because it returns a weak pointer which we can't use with
+  // Instrument. So we have to reimplement the same logic here, but returning a shared pointer instead.
+  try {
+    return self.retrieve(name);
+  } catch (Mantid::Kernel::Exception::NotFoundError &) {
+    const std::string err = "'" + name + "' does not exist.";
+    PyErr_SetString(PyExc_KeyError, err.c_str());
+    throw boost::python::error_already_set();
+  }
+}
+
+} // namespace
+
+void export_InstrumentDataService() {
+  using IDSExporter = DataServiceExporter<InstrumentDataServiceImpl, Mantid::Geometry::Instrument_sptr>;
+
+  class_<InstrumentDataServiceImpl, boost::noncopyable>("InstrumentDataServiceImpl", no_init)
+      .def("Instance", instance, return_value_policy<reference_existing_object>(),
+           "Return a reference to the singleton instance")
+      .staticmethod("Instance")
+      .def("doesExist", &InstrumentDataServiceImpl::doesExist, (arg("self"), arg("name")),
+           "Returns True if the object is found in the service.")
+      .def("retrieve", retrieveOrKeyError, (arg("self"), arg("name")),
+           "Retrieve the named object. Raises an exception if the name does not exist")
+      .def("remove", &IDSExporter::removeItem, (arg("self"), arg("name")), "Remove a named object")
+      .def("clear", &InstrumentDataServiceImpl::clear, arg("self"), "Removes all objects managed by the service.")
+      .def("size", &InstrumentDataServiceImpl::size, arg("self"), "Returns the number of objects within the service")
+      .def("getObjectNames", &IDSExporter::getObjectNamesAsList, (arg("self"), arg("contain") = ""),
+           "Return the list of names currently known to the IDS");
+}

--- a/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_PY_FILES
     IMaskWorkspaceTest.py
     IPeakFunctionTest.py
     IPeaksWorkspaceTest.py
+    InstrumentDataServiceTest.py
     ITableWorkspaceTest.py
     JacobianTest.py
     MatrixWorkspaceTest.py

--- a/Framework/PythonInterface/test/python/mantid/api/InstrumentDataServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/InstrumentDataServiceTest.py
@@ -1,0 +1,72 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from mantid.api import FrameworkManagerImpl, InstrumentDataService, InstrumentDataServiceImpl
+from mantid.geometry import Instrument
+from mantid.simpleapi import LoadEmptyInstrument
+
+
+class InstrumentDataServiceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        FrameworkManagerImpl.Instance()
+
+    def tearDown(self):
+        InstrumentDataService.clear()
+
+    def test_alias_is_instance_type(self):
+        self.assertTrue(isinstance(InstrumentDataService, InstrumentDataServiceImpl))
+
+    def test_only_limited_interface_is_exposed(self):
+        self.assertTrue(hasattr(InstrumentDataService, "doesExist"))
+        self.assertTrue(hasattr(InstrumentDataService, "retrieve"))
+        self.assertTrue(hasattr(InstrumentDataService, "remove"))
+        self.assertTrue(hasattr(InstrumentDataService, "clear"))
+        self.assertTrue(hasattr(InstrumentDataService, "size"))
+        self.assertTrue(hasattr(InstrumentDataService, "getObjectNames"))
+
+        self.assertFalse(hasattr(InstrumentDataService, "add"))
+        self.assertFalse(hasattr(InstrumentDataService, "addOrReplace"))
+        self.assertFalse(hasattr(InstrumentDataService, "__getitem__"))
+        self.assertFalse(hasattr(InstrumentDataService, "__setitem__"))
+
+    def test_empty_service_methods(self):
+        self.assertEqual(InstrumentDataService.getObjectNames(), [])
+        self.assertFalse(InstrumentDataService.doesExist("does_not_exist"))
+        InstrumentDataService.remove("does_not_exist")
+
+    def test_add_retrieve_remove(self):
+        # Check that the service is empty to start with.
+        self.assertEqual(InstrumentDataService.size(), 0)
+
+        # Add an instrument to the service and check it is there.
+        pg3 = LoadEmptyInstrument(InstrumentName="PG3")
+        self.assertEqual(InstrumentDataService.size(), 1)
+        objectName = InstrumentDataService.getObjectNames()
+        self.assertEqual(len(objectName), 1)
+        instrument_cache_name = objectName[0]
+        self.assertTrue(instrument_cache_name.startswith("POWGEN"))
+        self.assertTrue(InstrumentDataService.doesExist(instrument_cache_name))
+
+        # Retrieve the instrument and check it is the same one.
+        retrieved_pg3 = InstrumentDataService.retrieve(instrument_cache_name)
+        self.assertIsInstance(retrieved_pg3, Instrument)
+        self.assertEqual(retrieved_pg3.getName(), "POWGEN")
+
+        # Check that the object is removed and the service is empty again.
+        InstrumentDataService.remove(instrument_cache_name)
+        self.assertEqual(InstrumentDataService.size(), 0)
+        pg3.delete()
+
+    def test_retrieve_missing_raises_keyerror(self):
+        with self.assertRaises(KeyError):
+            InstrumentDataService.retrieve("does_not_exist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/InstrumentDataServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/InstrumentDataServiceTest.py
@@ -47,9 +47,14 @@ class InstrumentDataServiceTest(unittest.TestCase):
         # Add an instrument to the service and check it is there.
         pg3 = LoadEmptyInstrument(InstrumentName="PG3")
         self.assertEqual(InstrumentDataService.size(), 1)
-        objectName = InstrumentDataService.getObjectNames()
-        self.assertEqual(len(objectName), 1)
-        instrument_cache_name = objectName[0]
+        self.assertEqual(len(InstrumentDataService.getObjectNames()), 1)
+
+        # Check contains work for getObjectNames
+        self.assertEqual(len(InstrumentDataService.getObjectNames("TOPAZ")), 0)
+        self.assertEqual(len(InstrumentDataService.getObjectNames("POWGEN")), 1)
+
+        # Check the retrieved instrument
+        instrument_cache_name = InstrumentDataService.getObjectNames()[0]
         self.assertTrue(instrument_cache_name.startswith("POWGEN"))
         self.assertTrue(InstrumentDataService.doesExist(instrument_cache_name))
 

--- a/docs/source/api/python/mantid/api/InstrumentDataServiceImpl.rst
+++ b/docs/source/api/python/mantid/api/InstrumentDataServiceImpl.rst
@@ -1,0 +1,50 @@
+.. _mantid.api.InstrumentDataServiceImpl:
+
+===========================
+ InstrumentDataServiceImpl
+===========================
+
+This is a Python binding to the C++ class Mantid::API::InstrumentDataServiceImpl.
+
+What is it?
+-----------
+
+The Instrument Data Service is a :ref:`Data Service <Data Service>` that is
+specialized to hold cached :py:obj:`Instruments <mantid.geometry.Instrument>`.
+This cache is managed internally by Mantid when instruments are loaded through
+algorithms.
+
+Unlike the :py:obj:`AnalysisDataService <mantid.api.AnalysisDataServiceImpl>`,
+the Python interface intentionally exposes only a limited set of methods.
+Instruments should be added to the cache only by the framework, while Python is
+restricted to querying, retrieving, and clearing cached entries.
+
+Extracting an instrument from the Instrument Data Service
+---------------------------------------------------------
+
+The most usual way to populate the cache is to run an algorithm that loads an
+instrument.
+
+``LoadEmptyInstrument(InstrumentName="PG3")``
+
+The list of cached instruments can be queried as follows:
+
+``InstrumentDataService.getObjectNames()``
+
+You can then access the cached instrument directly from the
+InstrumentDataService.
+
+``instrument = InstrumentDataService.retrieve("POWGEN**************")``
+
+The returned object is a :py:obj:`mantid.geometry.Instrument`.
+
+
+Reference
+---------
+
+.. module:`mantid.api`
+
+.. autoclass:: mantid.api.InstrumentDataServiceImpl
+    :members:
+    :undoc-members:
+    :inherited-members:


### PR DESCRIPTION
### Description of work

This is to help diagnose memory issue. Not really for users. This limited set of methods is because instruments should only be added in a very prescribed manner.


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes [14474: [mantid] Expose InstrumentDataService to python](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14474)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

```python
from mantid.simpleapi import LoadEmptyInstrument
from mantid.api import InstrumentDataService

LoadEmptyInstrument(InstrumentName="PG3", OutputWorkspace="pg3")
LoadEmptyInstrument(InstrumentName="TOPAZ", OutputWorkspace="topaz")

print(InstrumentDataService.getObjectNames())
inst = InstrumentDataService.retrieve(InstrumentDataService.getObjectNames()[0])
print(type(inst))
print(inst.getName())
```

should print something like

```
['POWGENb626fea5ae9c824959ba29bf2d25f5e8617373d9', 'TOPAZa88209c8d30e8aeaf08451819a17e8983ea18166']
<class '_geometry.Instrument'>
POWGEN
```


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
