### PR TITLE
Refactor installing a fixed version of pixi into a reusable action

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -21,20 +21,21 @@ runs:
       working-directory: ${{ github.workspace }}
       run: echo "version=$(cat .pixi-version)" >> "$GITHUB_OUTPUT"
     # branch based on whether or not windows
+    - name: Determine pixi executable
+      id: pixi-exe
+      run: |
+        if [ ${{ runner.os == 'Windows' }} ]; then
+          echo "On windows"
+          echo "pixi_path=${{ runner.temp }}\Scripts\pixi.exe" >> "$GITHUB_OUTPUT"
+        else;
+          echo "Not on windows"
+          echo "pixi_path=${{ runner.temp }}/bin/pixi" >> "$GITHUB_OUTPUT"
+        fi
     - name: Set up pixi
-      if: ${{ runner.os == 'Windows' }}
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
         pixi-version: v${{ steps.pixi-version.outputs.version }}
-        pixi-bin-path: ${{ runner.temp }}/bin/pixi
-        run-install: ${{ inputs.run-install }}
-        frozen: ${{ inputs.run-install }}
-        activate-environment: ${{ inputs.activate-environment }}
-    - name: Set up pixi
-      if: ${{ runner.os != 'Windows' }}
-      uses: prefix-dev/setup-pixi@v0.9.5
-      with:
-        pixi-version: v${{ steps.pixi-version.outputs.version }}
+        pixi-bin-path: ${{ steps.pixi-exe.outputs.pixi_path }}
         run-install: ${{ inputs.run-install }}
         frozen: ${{ inputs.run-install }}
         activate-environment: ${{ inputs.activate-environment }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup Pixi'
+description: 'Setup Pixi executable after detecting version from .pixi-version. Most variables are forwarded directly setup-pixi'
+inputs: # copied from prefix-dev/setup-pixi
+  run-install:
+    description: Whether to run `pixi install` after installing pixi.
+    required: false
+    default: false
+  activate-environment:
+    description: |
+      If the installed environment should be "activated" for the current job, modifying `$GITHUB_ENV` and
+      `$GITHUB_PATH`. If more than one environment is specified in `environments`, this must be the name of the
+      environment. Defaults to `false`. Requires at least pixi v0.21.0.
+    required: false
+    default: false
+runs:
+  using: "composite"
+  steps:
+    - name: Read pixi version
+      id: pixi-version
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: echo "version=$(cat .pixi-version)" >> "$GITHUB_OUTPUT"
+    - name: Set up pixi
+      uses: prefix-dev/setup-pixi@v0.9.5
+      with:
+        pixi-version: v${{ steps.pixi-version.outputs.version }}
+        run-install: ${{ inputs.run-install }}
+        frozen: ${{ inputs.run-install }}
+        activate-environment: ${{ inputs.activate-environment }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -20,7 +20,18 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       run: echo "version=$(cat .pixi-version)" >> "$GITHUB_OUTPUT"
+    # branch based on whether or not windows
     - name: Set up pixi
+      if: ${{ runner.os == 'Windows' }}
+      uses: prefix-dev/setup-pixi@v0.9.5
+      with:
+        pixi-version: v${{ steps.pixi-version.outputs.version }}
+        pixi-bin-path: ${{ runner.temp }}/bin/pixi
+        run-install: ${{ inputs.run-install }}
+        frozen: ${{ inputs.run-install }}
+        activate-environment: ${{ inputs.activate-environment }}
+    - name: Set up pixi
+      if: ${{ runner.os != 'Windows' }}
       uses: prefix-dev/setup-pixi@v0.9.5
       with:
         pixi-version: v${{ steps.pixi-version.outputs.version }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -23,11 +23,12 @@ runs:
     # branch based on whether or not windows
     - name: Determine pixi executable
       id: pixi-exe
+      shell: bash
       run: |
-        if [ ${{ runner.os == 'Windows' }} ]; then
+        if [ "${{ runner.os }}" = "Windows" ]; then
           echo "On windows"
           echo "pixi_path=${{ runner.temp }}\Scripts\pixi.exe" >> "$GITHUB_OUTPUT"
-        else;
+        else
           echo "Not on windows"
           echo "pixi_path=${{ runner.temp }}/bin/pixi" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,8 +32,7 @@ jobs:
     # which includes pre-commit and other dependencies.
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: ./.github/actions/setup-pixi
         with:
-          manifest-path: pixi.toml
-          frozen: true
           activate-environment: true
+          run-install: true

--- a/.github/workflows/doxygen-publish.yml
+++ b/.github/workflows/doxygen-publish.yml
@@ -24,10 +24,8 @@ jobs:
         with:
           filters: .github/filters.yaml
 
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: ./.github/actions/setup-pixi
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
-        with:
-          frozen: true
 
       - uses: ./.github/actions/doxygen-build
         name: build doxygen

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -28,10 +28,8 @@ jobs:
         with:
           filters: .github/filters.yaml
 
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: ./.github/actions/setup-pixi
         if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
-        with:
-          frozen: true
 
       - uses: ./.github/actions/doxygen-build
         name: Build doxygen
@@ -93,11 +91,7 @@ jobs:
           fetch-tags: true
 
       - name: Install pixi
-        run: |
-          source ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/pixi-utils
-          install_pixi "${GITHUB_WORKSPACE}"
-          # Add pixi to path for use in other steps
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-pixi
 
       - name: Clean build tree
         # supplying --clean-build or CLEAN_BUILD=true should be added here

--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -21,14 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.UPDATE_BRANCH }}  # start from this branch
-      - name: Read pixi version
-        id: pixi-version
-        run: echo "version=$(cat .pixi-version)" >> "$GITHUB_OUTPUT"
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
-        with:
-          pixi-version: v${{ steps.pixi-version.outputs.version }}
-          run-install: false
+      - uses: ./.github/actions/setup-pixi
       - name: Update lockfiles
         run: |
           set -o pipefail


### PR DESCRIPTION
Rather than repeating the same 2 steps in several different places, pull the pixi setup into a reusable action. This allow for more central maintenance of the functionality. When `run-install: false`, supplying `frozen: true` is an error so the `run-install` parameter is copied over.

Refs #39497

### To test:

All github-actions should continue to work. Verify that the setup-pixi step for the various github jobs did what is expected. Examples:
**copilot-setup-steps:**
```
Run prefix-dev/setup-pixi@v0.9.5
  with:
    pixi-version: v0.60.0
    run-install: true
    frozen: true
    activate-environment: true
```
**build-and-test** linux:
```
Run prefix-dev/setup-pixi@v0.9.5
  with:
    pixi-version: v0.60.0
    run-install: false
    frozen: false
    activate-environment: false
```


*This does not require release notes* because it is a change to CI.

**References:**
* [setup-pixi on self hosted runners](https://github.com/prefix-dev/setup-pixi#self-hosted-runners)

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
