### PR TITLE
Amend invalidation of common bins flag internal to MatrixWorkspace 

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,17 +39,6 @@
       }
     },
     {
-      "name": "osx-debug",
-      "description": "Inherited by macOS presets for debugging. Disables optimization from conda compiler flags",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
-        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
-      }
-    },
-    {
       "name": "osx-default",
       "description": "Inherited by all macOS configurations",
       "hidden": true,
@@ -133,10 +122,15 @@
       "name": "osx-debug-max",
       "description": "Build options for a developer macOS build, with maximum debugging information",
       "inherits": [
-        "osx-debug",
         "osx-default",
         "conda"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
+      }
     },
     {
       "name": "linux",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,10 +29,22 @@
     },
     {
       "name": "unix-debug",
-      "description": "Inherited by all Unix-like presets for debugging. Overrides conda CXX flags for debugging",
+      "description": "Inherited by Unix-like presets for debugging. Overrides conda C and CXX flags for debugging",
       "hidden": true,
       "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-g -Og",
         "CMAKE_CXX_FLAGS_DEBUG": "-g -Og",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
+      }
+    },
+    {
+      "name": "osx-debug",
+      "description": "Inherited by macOS presets for debugging. Disables optimization from conda compiler flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
+        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstandalone-debug -fno-limit-debug-info",
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_DISABLE_PRECOMPILE_HEADERS": "ON"
       }
@@ -113,6 +125,15 @@
       "description": "Default build options for a developer macOS build",
       "inherits": [
         "unix-debug",
+        "osx-default",
+        "conda"
+      ]
+    },
+    {
+      "name": "osx-debug-max",
+      "description": "Build options for a developer macOS build, with maximum debugging information",
+      "inherits": [
+        "osx-debug",
         "osx-default",
         "conda"
       ]

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -407,7 +407,7 @@ float MatrixWorkspace::getMarkerSize() const { return m_marker_size; }
 
 void MatrixWorkspace::updateSpectraUsing(const SpectrumDetectorMapping &map) {
   for (size_t j = 0; j < getNumberHistograms(); ++j) {
-    auto &spec = getSpectrum(j);
+    auto &spec = getSpectrumWithoutInvalidation(j);
     try {
       if (map.indexIsSpecNumber())
         spec.setDetectorIDs(map.getDetectorIDsForSpectrumNo(spec.getSpectrumNo()));
@@ -448,7 +448,7 @@ void MatrixWorkspace::rebuildSpectraMapping(const bool includeMonitors, const sp
       const auto specNo = specnum_t(index + specNumOffset);
 
       if (index < NUM_HIST) {
-        auto &spec = getSpectrum(index);
+        auto &spec = getSpectrumWithoutInvalidation(index);
         spec.setSpectrumNo(specNo);
         spec.setDetectorID(detId);
       }
@@ -1068,7 +1068,7 @@ void MatrixWorkspace::setDistribution(bool newValue) {
   HistogramData::Histogram::YMode ymode =
       newValue ? HistogramData::Histogram::YMode::Frequencies : HistogramData::Histogram::YMode::Counts;
   for (size_t i = 0; i < getNumberHistograms(); ++i)
-    getSpectrum(i).setYMode(ymode);
+    getSpectrumWithoutInvalidation(i).setYMode(ymode);
 }
 
 /**
@@ -2168,7 +2168,7 @@ void MatrixWorkspace::rebuildDetectorIDGroupings() {
   std::atomic<ErrorCode> errorValue(ErrorCode::None);
 #pragma omp parallel for
   for (int64_t i = 0; i < indexInfoSize; ++i) {
-    auto &spec = getSpectrum(i);
+    auto &spec = getSpectrumWithoutInvalidation(i);
     // Prevent setting flags that require spectrum definition updates
     spec.setMatrixWorkspace(nullptr, i);
     spec.setSpectrumNo(static_cast<specnum_t>(m_indexInfo->spectrumNumber(i)));

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -116,6 +116,13 @@ MatrixWorkspace_sptr makeWorkspaceWithMixedValidAndInvalidDetectors(size_t inval
 
   return ws;
 }
+
+void makeActualXValuesUncommonWithoutInvalidating(MatrixWorkspace &ws) {
+  TS_ASSERT(ws.isCommonBins());
+  // This intentionally bypasses the mutating MatrixWorkspace API so the test can
+  // detect whether the next metadata-only operation invalidates the cached flag.
+  const_cast<HistogramData::HistogramX &>(ws.x(0))[0] = 2.;
+}
 } // namespace
 
 class MatrixWorkspaceTest : public CxxTest::TestSuite {
@@ -481,6 +488,64 @@ public:
     // Once we change the value, however, isCommonsBins should return false
     ws.mutableX(0)[0] = 2.;
     TS_ASSERT_EQUALS(ws.isCommonBins(), false);
+  }
+
+  void test_setDistribution_does_not_invalidate_common_bins_flag() {
+    WorkspaceTester ws;
+    ws.initialize(3, 1, 1);
+    makeActualXValuesUncommonWithoutInvalidating(ws);
+
+    ws.setDistribution(true);
+
+    TS_ASSERT(ws.isDistribution());
+    TS_ASSERT(ws.isCommonBins());
+  }
+
+  void test_updateSpectraUsing_does_not_invalidate_common_bins_flag() {
+    WorkspaceTester ws;
+    ws.initialize(3, 1, 1);
+    makeActualXValuesUncommonWithoutInvalidating(ws);
+
+    specnum_t specs[] = {1, 2, 2, 3};
+    detid_t detids[] = {10, 99, 20, 30};
+    ws.updateSpectraUsing(SpectrumDetectorMapping(specs, detids, 4));
+
+    TS_ASSERT(ws.isCommonBins());
+    TS_ASSERT(ws.getSpectrum(0).hasDetectorID(10));
+    TS_ASSERT(ws.getSpectrum(1).hasDetectorID(20));
+    TS_ASSERT(ws.getSpectrum(1).hasDetectorID(99));
+    TS_ASSERT(ws.getSpectrum(2).hasDetectorID(30));
+  }
+
+  void test_rebuildSpectraMapping_does_not_invalidate_common_bins_flag() {
+    auto ws = makeWorkspaceWithDetectors(3, 1);
+    makeActualXValuesUncommonWithoutInvalidating(*ws);
+
+    ws->rebuildSpectraMapping();
+
+    TS_ASSERT(ws->isCommonBins());
+  }
+
+  void test_setIndexInfo_does_not_invalidate_common_bins_flag() {
+    WorkspaceTester ws;
+    ws.initialize(3, 1, 1);
+    ws.setInstrument(ComponentCreationHelper::createTestInstrumentRectangular(1, 2));
+    makeActualXValuesUncommonWithoutInvalidating(ws);
+    IndexInfo indices(3);
+    indices.setSpectrumNumbers({2, 4, 6});
+    std::vector<SpectrumDefinition> specDefs(3);
+    specDefs[0].add(0);
+    specDefs[1].add(1);
+    specDefs[2].add(2);
+    specDefs[2].add(3);
+    indices.setSpectrumDefinitions(specDefs);
+
+    ws.setIndexInfo(std::move(indices));
+
+    TS_ASSERT(ws.isCommonBins());
+    TS_ASSERT_EQUALS(ws.getSpectrum(0).getSpectrumNo(), 2);
+    TS_ASSERT_EQUALS(ws.getSpectrum(1).getSpectrumNo(), 4);
+    TS_ASSERT_EQUALS(ws.getSpectrum(2).getSpectrumNo(), 6);
   }
 
   void testIsCommonLogAxis() {

--- a/dev-docs/source/CLion.md
+++ b/dev-docs/source/CLion.md
@@ -71,6 +71,7 @@ To set up CMake:
    ::: {.hlist columns="1"}
 
    - On Linux: `Debug`
+   - On macOS: `Debug`
    - On Windows: `DebugWithRelRuntime`
      :::
 
@@ -83,6 +84,7 @@ To set up CMake:
    ::: {.hlist columns="1"}
 
    - On Linux: `--preset=linux`
+   - On macOS: `--preset=osx`
    - On Windows: `--preset=win-ninja`
      :::
 

--- a/dev-docs/source/PyCharm.md
+++ b/dev-docs/source/PyCharm.md
@@ -16,7 +16,8 @@ If you have not, please do so before hand by following [this guide](GettingStart
 
 At any point in these instructions where `DebugWithRelRuntime` is used (including in file paths),
 you can replace it with any other build type such as `Debug` or `Release`.
-We use `DebugWithRelRuntime` for conda specific builds to allow debugging due to `Debug` not being functional with the `Release ABIs`.
+`DebugWithRelRuntime` is used for Windows conda builds because `Debug` is not compatible with the release runtime ABI.
+On Linux and macOS, use `Debug`.
 
 - Open PyCharm
 


### PR DESCRIPTION
### Description of work

### Summary

Avoid invalidating `MatrixWorkspace::isCommonBins()` cache for spectrum updates that don't actually mutate the x values.

`updateSpectraUsing`, `rebuildSpectraMapping`, `setDistribution`, and detector grouping rebuilds now use `getSpectrumWithoutInvalidation()`.

Noticed during work on https://github.com/mantidproject/mantid/pull/40886

### To test:

See new tests.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
