### PR TITLE
Add getMemorySize to Instrument

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -86,6 +86,7 @@ public:
   std::vector<size_t> componentsInSubtree(const size_t componentIndex) const;
   const std::vector<size_t> &children(const size_t componentIndex) const;
   size_t size() const;
+  size_t getMemorySize() const;
   size_t numberOfDetectorsInSubtree(const size_t componentIndex) const;
   bool isDetector(const size_t componentIndex) const {
     return componentIndex < m_assemblySortedDetectorIndices->size();

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -54,6 +54,7 @@ public:
   bool isEquivalent(const DetectorInfo &other) const;
 
   size_t size() const;
+  size_t getMemorySize() const;
   bool isScanning() const;
 
   bool isMonitor(const size_t index) const;

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -741,4 +741,56 @@ size_t ComponentInfo::nonDetectorSize() const {
     return 0;
 }
 
+/** Return memory used by the component info, in bytes.
+ * @return bytes used.
+ */
+size_t ComponentInfo::getMemorySize() const {
+  size_t mem = sizeof(*this);
+
+  // Shared sorted-index and range vectors
+  const auto sharedVecMem = [](const auto &ptr) -> size_t {
+    return ptr ? sizeof(*ptr) + ptr->size() * sizeof(typename std::decay_t<decltype(*ptr)>::value_type) : 0;
+  };
+  mem += sharedVecMem(m_assemblySortedDetectorIndices);
+  mem += sharedVecMem(m_assemblySortedComponentIndices);
+  mem += sharedVecMem(m_detectorRanges);
+  mem += sharedVecMem(m_componentRanges);
+  mem += sharedVecMem(m_parentIndices);
+
+  // m_children: outer vector buffer + all inner child-index buffers
+  if (m_children) {
+    mem += sizeof(*m_children) + m_children->size() * sizeof(std::vector<size_t>);
+    mem += std::accumulate(m_children->cbegin(), m_children->cend(), size_t{0},
+                           [](size_t acc, const auto &v) { return acc + v.capacity() * sizeof(size_t); });
+  }
+
+  // cow_ptr'd per-component arrays (positions/rotations are scan-multiplied)
+  if (m_positions)
+    mem += sizeof(*m_positions) + m_positions->size() * sizeof(Eigen::Vector3d);
+  if (m_rotations)
+    mem += sizeof(*m_rotations) + m_rotations->size() * sizeof(Eigen::Quaterniond);
+  if (m_scaleFactors)
+    mem += sizeof(*m_scaleFactors) + m_scaleFactors->size() * sizeof(Eigen::Vector3d);
+  if (m_componentType)
+    mem += sizeof(*m_componentType) + m_componentType->size() * sizeof(ComponentType);
+
+  // m_names: string objects in the vector buffer + any heap-spilled content
+  if (m_names) {
+    mem += sizeof(*m_names) + m_names->size() * sizeof(std::string);
+    mem += std::accumulate(m_names->cbegin(), m_names->cend(), size_t{0},
+                           [](size_t acc, const auto &str) { return acc + str.capacity(); });
+  }
+
+  // m_scanIntervals: inline vector's heap buffer
+  mem += m_scanIntervals.capacity() * sizeof(std::pair<int64_t, int64_t>);
+
+  // Scanning index structures (null for non-scanning instruments)
+  if (m_indexMap)
+    mem += sizeof(*m_indexMap) + m_indexMap->size() * sizeof(std::vector<size_t>);
+  if (m_indices)
+    mem += sizeof(*m_indices) + m_indices->size() * sizeof(std::pair<size_t, size_t>);
+
+  return mem;
+}
+
 } // namespace Mantid::Beamline

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -758,11 +758,10 @@ size_t ComponentInfo::getMemorySize() const {
   mem += sharedVecMem(m_parentIndices);
 
   // m_children: outer vector buffer + all inner child-index buffers
-  if (m_children) {
-    mem += sizeof(*m_children) + m_children->size() * sizeof(std::vector<size_t>);
+  mem += sharedVecMem(m_children);
+  if (m_children)
     mem += std::accumulate(m_children->cbegin(), m_children->cend(), size_t{0},
                            [](size_t acc, const auto &v) { return acc + v.capacity() * sizeof(size_t); });
-  }
 
   // cow_ptr'd per-component arrays (positions/rotations are scan-multiplied)
   if (m_positions)

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -226,4 +226,23 @@ void DetectorInfo::checkSizes(const DetectorInfo &other) const {
   // TODO If we make masking time-independent we need to check masking here.
 }
 
+/** Return memory used by the detector info, in bytes.
+ * @return bytes used.
+ */
+size_t DetectorInfo::getMemorySize() const {
+  const size_t n = size();
+  // Each cow_ptr holds a separately heap-allocated vector. Add sizeof(vector) + buffer.
+  // vector<bool> is bit-packed: ceil(n/8) bytes of data.
+  size_t mem = sizeof(*this);
+  if (m_isMonitor)
+    mem += sizeof(*m_isMonitor) + (n + 7) / 8;
+  if (m_isMasked)
+    mem += sizeof(*m_isMasked) + (n + 7) / 8;
+  if (m_positions)
+    mem += sizeof(*m_positions) + m_positions->size() * sizeof(Eigen::Vector3d);
+  if (m_rotations)
+    mem += sizeof(*m_rotations) + m_rotations->size() * sizeof(Eigen::Quaterniond);
+  return mem;
+}
+
 } // namespace Mantid::Beamline

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -1209,14 +1209,38 @@ public:
     TS_ASSERT(!d.isEquivalent(f));
   }
 
+  void test_getMemorySize_empty() {
+    const ComponentInfo empty;
+    // Default constructor sets m_assemblySortedDetectorIndices (one shared_ptr → empty vector) and
+    // default-constructs the four cow_ptrs (m_positions, m_rotations, m_scaleFactors, m_componentType),
+    // each of which allocates an empty heap vector. m_scanIntervals is initialized to {{0,1}}, capacity=1.
+    const size_t expected =
+        sizeof(ComponentInfo) + sizeof(std::vector<size_t>) + // m_assemblySortedDetectorIndices
+        sizeof(std::vector<Eigen::Vector3d>) +                // m_positions
+        sizeof(std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>) + // m_rotations
+        sizeof(std::vector<Eigen::Vector3d>) +                                                  // m_scaleFactors
+        sizeof(std::vector<ComponentType>) +                                                    // m_componentType
+        sizeof(std::pair<int64_t, int64_t>);                                                    // m_scanIntervals[0]
+    TS_ASSERT_EQUALS(empty.getMemorySize(), expected);
+  }
+
   void test_getMemorySize_nonzero() {
     auto [compInfo, detInfo] = makeFlatTree(PosVec(1), RotVec(1));
-    TS_ASSERT_LESS_THAN(static_cast<size_t>(0), compInfo->getMemorySize());
+    TS_ASSERT_LESS_THAN(size_t{0}, compInfo->getMemorySize());
   }
 
   void test_getMemorySize_scales_with_size() {
-    auto [compSmall, detSmall] = makeFlatTree(PosVec(2), RotVec(2));
-    auto [compLarge, detLarge] = makeFlatTree(PosVec(100), RotVec(100));
-    TS_ASSERT_LESS_THAN(compSmall->getMemorySize(), compLarge->getMemorySize());
+    auto [comp1, det1] = makeFlatTree(PosVec(10), RotVec(10));
+    auto [comp2, det2] = makeFlatTree(PosVec(20), RotVec(20));
+    auto [comp3, det3] = makeFlatTree(PosVec(30), RotVec(30));
+    TS_ASSERT_LESS_THAN(comp1->getMemorySize(), comp2->getMemorySize());
+    TS_ASSERT_LESS_THAN(comp2->getMemorySize(), comp3->getMemorySize());
+
+    // check that the increase in memory size grows linear with the number of components
+    auto size1 = comp1->getMemorySize(); // 10
+    auto size2 = comp2->getMemorySize(); // 20
+    auto size3 = comp3->getMemorySize(); // 30
+    // 20 - 10 == 30 - 20
+    TS_ASSERT_EQUALS(size2 - size1, size3 - size2);
   }
 };

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -1208,4 +1208,15 @@ public:
     // has not gone through any merge operations.
     TS_ASSERT(!d.isEquivalent(f));
   }
+
+  void test_getMemorySize_nonzero() {
+    auto [compInfo, detInfo] = makeFlatTree(PosVec(1), RotVec(1));
+    TS_ASSERT_LESS_THAN(static_cast<size_t>(0), compInfo->getMemorySize());
+  }
+
+  void test_getMemorySize_scales_with_size() {
+    auto [compSmall, detSmall] = makeFlatTree(PosVec(2), RotVec(2));
+    auto [compLarge, detLarge] = makeFlatTree(PosVec(100), RotVec(100));
+    TS_ASSERT_LESS_THAN(compSmall->getMemorySize(), compLarge->getMemorySize());
+  }
 };

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -277,4 +277,20 @@ public:
     detInfo.setComponentInfo(&compInfo);
     TS_ASSERT_EQUALS(detInfo.scanIntervals(), (std::vector<std::pair<int64_t, int64_t>>{{0, 1}}));
   }
+
+  void test_getMemorySize_empty() {
+    const DetectorInfo empty{};
+    TS_ASSERT_EQUALS(empty.getMemorySize(), sizeof(DetectorInfo));
+  }
+
+  void test_getMemorySize_with_data() {
+    const DetectorInfo withData(PosVec(5), RotVec(5));
+    TS_ASSERT_LESS_THAN(sizeof(DetectorInfo), withData.getMemorySize());
+  }
+
+  void test_getMemorySize_scales_with_size() {
+    const DetectorInfo small(PosVec(1), RotVec(1));
+    const DetectorInfo large(PosVec(100), RotVec(100));
+    TS_ASSERT_LESS_THAN(small.getMemorySize(), large.getMemorySize());
+  }
 };

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -289,8 +289,17 @@ public:
   }
 
   void test_getMemorySize_scales_with_size() {
-    const DetectorInfo small(PosVec(1), RotVec(1));
-    const DetectorInfo large(PosVec(100), RotVec(100));
-    TS_ASSERT_LESS_THAN(small.getMemorySize(), large.getMemorySize());
+    const DetectorInfo a(PosVec(10), RotVec(10));
+    const DetectorInfo b(PosVec(20), RotVec(20));
+    const DetectorInfo c(PosVec(30), RotVec(30));
+    TS_ASSERT_LESS_THAN(a.getMemorySize(), b.getMemorySize());
+    TS_ASSERT_LESS_THAN(b.getMemorySize(), c.getMemorySize());
+
+    // check that the increase in memory size grows linear with the number of components
+    auto sizeA = a.getMemorySize(); // 10
+    auto sizeB = b.getMemorySize(); // 20
+    auto sizeC = c.getMemorySize(); // 30
+    // 20 - 10 == 30 - 20
+    TS_ASSERT_EQUALS(sizeB - sizeA, sizeC - sizeB);
   }
 };

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -111,9 +111,6 @@ public:
 
   std::size_t getNumberDetectors(bool skipMonitors = false) const;
 
-  /// Get the footprint in memory in bytes.
-  size_t getMemorySize() const;
-
   void getMinMaxDetectorIDs(detid_t &min, detid_t &max) const;
 
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const IComponent &comp) const;
@@ -219,6 +216,9 @@ public:
   void parseTreeAndCacheBeamline();
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
   makeBeamline(ParameterMap &pmap, const ParameterMap *source = nullptr) const;
+
+  /// Get the footprint in memory in bytes.
+  size_t getMemorySize() const;
 
   friend InstrumentVisitor;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -111,6 +111,9 @@ public:
 
   std::size_t getNumberDetectors(bool skipMonitors = false) const;
 
+  /// Get the footprint in memory in bytes.
+  size_t getMemorySize() const;
+
   void getMinMaxDetectorIDs(detid_t &min, detid_t &max) const;
 
   void getDetectorsInBank(std::vector<IDetector_const_sptr> &dets, const IComponent &comp) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -75,6 +75,8 @@ public:
                 std::shared_ptr<const std::unordered_map<Geometry::IComponent const *, size_t>> componentIdToIndexMap,
                 std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes);
   ~ComponentInfo();
+  /// Returns the memory footprint in bytes for the component info and cached state.
+  size_t getMemorySize() const;
   /// Copy assignment is not possible for ComponentInfo
   ComponentInfo &operator=(const ComponentInfo &) = delete;
   std::unique_ptr<ComponentInfo> cloneWithoutDetectorInfo() const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -75,8 +75,6 @@ public:
                 std::shared_ptr<const std::unordered_map<Geometry::IComponent const *, size_t>> componentIdToIndexMap,
                 std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> shapes);
   ~ComponentInfo();
-  /// Returns the memory footprint in bytes for the component info and cached state.
-  size_t getMemorySize() const;
   /// Copy assignment is not possible for ComponentInfo
   ComponentInfo &operator=(const ComponentInfo &) = delete;
   std::unique_ptr<ComponentInfo> cloneWithoutDetectorInfo() const;
@@ -84,6 +82,7 @@ public:
   std::vector<size_t> componentsInSubtree(size_t componentIndex) const;
   const std::vector<size_t> &children(size_t componentIndex) const;
   size_t size() const;
+  size_t getMemorySize() const;
   QuadrilateralComponent quadrilateralComponent(const size_t componentIndex) const;
   size_t indexOf(Geometry::IComponent const *id) const;
   size_t indexOfAny(const std::string &name) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -58,6 +58,9 @@ public:
 
   bool isEquivalent(const DetectorInfo &other) const;
 
+  /// Returns the memory footprint in bytes for the detector info and cached state.
+  size_t getMemorySize() const;
+
   size_t size() const;
   size_t scanSize() const;
   bool isScanning() const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -58,11 +58,9 @@ public:
 
   bool isEquivalent(const DetectorInfo &other) const;
 
-  /// Returns the memory footprint in bytes for the detector info and cached state.
-  size_t getMemorySize() const;
-
   size_t size() const;
   size_t scanSize() const;
+  size_t getMemorySize() const;
   bool isScanning() const;
 
   bool isMonitor(const size_t index) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -57,6 +57,8 @@ public:
   inline bool empty() const { return m_map.empty(); }
   /// Return the size of the map
   inline int size() const { return static_cast<int>(m_map.size()); }
+  /// Returns the memory footprint in bytes for the map and related cached state.
+  size_t getMemorySize() const;
   /// Return string to be used in the map
   static const std::string &pos();
   static const std::string &posx();

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -57,7 +57,7 @@ public:
   inline bool empty() const { return m_map.empty(); }
   /// Return the size of the map
   inline int size() const { return static_cast<int>(m_map.size()); }
-  /// Returns the memory footprint in bytes for the map and related cached state.
+  /// Get the footprint in memory in bytes.
   size_t getMemorySize() const;
   /// Return string to be used in the map
   static const std::string &pos();

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -7,11 +7,8 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
-#include "MantidGeometry/Instrument/CompAssembly.h"
-#include "MantidGeometry/Instrument/Component.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentInfoBankHelpers.h"
-#include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/GridDetectorPixel.h"
@@ -32,7 +29,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <numeric>
 #include <queue>
 #include <utility>
 
@@ -51,32 +47,26 @@ void raiseDuplicateDetectorError(const size_t detectorId) {
   throw Exception::InstrumentDefinitionError(sstream.str());
 }
 
-size_t componentMemorySize(const IComponent &component) {
-  if (dynamic_cast<const RectangularDetector *>(&component)) {
+/// Returns the heap size of a single component object, using the most-derived type.
+size_t componentObjectSize(const IComponent *comp) {
+  if (dynamic_cast<const RectangularDetector *>(comp))
     return sizeof(RectangularDetector);
-  }
-  if (dynamic_cast<const GridDetector *>(&component)) {
+  if (const auto *sd = dynamic_cast<const StructuredDetector *>(comp))
+    return sizeof(StructuredDetector) + sd->getXValues().capacity() * sizeof(double) +
+           sd->getYValues().capacity() * sizeof(double);
+  if (dynamic_cast<const GridDetectorPixel *>(comp))
+    return sizeof(GridDetectorPixel);
+  if (dynamic_cast<const GridDetector *>(comp))
     return sizeof(GridDetector);
-  }
-  if (dynamic_cast<const StructuredDetector *>(&component)) {
-    return sizeof(StructuredDetector);
-  }
-  if (dynamic_cast<const ObjCompAssembly *>(&component)) {
-    return sizeof(ObjCompAssembly);
-  }
-  if (dynamic_cast<const CompAssembly *>(&component)) {
-    return sizeof(CompAssembly);
-  }
-  if (dynamic_cast<const Detector *>(&component)) {
+  if (dynamic_cast<const Detector *>(comp))
     return sizeof(Detector);
-  }
-  if (dynamic_cast<const ObjComponent *>(&component)) {
+  if (dynamic_cast<const ObjCompAssembly *>(comp))
+    return sizeof(ObjCompAssembly);
+  if (dynamic_cast<const ObjComponent *>(comp))
     return sizeof(ObjComponent);
-  }
-  if (dynamic_cast<const Component *>(&component)) {
-    return sizeof(Component);
-  }
-  return sizeof(IComponent);
+  if (dynamic_cast<const CompAssembly *>(comp))
+    return sizeof(CompAssembly);
+  return sizeof(Component);
 }
 } // namespace
 
@@ -272,79 +262,6 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   } else {
     return numDetIDs;
   }
-}
-
-size_t Instrument::getMemorySize() const {
-  if (m_map && m_instr) {
-    // Parametrized instruments share base geometry but own parameter overrides.
-    return m_instr->getMemorySize() + (m_map_nonconst ? m_map_nonconst->getMemorySize() : 0);
-  }
-
-  size_t memorySize = sizeof(Instrument);
-  memorySize += m_detectorCache.capacity() * sizeof(DetectorCache::value_type);
-  memorySize += m_logfileCache.size() * sizeof(InstrumentParameterCache::value_type);
-  memorySize += m_logfileUnit.size() * sizeof(std::map<std::string, std::string>::value_type);
-
-  memorySize += std::accumulate(m_logfileCache.cbegin(), m_logfileCache.cend(), static_cast<size_t>(0),
-                                [](size_t sum, const auto &cacheItem) { return sum + cacheItem.first.first.size(); });
-
-  memorySize += std::accumulate(
-      m_logfileUnit.cbegin(), m_logfileUnit.cend(), static_cast<size_t>(0),
-      [](size_t sum, const auto &unitItem) { return sum + unitItem.first.size() + unitItem.second.size(); });
-
-  memorySize += m_defaultView.size() + m_defaultViewAxis.size() + m_filename.size() + m_xmlText.size();
-
-  // Account for DetectorInfo if allocated.
-  if (m_detectorInfo) {
-    memorySize += m_detectorInfo->getMemorySize();
-  }
-
-  // Account for ComponentInfo if allocated.
-  if (m_componentInfo) {
-    memorySize += m_componentInfo->getMemorySize();
-  }
-
-  // Account for ReferenceFrame.
-  if (m_referenceFrame) {
-    memorySize += sizeof(ReferenceFrame);
-  }
-
-  // Account for ParameterMap where present.
-  if (m_map_nonconst) {
-    memorySize += m_map_nonconst->getMemorySize();
-  }
-
-  // Account for physical instrument (indirect geometry only)
-  if (m_physicalInstrument && !m_isPhysicalInstrument) {
-    memorySize += m_physicalInstrument->getMemorySize();
-  }
-
-  std::queue<IComponent_const_sptr> queue;
-  for (int i = 0; i < nelements(); ++i) {
-    queue.emplace(getChild(i));
-  }
-
-  while (!queue.empty()) {
-    auto component = queue.front();
-    queue.pop();
-    if (!component) {
-      continue;
-    }
-
-    memorySize += componentMemorySize(*component);
-    memorySize += component->getName().size();
-
-    const auto assembly = std::dynamic_pointer_cast<const ICompAssembly>(component);
-    if (!assembly) {
-      continue;
-    }
-
-    for (int i = 0; i < assembly->nelements(); ++i) {
-      queue.emplace(assembly->getChild(i));
-    }
-  }
-
-  return memorySize;
 }
 
 /** Get the minimum and maximum (inclusive) detector IDs
@@ -1477,6 +1394,59 @@ Instrument::makeWrappers(ParameterMap &pmap, const ComponentInfo &componentInfo,
       std::shared_ptr<const Instrument>(this, NoDeleting()), std::shared_ptr<ParameterMap>(&pmap, NoDeleting()));
   detInfo->m_instrument = parInstrument;
   return {std::move(compInfo), std::move(detInfo)};
+}
+
+/** Return memory used by the instrument, in bytes.
+ * @return bytes used.
+ */
+size_t Instrument::getMemorySize() const {
+  // A parametrized instrument is a thin wrapper around a base instrument: it holds a shared_ptr to
+  // the base (m_instr) but owns none of the component tree, detector cache, or beamline objects.
+  // Delegate to the base and add only the ParameterMap overhead.
+  if (m_instr) {
+    const size_t paramMapMem = m_map_nonconst ? m_map_nonconst->getMemorySize() : 0;
+    return sizeof(*this) + m_instr->getMemorySize() + paramMapMem;
+  }
+
+  // Each std::map node carries ~4 pointers of red-black-tree overhead beyond the stored value_type.
+  const size_t mapNodeOverhead = 4 * sizeof(void *);
+
+  const size_t logfileCacheMem =
+      m_logfileCache.size() * (sizeof(InstrumentParameterCache::value_type) + mapNodeOverhead);
+  const size_t logfileUnitMem = m_logfileUnit.size() * (sizeof(decltype(m_logfileUnit)::value_type) + mapNodeOverhead);
+
+  const size_t detectorInfoMem = m_detectorInfo ? m_detectorInfo->getMemorySize() : 0;
+  const size_t componentInfoMem = m_componentInfo ? m_componentInfo->getMemorySize() : 0;
+
+  // BFS over the component tree. The Instrument root is already counted via sizeof(*this),
+  // so start the traversal from the root and add each child's type-accurate object size plus
+  // the IComponent* slot it occupies in its parent's m_children buffer.
+  size_t componentTreeMem = 0;
+  std::queue<const ICompAssembly *> bfsQueue;
+  bfsQueue.push(this);
+  while (!bfsQueue.empty()) {
+    const auto *assembly = bfsQueue.front();
+    bfsQueue.pop();
+    const int n = assembly->nelements();
+    componentTreeMem += static_cast<size_t>(n) * sizeof(IComponent *);
+    for (int i = 0; i < n; ++i) {
+      auto child = assembly->getChild(i);
+      const IComponent *raw = child.get();
+      componentTreeMem += componentObjectSize(raw);
+      if (const auto *sub = dynamic_cast<const ICompAssembly *>(raw))
+        bfsQueue.push(sub);
+    }
+  }
+
+  // m_referenceFrame: heap-allocated ReferenceFrame object
+  const size_t referenceFrameMem = m_referenceFrame ? sizeof(ReferenceFrame) : 0;
+
+  // Indirect-geometry instruments hold a second full instrument for the physical geometry.
+  const size_t physicalInstrumentMem = m_physicalInstrument ? m_physicalInstrument->getMemorySize() : 0;
+
+  return sizeof(*this) + componentTreeMem + m_detectorCache.capacity() * sizeof(DetectorCacheEntry) + logfileCacheMem +
+         logfileUnitMem + m_defaultView.capacity() + m_defaultViewAxis.capacity() + m_xmlText.capacity() +
+         m_filename.capacity() + detectorInfoMem + componentInfoMem + referenceFrameMem + physicalInstrumentMem;
 }
 
 namespace Conversion {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -7,15 +7,22 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidGeometry/Instrument/CompAssembly.h"
+#include "MantidGeometry/Instrument/Component.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentInfoBankHelpers.h"
+#include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/GridDetectorPixel.h"
 #include "MantidGeometry/Instrument/InstrumentVisitor.h"
+#include "MantidGeometry/Instrument/ObjCompAssembly.h"
+#include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidGeometry/Instrument/StructuredDetector.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Logger.h"
@@ -25,6 +32,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <numeric>
 #include <queue>
 #include <utility>
 
@@ -41,6 +49,34 @@ void raiseDuplicateDetectorError(const size_t detectorId) {
   std::stringstream sstream;
   sstream << "Instrument Definition corrupt. Detector with ID " << detectorId << " already exists.";
   throw Exception::InstrumentDefinitionError(sstream.str());
+}
+
+size_t componentMemorySize(const IComponent &component) {
+  if (dynamic_cast<const RectangularDetector *>(&component)) {
+    return sizeof(RectangularDetector);
+  }
+  if (dynamic_cast<const GridDetector *>(&component)) {
+    return sizeof(GridDetector);
+  }
+  if (dynamic_cast<const StructuredDetector *>(&component)) {
+    return sizeof(StructuredDetector);
+  }
+  if (dynamic_cast<const ObjCompAssembly *>(&component)) {
+    return sizeof(ObjCompAssembly);
+  }
+  if (dynamic_cast<const CompAssembly *>(&component)) {
+    return sizeof(CompAssembly);
+  }
+  if (dynamic_cast<const Detector *>(&component)) {
+    return sizeof(Detector);
+  }
+  if (dynamic_cast<const ObjComponent *>(&component)) {
+    return sizeof(ObjComponent);
+  }
+  if (dynamic_cast<const Component *>(&component)) {
+    return sizeof(Component);
+  }
+  return sizeof(IComponent);
 }
 } // namespace
 
@@ -236,6 +272,79 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   } else {
     return numDetIDs;
   }
+}
+
+size_t Instrument::getMemorySize() const {
+  if (m_map && m_instr) {
+    // Parametrized instruments share base geometry but own parameter overrides.
+    return m_instr->getMemorySize() + (m_map_nonconst ? m_map_nonconst->getMemorySize() : 0);
+  }
+
+  size_t memorySize = sizeof(Instrument);
+  memorySize += m_detectorCache.capacity() * sizeof(DetectorCache::value_type);
+  memorySize += m_logfileCache.size() * sizeof(InstrumentParameterCache::value_type);
+  memorySize += m_logfileUnit.size() * sizeof(std::map<std::string, std::string>::value_type);
+
+  memorySize += std::accumulate(m_logfileCache.cbegin(), m_logfileCache.cend(), static_cast<size_t>(0),
+                                [](size_t sum, const auto &cacheItem) { return sum + cacheItem.first.first.size(); });
+
+  memorySize += std::accumulate(
+      m_logfileUnit.cbegin(), m_logfileUnit.cend(), static_cast<size_t>(0),
+      [](size_t sum, const auto &unitItem) { return sum + unitItem.first.size() + unitItem.second.size(); });
+
+  memorySize += m_defaultView.size() + m_defaultViewAxis.size() + m_filename.size() + m_xmlText.size();
+
+  // Account for DetectorInfo if allocated.
+  if (m_detectorInfo) {
+    memorySize += m_detectorInfo->getMemorySize();
+  }
+
+  // Account for ComponentInfo if allocated.
+  if (m_componentInfo) {
+    memorySize += m_componentInfo->getMemorySize();
+  }
+
+  // Account for ReferenceFrame.
+  if (m_referenceFrame) {
+    memorySize += sizeof(ReferenceFrame);
+  }
+
+  // Account for ParameterMap where present.
+  if (m_map_nonconst) {
+    memorySize += m_map_nonconst->getMemorySize();
+  }
+
+  // Account for physical instrument (indirect geometry only)
+  if (m_physicalInstrument && !m_isPhysicalInstrument) {
+    memorySize += m_physicalInstrument->getMemorySize();
+  }
+
+  std::queue<IComponent_const_sptr> queue;
+  for (int i = 0; i < nelements(); ++i) {
+    queue.emplace(getChild(i));
+  }
+
+  while (!queue.empty()) {
+    auto component = queue.front();
+    queue.pop();
+    if (!component) {
+      continue;
+    }
+
+    memorySize += componentMemorySize(*component);
+    memorySize += component->getName().size();
+
+    const auto assembly = std::dynamic_pointer_cast<const ICompAssembly>(component);
+    if (!assembly) {
+      continue;
+    }
+
+    for (int i = 0; i < assembly->nelements(); ++i) {
+      queue.emplace(assembly->getChild(i));
+    }
+  }
+
+  return memorySize;
 }
 
 /** Get the minimum and maximum (inclusive) detector IDs

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -49,24 +49,27 @@ void raiseDuplicateDetectorError(const size_t detectorId) {
 
 /// Returns the heap size of a single component object, using the most-derived type.
 size_t componentObjectSize(const IComponent *comp) {
+  size_t result;
   if (dynamic_cast<const RectangularDetector *>(comp))
-    return sizeof(RectangularDetector);
-  if (const auto *sd = dynamic_cast<const StructuredDetector *>(comp))
-    return sizeof(StructuredDetector) + sd->getXValues().capacity() * sizeof(double) +
-           sd->getYValues().capacity() * sizeof(double);
-  if (dynamic_cast<const GridDetectorPixel *>(comp))
-    return sizeof(GridDetectorPixel);
-  if (dynamic_cast<const GridDetector *>(comp))
-    return sizeof(GridDetector);
-  if (dynamic_cast<const Detector *>(comp))
-    return sizeof(Detector);
-  if (dynamic_cast<const ObjCompAssembly *>(comp))
-    return sizeof(ObjCompAssembly);
-  if (dynamic_cast<const ObjComponent *>(comp))
-    return sizeof(ObjComponent);
-  if (dynamic_cast<const CompAssembly *>(comp))
-    return sizeof(CompAssembly);
-  return sizeof(Component);
+    result = sizeof(RectangularDetector);
+  else if (const auto *sd = dynamic_cast<const StructuredDetector *>(comp))
+    result = sizeof(StructuredDetector) + sd->getXValues().capacity() * sizeof(double) +
+             sd->getYValues().capacity() * sizeof(double);
+  else if (dynamic_cast<const GridDetectorPixel *>(comp))
+    result = sizeof(GridDetectorPixel);
+  else if (dynamic_cast<const GridDetector *>(comp))
+    result = sizeof(GridDetector);
+  else if (dynamic_cast<const Detector *>(comp))
+    result = sizeof(Detector);
+  else if (dynamic_cast<const ObjCompAssembly *>(comp))
+    result = sizeof(ObjCompAssembly);
+  else if (dynamic_cast<const ObjComponent *>(comp))
+    result = sizeof(ObjComponent);
+  else if (dynamic_cast<const CompAssembly *>(comp))
+    result = sizeof(CompAssembly);
+  else
+    result = sizeof(Component);
+  return result;
 }
 } // namespace
 

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/Exception.h"
 
 #include <Eigen/Geometry>
+#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <string>
@@ -89,6 +90,41 @@ ComponentInfo::ComponentInfo(const ComponentInfo &other)
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ComponentInfo::~ComponentInfo() = default;
+
+size_t ComponentInfo::getMemorySize() const {
+  size_t total = sizeof(ComponentInfo);
+
+  if (m_componentInfo) {
+    total += sizeof(Beamline::ComponentInfo);
+    const auto componentCount = size();
+    const auto scans = std::max(scanCount(), static_cast<size_t>(1));
+    const auto pointCount = componentCount * scans;
+
+    // Beamline::ComponentInfo stores positions, rotations, scale factors, and component type arrays.
+    total += pointCount * (sizeof(Eigen::Vector3d) + sizeof(Eigen::Quaterniond) + sizeof(Eigen::Vector3d));
+    total += pointCount * sizeof(Beamline::ComponentType);
+    total += scans * sizeof(std::pair<int64_t, int64_t>);
+  }
+
+  if (m_componentIds) {
+    total += m_componentIds->capacity() * sizeof(decltype(m_componentIds)::element_type::value_type);
+  }
+
+  if (m_compIDToIndex) {
+    total += m_compIDToIndex->size() * sizeof(decltype(m_compIDToIndex)::element_type::value_type);
+    total += m_compIDToIndex->bucket_count() * sizeof(void *);
+  }
+
+  if (m_shapes) {
+    total += m_shapes->capacity() * sizeof(decltype(m_shapes)::element_type::value_type);
+  }
+
+  for (size_t i = 0; i < size(); ++i) {
+    total += name(i).size();
+  }
+
+  return total;
+}
 
 std::vector<size_t> ComponentInfo::detectorsInSubtree(size_t componentIndex) const {
   return m_componentInfo->detectorsInSubtree(componentIndex);

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -481,14 +481,16 @@ size_t ComponentInfo::getMemorySize() const {
   const size_t n = size();
   // Beamline::ComponentInfo holds all the per-component arrays
   const size_t beamlineMem = m_componentInfo->getMemorySize();
-  // m_componentIds: shared_ptr<const vector<IComponent*>>
-  const size_t componentIdsMem = n * sizeof(Geometry::IComponent *);
+  // m_componentIds: shared_ptr<const vector<IComponent*>> — count the heap-allocated vector object + its buffer
+  const size_t componentIdsMem = sizeof(std::vector<Geometry::IComponent *>) + n * sizeof(Geometry::IComponent *);
   // m_compIDToIndex: shared_ptr<const unordered_map<IComponent const*, size_t>>
-  // Each node: key + value + ~2 pointers for chaining and bucket slot
-  const size_t compIDToIndexMem = n * (sizeof(Geometry::IComponent const *) + sizeof(size_t) + 2 * sizeof(void *));
+  // Count the heap-allocated map object + each node (key + value + ~2 pointers for bucket/chain overhead)
+  const size_t compIDToIndexMem = sizeof(std::unordered_map<Geometry::IComponent const *, size_t>) +
+                                  n * (sizeof(Geometry::IComponent const *) + sizeof(size_t) + 2 * sizeof(void *));
   // m_shapes: shared_ptr<vector<shared_ptr<const IObject>>>
-  // IObject shapes are shared; count only the vector buffer of shared_ptrs, not the shapes themselves
-  const size_t shapesMem = m_shapes ? m_shapes->capacity() * sizeof(std::shared_ptr<const Geometry::IObject>) : 0;
+  // IObject shapes are shared; count the vector object + buffer of shared_ptrs, not the shapes themselves
+  const size_t shapesMem =
+      m_shapes ? sizeof(*m_shapes) + m_shapes->capacity() * sizeof(std::shared_ptr<const Geometry::IObject>) : 0;
   return sizeof(*this) + beamlineMem + componentIdsMem + compIDToIndexMem + shapesMem;
 }
 

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -14,7 +14,6 @@
 #include "MantidKernel/Exception.h"
 
 #include <Eigen/Geometry>
-#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <string>
@@ -90,41 +89,6 @@ ComponentInfo::ComponentInfo(const ComponentInfo &other)
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ComponentInfo::~ComponentInfo() = default;
-
-size_t ComponentInfo::getMemorySize() const {
-  size_t total = sizeof(ComponentInfo);
-
-  if (m_componentInfo) {
-    total += sizeof(Beamline::ComponentInfo);
-    const auto componentCount = size();
-    const auto scans = std::max(scanCount(), static_cast<size_t>(1));
-    const auto pointCount = componentCount * scans;
-
-    // Beamline::ComponentInfo stores positions, rotations, scale factors, and component type arrays.
-    total += pointCount * (sizeof(Eigen::Vector3d) + sizeof(Eigen::Quaterniond) + sizeof(Eigen::Vector3d));
-    total += pointCount * sizeof(Beamline::ComponentType);
-    total += scans * sizeof(std::pair<int64_t, int64_t>);
-  }
-
-  if (m_componentIds) {
-    total += m_componentIds->capacity() * sizeof(decltype(m_componentIds)::element_type::value_type);
-  }
-
-  if (m_compIDToIndex) {
-    total += m_compIDToIndex->size() * sizeof(decltype(m_compIDToIndex)::element_type::value_type);
-    total += m_compIDToIndex->bucket_count() * sizeof(void *);
-  }
-
-  if (m_shapes) {
-    total += m_shapes->capacity() * sizeof(decltype(m_shapes)::element_type::value_type);
-  }
-
-  for (size_t i = 0; i < size(); ++i) {
-    total += name(i).size();
-  }
-
-  return total;
-}
 
 std::vector<size_t> ComponentInfo::detectorsInSubtree(size_t componentIndex) const {
   return m_componentInfo->detectorsInSubtree(componentIndex);
@@ -508,6 +472,24 @@ size_t ComponentInfo::findBankParent(size_t index, const std::string &bankPart) 
     }
   }
   return invalidIndex;
+}
+
+/** Return memory used by the component info, in bytes.
+ * @return bytes used.
+ */
+size_t ComponentInfo::getMemorySize() const {
+  const size_t n = size();
+  // Beamline::ComponentInfo holds all the per-component arrays
+  const size_t beamlineMem = m_componentInfo->getMemorySize();
+  // m_componentIds: shared_ptr<const vector<IComponent*>>
+  const size_t componentIdsMem = n * sizeof(Geometry::IComponent *);
+  // m_compIDToIndex: shared_ptr<const unordered_map<IComponent const*, size_t>>
+  // Each node: key + value + ~2 pointers for chaining and bucket slot
+  const size_t compIDToIndexMem = n * (sizeof(Geometry::IComponent const *) + sizeof(size_t) + 2 * sizeof(void *));
+  // m_shapes: shared_ptr<vector<shared_ptr<const IObject>>>
+  // IObject shapes are shared; count only the vector buffer of shared_ptrs, not the shapes themselves
+  const size_t shapesMem = m_shapes ? m_shapes->capacity() * sizeof(std::shared_ptr<const Geometry::IObject>) : 0;
+  return sizeof(*this) + beamlineMem + componentIdsMem + compIDToIndexMem + shapesMem;
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -17,6 +17,8 @@
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/Unit.h"
 
+#include <algorithm>
+
 namespace Mantid::Geometry {
 /** Construct DetectorInfo based on an Instrument.
  *
@@ -64,6 +66,36 @@ DetectorInfo &DetectorInfo::operator=(const DetectorInfo &rhs) {
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 DetectorInfo::~DetectorInfo() = default;
+
+size_t DetectorInfo::getMemorySize() const {
+  size_t total = sizeof(DetectorInfo);
+
+  if (m_detectorInfo) {
+    total += sizeof(Beamline::DetectorInfo);
+    const auto detectorCount = size();
+    const auto scans = std::max(scanCount(), static_cast<size_t>(1));
+    const auto pointCount = detectorCount * scans;
+
+    // Beamline::DetectorInfo stores monitor/mask flags and position/rotation vectors.
+    total += detectorCount * (2 * sizeof(bool));
+    total += pointCount * (sizeof(Eigen::Vector3d) + sizeof(Eigen::Quaterniond));
+    total += scans * sizeof(std::pair<int64_t, int64_t>);
+  }
+
+  if (m_detectorIDs) {
+    total += m_detectorIDs->capacity() * sizeof(detid_t);
+  }
+
+  if (m_detIDToIndex) {
+    total += m_detIDToIndex->size() * sizeof(std::unordered_map<detid_t, size_t>::value_type);
+    total += m_detIDToIndex->bucket_count() * sizeof(void *);
+  }
+
+  total += m_lastDetector.capacity() * sizeof(decltype(m_lastDetector)::value_type);
+  total += m_lastIndex.capacity() * sizeof(decltype(m_lastIndex)::value_type);
+
+  return total;
+}
 
 /** Returns true if the content of this is equivalent to the content of other.
  *

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -471,6 +471,8 @@ size_t DetectorInfo::getMemorySize() const {
   // m_lastDetector and m_lastIndex: one slot per OpenMP thread
   const size_t cacheMem = m_lastDetector.capacity() * sizeof(std::shared_ptr<const Geometry::IDetector>) +
                           m_lastIndex.capacity() * sizeof(size_t);
+  // m_instrument is a shared_ptr to an Instrument owned by the workspace; its memory is counted in
+  // Instrument::getMemorySize() and excluded here to avoid double-counting.
   return sizeof(*this) + beamlineMem + detectorIDsMem + detIDToIndexMem + cacheMem;
 }
 

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -17,8 +17,6 @@
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/Unit.h"
 
-#include <algorithm>
-
 namespace Mantid::Geometry {
 /** Construct DetectorInfo based on an Instrument.
  *
@@ -66,36 +64,6 @@ DetectorInfo &DetectorInfo::operator=(const DetectorInfo &rhs) {
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 DetectorInfo::~DetectorInfo() = default;
-
-size_t DetectorInfo::getMemorySize() const {
-  size_t total = sizeof(DetectorInfo);
-
-  if (m_detectorInfo) {
-    total += sizeof(Beamline::DetectorInfo);
-    const auto detectorCount = size();
-    const auto scans = std::max(scanCount(), static_cast<size_t>(1));
-    const auto pointCount = detectorCount * scans;
-
-    // Beamline::DetectorInfo stores monitor/mask flags and position/rotation vectors.
-    total += detectorCount * (2 * sizeof(bool));
-    total += pointCount * (sizeof(Eigen::Vector3d) + sizeof(Eigen::Quaterniond));
-    total += scans * sizeof(std::pair<int64_t, int64_t>);
-  }
-
-  if (m_detectorIDs) {
-    total += m_detectorIDs->capacity() * sizeof(detid_t);
-  }
-
-  if (m_detIDToIndex) {
-    total += m_detIDToIndex->size() * sizeof(std::unordered_map<detid_t, size_t>::value_type);
-    total += m_detIDToIndex->bucket_count() * sizeof(void *);
-  }
-
-  total += m_lastDetector.capacity() * sizeof(decltype(m_lastDetector)::value_type);
-  total += m_lastIndex.capacity() * sizeof(decltype(m_lastIndex)::value_type);
-
-  return total;
-}
 
 /** Returns true if the content of this is equivalent to the content of other.
  *
@@ -486,5 +454,23 @@ DetectorInfoIt DetectorInfo::begin() { return DetectorInfoIt(*this, 0, size()); 
 
 // End method for iterator
 DetectorInfoIt DetectorInfo::end() { return DetectorInfoIt(*this, size(), size()); }
+
+/** Return memory used by the detector info, in bytes.
+ * @return bytes used.
+ */
+size_t DetectorInfo::getMemorySize() const {
+  const size_t n = size();
+  // Beamline::DetectorInfo holds the core position/rotation/flag arrays
+  const size_t beamlineMem = m_detectorInfo->getMemorySize();
+  // m_detectorIDs: shared_ptr<const vector<detid_t>>
+  const size_t detectorIDsMem = n * sizeof(detid_t);
+  // m_detIDToIndex: shared_ptr<const unordered_map<detid_t, size_t>>
+  // Each node: key + value + ~2 pointers for chaining and bucket slot
+  const size_t detIDToIndexMem = n * (sizeof(detid_t) + sizeof(size_t) + 2 * sizeof(void *));
+  // m_lastDetector and m_lastIndex: one slot per OpenMP thread
+  const size_t cacheMem = m_lastDetector.capacity() * sizeof(std::shared_ptr<const Geometry::IDetector>) +
+                          m_lastIndex.capacity() * sizeof(size_t);
+  return sizeof(*this) + beamlineMem + detectorIDsMem + detIDToIndexMem + cacheMem;
+}
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -462,11 +462,12 @@ size_t DetectorInfo::getMemorySize() const {
   const size_t n = size();
   // Beamline::DetectorInfo holds the core position/rotation/flag arrays
   const size_t beamlineMem = m_detectorInfo->getMemorySize();
-  // m_detectorIDs: shared_ptr<const vector<detid_t>>
-  const size_t detectorIDsMem = n * sizeof(detid_t);
+  // m_detectorIDs: shared_ptr<const vector<detid_t>> — count the heap-allocated vector object + its buffer
+  const size_t detectorIDsMem = sizeof(std::vector<detid_t>) + n * sizeof(detid_t);
   // m_detIDToIndex: shared_ptr<const unordered_map<detid_t, size_t>>
-  // Each node: key + value + ~2 pointers for chaining and bucket slot
-  const size_t detIDToIndexMem = n * (sizeof(detid_t) + sizeof(size_t) + 2 * sizeof(void *));
+  // Count the heap-allocated map object + each node (key + value + ~2 pointers for bucket/chain overhead)
+  const size_t detIDToIndexMem =
+      sizeof(std::unordered_map<detid_t, size_t>) + n * (sizeof(detid_t) + sizeof(size_t) + 2 * sizeof(void *));
   // m_lastDetector and m_lastIndex: one slot per OpenMP thread
   const size_t cacheMem = m_lastDetector.capacity() * sizeof(std::shared_ptr<const Geometry::IDetector>) +
                           m_lastIndex.capacity() * sizeof(size_t);

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -17,6 +17,7 @@
 #include "MantidNexus/NexusFile.h"
 #include <boost/algorithm/string.hpp>
 #include <cstring>
+#include <numeric>
 
 #ifdef _WIN32
 #define strcasecmp _stricmp
@@ -1144,13 +1145,19 @@ size_t ParameterMap::getMemorySize() const {
       parameterObjectsMem += param->m_description.capacity();
     }
   }
-  // m_cacheLocMap and m_cacheRotMap: position/rotation caches; count the heap objects
+  // m_parameterFileNames: vector of strings; sizeof(*this) covers the vector object, count the heap buffer
+  const size_t fileNamesMem = m_parameterFileNames.size() * sizeof(std::string) +
+                              std::accumulate(m_parameterFileNames.cbegin(), m_parameterFileNames.cend(), size_t{0},
+                                              [](size_t acc, const auto &s) { return acc + s.capacity(); });
+  // m_cacheLocMap and m_cacheRotMap: count the heap Cache objects; the internal std::map entries are not
+  // counted because Kernel::Cache::size() is non-const and cannot be called here.
   const size_t cacheLocMem = m_cacheLocMap ? sizeof(*m_cacheLocMap) : 0;
   const size_t cacheRotMem = m_cacheRotMap ? sizeof(*m_cacheRotMap) : 0;
   // m_detectorInfo and m_componentInfo: owned by ParameterMap for parametrized instruments
   const size_t detectorInfoMem = m_detectorInfo ? m_detectorInfo->getMemorySize() : 0;
   const size_t componentInfoMem = m_componentInfo ? m_componentInfo->getMemorySize() : 0;
-  return sizeof(*this) + mapMem + parameterObjectsMem + cacheLocMem + cacheRotMem + detectorInfoMem + componentInfoMem;
+  return sizeof(*this) + mapMem + parameterObjectsMem + fileNamesMem + cacheLocMem + cacheRotMem + detectorInfoMem +
+         componentInfoMem;
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -17,7 +17,6 @@
 #include "MantidNexus/NexusFile.h"
 #include <boost/algorithm/string.hpp>
 #include <cstring>
-#include <numeric>
 
 #ifdef _WIN32
 #define strcasecmp _stricmp
@@ -77,45 +76,6 @@ ParameterMap::ParameterMap(const ParameterMap &other)
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ParameterMap::~ParameterMap() = default;
-
-size_t ParameterMap::getMemorySize() const {
-  size_t total = sizeof(ParameterMap);
-
-  total += m_parameterFileNames.capacity() * sizeof(std::string);
-  total += std::accumulate(m_parameterFileNames.cbegin(), m_parameterFileNames.cend(), static_cast<size_t>(0),
-                           [](size_t sum, const auto &filename) { return sum + filename.size(); });
-
-  total += m_map.size() * sizeof(ParameterMap::pmap::value_type);
-  for (const auto &entry : m_map) {
-    const auto &parameter = entry.second;
-    if (!parameter) {
-      continue;
-    }
-
-    total += sizeof(Parameter);
-    total += parameter->type().size();
-    total += parameter->name().size();
-    total += parameter->asString().size();
-    total += parameter->getDescription().size();
-  }
-
-  if (m_cacheLocMap) {
-    total += sizeof(*m_cacheLocMap);
-  }
-  if (m_cacheRotMap) {
-    total += sizeof(*m_cacheRotMap);
-  }
-
-  if (m_detectorInfo) {
-    total += m_detectorInfo->getMemorySize();
-  }
-
-  if (m_componentInfo) {
-    total += m_componentInfo->getMemorySize();
-  }
-
-  return total;
-}
 
 /**
  * Return string to be inserted into the parameter map
@@ -1161,6 +1121,36 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
                            "base instrument, not a parametrized instrument");
   m_instrument = instrument;
   std::tie(m_componentInfo, m_detectorInfo) = m_instrument->makeBeamline(*this);
+}
+
+/** Return memory used by the parameter map, in bytes.
+ * @return bytes used.
+ */
+size_t ParameterMap::getMemorySize() const {
+  // m_map: tbb::concurrent_unordered_multimap<ComponentID, shared_ptr<Parameter>>
+  // Each node: key + value + ~2 pointers for chaining and bucket slot
+  const size_t n = static_cast<size_t>(m_map.size());
+  const size_t mapMem = n * (sizeof(ComponentID) + sizeof(std::shared_ptr<Parameter>) + 2 * sizeof(void *));
+  // Count the heap-allocated Parameter objects the shared_ptrs point to.
+  // ParameterMap is a friend of Parameter so private string members are accessible.
+  size_t parameterObjectsMem = 0;
+  for (const auto &entry : m_map) {
+    const auto &param = entry.second;
+    if (param) {
+      parameterObjectsMem += sizeof(Parameter);
+      parameterObjectsMem += param->m_name.capacity();
+      parameterObjectsMem += param->m_type.capacity();
+      parameterObjectsMem += param->m_str_value.capacity();
+      parameterObjectsMem += param->m_description.capacity();
+    }
+  }
+  // m_cacheLocMap and m_cacheRotMap: position/rotation caches; count the heap objects
+  const size_t cacheLocMem = m_cacheLocMap ? sizeof(*m_cacheLocMap) : 0;
+  const size_t cacheRotMem = m_cacheRotMap ? sizeof(*m_cacheRotMap) : 0;
+  // m_detectorInfo and m_componentInfo: owned by ParameterMap for parametrized instruments
+  const size_t detectorInfoMem = m_detectorInfo ? m_detectorInfo->getMemorySize() : 0;
+  const size_t componentInfoMem = m_componentInfo ? m_componentInfo->getMemorySize() : 0;
+  return sizeof(*this) + mapMem + parameterObjectsMem + cacheLocMem + cacheRotMem + detectorInfoMem + componentInfoMem;
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -17,6 +17,7 @@
 #include "MantidNexus/NexusFile.h"
 #include <boost/algorithm/string.hpp>
 #include <cstring>
+#include <numeric>
 
 #ifdef _WIN32
 #define strcasecmp _stricmp
@@ -76,6 +77,45 @@ ParameterMap::ParameterMap(const ParameterMap &other)
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ParameterMap::~ParameterMap() = default;
+
+size_t ParameterMap::getMemorySize() const {
+  size_t total = sizeof(ParameterMap);
+
+  total += m_parameterFileNames.capacity() * sizeof(std::string);
+  total += std::accumulate(m_parameterFileNames.cbegin(), m_parameterFileNames.cend(), static_cast<size_t>(0),
+                           [](size_t sum, const auto &filename) { return sum + filename.size(); });
+
+  total += m_map.size() * sizeof(ParameterMap::pmap::value_type);
+  for (const auto &entry : m_map) {
+    const auto &parameter = entry.second;
+    if (!parameter) {
+      continue;
+    }
+
+    total += sizeof(Parameter);
+    total += parameter->type().size();
+    total += parameter->name().size();
+    total += parameter->asString().size();
+    total += parameter->getDescription().size();
+  }
+
+  if (m_cacheLocMap) {
+    total += sizeof(*m_cacheLocMap);
+  }
+  if (m_cacheRotMap) {
+    total += sizeof(*m_cacheRotMap);
+  }
+
+  if (m_detectorInfo) {
+    total += m_detectorInfo->getMemorySize();
+  }
+
+  if (m_componentInfo) {
+    total += m_componentInfo->getMemorySize();
+  }
+
+  return total;
+}
 
 /**
  * Return string to be inserted into the parameter map

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1130,8 +1130,8 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
 size_t ParameterMap::getMemorySize() const {
   // m_map: tbb::concurrent_unordered_multimap<ComponentID, shared_ptr<Parameter>>
   // Each node: key + value + ~2 pointers for chaining and bucket slot
-  const size_t n = static_cast<size_t>(m_map.size());
-  const size_t mapMem = n * (sizeof(ComponentID) + sizeof(std::shared_ptr<Parameter>) + 2 * sizeof(void *));
+  const size_t n = m_map.size();
+  const size_t mapMem = n * (sizeof(pmap::value_type) + 2 * sizeof(void *));
   // Count the heap-allocated Parameter objects the shared_ptrs point to.
   // ParameterMap is a friend of Parameter so private string members are accessible.
   size_t parameterObjectsMem = 0;
@@ -1156,6 +1156,8 @@ size_t ParameterMap::getMemorySize() const {
   // m_detectorInfo and m_componentInfo: owned by ParameterMap for parametrized instruments
   const size_t detectorInfoMem = m_detectorInfo ? m_detectorInfo->getMemorySize() : 0;
   const size_t componentInfoMem = m_componentInfo ? m_componentInfo->getMemorySize() : 0;
+  // m_instrument is a non-owning raw pointer to the base Instrument; its memory is counted in
+  // Instrument::getMemorySize() and excluded here to avoid double-counting.
   return sizeof(*this) + mapMem + parameterObjectsMem + fileNamesMem + cacheLocMem + cacheRotMem + detectorInfoMem +
          componentInfoMem;
 }

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -636,4 +636,19 @@ public:
     TS_ASSERT(!componentInfo->hasDetectors(componentInfo->source()));
     TS_ASSERT(componentInfo->hasDetectors(componentInfo->indexOfAny("bank1")));
   }
+
+  void test_getMemorySize_nonzero() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    TS_ASSERT_LESS_THAN(static_cast<size_t>(0), componentInfo->getMemorySize());
+  }
+
+  void test_getMemorySize_scales_with_instrument_size() {
+    auto smallInstr = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    auto largeInstr = ComponentCreationHelper::createTestInstrumentCylindrical(10);
+    auto smallWrappers = InstrumentVisitor::makeWrappers(*smallInstr);
+    auto largeWrappers = InstrumentVisitor::makeWrappers(*largeInstr);
+    TS_ASSERT_LESS_THAN(std::get<0>(smallWrappers)->getMemorySize(), std::get<0>(largeWrappers)->getMemorySize());
+  }
 };

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -641,14 +641,32 @@ public:
     auto instrument = ComponentCreationHelper::createTestInstrumentCylindrical(1);
     auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
     const auto &componentInfo = std::get<0>(wrappers);
-    TS_ASSERT_LESS_THAN(static_cast<size_t>(0), componentInfo->getMemorySize());
+    const auto &detectorInfo = std::get<1>(wrappers);
+    TS_ASSERT_LESS_THAN(size_t{0}, componentInfo->getMemorySize());
+    TS_ASSERT_LESS_THAN(size_t{0}, detectorInfo->getMemorySize());
   }
 
   void test_getMemorySize_scales_with_instrument_size() {
-    auto smallInstr = ComponentCreationHelper::createTestInstrumentCylindrical(1);
-    auto largeInstr = ComponentCreationHelper::createTestInstrumentCylindrical(10);
-    auto smallWrappers = InstrumentVisitor::makeWrappers(*smallInstr);
-    auto largeWrappers = InstrumentVisitor::makeWrappers(*largeInstr);
-    TS_ASSERT_LESS_THAN(std::get<0>(smallWrappers)->getMemorySize(), std::get<0>(largeWrappers)->getMemorySize());
+    auto instr1 = ComponentCreationHelper::createTestInstrumentCylindrical(2);
+    auto instr2 = ComponentCreationHelper::createTestInstrumentCylindrical(4);
+    auto instr3 = ComponentCreationHelper::createTestInstrumentCylindrical(6);
+    auto wrappers1 = InstrumentVisitor::makeWrappers(*instr1);
+    auto wrappers2 = InstrumentVisitor::makeWrappers(*instr2);
+    auto wrappers3 = InstrumentVisitor::makeWrappers(*instr3);
+    TS_ASSERT_LESS_THAN(std::get<0>(wrappers1)->getMemorySize(), std::get<0>(wrappers2)->getMemorySize());
+    TS_ASSERT_LESS_THAN(std::get<0>(wrappers2)->getMemorySize(), std::get<0>(wrappers3)->getMemorySize());
+    TS_ASSERT_LESS_THAN(std::get<1>(wrappers1)->getMemorySize(), std::get<1>(wrappers2)->getMemorySize());
+    TS_ASSERT_LESS_THAN(std::get<1>(wrappers2)->getMemorySize(), std::get<1>(wrappers3)->getMemorySize());
+
+    // check that increase in memory size is linear with number of components/detectors
+    auto memSize1 = std::get<0>(wrappers1)->getMemorySize();
+    auto memSize2 = std::get<0>(wrappers2)->getMemorySize();
+    auto memSize3 = std::get<0>(wrappers3)->getMemorySize();
+    // 4 - 2 == 6 - 4
+    TS_ASSERT_EQUALS(memSize2 - memSize1, memSize3 - memSize2);
+    auto detMemSize1 = std::get<1>(wrappers1)->getMemorySize();
+    auto detMemSize2 = std::get<1>(wrappers2)->getMemorySize();
+    auto detMemSize3 = std::get<1>(wrappers3)->getMemorySize();
+    TS_ASSERT_EQUALS(detMemSize2 - detMemSize1, detMemSize3 - detMemSize2);
   }
 };

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -169,19 +169,6 @@ public:
 
   void testBeamDirection() { TS_ASSERT_EQUALS(instrument.getBeamDirection(), V3D(0, 0, 1)); }
 
-  void testGetMemorySizeReturnsPositiveValue() { TS_ASSERT_LESS_THAN(0u, instrument.getMemorySize()); }
-
-  void testGetMemorySizeIncreasesWhenComponentAdded() {
-    Instrument i;
-    const auto baseSize = i.getMemorySize();
-
-    auto *detector = new Detector("det", 1234, nullptr);
-    i.add(detector);
-    i.markAsDetector(detector);
-
-    TS_ASSERT_LESS_THAN(baseSize, i.getMemorySize());
-  }
-
   void testNumberDetectors() { // THIS MUST BE RUN BEFORE testDetector!!!!!!!
     // that test adds a detector to the instrument
     std::size_t ndets(3);
@@ -719,6 +706,21 @@ public:
     instrument->add(det);
     instrument->markAsDetectorIncomplete(det);
     TSM_ASSERT_THROWS("Duplicate ID, should throw", instrument->markAsDetectorFinalize(), std::runtime_error &);
+  }
+
+  void test_getMemorySize_nonzero() { TS_ASSERT_LESS_THAN(static_cast<size_t>(0), instrument.getMemorySize()); }
+
+  void test_getMemorySize_scales_with_instrument_size() {
+    auto small = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    auto large = ComponentCreationHelper::createTestInstrumentCylindrical(10);
+    TS_ASSERT_LESS_THAN(small->getMemorySize(), large->getMemorySize());
+  }
+
+  void test_getMemorySize_parametrized_larger_than_base() {
+    auto base = ComponentCreationHelper::createTestInstrumentCylindrical(5);
+    auto pmap = std::make_shared<ParameterMap>();
+    auto parametrized = std::make_shared<Instrument>(base, pmap);
+    TS_ASSERT_LESS_THAN(base->getMemorySize(), parametrized->getMemorySize());
   }
 
 private:

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -169,6 +169,19 @@ public:
 
   void testBeamDirection() { TS_ASSERT_EQUALS(instrument.getBeamDirection(), V3D(0, 0, 1)); }
 
+  void testGetMemorySizeReturnsPositiveValue() { TS_ASSERT_LESS_THAN(0u, instrument.getMemorySize()); }
+
+  void testGetMemorySizeIncreasesWhenComponentAdded() {
+    Instrument i;
+    const auto baseSize = i.getMemorySize();
+
+    auto *detector = new Detector("det", 1234, nullptr);
+    i.add(detector);
+    i.markAsDetector(detector);
+
+    TS_ASSERT_LESS_THAN(baseSize, i.getMemorySize());
+  }
+
   void testNumberDetectors() { // THIS MUST BE RUN BEFORE testDetector!!!!!!!
     // that test adds a detector to the instrument
     std::size_t ndets(3);

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -708,12 +708,15 @@ public:
     TSM_ASSERT_THROWS("Duplicate ID, should throw", instrument->markAsDetectorFinalize(), std::runtime_error &);
   }
 
-  void test_getMemorySize_nonzero() { TS_ASSERT_LESS_THAN(static_cast<size_t>(0), instrument.getMemorySize()); }
+  void test_getMemorySize_nonzero() { TS_ASSERT_LESS_THAN(size_t{0}, instrument.getMemorySize()); }
 
   void test_getMemorySize_scales_with_instrument_size() {
     auto small = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    auto medium = ComponentCreationHelper::createTestInstrumentCylindrical(5);
     auto large = ComponentCreationHelper::createTestInstrumentCylindrical(10);
-    TS_ASSERT_LESS_THAN(small->getMemorySize(), large->getMemorySize());
+    // check the the memory size increases with the number of detectors
+    TS_ASSERT_LESS_THAN(small->getMemorySize(), medium->getMemorySize());
+    TS_ASSERT_LESS_THAN(medium->getMemorySize(), large->getMemorySize());
   }
 
   void test_getMemorySize_parametrized_larger_than_base() {

--- a/Framework/Geometry/test/ParameterMapTest.h
+++ b/Framework/Geometry/test/ParameterMapTest.h
@@ -691,7 +691,22 @@ private:
     auto origParameter = pmap.get(m_testInstrument.get(), name);
     TS_ASSERT_EQUALS(origTypedValue, origParameter->value<ValueType>());
   }
-  // private instrument
+
+public:
+  void test_getMemorySize_nonzero() {
+    const ParameterMap empty;
+    TS_ASSERT_LESS_THAN(static_cast<size_t>(0), empty.getMemorySize());
+  }
+
+  void test_getMemorySize_grows_with_parameters() {
+    ParameterMap pmap;
+    const size_t before = pmap.getMemorySize();
+    auto comp = m_testInstrument->getChild(0);
+    pmap.addDouble(comp.get(), "testparam", 3.14);
+    TS_ASSERT_LESS_THAN(before, pmap.getMemorySize());
+  }
+
+private:
   Instrument_sptr m_testInstrument;
 };
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
@@ -50,6 +50,9 @@ void export_ComponentInfo() {
 
       .def("size", &ComponentInfo::size, arg("self"), "Returns the number of components.")
 
+      .def("getMemorySize", &ComponentInfo::getMemorySize, arg("self"),
+           "Return the footprint of the component info in memory in bytes")
+
       .def("isDetector", &ComponentInfo::isDetector, (arg("self"), arg("index")),
            "Checks if the component is a detector.")
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/ComponentInfo.cpp
@@ -50,9 +50,6 @@ void export_ComponentInfo() {
 
       .def("size", &ComponentInfo::size, arg("self"), "Returns the number of components.")
 
-      .def("getMemorySize", &ComponentInfo::getMemorySize, arg("self"),
-           "Return the footprint of the component info in memory in bytes")
-
       .def("isDetector", &ComponentInfo::isDetector, (arg("self"), arg("index")),
            "Checks if the component is a detector.")
 
@@ -147,5 +144,7 @@ void export_ComponentInfo() {
       .def("uniqueName", &ComponentInfo::uniqueName, (arg("self"), arg("name")),
            "Returns True if the name is a unique single occurance. Zero occurances yields False.")
 
-      .def("root", &ComponentInfo::root, arg("self"), "Returns the index of the root component");
+      .def("root", &ComponentInfo::root, arg("self"), "Returns the index of the root component")
+      .def("getMemorySize", &ComponentInfo::getMemorySize, arg("self"),
+           "Return the memory footprint of the component info in bytes.");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
@@ -75,6 +75,9 @@ void export_DetectorInfo() {
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")
 
+      .def("getMemorySize", &DetectorInfo::getMemorySize, arg("self"),
+           "Return the footprint of the detector info in memory in bytes")
+
       .def("indexOf", &DetectorInfo::indexOf, (arg("self"), arg("detId")),
            "Returns the index of the detector with the given id.")
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
@@ -75,9 +75,6 @@ void export_DetectorInfo() {
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")
 
-      .def("getMemorySize", &DetectorInfo::getMemorySize, arg("self"),
-           "Return the footprint of the detector info in memory in bytes")
-
       .def("indexOf", &DetectorInfo::indexOf, (arg("self"), arg("detId")),
            "Returns the index of the detector with the given id.")
 
@@ -115,5 +112,7 @@ void export_DetectorInfo() {
       .def("l2", l2, (arg("self"), arg("index")), "Returns the l2 scattering distance")
       .def("l1", &DetectorInfo::l1, arg("self"), "Returns the l1 scattering distance")
       .def("hasMaskedDetectors", &DetectorInfo::hasMaskedDetectors, arg("self"),
-           "Returns if there are masked detectors");
+           "Returns if there are masked detectors")
+      .def("getMemorySize", &DetectorInfo::getMemorySize, arg("self"),
+           "Return the memory footprint of the detector info in bytes.");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -62,6 +62,9 @@ void export_Instrument() {
       .def("getNumberDetectors", &Instrument::getNumberDetectors,
            Instrument_getNumberDetectors((arg("self"), arg("skipMonitors") = false)))
 
+      .def("getMemorySize", &Instrument::getMemorySize, arg("self"),
+           "Return the footprint of the instrument in memory in bytes")
+
       .def("getReferenceFrame", (std::shared_ptr<const ReferenceFrame> (Instrument::*)())&Instrument::getReferenceFrame,
            arg("self"), return_value_policy<RemoveConstSharedPtr>(),
            "Returns the :class:`~mantid.geometry.ReferenceFrame` attached that "

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -62,9 +62,6 @@ void export_Instrument() {
       .def("getNumberDetectors", &Instrument::getNumberDetectors,
            Instrument_getNumberDetectors((arg("self"), arg("skipMonitors") = false)))
 
-      .def("getMemorySize", &Instrument::getMemorySize, arg("self"),
-           "Return the footprint of the instrument in memory in bytes")
-
       .def("getReferenceFrame", (std::shared_ptr<const ReferenceFrame> (Instrument::*)())&Instrument::getReferenceFrame,
            arg("self"), return_value_policy<RemoveConstSharedPtr>(),
            "Returns the :class:`~mantid.geometry.ReferenceFrame` attached that "
@@ -89,5 +86,7 @@ void export_Instrument() {
            "Return reference to the base instrument")
 
       .def("findRectDetectors", &Instrument::findRectDetectors, arg("self"), "Return a list of rectangular detectors.")
-      .def("findGridDetectors", &Instrument::findGridDetectors, arg("self"), "Return a list of grid detectors.");
+      .def("findGridDetectors", &Instrument::findGridDetectors, arg("self"), "Return a list of grid detectors.")
+      .def("getMemorySize", &Instrument::getMemorySize, arg("self"),
+           "Return the memory footprint of the instrument in bytes.");
 }

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
@@ -39,12 +39,6 @@ class ComponentInfoTest(unittest.TestCase):
         info = self._ws.componentInfo()
         self.assertEqual(info.size(), 6)
 
-    def test_getMemorySize(self):
-        info = self._ws.componentInfo()
-        memory_size = info.getMemorySize()
-        self.assertIsInstance(memory_size, int)
-        self.assertGreater(memory_size, 0)
-
     def test_isDetector(self):
         """Check which components are detectors"""
         info = self._ws.componentInfo()
@@ -197,6 +191,18 @@ class ComponentInfoTest(unittest.TestCase):
         """Check a shape is returned"""
         info = self._ws.componentInfo()
         self.assertEqual(type(info.shape(0)), CSGObject)
+
+    def test_getMemorySize(self):
+        info = self._ws.componentInfo()
+        mem = info.getMemorySize()
+        self.assertIsInstance(mem, int)
+        self.assertGreater(mem, 0)
+
+    def test_getMemorySize_scales_with_instrument(self):
+        """A larger instrument should report more memory than a smaller one."""
+        small_ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(2, 1, False)
+        large_ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(100, 1, False)
+        self.assertGreater(large_ws.componentInfo().getMemorySize(), small_ws.componentInfo().getMemorySize())
 
     def test_createWorkspaceAndComponentInfo(self):
         """Try to create a workspace and see if ComponentInfo object is accessable"""

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentInfoTest.py
@@ -39,6 +39,12 @@ class ComponentInfoTest(unittest.TestCase):
         info = self._ws.componentInfo()
         self.assertEqual(info.size(), 6)
 
+    def test_getMemorySize(self):
+        info = self._ws.componentInfo()
+        memory_size = info.getMemorySize()
+        self.assertIsInstance(memory_size, int)
+        self.assertGreater(memory_size, 0)
+
     def test_isDetector(self):
         """Check which components are detectors"""
         info = self._ws.componentInfo()

--- a/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
@@ -39,6 +39,12 @@ class DetectorInfoTest(unittest.TestCase):
         info = self._ws.detectorInfo()
         self.assertEqual(info.size(), 2)
 
+    def test_getMemorySize(self):
+        info = self._ws.detectorInfo()
+        memory_size = info.getMemorySize()
+        self.assertIsInstance(memory_size, int)
+        self.assertGreater(memory_size, 0)
+
     def test_indexOf(self):
         """Check if detector is a monitor"""
         info = self._ws.detectorInfo()

--- a/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
@@ -39,12 +39,6 @@ class DetectorInfoTest(unittest.TestCase):
         info = self._ws.detectorInfo()
         self.assertEqual(info.size(), 2)
 
-    def test_getMemorySize(self):
-        info = self._ws.detectorInfo()
-        memory_size = info.getMemorySize()
-        self.assertIsInstance(memory_size, int)
-        self.assertGreater(memory_size, 0)
-
     def test_indexOf(self):
         """Check if detector is a monitor"""
         info = self._ws.detectorInfo()
@@ -141,6 +135,12 @@ class DetectorInfoTest(unittest.TestCase):
         l1_calc = sample_pos.distance(source_pos)
         det_info = self._ws.detectorInfo()
         self.assertEqual(det_info.l1(), l1_calc)
+
+    def test_getMemorySize(self):
+        info = self._ws.detectorInfo()
+        mem = info.getMemorySize()
+        self.assertIsInstance(mem, int)
+        self.assertGreater(mem, 0)
 
     """
     ---------------

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -40,11 +40,6 @@ class InstrumentTest(unittest.TestCase):
         num_detectors = self.__testws.getInstrument().getNumberDetectors()
         self.assertEqual(num_detectors, 1)
 
-    def test_getMemorySize(self):
-        memory_size = self.__testws.getInstrument().getMemorySize()
-        self.assertIsInstance(memory_size, int)
-        self.assertGreater(memory_size, 0)
-
     def test_getReferenceFrame(self):
         frame = self.__testws.getInstrument().getReferenceFrame()
         self.assertTrue(isinstance(frame, ReferenceFrame))
@@ -75,6 +70,11 @@ class InstrumentTest(unittest.TestCase):
         inst = self.__testws.getInstrument()
         base_inst = inst.getBaseInstrument()
         self.assertEqual("testInst", base_inst.getName())
+
+    def test_getMemorySize(self):
+        mem = self.__testws.getInstrument().getMemorySize()
+        self.assertIsInstance(mem, int)
+        self.assertGreater(mem, 0)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -40,6 +40,11 @@ class InstrumentTest(unittest.TestCase):
         num_detectors = self.__testws.getInstrument().getNumberDetectors()
         self.assertEqual(num_detectors, 1)
 
+    def test_getMemorySize(self):
+        memory_size = self.__testws.getInstrument().getMemorySize()
+        self.assertIsInstance(memory_size, int)
+        self.assertGreater(memory_size, 0)
+
     def test_getReferenceFrame(self):
         frame = self.__testws.getInstrument().getReferenceFrame()
         self.assertTrue(isinstance(frame, ReferenceFrame))

--- a/docs/source/release/v6.16.0/Framework/Data_Objects/New_features/41403.rst
+++ b/docs/source/release/v6.16.0/Framework/Data_Objects/New_features/41403.rst
@@ -1,0 +1,1 @@
+- Added ``getMemorySize()`` to :py:class:`~mantid.geometry.Instrument`, :py:class:`~mantid.geometry.DetectorInfo`, and :py:class:`~mantid.geometry.ComponentInfo` to report the memory footprint of instrument geometry objects in bytes.


### PR DESCRIPTION
### Description of work

Follow on from #41394, this adds the method `Instrument::getMemorySize`, in the same style as `MatrixWorkspace::getMemorySize`. This is to help debugging memory issues in Mantid.

I've tried to include everything in the class that seems appropriate. It may not include absolutely everything but it should contain all the significant stuff.

I haven't change `MatrixWorkspace::getMemorySize` to include the `Instrument` size but maybe I should?

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes [14477: [mantid] Add method to report memory of Mantid::Geometry::Instrument](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14477)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Looking at the instrument on the workspace
```python
for inst in ("ARCS", "CORELLI", "GEM", "PEARL", "PG3", "SNAP", "TOPAZ", "WAND", "WISH"):
    ws = LoadEmptyInstrument(InstrumentName=inst, OutputWorkspace=inst)
    print(f"{inst} Workspace size: {ws.getMemorySize()/1024/1024:.1f}Mb Instrument size: {ws.getInstrument().getMemorySize()/1024/1024:.1f}Mb")
```

gives me

```
ARCS Workspace size: 2.7Mb Instrument size: 84.7Mb
CORELLI Workspace size: 8.5Mb Instrument size: 269.8Mb
GEM Workspace size: 0.1Mb Instrument size: 4.8Mb
PEARL Workspace size: 0.0Mb Instrument size: 0.8Mb
PG3 Workspace size: 1.0Mb Instrument size: 36.7Mb
SNAP Workspace size: 27.0Mb Instrument size: 902.4Mb
TOPAZ Workspace size: 37.5Mb Instrument size: 1228.4Mb
WAND Workspace size: 45.0Mb Instrument size: 1398.9Mb
WISH Workspace size: 17.8Mb Instrument size: 560.5Mb
```

Looking at the instrument in the `InstrumentDataService`, these will be smaller than the instrument on the workspace since the `ComponentInfo`, `DetectorInfo`, etc hasn't been added to these.
```python
from mantid.api import InstrumentDataService
for inst_cache in InstrumentDataService.getObjectNames():
    print(f"{inst_cache} memory size: {InstrumentDataService.retrieve(inst_cache).getMemorySize()/1024/1024:.1f}Mb")
```
gives me
```
ARCSe69b371f7e854244be1a519319113ae690299ba8 memory size: 55.7Mb
CORELLI7175541ad3d909e03776dddac307d7fa7300ea03 memory size: 178.6Mb
GEM79cd9448aebda416934e7eaafbc9acde3319724b memory size: 3.2Mb
PEARL3011f39a5a2d259bdda6e751162199abf2deb9d2 memory size: 0.6Mb
POWGENb626fea5ae9c824959ba29bf2d25f5e8617373d9 memory size: 24.7Mb
SNAP61c541976010969559bc3b9e8c428353ce6f213f memory size: 614.1Mb
TOPAZa88209c8d30e8aeaf08451819a17e8983ea18166 memory size: 828.1Mb
WAND8be65433e4f44e27db591d304c79d017b27867f7 memory size: 919.4Mb
WISH36359b3519839e7e2bc5b2064da2dd0486110eff memory size: 370.7Mb
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
