### PR TITLE
Add TexturePlanner absorption helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/CMakeLists.txt
@@ -34,5 +34,6 @@ endif()
 
 add_subdirectory(test)
 add_subdirectory(mantidqtinterfaces/Engineering/gui)
+add_subdirectory(mantidqtinterfaces/TexturePlanner)
 add_subdirectory(mantidqtinterfaces/drill)
 add_subdirectory(mantidqtinterfaces/sans_isis/gui_logic/tests)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Tests for the Texture Planner interface
+
+set(TEST_PY_FILES helpers/test/test_absorption.py)
+
+check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
+
+if(ENABLE_WORKBENCH)
+  set(PYUNITTEST_QT_API pyqt5)
+  pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.TexturePlanner ${TEST_PY_FILES})
+  unset(PYUNITTEST_QT_API)
+endif()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -1,0 +1,121 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+
+from mantid.simpleapi import ConvertUnits, CopySample, MonteCarloAbsorption, RotateSampleShape
+from mantid.api import MatrixWorkspace
+from mantid.kernel import logger
+from Engineering.texture.correction.correction_model import read_attenuation_coefficient_at_value
+from Engineering.texture.texture_helper import define_gauge_volume
+from typing import Any, Protocol, Dict, Tuple
+from abc import abstractmethod
+from scipy.spatial.transform import Rotation
+
+
+class _WorkspaceManagerType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    WS_MC_OUTPUT: str
+    WS_MC_INPUT: str
+    wsname: str
+    attenuation_kwargs: Dict[str, str | float]
+    offset: Tuple[float | int, float | int, float | int]
+    mesh_ws: MatrixWorkspace
+    init_R: Rotation
+    gauge_volume_str: str | None
+
+    @staticmethod
+    @abstractmethod
+    def translate_shape(ws: MatrixWorkspace, x_pos: float | int, y_pos: float | int, z_pos: float | int):
+        pass
+
+
+class _BaseModelType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    workspaces: _WorkspaceManagerType
+    orientations: Any
+    geometry: Any
+
+
+class AbsorptionCalculator:
+    """Runs MonteCarloAbsorption per orientation.
+    Passes the resulting transmission factors onto the orientation table via the manager model"""
+
+    def __init__(self, model: _BaseModelType):
+        self._model = model
+        # MonteCarloAbsorption settings; the in/out workspace names come from the workspace manager,
+        # which the model constructs before this collaborator.
+        self.mc_kwargs = {
+            "InputWorkspace": model.workspaces.WS_MC_INPUT,
+            "OutputWorkspace": model.workspaces.WS_MC_OUTPUT,
+            "EventsPerPoint": 50,
+            "MaxScatterPtAttempts": int(1e4),
+            "SimulateScatteringPointIn": "SampleOnly",
+            "ResimulateTracksForDifferentWavelengths": False,
+        }
+
+    def calc_for_index(self, index: int) -> None:
+        m = self._model
+        wsm = m.workspaces
+        # create a workspace to run the absorption calculation on
+        mc_ws = self._create_mc_ws(wsm)
+
+        # extract goniometer for run index
+        R = m.orientations[index].R
+
+        # set sample state (orientated shape, material and gauge volume) for run index
+        self._set_mc_sample_state(wsm, mc_ws, R)
+
+        try:
+            MonteCarloAbsorption(**self.mc_kwargs)
+            transmission = read_attenuation_coefficient_at_value(
+                wsm.WS_MC_OUTPUT, wsm.attenuation_kwargs["point"], wsm.attenuation_kwargs["unit"]
+            )[m.geometry.starting_ind :]
+        except RuntimeError:
+            logger.warning("MonteCarloAbsorption has failed, sample is assumed to be outside the gauge volume ")
+            transmission = np.zeros(mc_ws.getNumberHistograms() - m.geometry.starting_ind)
+        m.orientations.set_transmission_at_index(transmission, index)
+
+    @staticmethod
+    def _create_mc_ws(wsm: _WorkspaceManagerType) -> MatrixWorkspace:
+        mc_ws = ConvertUnits(InputWorkspace=wsm.wsname, Target="Wavelength", OutputWorkspace=wsm.WS_MC_INPUT)
+        mc_ws.run().getGoniometer().setR(np.eye(3))
+        return mc_ws
+
+    @staticmethod
+    def _set_mc_sample_state(wsm: _WorkspaceManagerType, mc_ws: MatrixWorkspace, R: Rotation) -> None:
+        # copy sample shape and material from mesh ws (untransformed sample - no init_R, no translation, identity goniometer)
+        CopySample(
+            InputWorkspace=wsm.mesh_ws,
+            OutputWorkspace=wsm.WS_MC_INPUT,
+            CopyShape=True,
+            CopyMaterial=True,
+            CopyEnvironment=False,
+            CopyLattice=False,
+        )
+
+        # apply the initial translation
+        wsm.translate_shape(mc_ws, *wsm.offset)
+
+        # apply both the initial and the goniometer rotations
+        shapeR = R * wsm.init_R
+        rotvec = shapeR.as_rotvec(degrees=True)
+        ang = np.linalg.norm(rotvec)
+        if ang != 0:
+            vec = rotvec / ang
+            RotateSampleShape(wsm.WS_MC_INPUT, f"{ang},{vec[0]},{vec[1]},{vec[2]},1")
+
+        # define the gauge volume
+        define_gauge_volume(mc_ws, wsm.gauge_volume_str)
+
+    def calc_all(self) -> None:
+        for i in self._model.orientations.keys():
+            self.calc_for_index(i)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
@@ -1,0 +1,240 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+
+from unittest.mock import patch, MagicMock, call
+from scipy.spatial.transform import Rotation
+
+from mantidqtinterfaces.TexturePlanner.helpers.absorption import AbsorptionCalculator
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.absorption"
+
+WS_MC_INPUT = "__mc_ws"
+WS_MC_OUTPUT = "__abs_ws"
+WS_DATA = "__texture_planning_ws"
+
+
+def _make_wsm(offset=(0.0, 0.0, 0.0), init_R=None, gauge_volume_str="<gv/>"):
+    wsm = MagicMock()
+    wsm.WS_MC_INPUT = WS_MC_INPUT
+    wsm.WS_MC_OUTPUT = WS_MC_OUTPUT
+    wsm.wsname = WS_DATA
+    wsm.mesh_ws = "mesh_ws"
+    wsm.offset = offset
+    wsm.init_R = init_R if init_R is not None else Rotation.identity()
+    wsm.gauge_volume_str = gauge_volume_str
+    wsm.attenuation_kwargs = {"point": 1.5, "unit": "dSpacing"}
+    return wsm
+
+
+def _make_model(R=None, n_orientations=1, starting_ind=0):
+    model = MagicMock()
+    model.workspaces = _make_wsm()
+    orient = MagicMock()
+    orient.R = R if R is not None else Rotation.identity()
+    model.orientations = MagicMock()
+    model.orientations.__getitem__.side_effect = lambda i: orient
+    model.orientations.keys.return_value = list(range(n_orientations))
+    model.geometry.starting_ind = starting_ind
+    return model, orient
+
+
+@patch(file_path + ".ConvertUnits")
+class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
+    def test_converts_units_to_wavelength_into_mc_input(self, mock_convert):
+        wsm = _make_wsm()
+        mc_ws = MagicMock()
+        mock_convert.return_value = mc_ws
+
+        result = AbsorptionCalculator._create_mc_ws(wsm)
+
+        mock_convert.assert_called_once_with(InputWorkspace=WS_DATA, Target="Wavelength", OutputWorkspace=WS_MC_INPUT)
+        self.assertIs(result, mc_ws)
+
+    def test_resets_goniometer_to_identity(self, mock_convert):
+        wsm = _make_wsm()
+        mc_ws = MagicMock()
+        gonio = MagicMock()
+        mc_ws.run.return_value.getGoniometer.return_value = gonio
+        mock_convert.return_value = mc_ws
+
+        AbsorptionCalculator._create_mc_ws(wsm)
+
+        gonio.setR.assert_called_once()
+        np.testing.assert_array_equal(gonio.setR.call_args.args[0], np.eye(3))
+
+
+@patch(file_path + ".define_gauge_volume")
+@patch(file_path + ".RotateSampleShape")
+@patch(file_path + ".CopySample")
+class TestAbsorptionCalculator_SetMcSampleState(unittest.TestCase):
+    def test_copies_shape_and_material_from_mesh_ws(self, mock_copy, mock_rotate, mock_define_gv):
+        wsm = _make_wsm()
+        mc_ws = MagicMock()
+
+        AbsorptionCalculator._set_mc_sample_state(wsm, mc_ws, Rotation.identity())
+
+        mock_copy.assert_called_once_with(
+            InputWorkspace="mesh_ws",
+            OutputWorkspace=WS_MC_INPUT,
+            CopyShape=True,
+            CopyMaterial=True,
+            CopyEnvironment=False,
+            CopyLattice=False,
+        )
+
+    def test_applies_translate_with_offset(self, mock_copy, mock_rotate, mock_define_gv):
+        wsm = _make_wsm(offset=(1.0, 2.0, 3.0))
+        mc_ws = MagicMock()
+
+        AbsorptionCalculator._set_mc_sample_state(wsm, mc_ws, Rotation.identity())
+
+        wsm.translate_shape.assert_called_once_with(mc_ws, 1.0, 2.0, 3.0)
+
+    def test_skips_rotate_when_combined_rotation_is_identity(self, mock_copy, mock_rotate, mock_define_gv):
+        wsm = _make_wsm(init_R=Rotation.identity())
+        mc_ws = MagicMock()
+
+        AbsorptionCalculator._set_mc_sample_state(wsm, mc_ws, Rotation.identity())
+
+        mock_rotate.assert_not_called()
+
+    def test_rotates_with_composed_R_times_init_R(self, mock_copy, mock_rotate, mock_define_gv):
+        init_R = Rotation.from_euler("y", 30, degrees=True)
+        R = Rotation.from_euler("x", 60, degrees=True)
+        wsm = _make_wsm(init_R=init_R)
+        mc_ws = MagicMock()
+
+        AbsorptionCalculator._set_mc_sample_state(wsm, mc_ws, R)
+
+        mock_rotate.assert_called_once()
+        ws_arg, rot_str = mock_rotate.call_args.args
+        self.assertEqual(ws_arg, WS_MC_INPUT)
+
+        parts = rot_str.split(",")
+        ang = float(parts[0])
+        vec = np.array([float(parts[1]), float(parts[2]), float(parts[3])])
+        self.assertEqual(parts[4], "1")
+
+        expected = (R * init_R).as_rotvec(degrees=True)
+        expected_ang = np.linalg.norm(expected)
+        expected_vec = expected / expected_ang
+        self.assertAlmostEqual(ang, expected_ang)
+        np.testing.assert_allclose(vec, expected_vec, atol=1e-12)
+
+    def test_defines_gauge_volume_with_str_from_wsm(self, mock_copy, mock_rotate, mock_define_gv):
+        wsm = _make_wsm(gauge_volume_str="<gv/>")
+        mc_ws = MagicMock()
+
+        AbsorptionCalculator._set_mc_sample_state(wsm, mc_ws, Rotation.identity())
+
+        mock_define_gv.assert_called_once_with(mc_ws, "<gv/>")
+
+
+@patch(file_path + ".read_attenuation_coefficient_at_value")
+@patch(file_path + ".MonteCarloAbsorption")
+class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
+    def _make_calculator(self, starting_ind=0, n_hist=4):
+        model, orient = _make_model(starting_ind=starting_ind)
+        calc = AbsorptionCalculator(model)
+        calc._create_mc_ws = MagicMock()
+        mc_ws = MagicMock()
+        mc_ws.getNumberHistograms.return_value = n_hist
+        calc._create_mc_ws.return_value = mc_ws
+        calc._set_mc_sample_state = MagicMock()
+        return calc, model, orient, mc_ws
+
+    def test_orchestrates_create_then_set_state_then_mc_then_set_transmission(self, mock_mc, mock_read):
+        calc, model, orient, mc_ws = self._make_calculator(starting_ind=0)
+        mock_read.return_value = np.array([0.1, 0.2, 0.3, 0.4])
+
+        calc.calc_for_index(0)
+
+        calc._create_mc_ws.assert_called_once_with(model.workspaces)
+        calc._set_mc_sample_state.assert_called_once_with(model.workspaces, mc_ws, orient.R)
+        mock_mc.assert_called_once_with(**calc.mc_kwargs)
+
+    def test_passes_transmission_slice_from_starting_ind(self, mock_mc, mock_read):
+        calc, model, _, _ = self._make_calculator(starting_ind=2)
+        mock_read.return_value = np.array([0.1, 0.2, 0.3, 0.4])
+
+        calc.calc_for_index(0)
+
+        mock_read.assert_called_once_with(
+            WS_MC_OUTPUT,
+            model.workspaces.attenuation_kwargs["point"],
+            model.workspaces.attenuation_kwargs["unit"],
+        )
+        set_call = model.orientations.set_transmission_at_index.call_args
+        np.testing.assert_array_equal(set_call.args[0], np.array([0.3, 0.4]))
+        self.assertEqual(set_call.args[1], 0)
+
+    def test_zero_transmission_when_mc_absorption_raises(self, mock_mc, mock_read):
+        calc, model, _, _ = self._make_calculator(starting_ind=1, n_hist=5)
+        mock_mc.side_effect = RuntimeError("outside gauge volume")
+
+        calc.calc_for_index(0)
+
+        mock_read.assert_not_called()
+        set_call = model.orientations.set_transmission_at_index.call_args
+        np.testing.assert_array_equal(set_call.args[0], np.zeros(4))
+        self.assertEqual(set_call.args[1], 0)
+
+    @patch(file_path + ".logger")
+    def test_logs_warning_when_mc_absorption_raises(self, mock_logger, mock_mc, mock_read):
+        calc, _, _, _ = self._make_calculator()
+        mock_mc.side_effect = RuntimeError("boom")
+
+        calc.calc_for_index(0)
+
+        mock_logger.warning.assert_called_once()
+
+
+class TestAbsorptionCalculator_Init(unittest.TestCase):
+    def test_mc_kwargs_built_from_workspace_constants(self):
+        model, _ = _make_model()
+
+        calc = AbsorptionCalculator(model)
+
+        self.assertEqual(
+            calc.mc_kwargs,
+            {
+                "InputWorkspace": WS_MC_INPUT,
+                "OutputWorkspace": WS_MC_OUTPUT,
+                "EventsPerPoint": 50,
+                "MaxScatterPtAttempts": int(1e4),
+                "SimulateScatteringPointIn": "SampleOnly",
+                "ResimulateTracksForDifferentWavelengths": False,
+            },
+        )
+
+
+class TestAbsorptionCalculator_CalcAll(unittest.TestCase):
+    def test_iterates_over_all_orientation_keys(self):
+        model = MagicMock()
+        model.orientations.keys.return_value = [0, 2, 5]
+        calc = AbsorptionCalculator(model)
+        calc.calc_for_index = MagicMock()
+
+        calc.calc_all()
+
+        self.assertEqual(calc.calc_for_index.call_args_list, [call(0), call(2), call(5)])
+
+    def test_no_calls_when_no_orientations(self):
+        model = MagicMock()
+        model.orientations.keys.return_value = []
+        calc = AbsorptionCalculator(model)
+        calc.calc_for_index = MagicMock()
+
+        calc.calc_all()
+
+        calc.calc_for_index.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of work

**This module handles the logic for calculating transmission value estimates and ensuring the sample environment has been correctly defined**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
