### PR TITLE
QtPropertyBrowser: Fix mismatched const arguments in signals/slots

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -400,7 +400,7 @@ private slots:
   void stringChanged(QtProperty *prop);
   void filenameChanged(QtProperty *prop);
   void columnChanged(QtProperty *prop);
-  void currentItemChanged(QtBrowserItem * /*current*/);
+  void currentItemChanged(const QtBrowserItem * /*current*/);
   void vectorDoubleChanged(QtProperty *prop);
   void vectorSizeChanged(QtProperty *prop);
   void addTie();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -332,7 +332,7 @@ public:
   void setCurrentItem(QtBrowserItem * /*item*/);
 
 Q_SIGNALS:
-  void currentItemChanged(QtBrowserItem * /*_t1*/);
+  void currentItemChanged(const QtBrowserItem * /*_t1*/);
 
 public Q_SLOTS:
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -486,7 +486,8 @@ void FitPropertyBrowser::initBasicLayout(QWidget *w) {
 
   m_browser->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(m_browser, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(popupMenu(const QPoint &)));
-  connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), this, SLOT(currentItemChanged(QtBrowserItem *)));
+  connect(m_browser, SIGNAL(currentItemChanged(const QtBrowserItem *)), this,
+          SLOT(currentItemChanged(const QtBrowserItem *)));
   connect(this, SIGNAL(multifitFinished()), this, SLOT(processMultiBGResults()));
 
   connect(m_wsListWidget, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this,
@@ -2039,7 +2040,7 @@ QtBrowserItem *FitPropertyBrowser::findItem(QtBrowserItem *parent, QtProperty *p
 /**
  * Slot. Responds to changing the current item
  */
-void FitPropertyBrowser::currentItemChanged(QtBrowserItem *current) {
+void FitPropertyBrowser::currentItemChanged(const QtBrowserItem *current) {
   if (current) {
     m_currentHandler = getHandler()->findHandler(current->property());
   } else {

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -223,7 +223,7 @@ void FunctionTreeView::createBrowser() {
   connect(m_constraintManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(constraintChanged(QtProperty *)));
   connect(m_parameterManager, SIGNAL(valueChanged(QtProperty *, double)), SLOT(parameterPropertyChanged(QtProperty *)));
 
-  connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), SLOT(updateCurrentFunctionIndex()));
+  connect(m_browser, SIGNAL(currentItemChanged(const QtBrowserItem *)), SLOT(updateCurrentFunctionIndex()));
 
   m_browser->setFocusPolicy(Qt::StrongFocus);
 }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -202,7 +202,8 @@ void MuonFitPropertyBrowser::init() {
   m_functionsGroup = m_browser->addProperty(functionsGroup);
   m_settingsGroup = m_browser->addProperty(settingsGroup);
   m_multiFitSettingsGroup = m_browser->addProperty(multiFitSettingsGroup);
-  connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), this, SLOT(currentItemChanged(QtBrowserItem *)));
+  connect(m_browser, SIGNAL(currentItemChanged(const QtBrowserItem *)), this,
+          SLOT(currentItemChanged(QtBrowserItem *)));
 
   m_btnGroup = new QGroupBox(tr("Reselect Data"));
   auto *btnLayout = new QHBoxLayout;

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -203,7 +203,7 @@ void MuonFitPropertyBrowser::init() {
   m_settingsGroup = m_browser->addProperty(settingsGroup);
   m_multiFitSettingsGroup = m_browser->addProperty(multiFitSettingsGroup);
   connect(m_browser, SIGNAL(currentItemChanged(const QtBrowserItem *)), this,
-          SLOT(currentItemChanged(QtBrowserItem *)));
+          SLOT(currentItemChanged(const QtBrowserItem *)));
 
   m_btnGroup = new QGroupBox(tr("Reselect Data"));
   auto *btnLayout = new QHBoxLayout;

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -707,8 +707,8 @@ QtTreePropertyBrowser::QtTreePropertyBrowser(QWidget *parent, const QStringList 
   d_ptr->q_ptr = this;
 
   d_ptr->init(this, options, darkTopLevel);
-  connect(this, SIGNAL(currentItemChanged(QtBrowserItem *)), this,
-          SLOT(slotCurrentBrowserItemChanged(QtBrowserItem *)));
+  connect(this, SIGNAL(currentItemChanged(const QtBrowserItem *)), this,
+          SLOT(slotCurrentBrowserItemChanged(const QtBrowserItem *)));
 }
 
 /**


### PR DESCRIPTION
### Description of work

PR #41411 added some `const` qualifiers, but missed propagating them through some signal/slots. This causes runtime warnings.

I suspect that this issue does cause some broken behaviour due to the signal failing to be hooked up, though I did not dig deep enough to prove that.

Closes #41514 

*This does not require release notes* because its a small follow up to #41411 

### To test:

Run Mantid from a terminal. Open one the user interfaces, e.g. Engineering Diffraction or Bayes Fitting.
The terminal will no longer show a QObject::connect error

The warning also shows in some tests, e.g.
`ctest -V -R MantidQtWidgetsCommonTestQt5_FitOptionsBrowserTest`




<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
