### PR TITLE
Added the functionality to allow the user to supply CustomStepSizes for the derivatives for more control over fitting

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -625,7 +625,7 @@ public:
   /// Calculate numerical derivatives
   void calNumericalDeriv(const FunctionDomain &domain, Jacobian &jacobian);
   /// Calculate step size for the given parameter value
-  [[nodiscard]] double calculateStepSize(const double parameterValue) const;
+  [[nodiscard]] double calculateStepSize(size_t parameterIndex, double parameterValue) const;
   /// Set the covariance matrix
   void setCovarianceMatrix(const std::shared_ptr<Kernel::Matrix<double>> &covar);
   /// Get the covariance matrix
@@ -660,9 +660,12 @@ public:
   /// Describes the method in which the step size will be calculated:
   /// DEFAULT: Uses the traditional Mantid method of calculating the step size.
   /// SQRT_EPSILON: Uses the square root of epsilon to calculate the step size.
-  enum class StepSizeMethod { DEFAULT, SQRT_EPSILON };
+  /// CUSTOM: Uses the custom step sizes provided by the user.
+  enum class StepSizeMethod { DEFAULT, SQRT_EPSILON, CUSTOM };
   /// Sets the StepSizeMethod to use when calculation the step size
   virtual void setStepSizeMethod(const StepSizeMethod method);
+  /// Sets the custom step sizes
+  void setCustomStepSizes(const std::vector<double> &stepSizes);
 
 protected:
   /// Function initialization. Declare function parameters in this method.
@@ -730,7 +733,9 @@ private:
   /// whether the function usage has been registered
   bool m_isRegistered{false};
   /// The function used to calculate the step size
-  std::function<double(const double)> m_stepSizeFunction;
+  std::function<double(size_t, double)> m_stepSizeFunction;
+  /// The custom step sizes for the derivative
+  std::vector<double> m_stepSizes;
 
   // Creates and processes a single tie, handling constant expressions and validation
   std::unique_ptr<ParameterTie> createAndProcessTie(const std::string &parName, const std::string &expr,

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -733,7 +733,7 @@ private:
   /// whether the function usage has been registered
   bool m_isRegistered{false};
   /// The method used to calculate the step size
-  StepSizeMethod m_stepSizeMethod;
+  StepSizeMethod m_stepSizeMethod{StepSizeMethod::DEFAULT};
   /// The custom step sizes for the derivative
   std::vector<double> m_stepSizes;
 

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -732,8 +732,8 @@ private:
   std::vector<ParameterTie *> m_orderedTies;
   /// whether the function usage has been registered
   bool m_isRegistered{false};
-  /// The function used to calculate the step size
-  std::function<double(size_t, double)> m_stepSizeFunction;
+  /// The method used to calculate the step size
+  StepSizeMethod m_stepSizeMethod;
   /// The custom step sizes for the derivative
   std::vector<double> m_stepSizes;
 

--- a/Framework/API/inc/MantidAPI/IFunction1D.hxx
+++ b/Framework/API/inc/MantidAPI/IFunction1D.hxx
@@ -36,7 +36,7 @@ void IFunction1D::calcNumericalDerivative1D(Jacobian *jacobian, EvaluationMethod
   for (size_t iP = 0; iP < nParam; iP++) {
     if (isActive(iP)) {
       const double val = activeParameter(iP);
-      step = calculateStepSize(val);
+      step = calculateStepSize(iP, val);
 
       const double paramPstep = val + step;
       setActiveParameter(iP, paramPstep);

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -47,12 +47,14 @@ constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 constexpr double MIN_DOUBLE = std::numeric_limits<double>::min();
 constexpr double STEP_PERCENTAGE = 0.001;
 
-const auto defaultStepSize = [](const double parameterValue) -> double {
+const auto defaultStepSize = [](size_t index, const double parameterValue) -> double {
+  UNUSED_ARG(index);
   return fabs(parameterValue) < 100.0 * MIN_DOUBLE / STEP_PERCENTAGE ? 100.0 * EPSILON
                                                                      : parameterValue * STEP_PERCENTAGE;
 };
 
-const auto sqrtEpsilonStepSize = [](const double parameterValue) -> double {
+const auto sqrtEpsilonStepSize = [](size_t index, const double parameterValue) -> double {
+  UNUSED_ARG(index);
   return fabs(parameterValue) < 1 ? sqrt(EPSILON) : parameterValue * sqrt(EPSILON);
 };
 
@@ -124,6 +126,12 @@ void IFunction::setProgressReporter(std::shared_ptr<Kernel::ProgressBase> report
   m_progReporter = std::move(reporter);
   m_progReporter->setNotifyStep(0.01);
 }
+
+/**
+ * Saves the CustomStepSizes
+ * @param stepSizes :: A reference to the stepSizes vector
+ */
+void IFunction::setCustomStepSizes(const std::vector<double> &stepSizes) { m_stepSizes = stepSizes; }
 
 /**
  * If a reporter object is set, reports progress with an optional message
@@ -1128,7 +1136,7 @@ void IFunction::calNumericalDeriv(const FunctionDomain &domain, Jacobian &jacobi
   for (size_t iP = 0; iP < nParam; iP++) {
     if (isActive(iP)) {
       const double val = activeParameter(iP);
-      step = calculateStepSize(val);
+      step = calculateStepSize(iP, val);
 
       const double paramPstep = val + step;
       setActiveParameter(iP, paramPstep);
@@ -1146,10 +1154,13 @@ void IFunction::calNumericalDeriv(const FunctionDomain &domain, Jacobian &jacobi
 }
 
 /** Calculates the step size to use when calculating the numerical derivative.
+ * @param parameterIndex :: The parameter index.
  * @param parameterValue :: The value of the active parameter.
  * @returns The step size to use when calculating the numerical derivative.
  */
-double IFunction::calculateStepSize(const double parameterValue) const { return m_stepSizeFunction(parameterValue); }
+double IFunction::calculateStepSize(const size_t parameterIndex, const double parameterValue) const {
+  return m_stepSizeFunction(parameterIndex, parameterValue);
+}
 
 /** Sets the function to use when calculating the step size.
  * @param method :: An enum indicating which method to use when calculating the step size.
@@ -1161,6 +1172,12 @@ void IFunction::setStepSizeMethod(const StepSizeMethod method) {
     return;
   case StepSizeMethod::SQRT_EPSILON:
     m_stepSizeFunction = sqrtEpsilonStepSize;
+    return;
+  case StepSizeMethod::CUSTOM:
+    m_stepSizeFunction = [this](size_t index, double parameterValue) -> double {
+      UNUSED_ARG(parameterValue);
+      return m_stepSizes.at(index);
+    };
     return;
   }
   throw std::invalid_argument("An invalid method for calculating the step size was provided.");

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -83,8 +83,7 @@ const std::vector<std::string> EXCLUDEUSAGE = {"CompositeFunction"};
 /**
  * Constructor
  */
-IFunction ::IFunction()
-    : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0), m_stepSizeMethod(StepSizeMethod::DEFAULT) {}
+IFunction ::IFunction() : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0) {}
 
 /**
  * Destructor

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -47,14 +47,12 @@ constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 constexpr double MIN_DOUBLE = std::numeric_limits<double>::min();
 constexpr double STEP_PERCENTAGE = 0.001;
 
-const auto defaultStepSize = [](size_t index, const double parameterValue) -> double {
-  UNUSED_ARG(index);
+const auto defaultStepSize = [](const double parameterValue) -> double {
   return fabs(parameterValue) < 100.0 * MIN_DOUBLE / STEP_PERCENTAGE ? 100.0 * EPSILON
                                                                      : parameterValue * STEP_PERCENTAGE;
 };
 
-const auto sqrtEpsilonStepSize = [](size_t index, const double parameterValue) -> double {
-  UNUSED_ARG(index);
+const auto sqrtEpsilonStepSize = [](const double parameterValue) -> double {
   return fabs(parameterValue) < 1 ? sqrt(EPSILON) : parameterValue * sqrt(EPSILON);
 };
 
@@ -86,7 +84,7 @@ const std::vector<std::string> EXCLUDEUSAGE = {"CompositeFunction"};
  * Constructor
  */
 IFunction ::IFunction()
-    : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0), m_stepSizeFunction(defaultStepSize) {}
+    : m_isParallel(false), m_handler(nullptr), m_chiSquared(0.0), m_stepSizeMethod(StepSizeMethod::DEFAULT) {}
 
 /**
  * Destructor
@@ -1159,29 +1157,21 @@ void IFunction::calNumericalDeriv(const FunctionDomain &domain, Jacobian &jacobi
  * @returns The step size to use when calculating the numerical derivative.
  */
 double IFunction::calculateStepSize(const size_t parameterIndex, const double parameterValue) const {
-  return m_stepSizeFunction(parameterIndex, parameterValue);
+  switch (m_stepSizeMethod) {
+  case StepSizeMethod::DEFAULT:
+    return defaultStepSize(parameterValue);
+  case StepSizeMethod::SQRT_EPSILON:
+    return sqrtEpsilonStepSize(parameterValue);
+  case StepSizeMethod::CUSTOM:
+    return m_stepSizes.at(parameterIndex);
+  }
+  throw std::invalid_argument("An invalid method for calculating the step size was provided.");
 }
 
 /** Sets the function to use when calculating the step size.
  * @param method :: An enum indicating which method to use when calculating the step size.
  */
-void IFunction::setStepSizeMethod(const StepSizeMethod method) {
-  switch (method) {
-  case StepSizeMethod::DEFAULT:
-    m_stepSizeFunction = defaultStepSize;
-    return;
-  case StepSizeMethod::SQRT_EPSILON:
-    m_stepSizeFunction = sqrtEpsilonStepSize;
-    return;
-  case StepSizeMethod::CUSTOM:
-    m_stepSizeFunction = [this](size_t index, double parameterValue) -> double {
-      UNUSED_ARG(parameterValue);
-      return m_stepSizes.at(index);
-    };
-    return;
-  }
-  throw std::invalid_argument("An invalid method for calculating the step size was provided.");
-}
+void IFunction::setStepSizeMethod(const StepSizeMethod method) { m_stepSizeMethod = method; }
 
 /** Initialize the function providing it the workspace
  * @param workspace :: The workspace to set

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1467,10 +1467,11 @@ public:
     auto composite = createComposite();
 
     const double parameterValue = 0.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue),
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue),
                      std::numeric_limits<double>::epsilon() * 100);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue),
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue),
                      std::numeric_limits<double>::epsilon() * 100);
   }
 
@@ -1479,12 +1480,13 @@ public:
 
     const double parameterValue1 = 100.0 * std::numeric_limits<double>::min();
     const double parameterValue2 = -100.0 * std::numeric_limits<double>::min();
+    const size_t parameter_ix = 0;
 
     const double expectedStep = std::numeric_limits<double>::epsilon() * 100;
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue2), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue2), expectedStep);
   }
 
   void test_default_calculation_of_step_size_with_larger_parameter_values() {
@@ -1492,11 +1494,16 @@ public:
 
     const double parameterValue1 = 5.0;
     const double parameterValue2 = -5.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue1), parameterValue1 * 0.001);
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue2), parameterValue2 * 0.001);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue1), parameterValue1 * 0.001);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue2), parameterValue2 * 0.001);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue1),
+                     parameterValue1 * 0.001);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue2),
+                     parameterValue2 * 0.001);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue1),
+                     parameterValue1 * 0.001);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue2),
+                     parameterValue2 * 0.001);
   }
 
   void test_sqrt_epsilon_calculation_of_step_size_with_zero_parameter_value() {
@@ -1505,10 +1512,11 @@ public:
     composite->setStepSizeMethod(IFunction::StepSizeMethod::SQRT_EPSILON);
 
     const double parameterValue = 0.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue),
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue),
                      sqrt(std::numeric_limits<double>::epsilon()));
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue),
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue),
                      sqrt(std::numeric_limits<double>::epsilon()));
   }
 
@@ -1519,12 +1527,13 @@ public:
 
     const double parameterValue1 = 0.9;
     const double parameterValue2 = -0.9;
+    const size_t parameter_ix = 0;
 
     const double expectedStep = sqrt(std::numeric_limits<double>::epsilon());
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue2), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue2), expectedStep);
   }
 
   void test_sqrt_epsilon_calculation_of_step_size_with_large_parameter_values() {
@@ -1534,12 +1543,17 @@ public:
 
     const double parameterValue1 = 1.1;
     const double parameterValue2 = -1.1;
+    const size_t parameter_ix = 0;
 
     const double sqrtEpsilon = sqrt(std::numeric_limits<double>::epsilon());
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue1), parameterValue1 * sqrtEpsilon);
-    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue2), parameterValue2 * sqrtEpsilon);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue1), parameterValue1 * sqrtEpsilon);
-    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue2), parameterValue2 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue1),
+                     parameterValue1 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameter_ix, parameterValue2),
+                     parameterValue2 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue1),
+                     parameterValue1 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameter_ix, parameterValue2),
+                     parameterValue2 * sqrtEpsilon);
   }
 
   void test_getNumberDomains_throws_with_inconsistent_domain_numbers() {

--- a/Framework/API/test/IFunctionTest.h
+++ b/Framework/API/test/IFunctionTest.h
@@ -241,8 +241,9 @@ public:
     MockFunction fun;
 
     const double parameterValue = 0.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue), std::numeric_limits<double>::epsilon() * 100);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue), std::numeric_limits<double>::epsilon() * 100);
   }
 
   void test_default_calculation_of_step_size_with_small_parameter_values() {
@@ -250,10 +251,11 @@ public:
 
     const double parameterValue1 = 100.0 * std::numeric_limits<double>::min();
     const double parameterValue2 = -100.0 * std::numeric_limits<double>::min();
+    const size_t parameter_ix = 0;
 
     const double expectedStep = std::numeric_limits<double>::epsilon() * 100;
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue2), expectedStep);
   }
 
   void test_default_calculation_of_step_size_with_larger_parameter_values() {
@@ -261,9 +263,10 @@ public:
 
     const double parameterValue1 = 5.0;
     const double parameterValue2 = -5.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue1), parameterValue1 * 0.001);
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue2), parameterValue2 * 0.001);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue1), parameterValue1 * 0.001);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue2), parameterValue2 * 0.001);
   }
 
   void test_sqrt_epsilon_calculation_of_step_size_with_zero_parameter_value() {
@@ -271,8 +274,9 @@ public:
     fun.setStepSizeMethod(MockFunction::StepSizeMethod::SQRT_EPSILON);
 
     const double parameterValue = 0.0;
+    const size_t parameter_ix = 0;
 
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue), sqrt(std::numeric_limits<double>::epsilon()));
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue), sqrt(std::numeric_limits<double>::epsilon()));
   }
 
   void test_sqrt_epsilon_calculation_of_step_size_with_small_parameter_values() {
@@ -281,10 +285,11 @@ public:
 
     const double parameterValue1 = 0.9;
     const double parameterValue2 = -0.9;
+    const size_t parameter_ix = 0;
 
     const double expectedStep = sqrt(std::numeric_limits<double>::epsilon());
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue1), expectedStep);
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue2), expectedStep);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue1), expectedStep);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue2), expectedStep);
   }
 
   void test_sqrt_epsilon_calculation_of_step_size_with_large_parameter_values() {
@@ -293,9 +298,10 @@ public:
 
     const double parameterValue1 = 1.1;
     const double parameterValue2 = -1.1;
+    const size_t parameter_ix = 0;
 
     const double sqrtEpsilon = sqrt(std::numeric_limits<double>::epsilon());
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue1), parameterValue1 * sqrtEpsilon);
-    TS_ASSERT_EQUALS(fun.calculateStepSize(parameterValue2), parameterValue2 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue1), parameterValue1 * sqrtEpsilon);
+    TS_ASSERT_EQUALS(fun.calculateStepSize(parameter_ix, parameterValue2), parameterValue2 * sqrtEpsilon);
   }
 };

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -1312,18 +1312,18 @@ void FindPeaks::addInfoRow(const size_t spectrum, const API::IPeakFunction_const
   // peak and background function parameters
   if (isoutputraw) {
     // Output of raw peak parameters
-    size_t nparams = peakfunction->nParams();
-    size_t nparamsb = bkgdfunction->nParams();
+    size_t nParams = peakfunction->nParams();
+    size_t nParamsb = bkgdfunction->nParams();
 
     size_t numcols = m_outPeakTableWS->columnCount();
-    if (nparams + nparamsb + 2 != numcols) {
+    if (nParams + nParamsb + 2 != numcols) {
       throw std::runtime_error("Error 1307 number of columns do not matches");
     }
 
-    for (size_t i = 0; i < nparams; ++i) {
+    for (size_t i = 0; i < nParams; ++i) {
       t << peakfunction->getParameter(i);
     }
-    for (size_t i = 0; i < nparamsb; ++i) {
+    for (size_t i = 0; i < nParamsb; ++i) {
       t << bkgdfunction->getParameter(i);
     }
   } else {

--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -368,6 +368,7 @@ set(INC_FILES
     inc/MantidCurveFitting/SeqDomain.h
     inc/MantidCurveFitting/SeqDomainSpectrumCreator.h
     inc/MantidCurveFitting/SpecialFunctionSupport.h
+    inc/MantidCurveFitting/StepSizeConstants.h
     inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
 )
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/StepSizeConstants.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/StepSizeConstants.h
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#include <string>
+
+namespace Mantid {
+namespace CurveFitting {
+
+inline const std::string DEFAULT_STEP_SIZE = "Default";
+inline const std::string SQRT_EPSILON_STEP_SIZE = "Sqrt epsilon";
+inline const std::string CUSTOM_STEP_SIZE = "Custom";
+
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -91,6 +91,7 @@ void Fit::initConcrete() {
                   "workspace(s) with the calculated values\n"
                   "(default is false, ignored if CreateOutput is false and "
                   "Output is an empty string).");
+  declareProperty("CustomStepSizes", std::vector<double>{}, "Custom step sizes for numerical derivatives.");
 }
 
 std::map<std::string, std::string> Fit::validateInputs() {
@@ -112,6 +113,15 @@ std::map<std::string, std::string> Fit::validateInputs() {
     }
   }
 
+  const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
+  const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
+  if (stepSizeMethod == "Custom" && customStepSizes.empty()) {
+    issues["CustomStepSizes"] = "CustomStepSizes must be provided when StepSizeMethod is set to Custom.";
+  }
+  if (stepSizeMethod != "Custom" && !customStepSizes.empty()) {
+    issues["CustomStepSizes"] = "CustomStepSizes can only be provided when StepSizeMethod is set to Custom.";
+  }
+
   return issues;
 }
 
@@ -130,6 +140,12 @@ void Fit::readProperties() {
   // Try to retrieve optional properties
   int intMaxIterations = getProperty("MaxIterations");
   m_maxIterations = static_cast<size_t>(intMaxIterations);
+
+  const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
+  if (stepSizeMethod == "Custom") {
+    const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
+    m_function->setCustomStepSizes(customStepSizes);
+  }
 }
 
 /// Initialize the minimizer for this fit.

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -144,6 +144,12 @@ void Fit::readProperties() {
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   if (stepSizeMethod == "Custom") {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
+    size_t np = m_function->nParams();
+    if (customStepSizes.size() != np) {
+      g_log.error()
+          << "The 'CustomStepSizes' list must be the same lenght as the number of parameters. The list should contain "
+          << np << " values.\n";
+    }
     m_function->setCustomStepSizes(customStepSizes);
   }
 }

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -9,6 +9,7 @@
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/Algorithms/Fit.h"
 #include "MantidCurveFitting/CostFunctions/CostFuncFitting.h"
+#include "MantidCurveFitting/StepSizeConstants.h"
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/Expression.h"
@@ -118,10 +119,10 @@ std::map<std::string, std::string> Fit::validateInputs() {
 
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
-  if (stepSizeMethod == "Custom" && customStepSizes.empty()) {
+  if (stepSizeMethod == Mantid::CurveFitting::CUSTOM_STEP_SIZE && customStepSizes.empty()) {
     issues["CustomStepSizes"] = "CustomStepSizes must be provided when StepSizeMethod is set to Custom.";
   }
-  if (stepSizeMethod != "Custom" && !customStepSizes.empty()) {
+  if (stepSizeMethod != Mantid::CurveFitting::CUSTOM_STEP_SIZE && !customStepSizes.empty()) {
     issues["CustomStepSizes"] = "CustomStepSizes can only be provided when StepSizeMethod is set to Custom.";
   }
 
@@ -145,7 +146,7 @@ void Fit::readProperties() {
   m_maxIterations = static_cast<size_t>(intMaxIterations);
 
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
-  if (stepSizeMethod == "Custom") {
+  if (stepSizeMethod == Mantid::CurveFitting::CUSTOM_STEP_SIZE) {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
     const size_t nParams = m_function->nParams();
     if (customStepSizes.size() != nParams) {

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -144,13 +144,17 @@ void Fit::readProperties() {
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   if (stepSizeMethod == "Custom") {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
-    size_t nparams = m_function->nParams();
+    const size_t nparams = m_function->nParams();
     if (customStepSizes.size() != nparams) {
       g_log.error()
           << "The 'CustomStepSizes' list must be the same lenght as the number of parameters. The list should contain "
           << nparams << " values.\n";
     }
     m_function->setCustomStepSizes(customStepSizes);
+    for (size_t i = 0; i < nparams; i++) {
+      g_log.debug() << "The step size of " << m_function->parameterName(i) << " has been set to " << customStepSizes[i]
+                    << "\n";
+    }
   }
 }
 

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -147,14 +147,14 @@ void Fit::readProperties() {
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   if (stepSizeMethod == "Custom") {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
-    const size_t nparams = m_function->nParams();
-    if (customStepSizes.size() != nparams) {
+    const size_t nParams = m_function->nParams();
+    if (customStepSizes.size() != nParams) {
       g_log.error()
           << "The 'CustomStepSizes' list must be the same length as the number of parameters. The list should contain "
-          << nparams << " values.\n";
+          << nParams << " values.\n";
     }
     m_function->setCustomStepSizes(customStepSizes);
-    for (size_t i = 0; i < nparams; i++) {
+    for (size_t i = 0; i < nParams; i++) {
       g_log.debug() << "The step size of " << m_function->parameterName(i) << " has been set to " << customStepSizes[i]
                     << "\n";
     }
@@ -324,15 +324,15 @@ void Fit::createOutput() {
       }
     }
 
-    size_t nparams = m_function->nParams();
+    size_t nParams = m_function->nParams();
     size_t ia = 0;
-    for (size_t i = 0; i < nparams; i++) {
+    for (size_t i = 0; i < nParams; i++) {
       if (!m_function->isActive(i))
         continue;
       Mantid::API::TableRow row = covariance->appendRow();
       row << m_function->parameterName(i);
       size_t ja = 0;
-      for (size_t j = 0; j < nparams; j++) {
+      for (size_t j = 0; j < nParams; j++) {
         if (!m_function->isActive(j))
           continue;
         if (j == i)

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -144,11 +144,11 @@ void Fit::readProperties() {
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   if (stepSizeMethod == "Custom") {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
-    size_t np = m_function->nParams();
-    if (customStepSizes.size() != np) {
+    size_t nparams = m_function->nParams();
+    if (customStepSizes.size() != nparams) {
       g_log.error()
           << "The 'CustomStepSizes' list must be the same lenght as the number of parameters. The list should contain "
-          << np << " values.\n";
+          << nparams << " values.\n";
     }
     m_function->setCustomStepSizes(customStepSizes);
   }
@@ -317,15 +317,15 @@ void Fit::createOutput() {
       }
     }
 
-    size_t np = m_function->nParams();
+    size_t nparams = m_function->nParams();
     size_t ia = 0;
-    for (size_t i = 0; i < np; i++) {
+    for (size_t i = 0; i < nparams; i++) {
       if (!m_function->isActive(i))
         continue;
       Mantid::API::TableRow row = covariance->appendRow();
       row << m_function->parameterName(i);
       size_t ja = 0;
-      for (size_t j = 0; j < np; j++) {
+      for (size_t j = 0; j < nparams; j++) {
         if (!m_function->isActive(j))
           continue;
         if (j == i)

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -20,6 +20,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 
 #include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/StartsWithValidator.h"
 #include "MantidKernel/UsageService.h"
@@ -92,6 +93,8 @@ void Fit::initConcrete() {
                   "(default is false, ignored if CreateOutput is false and "
                   "Output is an empty string).");
   declareProperty("CustomStepSizes", std::vector<double>{}, "Custom step sizes for numerical derivatives.");
+  setPropertySettings("CustomStepSizes", std::make_unique<Kernel::EnabledWhenProperty>(
+                                             "StepSizeMethod", Kernel::ePropertyCriterion::IS_EQUAL_TO, "Custom"));
 }
 
 std::map<std::string, std::string> Fit::validateInputs() {
@@ -147,7 +150,7 @@ void Fit::readProperties() {
     const size_t nparams = m_function->nParams();
     if (customStepSizes.size() != nparams) {
       g_log.error()
-          << "The 'CustomStepSizes' list must be the same lenght as the number of parameters. The list should contain "
+          << "The 'CustomStepSizes' list must be the same length as the number of parameters. The list should contain "
           << nparams << " values.\n";
     }
     m_function->setCustomStepSizes(customStepSizes);

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -149,9 +149,9 @@ void Fit::readProperties() {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
     const size_t nParams = m_function->nParams();
     if (customStepSizes.size() != nParams) {
-      g_log.error()
-          << "The 'CustomStepSizes' list must be the same length as the number of parameters. The list should contain "
-          << nParams << " values.\n";
+      throw std::invalid_argument(
+          "The 'CustomStepSizes' list must be the same length as the number of parameters. The list should contain " +
+          std::to_string(nParams) + " values.\n");
     }
     m_function->setCustomStepSizes(customStepSizes);
     for (size_t i = 0; i < nParams; i++) {

--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -94,8 +94,9 @@ void Fit::initConcrete() {
                   "(default is false, ignored if CreateOutput is false and "
                   "Output is an empty string).");
   declareProperty("CustomStepSizes", std::vector<double>{}, "Custom step sizes for numerical derivatives.");
-  setPropertySettings("CustomStepSizes", std::make_unique<Kernel::EnabledWhenProperty>(
-                                             "StepSizeMethod", Kernel::ePropertyCriterion::IS_EQUAL_TO, "Custom"));
+  setPropertySettings("CustomStepSizes",
+                      std::make_unique<Kernel::EnabledWhenProperty>(
+                          "StepSizeMethod", Kernel::ePropertyCriterion::IS_EQUAL_TO, CUSTOM_STEP_SIZE));
 }
 
 std::map<std::string, std::string> Fit::validateInputs() {
@@ -119,10 +120,10 @@ std::map<std::string, std::string> Fit::validateInputs() {
 
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
   const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
-  if (stepSizeMethod == Mantid::CurveFitting::CUSTOM_STEP_SIZE && customStepSizes.empty()) {
+  if (stepSizeMethod == CUSTOM_STEP_SIZE && customStepSizes.empty()) {
     issues["CustomStepSizes"] = "CustomStepSizes must be provided when StepSizeMethod is set to Custom.";
   }
-  if (stepSizeMethod != Mantid::CurveFitting::CUSTOM_STEP_SIZE && !customStepSizes.empty()) {
+  if (stepSizeMethod != CUSTOM_STEP_SIZE && !customStepSizes.empty()) {
     issues["CustomStepSizes"] = "CustomStepSizes can only be provided when StepSizeMethod is set to Custom.";
   }
 
@@ -146,7 +147,7 @@ void Fit::readProperties() {
   m_maxIterations = static_cast<size_t>(intMaxIterations);
 
   const std::string stepSizeMethod = getPropertyValue("StepSizeMethod");
-  if (stepSizeMethod == Mantid::CurveFitting::CUSTOM_STEP_SIZE) {
+  if (stepSizeMethod == CUSTOM_STEP_SIZE) {
     const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
     const size_t nParams = m_function->nParams();
     if (customStepSizes.size() != nParams) {

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
@@ -145,10 +145,10 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
   EigenMatrix c;
   calActiveCovarianceMatrix(c, epsrel);
 
-  size_t np = m_function->nParams();
+  size_t nparams = m_function->nParams();
 
   bool isTransformationIdentity = true;
-  for (size_t i = 0; i < np; ++i) {
+  for (size_t i = 0; i < nparams; ++i) {
     if (!m_function->isActive(i))
       continue;
     isTransformationIdentity =
@@ -174,16 +174,16 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
  */
 void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
   checkValidity();
-  size_t np = m_function->nParams();
-  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(np, np));
+  size_t nparams = m_function->nParams();
+  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(nparams, nparams));
   m_function->setCovarianceMatrix(covarMatrix);
   size_t ia = 0;
-  for (size_t i = 0; i < np; ++i) {
+  for (size_t i = 0; i < nparams; ++i) {
     if (!m_function->isActive(i)) {
       m_function->setError(i, 0);
     } else {
       size_t ja = 0;
-      for (size_t j = 0; j < np; ++j) {
+      for (size_t j = 0; j < nparams; ++j) {
         if (m_function->isActive(j)) {
           (*covarMatrix)[i][j] = covar.get(ia, ja);
           ++ja;
@@ -201,7 +201,7 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
     }
   }
   m_function->setCovarianceMatrix(covarMatrix);
-  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - np)));
+  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - nparams)));
 }
 
 /**
@@ -210,11 +210,11 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
  */
 void CostFuncFitting::calTransformationMatrixNumerically(EigenMatrix &tm) {
   const double epsilon = std::numeric_limits<double>::epsilon() * 100;
-  size_t np = m_function->nParams();
+  size_t nparams = m_function->nParams();
   size_t na = nParams();
   tm.resize(na, na);
   size_t ia = 0;
-  for (size_t i = 0; i < np; ++i) {
+  for (size_t i = 0; i < nparams; ++i) {
     if (!m_function->isActive(i))
       continue;
     double p0 = m_function->getParameter(i);
@@ -390,9 +390,9 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   }
 
   // Add constraints penalty
-  size_t np = m_function->nParams();
+  size_t nparams = m_function->nParams();
   if (m_includePenalty) {
-    for (size_t i = 0; i < np; ++i) {
+    for (size_t i = 0; i < nparams; ++i) {
       API::IConstraint *c = m_function->getConstraint(i);
       if (c) {
         m_value += c->check();
@@ -404,7 +404,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   if (evalDeriv) {
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < np; ++ip) {
+      for (size_t ip = 0; ip < nparams; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);
@@ -419,7 +419,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
 
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < np; ++ip) {
+      for (size_t ip = 0; ip < nparams; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
@@ -145,10 +145,10 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
   EigenMatrix c;
   calActiveCovarianceMatrix(c, epsrel);
 
-  size_t nParams = m_function->nParams();
+  const size_t numParams = m_function->nParams();
 
   bool isTransformationIdentity = true;
-  for (size_t i = 0; i < nParams; ++i) {
+  for (size_t i = 0; i < numParams; ++i) {
     if (!m_function->isActive(i))
       continue;
     isTransformationIdentity =
@@ -174,16 +174,16 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
  */
 void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
   checkValidity();
-  size_t nParams = m_function->nParams();
-  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(nParams, nParams));
+  const size_t numParams = m_function->nParams();
+  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(numParams, numParams));
   m_function->setCovarianceMatrix(covarMatrix);
   size_t ia = 0;
-  for (size_t i = 0; i < nParams; ++i) {
+  for (size_t i = 0; i < numParams; ++i) {
     if (!m_function->isActive(i)) {
       m_function->setError(i, 0);
     } else {
       size_t ja = 0;
-      for (size_t j = 0; j < nParams; ++j) {
+      for (size_t j = 0; j < numParams; ++j) {
         if (m_function->isActive(j)) {
           (*covarMatrix)[i][j] = covar.get(ia, ja);
           ++ja;
@@ -201,7 +201,7 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
     }
   }
   m_function->setCovarianceMatrix(covarMatrix);
-  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - nParams)));
+  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - numParams)));
 }
 
 /**
@@ -210,11 +210,11 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
  */
 void CostFuncFitting::calTransformationMatrixNumerically(EigenMatrix &tm) {
   const double epsilon = std::numeric_limits<double>::epsilon() * 100;
-  size_t nParams = m_function->nParams();
+  const size_t numParams = m_function->nParams();
   size_t na = CostFuncFitting::nParams();
   tm.resize(na, na);
   size_t ia = 0;
-  for (size_t i = 0; i < nParams; ++i) {
+  for (size_t i = 0; i < numParams; ++i) {
     if (!m_function->isActive(i))
       continue;
     double p0 = m_function->getParameter(i);
@@ -365,7 +365,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
     return m_value;
   }
 
-  const size_t numParams = nParams();
+  const size_t numParams = CostFuncFitting::nParams();
 
   checkValidity();
 
@@ -390,9 +390,9 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   }
 
   // Add constraints penalty
-  size_t nParams = m_function->nParams();
+  const size_t parameterCount = m_function->nParams();
   if (m_includePenalty) {
-    for (size_t i = 0; i < nParams; ++i) {
+    for (size_t i = 0; i < parameterCount; ++i) {
       API::IConstraint *c = m_function->getConstraint(i);
       if (c) {
         m_value += c->check();
@@ -404,7 +404,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   if (evalDeriv) {
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < nParams; ++ip) {
+      for (size_t ip = 0; ip < parameterCount; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);
@@ -419,7 +419,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
 
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < nParams; ++ip) {
+      for (size_t ip = 0; ip < parameterCount; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
@@ -145,10 +145,10 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
   EigenMatrix c;
   calActiveCovarianceMatrix(c, epsrel);
 
-  size_t nparams = m_function->nParams();
+  size_t nParams = m_function->nParams();
 
   bool isTransformationIdentity = true;
-  for (size_t i = 0; i < nparams; ++i) {
+  for (size_t i = 0; i < nParams; ++i) {
     if (!m_function->isActive(i))
       continue;
     isTransformationIdentity =
@@ -174,16 +174,16 @@ void CostFuncFitting::calCovarianceMatrix(EigenMatrix &covar, double epsrel) {
  */
 void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
   checkValidity();
-  size_t nparams = m_function->nParams();
-  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(nparams, nparams));
+  size_t nParams = m_function->nParams();
+  auto covarMatrix = std::shared_ptr<Kernel::Matrix<double>>(new Kernel::Matrix<double>(nParams, nParams));
   m_function->setCovarianceMatrix(covarMatrix);
   size_t ia = 0;
-  for (size_t i = 0; i < nparams; ++i) {
+  for (size_t i = 0; i < nParams; ++i) {
     if (!m_function->isActive(i)) {
       m_function->setError(i, 0);
     } else {
       size_t ja = 0;
-      for (size_t j = 0; j < nparams; ++j) {
+      for (size_t j = 0; j < nParams; ++j) {
         if (m_function->isActive(j)) {
           (*covarMatrix)[i][j] = covar.get(ia, ja);
           ++ja;
@@ -201,7 +201,7 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
     }
   }
   m_function->setCovarianceMatrix(covarMatrix);
-  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - nparams)));
+  m_function->setReducedChiSquared(chi2 / static_cast<double>((m_values->size() - nParams)));
 }
 
 /**
@@ -210,11 +210,11 @@ void CostFuncFitting::calFittingErrors(const EigenMatrix &covar, double chi2) {
  */
 void CostFuncFitting::calTransformationMatrixNumerically(EigenMatrix &tm) {
   const double epsilon = std::numeric_limits<double>::epsilon() * 100;
-  size_t nparams = m_function->nParams();
-  size_t na = nParams();
+  size_t nParams = m_function->nParams();
+  size_t na = CostFuncFitting::nParams();
   tm.resize(na, na);
   size_t ia = 0;
-  for (size_t i = 0; i < nparams; ++i) {
+  for (size_t i = 0; i < nParams; ++i) {
     if (!m_function->isActive(i))
       continue;
     double p0 = m_function->getParameter(i);
@@ -390,9 +390,9 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   }
 
   // Add constraints penalty
-  size_t nparams = m_function->nParams();
+  size_t nParams = m_function->nParams();
   if (m_includePenalty) {
-    for (size_t i = 0; i < nparams; ++i) {
+    for (size_t i = 0; i < nParams; ++i) {
       API::IConstraint *c = m_function->getConstraint(i);
       if (c) {
         m_value += c->check();
@@ -404,7 +404,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
   if (evalDeriv) {
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < nparams; ++ip) {
+      for (size_t ip = 0; ip < nParams; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);
@@ -419,7 +419,7 @@ double CostFuncFitting::valDerivHessian(bool evalDeriv, bool evalHessian) const 
 
     if (m_includePenalty) {
       size_t i = 0;
-      for (size_t ip = 0; ip < nparams; ++ip) {
+      for (size_t ip = 0; ip < nParams; ++ip) {
         if (!m_function->isActive(ip))
           continue;
         API::IConstraint *c = m_function->getConstraint(ip);

--- a/Framework/CurveFitting/src/Functions/ComptonScatteringCountRate.cpp
+++ b/Framework/CurveFitting/src/Functions/ComptonScatteringCountRate.cpp
@@ -147,10 +147,10 @@ void ComptonScatteringCountRate::iterationStarting() {
    *   Cx >= 0, where C is the same matrix of J(y) values above
    *   Ax = 0, where A is the intensity constraints supplied by the user
    */
-  const size_t nparams(m_cmatrix.numCols());
+  const size_t nParams(m_cmatrix.numCols());
 
   // Compute minimization with of Cx where the amplitudes are set to 1.0
-  std::vector<double> x0(nparams, 1);
+  std::vector<double> x0(nParams, 1);
   setFixedParameterValues(x0);
   // Compute the constraint matrix
   this->updateCMatrixValues();
@@ -159,13 +159,13 @@ void ComptonScatteringCountRate::iterationStarting() {
     BkgdNorm2 objf(m_cmatrix, m_dataErrorRatio);
     using namespace std::placeholders;
     AugmentedLagrangianOptimizer::ObjFunction objfunc = std::bind(&BkgdNorm2::eval, objf, _1, _2);
-    AugmentedLagrangianOptimizer lsqmin(nparams, objfunc, m_eqMatrix, m_cmatrix);
+    AugmentedLagrangianOptimizer lsqmin(nParams, objfunc, m_eqMatrix, m_cmatrix);
     lsqmin.minimize(x0);
     // Set the parameters for the 'real' function calls
     setFixedParameterValues(x0);
   } else {
     NoBkgdNorm2 objfunc(m_cmatrix, m_dataErrorRatio);
-    Kernel::Math::SLSQPMinimizer lsqmin(nparams, objfunc, m_eqMatrix, m_cmatrix);
+    Kernel::Math::SLSQPMinimizer lsqmin(nParams, objfunc, m_eqMatrix, m_cmatrix);
     auto res = lsqmin.minimize(x0);
     // Set the parameters for the 'real' function calls
     setFixedParameterValues(res);
@@ -179,14 +179,14 @@ void ComptonScatteringCountRate::iterationStarting() {
 void ComptonScatteringCountRate::setFixedParameterValues(const std::vector<double> &values) {
   assert(values.size() == m_fixedParamIndices.size());
 
-  const size_t nparams = values.size();
-  for (size_t i = 0; i < nparams; ++i) {
+  const size_t nParams = values.size();
+  for (size_t i = 0; i < nParams; ++i) {
     this->setParameter(m_fixedParamIndices[i], values[i], true);
   }
 
   if (g_log.is(Logger::Priority::PRIO_DEBUG)) {
     g_log.debug() << "--- New Intensity Parameters ---\n";
-    for (size_t i = 0; i < nparams; ++i) {
+    for (size_t i = 0; i < nParams; ++i) {
       g_log.debug() << "x_" << i << "=" << values[i] << "\n";
     }
   }

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -98,11 +98,11 @@ void IFittingAlgorithm::init() {
                   "centre of each bin. If it is \"Histogram\" then function is "
                   "integrated within the bin and the integrals returned.",
                   Kernel::Direction::Input);
-  const std::array<std::string, 2> stepSizes = {{"Default", "Sqrt epsilon"}};
+  const std::array<std::string, 3> stepSizes = {{"Default", "Sqrt epsilon", "Custom"}};
   declareProperty(
       "StepSizeMethod", "Default", Kernel::IValidator_sptr(new Kernel::ListValidator<std::string>(stepSizes)),
       "The way the step size is calculated for numerical derivatives. See the section about step sizes in the Fit "
-      "algorithm documentation to understand the difference between \"Default\" and \"Sqrt epsilon\".",
+      "algorithm documentation to understand the difference between \"Default\", \"Sqrt epsilon\" and \"Custom\".",
       Kernel::Direction::Input);
   declareProperty("PeakRadius", 0,
                   "A value of the peak radius the peak functions should use. A "
@@ -184,8 +184,15 @@ void IFittingAlgorithm::setFunction() {
 void IFittingAlgorithm::setStepSizeMethod() {
   if (m_function) {
     const std::string stepSizeMethod = getProperty("StepSizeMethod");
-    m_function->setStepSizeMethod(stepSizeMethod == "Sqrt epsilon" ? IFunction::StepSizeMethod::SQRT_EPSILON
-                                                                   : IFunction::StepSizeMethod::DEFAULT);
+    if (stepSizeMethod == "Sqrt epsilon") {
+      m_function->setStepSizeMethod(IFunction::StepSizeMethod::SQRT_EPSILON);
+    } else if (stepSizeMethod == "Custom") {
+      m_function->setStepSizeMethod(IFunction::StepSizeMethod::CUSTOM);
+      const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
+      m_function->setCustomStepSizes(customStepSizes);
+    } else {
+      m_function->setStepSizeMethod(IFunction::StepSizeMethod::DEFAULT);
+    }
   }
 }
 

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -13,6 +13,7 @@
 #include "MantidCurveFitting/LatticeDomainCreator.h"
 #include "MantidCurveFitting/MultiDomainCreator.h"
 #include "MantidCurveFitting/SeqDomainSpectrumCreator.h"
+#include "MantidCurveFitting/StepSizeConstants.h"
 #include "MantidCurveFitting/TableWorkspaceDomainCreator.h"
 
 #include "MantidAPI/CostFunctionFactory.h"
@@ -29,10 +30,6 @@ namespace Mantid::CurveFitting {
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
-
-const std::string DEFAULT_STEP_SIZE = "Default";
-const std::string SQRT_EPSILON_STEP_SIZE = "Sqrt epsilon";
-const std::string CUSTOM_STEP_SIZE = "Custom";
 
 //----------------------------------------------------------------------------------------------
 namespace {

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -30,6 +30,10 @@ namespace Mantid::CurveFitting {
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 
+const std::string DEFAULT_STEP_SIZE = "Default";
+const std::string SQRT_EPSILON_STEP_SIZE = "Sqrt epsilon";
+const std::string CUSTOM_STEP_SIZE = "Custom";
+
 //----------------------------------------------------------------------------------------------
 namespace {
 /// Create a domain creator for a particular function and workspace pair.
@@ -98,11 +102,12 @@ void IFittingAlgorithm::init() {
                   "centre of each bin. If it is \"Histogram\" then function is "
                   "integrated within the bin and the integrals returned.",
                   Kernel::Direction::Input);
-  const std::array<std::string, 3> stepSizes = {{"Default", "Sqrt epsilon", "Custom"}};
+  const std::array<std::string, 3> stepSizes = {{DEFAULT_STEP_SIZE, SQRT_EPSILON_STEP_SIZE, CUSTOM_STEP_SIZE}};
   declareProperty(
       "StepSizeMethod", "Default", Kernel::IValidator_sptr(new Kernel::ListValidator<std::string>(stepSizes)),
       "The way the step size is calculated for numerical derivatives. See the section about step sizes in the Fit "
-      "algorithm documentation to understand the difference between \"Default\", \"Sqrt epsilon\" and \"Custom\".",
+      "algorithm documentation to understand the difference between \"" +
+          DEFAULT_STEP_SIZE + "\", \"" + SQRT_EPSILON_STEP_SIZE + "\" and \"" + CUSTOM_STEP_SIZE + "\".",
       Kernel::Direction::Input);
   declareProperty("PeakRadius", 0,
                   "A value of the peak radius the peak functions should use. A "
@@ -184,9 +189,9 @@ void IFittingAlgorithm::setFunction() {
 void IFittingAlgorithm::setStepSizeMethod() {
   if (m_function) {
     const std::string stepSizeMethod = getProperty("StepSizeMethod");
-    if (stepSizeMethod == "Sqrt epsilon") {
+    if (stepSizeMethod == SQRT_EPSILON_STEP_SIZE) {
       m_function->setStepSizeMethod(IFunction::StepSizeMethod::SQRT_EPSILON);
-    } else if (stepSizeMethod == "Custom") {
+    } else if (stepSizeMethod == CUSTOM_STEP_SIZE) {
       m_function->setStepSizeMethod(IFunction::StepSizeMethod::CUSTOM);
       const std::vector<double> customStepSizes = getProperty("CustomStepSizes");
       m_function->setCustomStepSizes(customStepSizes);

--- a/Framework/CurveFitting/test/AugmentedLagrangianOptimizerTest.h
+++ b/Framework/CurveFitting/test/AugmentedLagrangianOptimizerTest.h
@@ -28,16 +28,16 @@ public:
     using Mantid::CurveFitting::AugmentedLagrangianOptimizer;
     using Mantid::Kernel::DblMatrix;
 
-    const size_t nparams(2);
-    DblMatrix equality(1, nparams + 1); // cols > number parameters
+    const size_t nParams(2);
+    DblMatrix equality(1, nParams + 1); // cols > number parameters
     DblMatrix inequality;               // Empty indicates no constraint
 
     AugmentedLagrangianOptimizer::ObjFunction userFunc;
-    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nparams, userFunc, equality, inequality),
+    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nParams, userFunc, equality, inequality),
                      const std::invalid_argument &);
 
-    equality = DblMatrix(1, nparams - 1); // cols < number parameters
-    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nparams, userFunc, equality, inequality),
+    equality = DblMatrix(1, nParams - 1); // cols < number parameters
+    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nParams, userFunc, equality, inequality),
                      const std::invalid_argument &);
   }
 
@@ -45,16 +45,16 @@ public:
     using Mantid::CurveFitting::AugmentedLagrangianOptimizer;
     using Mantid::Kernel::DblMatrix;
 
-    const size_t nparams(2);
+    const size_t nParams(2);
     DblMatrix equality; // Empty indicates no constraint
-    DblMatrix inequality(1, nparams + 1);
+    DblMatrix inequality(1, nParams + 1);
 
     AugmentedLagrangianOptimizer::ObjFunction userFunc;
-    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nparams, userFunc, equality, inequality),
+    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nParams, userFunc, equality, inequality),
                      const std::invalid_argument &);
 
-    inequality = DblMatrix(1, nparams - 1); // cols < number parameters
-    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nparams, userFunc, equality, inequality),
+    inequality = DblMatrix(1, nParams - 1); // cols < number parameters
+    TS_ASSERT_THROWS(AugmentedLagrangianOptimizer(nParams, userFunc, equality, inequality),
                      const std::invalid_argument &);
   }
 
@@ -128,40 +128,40 @@ private:
     using Mantid::CurveFitting::AugmentedLagrangianOptimizer;
     using Mantid::Kernel::DblMatrix;
 
-    const size_t nparams = m_nparams;
+    const size_t nParams = m_nparams;
     AugmentedLagrangianOptimizer::ObjFunction userFunc = &TestObjFunction::eval;
 
-    std::vector<double> xv(nparams, -1);
+    std::vector<double> xv(nParams, -1);
     xv[1] = 1.0;
 
     // x-y==0 ==> [1 -1][x   == 0
     //                  y]
-    DblMatrix equality(1, nparams);
+    DblMatrix equality(1, nParams);
     equality[0][0] = 1.0;
     equality[0][1] = -1.0;
 
     // x-5y>=0 ==> [-1 5][x   <= 0
     //                  y]
-    DblMatrix inequality(1, nparams);
+    DblMatrix inequality(1, nParams);
     inequality[0][0] = -1.0;
     inequality[0][1] = 5.0;
 
     std::shared_ptr<AugmentedLagrangianOptimizer> lsqmin;
     switch (type) {
     case NOCONSTRAINTS:
-      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nparams, userFunc);
+      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nParams, userFunc);
       break;
     case EMPTYCONSTRAINTS:
-      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nparams, userFunc, DblMatrix(), DblMatrix());
+      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nParams, userFunc, DblMatrix(), DblMatrix());
       break;
     case EQUALITYCONSTRAINT:
-      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nparams, userFunc, equality, DblMatrix());
+      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nParams, userFunc, equality, DblMatrix());
       break;
     case INEQUALITYCONSTRAINT:
-      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nparams, userFunc, DblMatrix(), inequality);
+      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nParams, userFunc, DblMatrix(), inequality);
       break;
     case BOTHCONSTRAINTS:
-      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nparams, userFunc, equality, inequality);
+      lsqmin = std::make_shared<AugmentedLagrangianOptimizer>(nParams, userFunc, equality, inequality);
       break;
     };
 

--- a/Framework/CurveFitting/test/Functions/BSplineTest.h
+++ b/Framework/CurveFitting/test/Functions/BSplineTest.h
@@ -37,11 +37,11 @@ public:
     BSpline bsp;
     int order = bsp.getAttribute("Order").asInt();
     int nbreak = bsp.getAttribute("NBreak").asInt();
-    size_t nparams = bsp.nParams();
+    size_t nParams = bsp.nParams();
 
     TS_ASSERT_EQUALS(order, 3);
     TS_ASSERT_EQUALS(nbreak, 10);
-    TS_ASSERT_EQUALS(nparams, 11);
+    TS_ASSERT_EQUALS(nParams, 11);
     TS_ASSERT_EQUALS(bsp.getAttribute("StartX").asDouble(), 0.0);
     TS_ASSERT_EQUALS(bsp.getAttribute("EndX").asDouble(), 1.0);
     TS_ASSERT_EQUALS(bsp.getAttribute("Uniform").asBool(), true);

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTest.h
@@ -29,17 +29,17 @@ public:
 
   void test_initialized_object_has_expected_parameters() {
     auto profile = createFunction();
-    static const size_t nparams(1);
+    static const size_t nParams(1);
 
-    TS_ASSERT_EQUALS(nparams, profile->nParams());
+    TS_ASSERT_EQUALS(nParams, profile->nParams());
 
     // Test names as they are used in scripts
     if (profile->nParams() > 0) {
-      const char *expectedParams[nparams] = {"Mass"};
-      std::unordered_set<std::string> expectedParamStr(expectedParams, expectedParams + nparams);
+      const char *expectedParams[nParams] = {"Mass"};
+      std::unordered_set<std::string> expectedParamStr(expectedParams, expectedParams + nParams);
       std::vector<std::string> actualNames = profile->getParameterNames();
 
-      for (size_t i = 0; i < nparams; ++i) {
+      for (size_t i = 0; i < nParams; ++i) {
         const std::string &name = actualNames[i];
         size_t keyCount = expectedParamStr.count(name);
         TSM_ASSERT_EQUALS("Expected " + name + " to be found as parameter but it was not.", 1, keyCount);

--- a/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
@@ -30,14 +30,14 @@ public:
 
   void test_Initialized_Function_Has_Expected_Parameters_In_Right_Order() {
     Mantid::API::IFunction_sptr profile = createFunction();
-    static const size_t nparams(3);
+    static const size_t nParams(3);
 
     auto currentNames = profile->getParameterNames();
     const size_t nnames = currentNames.size();
-    TS_ASSERT_EQUALS(nparams, nnames);
+    TS_ASSERT_EQUALS(nParams, nnames);
 
-    if (nnames == nparams) {
-      const char *expectedParams[nparams] = {"Mass", "Width", "Intensity"};
+    if (nnames == nParams) {
+      const char *expectedParams[nParams] = {"Mass", "Width", "Intensity"};
       for (size_t i = 0; i < nnames; ++i) {
         TS_ASSERT_EQUALS(expectedParams[i], currentNames[i]);
       }

--- a/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
@@ -139,13 +139,13 @@ private:
   }
 
   void checkDefaultParametersExist(const Mantid::API::IFunction &profile) {
-    static const size_t nparams(3);
+    static const size_t nParams(3);
 
     auto currentNames = profile.getParameterNames();
     const size_t nnames = currentNames.size();
-    TS_ASSERT_LESS_THAN_EQUALS(nparams, nnames);
-    if (nnames <= nparams) {
-      const char *expectedParams[nparams] = {"Mass", "Width", "FSECoeff"};
+    TS_ASSERT_LESS_THAN_EQUALS(nParams, nnames);
+    if (nnames <= nParams) {
+      const char *expectedParams[nParams] = {"Mass", "Width", "FSECoeff"};
       for (size_t i = 0; i < nnames; ++i) {
         TS_ASSERT_EQUALS(expectedParams[i], currentNames[i]);
       }

--- a/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
@@ -28,13 +28,13 @@ public:
 
   void test_Initialized_Function_Has_Expected_Parameters_In_Right_Order() {
     Mantid::API::IFunction_sptr profile = createFunction();
-    static const size_t nparams(5);
+    static const size_t nParams(5);
     auto currentNames = profile->getParameterNames();
-    const size_t nnames = currentNames.size();
-    TS_ASSERT_EQUALS(nparams, nnames);
-    if (nnames == nparams) {
-      const char *expectedParams[nparams] = {"Mass", "Intensity", "SigmaX", "SigmaY", "SigmaZ"};
-      for (size_t i = 0; i < nnames; ++i) {
+    const size_t nNames = currentNames.size();
+    TS_ASSERT_EQUALS(nParams, nNames);
+    if (nNames == nParams) {
+      const char *expectedParams[nParams] = {"Mass", "Intensity", "SigmaX", "SigmaY", "SigmaZ"};
+      for (size_t i = 0; i < nNames; ++i) {
         TS_ASSERT_EQUALS(expectedParams[i], currentNames[i]);
       }
     }

--- a/Framework/Geometry/test/ParametrizedComponentTest.h
+++ b/Framework/Geometry/test/ParametrizedComponentTest.h
@@ -109,9 +109,9 @@ public:
     TS_ASSERT_EQUALS(grandchild->getRotationParameter(m_quatName, false).size(), 0);
 
     std::vector<std::string> params = grandchild->getStringParameter(m_strName + "_child2", false);
-    const size_t nparams = params.size();
-    TS_ASSERT_EQUALS(nparams, 1);
-    if (nparams > 0) {
+    const size_t nParams = params.size();
+    TS_ASSERT_EQUALS(nParams, 1);
+    if (nParams > 0) {
       TS_ASSERT_EQUALS(params[0], m_strValue + "_child2");
     }
 

--- a/Framework/Kernel/test/SLSQPMinimizerTest.h
+++ b/Framework/Kernel/test/SLSQPMinimizerTest.h
@@ -28,30 +28,30 @@ public:
     using Mantid::Kernel::DblMatrix;
     using Mantid::Kernel::Math::SLSQPMinimizer;
 
-    const size_t nparams(2);
-    DblMatrix equality(1, nparams + 1); // cols > number parameters
+    const size_t nParams(2);
+    DblMatrix equality(1, nParams + 1); // cols > number parameters
     DblMatrix inequality;               // Empty indicates no constraint
 
     ObjFunction userFunc;
-    TS_ASSERT_THROWS(SLSQPMinimizer(nparams, userFunc, equality, inequality), const std::invalid_argument &);
+    TS_ASSERT_THROWS(SLSQPMinimizer(nParams, userFunc, equality, inequality), const std::invalid_argument &);
 
-    equality = DblMatrix(1, nparams - 1); // cols < number parameters
-    TS_ASSERT_THROWS(SLSQPMinimizer(nparams, userFunc, equality, inequality), const std::invalid_argument &);
+    equality = DblMatrix(1, nParams - 1); // cols < number parameters
+    TS_ASSERT_THROWS(SLSQPMinimizer(nParams, userFunc, equality, inequality), const std::invalid_argument &);
   }
 
   void test_constuctor_with_inequality_matrix_whose_num_columns_dont_match_nparams_throws() {
     using Mantid::Kernel::DblMatrix;
     using Mantid::Kernel::Math::SLSQPMinimizer;
 
-    const size_t nparams(2);
+    const size_t nParams(2);
     DblMatrix equality; // Empty indicates no constraint
-    DblMatrix inequality(1, nparams + 1);
+    DblMatrix inequality(1, nParams + 1);
 
     ObjFunction userFunc;
-    TS_ASSERT_THROWS(SLSQPMinimizer(nparams, userFunc, equality, inequality), const std::invalid_argument &);
+    TS_ASSERT_THROWS(SLSQPMinimizer(nParams, userFunc, equality, inequality), const std::invalid_argument &);
 
-    inequality = DblMatrix(1, nparams - 1); // cols < number parameters
-    TS_ASSERT_THROWS(SLSQPMinimizer(nparams, userFunc, equality, inequality), const std::invalid_argument &);
+    inequality = DblMatrix(1, nParams - 1); // cols < number parameters
+    TS_ASSERT_THROWS(SLSQPMinimizer(nParams, userFunc, equality, inequality), const std::invalid_argument &);
   }
 
   void test_minimizer_calls_user_function() {
@@ -122,38 +122,38 @@ private:
     using Mantid::Kernel::Math::SLSQPMinimizer;
 
     auto lsqmin = std::shared_ptr<SLSQPMinimizer>();
-    const size_t nparams = m_nparams;
+    const size_t nParams = m_nparams;
     ObjFunction userFunc;
-    std::vector<double> start(nparams, -1);
+    std::vector<double> start(nParams, -1);
     start[1] = 1.0;
 
     // x-y>=0 ==> [1 -1][x   >= 0
     //                  y]
-    DblMatrix equality(1, nparams);
+    DblMatrix equality(1, nParams);
     equality[0][0] = 1.0;
     equality[0][1] = -1.0;
 
     // x-5y>=0 ==> [1 -5][x   >= 0
     //                  y]
-    DblMatrix inequality(1, nparams);
+    DblMatrix inequality(1, nParams);
     inequality[0][0] = 1.0;
     inequality[0][1] = -5.0;
 
     switch (type) {
     case NOCONSTRAINTS:
-      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nparams, userFunc));
+      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nParams, userFunc));
       break;
     case EMPTYCONSTRAINTS:
-      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nparams, userFunc, DblMatrix(), DblMatrix()));
+      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nParams, userFunc, DblMatrix(), DblMatrix()));
       break;
     case EQUALITYCONSTRAINT:
-      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nparams, userFunc, equality, DblMatrix()));
+      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nParams, userFunc, equality, DblMatrix()));
       break;
     case INEQUALITYCONSTRAINT:
-      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nparams, userFunc, DblMatrix(), inequality));
+      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nParams, userFunc, DblMatrix(), inequality));
       break;
     case BOTHCONSTRAINTS:
-      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nparams, userFunc, equality, inequality));
+      lsqmin = std::shared_ptr<SLSQPMinimizer>(new SLSQPMinimizer(nParams, userFunc, equality, inequality));
       break;
     };
 

--- a/docs/source/algorithms/Fit-v1.rst
+++ b/docs/source/algorithms/Fit-v1.rst
@@ -302,6 +302,9 @@ The ``Sqrt epsilon`` method calculates the step size as follows:
 
 where :math:`x_0` is the value of the active parameter and :math:`\epsilon \approx 2.22e-16`.
 
+The ``Custom`` method allows the user to specify the step sizes for the derivatives.
+They can be specified using the ``CustomStepSizes`` argument.
+
 Output
 ######
 

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/40023.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/40023.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-Fit` algorithm now allows setting step sizes to customize the perturbation applied to each parameter value while fitting. Setting the ``StepSizeMethod`` to ``Custom`` will allow the step sizes list to be passed using the ``CustomStepSizes`` parameter.

--- a/qt/widgets/common/src/RenameParDialog.cpp
+++ b/qt/widgets/common/src/RenameParDialog.cpp
@@ -22,9 +22,9 @@ RenameParDialog::RenameParDialog(std::vector<std::string> old_params, const std:
     : QDialog(parent), m_old_params(std::move(old_params)), m_new_params(new_params) {
   m_uiForm.setupUi(this);
   QAbstractItemModel *model = m_uiForm.tableWidget->model();
-  int nparams(static_cast<int>(new_params.size()));
-  model->insertRows(0, nparams);
-  for (int row = 0; row < nparams; ++row) {
+  int nParams(static_cast<int>(new_params.size()));
+  model->insertRows(0, nParams);
+  for (int row = 0; row < nParams; ++row) {
     QString par = QString::fromStdString(new_params[row]);
     model->setData(model->index(row, 0), par);
     model->setData(model->index(row, 1), par);


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40023 . <!-- One line per closed issue. -->
Adds the ability to pass in `CustomStepSizes`.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

1) Build the workbench using `pixi run cmake --build .`
2) Run `workbench` to launch the workbench.
3) Run the following code to test that it is possible to pass in `CustomStepSizes`.
```
from mantid.simpleapi import *

# Create simple Gaussian data with a little noise
ws = CreateSampleWorkspace(
    Function="User Defined",
    UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=5,Sigma=1",
    NumBanks=1,
    BankPixelWidth=1,
    XMin=0,
    XMax=10,
    BinWidth=0.1,
    Random=True,
    OutputWorkspace="fit_test_ws",
)

# Fit with default numerical derivative step size method
result = Fit(
    Function="name=Gaussian,Height=8,PeakCentre=4.5,Sigma=0.8",
    InputWorkspace="fit_test_ws",
    Output="fit_custom_steps",
    Minimizer="Levenberg-Marquardt",
    StepSizeMethod="Custom",
    CustomStepSizes=[1e-3, 1e-7, 1e-6],
)

print("Fit status:", result.OutputStatus)
print("Chi squared:", result.OutputChi2overDoF)
```
4) Change the `StepSizeMethod="Default"` and verify that an error is raised when the code is rerun.
5) Change the `StepSizeMethod="Custom"` and remove `CustomStepSizes=[1e-3, 1e-7, 1e-6]` and verify that an error is raised when the code is rerun.
6) Change the length of the list provided through `CustomStepSizes=[1e-3, 1e-7, 1e-6]` and verify that an error is raised when the list length does not match the number of parameters in the function.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
