### PR TITLE
Enable INP rule in `ruff` for `__init__.py` files

### DIFF
--- a/Framework/DataObjects/scripts/__init__.py
+++ b/Framework/DataObjects/scripts/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/mantid/LiveData/ADARA/utils/packet_playback/__init__.py
+++ b/Framework/PythonInterface/mantid/LiveData/ADARA/utils/packet_playback/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/plugins/algorithms/Examples/__init__.py
+++ b/Framework/PythonInterface/plugins/algorithms/Examples/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/plugins/functions/Examples/__init__.py
+++ b/Framework/PythonInterface/plugins/functions/Examples/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/plugins/functions/__init__.py
+++ b/Framework/PythonInterface/plugins/functions/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ lint.select = [
   "W",
   "NPY201",
   "S",
+  "INP",
 ]
 lint.ignore = [
   "E722", # bare except https://docs.astral.sh/ruff/rules/bare-except/
@@ -53,6 +54,24 @@ exclude = [
   "Testing/SystemTests/tests/framework/reference",
   "scripts/ErrorReporter/ui_errorreport.py",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"**/test/**" = ["INP001"]
+"**/tests/**" = ["INP001"]
+"**/test_helpers/**" = ["INP001"]
+"Testing/**" = ["INP001"]
+"scripts/**" = ["INP001"]
+"dev-docs/**" = ["INP001"]
+"docs/**" = ["INP001"]
+"tools/**" = ["INP001"]
+"installers/**" = ["INP001"]
+"**/setup.py" = ["INP001"]
+"conda/**" = ["INP001"]
+"buildconfig/**" = ["INP001"]
+"Framework/Doxygen/**" = ["INP001"]
+"qt/icons/**" = ["INP001"]
+"qt/python/mantidqt/resources.py" = ["INP001"]
+"Framework/DataObjects/src/**" = ["INP001"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 20

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/muon_context/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/muon_context/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/grouping_widget/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/grouping_widget/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +


### PR DESCRIPTION
This will detect any missing `__init__.py` files. There are several exclusions where we have Python files that are not intended to be in packages.

See [here](https://docs.astral.sh/ruff/rules/implicit-namespace-package/)

This happened and was fixed in #41505, but this rule would pick up the same mistake in future.

### To test:

Run `pre-commit run ruff-check --all-files`

Check package build

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
