### PR TITLE
HFIRPowderReduction - Add checks for sample attenuation data to autopopulate related fields

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -267,6 +267,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
                 array = f[dataset][()]
             return array
 
+        def readStringFromFile(filename, dataset):
+            stringValue = ""
+            with h5py.File(filename, "r") as f:
+                stringValue = f[dataset][0]
+                stringValue = stringValue.decode("utf-8")
+            return stringValue
+
         def checkFilenameforInstrument(algo, currentProp, watchedProp):
             run = watchedProp.value
             instrumentName = ""
@@ -304,6 +311,61 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             return True
 
         self.setPropertySettings("VanadiumDiameter", SetDefaultWhenProperty("SampleFilename", checkFilenameforVanadiumDiameter))
+
+        def checkFilenameforSampleChemicalFormula(algo, currentProp, watchedProp):
+            run = watchedProp.value
+            if not run:
+                return False
+            formula = readStringFromFile(run[0], "/entry/sample_chemical_formula")
+            logger.information(f"Auto-populating SampleChemicalFormula: {formula} from file: {run[0]}")
+            self.setProperty("SampleChemicalFormula", formula)
+            return True
+
+        self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleChemicalFormula))
+
+        def checkFilenameforSampleCrystalDensity(algo, currentProp, watchedProp):
+            run = watchedProp.value
+            if not run:
+                return False
+            density = readFloatFromFile(run[0], "/entry/sample_crystal_density")
+            logger.information(f"Auto-populating SampleCrystalDensity: {density} from file: {run[0]}")
+            currentProp.value = density
+            return True
+
+        self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleCrystalDensity))
+
+        def checkFilenameforSamplePackingFraction(algo, currentProp, watchedProp):
+            run = watchedProp.value
+            if not run:
+                return False
+            fraction = readFloatFromFile(run[0], "/entry/sample_packing_fraction")
+            logger.information(f"Auto-populating SamplePackingFraction: {fraction} from file: {run[0]}")
+            currentProp.value = fraction
+            return True
+
+        self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("SampleFilename", checkFilenameforSamplePackingFraction))
+
+        def checkFilenameforSampleDiameter(algo, currentProp, watchedProp):
+            run = watchedProp.value
+            if not run:
+                return False
+            diameter = readFloatFromFile(run[0], "/entry/sample_diameter")
+            logger.information(f"Auto-populating SampleDiameter: {diameter} from file: {run[0]}")
+            currentProp.value = diameter
+            return True
+
+        self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleDiameter))
+
+        def checkFilenameforSampleHeight(algo, currentProp, watchedProp):
+            run = watchedProp.value
+            if not run:
+                return False
+            height = readFloatFromFile(run[0], "/entry/sample_height")
+            logger.information(f"Auto-populating SampleHeight: {height} from file: {run[0]}")
+            currentProp.value = height
+            return True
+
+        self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleHeight))
 
         def checkInstrumentforNormaliseBy(algo, currentProp, watchedProp):
             instrument = watchedProp.value
@@ -408,6 +470,80 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         self.setPropertySettings("VanadiumDiameter", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforVanadiumDiameter))
         self.setPropertySettings("VanadiumDiameter", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforVanadiumDiameter))
 
+        def checkRunNumbersforSampleChemicalFormula(algo, currentProp, watchedProp):
+            runs = getRuns()
+            if len(runs) == 0:
+                return False
+            else:
+                formula = readStringFromFile(runs[0], "/entry/sample_chemical_formula")
+                logger.information(f"Auto-populating SampleChemicalFormula: {formula} from run numbers: {runs[0]}")
+                self.setProperty("SampleChemicalFormula", formula)
+            return True
+
+        self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleChemicalFormula))
+        self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleChemicalFormula))
+        self.setPropertySettings(
+            "SampleChemicalFormula", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforSampleChemicalFormula)
+        )
+
+        def checkRunNumbersforSampleCrystalDensity(algo, currentProp, watchedProp):
+            runs = getRuns()
+            if len(runs) == 0:
+                return False
+            else:
+                density = readFloatFromFile(runs[0], "/entry/sample_crystal_density")
+                logger.information(f"Auto-populating SampleCrystalDensity: {density} from run numbers: {runs[0]}")
+                currentProp.value = density
+            return True
+
+        self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleCrystalDensity))
+        self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleCrystalDensity))
+        self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforSampleCrystalDensity))
+
+        def checkRunNumbersforSamplePackingFraction(algo, currentProp, watchedProp):
+            runs = getRuns()
+            if len(runs) == 0:
+                return False
+            else:
+                fraction = readFloatFromFile(runs[0], "/entry/sample_packing_fraction")
+                logger.information(f"Auto-populating SamplePackingFraction: {fraction} from run numbers: {runs[0]}")
+                currentProp.value = fraction
+            return True
+
+        self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("Instrument", checkRunNumbersforSamplePackingFraction))
+        self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSamplePackingFraction))
+        self.setPropertySettings(
+            "SamplePackingFraction", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforSamplePackingFraction)
+        )
+
+        def checkRunNumbersforSampleDiameter(algo, currentProp, watchedProp):
+            runs = getRuns()
+            if len(runs) == 0:
+                return False
+            else:
+                diameter = readFloatFromFile(runs[0], "/entry/sample_diameter")
+                logger.information(f"Auto-populating SampleDiameter: {diameter} from run numbers: {runs[0]}")
+                currentProp.value = diameter
+            return True
+
+        self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleDiameter))
+        self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleDiameter))
+        self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforSampleDiameter))
+
+        def checkRunNumbersforSampleHeight(algo, currentProp, watchedProp):
+            runs = getRuns()
+            if len(runs) == 0:
+                return False
+            else:
+                height = readFloatFromFile(runs[0], "/entry/sample_height")
+                logger.information(f"Auto-populating SampleHeight: {height} from run numbers: {runs[0]}")
+                currentProp.value = height
+            return True
+
+        self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleHeight))
+        self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleHeight))
+        self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforSampleHeight))
+
         def checkRunNumbersforVanadiumRunNumbers(algo, currentProp, watchedProp):
             runs = getRuns()
             if len(runs) == 0:
@@ -488,6 +624,11 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             "/entry/vanadium_ipts",
             "/entry/vanadium_background_ipts",
             "/entry/vanadium_background_run_numbers",
+            "/entry/sample_chemical_formula",
+            "/entry/sample_crystal_density",
+            "/entry/sample_packing_fraction",
+            "/entry/sample_diameter",
+            "/entry/sample_height",
         ]
 
         inconsistencies = []

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -268,11 +268,11 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             return array
 
         def readStringFromFile(filename, dataset):
-            stringValue = ""
             with h5py.File(filename, "r") as f:
-                stringValue = f[dataset][0]
-                stringValue = stringValue.decode("utf-8")
-            return stringValue
+                value = f[dataset][0]
+                if isinstance(value, bytes):
+                    return value.decode("utf-8")
+                return str(value)
 
         def checkFilenameforInstrument(algo, currentProp, watchedProp):
             run = watchedProp.value
@@ -316,10 +316,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             run = watchedProp.value
             if not run:
                 return False
-            formula = readStringFromFile(run[0], "/entry/sample_chemical_formula")
-            logger.information(f"Auto-populating SampleChemicalFormula: {formula} from file: {run[0]}")
-            self.setProperty("SampleChemicalFormula", formula)
-            return True
+            try:
+                formula = readStringFromFile(run[0], "/entry/sample_chemical_formula")
+                logger.information(f"Auto-populating SampleChemicalFormula: {formula} from file: {run[0]}")
+                self.setProperty("SampleChemicalFormula", formula)
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleChemicalFormula))
 
@@ -327,10 +330,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             run = watchedProp.value
             if not run:
                 return False
-            density = readFloatFromFile(run[0], "/entry/sample_crystal_density")
-            logger.information(f"Auto-populating SampleCrystalDensity: {density} from file: {run[0]}")
-            currentProp.value = density
-            return True
+            try:
+                density = readFloatFromFile(run[0], "/entry/sample_crystal_density")
+                logger.information(f"Auto-populating SampleCrystalDensity: {density} from file: {run[0]}")
+                currentProp.value = density
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleCrystalDensity))
 
@@ -338,10 +344,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             run = watchedProp.value
             if not run:
                 return False
-            fraction = readFloatFromFile(run[0], "/entry/sample_packing_fraction")
-            logger.information(f"Auto-populating SamplePackingFraction: {fraction} from file: {run[0]}")
-            currentProp.value = fraction
-            return True
+            try:
+                fraction = readFloatFromFile(run[0], "/entry/sample_packing_fraction")
+                logger.information(f"Auto-populating SamplePackingFraction: {fraction} from file: {run[0]}")
+                currentProp.value = fraction
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("SampleFilename", checkFilenameforSamplePackingFraction))
 
@@ -349,10 +358,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             run = watchedProp.value
             if not run:
                 return False
-            diameter = readFloatFromFile(run[0], "/entry/sample_diameter")
-            logger.information(f"Auto-populating SampleDiameter: {diameter} from file: {run[0]}")
-            currentProp.value = diameter
-            return True
+            try:
+                diameter = readFloatFromFile(run[0], "/entry/sample_diameter")
+                logger.information(f"Auto-populating SampleDiameter: {diameter} from file: {run[0]}")
+                currentProp.value = diameter
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleDiameter))
 
@@ -360,10 +372,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             run = watchedProp.value
             if not run:
                 return False
-            height = readFloatFromFile(run[0], "/entry/sample_height")
-            logger.information(f"Auto-populating SampleHeight: {height} from file: {run[0]}")
-            currentProp.value = height
-            return True
+            try:
+                height = readFloatFromFile(run[0], "/entry/sample_height")
+                logger.information(f"Auto-populating SampleHeight: {height} from file: {run[0]}")
+                currentProp.value = height
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("SampleFilename", checkFilenameforSampleHeight))
 
@@ -474,11 +489,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             runs = getRuns()
             if len(runs) == 0:
                 return False
-            else:
+            try:
                 formula = readStringFromFile(runs[0], "/entry/sample_chemical_formula")
                 logger.information(f"Auto-populating SampleChemicalFormula: {formula} from run numbers: {runs[0]}")
                 self.setProperty("SampleChemicalFormula", formula)
-            return True
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleChemicalFormula))
         self.setPropertySettings("SampleChemicalFormula", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleChemicalFormula))
@@ -490,11 +507,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             runs = getRuns()
             if len(runs) == 0:
                 return False
-            else:
+            try:
                 density = readFloatFromFile(runs[0], "/entry/sample_crystal_density")
                 logger.information(f"Auto-populating SampleCrystalDensity: {density} from run numbers: {runs[0]}")
                 currentProp.value = density
-            return True
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleCrystalDensity))
         self.setPropertySettings("SampleCrystalDensity", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleCrystalDensity))
@@ -504,11 +523,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             runs = getRuns()
             if len(runs) == 0:
                 return False
-            else:
+            try:
                 fraction = readFloatFromFile(runs[0], "/entry/sample_packing_fraction")
                 logger.information(f"Auto-populating SamplePackingFraction: {fraction} from run numbers: {runs[0]}")
                 currentProp.value = fraction
-            return True
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("Instrument", checkRunNumbersforSamplePackingFraction))
         self.setPropertySettings("SamplePackingFraction", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSamplePackingFraction))
@@ -520,11 +541,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             runs = getRuns()
             if len(runs) == 0:
                 return False
-            else:
+            try:
                 diameter = readFloatFromFile(runs[0], "/entry/sample_diameter")
                 logger.information(f"Auto-populating SampleDiameter: {diameter} from run numbers: {runs[0]}")
                 currentProp.value = diameter
-            return True
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleDiameter))
         self.setPropertySettings("SampleDiameter", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleDiameter))
@@ -534,11 +557,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             runs = getRuns()
             if len(runs) == 0:
                 return False
-            else:
+            try:
                 height = readFloatFromFile(runs[0], "/entry/sample_height")
                 logger.information(f"Auto-populating SampleHeight: {height} from run numbers: {runs[0]}")
                 currentProp.value = height
-            return True
+                return True
+            except (OSError, KeyError):
+                return False
 
         self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("Instrument", checkRunNumbersforSampleHeight))
         self.setPropertySettings("SampleHeight", SetDefaultWhenProperty("SampleIPTS", checkRunNumbersforSampleHeight))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -679,6 +679,206 @@ class AutoPopulateTests(unittest.TestCase):
             compareResult = val == 987
             self.assertTrue(compareResult)
 
+    def test_auto_populate_sample_chemical_formula_from_filename(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        fp = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        algo.setProperty("SampleFilename", fp)
+        prop = algo.getProperty("SampleChemicalFormula")
+        if isinstance(prop.settings, list):
+            for setting in prop.settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, "SampleChemicalFormula")
+        else:
+            if hasattr(prop.settings, "_applyChanges"):
+                prop.settings._applyChanges(algo, "SampleChemicalFormula")
+        formula = prop.value
+        self.assertEqual(formula, "Fe2 O3")
+
+    def test_auto_populate_sample_crystal_density_from_filename(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        fp = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        algo.setProperty("SampleFilename", fp)
+        prop = algo.getProperty("SampleCrystalDensity")
+        if isinstance(prop.settings, list):
+            for setting in prop.settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, "SampleCrystalDensity")
+        else:
+            if hasattr(prop.settings, "_applyChanges"):
+                prop.settings._applyChanges(algo, "SampleCrystalDensity")
+        density = prop.value
+        self.assertEqual(density, 5.24)
+
+    def test_auto_populate_sample_packing_fraction_from_filename(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        fp = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        algo.setProperty("SampleFilename", fp)
+        prop = algo.getProperty("SamplePackingFraction")
+        if isinstance(prop.settings, list):
+            for setting in prop.settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, "SamplePackingFraction")
+        else:
+            if hasattr(prop.settings, "_applyChanges"):
+                prop.settings._applyChanges(algo, "SamplePackingFraction")
+        fraction = prop.value
+        self.assertEqual(fraction, 0.6)
+
+    def test_auto_populate_sample_diameter_from_filename(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        fp = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        algo.setProperty("SampleFilename", fp)
+        prop = algo.getProperty("SampleDiameter")
+        if isinstance(prop.settings, list):
+            for setting in prop.settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, "SampleDiameter")
+        else:
+            if hasattr(prop.settings, "_applyChanges"):
+                prop.settings._applyChanges(algo, "SampleDiameter")
+        diameter = prop.value
+        self.assertEqual(diameter, 0.8)
+
+    def test_auto_populate_sample_height_from_filename(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        fp = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        algo.setProperty("SampleFilename", fp)
+        prop = algo.getProperty("SampleHeight")
+        if isinstance(prop.settings, list):
+            for setting in prop.settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, "SampleHeight")
+        else:
+            if hasattr(prop.settings, "_applyChanges"):
+                prop.settings._applyChanges(algo, "SampleHeight")
+        height = prop.value
+        self.assertEqual(height, 3.0)
+
+    def test_auto_populate_sample_chemical_formula_from_run_numbers(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        original_h5py_File = h5py.File
+
+        def mock_file_func(path, mode="r"):
+            return original_h5py_File(existing_file, mode)
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
+            prop = algo.getProperty("SampleChemicalFormula")
+            if isinstance(prop.settings, list):
+                for setting in prop.settings:
+                    if hasattr(setting, "_applyChanges"):
+                        setting._applyChanges(algo, "SampleChemicalFormula")
+            else:
+                if hasattr(prop.settings, "_applyChanges"):
+                    prop.settings._applyChanges(algo, "SampleChemicalFormula")
+            self.assertEqual(prop.value, "Fe2 O3")
+
+    def test_auto_populate_sample_crystal_density_from_run_numbers(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        original_h5py_File = h5py.File
+
+        def mock_file_func(path, mode="r"):
+            return original_h5py_File(existing_file, mode)
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
+            prop = algo.getProperty("SampleCrystalDensity")
+            if isinstance(prop.settings, list):
+                for setting in prop.settings:
+                    if hasattr(setting, "_applyChanges"):
+                        setting._applyChanges(algo, "SampleCrystalDensity")
+            else:
+                if hasattr(prop.settings, "_applyChanges"):
+                    prop.settings._applyChanges(algo, "SampleCrystalDensity")
+            self.assertEqual(prop.value, 5.24)
+
+    def test_auto_populate_sample_packing_fraction_from_run_numbers(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        original_h5py_File = h5py.File
+
+        def mock_file_func(path, mode="r"):
+            return original_h5py_File(existing_file, mode)
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
+            prop = algo.getProperty("SamplePackingFraction")
+            if isinstance(prop.settings, list):
+                for setting in prop.settings:
+                    if hasattr(setting, "_applyChanges"):
+                        setting._applyChanges(algo, "SamplePackingFraction")
+            else:
+                if hasattr(prop.settings, "_applyChanges"):
+                    prop.settings._applyChanges(algo, "SamplePackingFraction")
+            self.assertEqual(prop.value, 0.6)
+
+    def test_auto_populate_sample_diameter_from_run_numbers(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        original_h5py_File = h5py.File
+
+        def mock_file_func(path, mode="r"):
+            return original_h5py_File(existing_file, mode)
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
+            prop = algo.getProperty("SampleDiameter")
+            if isinstance(prop.settings, list):
+                for setting in prop.settings:
+                    if hasattr(setting, "_applyChanges"):
+                        setting._applyChanges(algo, "SampleDiameter")
+            else:
+                if hasattr(prop.settings, "_applyChanges"):
+                    prop.settings._applyChanges(algo, "SampleDiameter")
+            self.assertEqual(prop.value, 0.8)
+
+    def test_auto_populate_sample_height_from_run_numbers(self):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+        original_h5py_File = h5py.File
+
+        def mock_file_func(path, mode="r"):
+            return original_h5py_File(existing_file, mode)
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
+            prop = algo.getProperty("SampleHeight")
+            if isinstance(prop.settings, list):
+                for setting in prop.settings:
+                    if hasattr(setting, "_applyChanges"):
+                        setting._applyChanges(algo, "SampleHeight")
+            else:
+                if hasattr(prop.settings, "_applyChanges"):
+                    prop.settings._applyChanges(algo, "SampleHeight")
+            self.assertEqual(prop.value, 3.0)
+
 
 class MetadataConsistencyTests(unittest.TestCase):
     def test_metadata_consistency_single_file(self):
@@ -763,6 +963,38 @@ class MetadataConsistencyTests(unittest.TestCase):
 
         finally:
             # Clean up temporary directory
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_metadata_consistency_detects_mismatched_sample_diameter(self):
+        """Test that mismatched sample diameter is detected between multiple files"""
+        existing_file = os.path.join(os.getcwd(), "../../ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5")
+
+        temp_dir = tempfile.mkdtemp()
+        try:
+            modified_file = os.path.join(temp_dir, "HB2C_457.nxs.h5")
+            shutil.copy(existing_file, modified_file)
+
+            with h5py.File(modified_file, "a") as f:
+                if "/entry/sample_diameter" in f:
+                    del f["/entry/sample_diameter"]
+                    f["/entry/sample_diameter"] = np.array([b"1.2"])  # Different from original 0.8
+
+            algo = AlgorithmManager.create("HFIRPowderReduction")
+            algo.initialize()
+
+            algo.setProperty("SampleFilename", f"{existing_file},{modified_file}")
+            algo.setProperty("Instrument", "WAND^2")
+            algo.setProperty("XMin", [1.0])
+            algo.setProperty("XMax", [10.0])
+            algo.setProperty("Wavelength", 2.5)
+            algo.setProperty("VanadiumDiameter", 0.5)
+
+            with patch.object(Logger, "warning") as mock_warning:
+                algo.validateInputs()
+
+                self.assertEqual(mock_warning.call_count, 1)
+
+        finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -21,7 +21,7 @@ from mantid.simpleapi import (
     mtd,
 )
 from mantid.api import AlgorithmManager, MatrixWorkspace, WorkspaceGroup
-from mantid.kernel import Logger, V3D
+from mantid.kernel import Logger, Property, V3D
 from plugins.algorithms.WorkflowAlgorithms.HFIRPowderReduction import HFIRPowderReduction as _HFIRPowderReduction
 import h5py
 import os
@@ -878,6 +878,95 @@ class AutoPopulateTests(unittest.TestCase):
                 if hasattr(prop.settings, "_applyChanges"):
                     prop.settings._applyChanges(algo, "SampleHeight")
             self.assertEqual(prop.value, 3.0)
+
+    # ---- Bad / corrupt file handling for sample auto-population ----
+    SAMPLE_PROPS = ["SampleChemicalFormula", "SampleCrystalDensity", "SamplePackingFraction", "SampleDiameter", "SampleHeight"]
+
+    def _apply_sample_settings(self, algo):
+        """Trigger every registered _applyChanges for the 5 sample auto-pop properties."""
+        for name in self.SAMPLE_PROPS:
+            prop = algo.getProperty(name)
+            settings = prop.settings if isinstance(prop.settings, list) else [prop.settings]
+            for setting in settings:
+                if hasattr(setting, "_applyChanges"):
+                    setting._applyChanges(algo, name)
+
+    def _assert_sample_defaults_unchanged(self, algo):
+        """Assert all 5 sample properties remain at their declared defaults."""
+        self.assertEqual(algo.getProperty("SampleChemicalFormula").value, "")
+        self.assertEqual(algo.getProperty("SampleCrystalDensity").value, Property.EMPTY_DBL)
+        self.assertEqual(algo.getProperty("SamplePackingFraction").value, 0.5)
+        self.assertEqual(algo.getProperty("SampleDiameter").value, Property.EMPTY_DBL)
+        self.assertEqual(algo.getProperty("SampleHeight").value, 0.0)
+
+    def test_sample_auto_populate_nonexistent_file_does_not_crash(self):
+        """Auto-pop should gracefully skip when SampleFilename points to a missing file."""
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        temp_dir = tempfile.mkdtemp()
+        try:
+            missing_file = os.path.join(temp_dir, "does_not_exist.nxs.h5")
+            algo.setProperty("SampleFilename", missing_file)
+            self._apply_sample_settings(algo)
+            self._assert_sample_defaults_unchanged(algo)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_sample_auto_populate_corrupted_file_does_not_crash(self):
+        """Auto-pop should gracefully skip when SampleFilename points to a non-HDF5 file."""
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        temp_dir = tempfile.mkdtemp()
+        try:
+            corrupt_file = os.path.join(temp_dir, "HB2C_999.nxs.h5")
+            with open(corrupt_file, "wb") as f:
+                f.write(b"not a valid HDF5 file - just garbage bytes")
+            algo.setProperty("SampleFilename", corrupt_file)
+            self._apply_sample_settings(algo)
+            self._assert_sample_defaults_unchanged(algo)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_sample_auto_populate_missing_datasets_does_not_crash(self):
+        """Auto-pop should gracefully skip when the HDF5 file is valid but lacks the sample datasets."""
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        temp_dir = tempfile.mkdtemp()
+        try:
+            stripped_file = os.path.join(temp_dir, "HB2C_999.nxs.h5")
+            with h5py.File(stripped_file, "w") as f:
+                # valid HDF5, but missing the sample_* datasets the auto-pop reads
+                f.create_dataset("/entry/instrument/name", data=[b"WAND^2"])
+                f.create_dataset("/entry/wavelength", data=[b"2.5"])
+            algo.setProperty("SampleFilename", stripped_file)
+            self._apply_sample_settings(algo)
+            self._assert_sample_defaults_unchanged(algo)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_sample_auto_populate_from_run_numbers_corrupted_file_does_not_crash(self):
+        """Run-number-driven auto-pop should gracefully skip when the resolved path is a corrupted file."""
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        temp_dir = tempfile.mkdtemp()
+        try:
+            corrupt_file = os.path.join(temp_dir, "HB2C_999.nxs.h5")
+            with open(corrupt_file, "wb") as f:
+                f.write(b"not a valid HDF5 file - just garbage bytes")
+
+            original_h5py_File = h5py.File
+
+            def mock_file_func(path, mode="r"):
+                return original_h5py_File(corrupt_file, mode)
+
+            with patch("h5py.File", side_effect=mock_file_func):
+                algo.setProperty("SampleIPTS", 123)
+                algo.setProperty("SampleRunNumbers", [456])
+                algo.setProperty("Instrument", "WAND^2")
+                self._apply_sample_settings(algo)
+                self._assert_sample_defaults_unchanged(algo)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 class MetadataConsistencyTests(unittest.TestCase):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -879,7 +879,7 @@ class AutoPopulateTests(unittest.TestCase):
                     prop.settings._applyChanges(algo, "SampleHeight")
             self.assertEqual(prop.value, 3.0)
 
-    # ---- Bad / corrupt file handling for sample auto-population ----
+    # Bad / corrupt file handling for sample auto-population
     SAMPLE_PROPS = ["SampleChemicalFormula", "SampleCrystalDensity", "SamplePackingFraction", "SampleDiameter", "SampleHeight"]
 
     def _apply_sample_settings(self, algo):
@@ -899,18 +899,24 @@ class AutoPopulateTests(unittest.TestCase):
         self.assertEqual(algo.getProperty("SampleDiameter").value, Property.EMPTY_DBL)
         self.assertEqual(algo.getProperty("SampleHeight").value, 0.0)
 
-    def test_sample_auto_populate_nonexistent_file_does_not_crash(self):
-        """Auto-pop should gracefully skip when SampleFilename points to a missing file."""
+    def test_sample_auto_populate_from_run_numbers_nonexistent_file_does_not_crash(self):
+        """Run-number-driven auto-pop should gracefully skip when the constructed path doesn't exist.
+
+        Note: SampleFilename itself validates existence at set-time, so this scenario is
+        only reachable via the SampleIPTS + SampleRunNumbers path that constructs file paths.
+        """
         algo = AlgorithmManager.create("HFIRPowderReduction")
         algo.initialize()
-        temp_dir = tempfile.mkdtemp()
-        try:
-            missing_file = os.path.join(temp_dir, "does_not_exist.nxs.h5")
-            algo.setProperty("SampleFilename", missing_file)
+
+        def mock_file_func(path, mode="r"):
+            raise FileNotFoundError(f"No such file: {path}")
+
+        with patch("h5py.File", side_effect=mock_file_func):
+            algo.setProperty("SampleIPTS", 123)
+            algo.setProperty("SampleRunNumbers", [456])
+            algo.setProperty("Instrument", "WAND^2")
             self._apply_sample_settings(algo)
             self._assert_sample_defaults_unchanged(algo)
-        finally:
-            shutil.rmtree(temp_dir, ignore_errors=True)
 
     def test_sample_auto_populate_corrupted_file_does_not_crash(self):
         """Auto-pop should gracefully skip when SampleFilename points to a non-HDF5 file."""

--- a/Testing/Data/UnitTest/HB2C_456.nxs.h5.md5
+++ b/Testing/Data/UnitTest/HB2C_456.nxs.h5.md5
@@ -1,1 +1,1 @@
-87d4c46fab9f24ad839e56cbeb3e75bc
+3a8cc41f6da99ad4b307cc4f5eb2b58d

--- a/docs/source/release/v6.17.0/Framework/Algorithms/New_features/41510.rst
+++ b/docs/source/release/v6.17.0/Framework/Algorithms/New_features/41510.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-HFIRPowderReduction` now attempts to autopopulate the sample absorption parameters if correct data is found in sample run files


### PR DESCRIPTION
### Description of work

This adds checking of run data to see if there exists data to set the fields for all sample absorption correction fields in HFIRPowderReduction. If the run does have the required data, the following fields will be set:
SampleChemicalFormula
SampleCrystalDensity
SamplePackingFraction
SampleDiameter
SampleHeight

EWM Item [16362](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16362)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Make sure the unit tests pass. To manually test, make sure the test data is built (run ```ninja AllTests```) and look for ExternalData/Testing/Data/UnitTest/HB2C_456.nxs.h5 in your build directory. Set the SampleFileName to this file in HFIRPowderReduction, and you should see the sample fields below have been autopopulated.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
