### PR TITLE
Fixed the invalid escape sequence '\m' warning in the plotting code snippets

### DIFF
--- a/dev-docs/source/GettingStarted/GettingStarted.md
+++ b/dev-docs/source/GettingStarted/GettingStarted.md
@@ -51,12 +51,12 @@ require some extra setup.
 ## OSX
 
 - In Finder "command"+k opens a mounting dialogue
-- For `Server address` enter `smb://isisdatar80.isis.cclrc.ac.uk/inst\$/` hit Connect
+- For `Server address` enter `smb://isisdatar80.isis.cclrc.ac.uk/inst$/` hit Connect
 - This should prompt you for federal ID `clrc....` and password
 - After completing this the drive is now mounted
-- It can be found at `/Volumes/inst\$`
+- It can be found at `/Volumes/inst$`
 
-**NB** the address in step 2 sometimes changes - if it does not work, replace `80` with 55`or`3\`.
+**NB** the address in step 2 sometimes changes - if it does not work, replace `80` with `55` or `3`.
 
 ## Linux
 

--- a/docs/source/plotting/ColorfillPlotsHelp.rst
+++ b/docs/source/plotting/ColorfillPlotsHelp.rst
@@ -84,7 +84,7 @@ Click the generate a script button |GenerateAScript.png| on a `Colorfill Plot <h
    cfill.set_norm(LogNorm(vmin=0.0001, vmax=3792.3352))
    # If no ticks appear on the color bar remove the subs argument inside the LogLocator below
    cbar = fig.colorbar(cfill, ax=[axes], ticks=LogLocator(subs=np.arange(1, 10)), pad=0.06)
-   cbar.set_label('Counts ($\\mu s$)$^{-1}$')
+   cbar.set_label(r'Counts ($\mu s$)$^{-1}$')
    axes.set_title('MAR11060')
    axes.set_xlabel('Time-of-flight ($\\mu s$)')
    axes.set_ylabel('Spectrum')
@@ -173,7 +173,7 @@ Basic example of plotting a `Contour Plot <https://matplotlib.org/stable/api/_as
    axes.contour(data, levels=np.linspace(10, 60, 6), colors='yellow', alpha=0.5)
    axes.set_title('SANSLOQCan2D.nxs')
    cbar=fig.colorbar(c)
-   cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
+   cbar.set_label(r'Counts ($\mu s$)$^{-1}$') #add text to colorbar
    fig.tight_layout()
 
    fig.show()

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -107,7 +107,7 @@ To overplot on the same window:
     # IMPORTANT to set origin to lower
     c = axes.imshow(data, origin = 'lower', cmap='viridis', aspect='auto', norm=LogNorm())
     cbar=fig.colorbar(c)
-    cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
+    cbar.set_label(r'Counts ($\mu s$)$^{-1}$') #add text to colorbar
     #fig.show()
 
 
@@ -154,7 +154,7 @@ To overplot on the same window:
     axes.contour(data, levels=np.linspace(10, 60, 6), colors='yellow', alpha=0.5)
 
     cbar=fig.colorbar(c)
-    cbar.set_label('Counts ($\mu s$)$^{-1}$') #add text to colorbar
+    cbar.set_label(r'Counts ($\mu s$)$^{-1}$') #add text to colorbar
     #fig.show()
 
 

--- a/docs/source/tutorials/python_in_mantid/solutions/03_pim_sol.rst
+++ b/docs/source/tutorials/python_in_mantid/solutions/03_pim_sol.rst
@@ -133,7 +133,7 @@ C - 2D and 3D Plot ILL Data
 
     # Add a Colorbar with a label
     cbar=figC.colorbar(c)
-    cbar.set_label('Counts ($\mu s$)$^{-1}$')
+    cbar.set_label(r'Counts ($\mu s$)$^{-1}$')
 
     '''3D Plotting - Surface and Wireframe'''
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41550 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

1) Test the snippets of code and verify that the waring is no longer there. Only that specific warning is fixed. Other warning are outside the scope of this PR. Richard has an issue open to rewrite some of the examples in the plotting manual test to make testing this feature smoother and those can be addressed in that overarching issue.


I am sneaking in another formatting fix. It is too small to open an issue for.
2) Run `cmake --build . --target dev-docs-html`
3) Navigate to `/mantid/build/dev-docs/html/GettingStarted/GettingStarted.html`.
4) Verify that the formatting of this section is correct.
<img width="737" height="281" alt="Screenshot 2026-06-02 at 10 54 22 am" src="https://github.com/user-attachments/assets/a3698d5e-4f24-4bc5-983d-2cd07a972b7a" />


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
