### PR TITLE
Fix segfault in instrument view when masking everything.

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41413.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/Bugfixes/41413.rst
@@ -1,0 +1,1 @@
+- Fixed a crash that occurred when masking all detectors in the :ref:`Instrument Viewer <InstrumentViewer>`.

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1063,6 +1063,14 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &
       if (sum > 0 && sum < m_DataPositiveMinValue)
         m_DataPositiveMinValue = sum;
     }
+
+    // All detectors were masked or had invalid values — use a safe fallback so
+    // the colorbar never receives DBL_MAX/-DBL_MAX as its range.
+    if (m_DataMinValue == DBL_MAX) {
+      m_DataMinValue = 0.0;
+      m_DataMaxValue = 1.0;
+      m_DataPositiveMinValue = 1.0;
+    }
   }
 
   if (m_autoscaling) {


### PR DESCRIPTION
Fix segfault in instrument view when masking everything. This caused the data range to be calculated with NaN/Inf which caused the segfault when updating the ColorBar.

### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes [14558: [Mantid] Workbench crashes when masking whole instrument in Instrument Viewer](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/14558)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Load something

```python
ws = LoadEventNexus("REF_L_183111")
```

Go to draw, select everything to mask and press "Apply To Data". You would get a segfault, that is now fixed.

<img width="1626" height="1160" alt="2026-05-14-150039_1626x1160_scrot" src="https://github.com/user-attachments/assets/8e30baff-d188-4ac5-8ab2-dde204ce7c6d" />


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
