### PR TITLE
Updated the `orso_helper_test.py` to mark the `test_create_mandatory_header_raises_error` as a skipped test incase of database unavailability

### DIFF
--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -129,7 +129,7 @@ class MantidORSODataset:
                     try:
                         future.result(timeout=5.0)
                     except concurrent.futures.TimeoutError:
-                        logger.error(f"The provided model description '{model}' could not be validated because of database unavalibility.")
+                        logger.error(f"The provided model description '{model}' could not be validated because of database unavailability.")
                         self._header = None
                         return
                     except:

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -246,11 +246,20 @@ class MantidORSODatasetTest(unittest.TestCase):
 
     @mock.patch("mantid.utils.reflectometry.orso_helper.logger.error")
     def test_create_mandatory_header_raises_error(self, mock_logger):
-        model_def = ["air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
+        model_def = ["air | Ni 100 | SiO2 0.5 | 02", "air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
         for model in model_def:
             MantidORSODataset(None, None, None, None, None, None, None, model=model, validate=True)
+
+        error_messages = [call.args[0] for call in mock_logger.call_args_list]
+        if any("could not be validated because of database unavailability." in msg for msg in error_messages):
+            self.skipTest("ORSO database unavailable; validation could not be performed.")
+
         mock_logger.assert_has_calls(
             [
+                mock.call(
+                    "The provided model description 'air | Ni 100 | SiO2 0.5 | 02' contains an error. "
+                    "Please check that the string follows the correct ORSO format."
+                ),
                 mock.call(
                     "The provided model description 'air | 25 [ Si 7 | Fe 7 ] | Si' contains an error. "
                     "Please check that the string follows the correct ORSO format."
@@ -273,7 +282,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         MantidORSODataset(None, None, None, None, None, None, None, model="air", validate=True)
         error_logger.assert_has_calls(
             [
-                mock.call("The provided model description 'air' could not be validated because of database unavalibility."),
+                mock.call("The provided model description 'air' could not be validated because of database unavailability."),
             ]
         )
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Fixes the failure seen [here](https://github.com/mantidproject/mantid/actions/runs/27170879177/job/80210164488?pr=41601). I have added back the test removed in #41368. The test will be marked as skipped if the database is not available. It does not need a release note.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
I have run the tests without the internet and because the `orsopy` library has a local copy of the database, it is difficult to reproduce the unavailability that leads to failures in the github actions CI runs.

1) Make this update to `_create_mandatory_header` for testing database unavailability.
<img width="1104" height="627" alt="image" src="https://github.com/user-attachments/assets/99ea302c-992d-45b7-bc9a-24f1ba4a1508" />

2) Build the tests using `ninja AllTests` and run the tests using `ctest -R orso_helper_test`.
3) Look at the logs in `build/Testing/Temporary/LastTest.log`
4) Verify that the test is marked as skipped and the cli reads that `0 tests failed out of 1`.
<img width="1032" height="388" alt="Screenshot 2026-06-09 at 2 32 34 pm" src="https://github.com/user-attachments/assets/5a87a1b2-69e8-499b-870a-ef3bedeacc71" />



<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
