### PR TITLE
Update memory requirement for `LETReduction` system test

### DIFF
--- a/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
@@ -517,7 +517,7 @@ class LETReduction(systemtesting.MantidSystemTest):
 
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places."""
-        return 6000
+        return 5500
 
     def runTest(self):
         """

--- a/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISDirectInelastic.py
@@ -516,8 +516,8 @@ class LETReduction(systemtesting.MantidSystemTest):
     tolerance_is_rel_err = True
 
     def requiredMemoryMB(self):
-        """Far too slow for managed workspaces. They're tested in other places. Requires 2Gb"""
-        return 2000
+        """Far too slow for managed workspaces. They're tested in other places."""
+        return 6000
 
     def runTest(self):
         """


### PR DESCRIPTION
I ran this system test on my machine and it needed about 5.4 GB of memory.

<img width="807" height="60" alt="image" src="https://github.com/user-attachments/assets/b328d337-6144-4fb8-908b-10b31558ee80" />

The screenshot shows 5.1 GB but it went up to 5.4 GB, I changed the memory requirement to 6 GB (well, 6000 MB, close enough) to make sure.

 *This does not require release notes* because it's a change to test code

### To test:

System tests should pass

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
