### PR TITLE
Only skip code building if actual built files exist

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -39,8 +39,8 @@ if [[ ${JOB_NAME} == *pull_requests* ]]; then
     EXTRA_CMAKE_FLAGS+=" -DPR_JOB=True"
 fi
 
-# MPI library is needed for some system tests and doc tests
-if [[ $ENABLE_SYSTEM_TESTS == true || $ENABLE_DOCS == true ]]; then
+# MPI library is needed for some system tests and doc tests, so we always want it avalaible on Linux
+if [[ $OSTYPE == "linux"* ]]; then
     EXTRA_CMAKE_FLAGS+=" -DMPI_BUILD=ON"
 fi
 

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -117,7 +117,7 @@ pushd $WORKSPACE
 install_pixi "$WORKSPACE"
 
 # Check whether this is an incremental build that only changes rst files
-if [ -d $BUILD_DIR ]; then
+if [ -d $BUILD_DIR/Framework ]; then
     if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
       ENABLE_BUILD_CODE=false
       ENABLE_UNIT_TESTS=false


### PR DESCRIPTION
This pulls #41470 into `ornl-next`