### PR TITLE
Implement basic Q3DLog transform for ConvertToMD

### DIFF
--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SRC_FILES
     src/MDTransfModQ.cpp
     src/MDTransfNoQ.cpp
     src/MDTransfQ3D.cpp
+    src/MDTransfQ3DLog.cpp
     src/MDWSDescription.cpp
     src/MDWSTransform.cpp
     src/MagneticFormFactorCorrectionMD.cpp
@@ -206,6 +207,7 @@ set(INC_FILES
     inc/MantidMDAlgorithms/MDTransfModQ.h
     inc/MantidMDAlgorithms/MDTransfNoQ.h
     inc/MantidMDAlgorithms/MDTransfQ3D.h
+    inc/MantidMDAlgorithms/MDTransfQ3DLog.h
     inc/MantidMDAlgorithms/MDWSDescription.h
     inc/MantidMDAlgorithms/MDWSTransform.h
     inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfInterface.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfInterface.h
@@ -13,7 +13,11 @@
 #include "MantidKernel/DeltaEMode.h"
 #include "MantidKernel/cow_ptr.h"
 
+#include "MantidTypes/Core/DateAndTime.h"
+
 #include "MantidMDAlgorithms/MDWSDescription.h"
+
+using Mantid::Types::Core::DateAndTime;
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -201,6 +205,20 @@ public:
    */
   virtual void setDisplayNormalization(Mantid::API::IMDWorkspace_sptr mdWorkspace,
                                        Mantid::API::MatrixWorkspace_sptr underlyingWorkspace) const = 0;
+
+  /** Calculates 3D transformation of the variable coordinates depending on 3D coordinates
+   * and rotation angle for a given neutron even pulse time.
+   */
+  virtual bool calcMatrixCoordTime(const double &deltaEOrK0, std::vector<coord_t> &Coord, const DateAndTime &pulseTime,
+                                   double &s, double &err) const {
+    UNUSED_ARG(pulseTime);
+    return calcMatrixCoord(deltaEOrK0, Coord, s, err);
+  }
+
+  /**
+   * Returns if this transformation supports computing Q from log values at a given pulse-time
+   */
+  virtual bool usesPulseTime() const { return false; }
 };
 
 using MDTransf_sptr = std::shared_ptr<MDTransfInterface>;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3DLog.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3DLog.h
@@ -1,0 +1,48 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+//
+#include "MantidKernel/Matrix.h"
+#include "MantidKernel/V3D.h"
+#include "MantidMDAlgorithms/MDTransfFactory.h"
+#include "MantidMDAlgorithms/MDTransfInterface.h"
+#include "MantidMDAlgorithms/MDTransfQ3D.h"
+//
+namespace Mantid {
+namespace MDAlgorithms {
+
+/** Class responsible for conversion of input EventWorkspace
+ * data into proper number of output dimensions for Q3D case
+ * where the sample rotation changes throughout the scan.
+ *
+ * We inherit methods from the main MDTransfQ3D class - see that
+ * class for more information.
+ */
+
+class MANTID_MDALGORITHMS_DLL MDTransfQ3DLog : public MDTransfQ3D {
+public:
+  const std::string transfID() const override;
+  bool calcMatrixCoordTime(const double &deltaEOrK0, std::vector<coord_t> &Coord, const DateAndTime &pulsetime,
+                           double &s, double &err) const override;
+  void initialize(const MDWSDescription &ConvParams) override;
+  bool usesPulseTime() const override { return true; }
+
+private:
+  Kernel::DblMatrix m_Wtransf;
+  Kernel::V3D m_rotAxis;
+  Kernel::TimeSeriesProperty<double> *m_rotLog;
+  double m_angZero;
+  /// how to transform workspace data in elastic case
+  inline bool calcMatrixCoord3DElasticTime(const double &k0, std::vector<coord_t> &Coord, const DateAndTime &pulsetime,
+                                           double &signal, double &errSq) const;
+  /// how to transform workspace data in inelastic case
+  inline bool calcMatrixCoord3DInelasticTime(const double &deltaE, std::vector<coord_t> &Coord,
+                                             const DateAndTime &pulsetime) const;
+};
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -56,7 +56,13 @@ template <class T> size_t ConvToMDEventsWS::convertEventList(size_t workspaceInd
     double val = localUnitConv.convertUnits(it->tof());
     double signal = it->weight();
     double errorSq = it->errorSquared();
-    if (!m_QConverter->calcMatrixCoord(val, locCoord, signal, errorSq))
+    bool ok;
+    if (m_QConverter->usesPulseTime()) {
+      ok = m_QConverter->calcMatrixCoordTime(val, locCoord, it->pulseTime(), signal, errorSq);
+    } else {
+      ok = m_QConverter->calcMatrixCoord(val, locCoord, signal, errorSq);
+    }
+    if (!ok)
       continue; // skip ND outside the range
 
     sig_err.emplace_back(static_cast<float>(signal));

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -219,7 +219,7 @@ void ConvertToMD::exec() {
   std::vector<double> dimMax = getProperty("MaxValues");
 
   // Sanity check some options
-  if (QModReq != MDTransfQ3D().transfID()) {
+  if (!QModReq.starts_with(MDTransfQ3D().transfID())) {
     MDWSTransform transform;
     const std::string autoSelect = transform.getTargetFrames()[CnvrtToMD::AutoSelect];
     if (QFrame != autoSelect) {
@@ -452,7 +452,7 @@ bool ConvertToMD::buildTargetWSDescription(const API::IMDEventWorkspace_sptr &sp
 
   // Set optional projections for Q3D mode
   MDAlgorithms::MDWSTransform MsliceProj;
-  if (QModReq == MDTransfQ3D().transfID()) {
+  if (!QModReq.starts_with(MDTransfQ3D().transfID())) {
     try {
       // otherwise input uv are ignored -> later it can be modified to set ub
       // matrix if no given, but this may over-complicate things.

--- a/Framework/MDAlgorithms/src/MDTransfQ3DLog.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3DLog.cpp
@@ -1,0 +1,165 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidMDAlgorithms/MDTransfQ3DLog.h"
+#include "MantidAPI/Run.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/Quat.h"
+#include "MantidKernel/RegistrationHelper.h"
+#include "MantidMDAlgorithms/MDTransfQ3D.h"
+
+using Mantid::Kernel::DblMatrix;
+
+namespace Mantid::MDAlgorithms {
+// register the class, whith conversion factory under namd "Q3DLog"
+DECLARE_MD_TRANSFID(MDTransfQ3DLog, Q3DLog)
+
+/** Initializes the class (calls parent and extract rotation logs)
+ * @param ConvParams - a MDWSDescription of the input workspace
+ * */
+void MDTransfQ3DLog::initialize(const MDWSDescription &ConvParams) {
+  MDTransfQ3D::initialize(ConvParams);
+  // Get the rotation log name from the Gonio (only first Gonio supported)
+  m_Wtransf = ConvParams.m_Wtransf; // This is the Bmatrix, converting to Q
+  Mantid::Geometry::Goniometer gon = ConvParams.getInWS()->run().getGoniometer();
+  Mantid::Geometry::GoniometerAxis a0 = gon.getAxis(0);
+  m_rotAxis = a0.rotationaxis;
+  if (a0.sense < 0) {
+    m_rotAxis = -m_rotAxis;
+  }
+  // TODO: here we assume that the log is in degrees - need to check this
+  m_rotLog = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(
+      ConvParams.getInWS()->run().getLogData(a0.name)->clone());
+  // TODO: subsequent axes can only be constants (we also assume they have the same axis as the first)
+  size_t nmot = gon.getNumberAxes();
+  m_angZero = 0;
+  if (nmot > 1) {
+    for (size_t ix = 1; ix < nmot; ix++) {
+      Mantid::Geometry::GoniometerAxis a1 = gon.getAxis(ix);
+      if (!a1.name.ends_with("FixedValue")) {
+        throw std::invalid_argument("Multiple goniometers with log values not implemented");
+      }
+      m_angZero += a1.angle * a1.sense;
+    }
+  }
+}
+
+/** Calculates 3D transformation of the variable coordinates depending on 3D coordinates
+ * and rotation angle for a given neutron even pulse time.
+ * Follows signature of parent calcMatrixCoord() method
+ */
+bool MDTransfQ3DLog::calcMatrixCoordTime(const double &deltaEOrK0, std::vector<coord_t> &Coord,
+                                         const DateAndTime &pulsetime, double &s, double &err) const {
+  if (m_Emode == Kernel::DeltaEMode::Elastic) {
+    return calcMatrixCoord3DElasticTime(deltaEOrK0, Coord, pulsetime, s, err);
+  } else {
+    return calcMatrixCoord3DInelasticTime(deltaEOrK0, Coord, pulsetime);
+  }
+}
+
+/** method calculates workspace-dependent coordinates in inelastic case
+ * for particular neutron event. Follows signature of parent calcMatrixCoord3DInelastic()
+ */
+bool MDTransfQ3DLog::calcMatrixCoord3DInelasticTime(const double &deltaE, std::vector<coord_t> &Coord,
+                                                    const DateAndTime &pulseTime) const {
+  Coord[3] = static_cast<coord_t>(deltaE);
+  if (Coord[3] < m_DimMin[3] || Coord[3] >= m_DimMax[3])
+    return false;
+
+  // x,y,z refer to internal coordinate system where Z is the beam direction
+  double qx{0.0}, qy{0.0}, qz{0.0};
+  if (m_Emode == Kernel::DeltaEMode::Direct) {
+    const double kFinal = sqrt((m_eFixed - deltaE) / PhysicalConstants::E_mev_toNeutronWavenumberSq);
+    qx = -m_ex * kFinal;
+    qy = -m_ey * kFinal;
+    qz = m_kFixed - m_ez * kFinal;
+  } else {
+    qx = -m_ex * m_kFixed;
+    qy = -m_ey * m_kFixed;
+    const double kInitial = sqrt((m_eFixed + deltaE) / PhysicalConstants::E_mev_toNeutronWavenumberSq);
+    qz = kInitial - m_ez * m_kFixed;
+  }
+
+  if (convention == "Crystallography") {
+    qx = -qx;
+    qy = -qy;
+    qz = -qz;
+  }
+
+  // Get rotmat from the current rotation angle
+  double ang = m_rotLog->getSingleValue(pulseTime) + m_angZero;
+  DblMatrix mat = DblMatrix(Mantid::Kernel::Quat(ang, m_rotAxis).getRotation()) * m_Wtransf;
+  mat.Invert();
+  std::vector<double> RotMat = mat.getVector();
+
+  Coord[0] = static_cast<coord_t>(RotMat[0] * qx + RotMat[1] * qy + RotMat[2] * qz);
+
+  if (Coord[0] < m_DimMin[0] || Coord[0] >= m_DimMax[0])
+    return false;
+  Coord[1] = static_cast<coord_t>(RotMat[3] * qx + RotMat[4] * qy + RotMat[5] * qz);
+  if (Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1])
+    return false;
+  Coord[2] = static_cast<coord_t>(RotMat[6] * qx + RotMat[7] * qy + RotMat[8] * qz);
+  if (Coord[2] < m_DimMin[2] || Coord[2] >= m_DimMax[2])
+    return false;
+
+  if (std::sqrt(Coord[0] * Coord[0] + Coord[1] * Coord[1] + Coord[2] * Coord[2]) < m_AbsMin)
+    return false;
+
+  return true;
+}
+
+/** function calculates workspace-dependent coordinates in elastic case.
+ * for particular neutron event. Follows signature of parent calcMatrixCoord3DElastic()
+ */
+bool MDTransfQ3DLog::calcMatrixCoord3DElasticTime(const double &k0, std::vector<coord_t> &Coord,
+                                                  const DateAndTime &pulseTime, double &signal, double &errSq) const {
+
+  double qx = -m_ex * k0;
+  double qy = -m_ey * k0;
+  double qz = (1 - m_ez) * k0;
+  if (convention == "Crystallography") {
+    qx = -qx;
+    qy = -qy;
+    qz = -qz;
+  }
+
+  // Get rotmat from the current rotation angle
+  double ang = m_rotLog->getSingleValue(pulseTime) + m_angZero;
+  DblMatrix mat = DblMatrix(Mantid::Kernel::Quat(ang, m_rotAxis).getRotation()) * m_Wtransf;
+  mat.Invert();
+  std::vector<double> RotMat = mat.getVector();
+
+  // Dimension limits have to be converted to coord_t, otherwise floating point
+  // error will cause valid events to be discarded.
+  Coord[0] = static_cast<coord_t>(RotMat[0] * qx + RotMat[1] * qy + RotMat[2] * qz);
+  if (Coord[0] < static_cast<coord_t>(m_DimMin[0]) || Coord[0] >= static_cast<coord_t>(m_DimMax[0]))
+    return false;
+
+  Coord[1] = static_cast<coord_t>(RotMat[3] * qx + RotMat[4] * qy + RotMat[5] * qz);
+  if (Coord[1] < static_cast<coord_t>(m_DimMin[1]) || Coord[1] >= static_cast<coord_t>(m_DimMax[1]))
+    return false;
+
+  Coord[2] = static_cast<coord_t>(RotMat[6] * qx + RotMat[7] * qy + RotMat[8] * qz);
+  if (Coord[2] < static_cast<coord_t>(m_DimMin[2]) || Coord[2] >= static_cast<coord_t>(m_DimMax[2]))
+    return false;
+
+  if (std::sqrt(Coord[0] * Coord[0] + Coord[1] * Coord[1] + Coord[2] * Coord[2]) < m_AbsMin)
+    return false;
+
+  /*Apply Lorentz corrections if necessary */
+  if (m_isLorentzCorrected) {
+    double kdash = k0 / (2 * M_PI);
+    double correct = m_SinThetaSq * kdash * kdash * kdash * kdash;
+    signal *= correct;
+    errSq *= (correct * correct);
+  }
+
+  return true;
+}
+
+} // namespace Mantid::MDAlgorithms


### PR DESCRIPTION
* Bare-bones implementation of new MDTransf class which checks the Goniometers for the log name and uses those log values as angles for the Q3D transformation for each neutron event.

* Only handles a single log value / gonio at present.

* Output workspaces not correctly normalised / have correct limits

### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Data and scripts are in this [archive on OneDrive](https://stfc365-my.sharepoint.com/:u:/g/personal/duc_le_stfc_ac_uk/IQCeimTfms5hSpt3o3Cv5AIWATEMk0efsY2YzV6vYMgUskE) (if not from STFC, ask me for access).

The script `gensqw_mno_single.py` ([updated file](https://github.com/user-attachments/files/27660222/gensqw_mno_single.py)) has two branches - set the flag `convert_with_logs` to `True` to use the new routines (with `QDimensions='Q3DLog'`) otherwise use the original approach of binning in angle.

<img width="1682" height="674" alt="image" src="https://github.com/user-attachments/assets/00357f7b-bcd5-453c-8d88-ec75888aa1bd" />

Left is the MDHistoWorkspace with the original workflow, right is with this PR - Bragg peaks are correctly positioned but the intensity is wrong (incorrect normalisation).

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
