### PR TITLE
Add osx-debug-max cmake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,17 +39,6 @@
       }
     },
     {
-      "name": "osx-debug",
-      "description": "Inherited by macOS presets for debugging. Disables optimization from conda compiler flags",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
-        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
-      }
-    },
-    {
       "name": "osx-default",
       "description": "Inherited by all macOS configurations",
       "hidden": true,
@@ -133,10 +122,15 @@
       "name": "osx-debug-max",
       "description": "Build options for a developer macOS build, with maximum debugging information",
       "inherits": [
-        "osx-debug",
         "osx-default",
         "conda"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
+      }
     },
     {
       "name": "linux",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,10 +29,22 @@
     },
     {
       "name": "unix-debug",
-      "description": "Inherited by all Unix-like presets for debugging. Overrides conda CXX flags for debugging",
+      "description": "Inherited by Unix-like presets for debugging. Overrides conda C and CXX flags for debugging",
       "hidden": true,
       "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-g -Og",
         "CMAKE_CXX_FLAGS_DEBUG": "-g -Og",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
+      }
+    },
+    {
+      "name": "osx-debug",
+      "description": "Inherited by macOS presets for debugging. Disables optimization from conda compiler flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
       }
@@ -113,6 +125,15 @@
       "description": "Default build options for a developer macOS build",
       "inherits": [
         "unix-debug",
+        "osx-default",
+        "conda"
+      ]
+    },
+    {
+      "name": "osx-debug-max",
+      "description": "Build options for a developer macOS build, with maximum debugging information",
+      "inherits": [
+        "osx-debug",
         "osx-default",
         "conda"
       ]

--- a/dev-docs/source/CLion.md
+++ b/dev-docs/source/CLion.md
@@ -71,6 +71,7 @@ To set up CMake:
    ::: {.hlist columns="1"}
 
    - On Linux: `Debug`
+   - On macOS: `Debug`
    - On Windows: `DebugWithRelRuntime`
      :::
 
@@ -83,6 +84,7 @@ To set up CMake:
    ::: {.hlist columns="1"}
 
    - On Linux: `--preset=linux`
+   - On macOS: `--preset=osx`
    - On Windows: `--preset=win-ninja`
      :::
 

--- a/dev-docs/source/PyCharm.md
+++ b/dev-docs/source/PyCharm.md
@@ -16,7 +16,8 @@ If you have not, please do so before hand by following [this guide](GettingStart
 
 At any point in these instructions where `DebugWithRelRuntime` is used (including in file paths),
 you can replace it with any other build type such as `Debug` or `Release`.
-We use `DebugWithRelRuntime` for conda specific builds to allow debugging due to `Debug` not being functional with the `Release ABIs`.
+`DebugWithRelRuntime` is used for Windows conda builds because `Debug` is not compatible with the release runtime ABI.
+On Linux and macOS, use `Debug`.
 
 - Open PyCharm
 


### PR DESCRIPTION
### Description of work

This PR adds a new cmake preset, `osx-debug-max`. This ensures all debug information is retained, removing optimisations, which makes debugging much easier.

This is not the default, as it significantly impacts run time.

Update some relevant docs

### To test:

Build using `osx-debug-max` on `osx`. Test debugging, see availability of variables etc.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
