### PR TITLE
Pin qscintilla to same version in run deps to ensure compatibility

### DIFF
--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -51,7 +51,7 @@ requirements:
   run:
     - mantid == ${{ version }}
     - matplotlib ${{ matplotlib }}
-    - ${{ pin_compatible("qscintilla2", upper_bound="x.x") }}
+    - qscintilla2 ${{ qscintilla2 }}
     - ${{ pin_compatible("qt-main", upper_bound="x.x") }}
     - qtpy ${{ qtpy }}
     - python


### PR DESCRIPTION
### Description of work
We need to pin to the same version in run as in host to avoid this error on macOS:

```
% pixi run workbench
Traceback (most recent call last):
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/utils/qt/__init__.py", line 55, in import_qt
    lib = import_module(modulename + LIB_SUFFIX, package)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 921, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 813, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1293, in create_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
ImportError: dlopen(/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/_commonqt5.so, 0x0002): Library not loaded: @rpath/libqscintilla2_qt5.15.dylib
  Referenced from: <68AB592A-FC87-3A2C-A587-CAE2ACA9AA6D> /Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/_commonqt5.so
  Reason: tried: '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../Frameworks/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../Frameworks/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/bin/../lib/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/bin/../lib/libqscintilla2_qt5.15.dylib' (no such file)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/utils/qt/__init__.py", line 58, in import_qt
    lib = import_module(modulename.lstrip(".") + LIB_SUFFIX)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named '_commonqt5'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/bin/workbench", line 11, in <module>
    sys.exit(launch())
             ^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/app/mantidworkbench_launch_wrapper.py", line 27, in launch
    main(args[1:])
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/app/main.py", line 67, in main
    start(options)
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/app/main.py", line 93, in start
    from workbench.app.start import start
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/app/start.py", line 27, in <module>
    import workbench.app.workbench_process as wp  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/app/workbench_process.py", line 32, in <module>
    from workbench.widgets.about.presenter import AboutPresenter  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/workbench/widgets/about/presenter.py", line 11, in <module>
    from mantidqt.interfacemanager import InterfaceManager
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/interfacemanager.py", line 12, in <module>
    InterfaceManager = import_qt("._common", "mantidqt", "InterfaceManager")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/utils/qt/__init__.py", line 62, in import_qt
    raise ImportError(msg)
ImportError: First import of "._commonqt5" failed with "dlopen(/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/_commonqt5.so, 0x0002): Library not loaded: @rpath/libqscintilla2_qt5.15.dylib
  Referenced from: <68AB592A-FC87-3A2C-A587-CAE2ACA9AA6D> /Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/_commonqt5.so
  Reason: tried: '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../Frameworks/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/lib/python3.12/site-packages/mantidqt/../../Frameworks/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/bin/../lib/libqscintilla2_qt5.15.dylib' (no such file), '/Users/user.name/repos/mantid-manual-616/.pixi/envs/default/bin/../lib/libqscintilla2_qt5.15.dylib' (no such file)". Second import of "_commonqt5" failed with "No module named '_commonqt5'"
```

### To test:
Check the [log of the package build ](https://builds.mantidproject.org/job/pull_requests-conda-packaging/11693/consoleFull), searching for qscintilla and ensure the correct version is installed throughout: 2.14.1 build variant 0 (the zero will be at the end of the version string).
For reference, [here](https://builds.mantidproject.org/job/pull_requests-conda-packaging/11691/consoleFull) is a build where it wasn't pinned to the same version, you can see there are build variant 2 in the logs.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
