### PR TITLE
Pin rstcheck-core to avoid pre-commit failures (#41526)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     rev: v6.2.5
     hooks:
       - id: rstcheck
-        additional_dependencies: [sphinx]
+        additional_dependencies: [sphinx, "rstcheck-core<1.3"]
         args: ["--config", ".rstcheck.project.cfg"]
         exclude: |
           (?x)^(


### PR DESCRIPTION
This is a version of #41526 into `ornl-next`