### PR TITLE
Fix rendering with new IV in Reflectometry interface

### DIFF
--- a/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
@@ -108,7 +108,7 @@ class ReflectometryInstrumentViewPresenter:
         plotter = self.view.main_plotter
         plotter.clear()
 
-        self._detector_mesh = self._renderer.build_detector_mesh(self._model.detector_positions, self._model.flip_z, self._model)
+        self._detector_mesh = self._renderer.build_detector_mesh(self._model.detector_positions, self._model.flip_beam, self._model)
         self._renderer.set_detector_scalars(self._detector_mesh, self._model.detector_counts, self._COUNTS_LABEL)
         self._renderer.add_detector_mesh_to_plotter(plotter, self._detector_mesh, scalars=self._COUNTS_LABEL, show_scalar_bar=False)
 

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter import ReflectometryInstrumentViewPresenter
 from instrumentview.Projections.ProjectionType import ProjectionType
+from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 
 
 def _make_presenter():
@@ -359,7 +360,7 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         ``flip_z`` would therefore raise AttributeError, catching the
         regression introduced by that typo.
         """
-        mock_model = MagicMock(spec=["detector_positions", "flip_beam", "detector_counts", "is_2d_projection"])
+        mock_model = mock.create_autospec(FullInstrumentViewModel, instance=True)
         mock_model.detector_positions = np.zeros((10, 3))
         mock_model.flip_beam = False
         mock_model.detector_counts = np.zeros(10)

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
@@ -350,6 +350,30 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         # Origin is 1 unit away from centre; after 2x scale it should be 2 units away
         np.testing.assert_allclose(result[:2], [-1.0, -1.0])
 
+    def test_render_does_not_raise(self):
+        """_render must complete without raising.
+
+        The model mock is spec-restricted to only the attributes that
+        FullInstrumentViewModel actually exposes (including ``flip_beam``).
+        Accessing a non-existent attribute such as the formerly incorrect
+        ``flip_z`` would therefore raise AttributeError, catching the
+        regression introduced by that typo.
+        """
+        mock_model = MagicMock(spec=["detector_positions", "flip_beam", "detector_counts", "is_2d_projection"])
+        mock_model.detector_positions = np.zeros((10, 3))
+        mock_model.flip_beam = False
+        mock_model.detector_counts = np.zeros(10)
+        mock_model.is_2d_projection = True
+
+        mock_renderer = MagicMock()
+        mock_renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+
+        self._presenter._model = mock_model
+        self._presenter._renderer = mock_renderer
+
+        # Should not raise
+        self._presenter._render()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work

Fixes an error when rendering the instrument in the Preview tab of the `ISIS Reflectometry` interface. It was generating an error, but the error was swallowed up by several other errors that come from `matplotlib` and the reduction.

### To test:

https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#preview-tab

Try the above manual testing with the new Instrument View enabled.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
