### PR TITLE
Add TexturePlanner detector_geometry helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Tests for the Texture Planner interface
 
-set(TEST_PY_FILES helpers/test/test_absorption.py)
+set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -78,10 +78,11 @@ class AbsorptionCalculator:
             MonteCarloAbsorption(**self.mc_kwargs)
             transmission = read_attenuation_coefficient_at_value(
                 wsm.WS_MC_OUTPUT, wsm.attenuation_kwargs["point"], wsm.attenuation_kwargs["unit"]
-            )[m.geometry.starting_ind :]
+            )
+            transmission = [transmission[spec_ind] for spec_ind in m.geometry.spec_inds]
         except RuntimeError:
             logger.warning("MonteCarloAbsorption has failed, sample is assumed to be outside the gauge volume ")
-            transmission = np.zeros(mc_ws.getNumberHistograms() - m.geometry.starting_ind)
+            transmission = [0 for _ in m.geometry.spec_inds]
         m.orientations.set_transmission_at_index(transmission, index)
 
     @staticmethod

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -82,7 +82,7 @@ class AbsorptionCalculator:
             transmission = [transmission[spec_ind] for spec_ind in m.geometry.spec_inds]
         except RuntimeError:
             logger.warning("MonteCarloAbsorption has failed, sample is assumed to be outside the gauge volume ")
-            transmission = [0 for _ in m.geometry.spec_inds]
+            transmission = [0] * len(m.geometry.spec_inds)
         m.orientations.set_transmission_at_index(transmission, index)
 
     @staticmethod

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/detector_geometry.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/detector_geometry.py
@@ -1,0 +1,136 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+
+from mantid.simpleapi import GroupDetectors, LoadDetectorsGroupingFile
+from Engineering.texture.texture_helper import define_gauge_volume
+from typing import Protocol
+from abc import abstractmethod
+from mantid.api import MatrixWorkspace
+
+
+class _WorkspaceManagerType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    ws: MatrixWorkspace
+    ungrouped_ws: MatrixWorkspace
+    wsname: str
+    gauge_volume_str: str
+    scattering_centre: np.ndarray
+
+    @abstractmethod
+    def copy_sample_preserving_initial_rotation(self, source_ws: MatrixWorkspace, dest_ws: MatrixWorkspace) -> None:
+        pass
+
+
+class _InstrumentType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    @abstractmethod
+    def get_grouping_path(self) -> str:
+        pass
+
+
+class _BaseModelType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    workspaces: _WorkspaceManagerType
+    instrument: _InstrumentType
+
+
+class DetectorGeometry:
+    """Computes and caches the per-detector-group lab-frame scattering
+    directions (det_k) and reduced Q vectors (detQs_lab) for the currently
+    selected detector grouping, and applies the grouping to the data workspace.
+    """
+
+    def __init__(self, model: _BaseModelType):
+        self._model = model
+        self.det_k = None
+        self.detQs_lab = None
+        # if the group_ws contains group label 0, this is the null group; we skip it
+        # when iterating over spectra by starting at starting_ind
+        self.starting_ind = 1
+        # Detector group and source positions captured at the last regroup, used to
+        # rebuild det_k / detQs_lab when only the scattering centre changes.
+        self._det_positions = None
+        self._source_position = None
+
+    def recompute(self):
+        wsm = self._model.workspaces
+        grouping_path = self._get_grouping_path()
+        group_ws = self._apply_grouping_to_wss(wsm, grouping_path)
+
+        # get grouping file to handle null group
+        tmp_grp = LoadDetectorsGroupingFile(InputFile=grouping_path, OutputWorkspace="tmp_grp", StoreInADS=False)
+        ydat = tmp_grp.extractY()
+        # if there is a null group (label 0), start the indexing at 1 to ignore it, otherwise start from 0
+        self.starting_ind = int(ydat.min() == 0)
+
+        # extract the detector positions for each spectrum in the group and the source position
+        spec_info = group_ws.spectrumInfo()
+        comp_info = group_ws.componentInfo()
+        n_hist = group_ws.getNumberHistograms()
+        # a user-supplied (custom) grouping file can leave the leading spectrum/spectra with no
+        # detectors (an empty group); skip these so spectrumInfo.position does not raise. Keeping
+        # starting_ind a contiguous prefix offset preserves the slice AbsorptionCalculator uses to
+        # line transmission factors up with these detector positions.
+        while self.starting_ind < n_hist and not spec_info.hasDetectors(self.starting_ind):
+            self.starting_ind += 1
+        self._det_positions = np.asarray([spec_info.position(i) for i in range(self.starting_ind, n_hist)])
+        self._source_position = np.asarray(comp_info.sourcePosition())
+
+        # calculate the required det_k and detQs_lab
+        self.recompute_scattering_geometry()
+
+    def _get_grouping_path(self) -> str:
+        return self._model.instrument.get_grouping_path()
+
+    @staticmethod
+    def _apply_grouping_to_wss(wsm: _WorkspaceManagerType, grouping_path: str) -> MatrixWorkspace:
+        # Always regroup from the pristine ungrouped workspace; grouping the previously grouped
+        # ws by a new MapFile is very slow.
+        if wsm.ws is not None:
+            wsm.copy_sample_preserving_initial_rotation(wsm.ws, wsm.ungrouped_ws)
+        wsm.ws = GroupDetectors(
+            InputWorkspace=wsm.ungrouped_ws,
+            MapFile=grouping_path,
+            OutputWorkspace=wsm.wsname,
+        )
+        # GroupDetectors rebuilds wsm.ws from ungrouped_ws, which never carries the GaugeVolume
+        # log, so re-apply it from the source-of-truth python state.
+        if wsm.gauge_volume_str:
+            define_gauge_volume(wsm.ws, wsm.gauge_volume_str)
+        return wsm.ws
+
+    def recompute_scattering_geometry(self) -> None:
+        """Recompute det_k / detQs_lab for the current goniometer orientation.
+
+        Reads the scattering centre lazily (it depends on the current goniometer R that the
+        caller is expected to have set on the workspace) and combines it with the detector
+        positions captured at the last regroup.
+        """
+        if self._det_positions is None:
+            return
+        # get the current scattering centre from the workspace manager
+        scattering_centre = self._model.workspaces.scattering_centre
+
+        # calculate the normalised vector from scattering centre to detector position: K_d
+        det_vecs = self._det_positions - scattering_centre
+        self.det_k = det_vecs / np.linalg.norm(det_vecs, axis=1)[:, None]
+
+        # calculate the normalised beam vector: K_i
+        ki = scattering_centre - self._source_position
+        ki_norm = ki / np.linalg.norm(ki)
+
+        # calculate the normalised Q vectors in lab reference frame Q = K_d - K_i
+        detQs_lab = self.det_k - ki_norm
+        self.detQs_lab = detQs_lab / np.linalg.norm(detQs_lab, axis=1)[:, None]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/detector_geometry.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/detector_geometry.py
@@ -54,15 +54,15 @@ class DetectorGeometry:
 
     def __init__(self, model: _BaseModelType):
         self._model = model
-        self.det_k = None
-        self.detQs_lab = None
+        self.det_k = np.empty((0, 3), dtype=float)
+        self.detQs_lab = np.empty((0, 3), dtype=float)
         # if the group_ws contains group label 0, this is the null group; we skip it
         # when iterating over spectra by starting at starting_ind
-        self.starting_ind = 1
+        self.spec_inds = []
         # Detector group and source positions captured at the last regroup, used to
         # rebuild det_k / detQs_lab when only the scattering centre changes.
-        self._det_positions = None
-        self._source_position = None
+        self._det_positions = np.empty((0, 3), dtype=float)
+        self._source_position = np.empty((0, 3), dtype=float)
 
     def recompute(self):
         wsm = self._model.workspaces
@@ -73,19 +73,14 @@ class DetectorGeometry:
         tmp_grp = LoadDetectorsGroupingFile(InputFile=grouping_path, OutputWorkspace="tmp_grp", StoreInADS=False)
         ydat = tmp_grp.extractY()
         # if there is a null group (label 0), start the indexing at 1 to ignore it, otherwise start from 0
-        self.starting_ind = int(ydat.min() == 0)
+        starting_ind = int(ydat.min() == 0)
 
         # extract the detector positions for each spectrum in the group and the source position
         spec_info = group_ws.spectrumInfo()
         comp_info = group_ws.componentInfo()
         n_hist = group_ws.getNumberHistograms()
-        # a user-supplied (custom) grouping file can leave the leading spectrum/spectra with no
-        # detectors (an empty group); skip these so spectrumInfo.position does not raise. Keeping
-        # starting_ind a contiguous prefix offset preserves the slice AbsorptionCalculator uses to
-        # line transmission factors up with these detector positions.
-        while self.starting_ind < n_hist and not spec_info.hasDetectors(self.starting_ind):
-            self.starting_ind += 1
-        self._det_positions = np.asarray([spec_info.position(i) for i in range(self.starting_ind, n_hist)])
+        self.spec_inds = [i for i in range(starting_ind, n_hist) if spec_info.hasDetectors(i)]
+        self._det_positions = np.asarray([spec_info.position(i) for i in self.spec_inds])
         self._source_position = np.asarray(comp_info.sourcePosition())
 
         # calculate the required det_k and detQs_lab
@@ -118,7 +113,9 @@ class DetectorGeometry:
         caller is expected to have set on the workspace) and combines it with the detector
         positions captured at the last regroup.
         """
-        if self._det_positions is None:
+        if len(self.spec_inds) == 0:
+            self.det_k = np.empty((0, 3), dtype=float)
+            self.detQs_lab = np.empty((0, 3), dtype=float)
             return
         # get the current scattering centre from the workspace manager
         scattering_centre = self._model.workspaces.scattering_centre

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
@@ -32,7 +32,7 @@ def _make_wsm(offset=(0.0, 0.0, 0.0), init_R=None, gauge_volume_str="<gv/>"):
     return wsm
 
 
-def _make_model(R=None, n_orientations=1, starting_ind=0):
+def _make_model(R=None, n_orientations=1, spec_inds=None):
     model = MagicMock()
     model.workspaces = _make_wsm()
     orient = MagicMock()
@@ -40,7 +40,7 @@ def _make_model(R=None, n_orientations=1, starting_ind=0):
     model.orientations = MagicMock()
     model.orientations.__getitem__.side_effect = lambda i: orient
     model.orientations.keys.return_value = list(range(n_orientations))
-    model.geometry.starting_ind = starting_ind
+    model.geometry.spec_inds = spec_inds or []
     return model, orient
 
 
@@ -139,8 +139,8 @@ class TestAbsorptionCalculator_SetMcSampleState(unittest.TestCase):
 @patch(file_path + ".read_attenuation_coefficient_at_value")
 @patch(file_path + ".MonteCarloAbsorption")
 class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
-    def _make_calculator(self, starting_ind=0, n_hist=4):
-        model, orient = _make_model(starting_ind=starting_ind)
+    def _make_calculator(self, spec_inds, n_hist=4):
+        model, orient = _make_model(spec_inds=spec_inds)
         calc = AbsorptionCalculator(model)
         calc._create_mc_ws = MagicMock()
         mc_ws = MagicMock()
@@ -150,7 +150,7 @@ class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
         return calc, model, orient, mc_ws
 
     def test_orchestrates_create_then_set_state_then_mc_then_set_transmission(self, mock_mc, mock_read):
-        calc, model, orient, mc_ws = self._make_calculator(starting_ind=0)
+        calc, model, orient, mc_ws = self._make_calculator(spec_inds=[0, 1, 2, 3])
         mock_read.return_value = np.array([0.1, 0.2, 0.3, 0.4])
 
         calc.calc_for_index(0)
@@ -160,7 +160,7 @@ class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
         mock_mc.assert_called_once_with(**calc.mc_kwargs)
 
     def test_passes_transmission_slice_from_starting_ind(self, mock_mc, mock_read):
-        calc, model, _, _ = self._make_calculator(starting_ind=2)
+        calc, model, _, _ = self._make_calculator(spec_inds=[2, 3])
         mock_read.return_value = np.array([0.1, 0.2, 0.3, 0.4])
 
         calc.calc_for_index(0)
@@ -175,7 +175,7 @@ class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
         self.assertEqual(set_call.args[1], 0)
 
     def test_zero_transmission_when_mc_absorption_raises(self, mock_mc, mock_read):
-        calc, model, _, _ = self._make_calculator(starting_ind=1, n_hist=5)
+        calc, model, _, _ = self._make_calculator(spec_inds=[1, 2, 3, 4], n_hist=5)
         mock_mc.side_effect = RuntimeError("outside gauge volume")
 
         calc.calc_for_index(0)
@@ -187,7 +187,7 @@ class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
 
     @patch(file_path + ".logger")
     def test_logs_warning_when_mc_absorption_raises(self, mock_logger, mock_mc, mock_read):
-        calc, _, _, _ = self._make_calculator()
+        calc, _, _, _ = self._make_calculator(spec_inds=[0])
         mock_mc.side_effect = RuntimeError("boom")
 
         calc.calc_for_index(0)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_detector_geometry.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_detector_geometry.py
@@ -1,0 +1,256 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+
+from unittest.mock import patch, MagicMock
+
+from mantidqtinterfaces.TexturePlanner.helpers.detector_geometry import DetectorGeometry
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.detector_geometry"
+
+
+def _make_wsm(ws="ws", ungrouped_ws="ungrouped_ws", gauge_volume_str=None, scattering_centre=(0, 0, 0)):
+    wsm = MagicMock()
+    wsm.ws = ws
+    wsm.ungrouped_ws = ungrouped_ws
+    wsm.wsname = "__texture_planning_ws"
+    wsm.gauge_volume_str = gauge_volume_str
+    wsm.scattering_centre = np.asarray(scattering_centre, dtype=float)
+    return wsm
+
+
+def _make_model(wsm=None, grouping_path="/calib/ENGINX_grouping.xml"):
+    model = MagicMock()
+    model.workspaces = wsm if wsm is not None else _make_wsm()
+    model.instrument.get_grouping_path.return_value = grouping_path
+    return model
+
+
+class TestDetectorGeometry_Init(unittest.TestCase):
+    def test_default_attributes(self):
+        dg = DetectorGeometry(_make_model())
+
+        self.assertIsNone(dg.det_k)
+        self.assertIsNone(dg.detQs_lab)
+        self.assertEqual(dg.starting_ind, 1)
+        self.assertIsNone(dg._det_positions)
+        self.assertIsNone(dg._source_position)
+
+
+class TestDetectorGeometry_GetGroupingPath(unittest.TestCase):
+    def test_delegates_to_instrument_helper(self):
+        model = _make_model(grouping_path="/calib/GRP.xml")
+        dg = DetectorGeometry(model)
+
+        self.assertEqual(dg._get_grouping_path(), "/calib/GRP.xml")
+        model.instrument.get_grouping_path.assert_called_once_with()
+
+
+@patch(file_path + ".define_gauge_volume")
+@patch(file_path + ".GroupDetectors")
+class TestDetectorGeometry_ApplyGroupingToWss(unittest.TestCase):
+    def test_syncs_ws_into_ungrouped_before_regroup_when_ws_present(self, mock_group, mock_define_gv):
+        wsm = _make_wsm(ws="ws", ungrouped_ws="ungrouped_ws")
+        mock_group.return_value = "new_ws"
+
+        DetectorGeometry._apply_grouping_to_wss(wsm, "/path/grp.xml")
+
+        # the sync must preserve the sample's initial rotation, so it goes through the dedicated
+        # workspace-manager helper rather than a bare CopySample (which drops init_R for a CSG shape)
+        wsm.copy_sample_preserving_initial_rotation.assert_called_once_with("ws", "ungrouped_ws")
+
+    def test_skips_sync_when_ws_is_none(self, mock_group, mock_define_gv):
+        wsm = _make_wsm(ws=None)
+        mock_group.return_value = "new_ws"
+
+        DetectorGeometry._apply_grouping_to_wss(wsm, "/path/grp.xml")
+
+        wsm.copy_sample_preserving_initial_rotation.assert_not_called()
+
+    def test_regroups_from_ungrouped_into_wsname_and_assigns_back_to_wsm(self, mock_group, mock_define_gv):
+        wsm = _make_wsm()
+        mock_group.return_value = "new_ws"
+
+        result = DetectorGeometry._apply_grouping_to_wss(wsm, "/path/grp.xml")
+
+        mock_group.assert_called_once_with(
+            InputWorkspace="ungrouped_ws",
+            MapFile="/path/grp.xml",
+            OutputWorkspace=wsm.wsname,
+        )
+        self.assertEqual(wsm.ws, "new_ws")
+        self.assertEqual(result, "new_ws")
+
+    def test_reapplies_gauge_volume_when_set(self, mock_group, mock_define_gv):
+        wsm = _make_wsm(gauge_volume_str="<gv/>")
+        mock_group.return_value = "new_ws"
+
+        DetectorGeometry._apply_grouping_to_wss(wsm, "/path/grp.xml")
+
+        mock_define_gv.assert_called_once_with("new_ws", "<gv/>")
+
+    def test_does_not_define_gauge_volume_when_unset(self, mock_group, mock_define_gv):
+        wsm = _make_wsm(gauge_volume_str=None)
+        mock_group.return_value = "new_ws"
+
+        DetectorGeometry._apply_grouping_to_wss(wsm, "/path/grp.xml")
+
+        mock_define_gv.assert_not_called()
+
+
+@patch(file_path + ".LoadDetectorsGroupingFile")
+class TestDetectorGeometry_Recompute(unittest.TestCase):
+    def _make_dg_with_stubs(self, group_ws=None, n_hist=4):
+        model = _make_model()
+        dg = DetectorGeometry(model)
+        dg._get_grouping_path = MagicMock(return_value="/path/grp.xml")
+        if group_ws is None:
+            group_ws = MagicMock()
+            group_ws.getNumberHistograms.return_value = n_hist
+            group_ws.spectrumInfo.return_value.position.side_effect = lambda i: np.array([float(i), 0.0, 0.0])
+            group_ws.componentInfo.return_value.sourcePosition.return_value = np.array([-1.0, 0.0, 0.0])
+        dg._apply_grouping_to_wss = MagicMock(return_value=group_ws)
+        dg.recompute_scattering_geometry = MagicMock()
+        return dg, group_ws
+
+    def test_delegates_to_apply_grouping_to_wss(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2], [3]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        dg._apply_grouping_to_wss.assert_called_once_with(dg._model.workspaces, "/path/grp.xml")
+
+    def test_loads_detector_grouping_file_without_ads(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        mock_load_grp.assert_called_once_with(InputFile="/path/grp.xml", OutputWorkspace="tmp_grp", StoreInADS=False)
+
+    def test_starting_ind_one_when_null_group_present(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[0], [1], [2]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        self.assertEqual(dg.starting_ind, 1)
+
+    def test_starting_ind_zero_when_no_null_group(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2], [3]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        self.assertEqual(dg.starting_ind, 0)
+
+    def test_captures_det_positions_from_starting_ind(self, mock_load_grp):
+        dg, group_ws = self._make_dg_with_stubs(n_hist=4)
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[0], [1], [2]])  # null group -> starting_ind=1
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        # positions captured for spec 1,2,3 (skipping null group at 0)
+        np.testing.assert_array_equal(dg._det_positions, np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]))
+
+    def test_skips_leading_spectra_without_detectors(self, mock_load_grp):
+        # a custom grouping file can leave the leading group empty (no detectors); these must be
+        # skipped so spectrumInfo.position is never asked for a detector-less spectrum
+        dg, group_ws = self._make_dg_with_stubs(n_hist=4)
+        group_ws.spectrumInfo.return_value.hasDetectors.side_effect = lambda i: i != 0
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2], [3]])  # no null group -> base starting_ind=0
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        # advanced past the empty leading spectrum at index 0
+        self.assertEqual(dg.starting_ind, 1)
+        np.testing.assert_array_equal(dg._det_positions, np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]))
+
+    def test_captures_source_position_from_component_info(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        np.testing.assert_array_equal(dg._source_position, np.array([-1.0, 0.0, 0.0]))
+
+    def test_finishes_by_calling_recompute_scattering_geometry(self, mock_load_grp):
+        dg, _ = self._make_dg_with_stubs()
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1], [2]])
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        dg.recompute_scattering_geometry.assert_called_once_with()
+
+
+class TestDetectorGeometry_RecomputeScatteringGeometry(unittest.TestCase):
+    def test_returns_early_when_no_det_positions(self):
+        dg = DetectorGeometry(_make_model())
+        # untouched, so _det_positions is None
+
+        dg.recompute_scattering_geometry()
+
+        self.assertIsNone(dg.det_k)
+        self.assertIsNone(dg.detQs_lab)
+
+    def test_det_k_is_unit_vectors_from_scattering_centre_to_detectors(self):
+        wsm = _make_wsm(scattering_centre=(0.0, 0.0, 0.0))
+        model = _make_model(wsm=wsm)
+        dg = DetectorGeometry(model)
+        dg._det_positions = np.array([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0]])
+        dg._source_position = np.array([-1.0, 0.0, 0.0])
+
+        dg.recompute_scattering_geometry()
+
+        np.testing.assert_allclose(dg.det_k, np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]))
+
+    def test_det_k_uses_scattering_centre_as_origin(self):
+        wsm = _make_wsm(scattering_centre=(1.0, 0.0, 0.0))
+        model = _make_model(wsm=wsm)
+        dg = DetectorGeometry(model)
+        dg._det_positions = np.array([[3.0, 0.0, 0.0]])
+        dg._source_position = np.array([-1.0, 0.0, 0.0])
+
+        dg.recompute_scattering_geometry()
+
+        # vector from scattering centre (1,0,0) to det (3,0,0) is (2,0,0) -> normalised (1,0,0)
+        np.testing.assert_allclose(dg.det_k, np.array([[1.0, 0.0, 0.0]]))
+
+    def test_detQs_lab_is_kd_minus_ki_normalised(self):
+        wsm = _make_wsm(scattering_centre=(0.0, 0.0, 0.0))
+        model = _make_model(wsm=wsm)
+        dg = DetectorGeometry(model)
+        # one detector perpendicular to beam: K_d=(0,1,0), beam K_i=(1,0,0) -> Q=(-1,1,0)/sqrt(2)
+        dg._det_positions = np.array([[0.0, 1.0, 0.0]])
+        dg._source_position = np.array([-1.0, 0.0, 0.0])
+
+        dg.recompute_scattering_geometry()
+
+        expected = np.array([[-1.0, 1.0, 0.0]]) / np.sqrt(2.0)
+        np.testing.assert_allclose(dg.detQs_lab, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_detector_geometry.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_detector_geometry.py
@@ -32,14 +32,17 @@ def _make_model(wsm=None, grouping_path="/calib/ENGINX_grouping.xml"):
 
 
 class TestDetectorGeometry_Init(unittest.TestCase):
+    def assertEmptyArray(self, arr):
+        return self.assertTrue(arr.size == 0)
+
     def test_default_attributes(self):
         dg = DetectorGeometry(_make_model())
 
-        self.assertIsNone(dg.det_k)
-        self.assertIsNone(dg.detQs_lab)
-        self.assertEqual(dg.starting_ind, 1)
-        self.assertIsNone(dg._det_positions)
-        self.assertIsNone(dg._source_position)
+        self.assertEmptyArray(dg.det_k)
+        self.assertEmptyArray(dg.detQs_lab)
+        self.assertEqual(len(dg.spec_inds), 0)
+        self.assertEmptyArray(dg._det_positions)
+        self.assertEmptyArray(dg._source_position)
 
 
 class TestDetectorGeometry_GetGroupingPath(unittest.TestCase):
@@ -105,15 +108,15 @@ class TestDetectorGeometry_ApplyGroupingToWss(unittest.TestCase):
 
 @patch(file_path + ".LoadDetectorsGroupingFile")
 class TestDetectorGeometry_Recompute(unittest.TestCase):
-    def _make_dg_with_stubs(self, group_ws=None, n_hist=4):
+    def _make_dg_with_stubs(self, n_hist=4, inds_with_dets=(0, 1, 2, 3)):
         model = _make_model()
         dg = DetectorGeometry(model)
         dg._get_grouping_path = MagicMock(return_value="/path/grp.xml")
-        if group_ws is None:
-            group_ws = MagicMock()
-            group_ws.getNumberHistograms.return_value = n_hist
-            group_ws.spectrumInfo.return_value.position.side_effect = lambda i: np.array([float(i), 0.0, 0.0])
-            group_ws.componentInfo.return_value.sourcePosition.return_value = np.array([-1.0, 0.0, 0.0])
+        group_ws = MagicMock()
+        group_ws.getNumberHistograms.return_value = n_hist
+        group_ws.spectrumInfo.return_value.hasDetectors.side_effect = lambda i: i in inds_with_dets
+        group_ws.spectrumInfo.return_value.position.side_effect = lambda i: np.array([float(i), 0.0, 0.0])
+        group_ws.componentInfo.return_value.sourcePosition.return_value = np.array([-1.0, 0.0, 0.0])
         dg._apply_grouping_to_wss = MagicMock(return_value=group_ws)
         dg.recompute_scattering_geometry = MagicMock()
         return dg, group_ws
@@ -138,25 +141,26 @@ class TestDetectorGeometry_Recompute(unittest.TestCase):
 
         mock_load_grp.assert_called_once_with(InputFile="/path/grp.xml", OutputWorkspace="tmp_grp", StoreInADS=False)
 
-    def test_starting_ind_one_when_null_group_present(self, mock_load_grp):
+    def test_ignore_first_group_when_null_group_present(self, mock_load_grp):
         dg, _ = self._make_dg_with_stubs()
         tmp_grp = MagicMock()
-        tmp_grp.extractY.return_value = np.array([[0], [1], [2]])
+        tmp_grp.extractY.return_value = np.array([[0, 1, 1, 2, 2, 3, 2]])  # group will be array of int group labels
         mock_load_grp.return_value = tmp_grp
 
         dg.recompute()
 
-        self.assertEqual(dg.starting_ind, 1)
+        self.assertEqual(dg.spec_inds, [1, 2, 3])
 
-    def test_starting_ind_zero_when_no_null_group(self, mock_load_grp):
-        dg, _ = self._make_dg_with_stubs()
+    def test_all_specs_included_when_no_null_group(self, mock_load_grp):
+        specs_with_dets = (0, 1, 2, 3)
+        dg, _ = self._make_dg_with_stubs(inds_with_dets=specs_with_dets)
         tmp_grp = MagicMock()
-        tmp_grp.extractY.return_value = np.array([[1], [2], [3]])
+        tmp_grp.extractY.return_value = np.array([[1, 2, 3, 2, 3]])
         mock_load_grp.return_value = tmp_grp
 
         dg.recompute()
 
-        self.assertEqual(dg.starting_ind, 0)
+        self.assertEqual(dg.spec_inds, list(specs_with_dets))
 
     def test_captures_det_positions_from_starting_ind(self, mock_load_grp):
         dg, group_ws = self._make_dg_with_stubs(n_hist=4)
@@ -172,17 +176,40 @@ class TestDetectorGeometry_Recompute(unittest.TestCase):
     def test_skips_leading_spectra_without_detectors(self, mock_load_grp):
         # a custom grouping file can leave the leading group empty (no detectors); these must be
         # skipped so spectrumInfo.position is never asked for a detector-less spectrum
-        dg, group_ws = self._make_dg_with_stubs(n_hist=4)
-        group_ws.spectrumInfo.return_value.hasDetectors.side_effect = lambda i: i != 0
+        dg, group_ws = self._make_dg_with_stubs(n_hist=4, inds_with_dets=(1, 2, 3))
         tmp_grp = MagicMock()
         tmp_grp.extractY.return_value = np.array([[1], [2], [3]])  # no null group -> base starting_ind=0
         mock_load_grp.return_value = tmp_grp
 
         dg.recompute()
 
-        # advanced past the empty leading spectrum at index 0
-        self.assertEqual(dg.starting_ind, 1)
+        self.assertEqual(dg.spec_inds, [1, 2, 3])
         np.testing.assert_array_equal(dg._det_positions, np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]))
+
+    def test_skips_any_spectra_without_detectors(self, mock_load_grp):
+        # not sure it is likely that any of the other spectra might end up without detectors but guard in case
+        # we will make it so the first and last spectra don't have any detectors attached
+        dg, group_ws = self._make_dg_with_stubs(n_hist=4, inds_with_dets=(1, 2))
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1, 1, 1, 2, 2, 2, 3, 3, 3]])  # no 0 ind -> no null group
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        self.assertEqual(dg.spec_inds, [1, 2])
+        np.testing.assert_array_equal(dg._det_positions, np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]))
+
+    def test_handles_no_detectors(self, mock_load_grp):
+        # check sensible things happen if no spectra have detectors
+        dg, group_ws = self._make_dg_with_stubs(n_hist=4, inds_with_dets=())
+        tmp_grp = MagicMock()
+        tmp_grp.extractY.return_value = np.array([[1, 1, 1, 2, 2, 2, 3, 3, 3]])  # no 0 ind -> no null group
+        mock_load_grp.return_value = tmp_grp
+
+        dg.recompute()
+
+        self.assertEqual(dg.spec_inds, [])
+        self.assertEqual(len(dg._det_positions), 0)
 
     def test_captures_source_position_from_component_info(self, mock_load_grp):
         dg, _ = self._make_dg_with_stubs()
@@ -206,14 +233,17 @@ class TestDetectorGeometry_Recompute(unittest.TestCase):
 
 
 class TestDetectorGeometry_RecomputeScatteringGeometry(unittest.TestCase):
+    def assertEmptyArray(self, arr):
+        return self.assertTrue(arr.size == 0)
+
     def test_returns_early_when_no_det_positions(self):
         dg = DetectorGeometry(_make_model())
         # untouched, so _det_positions is None
 
         dg.recompute_scattering_geometry()
 
-        self.assertIsNone(dg.det_k)
-        self.assertIsNone(dg.detQs_lab)
+        self.assertEmptyArray(dg.det_k)
+        self.assertEmptyArray(dg.detQs_lab)
 
     def test_det_k_is_unit_vectors_from_scattering_centre_to_detectors(self):
         wsm = _make_wsm(scattering_centre=(0.0, 0.0, 0.0))
@@ -221,6 +251,7 @@ class TestDetectorGeometry_RecomputeScatteringGeometry(unittest.TestCase):
         dg = DetectorGeometry(model)
         dg._det_positions = np.array([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0]])
         dg._source_position = np.array([-1.0, 0.0, 0.0])
+        dg.spec_inds = [0, 1]
 
         dg.recompute_scattering_geometry()
 
@@ -232,6 +263,9 @@ class TestDetectorGeometry_RecomputeScatteringGeometry(unittest.TestCase):
         dg = DetectorGeometry(model)
         dg._det_positions = np.array([[3.0, 0.0, 0.0]])
         dg._source_position = np.array([-1.0, 0.0, 0.0])
+        dg.spec_inds = [
+            0,
+        ]
 
         dg.recompute_scattering_geometry()
 
@@ -245,6 +279,9 @@ class TestDetectorGeometry_RecomputeScatteringGeometry(unittest.TestCase):
         # one detector perpendicular to beam: K_d=(0,1,0), beam K_i=(1,0,0) -> Q=(-1,1,0)/sqrt(2)
         dg._det_positions = np.array([[0.0, 1.0, 0.0]])
         dg._source_position = np.array([-1.0, 0.0, 0.0])
+        dg.spec_inds = [
+            0,
+        ]
 
         dg.recompute_scattering_geometry()
 


### PR DESCRIPTION
### Description of work

**This module handles the logic for reading the instrument geometry and calculating diffraction vectors etc.**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
