### PR TITLE
Instrument View 2.0: Limit detector info shown

### DIFF
--- a/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/40989.rst
+++ b/docs/source/release/v6.16.0/Workbench/InstrumentViewer/New_features/40989.rst
@@ -1,0 +1,1 @@
+- Detector Info box now shows up at the bottom and is hidden when no detectors are selected or when too many detectors (more than 3) are selected. This should reduce the visual clutter on the GUI.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -46,6 +46,8 @@ class PeakPickingStatus(Enum):
 class FullInstrumentViewModel:
     """Model for the Instrument View Window. Will calculate detector positions, indices, and integrated counts that give the colours"""
 
+    MAX_DET_INFO_SHOWN = 3
+
     _sample_position = np.array([0, 0, 0])
     _source_position = np.array([0, 0, 0])
     _beam_axis = np.array([0, 0, 1])
@@ -372,16 +374,16 @@ class FullInstrumentViewModel:
         picked_spherical_positions = self._spherical_positions[self._detector_is_picked]
         picked_counts = self._counts[self._detector_is_picked]
 
-        picked_info = []
-        for i, ws_index in enumerate(picked_ws_indices):
-            ws_detector = self._workspace.getDetector(int(ws_index))
-            name = ws_detector.getName()
-            component_path = ws_detector.getFullName()
-            det_info = DetectorInfo(
-                name, picked_ids[i], ws_index, picked_xyz_positions[i], picked_spherical_positions[i], component_path, int(picked_counts[i])
+        if len(picked_ws_indices) > self.MAX_DET_INFO_SHOWN:
+            return []
+
+        return [
+            DetectorInfo(det.getName(), det_id, ws_index, xyz, spherical, det.getFullName(), int(count))
+            for ws_index, det_id, xyz, spherical, count in zip(
+                picked_ws_indices, picked_ids, picked_xyz_positions, picked_spherical_positions, picked_counts
             )
-            picked_info.append(det_info)
-        return picked_info
+            for det in (self._workspace.getDetector(int(ws_index)),)
+        ]
 
     def get_default_projection_index_and_options(self) -> tuple[int, list[str]]:
         possible_returns_map = {

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -192,8 +192,8 @@ class FullInstrumentViewWindow(QMainWindow):
 
         pyvista_vertical_layout.addWidget(vsplitter)
 
-        detector_group_box = QGroupBox("Detector Info")
-        detector_info_layout = QVBoxLayout(detector_group_box)
+        self._detector_group_box = QGroupBox("Detector Info")
+        detector_info_layout = QVBoxLayout(self._detector_group_box)
         self._detector_name_edit = self._add_detector_info_boxes(detector_info_layout, "Name")
         self._detector_id_edit = self._add_detector_info_boxes(detector_info_layout, "Detector ID")
         self._detector_workspace_index_edit = self._add_detector_info_boxes(detector_info_layout, "Workspace Index")
@@ -359,7 +359,6 @@ class FullInstrumentViewWindow(QMainWindow):
 
         options_vertical_widget = QWidget()
         options_vertical_layout = QVBoxLayout(options_vertical_widget)
-        options_vertical_layout.addWidget(detector_group_box)
         options_vertical_layout.addWidget(self._integration_limit_group_box)
         options_vertical_layout.addWidget(self._contour_range_group_box)
         options_vertical_layout.addWidget(projection_group_box)
@@ -380,13 +379,25 @@ class FullInstrumentViewWindow(QMainWindow):
         lineplot_layout.addWidget(self._sum_spectra_checkbox)
 
         options_vertical_layout.addWidget(lineplot_group_box)
-        options_vertical_layout.addWidget(peak_ws_group_box)
-        options_vertical_layout.addWidget(grouping_masking_group_box)
-        options_vertical_layout.addWidget(QSplitter(Qt.Horizontal))
+
+        vsplitter = QSplitter(Qt.Vertical)
+        vsplitter.addWidget(peak_ws_group_box)
+        vsplitter.addWidget(grouping_masking_group_box)
+        vsplitter.addWidget(self._detector_group_box)
+        self._detector_group_box.setMaximumHeight(self._detector_group_box.sizeHint().height())
+        spacer = QWidget()
+        spacer.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        vsplitter.addWidget(spacer)
+        vsplitter.setStretchFactor(0, 1)  # peak_ws_group_box stretches
+        vsplitter.setStretchFactor(1, 1)  # grouping_masking_group_box stretches
+        vsplitter.setStretchFactor(2, 0)  # detector_group_box fixed
+        vsplitter.setStretchFactor(3, 1)  # spacer absorbs extra space
+        vsplitter.setChildrenCollapsible(False)
+
+        options_vertical_layout.addWidget(vsplitter)
 
         options_vertical_layout.addWidget(self.status_group_box)
         left_column_layout.addWidget(options_vertical_widget)
-        left_column_layout.addStretch()
 
         component_tree_tab = QWidget()
         component_layout = QVBoxLayout(component_tree_tab)
@@ -975,6 +986,7 @@ class FullInstrumentViewWindow(QMainWindow):
 
     def set_selected_detector_info(self, detector_infos: list[DetectorInfo]) -> None:
         """For a list of detectors, with their info wrapped up in a class, update all of the info text boxes"""
+        self._detector_group_box.setVisible(bool(detector_infos))
         self._set_detector_edit_text(self._detector_name_edit, detector_infos, lambda d: d.name)
         self._set_detector_edit_text(self._detector_id_edit, detector_infos, lambda d: str(d.detector_id))
         self._set_detector_edit_text(self._detector_workspace_index_edit, detector_infos, lambda d: str(d.workspace_index))

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -999,7 +999,7 @@ class FullInstrumentViewWindow(QMainWindow):
         self, edit_box: QTextEdit, detector_infos: list[DetectorInfo], property_lambda: Callable[[DetectorInfo], str]
     ) -> None:
         """Set the text in one of the detector info boxes"""
-        edit_box.setPlainText(",".join(property_lambda(d) for d in detector_infos))
+        edit_box.setPlainText("; ".join(property_lambda(d) for d in detector_infos))
 
     def selected_peaks_workspaces(self) -> list[str]:
         return [

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -148,6 +148,24 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         self.assertEqual(mock_args[5], "Full_2")
         self.assertEqual(mock_args[6], 30000)
 
+    def test_picked_detectors_info_text_exceeds_max_returns_empty(self):
+        model, mock_workspace = self._setup_model([1, 20, 300, 4000])
+        model._detector_is_picked = np.array([True, True, True, True])
+        result = model.picked_detectors_info_text()
+        self.assertEqual(result, [])
+        mock_workspace.getDetector.assert_not_called()
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.DetectorInfo")
+    def test_picked_detectors_info_text_at_max_returns_all(self, det_info_mock):
+        model, mock_workspace = self._setup_model([1, 20, 300])
+        mock_workspace.getDetector.side_effect = lambda i: MagicMock(
+            getName=mock.Mock(return_value=str(i)), getFullName=mock.Mock(return_value=f"Full_{i}")
+        )
+        model._detector_is_picked = np.array([True, True, True])
+        result = model.picked_detectors_info_text()
+        self.assertEqual(det_info_mock.call_count, 3)
+        self.assertEqual(len(result), 3)
+
     def test_negate_picked_visibility(self):
         model, _ = self._setup_model([1, 2, 3])
         model._detector_is_picked = np.array([False, False, False])

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -285,6 +285,22 @@ class TestFullInstrumentViewWindow(unittest.TestCase):
         self._view.set_delete_all_selected_peaks_button_enabled(False)
         self._view._delete_all_selected_peaks_button.setEnabled.assert_called_once_with(False)
 
+    def test_set_detector_edit_text_joins_with_semicolon_separator(self):
+        mock_edit = MagicMock()
+        det_1 = MagicMock()
+        det_1.detector_id = 1
+        det_2 = MagicMock()
+        det_2.detector_id = 2
+        self._view._set_detector_edit_text(mock_edit, [det_1, det_2], lambda d: str(d.detector_id))
+        mock_edit.setPlainText.assert_called_once_with("1; 2")
+
+    def test_set_detector_edit_text_single_item_no_separator(self):
+        mock_edit = MagicMock()
+        det = MagicMock()
+        det.detector_id = 42
+        self._view._set_detector_edit_text(mock_edit, [det], lambda d: str(d.detector_id))
+        mock_edit.setPlainText.assert_called_once_with("42")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Very small PR to limit the number of detectors shown to 3, since detector information is not useful when many detectors are selected. 

Closes #40989 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Select multiple detectors and check that for more than 3 picked detectors no information is shown.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
