### PR TITLE
Muon manual testing `GuasOsc` typo

### DIFF
--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_MUSR.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_MUSR.rst
@@ -89,7 +89,7 @@ This test will look at transverse field data.
 - In the **grouping tab** you will see four groups and no pairs (you may need to press ``Default``)
 - Go to the **fitting tab**
 	- Right click the empty table area; Select ``Add Function``
-	- Add ``GuasOsc``
+	- Add ``GausOsc``
 	- Set ``Frequency = 1.3``
 	- Add a ``FlatBackground``
 	- Do a fit, the value for the background should be non-zero

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
@@ -90,5 +90,5 @@ HIFI MultiPeriod Data
 	- Tick the ``Analyse`` box in the grouping table for "fwd1"
 	- Untick all of the ``Analyse`` boxes in the pair table
 	- This will leave you with 3 lines (one for each run)
-	- In the ``Periods`` column you can sum periods byusing a comma seperated list or a range using a dash
+	- In the ``Periods`` column you can sum periods by using a comma seperated list or a range using a dash
 	- When you change the periods summed the plot will change


### PR DESCRIPTION
### Description of work

Should be `GausOsc`

### To test:

Confirm there is no GuasOsc func.

No release note - dev doc typo

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
