### PR TITLE
Fix symmetry bug in MDNorm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     rev: v6.2.5
     hooks:
       - id: rstcheck
-        additional_dependencies: [sphinx]
+        additional_dependencies: [sphinx, "rstcheck-core<1.3"]
         args: ["--config", ".rstcheck.project.cfg"]
         exclude: |
           (?x)^(

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -978,6 +978,7 @@ inline DblMatrix MDNorm::buildSymmetryMatrix(const Geometry::SymmetryOperation &
   soMatrix.setColumn(1, v);
   v = so.transformHKL(V3D(0, 0, 1));
   soMatrix.setColumn(2, v);
+  soMatrix.Invert();
 
   return soMatrix;
 }

--- a/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41516.rst
+++ b/docs/source/release/v6.16.0/Framework/Algorithms/Bugfixes/41516.rst
@@ -1,0 +1,1 @@
+- Fix symmetry bug in :ref:`MDNorm <algm-MDNorm>`

--- a/docs/source/release/v6.16.0/Workbench/Bugfixes/41515.rst
+++ b/docs/source/release/v6.16.0/Workbench/Bugfixes/41515.rst
@@ -1,0 +1,1 @@
+- Dialog menus will no longer crash when populating algorithms.

--- a/qt/python/mantidqt/create_resources.cmake.in
+++ b/qt/python/mantidqt/create_resources.cmake.in
@@ -2,5 +2,5 @@ execute_process(
     COMMAND @PYRCC5_CMD@  @_qrc_file@
     OUTPUT_VARIABLE _res_py_content
 )
-string(REPLACE "PyQt5" "qtpy" _res_py_content ${_res_py_content})
+string(REPLACE "PyQt5" "qtpy" _res_py_content "${_res_py_content}")
 file(WRITE @_output_res_py@ ${_res_py_content})

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -162,7 +162,12 @@ void AlgorithmPropertiesWidget::initLayout() {
   if (!getAlgorithm())
     return;
 
-  // Delete all widgets in the layout
+  // Delete PropertyWidgets first. This prevents a use-after-free / pure-virtual-call crash
+  // when the event loop later delivers a stale DeferredDelete event
+  for (auto &propWidget : m_propWidgets)
+    propWidget->deleteLater();
+
+  // Now drain the grid of any remaining widgets and layouts
   QLayoutItem *child;
   while ((child = m_inputGrid->takeAt(0)) != nullptr) {
     if (child->widget())
@@ -171,10 +176,6 @@ void AlgorithmPropertiesWidget::initLayout() {
     delete child;
   }
 
-  // This also deletes the PropertyWidget, which does not actually
-  // contain the sub-widgets because they are shared in the grid layout
-  for (auto &propWidget : m_propWidgets)
-    propWidget->deleteLater();
   QCoreApplication::processEvents();
   m_propWidgets.clear();
 

--- a/qt/widgets/common/test/AlgorithmPropertiesWidgetTest.h
+++ b/qt/widgets/common/test/AlgorithmPropertiesWidgetTest.h
@@ -12,6 +12,8 @@
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidQtWidgets/Common/AlgorithmPropertiesWidget.h"
 #include <QCoreApplication>
+#include <QEventLoop>
+#include <QMetaObject>
 #include <QWidget>
 
 #include <cxxtest/TestSuite.h>
@@ -521,6 +523,95 @@ public:
     //   due to `ctest`, `gtest` and `Qt` interactions during shutdown.
     Mock::VerifyAndClearExpectations(settings_b);
     Mock::VerifyAndClearExpectations(settings_c);
+  }
+
+  /// Regression test for a use-after-free / pure-virtual crash that occurred when
+  /// `initLayout()` was called a second time on a widget that already had
+  /// PropertyWidgets and their associated infoWidgets (icon-strip QWidgets living
+  /// in column 4 of the grid).
+  ///
+  /// Root cause: `initLayout()` removed items from the grid layout first (queuing
+  /// infoWidget deletions), then queued PropertyWidget deletions, then called
+  /// `processEvents()`. Since infoWidgets were processed (freed) before their
+  /// PropertyWidgets, the `destroyed`-signal lambda on each PropertyWidget
+  /// subsequently called `deleteLater()` on already-freed memory. The stale
+  /// DeferredDelete event caused a pure-virtual call via the freed vtable when
+  /// next processed, triggering `std::terminate()` via Mantid's terminate handler.
+  ///
+  /// Fix: PropertyWidgets must be queued for deletion before grid widgets so that
+  /// the lambda fires while the infoWidget is still alive.
+  ///
+  /// See: https://github.com/mantidproject/mantid/issues/41471
+  void testInitLayout_ReinitializationDoesNotUseAfterFree() {
+    // The bug is a deletion-order violation introduced in PR #40132.
+    // initLayout() must queue PropertyWidget deletions BEFORE grid-widget deletions
+    // (which include the infoWidgets at column 4). If the order is reversed:
+    //
+    //   1. infoWidgets get deleteLater() first.
+    //   2. PropWidgets get deleteLater() second.
+    //   3. processEvents() fires DeferredDelete events FIFO.
+    //   4. infoWidget is freed; its memory may be reused.
+    //   5. propWidget's `destroyed`-signal lambda calls infoWidget->deleteLater()
+    //      on freed / reused memory.
+    //   6. The stale DeferredDelete reaches a garbage vtable → pure-virtual crash.
+    //
+    // Fix: propWidgets queued first → lambda fires while infoWidget is still alive.
+    //
+    // Test strategy: connect to the `destroyed` signals of both the OLD infoWidgets
+    // and OLD propWidgets. Count how many infoWidgets fire `destroyed` before any
+    // propWidget does. With the bug that count will be > 0; with the fix it is 0.
+    //
+    // Important: Qt only processes DeferredDelete events when the event-loop level
+    // is exactly (post_level + 1). Because tests run outside any event loop
+    // (loopLevel = 0), QCoreApplication::processEvents() alone cannot drain them.
+    // Running a brief QEventLoop bumps the level to 1 and lets Qt flush the queue
+    // while this stack frame — and therefore the shared_ptr captures — is still alive.
+
+    QGridLayout *inputGrid = m_widget->m_propWidgets.begin().value()->getGridLayout();
+
+    // Count OLD infoWidgets (column 4) that have already fired `destroyed` by the
+    // time the first OLD propWidget fires `destroyed`.
+    auto infoWidgetsDestroyedCount = std::make_shared<int>(0);
+    int totalInfoWidgets = 0;
+    for (int row = 0; row < inputGrid->rowCount(); ++row) {
+      auto *item = inputGrid->itemAtPosition(row, 4);
+      if (item && item->widget()) {
+        ++totalInfoWidgets;
+        QObject::connect(item->widget(), &QObject::destroyed,
+                         [infoWidgetsDestroyedCount]() { (*infoWidgetsDestroyedCount)++; });
+      }
+    }
+    TS_ASSERT_LESS_THAN(0, totalInfoWidgets);
+
+    // Bug present  → infoWidgets freed first → count > 0 when propWidget fires → flag set.
+    // Bug fixed    → propWidgets freed first → count == 0 when propWidget fires → flag clear.
+    auto infoWidgetDestroyedBeforePropWidget = std::make_shared<bool>(false);
+    for (auto *propWidget : m_widget->m_propWidgets) {
+      QObject::connect(propWidget, &QObject::destroyed,
+                       [infoWidgetsDestroyedCount, infoWidgetDestroyedBeforePropWidget]() {
+                         if (*infoWidgetsDestroyedCount > 0)
+                           *infoWidgetDestroyedBeforePropWidget = true;
+                       });
+    }
+
+    // Trigger the cleanup.
+    m_widget->setAlgorithm(m_algorithm);
+
+    // Flush DeferredDelete events. QEventLoop::exec() raises the loopLevel to 1,
+    // which satisfies Qt's condition for processing events posted at level 0.
+    // The invokeMethod queues the quit *after* the deletions so the loop exits
+    // only once all DeferredDelete events have been dispatched.
+    {
+      QEventLoop loop;
+      QMetaObject::invokeMethod(&loop, "quit", Qt::QueuedConnection);
+      loop.exec();
+    }
+
+    // Sanity check: all OLD infoWidgets must have been destroyed.
+    // If this fails, the event-loop flush above did not process DeferredDelete events.
+    TS_ASSERT_EQUALS(*infoWidgetsDestroyedCount, totalInfoWidgets);
+
+    TS_ASSERT(!*infoWidgetDestroyedBeforePropWidget);
   }
 
   /// Verifies that `hideOrDisableProperties()` computes the enabled state


### PR DESCRIPTION
### Description of work
Fixed missing matrix inversion in symmetry operation. Now binning is consistent with normalization

Closes #41516

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Run the script in the related issue

<img width="3121" height="1117" alt="image" src="https://github.com/user-attachments/assets/062eb23a-c0b7-441e-9e30-00cfe79508bc" />


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
