### PR TITLE
Copy usagedata-note.txt into dev-docs sphinx site

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     rev: v6.2.5
     hooks:
       - id: rstcheck
-        additional_dependencies: [sphinx, "rstcheck-core<1.3"]
+        additional_dependencies: [sphinx]
         args: ["--config", ".rstcheck.project.cfg"]
         exclude: |
           (?x)^(

--- a/dev-docs/source/usagedata-note.txt
+++ b/dev-docs/source/usagedata-note.txt
@@ -1,0 +1,6 @@
+.. note::
+
+   To run these usage examples please first download the
+   `usage data <https://sourceforge.net/projects/mantid/files/Sample%20Data/UsageData.zip/download>`_,
+   and add these to your path.
+   In Mantid this is done using :ref:`ManageUserDirectories`.


### PR DESCRIPTION
#41526 introduced a temporary pin to fix failling pre-commit jobs. The issue was an 8-year old `.. include` directive to a missing file in the dev-docs site, file `dev-docs/source/Standards/AlgorithmUsageExamples.rst`. This copies the file from the user docs site and removes the pin.

There is no associated issue.

### To test:

The pre-commit job should pass.

*This does not require release notes* because it is fixing a failing build.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
