### PR TITLE
Be more particular about workflow files in gh-actions

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -20,7 +20,10 @@ configuration: &files_config
 # files that affect CI
 workflows: &files_workflow
  - 'buildconfig/Jenkins/**'
- - '.github/**'
+ - '.github/actions/**'
+ - '.github/matchers/**'
+ - '.github/workflows/**'
+ - '.github/filters.yaml'
 ### filters used in individual jobs and steps
 doxygen:
  - *files_config


### PR DESCRIPTION
After prompting from others, reduce what files are considered for the generic `files_workflow` filter. This no longer returns true for things generically in the `.github/` directory.

There is no associated issue

### To test:

Unfortunately, this file is one of the things that is deemed important for selecting workflows so the normal pr-build will run. After this is merged, we can update something in `.gihub/copilot/` and the pr-build shouldn't run.

*This does not require release notes* because it is a change to when github-actions run

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
