### PR TITLE
Skip ILLDirectGeometryReductionTest.IN5 on Windows

### DIFF
--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -90,6 +90,10 @@ class IN4(systemtesting.MantidSystemTest):
 
 
 class IN5(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        # Frequently fails on Windows for no obvious reason. Maybe it's using too much RAM and timing out.
+        return sys.platform.startswith("win")
+
     def runTest(self):
         config["default.facility"] = "ILL"
         config["default.instrument"] = "IN5"

--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -21,6 +21,7 @@ from mantid.simpleapi import (
     Load,
 )
 import platform
+import sys
 import systemtesting
 from testhelpers import assertRaisesNothing, create_algorithm
 


### PR DESCRIPTION
### Description of work
This test frequently fails on Windows, which prevents nightly publishing. We don't want this to happen because it will likely delay the release.

### To test:
Inspect code.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
