### PR TITLE
Fixing crash in Muon GUI when a Composite Function

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
@@ -141,14 +141,19 @@ class BasicFittingContext(FittingContext):
     @single_fit_functions.setter
     def single_fit_functions(self, fit_functions: list) -> None:
         """Sets all of the single fit functions stored in the model."""
+        if len(fit_functions) == self.number_of_datasets:
+            self._single_fit_functions = fit_functions
+            return
+
         if len(fit_functions) == 1 and type(fit_functions[0]) is CompositeFunction:
             assert fit_functions[0].nFunctions() == self.number_of_datasets, (
                 f"The number of functions inside CompositeFunction={fit_functions[0].nFunctions()} "
                 f"is not equal to the number of datasets={self.number_of_datasets}."
             )
-        else:
-            assert len(fit_functions) == self.number_of_datasets, "The number of functions is not equal to the number of datasets."
-        self._single_fit_functions = fit_functions
+            self._single_fit_functions = fit_functions
+            return
+
+        assert False, f"The number of functions={len(fit_functions)} is not equal to the number of datasets={self.number_of_datasets}."
 
     @property
     def single_fit_functions_for_undo(self) -> list:

--- a/qt/python/mantidqtinterfaces/test/Muon/basic_fitting_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/basic_fitting_context_test.py
@@ -98,8 +98,28 @@ class BasicFittingContextTest(unittest.TestCase):
     def test_that_single_fit_functions_with_composite_does_not_assert_false_when_num_of_datasets_equal_nfunctions(self):
         comp_function = FunctionFactory.createFunction("CompositeFunction")
         comp_function.add(FunctionFactory.createFunction("FlatBackground"))
-        comp_function.add(FunctionFactory.createFunction("FlatBackground"))
+        comp_function.add(FunctionFactory.createFunction("BackToBackExponential"))
         self.fitting_context.dataset_names = ["Name1", "Name2"]
+        self.single_fit_functions = [comp_function]
+        self.fitting_context.single_fit_functions = self.single_fit_functions
+        self.assertEqual(self.fitting_context.single_fit_functions, self.single_fit_functions)
+
+    def test_that_single_fit_functions_with_composite_assert_false_when_num_of_datasets_not_equal_nfunctions(self):
+        comp_function = FunctionFactory.createFunction("CompositeFunction")
+        comp_function.add(FunctionFactory.createFunction("FlatBackground"))
+        comp_function.add(FunctionFactory.createFunction("BackToBackExponential"))
+        comp_function.add(FunctionFactory.createFunction("Gaussian"))
+        self.fitting_context.dataset_names = ["Name1", "Name2"]
+        self.single_fit_functions = [comp_function]
+        with self.assertRaises(AssertionError) as context:
+            self.fitting_context.single_fit_functions = self.single_fit_functions
+            self.assertEqual(str(context.exception), "The number of functions=3 is not equal to the number of datasets=2.")
+
+    def test_that_single_fit_functions_with_composite_does_not_assert_false(self):
+        comp_function = FunctionFactory.createFunction("CompositeFunction")
+        comp_function.add(FunctionFactory.createFunction("FlatBackground"))
+        comp_function.add(FunctionFactory.createFunction("Gaussian"))
+        self.fitting_context.dataset_names = ["Name1"]
         self.single_fit_functions = [comp_function]
         self.fitting_context.single_fit_functions = self.single_fit_functions
         self.assertEqual(self.fitting_context.single_fit_functions, self.single_fit_functions)


### PR DESCRIPTION
### Description of work

This PR fixes a crash in Muon GUI when adding a Composite Function to its fitting tab. 

The crash was due to a failed assertion between the number of fitting functions and the number of datasets not being equal when the fitting function was a Composite function.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41594. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

1. Open Muon Analysis.
2. Load a dataset so the fitting tab has one dataset available.
3. In the fitting tab, add a `FlatBackground`.
4. Add another fit function so the selected fit model becomes a `CompositeFunction`.
5. There should be no any errors
6. Play around with different fitting functions(ex: Product Function) and see is if there are any errors.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
