### PR TITLE
Remove duplicate `getMemorySize()` method

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -225,9 +225,6 @@ public:
   /// Get the footprint in memory in bytes.
   size_t getMemorySize() const;
 
-  /// Get the footprint in memory in bytes.
-  size_t getMemorySize() const;
-
   friend InstrumentVisitor;
 
 private:

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1166,42 +1166,4 @@ size_t ParameterMap::getMemorySize() const {
          componentInfoMem;
 }
 
-/** Return memory used by the parameter map, in bytes.
- * @return bytes used.
- */
-size_t ParameterMap::getMemorySize() const {
-  // m_map: tbb::concurrent_unordered_multimap<ComponentID, shared_ptr<Parameter>>
-  // Each node: key + value + ~2 pointers for chaining and bucket slot
-  const size_t n = m_map.size();
-  const size_t mapMem = n * (sizeof(pmap::value_type) + 2 * sizeof(void *));
-  // Count the heap-allocated Parameter objects the shared_ptrs point to.
-  // ParameterMap is a friend of Parameter so private string members are accessible.
-  size_t parameterObjectsMem = 0;
-  for (const auto &entry : m_map) {
-    const auto &param = entry.second;
-    if (param) {
-      parameterObjectsMem += sizeof(Parameter);
-      parameterObjectsMem += param->m_name.capacity();
-      parameterObjectsMem += param->m_type.capacity();
-      parameterObjectsMem += param->m_str_value.capacity();
-      parameterObjectsMem += param->m_description.capacity();
-    }
-  }
-  // m_parameterFileNames: vector of strings; sizeof(*this) covers the vector object, count the heap buffer
-  const size_t fileNamesMem = m_parameterFileNames.size() * sizeof(std::string) +
-                              std::accumulate(m_parameterFileNames.cbegin(), m_parameterFileNames.cend(), size_t{0},
-                                              [](size_t acc, const auto &s) { return acc + s.capacity(); });
-  // m_cacheLocMap and m_cacheRotMap: count the heap Cache objects; the internal std::map entries are not
-  // counted because Kernel::Cache::size() is non-const and cannot be called here.
-  const size_t cacheLocMem = m_cacheLocMap ? sizeof(*m_cacheLocMap) : 0;
-  const size_t cacheRotMem = m_cacheRotMap ? sizeof(*m_cacheRotMap) : 0;
-  // m_detectorInfo and m_componentInfo: owned by ParameterMap for parametrized instruments
-  const size_t detectorInfoMem = m_detectorInfo ? m_detectorInfo->getMemorySize() : 0;
-  const size_t componentInfoMem = m_componentInfo ? m_componentInfo->getMemorySize() : 0;
-  // m_instrument is a non-owning raw pointer to the base Instrument; its memory is counted in
-  // Instrument::getMemorySize() and excluded here to avoid double-counting.
-  return sizeof(*this) + mapMem + parameterObjectsMem + fileNamesMem + cacheLocMem + cacheRotMem + detectorInfoMem +
-         componentInfoMem;
-}
-
 } // namespace Mantid::Geometry


### PR DESCRIPTION
Through some combination of #41403 and #41464 and some merging, we've ended up with a duplicate definition of `getMemorySize` in `Instrument.h`, and a duplicate implementation in `ParameterMap.cpp`.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
