### PR TITLE
Skip gh-action builds when nothing has changed

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,20 +1,29 @@
+# extensions associated with c++
 cpp: &files_cpp
  - '**/*.cxx'
  - '**/*.cpp'
  - '**/*.h'
  - '**/*.hxx'
  - '**/*.tcc'
+# extensions associated with python
 py: &files_py
  - '**/*.py'
+# extensions associated with python
 configuration: &files_config
- - 'Framework/**'
  - CMakePresets.json
+ - 'buildconfig/CMake/**'
  - .pixi-version
  - pixi.lock
  - pixi.toml
  - pyproject.toml
  - setup.py
+# files that affect CI
+workflows: &files_workflow
+ - 'buildconfig/Jenkins/**'
+ - '.github/**'
+### filters used in individual jobs and steps
 doxygen:
+ - *files_config
  - *files_cpp
  - 'Framework/Doxygen/**'
  - 'conda/recipes/mantid-developer/**'
@@ -24,6 +33,7 @@ doxygen:
  - '.github/workflows/doxygen-publish.yml'
  - 'pixi.toml'
 devsite:
+ - *files_config
  - 'dev-docs/**'
  - 'conda/recipes/mantid-developer/**'
  - 'conda/recipes/conda_build_config.yaml'
@@ -35,12 +45,8 @@ code_changes:
  - *files_cpp
  - *files_py
  - *files_config
- - 'buildconfig/**'
- - '.github/**'
- # not conda
- # not docs
- # not images
- # not installers
+ - *files_workflow
+ - 'Framework/**'
  - 'instrument/**'
  - 'qt/**'
  - 'scripts/**'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,8 +1,21 @@
-cpp:
+cpp: &files_cpp
+ - '**/*.cxx'
  - '**/*.cpp'
  - '**/*.h'
  - '**/*.hxx'
+ - '**/*.tcc'
+py: &files_py
+ - '**/*.py'
+configuration: &files_config
+ - 'Framework/**'
+ - CMakePresets.json
+ - .pixi-version
+ - pixi.lock
+ - pixi.toml
+ - pyproject.toml
+ - setup.py
 doxygen:
+ - *files_cpp
  - 'Framework/Doxygen/**'
  - 'conda/recipes/mantid-developer/**'
  - 'conda/recipes/conda_build_config.yaml'
@@ -18,3 +31,17 @@ devsite:
  - '.github/actions/devsite-build/**'
  - '.github/workflows/devdocs-publish.yml'
  - 'pixi.toml'
+code_changes:
+ - *files_cpp
+ - *files_py
+ - *files_config
+ - 'buildconfig/**'
+ - '.github/**'
+ # not conda
+ # not docs
+ # not images
+ # not installers
+ - 'instrument/**'
+ - 'qt/**'
+ - 'scripts/**'
+ - 'tools/**'

--- a/.github/workflows/doxygen-publish.yml
+++ b/.github/workflows/doxygen-publish.yml
@@ -25,15 +25,15 @@ jobs:
           filters: .github/filters.yaml
 
       - uses: ./.github/actions/setup-pixi
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
 
       - uses: ./.github/actions/doxygen-build
         name: build doxygen
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
 
       # publish documentation if on main branch of mantidproject/mantid
       - name: Checkout Doxygen repository
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         uses: actions/checkout@v6
         with:
           repository: mantidproject/doxygen
@@ -41,13 +41,13 @@ jobs:
           token: ${{ secrets.DOXYGEN_REPO_TOKEN }}
 
       - name: Copy Doxygen artifacts
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         run: |
           rm -rf doxygen_repo/* # delete old version of the repository
           cp -r $GITHUB_WORKSPACE/build/doxygen/html/* doxygen_repo/
 
       - name: Commit Doxygen and push
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
         working-directory: doxygen_repo
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -29,11 +29,11 @@ jobs:
           filters: .github/filters.yaml
 
       - uses: ./.github/actions/setup-pixi
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
 
       - uses: ./.github/actions/doxygen-build
         name: Build doxygen
-        if: ${{ steps.changes.outputs.doxygen == 'true' || steps.changes.outputs.cpp == 'true' }}
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
 
 
   build-and-test:
@@ -90,19 +90,27 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
       - name: Install pixi
         uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
 
       - name: Clean build tree
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         # supplying --clean-build or CLEAN_BUILD=true should be added here
         run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
 
       - name: Determine if a PR build
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.code_changes == 'true' }}
         # telling jenkins scripts this is a PR build
         run: echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
 
       - name: Build code
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         run: |
           echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
           cd ${GITHUB_WORKSPACE}
@@ -111,6 +119,7 @@ jobs:
           echo "::remove-matcher owner=gcc-problem-matcher::"
 
       - name: Run unit tests
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         id: testunit
         run: |
           cd ${GITHUB_WORKSPACE}
@@ -137,7 +146,7 @@ jobs:
           files: build/Testing/*unittest.xml
 
       - name: Run system tests
-        if: matrix.os == 'Linux'
+        if: ${{ matrix.os == 'Linux' && steps.changes.outputs.code_changes == 'true' }}
         id: testsystem
         run: |
           cd ${GITHUB_WORKSPACE}


### PR DESCRIPTION
[dorny/paths-filter](https://github.com/dorny/paths-filter) docs suggest using yaml anchors to shorten the `filter.yaml`.

The main PR build and test, now only runs if there are changes in the main part of the code (e.g. don't worry about `dev-docs/` changing). The filter can be further refined, but this will create less builds.

Refs #39497

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
