### PR TITLE
Pin qscintilla2 to build variant to force Qt5 version.

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -140,7 +140,7 @@ qtconsole:
   - '>5.5.0'
 
 qscintilla2:
-  - '>=2.14.1'
+  - '==2.14.1 *_0'
 
 # 2.4.2 fails workbench.test_mainwindow.test_mainwindow which uses isinstance()
 qtpy:

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -139,6 +139,7 @@ qt_main:
 qtconsole:
   - '>5.5.0'
 
+# This is the last version that is both built for Qt5 and compatible with the rest of our pins.
 qscintilla2:
   - '==2.14.1 *_0'
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -113,7 +113,7 @@ python = "3.12.*"
 pyvista = ">=0.46"
 pyvistaqt = ">=0.11.3,<0.12"
 pyyaml = ">=5.4.1"
-qscintilla2 = ">=2.14.1"
+qscintilla2 = { version = "==2.14.1", build = "*_0" }
 qt-main = "5.15.*"
 qtconsole = ">5.5.0"
 qtpy = ">=2.4,!=2.4.2"


### PR DESCRIPTION
### Description of work
Pin qscintilla2 to exact version and build variant to ensure the Qt5 version is picked up by the conda recipes. This will resolve the recent [nightly failures in macOS packaging](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/1302/execution/node/213/log/), where the following error message was printed:

```
01:40:23   │ │ CMake Error at buildconfig/CMake/QtTargetFunctions.cmake:177 (target_link_libraries):
01:40:23   │ │   Target "MantidQtWidgetsCommonQt5" links to:
01:40:23   │ │     Qt5::Qscintilla
01:40:23   │ │   but the target was not found.  Possible reasons include:
01:40:23   │ │     * There is a typo in the target name.
01:40:23   │ │     * A find_package call is missing for an IMPORTED target.
01:40:23   │ │     * An ALIAS target is missing.
```

The QScintilla2 feedstock was [recently updated to Qt6](https://github.com/conda-forge/qscintilla2-feedstock/pull/59), and there is seemingly no other way to restrict it to the Qt5 version.

### To test:
1. Verify that the following package build on all OS passed:
 [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_branch&build=1617)](https://builds.mantidproject.org/job/build_branch/1617/) 
2. Install test package either with standalone from the above build or with:
`mamba install -c mantid-test/label/qscintilla-pin mantidworkbench --yes`
3. Launch workbench and check that the script editor works as expected.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
