### PR TITLE
Skip mantiddocs for ornl-next pipeline

### DIFF
--- a/.github/workflows/devdocs-publish.yml
+++ b/.github/workflows/devdocs-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Setup pixi
         if: steps.changes.outputs.devsite == 'true'
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v${{ steps.pixi-version.outputs.version }}
           frozen: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
         - mdformat-ruff # ruff format code snippets
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.15
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff-check

--- a/Testing/Tools/cxxtest/cxxtest/QtGui.h
+++ b/Testing/Tools/cxxtest/cxxtest/QtGui.h
@@ -224,11 +224,7 @@ namespace CxxTest
 
         void setIcon( QMessageBox::Icon icon )
         {
-#if QT_VERSION >= 0x030000
             _mainWindow->setIcon( QMessageBox::standardIcon( icon ) );
-#else // Qt version < 3.0.0
-            _mainWindow->setIcon( QMessageBox::standardIcon( icon, QApplication::style().guiStyle() ) );
-#endif // QT_VERSION
         }
 
         void processEvents()

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -681,6 +681,10 @@ def package_standalone_options(platform) {
     package_options += " --package-suffix ${PACKAGE_SUFFIX}"
   }
   package_options += " --git-tag ${GIT_TAG}"
+  // For branches that don't build mantiddocs (e.g., ornl-next), skip docs installation
+  if(!buildMantiddocs) {
+    package_options += " --skip-docs"
+  }
   return package_options.trim() + " --platform ${platform}"
 }
 

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -22,6 +22,8 @@
 #   --git-tag: The version tag to pin the locally-built mantid packages in the installer
 #              environment. Required to prevent the solver silently picking a remote version
 #              instead of the locally-built one.
+#   --skip-docs: Skip mantiddocs installation. Required for branches (like ornl-next) that
+#                don't build mantiddocs. Uses online documentation only.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/pixi-utils
@@ -51,6 +53,7 @@ fi
 STANDALONE_PACKAGE_SUFFIX=
 PLATFORM=""
 GIT_TAG=""
+SKIP_DOCS=false
 while [ ! $# -eq 0 ]
 do
     case "$1" in
@@ -63,6 +66,8 @@ do
         --git-tag)
             GIT_TAG="$2"
             shift ;;
+        --skip-docs)
+            SKIP_DOCS=true ;;
         *)
             echo "Argument not accepted: $1"
             exit 1
@@ -94,11 +99,14 @@ if [ -z "${GIT_TAG}" ]; then
 fi
 # Strip leading 'v' to match the version format used by versioningit in package-conda
 MANTID_VERSION="${GIT_TAG#v}"
-echo "Pinning mantidworkbench and mantiddocs to version: ${MANTID_VERSION}"
+echo "Pinning mantidworkbench to version: ${MANTID_VERSION}"
 
 PACKAGING_ARGS="-c ${LOCAL_CHANNEL} -v ${MANTID_VERSION}"
 if [ -n "${STANDALONE_PACKAGE_SUFFIX}" ]; then
     PACKAGING_ARGS="${PACKAGING_ARGS} -s ${STANDALONE_PACKAGE_SUFFIX}"
+fi
+if [ "${SKIP_DOCS}" = true ]; then
+    PACKAGING_ARGS="${PACKAGING_ARGS} --skip-docs"
 fi
 
 if [[ $OSTYPE == 'msys'* ]]; then

--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -68,6 +68,7 @@ function usage() {
   echo "Options:"
   echo "  -c Optional conda channel overriding the default mantid"
   echo "  -s Optional Add a suffix to the output mantid file, has to be Unstable, or Nightly or not used"
+  echo "  --skip-docs Optional Skip mantiddocs installation (uses online documentation only)"
   echo
   exit $exitcode
 }
@@ -77,6 +78,7 @@ function usage() {
 conda_channel=mantid
 suffix=
 mantid_version=
+skip_docs=false
 while [ ! $# -eq 0 ]
 do
   case "$1" in
@@ -91,6 +93,9 @@ do
     -v)
         mantid_version="$2"
         shift
+        ;;
+    --skip-docs)
+        skip_docs=true
         ;;
     -h)
         usage 0
@@ -150,13 +155,20 @@ if [ -z "$mantid_version" ]; then
   exit 1
 fi
 
+# Build conda packages list
+conda_packages=("mantidworkbench==${mantid_version}")
+if [ "$skip_docs" = false ]; then
+  conda_packages+=("mantiddocs==${mantid_version}")
+  echo "Installing mantiddocs ${mantid_version}"
+else
+  echo "Skipping mantiddocs installation (will use online documentation)"
+fi
+conda_packages+=(mslice jq)
+
 echo "Creating conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
   --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
-  "mantidworkbench==${mantid_version}" \
-  "mantiddocs==${mantid_version}" \
-  mslice \
-  jq  # used for processing the version string
+  "${conda_packages[@]}"
 echo
 
 # Determine version information

--- a/pixi.lock
+++ b/pixi.lock
@@ -1882,7 +1882,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -14081,9 +14081,9 @@ packages:
   license_family: MIT
   size: 24279
   timestamp: 1766494826559
-- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.4-pyhcf101f3_0.conda
-  sha256: 46edea2ebeebfc0e75d907e0c1d75f236808c14f086f4d5b6cb28d38724c6435
-  md5: 26bacc1f063228f892d02212c2966404
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.5-pyhcf101f3_0.conda
+  sha256: 9ae0a38b5ccf9e2cb07f7fa4f7a5b070e4e0680831abf391b7fd1be296273319
+  md5: af2517b95781c326d315514ff1460453
   depends:
   - annotated-doc >=0.0.2
   - colorama
@@ -14092,8 +14092,8 @@ packages:
   - shellingham >=1.3.0
   - python
   license: MIT AND BSD-3-Clause
-  size: 185523
-  timestamp: 1780177133513
+  size: 185681
+  timestamp: 1780362483765
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtbuttonpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtbuttonpropertybrowser.h
@@ -90,9 +90,7 @@
 #include "qtpropertybrowser.h"
 #include <QMap>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtButtonPropertyBrowserPrivate;
 class QLabel;
@@ -177,6 +175,4 @@ private:
   QList<WidgetItem *> m_recreateQueue;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
@@ -98,9 +98,7 @@
 #include <QSpinBox>
 #include <QTimerEvent>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QColor;
 class QLabel;
@@ -883,6 +881,4 @@ public:
   void slotSetValue(const QTime &value);
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtgroupboxpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtgroupboxpropertybrowser.h
@@ -90,9 +90,7 @@
 #include "qtpropertybrowser.h"
 #include <QMap>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtGroupBoxPropertyBrowserPrivate;
 class QLabel;
@@ -163,6 +161,4 @@ private:
   QList<WidgetItem *> m_recreateQueue;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -92,9 +92,7 @@
 #include <QSet>
 #include <QWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtAbstractPropertyManager;
 class QtPropertyPrivate;
@@ -409,6 +407,4 @@ public:
   QtBrowserItem *m_currentItem;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
@@ -103,9 +103,7 @@
 #include <QStringList>
 #include <QWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QMouseEvent;
 class QCheckBox;
@@ -198,6 +196,4 @@ private:
   QLineEdit *m_lineEdit;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h
@@ -91,9 +91,7 @@
 
 #include <utility>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QDate;
 class QTime;
@@ -1415,6 +1413,4 @@ private:
   QtMetaEnumWrapper(QObject *parent) : QObject(parent) {}
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
@@ -97,9 +97,7 @@
 #include <QStyleOptionButton>
 #include <QTreeWidget>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QTreeWidgetItem;
 class QtTreePropertyBrowserPrivate;
@@ -352,6 +350,4 @@ private:
   mutable QWidget *m_editedWidget;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
@@ -91,9 +91,7 @@
 #include <QIcon>
 #include <QVariant>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 using QtIconMap = QMap<int, QIcon>;
 
@@ -300,9 +298,7 @@ public:
   const QString m_regExpAttribute;
 };
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif
 
 Q_DECLARE_METATYPE(QIcon)
 Q_DECLARE_METATYPE(QtIconMap)

--- a/qt/widgets/common/src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp
@@ -93,9 +93,7 @@
 #include <QTimer>
 #include <QToolButton>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 QToolButton *QtButtonPropertyBrowserPrivate::createButton(QWidget *parent) const {
   auto *button = new QToolButton(parent);
@@ -588,6 +586,4 @@ bool QtButtonPropertyBrowser::isExpanded(QtBrowserItem *item) const {
   return false;
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -107,9 +107,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 // Set a hard coded left margin to account for the indentation
 // of the tree view icon when switching to an editor
@@ -1984,6 +1982,4 @@ void QtFontEditorFactory::disconnectPropertyManager(QtFontPropertyManager *manag
   disconnect(manager, SIGNAL(valueChanged(QtProperty *, QFont)), this, SLOT(slotPropertyChanged(QtProperty *, QFont)));
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtgroupboxpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtgroupboxpropertybrowser.cpp
@@ -92,9 +92,7 @@
 #include <QSet>
 #include <QTimer>
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 void QtGroupBoxPropertyBrowserPrivate::init(QWidget *parent) {
   m_mainLayout = new QGridLayout(parent);
@@ -488,6 +486,4 @@ void QtGroupBoxPropertyBrowser::itemRemoved(QtBrowserItem *item) { d_ptr->proper
 */
 void QtGroupBoxPropertyBrowser::itemChanged(QtBrowserItem *item) { d_ptr->propertyChanged(item); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp
@@ -93,9 +93,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 /**
     \class QtProperty
@@ -1848,6 +1846,4 @@ void QtAbstractPropertyBrowser::setCurrentItem(QtBrowserItem *item) {
     emit currentItemChanged(item);
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
@@ -101,9 +101,7 @@ QString translateUtf8Encoded(const char *context, const char *key, const char *d
 }
 } // namespace
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 QtCursorDatabase::QtCursorDatabase() {
   appendCursor(Qt::ArrowCursor, translateUtf8Encoded("QtCursorDatabase", "Arrow", nullptr),
@@ -428,6 +426,4 @@ bool QtKeySequenceEdit::event(QEvent *e) {
   return QWidget::event(e);
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -109,9 +109,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 // Match the exact signature of qBound for VS 6.
 QSize qBound(QSize minVal, QSize val, QSize maxVal) { return qBoundSize(minVal, val, maxVal); }
@@ -145,22 +143,6 @@ private:
   QMetaEnum m_policyEnum;
 };
 
-#if QT_VERSION < 0x040300
-
-static QList<QLocale::Country> countriesForLanguage(QLocale::Language language) {
-  QList<QLocale::Country> countries;
-  QLocale::Country country = QLocale::AnyCountry;
-  while (country <= QLocale::LastCountry) {
-    QLocale locale(language, country);
-    if (locale.language() == language && !countries.contains(locale.country()))
-      countries << locale.country();
-    country = (QLocale::Country)((uint)country + 1); // ++country
-  }
-  return countries;
-}
-
-#endif
-
 static QList<QLocale::Country> sortCountries(const QList<QLocale::Country> &countries) {
   QMultiMap<QString, QLocale::Country> nameToCountry;
   QListIterator<QLocale::Country> itCountry(countries);
@@ -188,11 +170,7 @@ void QtMetaEnumProvider::initLocale() {
   QListIterator<QLocale::Language> itLang(languages);
   for (const auto language : languages) {
     QList<QLocale::Country> countries;
-#if QT_VERSION < 0x040300
-    countries = countriesForLanguage(language);
-#else
     countries = QLocale::countriesForLanguage(language);
-#endif
     if (countries.isEmpty() && language == system.language())
       countries << system.country();
 
@@ -4828,9 +4806,7 @@ void QtFontPropertyManagerPrivate::slotFontDatabaseDelayedChange() {
 QtFontPropertyManager::QtFontPropertyManager(QObject *parent) : QtAbstractPropertyManager(parent) {
   d_ptr = new QtFontPropertyManagerPrivate;
   d_ptr->q_ptr = this;
-#if QT_VERSION >= 0x040500
   QObject::connect(qApp, SIGNAL(fontDatabaseChanged()), this, SLOT(slotFontDatabaseChanged()));
-#endif
 
   d_ptr->m_intPropertyManager = new QtIntPropertyManager(this);
   connect(d_ptr->m_intPropertyManager, SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -5457,6 +5433,4 @@ void QtCursorPropertyManager::initializeProperty(QtProperty *property) {
 */
 void QtCursorPropertyManager::uninitializeProperty(QtProperty *property) { d_ptr->m_values.remove(property); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -107,9 +107,7 @@ QString translateUtf8Encoded(const char *context, const char *key, const char *d
 }
 } // namespace
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtPropertyEditorView;
 
@@ -996,6 +994,4 @@ QTreeWidget *QtTreePropertyBrowser::treeWidget() { return d_ptr->treeWidget(); }
 
 void QtTreePropertyBrowser::closeEditor() { d_ptr->closeEditor(); }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif

--- a/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
@@ -97,9 +97,7 @@
 #pragma warning(disable : 4786) /* MS VS 6: truncating debug info after 255 characters */
 #endif
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 class QtEnumPropertyType {};
 
@@ -107,17 +105,13 @@ class QtFlagPropertyType {};
 
 class QtGroupPropertyType {};
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif
 
 Q_DECLARE_METATYPE(QtEnumPropertyType)
 Q_DECLARE_METATYPE(QtFlagPropertyType)
 Q_DECLARE_METATYPE(QtGroupPropertyType)
 
-#if QT_VERSION >= 0x040400
 QT_BEGIN_NAMESPACE
-#endif
 
 /**
     Returns the type id for an enum property.
@@ -2108,6 +2102,4 @@ void QtVariantEditorFactory::disconnectPropertyManager(QtVariantPropertyManager 
     d_ptr->m_checkBoxFactory->removePropertyManager(itFlag.next()->subBoolPropertyManager());
 }
 
-#if QT_VERSION >= 0x040400
 QT_END_NAMESPACE
-#endif


### PR DESCRIPTION
This pulls the following into `ornl-next`:
* #41538 
* #41568 
* #41571 
* #41476 
* #41558