### PR TITLE
Add MPIAlgorithms as a dependency of docs

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -116,21 +116,17 @@ pushd $WORKSPACE
 # install pixi if not already installed
 install_pixi "$WORKSPACE"
 
-# Check whether this is an incremental build that only changes rst files
-if [ -d $BUILD_DIR/Framework ]; then
-    if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
-      ENABLE_BUILD_CODE=false
-      ENABLE_UNIT_TESTS=false
-      ENABLE_SYSTEM_TESTS=false
-    elif ${SCRIPT_DIR}/../check_for_changes dev-docs-only; then
-      ENABLE_BUILD_CODE=false
-      ENABLE_UNIT_TESTS=false
-      ENABLE_SYSTEM_TESTS=false
-      ENABLE_DOC_TESTS=false
-      ENABLE_DOCS=false
-    fi
-else
-  mkdir -p $BUILD_DIR
+# For a docs only change, don't need code build (doc targets include the code targets that they need)
+if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
+    ENABLE_BUILD_CODE=false
+    ENABLE_UNIT_TESTS=false
+    ENABLE_SYSTEM_TESTS=false
+elif ${SCRIPT_DIR}/../check_for_changes dev-docs-only; then
+    ENABLE_BUILD_CODE=false
+    ENABLE_UNIT_TESTS=false
+    ENABLE_SYSTEM_TESTS=false
+    ENABLE_DOC_TESTS=false
+    ENABLE_DOCS=false
 fi
 
 # Remake the directory for the test logs.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -76,6 +76,9 @@ function(add_sphinx_build_target builder)
 
   if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
     set(target_dependencies ${target_dependencies} Framework)
+    if(MPI_BUILD)
+      set(target_dependencies ${target_dependencies} MPIAlgorithms)
+    endif()
   endif()
 
   if(MANTID_QT_LIB STREQUAL "BUILD")


### PR DESCRIPTION
### Description of work

Add MPIAlgorithms as a dependency of docs
* Building the docs requires enough of mantid built to be able to import a query all the algorithms. Add MPIAlgorithms as a dependency so that this works independent of the current build state.

Remove check for partial builds
* Now that the docs targets depends on everything it needs, there is no need for an explicit code build or the logic trying to work out if it is needed.

Closes #41467  <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

The aim of this is that docs build correctly independent of the existing build state. So it should be possible to do.
```
ninja clean
ninja docs-html
```

make sure you have `MPI_BUILD=ON`.
```
cmake -S .. -B . -DMPI_BUILD=ON
```

I've been working with a clean cmake, e.g.
```
cmake --fresh -S .. -B . -GNinja -DCMAKE_BUILD_TYPE=Debug -DMPI_BUILD=ON
```

### To test:
If you build docs with `MPI_BUILD=OFF`, you will still see the warning. Hopefully it should be obvious from the warning that this is due to doing a non-mpi build. Turning `MPI_BUILD=ON` and rerunning `ninja docs-html` should then work without warnings.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
