### PR TITLE
Changes to detector access

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -2160,8 +2160,8 @@ void MatrixWorkspace::buildDefaultSpectrumDefinitions() {
 void MatrixWorkspace::rebuildDetectorIDGroupings() {
   const auto &detInfo = detectorInfo();
   const auto detInfo_scanCount = detInfo.scanCount(); // cache value outside of the loop
-  const auto &allDetIDs = detInfo.detectorIDs();
-  const auto allDetIDs_size = allDetIDs.size(); // cache value outside of the loop
+  // Use size() directly; avoid detectorIDs() to keep compact m_detectorIDs for PA instruments.
+  const auto allDetIDs_size = detInfo.size();
   const auto &specDefs = m_indexInfo->spectrumDefinitions();
   const auto indexInfoSize = static_cast<int64_t>(m_indexInfo->size());
   enum class ErrorCode { None, InvalidDetIndex, InvalidTimeIndex };
@@ -2180,7 +2180,7 @@ void MatrixWorkspace::rebuildDetectorIDGroupings() {
       } else if (index.second >= detInfo_scanCount) { // timeIndex is second
         errorValue = ErrorCode::InvalidTimeIndex;
       } else {
-        detIDs.insert(allDetIDs[detIndex]);
+        detIDs.insert(detInfo.detid(detIndex));
       }
     }
     spec.setDetectorIDs(std::move(detIDs));

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -2160,7 +2160,7 @@ void MatrixWorkspace::buildDefaultSpectrumDefinitions() {
 void MatrixWorkspace::rebuildDetectorIDGroupings() {
   const auto &detInfo = detectorInfo();
   const auto detInfo_scanCount = detInfo.scanCount(); // cache value outside of the loop
-  // Use size() directly; avoid detectorIDs() to keep compact m_detectorIDs for PA instruments.
+  // Use size() directly; avoid detectorIDs()
   const auto allDetIDs_size = detInfo.size();
   const auto &specDefs = m_indexInfo->spectrumDefinitions();
   const auto indexInfoSize = static_cast<int64_t>(m_indexInfo->size());

--- a/Framework/API/test/WorkspaceNearestNeighboursTest.h
+++ b/Framework/API/test/WorkspaceNearestNeighboursTest.h
@@ -145,8 +145,8 @@ public:
 
     RectangularDetector_const_sptr bank1 =
         std::dynamic_pointer_cast<const RectangularDetector>(m_instrument->getComponentByName("bank1"));
-    std::shared_ptr<const Detector> det = bank1->getAtXY(2, 3);
-    TS_ASSERT(det);
+    auto id = bank1->getDetectorIDAtXY(2, 3);
+    TS_ASSERT_DIFFERS(id, -1);
     std::map<specnum_t, V3D> nb;
 
     // Too close!

--- a/Framework/API/test/WorkspaceNearestNeighboursTest.h
+++ b/Framework/API/test/WorkspaceNearestNeighboursTest.h
@@ -145,12 +145,12 @@ public:
 
     RectangularDetector_const_sptr bank1 =
         std::dynamic_pointer_cast<const RectangularDetector>(m_instrument->getComponentByName("bank1"));
+    specnum_t spec = 256 + 2 * 16 + 3; // This gives the spectrum number for this detector
     auto id = bank1->getDetectorIDAtXY(2, 3);
-    TS_ASSERT_DIFFERS(id, -1);
+    TS_ASSERT_EQUALS(id, spec); // bank1 idstart=256, idFillOrder=yxz: id = 256 + y + x*16
     std::map<specnum_t, V3D> nb;
 
     // Too close!
-    specnum_t spec = 256 + 2 * 16 + 3; // This gives the spectrum number for this detector
     nb = nn.neighboursInRadius(spec, 0.003);
     TS_ASSERT_EQUALS(nb.size(), 0);
 

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -320,7 +320,7 @@ double ConvertSpectrumAxis2::getEfixed(const size_t detectorIndex, const Geometr
                                        const Mantid::API::MatrixWorkspace &inputWS, const int emode) const {
   double efixed(0);
   double efixedProp = getProperty("Efixed");
-  Mantid::detid_t detectorID = detectorInfo.detectorIDs()[detectorIndex];
+  Mantid::detid_t detectorID = detectorInfo.detid(detectorIndex);
   if (efixedProp != EMPTY_DBL()) {
     efixed = efixedProp;
     g_log.debug() << "Detector: " << detectorID << " Efixed: " << efixed << "\n";

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -479,14 +479,14 @@ void DiffractionEventCalibrateDetectors::exec() {
     int pixmax = detList[det]->xpixels() - 1;
     int pixmid = (detList[det]->ypixels() - 1) / 2;
     BoundingBox box;
-    detList[det]->getAtXY(pixmax, pixmid)->getBoundingBox(box);
+    detList[det]->getBoundingBoxAtXY(pixmax, pixmid, box);
     double baseX = box.xMax();
     double baseY = box.yMax();
     double baseZ = box.zMax();
     Kernel::V3D Base = V3D(baseX, baseY, baseZ) + CalCenter;
     pixmid = (detList[det]->xpixels() - 1) / 2;
     pixmax = detList[det]->ypixels() - 1;
-    detList[det]->getAtXY(pixmid, pixmax)->getBoundingBox(box);
+    detList[det]->getBoundingBoxAtXY(pixmid, pixmax, box);
     double upX = box.xMax();
     double upY = box.yMax();
     double upZ = box.zMax();

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -250,7 +250,7 @@ void SmoothNeighbours::findNeighboursRectangular() {
   std::vector<std::pair<int, int>> idToIndexMap;
   idToIndexMap.reserve(detList.size());
   for (int i = 0; i < static_cast<int>(detList.size()); i++)
-    idToIndexMap.emplace_back(detList[i]->getAtXY(0, 0)->getID(), i);
+    idToIndexMap.emplace_back(detList[i]->getDetectorIDAtXY(0, 0), i);
 
   // To sort in descending order
   if (sum)
@@ -277,7 +277,7 @@ void SmoothNeighbours::findNeighboursRectangular() {
               continue;
             if (k + iy >= det->ypixels() - m_edge || k + iy < m_edge)
               continue;
-            int pixelID = det->getAtXY(j + ix, k + iy)->getID();
+            int pixelID = det->getDetectorIDAtXY(j + ix, k + iy);
 
             // Find the corresponding workspace index, if any
             auto mapEntry = pixel_to_wi.find(pixelID);

--- a/Framework/Algorithms/src/SofQCommon.cpp
+++ b/Framework/Algorithms/src/SofQCommon.cpp
@@ -218,7 +218,7 @@ std::pair<double, double> SofQCommon::qBinHintsIndirect(const API::MatrixWorkspa
     if (!std::isfinite(Q1) || !std::isfinite(Q2)) {
       throw std::invalid_argument("Cannot compute Q binning range: non-finite "
                                   "Q found for detector ID " +
-                                  std::to_string(detectorInfo.detectorIDs()[i]));
+                                  std::to_string(detectorInfo.detid(i)));
     }
     const auto minmaxQ = std::minmax(Q1, Q2);
     minQ = std::min(minQ, minmaxQ.first);

--- a/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
+++ b/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
@@ -64,7 +64,7 @@ public:
     const auto &spectrumInfo = ws->spectrumInfo();
     const auto &pixel = spectrumInfo.detector(11);
     detid_t recDetPixID = det->getDetectorIDAtXY(1, 1);
-    TSM_ASSERT("getDetectorIDAtXY() returns a GridDetectorPixel", recDetPixID > 0);
+    TSM_ASSERT("getDetectorIDAtXY() returns a valid detector ID", recDetPixID > 0);
     pos = pixel.getPos();
     TS_ASSERT_EQUALS(pos, V3D(0.008 * 2, 0.008 * 0.5, 5.0));
 

--- a/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
+++ b/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
@@ -54,24 +54,23 @@ public:
 
     // Bank 1 got scaled
     V3D pos;
-    pos = det->getAtXY(1, 1)->getPos();
+    pos = det->getPosAtXY(1, 1);
     TS_ASSERT(ws->constInstrumentParameters().contains(det.get(), "scalex"));
     TS_ASSERT(ws->constInstrumentParameters().contains(det.get(), "scaley"));
     TS_ASSERT_EQUALS(pos, V3D(0.008 * 2, 0.008 * 0.5, 5.0));
     TS_ASSERT_DELTA(det->xstep(), 0.008 * 2, 1e-6);
 
     // Check that accessing through spectrumInfo.detector() also works
-    const GridDetectorPixel *recDetPix;
     const auto &spectrumInfo = ws->spectrumInfo();
     const auto &pixel = spectrumInfo.detector(11);
-    recDetPix = dynamic_cast<const GridDetectorPixel *>(det->getAtXY(1, 1).get());
-    TSM_ASSERT("getDetector() returns a GridDetectorPixel", recDetPix);
+    detid_t recDetPixID = det->getDetectorIDAtXY(1, 1);
+    TSM_ASSERT("getDetectorIDAtXY() returns a GridDetectorPixel", recDetPixID > 0);
     pos = pixel.getPos();
     TS_ASSERT_EQUALS(pos, V3D(0.008 * 2, 0.008 * 0.5, 5.0));
 
     // Bank 2 did not get scaled
     det = std::dynamic_pointer_cast<const RectangularDetector>(inst->getComponentByName("bank2"));
-    pos = det->getAtXY(1, 1)->getPos();
+    pos = det->getPosAtXY(1, 1);
     TS_ASSERT_EQUALS(pos, V3D(0.008 * 1.0, 0.008 * 1.0, 10.0));
     TS_ASSERT_DELTA(det->xstep(), 0.008 * 1, 1e-6);
   }

--- a/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
+++ b/Framework/Algorithms/test/ResizeRectangularDetectorTest.h
@@ -65,6 +65,7 @@ public:
     const auto &pixel = spectrumInfo.detector(11);
     detid_t recDetPixID = det->getDetectorIDAtXY(1, 1);
     TSM_ASSERT("getDetectorIDAtXY() returns a valid detector ID", recDetPixID > 0);
+    TS_ASSERT_EQUALS(recDetPixID, pixel.getID());
     pos = pixel.getPos();
     TS_ASSERT_EQUALS(pos, V3D(0.008 * 2, 0.008 * 0.5, 5.0));
 

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -90,9 +90,31 @@ public:
   size_t numberOfDetectorsInSubtree(const size_t componentIndex) const;
   bool isDetector(const size_t componentIndex) const { return componentIndex < totalDetectorCount(); }
   bool isMonitor(const size_t componentIndex) const;
-  size_t compOffsetIndex(const size_t componentIndex) const {
-    return componentIndex - m_assemblySortedDetectorIndices->size();
+  size_t compOffsetIndex(const size_t componentIndex) const { return componentIndex - totalDetectorCount(); }
+
+  /// Total number of detectors (real + virtual pixels).  Real detectors are
+  /// stored in m_assemblySortedDetectorIndices; virtual pixels are synthesised
+  /// on demand from m_virtualBanks.
+  size_t totalDetectorCount() const noexcept { return m_detectorRanges ? m_size - m_detectorRanges->size() : 0; }
+
+  /// Call @p f(detectorIndex) for every detector in the subtree rooted at
+  /// @p componentIndex.  Real detector indices come from the flat array.
+  template <typename Callable> void forEachDetectorInSubtree(size_t componentIndex, Callable &&f) const {
+    if (isDetector(componentIndex)) {
+      f(componentIndex);
+      return;
+    }
+    const auto rangesIndex = compOffsetIndex(componentIndex);
+    // Real detectors stored in the flat array.
+    const auto detRange = (*m_detectorRanges)[rangesIndex];
+    for (size_t i = detRange.first; i < detRange.second; ++i)
+      f((*m_assemblySortedDetectorIndices)[i]);
   }
+
+  /// Maps a logical component index to its offset in the compact arrays
+  /// (m_names, m_scaleFactors, m_parentIndices, etc.).
+  /// For virtual-bank instruments only; behaviour is undefined otherwise.
+  size_t compactComponentIndex(size_t componentIndex) const noexcept;
 
   const Eigen::Vector3d &position(const size_t componentIndex) const;
   const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
@@ -164,6 +186,21 @@ private:
                      const ComponentInfo::Range &detectorRange);
   void doScaleComponent(const std::pair<size_t, size_t> &index, const Eigen::Vector3d &newScaling,
                         const ComponentInfo::Range &detectorRange);
+
+  /// Inverse of compactComponentIndex: maps a compact array offset to the
+  /// corresponding logical component index.
+  size_t logicalComponentIndex(size_t compactIdx) const noexcept;
+
+  /// Precomputes m_nNonVirtualDetectors and m_nonVirtualDetectorLogicalIndices.
+  void buildNonVirtualDetectorTable();
+
+  /// Returns realDetectors.size() + sum(virtual pixels) + detRanges.size().
+  /// Used to initialise the const m_size in the constructor initialiser list,
+  /// before m_virtualBanks has been moved into place.
+  static size_t computeTotalSize(const std::vector<size_t> &realDetectors,
+                                 const std::vector<std::pair<size_t, size_t>> &detRanges) noexcept {
+    return realDetectors.size() + detRanges.size();
+  }
 };
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -88,9 +88,7 @@ public:
   size_t size() const;
   size_t getMemorySize() const;
   size_t numberOfDetectorsInSubtree(const size_t componentIndex) const;
-  bool isDetector(const size_t componentIndex) const {
-    return componentIndex < m_assemblySortedDetectorIndices->size();
-  }
+  bool isDetector(const size_t componentIndex) const { return componentIndex < totalDetectorCount(); }
   bool isMonitor(const size_t componentIndex) const;
   size_t compOffsetIndex(const size_t componentIndex) const {
     return componentIndex - m_assemblySortedDetectorIndices->size();

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -111,11 +111,6 @@ public:
       f((*m_assemblySortedDetectorIndices)[i]);
   }
 
-  /// Maps a logical component index to its offset in the compact arrays
-  /// (m_names, m_scaleFactors, m_parentIndices, etc.).
-  /// For virtual-bank instruments only; behaviour is undefined otherwise.
-  size_t compactComponentIndex(size_t componentIndex) const noexcept;
-
   const Eigen::Vector3d &position(const size_t componentIndex) const;
   const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
   Eigen::Quaterniond rotation(const size_t componentIndex) const;
@@ -186,13 +181,6 @@ private:
                      const ComponentInfo::Range &detectorRange);
   void doScaleComponent(const std::pair<size_t, size_t> &index, const Eigen::Vector3d &newScaling,
                         const ComponentInfo::Range &detectorRange);
-
-  /// Inverse of compactComponentIndex: maps a compact array offset to the
-  /// corresponding logical component index.
-  size_t logicalComponentIndex(size_t compactIdx) const noexcept;
-
-  /// Precomputes m_nNonVirtualDetectors and m_nonVirtualDetectorLogicalIndices.
-  void buildNonVirtualDetectorTable();
 
   /// Returns realDetectors.size() + sum(virtual pixels) + detRanges.size().
   /// Used to initialise the const m_size in the constructor initialiser list,

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -91,6 +91,10 @@ public:
    */
   friend class ComponentInfo;
 
+  /// Maps a logical detector index to its compact array offset, skipping virtual pixel ranges.
+  /// Only valid for non-virtual indices.
+  size_t compactDetectorIndex(size_t index) const noexcept;
+
 private:
   size_t linearIndex(const std::pair<size_t, size_t> &index) const;
   void checkNoTimeDependence() const;
@@ -119,16 +123,10 @@ inline size_t DetectorInfo::size() const {
 inline bool DetectorInfo::isScanning() const {
   if (!m_positions)
     return false;
-  return size() != m_positions->size();
-}
-
-/** Returns the position of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline const Eigen::Vector3d &DetectorInfo::position(const size_t index) const {
-  checkNoTimeDependence();
-  return (*m_positions)[index];
+  // Scanning instruments hold N * T positions (T scan points, T > 1).
+  // Compact virtual-bank instruments hold N_real < N_total positions.
+  // Only the scanning case has *more* positions than total detectors.
+  return m_positions->size() > size();
 }
 
 /// Returns the position of the detector with given index.
@@ -150,16 +148,7 @@ inline const Eigen::Quaterniond &DetectorInfo::rotation(const std::pair<size_t, 
   return (*m_rotations)[linearIndex(index)];
 }
 
-/** Set the position of the detector with given detector index.
- *
- * Convenience method for beamlines with static (non-moving) detectors.
- * Throws if there are time-dependent detectors. */
-inline void DetectorInfo::setPosition(const size_t index, const Eigen::Vector3d &position) {
-  checkNoTimeDependence();
-  m_positions.access()[index] = position;
-}
-
-/// Set the position of the detector with given index.
+/// Set the position of the detector with given index (scanning pair overload).
 inline void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index, const Eigen::Vector3d &position) {
   m_positions.access()[linearIndex(index)] = position;
 }

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -92,8 +92,8 @@ public:
   friend class ComponentInfo;
 
   /// Maps a logical detector index to its compact array offset, skipping virtual pixel ranges.
-  /// Only valid for non-virtual indices.
-  size_t compactDetectorIndex(size_t index) const noexcept;
+  /// Only valid for non-virtual indices. Identity for non-virtual-bank instruments.
+  size_t compactDetectorIndex(size_t index) const noexcept { return index; }
 
 private:
   size_t linearIndex(const std::pair<size_t, size_t> &index) const;
@@ -123,10 +123,16 @@ inline size_t DetectorInfo::size() const {
 inline bool DetectorInfo::isScanning() const {
   if (!m_positions)
     return false;
-  // Scanning instruments hold N * T positions (T scan points, T > 1).
-  // Compact virtual-bank instruments hold N_real < N_total positions.
-  // Only the scanning case has *more* positions than total detectors.
-  return m_positions->size() > size();
+  return size() != m_positions->size();
+}
+
+/** Returns the position of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
+inline const Eigen::Vector3d &DetectorInfo::position(const size_t index) const {
+  checkNoTimeDependence();
+  return (*m_positions)[index];
 }
 
 /// Returns the position of the detector with given index.
@@ -146,6 +152,15 @@ inline const Eigen::Quaterniond &DetectorInfo::rotation(const size_t index) cons
 /// Returns the rotation of the detector with given index.
 inline const Eigen::Quaterniond &DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
   return (*m_rotations)[linearIndex(index)];
+}
+
+/** Set the position of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
+inline void DetectorInfo::setPosition(const size_t index, const Eigen::Vector3d &position) {
+  checkNoTimeDependence();
+  m_positions.access()[index] = position;
 }
 
 /// Set the position of the detector with given index (scanning pair overload).

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -1,4 +1,3 @@
-
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
@@ -60,8 +59,8 @@ ComponentInfo::ComponentInfo(
       m_parentIndices(std::move(parentIndices)), m_children(std::move(children)), m_positions(std::move(positions)),
       m_rotations(std::move(rotations)), m_scaleFactors(std::move(scaleFactors)),
       m_componentType(std::move(componentType)), m_names(std::move(names)),
-      m_size(m_assemblySortedDetectorIndices->size() + m_detectorRanges->size()), m_sourceIndex(sourceIndex),
-      m_sampleIndex(sampleIndex), m_detectorInfo(nullptr) {
+      m_size(ComponentInfo::computeTotalSize(*m_assemblySortedDetectorIndices, *m_detectorRanges)),
+      m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex), m_detectorInfo(nullptr) {
   if (m_rotations->size() != m_positions->size()) {
     throw std::invalid_argument("ComponentInfo should have been provided same "
                                 "number of postions and rotations");
@@ -74,7 +73,7 @@ ComponentInfo::ComponentInfo(
     throw std::invalid_argument("ComponentInfo should have as many rotations "
                                 "as number of components ");
   }
-  if (m_assemblySortedComponentIndices->size() + m_assemblySortedDetectorIndices->size() != m_size) {
+  if (m_assemblySortedComponentIndices->size() + totalDetectorCount() != m_size) {
     throw std::invalid_argument("ComponentInfo must have component indices "
                                 "input of same size as the sum of "
                                 "non-detector and detector components");
@@ -128,19 +127,16 @@ std::vector<size_t> ComponentInfo::detectorsInSubtree(const size_t componentInde
 
 std::vector<size_t> ComponentInfo::componentsInSubtree(const size_t componentIndex) const {
   if (isDetector(componentIndex)) {
-    /* This is a single detector. Just return the corresponding index.
-     * detectorIndex == componentIndex. Never any sub-components for detectors.
-     */
-    return std::vector<size_t>{componentIndex};
+    return {componentIndex};
   }
-  // Calculate index into our ranges (non-detector) component items.
+  std::vector<size_t> indices;
+  // Detectors first (real from flat array + virtual pixels from segments).
+  forEachDetectorInSubtree(componentIndex, [&indices](size_t idx) { indices.push_back(idx); });
+  // Non-detector components.
   const auto rangesIndex = compOffsetIndex(componentIndex);
-  const auto detRange = (*m_detectorRanges)[rangesIndex];
   const auto compRange = (*m_componentRanges)[rangesIndex];
 
   // Extract as a block
-  std::vector<size_t> indices(m_assemblySortedDetectorIndices->begin() + detRange.first,
-                              m_assemblySortedDetectorIndices->begin() + detRange.second);
   indices.insert(indices.end(), m_assemblySortedComponentIndices->begin() + compRange.first,
                  m_assemblySortedComponentIndices->begin() + compRange.second);
   return indices;
@@ -158,8 +154,13 @@ const std::vector<size_t> &ComponentInfo::children(const size_t componentIndex) 
 size_t ComponentInfo::size() const { return m_size; }
 
 size_t ComponentInfo::numberOfDetectorsInSubtree(const size_t componentIndex) const {
-  auto range = detectorRangeInSubtree(componentIndex);
-  return std::distance(range.begin(), range.end());
+  if (isDetector(componentIndex))
+    return 1;
+  // Real detectors from the flat array slice.
+  const auto rangesIndex = compOffsetIndex(componentIndex);
+  const auto detRange = (*m_detectorRanges)[rangesIndex];
+  size_t count = detRange.second - detRange.first;
+  return count;
 }
 
 bool ComponentInfo::isMonitor(const size_t componentIndex) const {
@@ -265,7 +266,8 @@ void ComponentInfo::doSetPosition(const std::pair<size_t, size_t> &index, const 
     m_detectorInfo->setPosition({subIndex, timeIndex}, m_detectorInfo->position({subIndex, timeIndex}) + offset);
   }
 
-  for (const auto &subIndex : componentRangeInSubtree(componentIndex)) {
+  const auto compRange = componentRangeInSubtree(componentIndex);
+  for (const auto &subIndex : compRange) {
     size_t offsetIndex = compOffsetIndex(subIndex);
     m_positions.access()[offsetIndex] += offset;
   }
@@ -289,7 +291,8 @@ void ComponentInfo::doSetRotation(const std::pair<size_t, size_t> &index, const 
     m_detectorInfo->setRotation({subDetIndex, timeIndex}, newRot);
   }
 
-  for (const auto &subCompIndex : componentRangeInSubtree(componentIndex)) {
+  const auto compRange = componentRangeInSubtree(componentIndex);
+  for (const auto &subCompIndex : compRange) {
     auto oldPos = position({subCompIndex, timeIndex});
     auto newPos = transform * (oldPos - compPos) + compPos;
     auto newRot = rotDelta * rotation({subCompIndex, timeIndex});
@@ -487,7 +490,7 @@ bool ComponentInfo::hasParent(const size_t componentIndex) const { return parent
 bool ComponentInfo::hasDetectorInfo() const { return m_detectorInfo != nullptr; }
 
 void ComponentInfo::setDetectorInfo(DetectorInfo *detectorInfo) {
-  if (detectorInfo && detectorInfo->size() != m_assemblySortedDetectorIndices->size()) {
+  if (detectorInfo && detectorInfo->size() != totalDetectorCount()) {
     throw std::invalid_argument("ComponentInfo must have detector indices "
                                 "input of same size as size of DetectorInfo");
   }

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -319,9 +319,7 @@ int CentroidPeaks::findPixelID(const std::string &bankName, int col, int row) {
   std::shared_ptr<const IComponent> parent = m_inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-
-    std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
-    return pixel->getID();
+    return RDet->getDetectorIDAtXY(col, row);
   } else {
     std::string bankName0 = bankName;
     // Only works for WISH

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -354,9 +354,7 @@ int LoadIsawPeaks::findPixelID(const PeaksWorkspace_sptr &ws, const std::string 
 
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-
-    std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
-    return pixel->getID();
+    return RDet->getDetectorIDAtXY(col, row);
   } else {
     const auto &componentInfo = ws->componentInfo();
     const size_t parentIndex = componentInfo.indexOfAny(bankName);

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -195,7 +195,7 @@ size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, cons
       return EMPTY_INT();
     }
 
-    int pixelID = det->getAtXY(x, y)->getID();
+    int pixelID = det->getDetectorIDAtXY(x, y);
 
     // Find the corresponding workspace index, if any
     auto wiEntry = pixel_to_wi.find(pixelID);
@@ -278,9 +278,7 @@ int MaskPeaksWorkspace::findPixelID(const std::string &bankName, int col, int ro
 
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-
-    std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
-    return pixel->getID();
+    return RDet->getDetectorIDAtXY(col, row);
   } else if (Iptr->getName().compare("CORELLI") == 0) {
     // Checking for CORELLI
     // pixel full name example

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -333,7 +333,7 @@ int PeakIntegration::fitneighbours(int ipeak, const std::string &det_name, int x
 
   outputW->getSpectrum(idet).clearDetectorIDs();
   // Find the pixel ID at that XY position on the rectangular detector
-  int pixelID = peak.getDetectorID(); // det->getAtXY(x0,y0)->getID();
+  int pixelID = peak.getDetectorID();
 
   // Find the corresponding workspace index, if any
   auto wiEntry = pixel_to_wi.find(pixelID);

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -453,8 +453,7 @@ V3D SaveIsawPeaks::findPixelPos(const std::string &bankName, int col, int row) {
   auto parent = inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
     const auto RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    const auto pixel = RDet->getAtXY(col, row);
-    return pixel->getPos();
+    return RDet->getPosAtXY(col, row);
   } else {
     const auto &componentInfo = this->m_ws->componentInfo();
     const size_t parentIndex = componentInfo.indexOfAny(bankName);

--- a/Framework/Crystal/test/IntegratePeakTimeSlicesTest.h
+++ b/Framework/Crystal/test/IntegratePeakTimeSlicesTest.h
@@ -96,9 +96,9 @@ public:
     std::shared_ptr<const Geometry::RectangularDetector> bankR =
         std::dynamic_pointer_cast<const Geometry::RectangularDetector>(bankC);
 
-    std::shared_ptr<Geometry::Detector> pixelp = bankR->getAtXY(PeakCol, PeakRow);
+    detid_t pixelID = bankR->getDetectorIDAtXY(PeakCol, PeakRow);
     const auto &detectorInfo = wsPtr->detectorInfo();
-    const auto detInfoIndex = detectorInfo.indexOf(pixelp->getID());
+    const auto detInfoIndex = detectorInfo.indexOf(pixelID);
 
     // Now get Peak.
     double PeakTime = 18000 + (PeakChan + .5) * 100;
@@ -113,7 +113,7 @@ public:
     wl.fromTOF(x, x, L1, 0, {{Kernel::UnitParams::l2, L2}, {Kernel::UnitParams::twoTheta, ScatAng}});
     double wavelength = x[0];
 
-    Peak peak(instP, pixelp->getID(), wavelength);
+    Peak peak(instP, pixelID, wavelength);
 
     // Now set up data in workspace2D
     double dQ = 0;
@@ -122,10 +122,7 @@ public:
 
     for (int row = 0; row < NRC; row++)
       for (int col = 0; col < NRC; col++) {
-
-        std::shared_ptr<Detector> detP = bankR->getAtXY(col, row);
-
-        detid2index_map::const_iterator it = map.find(detP->getID());
+        detid2index_map::const_iterator it = map.find(bankR->getDetectorIDAtXY(col, row));
         size_t wsIndex = (*it).second;
 
         double MaxR = max<double>(0.0, MaxPeakIntensity * (1 - abs(row - PeakRow) / MaxPeakRCSpan));
@@ -220,8 +217,7 @@ private:
    */
   double calcQ(const RectangularDetector_const_sptr &bankP, const DetectorInfo &detectorInfo, int row, int col,
                double time) {
-    std::shared_ptr<Detector> detP = bankP->getAtXY(col, row);
-    const auto detInfoIndex = detectorInfo.indexOf(detP->getID());
+    const auto detInfoIndex = detectorInfo.indexOf(bankP->getDetectorIDAtXY(col, row));
     const auto L1 = detectorInfo.l1();
     const auto L2 = detectorInfo.l2(detInfoIndex);
 

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -225,7 +225,7 @@ void LoadDetectorsGroupingFile::setByComponents() {
 
       for (const auto &detIndex : detectorIndices) {
         // c) get detector ID
-        const auto detid = detectorInfo.detectorIDs()[detIndex];
+        const auto detid = detectorInfo.detid(detIndex);
         auto itx = indexmap.find(detid);
         if (itx != indexmap.end()) {
           size_t wsindex = itx->second;

--- a/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
+++ b/Framework/DataHandling/src/LoadEventNexusIndexSetup.cpp
@@ -112,7 +112,7 @@ IndexInfo LoadEventNexusIndexSetup::makeIndexInfo(const std::vector<std::string>
       dets = componentInfo.detectorsInSubtree(bankIndex);
       for (const auto detIndex : dets) {
         spectrumDefinitions.emplace_back(detIndex);
-        spectrumNumbers.emplace_back(detectorInfo.detectorIDs()[detIndex]);
+        spectrumNumbers.emplace_back(detectorInfo.detid(detIndex));
       }
     }
     if (dets.empty())

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -402,7 +402,7 @@ void LoadMask::componentToDetectors(const std::vector<std::string> &componentnam
     detid_t id_max(0);
 
     for (const auto &detIndex : detectorIndices) {
-      detid_t detid = detectorInfo.detectorIDs()[detIndex];
+      detid_t detid = detectorInfo.detid(detIndex);
       detectors.emplace_back(detid);
       numdets++;
       if (detid < id_min)

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -212,9 +212,7 @@ V3D SaveIsawDetCal::findPixelPos(const std::string &bankName, int col, int row, 
   std::shared_ptr<const IComponent> parent = inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
     std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-
-    std::shared_ptr<Detector> pixel = RDet->getAtXY(col, row);
-    return pixel->getPos();
+    return RDet->getPosAtXY(col, row);
   } else {
     const size_t parentIndex = componentInfo.indexOfAny(bankName);
     auto children = componentInfo.children(parentIndex);

--- a/Framework/DataHandling/src/SetScalingPSD.cpp
+++ b/Framework/DataHandling/src/SetScalingPSD.cpp
@@ -241,7 +241,7 @@ void SetScalingPSD::movePos(API::MatrixWorkspace_sptr &WS, std::map<int, Kernel:
   Progress prog(this, 0.5, 1.0, static_cast<int>(detectorInfo.size()));
 
   for (size_t i = 0; i < detectorInfo.size(); ++i) {
-    int idet = detectorInfo.detectorIDs()[i];
+    int idet = detectorInfo.detid(i);
 
     // Check if we have a shift, else do nothing.
     auto itPos = posMap.find(idet);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -118,9 +118,7 @@ public:
   void setScaleFactor(const size_t componentIndex, const Kernel::V3D &scaleFactor);
   size_t root() const;
 
-  const IComponent *componentID(const size_t componentIndex) const {
-    return m_componentIds->operator[](componentIndex);
-  }
+  const IComponent *componentID(const size_t componentIndex) const { return m_componentIds[componentIndex]; }
   bool hasValidShape(const size_t componentIndex) const;
 
   const Geometry::IObject &shape(const size_t componentIndex) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -118,7 +118,7 @@ public:
   void setScaleFactor(const size_t componentIndex, const Kernel::V3D &scaleFactor);
   size_t root() const;
 
-  const IComponent *componentID(const size_t componentIndex) const { return m_componentIds[componentIndex]; }
+  const IComponent *componentID(const size_t componentIndex) const { return (*m_componentIds)[componentIndex]; }
   bool hasValidShape(const size_t componentIndex) const;
 
   const Geometry::IObject &shape(const size_t componentIndex) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -54,14 +54,12 @@ public:
   //! Make a clone of the present component
   GridDetector *clone() const override;
 
-  std::shared_ptr<Detector> getAtXYZ(const int x, const int y, const int z) const;
-
   detid_t getDetectorIDAtXYZ(const int x, const int y, const int z) const;
   std::tuple<int, int, int> getXYZForDetectorID(const detid_t detectorID) const;
 
-  int xpixels() const;
-  int ypixels() const;
-  int zpixels() const;
+  int const &xpixels() const;
+  int const &ypixels() const;
+  int const &zpixels() const;
 
   double xstep() const;
   double ystep() const;
@@ -78,18 +76,20 @@ public:
   /// Size in Z of the detector
   double zsize() const;
 
-  int idstart() const;
-  bool idfillbyfirst_y() const;
-  std::string idFillOrder() const;
-  int idstepbyrow() const;
-  int idstep() const;
+  int const &idstart() const;
+  int const &idstepbyrow() const;
+  int const &idstep() const;
+  /// returns if IDs are filled along y direction first
+  bool const &idfillbyfirst_y() const;
 
-  Kernel::V3D getRelativePosAtXYZ(int x, int y, int z) const;
+  Kernel::V3D getRelativePosAtXYZ(int const x, int const y, int const z) const;
   /// minimum detector id
-  detid_t minDetectorID() const;
+  detid_t const &minDetectorID() const;
   /// maximum detector id
-  detid_t maxDetectorID() const;
+  detid_t const &maxDetectorID() const;
   std::shared_ptr<const IComponent> getComponentByName(const std::string &cname, int nlevels = 0) const override;
+
+  Kernel::V3D getPosAtXYZ(int const x, int const y, int const z) const;
 
   // This should inherit the getBoundingBox implementation from  CompAssembly
   // but the multiple inheritance seems to confuse it so we'll explicityly tell
@@ -115,6 +115,8 @@ public:
   /// Retrieve the cached bounding box
   void getBoundingBox(BoundingBox &assemblyBox) const override;
 
+  void getBoundingBoxAtXYZ(int const x, int const y, int const z, BoundingBox &box) const;
+
   /// Try to find a point that lies within (or on) the object
   int getPointInObject(Kernel::V3D &point) const override;
 
@@ -136,11 +138,18 @@ public:
 
   virtual size_t registerContents(class ComponentVisitor &componentVisitor) const override;
 
+  /// returns dimensions of filling in order
+  std::array<char, 3UL> const &idFillOrder() const;
+
+  bool inBoundsXYZ(const int x, const int y, const int z) const;
+
   // ------------ End of IObjComponent methods ----------------
 protected:
   /// initialize members to bare defaults
   void init();
   void createLayer(const std::string &name, CompAssembly *parent, int iz, int &minDetID, int &maxDetID);
+
+  std::shared_ptr<Detector> getAtXYZ(const int x, const int y, const int z) const;
 
 private:
   void initializeValues(std::shared_ptr<IObject> shape, int xpixels, double xstart, double xstep, int ypixels,
@@ -194,7 +203,7 @@ private:
   /// IDs are filled in Y fastest
   bool m_idfillbyfirst_y;
   /// The order in which to fill IDs
-  std::string m_idFillOrder;
+  std::array<char, 3UL> m_idFillOrder;
   /// Step size in ID in each row
   int m_idstepbyrow;
   /// Step size in ID in each col

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetector.h
@@ -57,16 +57,19 @@ public:
   detid_t getDetectorIDAtXY(const int X, const int Y) const;
   std::pair<int, int> getXYForDetectorID(const int detectorID) const;
 
+  Kernel::V3D getPosAtXY(const int x, const int y) const;
   Kernel::V3D getRelativePosAtXY(int x, int y) const;
   void getTextureSize(int &xsize, int &ysize) const;
 
   unsigned int getTextureID() const;
   void setTextureID(unsigned int textureID);
 
-  // This should inherit the getBoundingBox implementation from  CompAssembly
-  // but
-  // the multiple inheritance seems to confuse it so we'll explicityly tell it
-  // that here
+  void getBoundingBoxAtXY(const int x, const int y, BoundingBox &box) const;
+
+  bool inBoundsXY(int x, int y) const;
+
+  // This should inherit the getBoundingBox implementation from  CompAssembly but
+  // the multiple inheritance seems to confuse it so we'll explicityly tell it that here
   using CompAssembly::getBoundingBox;
 
   void testIntersectionWithChildren(Track &testRay, std::deque<IComponent_const_sptr> &searchQueue) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetector.h
@@ -68,8 +68,8 @@ public:
 
   bool inBoundsXY(int x, int y) const;
 
-  // This should inherit the getBoundingBox implementation from  CompAssembly but
-  // the multiple inheritance seems to confuse it so we'll explicityly tell it that here
+  // This should inherit the getBoundingBox implementation from CompAssembly but
+  // the multiple inheritance seems to confuse it so we'll explicitly tell it that here
   using CompAssembly::getBoundingBox;
 
   void testIntersectionWithChildren(Track &testRay, std::deque<IComponent_const_sptr> &searchQueue) const override;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -297,13 +297,12 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
 
   std::size_t numDetIDs = in_dets.size();
 
-  if (skipMonitors) // this slow, but gets the right answer
-  {
-    std::size_t monitors(0);
-    monitors = std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });
-    return (numDetIDs - monitors);
+  if (skipMonitors) {
+    const std::size_t monitors =
+        std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });
+    return (in_dets.size() - monitors);
   } else {
-    return numDetIDs;
+    return in_dets.size();
   }
 }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -295,8 +295,6 @@ std::vector<detid_t> Instrument::getMonitorIDs() const {
 std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
   const auto &in_dets = m_map ? m_instr->m_detectorCache : m_detectorCache;
 
-  std::size_t numDetIDs = in_dets.size();
-
   if (skipMonitors) {
     const std::size_t monitors =
         std::count_if(in_dets.cbegin(), in_dets.cend(), [](const auto &in_det) { return in_det.isMonitor(); });

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -52,7 +52,7 @@ DetectorInfo::DetectorInfo(const DetectorInfo &other)
 
 /// Assigns the contents of the non-wrapping part of `rhs` to this.
 DetectorInfo &DetectorInfo::operator=(const DetectorInfo &rhs) {
-  if (detectorIDs() != rhs.detectorIDs())
+  if (*m_detectorIDs != *rhs.m_detectorIDs)
     throw std::runtime_error("DetectorInfo::operator=: Detector IDs in "
                              "assignment do not match. Assignment not "
                              "possible");
@@ -79,8 +79,8 @@ bool DetectorInfo::isEquivalent(const DetectorInfo &other) const {
 }
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
-/// instrument.
-size_t DetectorInfo::size() const { return m_detectorIDs->size(); }
+/// instrument
+size_t DetectorInfo::size() const { return m_detectorInfo->size(); }
 
 /// Returns true if the beamline has scanning detectors.
 bool DetectorInfo::isScanning() const { return m_detectorInfo->isScanning(); }
@@ -271,12 +271,13 @@ double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
 std::tuple<double, double, double> DetectorInfo::diffractometerConstants(const size_t index,
                                                                          std::vector<detid_t> &calibratedDets,
                                                                          std::vector<detid_t> &uncalibratedDets) const {
-  auto det = m_instrument->getDetector((*m_detectorIDs)[index]);
+  const detid_t detectorId = detid(index);
+  auto det = m_instrument->getDetector(detectorId);
   auto pmap = m_instrument->getParameterMap();
   auto par = pmap->get(det.get(), "DIFC");
   if (par) {
     double difc = par->value<double>();
-    calibratedDets.push_back((*m_detectorIDs)[index]);
+    calibratedDets.push_back(detectorId);
     double difa = 0., tzero = 0.;
     par = pmap->get(det.get(), "DIFA");
     if (par)
@@ -288,7 +289,7 @@ std::tuple<double, double, double> DetectorInfo::diffractometerConstants(const s
   } else {
     // if calibrated difc not available, revert to uncalibrated difc with other
     // two constants=0
-    uncalibratedDets.push_back((*m_detectorIDs)[index]);
+    uncalibratedDets.push_back(detectorId);
     double difc = difcUncalibrated(index);
     return {0., difc, 0.};
   }
@@ -371,7 +372,7 @@ void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index, const Ker
 // Clear any parameters whose value is only valid for specific positions
 // Currently diffractometer constants
 void DetectorInfo::clearPositionDependentParameters(const size_t index) {
-  auto det = m_instrument->getDetector((*m_detectorIDs)[index]);
+  auto det = m_instrument->getDetector(detid(index));
   auto pmap = m_instrument->getParameterMap();
   pmap->clearParametersByName("DIFA", det.get());
   pmap->clearParametersByName("DIFC", det.get());
@@ -407,14 +408,17 @@ std::size_t DetectorInfo::indexOf(const detid_t id) const {
   try {
     return m_detIDToIndex->at(id);
   } catch (const std::out_of_range &) {
-    // customize the error message
     std::stringstream msg;
     msg << "Failed to find detector with id=" << id;
     throw std::out_of_range(msg.str());
   }
 }
 
-detid_t DetectorInfo::detid(const size_t index) const { return getDetector(index).getID(); }
+/// Returns the detector ID for the given logical detector index.
+/// Works without allocating the full ID vector.
+detid_t DetectorInfo::detid(const size_t index) const {
+  return (*m_detectorIDs)[m_detectorInfo->compactDetectorIndex(index)];
+}
 
 /// Returns the scan count of the detector with given detector index.
 size_t DetectorInfo::scanCount() const { return m_detectorInfo->scanCount(); }
@@ -437,7 +441,7 @@ const Geometry::IDetector &DetectorInfo::getDetector(const size_t index) const {
   if (m_lastIndex[thread] != index) {
     m_lastIndex[thread] = index;
     try {
-      m_lastDetector[thread] = m_instrument->getDetector((*m_detectorIDs)[index]);
+      m_lastDetector[thread] = m_instrument->getDetector(detid(index));
     } catch (...) {
       // Reset so a future call for this index retries rather than returning
       // whatever stale pointer m_lastDetector holds from a previous access.

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -159,7 +159,7 @@ int const &pixelsXYZ(char const order, GridDetector const *const me) {
   case 'z':
     return me->zpixels();
   default:
-    throw std::runtime_error("Not a dimensional label: " + std::to_string(order));
+    throw std::runtime_error(std::string("Not a dimensional label: ") + order);
   }
 }
 } // namespace

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -79,6 +79,21 @@ void GridDetector::init() {
  */
 GridDetector *GridDetector::clone() const { return new GridDetector(*this); }
 
+bool GridDetector::inBoundsXYZ(const int x, const int y, const int z) const {
+  if ((xpixels() <= 0) || (ypixels() <= 0))
+    throw std::runtime_error("GridDetector::inBoundsXYZ: invalid X or Y "
+                             "width set in the object.");
+  if ((x < 0) || (x >= xpixels()))
+    return false;
+  if ((y < 0) || (y >= ypixels()))
+    return false;
+  if (zpixels() > 0) {
+    if ((z < 0) || (z >= zpixels()))
+      return false;
+  }
+  return true;
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Return a pointer to the component in the assembly at the
  * (X,Y) pixel position.
@@ -122,27 +137,32 @@ std::shared_ptr<Detector> GridDetector::getAtXYZ(const int x, const int y, const
 }
 
 namespace {
-detid_t getFillFirstZ(const GridDetector *me, int x, int y, int z) {
-  if (me->idFillOrder()[1] == 'y')
-    return me->idstart() + z * me->idstep() + y * me->idstepbyrow() + x * (me->ypixels() * me->idstepbyrow());
-  else
-    return me->idstart() + z * me->idstep() + x * me->idstepbyrow() + y * (me->xpixels() * me->idstepbyrow());
+int const &orderXYZ(char const order, int const &x, int const &y, int const &z) {
+  switch (order) {
+  case 'x':
+    return x;
+  case 'y':
+    return y;
+  case 'z':
+    return z;
+  default:
+    throw std::runtime_error("Not a dimensional label: " + std::to_string(order));
+  }
 }
 
-detid_t getFillFirstY(const GridDetector *me, int x, int y, int z) {
-  if (me->idFillOrder()[1] == 'x')
-    return me->idstart() + y * me->idstep() + x * me->idstepbyrow() + z * (me->xpixels() * me->idstepbyrow());
-  else
-    return me->idstart() + y * me->idstep() + z * me->idstepbyrow() + x * (me->zpixels() * me->idstepbyrow());
+int const &pixelsXYZ(char const order, GridDetector const *const me) {
+  switch (order) {
+  case 'x':
+    return me->xpixels();
+  case 'y':
+    return me->ypixels();
+  case 'z':
+    return me->zpixels();
+  default:
+    throw std::runtime_error("Not a dimensional label: " + std::to_string(order));
+  }
 }
-
-detid_t getFillFirstX(const GridDetector *me, int x, int y, int z) {
-  if (me->idFillOrder()[1] == 'y')
-    return me->idstart() + x * me->idstep() + y * me->idstepbyrow() + z * (me->ypixels() * me->idstepbyrow());
-  else
-    return me->idstart() + x * me->idstep() + z * me->idstepbyrow() + y * (me->zpixels() * me->idstepbyrow());
-}
-} // end namespace
+} // namespace
 
 //-------------------------------------------------------------------------------------------------
 /** Return the detector ID corresponding to the component in the assembly at the
@@ -156,16 +176,13 @@ detid_t getFillFirstX(const GridDetector *me, int x, int y, int z) {
  *range
  */
 detid_t GridDetector::getDetectorIDAtXYZ(const int x, const int y, const int z) const {
-  const GridDetector *me = this;
-  if (isParametrized())
-    me = this->m_gridBase;
+  auto order = idFillOrder();
 
-  if (me->idFillOrder()[0] == 'z')
-    return getFillFirstZ(me, x, y, z);
-  else if (me->idFillOrder()[0] == 'y')
-    return getFillFirstY(me, x, y, z);
-  else
-    return getFillFirstX(me, x, y, z);
+  int const &first = orderXYZ(order[0], x, y, z);
+  int const &second = orderXYZ(order[1], x, y, z);
+  int const &third = orderXYZ(order[2], x, y, z);
+
+  return idstart() + first * idstep() + second * idstepbyrow() + third * (pixelsXYZ(order[1], this) * idstepbyrow());
 }
 
 namespace {
@@ -233,7 +250,7 @@ std::tuple<int, int, int> GridDetector::getXYZForDetectorID(const detid_t detect
 //-------------------------------------------------------------------------------------------------
 /// Returns the number of pixels in the X direction.
 /// @return number of X pixels
-int GridDetector::xpixels() const {
+int const &GridDetector::xpixels() const {
   if (isParametrized())
     return m_gridBase->xpixels();
   else
@@ -243,7 +260,7 @@ int GridDetector::xpixels() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the number of pixels in the Y direction.
 /// @return number of y pixels
-int GridDetector::ypixels() const {
+int const &GridDetector::ypixels() const {
   if (isParametrized())
     return m_gridBase->ypixels();
   else
@@ -253,7 +270,7 @@ int GridDetector::ypixels() const {
 //-------------------------------------------------------------------------------------------------
 /// Returns the number of pixels in the Z direction.
 /// @return number of z pixels
-int GridDetector::zpixels() const {
+int const &GridDetector::zpixels() const {
   if (isParametrized())
     return m_gridBase->zpixels();
   else
@@ -370,7 +387,7 @@ double GridDetector::zsize() const {
 
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstart
-int GridDetector::idstart() const {
+int const &GridDetector::idstart() const {
   if (isParametrized())
     return m_gridBase->idstart();
   else
@@ -379,7 +396,7 @@ int GridDetector::idstart() const {
 
 //-------------------------------------------------------------------------------------------------
 /// Returns the idfillbyfirst_y
-bool GridDetector::idfillbyfirst_y() const {
+bool const &GridDetector::idfillbyfirst_y() const {
   if (isParametrized())
     return m_gridBase->idfillbyfirst_y();
   else
@@ -387,7 +404,7 @@ bool GridDetector::idfillbyfirst_y() const {
 }
 
 /// Returns the id fill order
-std::string GridDetector::idFillOrder() const {
+std::array<char, 3UL> const &GridDetector::idFillOrder() const {
   if (isParametrized())
     return m_gridBase->idFillOrder();
   else
@@ -396,7 +413,7 @@ std::string GridDetector::idFillOrder() const {
 
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstepbyrow
-int GridDetector::idstepbyrow() const {
+int const &GridDetector::idstepbyrow() const {
   if (isParametrized())
     return m_gridBase->idstepbyrow();
   else
@@ -405,11 +422,27 @@ int GridDetector::idstepbyrow() const {
 
 //-------------------------------------------------------------------------------------------------
 /// Returns the idstep
-int GridDetector::idstep() const {
+int const &GridDetector::idstep() const {
   if (isParametrized())
     return m_gridBase->idstep();
   else
     return this->m_idstep;
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Returns the position of the center of the pixel at x,y, relative to the
+ * center
+ * of the GridDetector, in the plain X,Y coordinates of the
+ * pixels (i.e. unrotated).
+ * @param x :: x pixel integer
+ * @param y :: y pixel integer
+ * @param z :: z pixel integer
+ * @return a V3D vector of the relative position
+ */
+V3D GridDetector::getPosAtXYZ(int x, int y, int z) const {
+  V3D relPos = getRelativePosAtXYZ(x, y, z);
+  V3D anchorPos = this->getPos();
+  return (anchorPos + relPos);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -479,11 +512,11 @@ void GridDetector::createLayer(const std::string &name, CompAssembly *parent, in
   }
 }
 
-bool checkValidOrderString(const std::string &order) {
-  static const boost::regex exp("xyz|xzy|yzx|yxz|zyx|zxy");
-
-  return boost::regex_match(order, exp);
+namespace {
+bool checkValidOrderString(std::array<char, 3UL> const &order) {
+  return std::all_of(order.cbegin(), order.cend(), [](char const &c) { return (c >= 'x') && (c <= 'z'); });
 }
+} // end namespace
 
 void GridDetector::validateInput() const {
   // Some safety checks
@@ -519,7 +552,7 @@ void GridDetector::initializeValues(std::shared_ptr<IObject> shape, int xpixels,
   /// IDs are filled in Y fastest
   m_idfillbyfirst_y = idFillOrder[0] == 'y';
   /// IDs are filled by Y fastest
-  m_idFillOrder = idFillOrder;
+  m_idFillOrder = std::array<char, 3>{idFillOrder[0], idFillOrder[1], idFillOrder[2]};
   /// Step size in ID in each row
   m_idstepbyrow = idstepbyrow;
   /// Step size in ID in each col
@@ -593,7 +626,7 @@ void GridDetector::initialize(std::shared_ptr<IObject> shape, int xpixels, doubl
 /** Returns the minimum detector id
  * @return minimum detector id
  */
-detid_t GridDetector::minDetectorID() const {
+detid_t const &GridDetector::minDetectorID() const {
   if (isParametrized())
     return m_gridBase->minDetectorID();
   return m_minDetId;
@@ -603,7 +636,7 @@ detid_t GridDetector::minDetectorID() const {
 /** Returns the maximum detector id
  * @return maximum detector id
  */
-detid_t GridDetector::maxDetectorID() const {
+detid_t const &GridDetector::maxDetectorID() const {
   if (isParametrized())
     return m_gridBase->maxDetectorID();
   return m_maxDetId;
@@ -693,9 +726,12 @@ void GridDetector::testIntersectionWithChildren(Track &testRay,
   if (yIndex >= ypixels())
     return;
 
-  // TODO: Do I need to put something smart here for the first 3 parameters?
+  // All pixels share the same pixel shape stored on the detector.
+  // The parametrized form delegates to the base detector's shape.
+  std::shared_ptr<IObject> const &pixelShape = isParametrized() ? m_gridBase->m_shape : m_shape;
+
   auto comp = getAtXYZ(xIndex, yIndex, 0);
-  testRay.addLink(intersec, intersec, 0.0, *(comp->shape()), comp->getComponentID());
+  testRay.addLink(intersec, intersec, 0.0, *pixelShape, comp->getComponentID());
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -735,6 +771,41 @@ int GridDetector::getPointInObject(V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError("GridDetector::getPointInObject() is not implemented.");
 }
 
+void GridDetector::getBoundingBoxAtXYZ(int const x, int const y, int const z, BoundingBox &box) const {
+  // Compute the pixel bounding box analytically, replicating ObjComponent::getBoundingBox
+  // without needing an actual child Detector object.  Each pixel shares the same shape
+  // (m_shape) and inherits the GridDetector's rotation with no additional per-pixel rotation.
+
+  // For a parametrized detector the shape lives on the base.
+  std::shared_ptr<IObject> const &pixelShape = isParametrized() ? m_gridBase->m_shape : m_shape;
+  if (!pixelShape || !pixelShape->hasValidShape()) {
+    box = BoundingBox();
+    return;
+  }
+
+  const BoundingBox &shapeBox = pixelShape->getBoundingBox();
+  if (shapeBox.isNull()) {
+    box = BoundingBox();
+    return;
+  }
+
+  // 1. Copy the shape's axis-aligned bounding box in the local (pixel) frame.
+  box = BoundingBox(shapeBox);
+
+  // 2. Rotate: pixels have the same orientation as the parent GridDetector; there
+  //    is no additional per-pixel rotation, so we apply the detector's own rotation.
+  this->getRotation().rotateBB(box.xMin(), box.yMin(), box.zMin(), box.xMax(), box.yMax(), box.zMax());
+
+  // 3. Translate to the pixel's absolute position in the instrument frame.
+  Kernel::V3D const pixelPos = getPosAtXYZ(x, y, z);
+  box.xMin() += pixelPos.X();
+  box.xMax() += pixelPos.X();
+  box.yMin() += pixelPos.Y();
+  box.yMax() += pixelPos.Y();
+  box.zMin() += pixelPos.Z();
+  box.zMax() += pixelPos.Z();
+}
+
 //-------------------------------------------------------------------------------------------------
 /**
  * Get the bounding box and store it in the given object. This is cached after
@@ -750,21 +821,21 @@ void GridDetector::getBoundingBox(BoundingBox &assemblyBox) const {
   }
   BoundingBox bb;
   BoundingBox compBox;
-  getAtXYZ(0, 0, 0)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(0, 0, 0, compBox);
   bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, 0, 0)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(this->xpixels() - 1, 0, 0, compBox);
   bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, 0)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(this->xpixels() - 1, this->ypixels() - 1, 0, compBox);
   bb.grow(compBox);
-  getAtXYZ(0, this->ypixels() - 1, 0)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(0, this->ypixels() - 1, 0, compBox);
   bb.grow(compBox);
-  getAtXYZ(0, 0, this->zpixels() - 1)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(0, 0, this->zpixels() - 1, compBox);
   bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, 0, this->zpixels() - 1)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(this->xpixels() - 1, 0, this->zpixels() - 1, compBox);
   bb.grow(compBox);
-  getAtXYZ(this->xpixels() - 1, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(this->xpixels() - 1, this->ypixels() - 1, this->zpixels() - 1, compBox);
   bb.grow(compBox);
-  getAtXYZ(0, this->ypixels() - 1, this->zpixels() - 1)->getBoundingBox(compBox);
+  getBoundingBoxAtXYZ(0, this->ypixels() - 1, this->zpixels() - 1, compBox);
   bb.grow(compBox);
 
   assemblyBox = bb;

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -441,8 +441,8 @@ int const &GridDetector::idstep() const {
  */
 V3D GridDetector::getPosAtXYZ(int x, int y, int z) const {
   V3D relPos = getRelativePosAtXYZ(x, y, z);
-  V3D anchorPos = this->getPos();
-  return (anchorPos + relPos);
+  this->getRotation().rotate(relPos);
+  return this->getPos() + relPos;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -176,6 +176,9 @@ int const &pixelsXYZ(char const order, GridDetector const *const me) {
  *range
  */
 detid_t GridDetector::getDetectorIDAtXYZ(const int x, const int y, const int z) const {
+  if (!inBoundsXYZ(x, y, z))
+    throw std::out_of_range("GridDetector::getDetectorIDAtXYZ: pixel indices are out of range.");
+
   auto order = idFillOrder();
 
   int const &first = orderXYZ(order[0], x, y, z);
@@ -440,6 +443,8 @@ int const &GridDetector::idstep() const {
  * @return a V3D vector of the relative position
  */
 V3D GridDetector::getPosAtXYZ(int x, int y, int z) const {
+  if (!inBoundsXYZ(x, y, z))
+    throw std::out_of_range("GridDetector::getPosAtXYZ: pixel indices are out of range.");
   V3D relPos = getRelativePosAtXYZ(x, y, z);
   this->getRotation().rotate(relPos);
   return this->getPos() + relPos;
@@ -791,6 +796,24 @@ void GridDetector::getBoundingBoxAtXYZ(int const x, int const y, int const z, Bo
 
   // 1. Copy the shape's axis-aligned bounding box in the local (pixel) frame.
   box = BoundingBox(shapeBox);
+
+  // 1a. For parametrized detectors, scale the shape extents by scalex/scaley/scalez
+  //     so the per-pixel box matches the scaled pixel size (consistent with getPosAtXYZ).
+  if (isParametrized()) {
+    double scalex = 1.0, scaley = 1.0, scalez = 1.0;
+    if (m_map->contains(m_gridBase, "scalex"))
+      scalex = m_map->get(m_gridBase, "scalex")->value<double>();
+    if (m_map->contains(m_gridBase, "scaley"))
+      scaley = m_map->get(m_gridBase, "scaley")->value<double>();
+    if (m_map->contains(m_gridBase, "scalez"))
+      scalez = m_map->get(m_gridBase, "scalez")->value<double>();
+    box.xMin() *= scalex;
+    box.xMax() *= scalex;
+    box.yMin() *= scaley;
+    box.yMax() *= scaley;
+    box.zMin() *= scalez;
+    box.zMax() *= scalez;
+  }
 
   // 2. Rotate: pixels have the same orientation as the parent GridDetector; there
   //    is no additional per-pixel rotation, so we apply the detector's own rotation.

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -318,7 +318,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
   (*m_detectorRotations)[detectorIndex] = Kernel::toQuaterniond(detector.getRotation());
   (*m_shapes)[detectorIndex] = detector.shape();
   (*m_scaleFactors)[detectorIndex] = Kernel::toVector3d(detector.getScaleFactor());
-  if (m_instrument->isMonitorViaIndex(detectorIndex)) {
+  if (m_instrument->isMonitor(detector.getID())) {
     m_monitorIndices->emplace_back(detectorIndex);
   }
   (*m_names)[detectorIndex] = detector.getName();

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -123,6 +123,8 @@ std::pair<int, int> RectangularDetector::getXYForDetectorID(const int detectorID
   return std::pair<int, int>(std::get<0>(xyz), std::get<1>(xyz));
 }
 
+V3D RectangularDetector::getPosAtXY(const int x, const int y) const { return GridDetector::getPosAtXYZ(x, y, 0); }
+
 //-------------------------------------------------------------------------------------------------
 /** Returns the position of the center of the pixel at x,y, relative to the
  * center
@@ -133,6 +135,12 @@ std::pair<int, int> RectangularDetector::getXYForDetectorID(const int detectorID
  * @return a V3D vector of the relative position
  */
 V3D RectangularDetector::getRelativePosAtXY(int x, int y) const { return GridDetector::getRelativePosAtXYZ(x, y, 0); }
+
+void RectangularDetector::getBoundingBoxAtXY(const int x, const int y, BoundingBox &box) const {
+  GridDetector::getBoundingBoxAtXYZ(x, y, 0, box);
+}
+
+bool RectangularDetector::inBoundsXY(int x, int y) const { return GridDetector::inBoundsXYZ(x, y, 0); }
 
 //-------------------------------------------------------------------------------------------------
 /** Initialize a RectangularDetector by creating all of the pixels
@@ -185,17 +193,13 @@ void RectangularDetector::initialize(std::shared_ptr<IObject> shape, int xpixels
 void RectangularDetector::testIntersectionWithChildren(Track &testRay,
                                                        std::deque<IComponent_const_sptr> & /*searchQueue*/) const {
   /// Base point (x,y,z) = position of pixel 0,0
-  V3D basePoint;
+  V3D basePoint = getPosAtXY(0, 0);
 
   /// Vertical (y-axis) basis vector of the detector
-  V3D vertical;
+  V3D vertical = getPosAtXY(0, ypixels() - 1) - basePoint;
 
   /// Horizontal (x-axis) basis vector of the detector
-  V3D horizontal;
-
-  basePoint = getAtXY(0, 0)->getPos();
-  horizontal = getAtXY(xpixels() - 1, 0)->getPos() - basePoint;
-  vertical = getAtXY(0, ypixels() - 1)->getPos() - basePoint;
+  V3D horizontal = getPosAtXY(xpixels() - 1, 0) - basePoint;
 
   // The beam direction
   V3D beam = testRay.direction();

--- a/Framework/Geometry/test/GridDetectorTest.h
+++ b/Framework/Geometry/test/GridDetectorTest.h
@@ -134,11 +134,11 @@ public:
     TS_ASSERT_EQUALS(pos, V3D(-4.5, -12.5, -1.0));
 
     // Check some positions
-    pos = parDet->getAtXYZ(0, 0, 0)->getPos();
+    pos = parDet->getPosAtXYZ(0, 0, 0);
     TS_ASSERT_EQUALS(pos, V3D(-6.5, -15.5, -2.0));
-    pos = parDet->getAtXYZ(1, 0, 0)->getPos();
+    pos = parDet->getPosAtXYZ(1, 0, 0);
     TS_ASSERT_EQUALS(pos, V3D(-3.5, -15.5, -2.0));
-    pos = parDet->getAtXYZ(1, 1, 2)->getPos();
+    pos = parDet->getPosAtXYZ(1, 1, 2);
     TS_ASSERT_EQUALS(pos, V3D(-3.5, -10.5, 2.0));
   }
 
@@ -153,7 +153,7 @@ private:
     do_test_positions(det);
 
     // Name
-    TS_ASSERT_EQUALS(det.getAtXYZ(1, 2, 0)->getName(), "MyGrid(1,2,0)");
+    // TS_ASSERT_EQUALS(det.getAtXYZ(1, 2, 0)->getName(), "MyGrid(1,2,0)");
     TS_ASSERT_EQUALS(det.getChild(1)->getName(), "MyGrid(z=1)");
     auto layer = std::dynamic_pointer_cast<ICompAssembly>(det.getChild(2));
     TS_ASSERT_EQUALS(layer->getChild(1)->getName(), "MyGrid(z=2,x=1)");
@@ -170,9 +170,8 @@ private:
 
     // Pull out a component and check that
     // position of det (-1.5, -1.5, -0.5) and size 0.5
-    auto pixelDet = det.getAtXYZ(1, 2, 1);
     box = BoundingBox();
-    pixelDet->getBoundingBox(box);
+    det.getBoundingBoxAtXYZ(1, 2, 1, box);
     TS_ASSERT_DELTA(box.xMin(), -2.0, 1e-08);
     TS_ASSERT_DELTA(box.yMin(), -2.0, 1e-08);
     TS_ASSERT_DELTA(box.zMin(), -1.0, 1e-08);
@@ -198,17 +197,17 @@ private:
 
   void do_test_bounds(const GridDetector &det) {
     // Go out of bounds
-    TS_ASSERT_THROWS(det.getAtXYZ(-1, 0, 0), const std::runtime_error &);
-    TS_ASSERT_THROWS(det.getAtXYZ(0, -1, 0), const std::runtime_error &);
-    TS_ASSERT_THROWS(det.getAtXYZ(100, 0, 0), const std::runtime_error &);
-    TS_ASSERT_THROWS(det.getAtXYZ(0, 205, 0), const std::runtime_error &);
+    TS_ASSERT(!det.inBoundsXYZ(-1, 0, 0));
+    TS_ASSERT(!det.inBoundsXYZ(0, -1, 0));
+    TS_ASSERT(!det.inBoundsXYZ(100, 0, 0));
+    TS_ASSERT(!det.inBoundsXYZ(0, 205, 0));
   }
 
   void do_test_ids(const GridDetector &det) {
     // Check some ids
-    TS_ASSERT_EQUALS(det.getAtXYZ(0, 0, 1)->getID() - 1000000, 1);
-    TS_ASSERT_EQUALS(det.getAtXYZ(0, 1, 0)->getID() - 1000000, 3);
-    TS_ASSERT_EQUALS(det.getAtXYZ(1, 0, 0)->getID() - 1000000, 21);
+    TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(0, 0, 1) - 1000000, 1);
+    TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(0, 1, 0) - 1000000, 3);
+    TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(1, 0, 0) - 1000000, 21);
     TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(0, 0, 1), 1000001);
     TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(0, 1, 0), 1000003);
     TS_ASSERT_EQUALS(det.getDetectorIDAtXYZ(1, 0, 0), 1000021);
@@ -237,13 +236,13 @@ private:
     TS_ASSERT_EQUALS(z, 1);
 
     // Check some positions
-    auto pos = det.getAtXYZ(0, 0, 0)->getPos();
+    auto pos = det.getPosAtXYZ(0, 0, 0);
     TS_ASSERT_EQUALS(pos, V3D(-2.5, -3.5, -1.5));
-    pos = det.getAtXYZ(1, 0, 0)->getPos();
+    pos = det.getPosAtXYZ(1, 0, 0);
     TS_ASSERT_EQUALS(pos, V3D(-1.5, -3.5, -1.5));
-    pos = det.getAtXYZ(1, 1, 0)->getPos();
+    pos = det.getPosAtXYZ(1, 1, 0);
     TS_ASSERT_EQUALS(pos, V3D(-1.5, -2.5, -1.5));
-    pos = det.getAtXYZ(2, 5, 2)->getPos();
+    pos = det.getPosAtXYZ(2, 5, 2);
     TS_ASSERT_EQUALS(pos, V3D(-0.5, 1.5, 0.5));
   }
 };

--- a/Framework/Geometry/test/GridDetectorTest.h
+++ b/Framework/Geometry/test/GridDetectorTest.h
@@ -140,6 +140,19 @@ public:
     TS_ASSERT_EQUALS(pos, V3D(-3.5, -15.5, -2.0));
     pos = parDet->getPosAtXYZ(1, 1, 2);
     TS_ASSERT_EQUALS(pos, V3D(-3.5, -10.5, 2.0));
+
+    // Pixel bounding box for parametrized detector: shape extents should be
+    // scaled by (scalex, scaley, scalez). Cuboid half-size 0.5 becomes
+    // (1.5, 2.5, 1.0). Pixel (1,1,1) is at getPosAtXYZ(1,1,1) =
+    // (1,2,1) + (-4.5,-12.5,-1.0) = (-3.5,-10.5, 0.0) (no rotation).
+    BoundingBox bbox;
+    parDet->getBoundingBoxAtXYZ(1, 1, 1, bbox);
+    TS_ASSERT_DELTA(bbox.xMin(), -5.0, 1e-08);
+    TS_ASSERT_DELTA(bbox.xMax(), -2.0, 1e-08);
+    TS_ASSERT_DELTA(bbox.yMin(), -13.0, 1e-08);
+    TS_ASSERT_DELTA(bbox.yMax(), -8.0, 1e-08);
+    TS_ASSERT_DELTA(bbox.zMin(), -1.0, 1e-08);
+    TS_ASSERT_DELTA(bbox.zMax(), 1.0, 1e-08);
   }
 
 private:

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -508,16 +508,16 @@ public:
     TS_ASSERT_EQUALS(bank1->nelements(), 100);
 
     // Positions according to formula
-    TS_ASSERT_DELTA(bank1->getAtXY(0, 0)->getPos().X(), -0.1, 1e-4);
-    TS_ASSERT_DELTA(bank1->getAtXY(0, 0)->getPos().Y(), -0.2, 1e-4);
-    TS_ASSERT_DELTA(bank1->getAtXY(1, 0)->getPos().X(), -0.098, 1e-4);
-    TS_ASSERT_DELTA(bank1->getAtXY(1, 1)->getPos().Y(), -0.198, 1e-4);
+    TS_ASSERT_DELTA(bank1->getPosAtXY(0, 0).X(), -0.1, 1e-4);
+    TS_ASSERT_DELTA(bank1->getPosAtXY(0, 0).Y(), -0.2, 1e-4);
+    TS_ASSERT_DELTA(bank1->getPosAtXY(1, 0).X(), -0.098, 1e-4);
+    TS_ASSERT_DELTA(bank1->getPosAtXY(1, 1).Y(), -0.198, 1e-4);
 
     // Some IDs
-    TS_ASSERT_EQUALS(bank1->getAtXY(0, 0)->getID(), 1000);
-    TS_ASSERT_EQUALS(bank1->getAtXY(0, 1)->getID(), 1001);
-    TS_ASSERT_EQUALS(bank1->getAtXY(1, 0)->getID(), 1300);
-    TS_ASSERT_EQUALS(bank1->getAtXY(1, 1)->getID(), 1301);
+    TS_ASSERT_EQUALS(bank1->getDetectorIDAtXY(0, 0), 1000);
+    TS_ASSERT_EQUALS(bank1->getDetectorIDAtXY(0, 1), 1001);
+    TS_ASSERT_EQUALS(bank1->getDetectorIDAtXY(1, 0), 1300);
+    TS_ASSERT_EQUALS(bank1->getDetectorIDAtXY(1, 1), 1301);
 
     // The total number of detectors
     detid2det_map dets;

--- a/Framework/Geometry/test/RectangularDetectorTest.h
+++ b/Framework/Geometry/test/RectangularDetectorTest.h
@@ -111,17 +111,17 @@ public:
     TS_ASSERT_EQUALS(det->ystep(), 1.0);
     TS_ASSERT_EQUALS(det->ysize(), 200.0);
 
-    // Go out of bounds
-    TS_ASSERT_THROWS(det->getAtXY(-1, 0), const std::runtime_error &);
-    TS_ASSERT_THROWS(det->getAtXY(0, -1), const std::runtime_error &);
-    TS_ASSERT_THROWS(det->getAtXY(100, 0), const std::runtime_error &);
-    TS_ASSERT_THROWS(det->getAtXY(0, 205), const std::runtime_error &);
+    // Out-of-bounds coordinates return false (inBoundsXY is a predicate, not a guard)
+    TS_ASSERT_EQUALS(det->inBoundsXY(-1, 0), false);
+    TS_ASSERT_EQUALS(det->inBoundsXY(0, -1), false);
+    TS_ASSERT_EQUALS(det->inBoundsXY(100, 0), false);
+    TS_ASSERT_EQUALS(det->inBoundsXY(0, 205), false);
 
     // Check some ids
-    TS_ASSERT_EQUALS(det->getAtXY(0, 0)->getID() - 1000000, 0);
-    TS_ASSERT_EQUALS(det->getAtXY(0, 12)->getID() - 1000000, 12);
-    TS_ASSERT_EQUALS(det->getAtXY(0, 112)->getID() - 1000000, 112);
-    TS_ASSERT_EQUALS(det->getAtXY(1, 12)->getID() - 1000000, 1012);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0) - 1000000, 0);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 12) - 1000000, 12);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 112) - 1000000, 112);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(1, 12) - 1000000, 1012);
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0), 1000000);
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 12), 1000012);
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 112), 1000112);
@@ -156,9 +156,9 @@ public:
     TS_ASSERT_EQUALS(y, 12);
 
     // Check some positions
-    TS_ASSERT_EQUALS(det->getAtXY(0, 0)->getPos(), V3D(1000 - 50., 2000 - 100., 3000.));
-    TS_ASSERT_EQUALS(det->getAtXY(1, 0)->getPos(), V3D(1000 - 50. + 1., 2000 - 100., 3000.));
-    TS_ASSERT_EQUALS(det->getAtXY(1, 1)->getPos(), V3D(1000 - 50. + 1., 2000 - 100. + 1., 3000.));
+    TS_ASSERT_EQUALS(det->getPosAtXY(0, 0), V3D(1000 - 50., 2000 - 100., 3000.));
+    TS_ASSERT_EQUALS(det->getPosAtXY(1, 0), V3D(1000 - 50. + 1., 2000 - 100., 3000.));
+    TS_ASSERT_EQUALS(det->getPosAtXY(1, 1), V3D(1000 - 50. + 1., 2000 - 100. + 1., 3000.));
 
     // Name
     TS_ASSERT_EQUALS(det->getAtXY(1, 2)->getName(), "MyRectangle(1,2)");
@@ -213,9 +213,9 @@ public:
     TS_ASSERT_EQUALS(pos, V3D((-50 + 1) * 12., (-100 + 1) * 23., 0.));
 
     // Check some positions
-    TS_ASSERT_EQUALS(parDet->getAtXY(0, 0)->getPos(), V3D(1000 - (50) * 12., 2000 - (100 * 23.), 3000.));
-    TS_ASSERT_EQUALS(parDet->getAtXY(1, 0)->getPos(), V3D(1000 + (-50. + 1) * 12., 2000 - (100 * 23.), 3000.));
-    TS_ASSERT_EQUALS(parDet->getAtXY(1, 1)->getPos(), V3D(1000 + (-50. + 1) * 12., 2000 + (-100. + 1) * 23., 3000.));
+    TS_ASSERT_EQUALS(parDet->getPosAtXY(0, 0), V3D(1000 - (50) * 12., 2000 - (100 * 23.), 3000.));
+    TS_ASSERT_EQUALS(parDet->getPosAtXY(1, 0), V3D(1000 + (-50. + 1) * 12., 2000 - (100 * 23.), 3000.));
+    TS_ASSERT_EQUALS(parDet->getPosAtXY(1, 1), V3D(1000 + (-50. + 1) * 12., 2000 + (-100. + 1) * 23., 3000.));
 
     delete det;
     delete parDet;

--- a/Framework/Geometry/test/RectangularDetectorTest.h
+++ b/Framework/Geometry/test/RectangularDetectorTest.h
@@ -117,6 +117,12 @@ public:
     TS_ASSERT_EQUALS(det->inBoundsXY(100, 0), false);
     TS_ASSERT_EQUALS(det->inBoundsXY(0, 205), false);
 
+    // Out-of-bounds coordinates throw for getDetectorIDAtXY and getPosAtXY
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(-1, 0), std::out_of_range);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, -1), std::out_of_range);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(100, 0), std::out_of_range);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, 205), std::out_of_range);
+
     // Check some ids
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0) - 1000000, 0);
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 12) - 1000000, 12);

--- a/Framework/Geometry/test/RectangularDetectorTest.h
+++ b/Framework/Geometry/test/RectangularDetectorTest.h
@@ -118,10 +118,10 @@ public:
     TS_ASSERT_EQUALS(det->inBoundsXY(0, 205), false);
 
     // Out-of-bounds coordinates throw for getDetectorIDAtXY and getPosAtXY
-    TS_ASSERT_THROWS(det->getDetectorIDAtXY(-1, 0), std::out_of_range);
-    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, -1), std::out_of_range);
-    TS_ASSERT_THROWS(det->getDetectorIDAtXY(100, 0), std::out_of_range);
-    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, 205), std::out_of_range);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(-1, 0), std::out_of_range const &);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, -1), std::out_of_range const &);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(100, 0), std::out_of_range const &);
+    TS_ASSERT_THROWS(det->getDetectorIDAtXY(0, 205), std::out_of_range const &);
 
     // Check some ids
     TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0) - 1000000, 0);

--- a/Framework/Geometry/test/StructuredDetectorTest.h
+++ b/Framework/Geometry/test/StructuredDetectorTest.h
@@ -209,9 +209,9 @@ public:
     TS_ASSERT_THROWS(det->getAtXY(0, 6), const std::runtime_error &);
 
     // Check some ids
-    TS_ASSERT_EQUALS(det->getAtXY(0, 0)->getID(), 0);
-    TS_ASSERT_EQUALS(det->getAtXY(0, 1)->getID(), 1);
-    TS_ASSERT_EQUALS(det->getAtXY(1, 1)->getID(), 3);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0), 0);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 1), 1);
+    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(1, 1), 3);
 
     std::pair<size_t, size_t> xy;
     size_t x;

--- a/Framework/Geometry/test/StructuredDetectorTest.h
+++ b/Framework/Geometry/test/StructuredDetectorTest.h
@@ -209,9 +209,9 @@ public:
     TS_ASSERT_THROWS(det->getAtXY(0, 6), const std::runtime_error &);
 
     // Check some ids
-    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 0), 0);
-    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(0, 1), 1);
-    TS_ASSERT_EQUALS(det->getDetectorIDAtXY(1, 1), 3);
+    TS_ASSERT_EQUALS(det->getAtXY(0, 0)->getID(), 0);
+    TS_ASSERT_EQUALS(det->getAtXY(0, 1)->getID(), 1);
+    TS_ASSERT_EQUALS(det->getAtXY(1, 1)->getID(), 3);
 
     std::pair<size_t, size_t> xy;
     size_t x;

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/GridDetector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/GridDetector.cpp
@@ -10,7 +10,9 @@
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/core/StlExportDefinitions.h"
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_value_policy.hpp>
 
 using Mantid::PythonInterface::std_vector_exporter;
 using namespace Mantid::Geometry;
@@ -29,9 +31,12 @@ void export_GridDetector() {
   std_vector_exporter<GridDetector_const_sptr, /*NoProxy=*/true>::wrap("std_vector_grid_detector");
 
   class_<GridDetector, bases<CompAssembly, IObjComponent>, boost::noncopyable>("GridDetector", no_init)
-      .def("xpixels", &GridDetector::xpixels, arg("self"), "Returns the number of pixels in the X direction")
-      .def("ypixels", &GridDetector::ypixels, arg("self"), "Returns the number of pixels in the Y direction")
-      .def("zpixels", &GridDetector::zpixels, arg("self"), "Returns the number of pixels in the Z direction")
+      .def("xpixels", &GridDetector::xpixels, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the number of pixels in the X direction")
+      .def("ypixels", &GridDetector::ypixels, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the number of pixels in the Y direction")
+      .def("zpixels", &GridDetector::zpixels, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the number of pixels in the Z direction")
       .def("xstep", &GridDetector::xstep, arg("self"), "Returns the step size in the X direction")
       .def("ystep", &GridDetector::ystep, arg("self"), "Returns the step size in the Y direction")
       .def("zstep", &GridDetector::zstep, arg("self"), "Returns the step size in the Z direction")
@@ -41,12 +46,18 @@ void export_GridDetector() {
       .def("xstart", &GridDetector::xstart, arg("self"), "Returns the start position in the X direction")
       .def("ystart", &GridDetector::ystart, arg("self"), "Returns the start position in the Y direction")
       .def("zstart", &GridDetector::zstart, arg("self"), "Returns the start position in the Z direction")
-      .def("idstart", &GridDetector::idstart, arg("self"), "Returns the idstart")
-      .def("idFillOrder", &GridDetector::idFillOrder, arg("self"), "Returns the idFillOrder")
-      .def("idstepbyrow", &GridDetector::idstepbyrow, arg("self"), "Returns the idstepbyrow")
-      .def("idstep", &GridDetector::idstep, arg("self"), "Returns the idstep")
-      .def("minDetectorID", &GridDetector::minDetectorID, arg("self"), "Returns the minimum detector id")
-      .def("maxDetectorID", &GridDetector::maxDetectorID, arg("self"), "Returns the maximum detector id");
+      .def("idstart", &GridDetector::idstart, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstart")
+      .def("idFillOrder", &GridDetector::idFillOrder, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idFillOrder")
+      .def("idstepbyrow", &GridDetector::idstepbyrow, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstepbyrow")
+      .def("idstep", &GridDetector::idstep, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstep")
+      .def("minDetectorID", &GridDetector::minDetectorID, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the minimum detector id")
+      .def("maxDetectorID", &GridDetector::maxDetectorID, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the maximum detector id");
 }
 
 void export_GridDetectorPixel() {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
@@ -8,7 +8,9 @@
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/core/StlExportDefinitions.h"
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_value_policy.hpp>
 
 using Mantid::PythonInterface::std_vector_exporter;
 using namespace Mantid::Geometry;
@@ -28,18 +30,26 @@ void export_RectangularDetector() {
   std_vector_exporter<RectangularDetector_const_sptr, /*NoProxy=*/true>::wrap("std_vector_rectangular_detector");
 
   class_<RectangularDetector, bases<GridDetector>, boost::noncopyable>("RectangularDetector", no_init)
-      .def("xpixels", &RectangularDetector::xpixels, arg("self"), "Returns the number of pixels in the X direction")
-      .def("ypixels", &RectangularDetector::ypixels, arg("self"), "Returns the number of pixels in the Y direction")
+      .def("xpixels", &RectangularDetector::xpixels, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the number of pixels in the X direction")
+      .def("ypixels", &RectangularDetector::ypixels, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the number of pixels in the Y direction")
       .def("xstep", &RectangularDetector::xstep, arg("self"), "Returns the step size in the X direction")
       .def("ystep", &RectangularDetector::ystep, arg("self"), "Returns the step size in the Y direction")
       .def("xsize", &RectangularDetector::xsize, arg("self"), "Returns the size in the X direction")
       .def("ysize", &RectangularDetector::ysize, arg("self"), "Returns the size in the Y direction")
       .def("xstart", &RectangularDetector::xstart, arg("self"), "Returns the start position in the X direction")
       .def("ystart", &RectangularDetector::ystart, arg("self"), "Returns the start position in the Y direction")
-      .def("idstart", &RectangularDetector::idstart, arg("self"), "Returns the idstart")
-      .def("idfillbyfirst_y", &RectangularDetector::idfillbyfirst_y, arg("self"), "Returns the idfillbyfirst_y")
-      .def("idstepbyrow", &RectangularDetector::idstepbyrow, arg("self"), "Returns the idstepbyrow")
-      .def("idstep", &RectangularDetector::idstep, arg("self"), "Returns the idstep")
-      .def("minDetectorID", &RectangularDetector::minDetectorID, arg("self"), "Returns the minimum detector id")
-      .def("maxDetectorID", &RectangularDetector::maxDetectorID, arg("self"), "Returns the maximum detector id");
+      .def("idstart", &RectangularDetector::idstart, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstart")
+      .def("idfillbyfirst_y", &RectangularDetector::idfillbyfirst_y, arg("self"),
+           return_value_policy<copy_const_reference>(), "Returns the idfillbyfirst_y")
+      .def("idstepbyrow", &RectangularDetector::idstepbyrow, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstepbyrow")
+      .def("idstep", &RectangularDetector::idstep, arg("self"), return_value_policy<copy_const_reference>(),
+           "Returns the idstep")
+      .def("minDetectorID", &RectangularDetector::minDetectorID, arg("self"),
+           return_value_policy<copy_const_reference>(), "Returns the minimum detector id")
+      .def("maxDetectorID", &RectangularDetector::maxDetectorID, arg("self"),
+           return_value_policy<copy_const_reference>(), "Returns the maximum detector id");
 }

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -405,8 +405,11 @@ std::vector<Mantid::detid_t> InstrumentActor::getDetIDs(const std::vector<size_t
 Mantid::Geometry::ComponentID InstrumentActor::getComponentID(size_t pickID) const {
   auto compID = Mantid::Geometry::ComponentID();
   const auto &compInfo = componentInfo();
-  if (pickID < compInfo.size())
-    compID = compInfo.componentID(pickID)->getComponentID();
+  if (pickID < compInfo.size()) {
+    const auto *comp = compInfo.componentID(pickID);
+    if (comp)
+      compID = comp->getComponentID();
+  }
   return compID;
 }
 


### PR DESCRIPTION
### Description of work

One of the problems with `Instrument` is the reliance on extracting information from a `Detector` object, rather than using predictable mathematical relations for detectors stored in regular rectangular grids.

As part of the change to "virtual" detectors (not initialized in memory, but existing on the instrument), this PR removes the ability to access the children detectors for `GridDetector` or `RectangularDetector`, relying instead on computing the information as needed.

Related to 
- https://github.com/mantidproject/mantid/pull/41081
- https://github.com/mantidproject/mantid/issues/40839

### To test:

Build workbench.  Open any data.  Examine the instrument.  Make sure to use the Pick tab to look at data.  Try to select individual components in the instrument.  Poke around a bunch.  Try accessing detector info.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
