### PR TITLE
Enabled the masking feature in the Reduction Preview tab of the Reflectometry GUI

### DIFF
--- a/docs/source/release/v6.16.0/Reflectometry/New_features/39909.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/New_features/39909.rst
@@ -1,0 +1,1 @@
+- The :ref:`Reduction Preview <refl_preview>` tab in the ``ISIS Reflectometry`` interface now supports creating mask and inverted mask tables using rectangular, elliptical and polygonal selectors.

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -12,6 +12,7 @@ from ..sliceviewer.models.dimensions import Dimensions
 from ..sliceviewer.models.workspaceinfo import WorkspaceInfo, WS_TYPE
 from ..sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
+from mantidqt.widgets.sliceviewer.presenters.masking import Masking
 from mantid.api import RegionSelectorObserver
 
 # 3rd party imports
@@ -262,9 +263,18 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
     def is_integer_frame(self):
         return False, False
 
+    def _activate_masking(self) -> None:
+        self._data_view.deactivate_and_disable_tool(ToolItemText.ZOOM)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.PAN)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
+        self._data_view.masking = Masking(self._data_view, self.model.ws.name(), auto_update_mask_file=True)
+        self._data_view.masking.new_selector(ToolItemText.RECT_MASKING)  # default to rect masking
+        self._data_view.activate_tool(ToolItemText.RECT_MASKING, True)
+
     def masking(self, active) -> None:
         super().masking(active)
         self._data_view.deactivate_and_disable_tool(ToolItemText.APPLY_MASKING)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.EXPORT_MASKING)
 
     def rect_masking_clicked(self, active):
         self.view.data_view.check_masking_shape_toolbar_icons(ToolItemText.RECT_MASKING)
@@ -287,3 +297,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
     def invert_masking_clicked(self, active) -> None:
         self.view.data_view.masking.invert_masking_clicked(active)
+
+    @property
+    def _is_masking_disabled(self):
+        return False

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -289,8 +289,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         self.view.data_view.masking.new_selector(ToolItemText.POLY_MASKING)
 
     def export_masking_clicked(self):
-        self.view.data_view.masking.export_selectors()
-        self.view.data_view.canvas.draw_idle()
+        pass
 
     def apply_masking_clicked(self):
         pass

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -11,6 +11,7 @@ from ..observers.observing_presenter import ObservingPresenter
 from ..sliceviewer.models.dimensions import Dimensions
 from ..sliceviewer.models.workspaceinfo import WorkspaceInfo, WS_TYPE
 from ..sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
+from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantid.api import RegionSelectorObserver
 
 # 3rd party imports
@@ -53,11 +54,10 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
         self.notifyee = None
         self.view = view or RegionSelectorView(self, parent, image_info_widget=image_info_widget)
-        super().__init__(ws, self.view.data_view, disable_masking_override=True)
+        super().__init__(ws, self.view.data_view)
         self._selectors: list[Selector] = []
         self._drawing_region = False
 
-        # For now, disable masking - not implemented for regionselector
         self._toggle_masking_options(False)
 
         if ws:
@@ -262,23 +262,28 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
     def is_integer_frame(self):
         return False, False
 
-    def masking(self, active):
-        pass
+    def masking(self, active) -> None:
+        super().masking(active)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.APPLY_MASKING)
 
     def rect_masking_clicked(self, active):
-        pass
+        self.view.data_view.check_masking_shape_toolbar_icons(ToolItemText.RECT_MASKING)
+        self.view.data_view.masking.new_selector(ToolItemText.RECT_MASKING)
 
     def elli_masking_clicked(self, active):
-        pass
+        self.view.data_view.check_masking_shape_toolbar_icons(ToolItemText.ELLI_MASKING)
+        self.view.data_view.masking.new_selector(ToolItemText.ELLI_MASKING)
 
     def poly_masking_clicked(self, active):
-        pass
+        self.view.data_view.check_masking_shape_toolbar_icons(ToolItemText.POLY_MASKING)
+        self.view.data_view.masking.new_selector(ToolItemText.POLY_MASKING)
 
     def export_masking_clicked(self):
-        pass
+        self.view.data_view.masking.export_selectors()
+        self.view.data_view.canvas.draw_idle()
 
     def apply_masking_clicked(self):
         pass
 
     def invert_masking_clicked(self, active) -> None:
-        pass
+        self.view.data_view.masking.invert_masking_clicked(active)

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -9,7 +9,9 @@ import unittest
 from unittest.mock import call, DEFAULT, Mock, patch, MagicMock
 
 from mantidqt.widgets.regionselector.presenter import RegionSelector
+from mantidqt.widgets.sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantidqt.widgets.sliceviewer.models.workspaceinfo import WS_TYPE
+from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantid.api import MatrixWorkspace
 
 
@@ -85,6 +87,10 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertEqual(1, len(region_selector._selectors))
         self.assertTrue(region_selector._selectors[0].active)
         self.assertEqual("test", region_selector._selectors[0].region_type())
+
+    def test_is_masking_disabled_returns_false(self):
+        region_selector = RegionSelector(view=self.mock_view)
+        self.assertFalse(region_selector._is_masking_disabled)
 
     def test_add_second_rectangular_region_deactivates_first_selector(self):
         region_selector = RegionSelector(ws=Mock(spec=MatrixWorkspace), view=self.mock_view)
@@ -319,6 +325,113 @@ class RegionSelectorTest(unittest.TestCase):
 
         self.assertEqual(1, len(region_selector._selectors))
         self._check_rectangular_region(region_selector._selectors[0], region_type, expected_extents)
+
+    def test_invert_masking_clicked(self):
+        mock_masking = MagicMock()
+        mock_data_view = MagicMock()
+        mock_data_view.masking = mock_masking
+        self.mock_view.data_view = mock_data_view
+
+        region_selector = RegionSelector(view=self.mock_view)
+
+        region_selector.invert_masking_clicked(True)
+        mock_masking.invert_masking_clicked.assert_called_once_with(True)
+        mock_masking.reset_mock()
+        region_selector.invert_masking_clicked(False)
+        mock_masking.invert_masking_clicked.assert_called_once_with(False)
+
+    def test_rect_masking_clicked(self):
+        mock_masking = MagicMock()
+        mock_data_view = MagicMock()
+        mock_data_view.masking = mock_masking
+        self.mock_view.data_view = mock_data_view
+
+        region_selector = RegionSelector(view=self.mock_view)
+
+        region_selector.rect_masking_clicked(True)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.RECT_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.RECT_MASKING)
+        mock_masking.reset_mock()
+        mock_data_view.reset_mock()
+        region_selector.rect_masking_clicked(False)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.RECT_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.RECT_MASKING)
+
+    def test_elli_masking_clicked(self):
+        mock_masking = MagicMock()
+        mock_data_view = MagicMock()
+        mock_data_view.masking = mock_masking
+        self.mock_view.data_view = mock_data_view
+
+        region_selector = RegionSelector(view=self.mock_view)
+
+        region_selector.elli_masking_clicked(True)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.ELLI_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.ELLI_MASKING)
+        mock_masking.reset_mock()
+        mock_data_view.reset_mock()
+        region_selector.elli_masking_clicked(False)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.ELLI_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.ELLI_MASKING)
+
+    def test_poly_masking_clicked(self):
+        mock_masking = MagicMock()
+        mock_data_view = MagicMock()
+        mock_data_view.masking = mock_masking
+        self.mock_view.data_view = mock_data_view
+
+        region_selector = RegionSelector(view=self.mock_view)
+
+        region_selector.poly_masking_clicked(True)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.POLY_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.POLY_MASKING)
+        mock_masking.reset_mock()
+        mock_data_view.reset_mock()
+        region_selector.poly_masking_clicked(False)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.POLY_MASKING)
+        mock_data_view.check_masking_shape_toolbar_icons.assert_called_once_with(ToolItemText.POLY_MASKING)
+
+    @patch.object(SliceViewerBasePresenter, "masking")
+    def test_masking(self, mock_super_masking):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector._data_view = MagicMock()
+        region_selector.masking(True)
+        mock_super_masking.assert_called_once_with(True)
+        region_selector._data_view.deactivate_and_disable_tool.assert_has_calls(
+            [
+                call(ToolItemText.APPLY_MASKING),
+                call(ToolItemText.EXPORT_MASKING),
+            ]
+        )
+
+    @patch("mantidqt.widgets.regionselector.presenter.Masking")
+    def test_activate_masking(self, mock_masking_cls):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector._data_view = MagicMock()
+        region_selector.model = MagicMock()
+        region_selector.model.ws.name.return_value = "test_ws"
+        mock_masking = MagicMock()
+        mock_masking_cls.return_value = mock_masking
+
+        region_selector._activate_masking()
+        region_selector._data_view.deactivate_and_disable_tool.assert_has_calls(
+            [
+                call(ToolItemText.ZOOM),
+                call(ToolItemText.PAN),
+                call(ToolItemText.REGIONSELECTION),
+            ]
+        )
+        mock_masking_cls.assert_called_once_with(
+            region_selector._data_view,
+            "test_ws",
+            auto_update_mask_file=True,
+        )
+        self.assertEqual(region_selector._data_view.masking, mock_masking)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.RECT_MASKING)
+        region_selector._data_view.activate_tool.assert_called_once_with(
+            ToolItemText.RECT_MASKING,
+            True,
+        )
 
     def test_display_rectangular_region_y1_out_of_bounds_does_not_add_selector(self):
         y_limits = (200, 500)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -389,7 +389,7 @@ class MaskingModel:
     def __init__(self, ws_name):
         self._active_mask = None
         self._masks = []
-        self._ws_name = ws_name
+        self._ws_name = ws_name or "ws"
         self._apply_inverted_mask = False
 
     def update_active_mask(self, mask):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -386,14 +386,19 @@ class PolyCursorInfo(CursorInfoBase):
 
 
 class MaskingModel:
-    def __init__(self, ws_name):
+    def __init__(self, ws_name, auto_update_mask_file=False):
         self._active_mask = None
         self._masks = []
         self._ws_name = ws_name or "ws"
         self._apply_inverted_mask = False
+        self._auto_update_mask_file = auto_update_mask_file
 
     def update_active_mask(self, mask):
         self._active_mask = mask
+        if self._auto_update_mask_file:
+            self._masks.append(self._active_mask)
+            self.export_selectors()
+            self._masks.remove(self._active_mask)
 
     def clear_active_mask(self):
         self._active_mask = None
@@ -454,3 +459,5 @@ class MaskingModel:
 
     def invert_masking_clicked(self, active):
         self._apply_inverted_mask = active
+        if self._auto_update_mask_file and self._masks:
+            self.export_selectors()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -459,5 +459,7 @@ class MaskingModel:
 
     def invert_masking_clicked(self, active):
         self._apply_inverted_mask = active
-        if self._auto_update_mask_file and self._masks:
+        if self._auto_update_mask_file and self._active_mask:
+            self._masks.append(self._active_mask)
             self.export_selectors()
+            self._masks.remove(self._active_mask)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -16,11 +16,10 @@ from mantidqt.widgets.sliceviewer.presenters.masking import Masking
 
 
 class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
-    def __init__(self, ws, data_view: SliceViewerDataView, model: SliceViewerBaseModel = None, disable_masking_override=False):
+    def __init__(self, ws, data_view: SliceViewerDataView, model: SliceViewerBaseModel = None):
         self.model = model or SliceViewerBaseModel(ws)
         self._data_view: SliceViewerDataView = data_view
         self.normalization = False
-        self._disable_masking_override = disable_masking_override
 
         if self._is_masking_disabled:
             self._data_view.deactivate_and_disable_tool(ToolItemText.MASKING)
@@ -153,11 +152,6 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
 
     @property
     def _is_masking_disabled(self):
-        #  Disable masking if not supported.
-        #  If a use case arises, we could extend support to these areas
-        if self._disable_masking_override:
-            return True
-
         # if not histo workspace
         ws_type = None if not self.model.ws else WorkspaceInfo.get_ws_type(self.model.ws)
         if not ws_type == WS_TYPE.MATRIX:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -128,15 +128,18 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             data_view.extents_set_enabled(True)
             data_view.switch_line_plots_tool(PixelLinePlot, self)
 
+    def _activate_masking(self) -> None:
+        self._data_view.deactivate_and_disable_tool(ToolItemText.ZOOM)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.PAN)
+        self._data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
+        self._data_view.masking = Masking(self._data_view, self.model.ws.name(), auto_update_mask_file=False)
+        self._data_view.masking.new_selector(ToolItemText.RECT_MASKING)  # default to rect masking
+        self._data_view.activate_tool(ToolItemText.RECT_MASKING, True)
+
     def masking(self, active) -> None:
         self._toggle_masking_options(active)
         if active:
-            self._data_view.deactivate_and_disable_tool(ToolItemText.ZOOM)
-            self._data_view.deactivate_and_disable_tool(ToolItemText.PAN)
-            self._data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
-            self._data_view.masking = Masking(self._data_view, self.model.ws.name())
-            self._data_view.masking.new_selector(ToolItemText.RECT_MASKING)  # default to rect masking
-            self._data_view.activate_tool(ToolItemText.RECT_MASKING, True)
+            self._activate_masking()
             return
         self._data_view.enable_tool_button(ToolItemText.ZOOM)
         self._data_view.enable_tool_button(ToolItemText.PAN)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
@@ -184,11 +184,11 @@ class Masking:
     Manages Masking
     """
 
-    def __init__(self, dataview, ws_name):
+    def __init__(self, dataview, ws_name, auto_update_mask_file=False):
         self._selectors = []
         self._active_selector = None
         self._dataview = dataview
-        self._model = MaskingModel(ws_name)
+        self._model = MaskingModel(ws_name, auto_update_mask_file)
 
     def _reset_active_selector(self):
         if self._active_selector:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -7,7 +7,9 @@
 import unittest
 
 from unittest import mock
+from unittest.mock import call, patch, MagicMock
 from mantidqt.widgets.sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
+from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 
 
 class SliceViewerBasePresenterShim(SliceViewerBasePresenter):
@@ -71,6 +73,35 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self._ws_info_patcher.stop()
+
+    @patch("mantidqt.widgets.sliceviewer.presenters.base_presenter.Masking")
+    def test_activate_masking(self, mock_masking_cls):
+        presenter = SliceViewerBasePresenterShim(None, model=mock.Mock(), data_view=mock.Mock())
+        presenter._data_view = MagicMock()
+        presenter.model = MagicMock()
+        presenter.model.ws.name.return_value = "test_ws"
+        mock_masking = MagicMock()
+        mock_masking_cls.return_value = mock_masking
+
+        presenter._activate_masking()
+        presenter._data_view.deactivate_and_disable_tool.assert_has_calls(
+            [
+                call(ToolItemText.ZOOM),
+                call(ToolItemText.PAN),
+                call(ToolItemText.REGIONSELECTION),
+            ]
+        )
+        mock_masking_cls.assert_called_once_with(
+            presenter._data_view,
+            "test_ws",
+            auto_update_mask_file=False,
+        )
+        self.assertEqual(presenter._data_view.masking, mock_masking)
+        mock_masking.new_selector.assert_called_once_with(ToolItemText.RECT_MASKING)
+        presenter._data_view.activate_tool.assert_called_once_with(
+            ToolItemText.RECT_MASKING,
+            True,
+        )
 
     def test_data_limits_changed_creates_new_plot_if_dynamic_rebinning_supported(self):
         presenter = SliceViewerBasePresenterShim(None, model=mock.Mock(), data_view=mock.Mock())

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -128,7 +128,7 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
 
     def test_invert_masking_clicked(self):
         self.model._auto_update_mask_file = True
-        self.model._masks = ["test_mask"]
+        self.model._active_mask = "test_mask"
         export_selectors = MagicMock()
         self.model.export_selectors = export_selectors
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from unittest.mock import patch, Mock, call
+from unittest.mock import patch, Mock, call, MagicMock
 from collections import namedtuple
 from functools import partial
 
@@ -31,6 +31,24 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
     @staticmethod
     def _set_up_model_test(text, transpose=False, images=None):
         pass
+
+    def test_masking_model_initialization(self):
+        model = MaskingModel("")
+        self.assertEqual(model._active_mask, None)
+        self.assertEqual(model._masks, [])
+        self.assertEqual(model._ws_name, "ws")
+        self.assertEqual(model._apply_inverted_mask, False)
+        self.assertEqual(model._auto_update_mask_file, False)
+        model = MaskingModel("", auto_update_mask_file=True)
+        self.assertEqual(model._auto_update_mask_file, True)
+
+    def test_update_active_mask(self):
+        self.model._auto_update_mask_file = True
+        export_selectors = MagicMock()
+        self.model.export_selectors = export_selectors
+        self.model.update_active_mask("test_mask")
+        self.assertEqual(self.model._active_mask, "test_mask")
+        self.model.export_selectors.assert_called_once()
 
     def test_clear_active_mask(self):
         self.model._active_mask = "test"
@@ -109,10 +127,18 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         create_tbl_mock.assert_called_once_with(["consolidated"], False)
 
     def test_invert_masking_clicked(self):
+        self.model._auto_update_mask_file = True
+        self.model._masks = ["test_mask"]
+        export_selectors = MagicMock()
+        self.model.export_selectors = export_selectors
+
         self.model.invert_masking_clicked(True)
         self.assertTrue(self.model._apply_inverted_mask)
+        self.model.export_selectors.assert_called_once()
+        self.model.export_selectors.reset_mock()
         self.model.invert_masking_clicked(False)
         self.assertFalse(self.model._apply_inverted_mask)
+        self.model.export_selectors.assert_called_once()
 
     def test_export_selectors(self):
         with (

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
@@ -30,6 +30,17 @@ class SliceViewerMaskingPresenterTest(unittest.TestCase):
             "active_selector": active_selector,
         }
 
+    @patch("mantidqt.widgets.sliceviewer.presenters.masking.MaskingModel")
+    def test_masking_initialization(self, mock_masking_model_fn):
+        presenter = Masking(dataview="dataview", ws_name="ws")
+        self.assertEqual(presenter._selectors, [])
+        self.assertEqual(presenter._active_selector, None)
+        self.assertEqual(presenter._dataview, "dataview")
+        mock_masking_model_fn.assert_called_once_with("ws", False)
+        mock_masking_model_fn.reset_mock()
+        presenter = Masking(dataview="dataview", ws_name="ws", auto_update_mask_file=True)
+        mock_masking_model_fn.assert_called_once_with("ws", True)
+
     @patch("mantidqt.widgets.sliceviewer.presenters.masking.MaskingModel", autospec=True)
     def test_new_selector_no_active_selector(self, mock_masking_model_fn):
         mock_model = mock_masking_model_fn.return_value


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39909. <!-- One line per closed issue. -->
The user can use the masking features that is available in the `SliceViewer` to draw masks and export the mask table.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

1) Launch the **ISIS Reflectometry** interface from `interfaces -> Reflectometry - ISIS Reflectometry`. 
2) Go to the **Reduction Preview** tab.
3) Type `INTER45455` into the Run input and click **Load**.
4) Click the `Toggle masking on/off` button.
<img width="357" height="49" alt="image" src="https://github.com/user-attachments/assets/e74d3aac-8692-4131-9829-3a0683838ae1" />

5) Verify that the `Apply drawn mask` and `Export drawn mask to table` buttons are disabled
<img width="357" height="48" alt="image" src="https://github.com/user-attachments/assets/e8daed6e-a312-4b91-9ce1-eb7810774358" />

6) Draw a rectangular mask.
<img width="1785" height="919" alt="image" src="https://github.com/user-attachments/assets/3c023987-a2a8-44e7-81be-1ca0ec9cc37b" />

7) Verify that a mask table is automatically created
<img width="170" height="25" alt="image" src="https://github.com/user-attachments/assets/65a62a16-89fd-470e-aedb-2b66306ef7a2" />

8) Verify that the readings in the table are correct based on a visual inspection.
<img width="602" height="419" alt="image" src="https://github.com/user-attachments/assets/3f77b862-54fa-479f-98dd-4c67969e325b" />

9) Modify the drawn rectangular mask (it should still be active and editable).
<img width="1786" height="922" alt="image" src="https://github.com/user-attachments/assets/7adff568-7b8b-4014-8948-dd3526aa1ab9" />

10) Verify that the table automatically updates with the edited mask.
<img width="603" height="419" alt="image" src="https://github.com/user-attachments/assets/f4abbac6-e307-4a6f-8526-46f98bde7a51" />

11) Press **Esc** to delete the mask.

12) Click the `Toggle inverted masking on/off` button.
<img width="359" height="46" alt="image" src="https://github.com/user-attachments/assets/c8ff7284-7fca-4ebe-baf7-5c819a2f3092" />

13) Draw a rectangular mask.
<img width="1785" height="918" alt="image" src="https://github.com/user-attachments/assets/c4d568cf-176a-4c8f-890f-65bb3d47fe0d" />

14) Verify that the table now has **four** entries for the inverted mask.
<img width="602" height="416" alt="image" src="https://github.com/user-attachments/assets/47046844-7d71-4941-8534-6f11e79d0b2f" />

15) Modify the drawn rectangular mask (it should still be active and editable).
<img width="1784" height="921" alt="image" src="https://github.com/user-attachments/assets/a3747fc5-d9ac-44ea-b18a-f8b4ad5a7d95" />

16) Verify that the table automatically updates with the edited mask.
<img width="601" height="421" alt="image" src="https://github.com/user-attachments/assets/3494e8c7-e196-40e0-8520-083f7fd2cd18" />



<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
