### PR TITLE
Remove old qt3, qt4 compatability code

### DIFF
--- a/Testing/Tools/cxxtest/cxxtest/QtGui.h
+++ b/Testing/Tools/cxxtest/cxxtest/QtGui.h
@@ -224,11 +224,7 @@ namespace CxxTest
 
         void setIcon( QMessageBox::Icon icon )
         {
-#if QT_VERSION >= 0x030000
             _mainWindow->setIcon( QMessageBox::standardIcon( icon ) );
-#else // Qt version < 3.0.0
-            _mainWindow->setIcon( QMessageBox::standardIcon( icon, QApplication::style().guiStyle() ) );
-#endif // QT_VERSION
         }
 
         void processEvents()

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtbuttonpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtbuttonpropertybrowser.h
@@ -90,9 +90,7 @@
 #include "qtpropertybrowser.h"
 #include <QMap>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtButtonPropertyBrowserPrivate;
 class QLabel;
@@ -177,6 +175,4 @@ private:
   QList<WidgetItem *> m_recreateQueue;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
@@ -98,9 +98,7 @@
 #include <QSpinBox>
 #include <QTimerEvent>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QColor;
 class QLabel;
@@ -883,6 +881,4 @@ public:
   void slotSetValue(const QTime &value);
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtgroupboxpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtgroupboxpropertybrowser.h
@@ -90,9 +90,7 @@
 #include "qtpropertybrowser.h"
 #include <QMap>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtGroupBoxPropertyBrowserPrivate;
 class QLabel;
@@ -163,6 +161,4 @@ private:
   QList<WidgetItem *> m_recreateQueue;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -92,9 +92,7 @@
 #include <QSet>
 #include <QWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtAbstractPropertyManager;
 class QtPropertyPrivate;
@@ -409,6 +407,4 @@ public:
   QtBrowserItem *m_currentItem;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
@@ -103,9 +103,7 @@
 #include <QStringList>
 #include <QWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QMouseEvent;
 class QCheckBox;
@@ -198,6 +196,4 @@ private:
   QLineEdit *m_lineEdit;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
@@ -91,9 +91,7 @@
 
 #include <utility>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QDate;
 class QTime;
@@ -1415,6 +1413,4 @@ private:
   QtMetaEnumWrapper(QObject *parent) : QObject(parent) {}
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
@@ -97,9 +97,7 @@
 #include <QStyleOptionButton>
 #include <QTreeWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QTreeWidgetItem;
 class QtTreePropertyBrowserPrivate;
@@ -352,6 +350,4 @@ private:
   mutable QWidget *m_editedWidget;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
@@ -91,9 +91,7 @@
 #include <QIcon>
 #include <QVariant>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 using QtIconMap = QMap<int, QIcon>;
 
@@ -300,9 +298,7 @@ public:
   const QString m_regExpAttribute;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif
 
 Q_DECLARE_METATYPE(QIcon)
 Q_DECLARE_METATYPE(QtIconMap)

--- a/qt/widgets/common/src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp
@@ -93,9 +93,7 @@
 #include <QTimer>
 #include <QToolButton>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 QToolButton *QtButtonPropertyBrowserPrivate::createButton(QWidget *parent) const {
   auto *button = new QToolButton(parent);
@@ -588,6 +586,4 @@ bool QtButtonPropertyBrowser::isExpanded(QtBrowserItem *item) const {
   return false;
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -107,9 +107,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 // Set a hard coded left margin to account for the indentation
 // of the tree view icon when switching to an editor
@@ -1984,6 +1982,4 @@ void QtFontEditorFactory::disconnectPropertyManager(QtFontPropertyManager *manag
   disconnect(manager, SIGNAL(valueChanged(QtProperty *, QFont)), this, SLOT(slotPropertyChanged(QtProperty *, QFont)));
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtgroupboxpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtgroupboxpropertybrowser.cpp
@@ -92,9 +92,7 @@
 #include <QSet>
 #include <QTimer>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 void QtGroupBoxPropertyBrowserPrivate::init(QWidget *parent) {
   m_mainLayout = new QGridLayout(parent);
@@ -488,6 +486,4 @@ void QtGroupBoxPropertyBrowser::itemRemoved(QtBrowserItem *item) { d_ptr->proper
 */
 void QtGroupBoxPropertyBrowser::itemChanged(QtBrowserItem *item) { d_ptr->propertyChanged(item); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -93,9 +93,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 /**
     \class QtProperty
@@ -1848,6 +1846,4 @@ void QtAbstractPropertyBrowser::setCurrentItem(QtBrowserItem *item) {
     emit currentItemChanged(item);
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
@@ -101,9 +101,7 @@ QString translateUtf8Encoded(const char *context, const char *key, const char *d
 }
 } // namespace
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 QtCursorDatabase::QtCursorDatabase() {
   appendCursor(Qt::ArrowCursor, translateUtf8Encoded("QtCursorDatabase", "Arrow", nullptr),
@@ -428,6 +426,4 @@ bool QtKeySequenceEdit::event(QEvent *e) {
   return QWidget::event(e);
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -109,9 +109,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 // Match the exact signature of qBound for VS 6.
 QSize qBound(QSize minVal, QSize val, QSize maxVal) { return qBoundSize(minVal, val, maxVal); }
@@ -145,22 +143,6 @@ private:
   QMetaEnum m_policyEnum;
 };
 
-#if QT_VERSION < 0x040300
-
-static QList<QLocale::Country> countriesForLanguage(QLocale::Language language) {
-  QList<QLocale::Country> countries;
-  QLocale::Country country = QLocale::AnyCountry;
-  while (country <= QLocale::LastCountry) {
-    QLocale locale(language, country);
-    if (locale.language() == language && !countries.contains(locale.country()))
-      countries << locale.country();
-    country = (QLocale::Country)((uint)country + 1); // ++country
-  }
-  return countries;
-}
-
-#endif
-
 static QList<QLocale::Country> sortCountries(const QList<QLocale::Country> &countries) {
   QMultiMap<QString, QLocale::Country> nameToCountry;
   QListIterator<QLocale::Country> itCountry(countries);
@@ -188,11 +170,7 @@ void QtMetaEnumProvider::initLocale() {
   QListIterator<QLocale::Language> itLang(languages);
   for (const auto language : languages) {
     QList<QLocale::Country> countries;
-#if QT_VERSION < 0x040300
-    countries = countriesForLanguage(language);
-#else
     countries = QLocale::countriesForLanguage(language);
-#endif
     if (countries.isEmpty() && language == system.language())
       countries << system.country();
 
@@ -4828,9 +4806,7 @@ void QtFontPropertyManagerPrivate::slotFontDatabaseDelayedChange() {
 QtFontPropertyManager::QtFontPropertyManager(QObject *parent) : QtAbstractPropertyManager(parent) {
   d_ptr = new QtFontPropertyManagerPrivate;
   d_ptr->q_ptr = this;
-#if QT_VERSION >= 0x040500
   QObject::connect(qApp, SIGNAL(fontDatabaseChanged()), this, SLOT(slotFontDatabaseChanged()));
-#endif
 
   d_ptr->m_intPropertyManager = new QtIntPropertyManager(this);
   connect(d_ptr->m_intPropertyManager, SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -5457,6 +5433,4 @@ void QtCursorPropertyManager::initializeProperty(QtProperty *property) {
 */
 void QtCursorPropertyManager::uninitializeProperty(QtProperty *property) { d_ptr->m_values.remove(property); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -107,9 +107,7 @@ QString translateUtf8Encoded(const char *context, const char *key, const char *d
 }
 } // namespace
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtPropertyEditorView;
 
@@ -996,6 +994,4 @@ QTreeWidget *QtTreePropertyBrowser::treeWidget() { return d_ptr->treeWidget(); }
 
 void QtTreePropertyBrowser::closeEditor() { d_ptr->closeEditor(); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
@@ -97,9 +97,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtEnumPropertyType {};
 
@@ -107,17 +105,13 @@ class QtFlagPropertyType {};
 
 class QtGroupPropertyType {};
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif
 
 Q_DECLARE_METATYPE(QtEnumPropertyType)
 Q_DECLARE_METATYPE(QtFlagPropertyType)
 Q_DECLARE_METATYPE(QtGroupPropertyType)
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 /**
     Returns the type id for an enum property.
@@ -2108,6 +2102,4 @@ void QtVariantEditorFactory::disconnectPropertyManager(QtVariantPropertyManager 
     d_ptr->m_checkBoxFactory->removePropertyManager(itFlag.next()->subBoolPropertyManager());
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif


### PR DESCRIPTION
### Description of work

Move some old Qt preprocessor checks for supporting pre Qt5 versions.

This should not change what is output from the preprocessor, its effectively just evaluating and fixing it for Qt version >= 5.

Good to clean these up to simplify things before the Qt6 migration #38415 

Changes were made with `unifdef` tool
```
rg -tcpp "if.*QT_VERSION.*0x03" --files-with-matches | xargs -n1 unifdef -DQT_VERSION=0x050000 -m
rg -tcpp "if.*QT_VERSION.*0x04" --files-with-matches | xargs -n1 unifdef -DQT_VERSION=0x050000 -m
```

### To test:

If it builds and passes tests is should be good.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
