### PR TITLE
Add `on_data_updated` method to refresh line plots on data changes

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -224,6 +224,10 @@ class KeyHandler:
         """Called to disconnect from the axes events"""
         self.plotter.image_axes.figure.canvas.mpl_disconnect(self._key_cid)
 
+    def on_data_updated(self):
+        """Called when the underlying image data changes. Subclasses override to refresh line plots."""
+        pass
+
     def status_message(self):
         """
         Return a status message to display when this tool is active
@@ -302,6 +306,10 @@ class PixelLinePlot(CursorTracker, KeyHandler):
         self._plotter.delete_line_plot_lines()
         self._cursor_pos = None
 
+    def on_data_updated(self):
+        if self._cursor_pos is not None:
+            self.on_cursor_at(*self._cursor_pos)
+
     # KeyHandler interface
     def handle_key(self, key):
         """
@@ -372,21 +380,30 @@ class RectangleSelectionLinePlot(KeyHandler):
         if key in ("c", "x", "y"):
             self.exporter.export_cut(limits, cut_type=key)
 
+    def on_data_updated(self):
+        if not self._selector.artists[0].get_visible():
+            return
+        rect = self._selector._selection_artist
+        ll_x, ll_y = rect.get_xy()
+        self._plot_from_corners(ll_x, ll_y, ll_x + rect.get_width(), ll_y + rect.get_height())
+
     # private api
     def _on_rectangle_selected(self, eclick, erelease):
         """
-        Callback when a rectangle has been draw on the axes
+        Callback when a rectangle has been drawn on the axes
         :param eclick: Event marking where the mouse was clicked
         :param erelease: Event marking where the mouse was released
         """
+        self._plot_from_corners(eclick.xdata, eclick.ydata, erelease.xdata, erelease.ydata)
+
+    def _plot_from_corners(self, x1, y1, x2, y2):
         plotter = self.plotter
-        cinfo_click = cursor_info(plotter.image, eclick.xdata, eclick.ydata)
+        cinfo_click = cursor_info(plotter.image, x1, y1)
         if cinfo_click is None:
             return
-        cinfo_release = cursor_info(plotter.image, erelease.xdata, erelease.ydata)
+        cinfo_release = cursor_info(plotter.image, x2, y2)
         if cinfo_release is None:
             return
-
         arr, (xmin, xmax, ymin, ymax), (imin, jmin), _ = cinfo_click
         imax, jmax = cinfo_release.point
         plotter.plot_x_line(np.linspace(xmin, xmax, arr.shape[1])[jmin:jmax], np.sum(arr[imin:imax, jmin:jmax], axis=0))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -33,6 +33,7 @@ from mantid.plots.resampling_image import samplingimage
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
 from mantidqt.widgets.sliceviewer.presenters.imageinfowidget import ImageInfoWidget, ImageInfoTracker
 from mantidqt.widgets.sliceviewer.presenters.lineplots import LinePlots
+from mantidqt.widgets.sliceviewer.presenters.selector import cursor_info
 from mantidqt.widgets.sliceviewer.views.dataviewsubscriber import IDataViewSubscriber
 from mantidqt.widgets.sliceviewer.views.dimensionwidget import DimensionWidget
 from mantidqt.widgets.sliceviewer.views.toolbar import SliceViewerNavigationToolbar, ToolItemText
@@ -451,6 +452,9 @@ class SliceViewerDataView(QWidget):
         else:
             self.image.set_data(data.T)
         self.colorbar.update_clim()
+        if self.line_plots_active and self._line_plots is not None:
+            cursor_info.cache_clear()
+            self._line_plots.on_data_updated()
 
     def track_cursor_checked(self):
         return self.track_cursor.isChecked() if self.track_cursor else False


### PR DESCRIPTION
### Description of work

Adds an `on_data_updated` hook so that the slice viewer's line plots (pixel cuts and rectangle-selection cuts) refresh when the underlying 2D image data changes (e.g. when the slice slider is dragged). Previously, the histograms remained stale after slicing.

No need for release notes because this change adds an internal method to fix reactive plot updates — it doesn't introduce new user-facing functionality.

### To test:
The problem is exemplified by this screencast. It shows that dragging the slice bar doesn't change the histogram line-plots even the 2D slice changes.

https://github.com/user-attachments/assets/114a5103-eb68-4cc6-8cd5-f5efe71fe688

In the workbench, run the following script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import os

folder = "/SNS/TOPAZ/IPTS-36169/shared/nxv/"
filename = "Si_AG_300K_normalization/Si_AG_300K_(h,k,0)_[0,0,l]_[-10.0,10.0]_[-10.0,10.0]_[-10.0,10.0]_201x201x201_m-3m_sub_bkg.nxs"
ws = "Si_300K"

LoadMD(
    Filename=os.path.join(folder, filename),
    LoadHistory=False,
    OutputWorkspace="Si_300K"
)
```
After that:
  - show the slicedViewer for workspace "Si_300K"                                                                                
  - toggle the lineplots on                                                                                                       
  - toggle the region selection on                                                                                                 
  - selected a rectangular region with the mouse --> histograms where produced                                                     
  - drag the slice bar to change the L value, or change the value in the adjacent box

You should see the histogram line-plot changes as in this screencast:


https://github.com/user-attachments/assets/9686379b-b3cd-4999-a82c-9adcddeba100

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
