### PR TITLE
Improve readability of labels in pawley utils

### DIFF
--- a/docs/source/release/v6.16.0/Diffraction/Powder/New_features/40095.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Powder/New_features/40095.rst
@@ -1,0 +1,1 @@
+- Add `get_profile_param`/`set_profile_param` and `get_profile_free_param`/`set_profile_free_param` functions in ``PawleyPattern`` classes to support setting a profile parameters and fixing free parameters for a given phase through a profile parameter label.

--- a/docs/source/release/v6.16.0/Diffraction/Powder/New_features/40095.rst
+++ b/docs/source/release/v6.16.0/Diffraction/Powder/New_features/40095.rst
@@ -1,1 +1,2 @@
 - Add `get_profile_param`/`set_profile_param` and `get_profile_free_param`/`set_profile_free_param` functions in ``PawleyPattern`` classes to support setting a profile parameters and fixing free parameters for a given phase through a profile parameter label.
+- Add `get_phase_param`/`set_phase_param` and `get_phase_free_param`/`set_phase_free_param` functions in ``PawleyPattern`` classes to support setting phase parameters and fixing free parameters for a given phase through a phase parameter label.

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -150,16 +150,19 @@ class Phase:
         match ptgr.getLatticeSystem():
             case PointGroup.LatticeSystem.Cubic:
                 # a=b=c, alpha=beta=gamma=90
-                self.ipars = [self.labels["a"]]
+                self.ipars = [slice(self.labels["a"], self.labels["c"] + 1)]  # a:c
             case PointGroup.LatticeSystem.Tetragonal | PointGroup.LatticeSystem.Hexagonal:
                 # a=b!=c (tetrag has alpha=beta=gamma=90, hexag has alpha=beta=90, gamma= 120)
-                self.ipars = [self.labels["a"], self.labels["c"]]
+                self.ipars = [slice(self.labels["a"], self.labels["b"] + 1), self.labels["c"]]  # a:b, c
             case PointGroup.LatticeSystem.Orthorhombic:
                 # alpha=beta=gamma=90
                 self.ipars = [self.labels["a"], self.labels["b"], self.labels["c"]]
             case PointGroup.LatticeSystem.Rhombohedral:
                 # a=b=c, alpha=beta=gamma
-                self.ipars = [self.labels["a"], self.labels["alpha"]]
+                self.ipars = [
+                    slice(self.labels["a"], self.labels["c"] + 1),
+                    slice(self.labels["alpha"], self.labels["gamma"] + 1),
+                ]  # a:c, alpha:gamma
             case PointGroup.LatticeSystem.Monoclinic:
                 # a!=b!=c, alpha=gamma=90
                 self.ipars = [self.labels["a"], self.labels["b"], self.labels["c"], self.labels["beta"]]
@@ -182,10 +185,12 @@ class Phase:
         return np.array([getattr(self.unit_cell, method)() for method in self.labels.keys()])
 
     def get_params(self) -> np.ndarray[float]:
-        return np.array([self.alatt[ipar] for _, ipar in self.labels.items() if ipar in self.ipars])
+        return np.array([self.alatt[ipar][0] if isinstance(ipar, slice) else self.alatt[ipar] for ipar in self.ipars])
 
     def get_param_names(self) -> np.ndarray[str]:
-        return np.array([key for key, value in self.labels.items() if value in self.ipars])
+        return np.array(
+            [key for key, value in self.labels.items() if value in [idx.start if isinstance(idx, slice) else idx for idx in self.ipars]]
+        )
 
     def set_params(self, pars: np.ndarray[float]):
         for ipar, par in enumerate(pars):

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -30,6 +30,9 @@ class InstrumentParams:
     def get_peak_centre(self, dpk: float) -> np.ndarray[Any, np.dtype[Any]]:
         return self.p[self.labels["scale"]] * dpk + self.p[self.labels["shift"]]
 
+    def set_param(self, param_name: str, param_value: float):
+        self.p[self.labels[param_name]] = param_value
+
 
 class PeakProfile(ABC):
     def __init__(self):
@@ -139,28 +142,29 @@ class Phase:
         # add hkls - check if compatible wth spacegorup
         if hkls is not None:
             self.set_hkls(hkls)
-        # set free parameters beased on lattice system
-        self.param_names = np.array(["a", "b", "c", "alpha", "beta", "gamma"])
+        # set free parameters based on lattice system
+        self.labels = {val: idx for idx, val in enumerate(["a", "b", "c", "alpha", "beta", "gamma"])}
         self.alatt = self._get_alatt()
         ptgr = PointGroupFactory.createPointGroupFromSpaceGroup(self.spgr)
+
         match ptgr.getLatticeSystem():
             case PointGroup.LatticeSystem.Cubic:
                 # a=b=c, alpha=beta=gamma=90
-                self.ipars = [slice(0, 3)]  # a
+                self.ipars = [self.labels["a"]]
             case PointGroup.LatticeSystem.Tetragonal | PointGroup.LatticeSystem.Hexagonal:
                 # a=b!=c (tetrag has alpha=beta=gamma=90, hexag has alpha=beta=90, gamma= 120)
-                self.ipars = [slice(0, 2), 2]  # a, c
+                self.ipars = [self.labels["a"], self.labels["c"]]
             case PointGroup.LatticeSystem.Orthorhombic:
                 # alpha=beta=gamma=90
-                self.ipars = range(3)  # a, b, c
+                self.ipars = [self.labels["a"], self.labels["b"], self.labels["c"]]
             case PointGroup.LatticeSystem.Rhombohedral:
                 # a=b=c, alpha=beta=gamma
-                self.ipars = [slice(0, 3), slice(3, 6)]  # a, alpha
+                self.ipars = [self.labels["a"], self.labels["alpha"]]
             case PointGroup.LatticeSystem.Monoclinic:
                 # a!=b!=c, alpha=gamma=90
-                self.ipars = [0, 1, 2, 4]  # a, b, c, beta
+                self.ipars = [self.labels["a"], self.labels["b"], self.labels["c"], self.labels["beta"]]
             case _:  # Triclinic
-                self.ipars = range(len(self.alatt))  # a, b, c, alpha, beta, gamma
+                self.ipars = range(len(self.labels.keys()))  # a, b, c, alpha, beta, gamma
 
     @classmethod
     def from_cif(cls, cif_file: str):
@@ -175,13 +179,13 @@ class Phase:
         return Phase(xtal)
 
     def _get_alatt(self) -> np.ndarray[float]:
-        return np.array([getattr(self.unit_cell, method)() for method in self.param_names])
+        return np.array([getattr(self.unit_cell, method)() for method in self.labels.keys()])
 
     def get_params(self) -> np.ndarray[float]:
-        return np.array([self.alatt[ipar][0] if isinstance(ipar, slice) else self.alatt[ipar] for ipar in self.ipars])
+        return np.array([self.alatt[ipar] for _, ipar in self.labels.items() if ipar in self.ipars])
 
     def get_param_names(self) -> np.ndarray[str]:
-        return np.array([self.param_names[ipar][0] if isinstance(ipar, slice) else self.param_names[ipar] for ipar in self.ipars])
+        return np.array([key for key, value in self.labels.items() if value in self.ipars])
 
     def set_params(self, pars: np.ndarray[float]):
         for ipar, par in enumerate(pars):
@@ -225,6 +229,9 @@ class MtdFuncMixin:
     PawleyPattern2DNoConstraints (although the getters may also be helpful for debugging PawleyPattern2D fits
     """
 
+    def __init__(self):
+        self.comp_func: CompositeFunctionWrapper = None
+
     def get_peak_centres(self) -> np.ndarray[float]:
         cen_par_name = self.comp_func[0].function.getCentreParameterName()
         return self.get_peak_params(cen_par_name)
@@ -245,7 +252,7 @@ class MtdFuncMixin:
         # relevant only for subsequent unconstrained fits - not used in Pawley fits
         bg_func_names = FunctionFactory.Instance().getBackgroundFunctionNames()
         if isinstance(param_names, str):
-            param_names = [param_names]  #  force ot be list with single element
+            param_names = [param_names]  # force ot be list with single element
         for func in self.comp_func:
             if func.name not in bg_func_names:
                 for param_name in param_names:
@@ -256,7 +263,7 @@ class MtdFuncMixin:
 
 
 class PawleyPatternBase(MtdFuncMixin, ABC):
-    def __init__(self, ws: Workspace2D, phases: Phase, profile: PeakProfile, bg_func: Optional[FunctionWrapper] = None):
+    def __init__(self, ws: Workspace2D, phases: Phase | Sequence[Phase], profile: PeakProfile, bg_func: Optional[FunctionWrapper] = None):
         self.ws = ws
         self.phases = phases
         self.alatt_params = [phase.get_params() for phase in self.phases]
@@ -343,10 +350,32 @@ class PawleyPatternBase(MtdFuncMixin, ABC):
         if len(self.bg_params) > 0:
             self.bg_params = params[iend:]
 
+    def _validate_profile_params(self, param_name: str, phase: int):
+        if phase > ((plen := len(self.phases)) - 1):
+            raise ValueError(f"Phase with index: {phase} does not exists. Number of phases is {plen}")
+        elif param_name not in self.profile.labels.keys():
+            raise ValueError(f"Invalid profile parameter name: {param_name}, for profile {self.profile.func_name}")
+
     def set_free_params(self, free_params: np.ndarray[float]):
         params = self.get_params()
         params[self.get_isfree()] = free_params
         self.set_params(params)
+
+    def set_profile_free_param(self, param_value: bool, param_name: str, phase: int):
+        self._validate_profile_params(param_name, phase)
+        self.profile_isfree[phase][self.profile.labels[param_name]] = param_value
+
+    def get_profile_free_param(self, param_name: str, phase: int) -> bool:
+        self._validate_profile_params(param_name, phase)
+        return self.profile_isfree[phase][self.profile.labels[param_name]]
+
+    def set_profile_param(self, param_value: float, param_name: str, phase: int):
+        self._validate_profile_params(param_name, phase)
+        self.profile_params[phase][self.profile.labels[param_name]] = param_value
+
+    def get_profile_param(self, param_name: str, phase: int) -> float:
+        self._validate_profile_params(param_name, phase)
+        return self.profile_params[phase][self.profile.labels[param_name]]
 
     def fit(self, **kwargs) -> OptimizeResult:
         default_kwargs = {"xtol": 1e-5, "diff_step": 1e-3, "x_scale": "jac", "verbose": 2}

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -350,32 +350,54 @@ class PawleyPatternBase(MtdFuncMixin, ABC):
         if len(self.bg_params) > 0:
             self.bg_params = params[iend:]
 
-    def _validate_profile_params(self, param_name: str, phase: int):
-        if phase > ((plen := len(self.phases)) - 1):
-            raise ValueError(f"Phase with index: {phase} does not exists. Number of phases is {plen}")
+    def _validate_profile_params(self, param_name: str, iphase: int):
+        if iphase > ((plen := len(self.phases)) - 1):
+            raise ValueError(f"Phase with index: {iphase} does not exists. Number of phases is {plen}")
         elif param_name not in self.profile.labels.keys():
             raise ValueError(f"Invalid profile parameter name: {param_name}, for profile {self.profile.func_name}")
+
+    def _validate_phase_params(self, param_name: str, iphase: int):
+        if iphase > ((plen := len(self.phases)) - 1):
+            raise ValueError(f"Phase with index: {iphase} does not exists. Number of phases is {plen}")
+        elif param_name not in self.phases[iphase].get_param_names():
+            raise ValueError(f"Parameter {param_name} is not a parameter of Phase")
 
     def set_free_params(self, free_params: np.ndarray[float]):
         params = self.get_params()
         params[self.get_isfree()] = free_params
         self.set_params(params)
 
-    def set_profile_free_param(self, param_value: bool, param_name: str, phase: int):
-        self._validate_profile_params(param_name, phase)
-        self.profile_isfree[phase][self.profile.labels[param_name]] = param_value
+    def set_profile_free_param(self, is_free: bool, param_name: str, iphase: int):
+        self._validate_profile_params(param_name, iphase)
+        self.profile_isfree[iphase][self.profile.labels[param_name]] = is_free
 
-    def get_profile_free_param(self, param_name: str, phase: int) -> bool:
-        self._validate_profile_params(param_name, phase)
-        return self.profile_isfree[phase][self.profile.labels[param_name]]
+    def get_profile_free_param(self, param_name: str, iphase: int) -> bool:
+        self._validate_profile_params(param_name, iphase)
+        return self.profile_isfree[iphase][self.profile.labels[param_name]]
 
-    def set_profile_param(self, param_value: float, param_name: str, phase: int):
-        self._validate_profile_params(param_name, phase)
-        self.profile_params[phase][self.profile.labels[param_name]] = param_value
+    def set_profile_param(self, param_value: float, param_name: str, iphase: int):
+        self._validate_profile_params(param_name, iphase)
+        self.profile_params[iphase][self.profile.labels[param_name]] = param_value
 
-    def get_profile_param(self, param_name: str, phase: int) -> float:
-        self._validate_profile_params(param_name, phase)
-        return self.profile_params[phase][self.profile.labels[param_name]]
+    def get_profile_param(self, param_name: str, iphase: int) -> float:
+        self._validate_profile_params(param_name, iphase)
+        return self.profile_params[iphase][self.profile.labels[param_name]]
+
+    def set_phase_param(self, param_value: float, param_name: str, iphase: int):
+        self._validate_phase_params(param_name, iphase)
+        self.alatt_params[iphase][self.phases[iphase].labels[param_name]] = param_value
+
+    def get_phase_param(self, param_name: str, iphase: int) -> float:
+        self._validate_phase_params(param_name, iphase)
+        return self.alatt_params[iphase][self.phases[iphase].labels[param_name]]
+
+    def set_phase_free_param(self, is_free: float, param_name: str, iphase: int):
+        self._validate_phase_params(param_name, iphase)
+        self.alatt_isfree[iphase][self.phases[iphase].labels[param_name]] = is_free
+
+    def get_phase_free_param(self, param_name: str, iphase: int) -> float:
+        self._validate_phase_params(param_name, iphase)
+        return self.alatt_isfree[iphase][self.phases[iphase].labels[param_name]]
 
     def fit(self, **kwargs) -> OptimizeResult:
         default_kwargs = {"xtol": 1e-5, "diff_step": 1e-3, "x_scale": "jac", "verbose": 2}

--- a/scripts/Engineering/pawley_utils.py
+++ b/scripts/Engineering/pawley_utils.py
@@ -11,11 +11,10 @@ from mantid.fitfunctions import FunctionWrapper, CompositeFunctionWrapper
 from mantid.api import FunctionFactory
 from mantid.geometry import CrystalStructure, ReflectionGenerator, PointGroupFactory, PointGroup
 from mantid.kernel import V3D, logger, UnitConversion, DeltaEModeType
-from typing import Optional, Tuple, TYPE_CHECKING, Sequence
+from typing import Optional, TYPE_CHECKING, Sequence, Any
 from scipy.optimize import least_squares
 from plugins.algorithms.poldi_utils import simulate_2d_data, get_dspac_array_from_ws
 from abc import ABC, abstractmethod
-
 
 if TYPE_CHECKING:
     from mantid.dataobjects import Workspace2D
@@ -24,18 +23,18 @@ if TYPE_CHECKING:
 
 class InstrumentParams:
     def __init__(self):
+        self.labels: dict[str, int] = {"scale": 0, "shift": 1}
         self.p: np.ndarray = np.array([1.0, 0.0])
-        self.labels = ("scale", "shift")
         self.default_isfree: np.ndarray = np.zeros_like(self.p, dtype=bool)
 
-    def get_peak_centre(self, dpk: float) -> float:
-        return self.p[0] * dpk + self.p[1]
+    def get_peak_centre(self, dpk: float) -> np.ndarray[Any, np.dtype[Any]]:
+        return self.p[self.labels["scale"]] * dpk + self.p[self.labels["shift"]]
 
 
 class PeakProfile(ABC):
     def __init__(self):
         self.func_name: str
-        self.labels: Tuple[str]
+        self.labels: dict[str, int]
         self.p: np.ndarray
         self.default_isfree: np.ndarray
 
@@ -47,7 +46,7 @@ class PeakProfile(ABC):
 class PVProfile(PeakProfile):
     def __init__(self):
         self.func_name = "PseudoVoigt"
-        self.labels = ("sig0", "sig1", "sig2", "gam0", "gam1", "gam2", "gsize", "dst2", "zeta", "fsz")
+        self.labels = {val: idx for idx, val in enumerate(["sig0", "sig1", "sig2", "gam0", "gam1", "gam2", "gsize", "dst2", "zeta", "fsz"])}
         self.p: np.ndarray = np.array([5.0e-4, 1.0e-3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
         self.default_isfree: np.ndarray = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
 
@@ -62,12 +61,16 @@ class PVProfile(PeakProfile):
             8
             * np.log(2)
             * (
-                (self.p[0] ** 2)
-                + ((self.p[1] ** 2) + self.p[-3] * ((1 - self.p[-2]) ** 2)) * dpk**2
-                + ((self.p[2] ** 2) + self.p[-4]) * dpk**4
+                (self.p[self.labels["sig0"]] ** 2)
+                + ((self.p[self.labels["sig1"]] ** 2) + self.p[self.labels["dst2"]] * ((1 - self.p[self.labels["fsz"]]) ** 2)) * dpk**2
+                + ((self.p[self.labels["sig2"]] ** 2) + self.p[self.labels["gsize"]]) * dpk**4
             )
         )  # Panel 6 in [2] Hg**2 / (8ln2)
-        fwhm_l = self.p[3] + (self.p[4] + self.p[-2] * np.sqrt(8 * np.log(2) * self.p[-3])) * dpk + (self.p[5] + self.p[-1]) * dpk**2
+        fwhm_l = (
+            self.p[self.labels["gam0"]]
+            + (self.p[self.labels["gam1"]] + self.p[self.labels["zeta"]] * np.sqrt(8 * np.log(2) * self.p[self.labels["dst2"]])) * dpk
+            + (self.p[self.labels["gam2"]] + self.p[self.labels["fsz"]]) * dpk**2
+        )
         fwhm_pv = (
             fwhm_g**5
             + 2.69269 * (fwhm_g**4) * (fwhm_l)
@@ -85,7 +88,7 @@ class PVProfile(PeakProfile):
 class GaussianProfile(PeakProfile):
     def __init__(self):
         self.func_name = "Gaussian"
-        self.labels = ("sig0", "sig1", "sig2")
+        self.labels = {val: idx for idx, val in enumerate(["sig0", "sig1", "sig2"])}
         self.p: np.ndarray = np.array([5.0e-4, 1.0e-3, 0.0])
         self.default_isfree: np.ndarray = np.array([1, 1, 0], dtype=bool)
 
@@ -95,13 +98,19 @@ class GaussianProfile(PeakProfile):
         Note dst2 and gsize perfectly corralated withsig1 and sig2 respectively
         [1] Using FullProf to analyze Time of Flight Neutron Powder Diffraction data (https://www.ill.eu/sites/fullprof/downloads/Docs/TOF_FullProf.pdf)
         """
-        return {"Sigma": np.sqrt((self.p[0] ** 2) + (self.p[1] ** 2) * dpk**2 + (self.p[2] ** 2) * dpk**4)}  # Panel 6 in [1] with zeta=0
+        return {
+            "Sigma": np.sqrt(
+                (self.p[self.labels["sig0"]] ** 2)
+                + (self.p[self.labels["sig1"]] ** 2) * dpk**2
+                + (self.p[self.labels["sig2"]] ** 2) * dpk**4
+            )
+        }  # Panel 6 in [1] with zeta=0
 
 
 class BackToBackGauss(PeakProfile):
     def __init__(self):
         self.func_name = "BackToBackExponential"
-        self.labels = ("sig0", "sig1", "sig2", "alpha_0", "alpha_1", "beta_0", "beta_1")
+        self.labels = {val: idx for idx, val in enumerate(["sig0", "sig1", "sig2", "alpha_0", "alpha_1", "beta_0", "beta_1"])}
         self.p: np.ndarray = np.array([0, 9.06, 6.52, 0, 0.0968, 0.0216, 0.0123])  # for ENGIN-X North Bank
         self.default_isfree: np.ndarray = np.zeros_like(self.p, dtype=bool)
 
@@ -109,13 +118,15 @@ class BackToBackGauss(PeakProfile):
         return {"S": self._calc_sigma(dpk), "A": self._calc_alpha(dpk), "B": self._calc_beta(dpk)}
 
     def _calc_sigma(self, dpk: float) -> float:
-        return np.sqrt((self.p[0] ** 2) + (self.p[1] * dpk) ** 2 + (self.p[2] ** 2) * dpk**4)
+        return np.sqrt(
+            (self.p[self.labels["sig0"]] ** 2) + (self.p[self.labels["sig1"]] * dpk) ** 2 + (self.p[self.labels["sig2"]] ** 2) * dpk**4
+        )
 
     def _calc_alpha(self, dpk: float) -> float:
-        return self.p[3] + self.p[4] / dpk
+        return self.p[self.labels["alpha_0"]] + self.p[self.labels["alpha_1"]] / dpk
 
     def _calc_beta(self, dpk: float) -> float:
-        return self.p[5] + self.p[6] / (dpk**4)
+        return self.p[self.labels["beta_0"]] + self.p[self.labels["beta_1"]] / (dpk**4)
 
 
 class Phase:

--- a/scripts/test/Engineering/test_pawley_utils.py
+++ b/scripts/test/Engineering/test_pawley_utils.py
@@ -140,6 +140,28 @@ class PawleyPattern1DTest(unittest.TestCase):
         pawley.set_free_params(ones(4))
         assert_array_equal(pawley.get_params().astype(int), array([1, 1, 1, 1, 0, 1, 0]))
 
+    def test_set_get_profile_by_name(self):
+        pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
+        pawley.set_profile_param(2.2, "sig0", 0)
+        self.assertEqual(pawley.get_profile_param("sig0", 0), 2.2)
+        assert_array_equal(pawley.get_params().astype(int), array([5, 1, 2, 0, 0, 1, 0]))
+
+    def test_set_get_profile_free_param_by_name(self):
+        pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
+        assert_array_equal(pawley.get_isfree(), array([True, True, True, True, False, False, False]))
+        pawley.set_profile_free_param(True, "sig2", 0)
+        self.assertEqual(pawley.get_profile_free_param("sig2", 0), True)
+        assert_array_equal(pawley.get_isfree(), array([True, True, True, True, True, False, False]))
+
+    def test_profile_param_by_name_validator(self):
+        pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
+        self.assertRaisesRegex(
+            ValueError, "Invalid profile parameter name: alpha, for profile Gaussian", pawley.get_profile_param, "alpha", 0
+        )
+        self.assertRaisesRegex(
+            ValueError, "Phase with index: 3 does not exists. Number of phases is 1", pawley.get_profile_param, "sig0", 3
+        )
+
     def test_estimate_initial_params(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
         pawley.estimate_initial_params()

--- a/scripts/test/Engineering/test_pawley_utils.py
+++ b/scripts/test/Engineering/test_pawley_utils.py
@@ -146,6 +146,18 @@ class PawleyPattern1DTest(unittest.TestCase):
         self.assertEqual(pawley.get_profile_param("sig0", 0), 2.2)
         assert_array_equal(pawley.get_params().astype(int), array([5, 1, 2, 0, 0, 1, 0]))
 
+    def test_set_get_phase_by_name(self):
+        pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
+        pawley.set_phase_param(4.65, "a", 0)
+        self.assertEqual(pawley.get_phase_param("a", 0), 4.65)
+        self.assertEqual(pawley.get_params()[0], 4.65)
+
+    def test_set_get_phase_free_by_name(self):
+        pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
+        pawley.set_phase_free_param(False, "a", 0)
+        self.assertEqual(pawley.get_phase_free_param("a", 0), False)
+        self.assertFalse(pawley.get_isfree()[0])
+
     def test_set_get_profile_free_param_by_name(self):
         pawley = PawleyPattern1D(self.ws, [self.phase], profile=GaussianProfile())
         assert_array_equal(pawley.get_isfree(), array([True, True, True, True, False, False, False]))


### PR DESCRIPTION
Peak profiles helper classes for the PawleyPattern classes store fitting parameters as a np.array (`self.p`). To know which parameter corresponds to which array index, there is another list call labels(`self.labels`). 
In #40095 it was discussed that it would be beneficial to have some sort of getter/setter methods in place to directly access these peak parameters. In looking at pawley_utils, it seems the methods requiring the parameters are best served with them being np.array attributes, so the solution I opted for to make the code more readable is to convert the labels to a dictionary of label:index on array. Creating a setter/getter for each parameter seems unnecesary given that they are all copied as a np.array on the PawleyPattern classes, and they are also masked with a boolean np.array of the same size.  The use of parameter by index is just on one method ('get_mantid_peak_params')

__Does not require release notes as it is an internal change__
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40185 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- syntax review

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
