### PR TITLE
Stop disruption of Mantid plotting after DeleteWorkspace

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -117,7 +117,7 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
                 empty_axes.append(MantidAxes.is_empty(ax))
             redraw = redraw | to_redraw
 
-        if all(empty_axes):
+        if all(empty_axes) and redraw:
             self.window.emit_close()
         elif redraw:
             self.canvas.draw_idle()


### PR DESCRIPTION
### Description of work

Small fix to small issue

Closes #41446 

### To test:

In workbench, run the following:
```python
import numpy as np
import matplotlib.pyplot as plt
from mantid.simpleapi import CreateWorkspace, DeleteWorkspace

x = np.arange(20)
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
w = CreateWorkspace(DataX=x, DataY=x, NSpec=1, UnitX='DeltaE')
DeleteWorkspace('w')
ax.plot([1,2,3],[1,3,2])
fig.show()
```

If you can see the plot, then this fixed it.


Minor issue, no release notes necessary

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
