### PR TITLE
Only skip code building if actual built files exist

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -39,8 +39,8 @@ if [[ ${JOB_NAME} == *pull_requests* ]]; then
     EXTRA_CMAKE_FLAGS+=" -DPR_JOB=True"
 fi
 
-# MPI library is needed for some system tests and doc tests
-if [[ $ENABLE_SYSTEM_TESTS == true || $ENABLE_DOCS == true ]]; then
+# MPI library is needed for some system tests and doc tests, so we always want it avalaible on Linux
+if [[ $OSTYPE == "linux"* ]]; then
     EXTRA_CMAKE_FLAGS+=" -DMPI_BUILD=ON"
 fi
 

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -117,7 +117,7 @@ pushd $WORKSPACE
 install_pixi "$WORKSPACE"
 
 # Check whether this is an incremental build that only changes rst files
-if [ -d $BUILD_DIR ]; then
+if [ -f $BUILD_DIR/bin/libMantidAPI.so ]; then
     if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
       ENABLE_BUILD_CODE=false
       ENABLE_UNIT_TESTS=false

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -117,7 +117,7 @@ pushd $WORKSPACE
 install_pixi "$WORKSPACE"
 
 # Check whether this is an incremental build that only changes rst files
-if [ -f $BUILD_DIR/bin/libMantidAPI.so ]; then
+if [ -d $BUILD_DIR/Framework ]; then
     if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
       ENABLE_BUILD_CODE=false
       ENABLE_UNIT_TESTS=false


### PR DESCRIPTION
### Description of work

To save time when building docs, mantid is only rebuilt if needed. We suspect that there are some cases that can result in there being a build directory on the runner, but either without a code build or with a code build that without MPI.

Make the test for this check the Framework directory, not just the build directory. This covers the case that a build directory is made, but a code build has not been done.

Also always enable MPI in `buildconfig/Jenkins/Conda/build` on linux, to handle cases when a code build can happen without MPI enabled (dev-docs or cppcheck?). This would leave a complete build directory without MPI, which would trip up the next doc build.

Closes #41467

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
