### PR TITLE
Wired correct widget to plot focused workspace in Engineering Diffraction GUI

### DIFF
--- a/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
+++ b/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
@@ -81,7 +81,7 @@ Focus
 
 3. Tick the ``Plot Focused Workspace`` option and click ``Focus``. It should produce a plot of a single spectrum for bank 2.
 
-4. In the ``Calibration`` group and load in an existing calibration for both banks e.g. `ENGINX_305738_all_banks.prm`
+4. In the ``Calibration`` group select an existing calibration file for both banks e.g. `ENGINX_305738_all_banks.prm` and click ``Load``.
 
 5. Click the ``Focus`` button, after completing calibration it should produce a plot.
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -65,7 +65,7 @@ class FocusPresenter(object):
             return
         focus_paths = self.view.get_focus_filenames()
         if self._number_of_files_warning(focus_paths):
-            self.start_focus_worker(focus_paths, self.view.get_plot_output(), self.rb_num, self.current_calibration)
+            self.start_focus_worker(focus_paths, self.view.get_focus_plot_output(), self.rb_num, self.current_calibration)
 
     def start_focus_worker(self, focus_paths: list, plot_output: bool, rb_num: str, calibration: CalibrationInfo) -> None:
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
@@ -25,7 +25,7 @@ class FocusPresenterTest(unittest.TestCase):
     @patch(tab_path + ".presenter.FocusPresenter._validate")
     def test_worker_started_with_correct_params(self, mock_validate, mock_worker):
         self.view.get_focus_filenames.return_value = "305738"
-        self.view.get_plot_output.return_value = True
+        self.view.get_focus_plot_output.return_value = True
         mock_validate.return_value = True
 
         self.presenter.on_focus_clicked()


### PR DESCRIPTION
### Description of work
This PR fixes Engineering diffraction GUI not adhering to the `Plot Focused Workspace` tick box due to incorrect widget wiring. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41530. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Follow [test 2](https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#focus) of engineering diffraction GUI 
2. Check whether the Focus plot adheres to the `Plot Focused Workspace` tick box

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
