### PR TITLE
Change FABADA PDF parameter to be the name of the output pdf workspace

### DIFF
--- a/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
@@ -41,7 +41,7 @@ using namespace Mantid::API;
 
 namespace {
 
-std::string const PDF_GROUP_NAME = "__PDF_Workspace";
+std::string const DEFAULT_PDF_GROUP_NAME = "__PDF_Workspace";
 
 // static logger object
 Kernel::Logger g_log("FABADAMinimizer");
@@ -104,7 +104,8 @@ FABADAMinimizer::FABADAMinimizer()
                   " constant during the convergence period)."
                   " Useful to find the exact minimum.");
   // Output Properties
-  declareProperty("PDF", true, "If the PDF's should be calculated or not.");
+  declareProperty("PDF", DEFAULT_PDF_GROUP_NAME,
+                  "Name for the output PDF workspace group. Default is " + DEFAULT_PDF_GROUP_NAME);
   declareProperty("NumberBinsPDF", 20, "Number of bins used for the output PDFs");
   declareProperty(std::make_unique<API::WorkspaceProperty<>>("Chains", "", Kernel::Direction::Output),
                   "The name to give the output workspace for the"
@@ -791,8 +792,7 @@ double FABADAMinimizer::outputPDF(std::size_t const &convLength, std::vector<std
 
     mostPchi2 = getMostProbableChiSquared(convLength, reducedChain, pdfLength, xValues, yValues, PDFYAxis, start, bin);
 
-    if (getProperty("PDF"))
-      outputPDF(xValues, yValues, reducedChain, convLength, pdfLength);
+    outputPDF(xValues, yValues, reducedChain, convLength, pdfLength);
 
   } // if convLength > 0
   else {
@@ -811,14 +811,15 @@ void FABADAMinimizer::outputPDF(std::vector<double> &xValues, std::vector<double
   parameterNames.emplace_back("Chi Squared");
   auto const workspace = createWorkspace(xValues, yValues, int(m_nParams) + 1, parameterNames);
 
-  if (AnalysisDataService::Instance().doesExist(PDF_GROUP_NAME)) {
-    auto groupPDF = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(PDF_GROUP_NAME);
+  const auto pdfName = getPropertyValue("PDF");
+  if (AnalysisDataService::Instance().doesExist(pdfName)) {
+    auto groupPDF = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(pdfName);
     groupPDF->addWorkspace(workspace);
-    AnalysisDataService::Instance().addOrReplace(PDF_GROUP_NAME, groupPDF);
+    AnalysisDataService::Instance().addOrReplace(pdfName, groupPDF);
   } else {
     auto groupPDF = std::make_shared<WorkspaceGroup>();
     groupPDF->addWorkspace(workspace);
-    AnalysisDataService::Instance().addOrReplace(PDF_GROUP_NAME, groupPDF);
+    AnalysisDataService::Instance().addOrReplace(pdfName, groupPDF);
   }
 }
 

--- a/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
@@ -27,7 +27,7 @@ using namespace Mantid::CurveFitting::Functions;
 
 namespace {
 
-std::string const PDF_GROUP_NAME = "__PDF_Workspace";
+std::string const DEFAULT_PDF_GROUP_NAME = "__PDF_Workspace";
 
 MatrixWorkspace_sptr createTestWorkspace(size_t NVectors = 2, size_t XYLength = 20) {
   MatrixWorkspace_sptr ws2(new WorkspaceTester);
@@ -78,8 +78,8 @@ void doTestExpDecay(const MatrixWorkspace_sptr &ws2) {
 
   size_t n = fun->nParams();
 
-  TS_ASSERT(AnalysisDataService::Instance().doesExist(PDF_GROUP_NAME));
-  auto const pdfGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(PDF_GROUP_NAME);
+  TS_ASSERT(AnalysisDataService::Instance().doesExist(DEFAULT_PDF_GROUP_NAME));
+  auto const pdfGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(DEFAULT_PDF_GROUP_NAME);
   TS_ASSERT(pdfGroup);
   auto const wsPDF = std::dynamic_pointer_cast<MatrixWorkspace>(pdfGroup->getItem(0));
   TS_ASSERT_EQUALS(wsPDF->getNumberHistograms(), n + 1);
@@ -190,7 +190,7 @@ public:
     size_t nParams = fun->nParams();
 
     // Test PDF workspace
-    auto const PDFGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(PDF_GROUP_NAME);
+    auto const PDFGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(DEFAULT_PDF_GROUP_NAME);
     TS_ASSERT(PDFGroup);
     auto const PDF = std::dynamic_pointer_cast<MatrixWorkspace>(PDFGroup->getItem(0));
     TS_ASSERT_EQUALS(PDF->getNumberHistograms(), nParams + 1);

--- a/docs/source/release/v6.16.0/Framework/Fit_Functions/New_features/41395.rst
+++ b/docs/source/release/v6.16.0/Framework/Fit_Functions/New_features/41395.rst
@@ -1,0 +1,1 @@
+- The `PDF` parameter of the :ref:`FABADA Minimizer <FABADA>` has been changed from a bool to a string. This allows the user to specify the name of the output workspace for the PDF.


### PR DESCRIPTION
### Description of work

Change the PDF parameter of the FABADA minimizer to be the string name of the output pdf workspace. Before it was a bool (default to true) and would output as a hidden workspace (not very useful for users).
The minimizer will work the same by default (default pdf name is the same as before). This does remove the option of not adding the workspace to the ads, this doesn't seem like a huge deal to me since it was already being added by default.

Closes #41395

### To test:

Run the example script from the docs

```
ws_data = Load(Filename='irs26176_graphite002_red.nxs')
ws_res = Load(Filename='irs26173_graphite002_res.nxs')

function_str = 'composite=Convolution,FixResolution=tue,NumDeriv=false;name=Resolution,Workspace=ws_res,WorkspaceIndex=0;(composite=CompositeFunction,NumDeriv=true;name=Lorentzian,Amplitude=1,PeakCentre=0.01,FWHM=0.5;name=Lorentzian,Amplitude=1,PeakCentre=0.01,FWHM=0.5)'
minimizer_str = "FABADA,Chain Length=1000000,Steps between values=10,Convergence Criteria=0.01,PDF=pdf,Chains=chain,Converged chain=conv,Cost Function Table=CostFunction,Parameter Erros =Errors"

Fit(Function = function_str,InputWorkspace=ws_data,WorkspaceIndex=3,StartX=-0.25,EndX=0.25,CreateOutput=True,Output = 'result',OutputCompositeMembers=True,MaxIterations=2000000, Minimizer=minimizer_str)
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
