### PR TITLE
Fixed misformed citations in documentation

### DIFF
--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -163,4 +163,4 @@ Output:
 References
 ----------
 
-.. [1] K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
+.. [1] \K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).

--- a/docs/source/algorithms/Abins2D-v1.rst
+++ b/docs/source/algorithms/Abins2D-v1.rst
@@ -134,4 +134,4 @@ Output:
 References
 ----------
 
-.. [1] K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
+.. [1] \K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).

--- a/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
+++ b/docs/source/algorithms/CalculateEfficiencyCorrection-v1.rst
@@ -332,10 +332,10 @@ Output:
 References
 ------------
 
-.. [1] D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
-.. [2] J. P. Hodges, J. D. Jorgensen, S. Short, D. N. Argyiou, and J. W. Richardson, Jr.  *Incident Spectrum Determination for Time-of-Flight Neutron Powder Diffraction Data Analysis* ICANS 14th Meeting of the International Collaboration on Advanced Neutron Sources 813-822 `link to paper <http://www.neutronresearch.com/parch/1998/01/199801008130.pdf>`__
-.. [3] F. Issa, A. Khaplanov, R. Hall-Wilton, I. Llamas, M. Dalseth Ricktor, S. R. Brattheim, and H. Perrey (2017) *Characterization of Thermal Neutron Beam Monitors* Physical Review Accelerators and Beams 20 092801 `doi: 10.1103/PhysRevAccelBeams.20.092801 <https://doi.org/10.1103/PhysRevAccelBeams.20.092801>`__
-.. [4] W. S. Howells (1983) *On the Choice of Moderator for Liquids Diffractometer on a Pulsed Neutron Source*, Nuclear Instruments and Methods in Physics Research 223 141-146 `doi: 10.1016/0167-5087(84)90256-4 <https://doi.org/10.1016/0167-5087(84)90256-4>`__
+.. [1] \D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
+.. [2] \J. P. Hodges, J. D. Jorgensen, S. Short, D. N. Argyiou, and J. W. Richardson, Jr.  *Incident Spectrum Determination for Time-of-Flight Neutron Powder Diffraction Data Analysis* ICANS 14th Meeting of the International Collaboration on Advanced Neutron Sources 813-822 `link to paper <http://www.neutronresearch.com/parch/1998/01/199801008130.pdf>`__
+.. [3] \F. Issa, A. Khaplanov, R. Hall-Wilton, I. Llamas, M. Dalseth Ricktor, S. R. Brattheim, and H. Perrey (2017) *Characterization of Thermal Neutron Beam Monitors* Physical Review Accelerators and Beams 20 092801 `doi: 10.1103/PhysRevAccelBeams.20.092801 <https://doi.org/10.1103/PhysRevAccelBeams.20.092801>`__
+.. [4] \W. S. Howells (1983) *On the Choice of Moderator for Liquids Diffractometer on a Pulsed Neutron Source*, Nuclear Instruments and Methods in Physics Research 223 141-146 `doi: 10.1016/0167-5087(84)90256-4 <https://doi.org/10.1016/0167-5087(84)90256-4>`__
 
 
 .. categories::

--- a/docs/source/algorithms/CalculatePlaczekSelfScattering-v1.rst
+++ b/docs/source/algorithms/CalculatePlaczekSelfScattering-v1.rst
@@ -81,10 +81,10 @@ Usage
 References
 ------------
 
-.. [1] G. Placzek, (1952), *The Scattering of Neutrons by Systems of Heavy Nuclei*, Physical Review, Volume 86, Page 377-388 `doi: 10.1103/PhysRev.86.377 <https://doi.org/10.1103/PhysRev.86.377>`__
+.. [1] \G. Placzek, (1952), *The Scattering of Neutrons by Systems of Heavy Nuclei*, Physical Review, Volume 86, Page 377-388 `doi: 10.1103/PhysRev.86.377 <https://doi.org/10.1103/PhysRev.86.377>`__
 .. [2] J.G. Powles, (1973), *The analysis of a time-of-flight neutron diffractometer for amorphous materials: the structure of a molecule in a liquid*, Molecular Physics, Volume 26, Issue 6, Page 1325-1350, `doi: 10.1080/00268977300102521 <https://doi.org/10.1080/00268977300102521>`__
 .. [3] Howe, McGreevy, and Howells, J., (1989), *The analysis of liquid structure data from time-of-flight neutron diffractometry*,Journal of Physics: Condensed Matter, Volume 1, Issue 22, pp. 3433-3451, `doi: 10.1088/0953-8984/1/22/005 <https://doi.org/10.1088/0953-8984/1/22/005>`__
-.. [4] D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
+.. [4] \D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
 
 .. categories::
 

--- a/docs/source/algorithms/CalculatePlaczekSelfScattering-v2.rst
+++ b/docs/source/algorithms/CalculatePlaczekSelfScattering-v2.rst
@@ -83,10 +83,10 @@ Usage
 References
 ------------
 
-.. [1] G. Placzek, (1952), *The Scattering of Neutrons by Systems of Heavy Nuclei*, Physical Review, Volume 86, Page 377-388 `doi: 10.1103/PhysRev.86.377 <https://doi.org/10.1103/PhysRev.86.377>`__
+.. [1] \G. Placzek, (1952), *The Scattering of Neutrons by Systems of Heavy Nuclei*, Physical Review, Volume 86, Page 377-388 `doi: 10.1103/PhysRev.86.377 <https://doi.org/10.1103/PhysRev.86.377>`__
 .. [2] J.G. Powles, (1973), *The analysis of a time-of-flight neutron diffractometer for amorphous materials: the structure of a molecule in a liquid*, Molecular Physics, Volume 26, Issue 6, Page 1325-1350, `doi: 10.1080/00268977300102521 <https://doi.org/10.1080/00268977300102521>`__
 .. [3] Howe, McGreevy, and Howells, J., (1989), *The analysis of liquid structure data from time-of-flight neutron diffractometry*,Journal of Physics: Condensed Matter, Volume 1, Issue 22, pp. 3433-3451, `doi: 10.1088/0953-8984/1/22/005 <https://doi.org/10.1088/0953-8984/1/22/005>`__
-.. [4] D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
+.. [4] \D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
 
 .. categories::
 

--- a/docs/source/algorithms/FitIncidentSpectrum-v1.rst
+++ b/docs/source/algorithms/FitIncidentSpectrum-v1.rst
@@ -110,7 +110,7 @@ Output:
 References
 ------------
 
-.. [1] D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
+.. [1] \D. F. R. Mildner, B. C. Boland, R. N. Sinclair, C. G. Windsor, L. J. Bunce, and J. H. Clarke (1977) *A Cooled Polyethylene Moderator on a Pulsed Neutron Source*, Nuclear Instruments and Methods 152 437-446 `doi: 10.1016/0029-554X(78)90043-5 <https://doi.org/10.1016/0029-554X(78)90043-5>`__
 
 .. categories::
 

--- a/docs/source/algorithms/ProfileChiSquared1D-v1.rst
+++ b/docs/source/algorithms/ProfileChiSquared1D-v1.rst
@@ -14,8 +14,8 @@ This algorithm explores the surface of the :math:`\chi^{2}` around its minimum a
 The value of the output property is a base name for two output table workspaces: '<Output>_errors' and '<Output>_pdf'.
 The former workspace contains parameter error estimates and the latter shows :math:`\chi^{2}`'s 1d slices along each parameter.
 
-The procedure for calculating errors of parameters is described in Chapter 15 of Numerical recipes in C [1] and Chapter 9
-of Statistical Data Analysis [2]. Here, we summarise the main results.
+The procedure for calculating errors of parameters is described in Chapter 15 of Numerical recipes in C [1]_ and Chapter 9
+of Statistical Data Analysis [2]_. Here, we summarise the main results.
 
 Consider the input dataset :math:`D_0`, with fit parameters :math:`\mathbf a_0`. Assuming Gaussian noise in the data, it is possible
 to create :math:`n` artificial datasets :math:`D_j` for :math:`j=1,2,..,n`. If we were to run the fit on each dataset,
@@ -173,10 +173,8 @@ the parameter value.
 References
 ----------
 
-[1] William H. Press, Saul A. Teukolsky, William T. Vetterling, and Brian P. Flannery. 1992.
-Numerical recipes in C (2nd ed.): the art of scientific computing. Cambridge University Press, USA.
-
-[2] G. Cowan, Statistical Data Analysis, Clarendon, Oxford, 1998
+.. [1] William H. Press, Saul A. Teukolsky, William T. Vetterling, and Brian P. Flannery. 1992. Numerical recipes in C (2nd ed.): the art of scientific computing. Cambridge University Press, USA.
+.. [2] \G. Cowan, Statistical Data Analysis, Clarendon, Oxford, 1998
 
 
 .. categories::

--- a/docs/source/algorithms/SaveGEMMAUDParamFile-v1.rst
+++ b/docs/source/algorithms/SaveGEMMAUDParamFile-v1.rst
@@ -29,7 +29,7 @@ The parameters of interest in the ``.maud`` file are:
   explained in section 1 of `Refinement of time of flight Profile
   Parameters in GSAS
   <https://www.isis.stfc.ac.uk/Pages/refinement-of-profile-parameters-with-polaris-data.pdf>`_
-  [RonSmith]_
+  [#RonSmith]_
 - Scattering angles for each bank, **theta** and **eta** (more
   normally called **phi**
 - Profile coefficients for GEM's chosen peak shape (GSAS TOF function
@@ -37,7 +37,7 @@ The parameters of interest in the ``.maud`` file are:
   **sigma-0**, **sigma-1** and **sigma-2**. These are explained on
   page 143 of the `GSAS Manual
   <http://www.ccp14.ac.uk/ccp/ccp14/ftp-mirror/gsas/public/gsas/manual/GSASManual.pdf>`_
-  [GSASManual]_
+  [#GSASManual]_
 - Sample-detector distance
 - There are also parameters for a second function, GSAS TOF function
   type 2, which are zeroed
@@ -55,12 +55,13 @@ algorithm', :ref:`SaveGDA <algm-SaveGDA>` applies a D to TOF
 conversion using the same parameters per bank (essentially faking the
 time-of-flight). See :ref:`save_gda_tof` for more details on this.
 
-*References*:
+References
+^^^^^^^^^^
 
-.. [RonSmith] Smith, R. "Refinement of time of flight Profile
+.. [#RonSmith] Smith, R. "Refinement of time of flight Profile
               Parameters in GSAS"
 
-.. [GSASManual] Larson, A. C. & Von Dreele, R. B (2004). "General
+.. [#GSASManual] Larson, A. C. & Von Dreele, R. B (2004). "General
 		Structure Analysis System (GSAS)", Los Alamos National
 		Laboratory Report LAUR 86-748
 

--- a/docs/source/algorithms/SaveHKL-v1.rst
+++ b/docs/source/algorithms/SaveHKL-v1.rst
@@ -135,7 +135,7 @@ Output:
 References
 ----------
 
-.. [1] A. Katrusiak, *Absorption Correction for Crystal-Environment Attachments from Direction Cosines*, Zeitschrift für Kristallographie - Crystalline Materials, **216** (2001) 646–647. doi: `10.1524/zkri.216.12.646.22488 <http://dx.doi.org/10.1524/zkri.216.12.646.22488>`_
+.. [1] \A. Katrusiak, *Absorption Correction for Crystal-Environment Attachments from Direction Cosines*, Zeitschrift für Kristallographie - Crystalline Materials, **216** (2001) 646–647. doi: `10.1524/zkri.216.12.646.22488 <http://dx.doi.org/10.1524/zkri.216.12.646.22488>`_
 
 
 .. categories::

--- a/docs/source/algorithms/TransformToIqt-v1.rst
+++ b/docs/source/algorithms/TransformToIqt-v1.rst
@@ -52,7 +52,7 @@ height to the elastic peak.
 
 The interpretation of the data must also take into account the propagation of
 statistical errors (counting statistics) in the measured data as discussed by
-Wild et al [1]. If the count in channel :math:`k` is :math:`X_{k}` , then
+Wild et al [1]_. If the count in channel :math:`k` is :math:`X_{k}` , then
 :math:`X_{k}=<X_{k}>+\Delta X_{k}` where :math:`<X_{k}>` is the mean value and
 :math:`\Delta X_{k}` the error. The standard deviation for channel :math:`k` is
 :math:`\sigma k` :math:`2=<\Delta X_{k}>2` which is assumed to be given by
@@ -81,7 +81,7 @@ automatic back transform is not provided.
 References
 ----------
 
-1. U P Wild, R Holzwarth & H P Good, `Rev Sci Instr 48 1621 (1977) <http://dx.doi.org/10.1063/1.1134962>`_
+.. [1] U P Wild, R Holzwarth & H P Good, `Rev Sci Instr 48 1621 (1977) <http://dx.doi.org/10.1063/1.1134962>`_
 
 Workflow
 --------

--- a/docs/source/algorithms/VesuvioCalculateMS-v1.rst
+++ b/docs/source/algorithms/VesuvioCalculateMS-v1.rst
@@ -56,7 +56,7 @@ Usage
 References
 ----------
 
-.. [1] J. Mayers, A.L. Fielding and R. Senesi, `Nucl. Inst Methods A 481, 454(2002) <http://dx.doi.org/10.1016/S0168-9002(01)01335-3>`__
+.. [1] \J. Mayers, A.L. Fielding and R. Senesi, `Nucl. Inst Methods A 481, 454(2002) <http://dx.doi.org/10.1016/S0168-9002(01)01335-3>`__
 
 
 

--- a/docs/source/concepts/AbsorptionAndMultipleScattering.rst
+++ b/docs/source/concepts/AbsorptionAndMultipleScattering.rst
@@ -752,18 +752,18 @@ References
 .. [1] NIST Center for Neutron Research tabulated neutron scattering lengths and cross sections. - https://www.ncnr.nist.gov/resources/n-lengths/list.html
 .. [2] A.K. Soper (2012). GudrunN and GudrunX manual. - https://www.isis.stfc.ac.uk/OtherFiles/Disordered%20Materials/Gudrun-Manual-2017-10.pdf
 .. [3] Mantid source code for `NeutronAtom.cpp to define ReferenceLambda variable. <https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/src/NeutronAtom.cpp#L23>`__
-.. [4] H. H. Paalman, and C. J. Pings. (1962) *Numerical Evaluation of X‐Ray Absorption Factors for Cylindrical Samples and Annular Sample Cells*, Journal of Applied Physics 33:8 2635–2639 `doi: 10.1063/1.1729034 <http://dx.doi.org/10.1063/1.1729034>`__
-.. [5] H. L. Ritter, R. L. Harris, & R. E. Wood (1951) *On the X-Ray Absorption Correction for Encased Diffracters in the Debye-Sherrer Technique*, Journal of Applied Physics 22:2 169-176 `doi: 10.1063/1.699919 <https://doi.org/10.1063/1.1699919>`__
-.. [6] E. J. Lindley & J. Mayers (Ed.). (1988). *Chapter 10: Experimental method and corrections to data*. United Kingdom: Adam Hilger. - https://inis.iaea.org/search/search.aspx?orig_q=RN:20000574
+.. [4] \H. H. Paalman, and C. J. Pings. (1962) *Numerical Evaluation of X‐Ray Absorption Factors for Cylindrical Samples and Annular Sample Cells*, Journal of Applied Physics 33:8 2635–2639 `doi: 10.1063/1.1729034 <http://dx.doi.org/10.1063/1.1729034>`__
+.. [5] \H. L. Ritter, R. L. Harris, & R. E. Wood (1951) *On the X-Ray Absorption Correction for Encased Diffracters in the Debye-Sherrer Technique*, Journal of Applied Physics 22:2 169-176 `doi: 10.1063/1.699919 <https://doi.org/10.1063/1.1699919>`__
+.. [6] \E. J. Lindley & J. Mayers (Ed.). (1988). *Chapter 10: Experimental method and corrections to data*. United Kingdom: Adam Hilger. - https://inis.iaea.org/search/search.aspx?orig_q=RN:20000574
 .. [7] V.F. Sears (1975): *Slow-neutron multiple scattering*, `Advances in Physics <http://dx.doi.org/10.1080/00018737500101361>`__, 24:1, 1-45
 .. [8] A.K.Soper, W.S.Howells and A.C.Hannon *ATLAS - Analysis of Time-of-Flight Diffraction Data from Liquid and Amorphous Samples* Rutherford Appleton Laboratory Report (1989): `RAL-89-046 <http://wwwisis2.isis.rl.ac.uk/disordered/Manuals/ATLAS/ATLAS%20manual%20v1.0.pdf>`__
-.. [9] I. A. Blech,& B. L. Averbach (Ed.). (1965). *Multiple Scattering of Neutrons in Vanadium and Copper*. Physical Review 137:4A A1113–A1116 `doi: 10.1103/PhysRev.137.A1113 <https://doi.org/10.1103/PhysRev.137.A1113>`__
-.. [10] A. K. Soper & P. A. Egelstaff (1980). *Multiple Scattering and Attenuation of Neutrons in Concentric Cylinders: I. Isotropic First Scattering*. Nuclear Instruments and Methods 178 415–425 `doi: 10.1016/0029-554X(80)90820-4 <https://doi.org/10.1016/0029-554X(80)90820-4>`__
-.. [11] S. J. Cocking & C. R. T. Heard (1965). *Multiple Scattering in Plane Samples: Application to Scattering of Thermal Neutrons*. Report AERE - R5016, Harwell, Berkshire.
-.. [12] J. Mayers & R. Cywinski (1985). *A Monte Carlo Evaluation of Analytical Multiple Scattering Corrections for Unpolarised Neutron Scatting and Polarization Analysis Data*. Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors, and Associated Equipment 241, 519-531 `doi: 10.1016/0168-9002(85)90607-2 <https://doi.org/10.1016/0168-9002(85)90607-2>`__
+.. [9] \I. A. Blech,& B. L. Averbach (Ed.). (1965). *Multiple Scattering of Neutrons in Vanadium and Copper*. Physical Review 137:4A A1113–A1116 `doi: 10.1103/PhysRev.137.A1113 <https://doi.org/10.1103/PhysRev.137.A1113>`__
+.. [10] \A. K. Soper & P. A. Egelstaff (1980). *Multiple Scattering and Attenuation of Neutrons in Concentric Cylinders: I. Isotropic First Scattering*. Nuclear Instruments and Methods 178 415–425 `doi: 10.1016/0029-554X(80)90820-4 <https://doi.org/10.1016/0029-554X(80)90820-4>`__
+.. [11] \S. J. Cocking & C. R. T. Heard (1965). *Multiple Scattering in Plane Samples: Application to Scattering of Thermal Neutrons*. Report AERE - R5016, Harwell, Berkshire.
+.. [12] \J. Mayers & R. Cywinski (1985). *A Monte Carlo Evaluation of Analytical Multiple Scattering Corrections for Unpolarised Neutron Scatting and Polarization Analysis Data*. Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors, and Associated Equipment 241, 519-531 `doi: 10.1016/0168-9002(85)90607-2 <https://doi.org/10.1016/0168-9002(85)90607-2>`__
 .. [13] J.Schelten & W.Schmatz, J.Appl.Cryst. 13(1980)385-390
 .. [14] J.R.D.Copley J.Appl.Cryst 21(1988)639-644
 .. [15] McStas: A neutron ray-trace simulation package `website <http://mcstas.org/>`__
-.. [16] M. W. Johnson, (1974). *Discus: A computer program for calculation of multiple scattering effects in inelastic neutron scattering experiments*. Report AERE-R7682 UKAEA AERE Harwell, Oxfordshire. `Report <https://www.isis.stfc.ac.uk/Pages/discus-manual6827.pdf>`__
+.. [16] \M. W. Johnson, (1974). *Discus: A computer program for calculation of multiple scattering effects in inelastic neutron scattering experiments*. Report AERE-R7682 UKAEA AERE Harwell, Oxfordshire. `Report <https://www.isis.stfc.ac.uk/Pages/discus-manual6827.pdf>`__
 
 .. categories:: Concepts

--- a/docs/source/concepts/CrystalField.rst
+++ b/docs/source/concepts/CrystalField.rst
@@ -39,7 +39,7 @@ where the radial part is
     A_l^m = \frac{1}{4\pi\epsilon_0} \left\{ (-1)^m \frac{4\pi}{2l+1} \sum_j \frac{q_j}{r_j^{l+1}} Y_{l,-m}(\mathbf{r}_j) \right\}.
   :label: alm
 
-The above equations define the *point charge model* `[Hutchings64]`_.
+The above equations define the *point charge model* [#Hutchings64]_.
 In many solids, though, the point charge approximation breaks down,
 because the ligand electrons may be involved in bonding or charge transfer processes,
 and thus have a spatial extent and may no longer be treated as point charges situated at the atomic sites.
@@ -113,7 +113,7 @@ which transform in the same way as the *tesseral harmonic functions* (also calle
 Expressing the Hamiltonian in terms of the hermitian operators means that the coefficients in the sum can be purely real
 (using spherical tensor operators means the coefficients are in general complex) [#]_.
 
-The first attempt to construct such a crystal field Hamiltonian was by Stevens `[Stevens52]`_ who took the expressions
+The first attempt to construct such a crystal field Hamiltonian was by Stevens [#Stevens52]_ who took the expressions
 for the tesseral harmonic functions  in `Cartesian coordinates <http://www.mcphase.de/manual/node123.html>`_,
 removed the constant prefactors and replaced the :math:`x`, :math:`y` and :math:`z` coordinates
 with the angular momentum operators :math:`\hat{J}_x`, :math:`\hat{J}_y`, :math:`\hat{J}_z` respectively,
@@ -122,14 +122,14 @@ These `Stevens operators <http://www.mcphase.de/manual/node124.html>`_ are used 
 from the :math:`\hat{J}_x`, :math:`\hat{J}_y`, :math:`\hat{J}_z` operators expressed as a matrix
 using the :math:`J_z` basis states.
 
-In Stevens' original work `[Stevens52]`_, attention was paid to how the crystal field parameters determined for one magnetic
+In Stevens' original work [#Stevens52]_, attention was paid to how the crystal field parameters determined for one magnetic
 ion might be transfered to another ion in the same crystalline environment.
 In order to account for the different electronic configurations of the ions,
 the crystal field parameters are additionally weighted by the *Stevens factor*
 :math:`\theta_k = \langle \nu,L,S | |O^{(k)}|| \nu,L,S \rangle` which may be thought of as an additional reduced matrix
 element which depends on quantum numbers :math:`\nu` other than the angular momentum quantum numbers.
 The values of :math:`\theta_k` are tabulated in `Table 1`_,
-or may be calculated using the techniques in `[Judd63]`_.
+or may be calculated using the techniques in [#Judd63]_.
 Thus Stevens' Hamiltonian is
 
 .. math::
@@ -150,7 +150,7 @@ Instead, in the neutron spectroscopy literature, the full product
 is often used as the crystal field parameter to be fitted, and this convention is used by Mantid
 (e.g. the fittable coefficients in Mantid are the :math:`B_q^k` rather than the :math:`A_q^k`).
 
-An alternative formulation of the crystal field Hamiltonian developed by Wybourne `[Wybourne65]`_, Judd `[Judd63]`_ and others used
+An alternative formulation of the crystal field Hamiltonian developed by Wybourne [#Wybourne65]_, Judd [#Judd63]_ and others used
 the spherical tensor operators :math:`T_q^{(k)}` instead of the Stevens operators.
 The matrix elements of the :math:`T_q^{(k)}` are then calculated directly using the Wigner-Eckart theorem.
 This is a faster calculation but results in different Hamiltonian matrix elements for a given set of crystal field parameter values.
@@ -245,7 +245,7 @@ along the axis of highest symmetry), rather than necessarily relating to any cry
 necessary to rotate the coordinate systems (or equivalently, the crystal field parameters) for actual calculations for
 magnetic fields applied parallel to particular crystallographic directions.
 The `FOCUS manual <https://epubs.stfc.ac.uk/manifestation/5723/RAL-TR-95-023.pdf>`_ [#]_
-has some details of how these calculations may be accomplished, and further details may be found in reference `[Buckmaster72]`_.
+has some details of how these calculations may be accomplished, and further details may be found in reference [#Buckmaster72]_.
 
 The :math:`\hat{J}_x`, :math:`\hat{J}_y`, :math:`\hat{J}_z` operators may be identified with the :math:`\hat{C}_q^{(k)}` operators for :math:`k=1`
 with :math:`x`, :math:`y` and :math:`z` corresponding to :math:`q=1,-1` and 0 respectively [#]_.
@@ -330,7 +330,7 @@ Appendix A: Wybourne Normalisation
 
 It turns out that the spherical harmonic functions :math:`Y_{lm}` are not the most convenient form in which to express the
 expansion of the crystal field potential when we want to transform it into a Hamiltonian operator matrix.
-Instead, an alternative *normalisation* convention, called the *Wybourne* normalisation after `[Wybourne65]`_,
+Instead, an alternative *normalisation* convention, called the *Wybourne* normalisation after [#Wybourne65]_,
 is used, where the crystal field potential is expressed in terms of the functions
 
 .. math::
@@ -362,7 +362,7 @@ where we have expressed the Clebsch-Gordan coefficient (in the round brackets) a
 and the reduced matrix element :math:`\langle L ||t^{(k)}|| L \rangle`
 depends only on the operator rank :math:`k` and the total angular momentum :math:`L`.
 Within a single :math:`L`-manifold (that is ignoring other states with different :math:`L`, and just considering the splitting
-of the :math:`2L+1` formerly degenerate :math:`L_z` levels), it can be set to `[SmithThornley66]`_
+of the :math:`2L+1` formerly degenerate :math:`L_z` levels), it can be set to [#SmithThornley66]_
 
 .. math::
     \langle L ||t^{(k)}|| L \rangle = \frac{1}{2^k} \sqrt{\frac{(2L+k+1)!}{(2L-k)!}}.
@@ -478,7 +478,7 @@ Appendix B: Tables
 
 Table 1: *Total angular momentum quantum numbers* :math:`L`, :math:`S` and :math:`J`, *Landé* :math:`g_J` *factors,
 and Stevens factors* :math:`\theta_k` *for the ground states of the trivalent rare-earth ions*.
-After `[JensenMackintosh91]`_.
+After [#JensenMackintosh91]_.
 The ground state of :math:`\mathrm{Gd}^{3+}` is a pure spin state, on which the crystal field does not operate.
 Eu compound often do not adopt the trivalent state, and Pm is radioactive so not much studied.
 
@@ -574,43 +574,21 @@ Note, that for cubic symmetry additionally :math:`\mathrm{B}_4^4=5 \mathrm{B}_4^
 +-----+----------------------+-------+-------+-------+-------+-------+-------+
 
 Table 3: *Ratios* :math:`\lambda_{lm}` *of the Stevens to the real valued Wybourne normalised parameters.*
-After `[NewmanNg00]`_.
+After [#NewmanNg00]_.
 
 
 References
 ----------
 
-.. _[Buckmaster72]:
 
-[Buckmaster72] `H. A. Buckmaster, R. Chatterjee, and Y. H. Shing, phys. stat. sol.  (a) 13, 9 (1972). <https://doi.org/10.1002/pssa.2210130102>`_
-
-.. _[Hutchings64]:
-
-[Hutchings64] `M. T. Hutchings, in Solid State Physics, edited by F. Seitz and D. Turnbull (Academic Press, New York, 1964), vol. 16, pp.  227–273. <https://doi.org/10.1016/S0081-1947(08)60517-2>`_
-
-.. _[JensenMackintosh91]:
-
-[JensenMackintosh91] `J. Jensen and A. R. Mackintosh, Rare Earth Magnetism (Clarendon Press, 1991). <https://www.fys.ku.dk/~jjensen/REM.htm>`_
-
-.. _[Judd63]:
-
-[Judd63] B. R. Judd, Operator Techniques in Atomic Spectroscopy (McGraw-Hill, 1963), reprinted (1998) by Princeton University Press.
-
-.. _[NewmanNg00]:
-
-[NewmanNg00] D. J. Newman and B. K. C. Ng, Crystal Field Handbook (Cambridge University Press, 2000).
-
-.. _[SmithThornley66]:
-
-[SmithThornley66] `D. Smith and J. H. M. Thornley, Proc. Phys. Soc. 89, 779 (1966) <https://doi.org/10.1088/0370-1328/89/4/301>`_
-
-.. _[Stevens52]:
-
-[Stevens52] `K. W. H. Stevens, Proc. Phys. Soc. A 65, 209 (1952). <https://doi.org/10.1088/0370-1298/65/3/308>`_
-
-.. _[Wybourne65]:
-
-[Wybourne65] B. G. Wybourne, Spectroscopic Properties of Rare Earths (Interscience, New York, 1965).
+.. [#Buckmaster72] \H. A. Buckmaster, R. Chatterjee, and Y. H. Shing, phys. stat. sol.  (a) 13, 9 (1972). `<https://doi.org/10.1002/pssa.2210130102>`_
+.. [#Hutchings64] \M. T. Hutchings, in Solid State Physics, edited by F. Seitz and D. Turnbull (Academic Press, New York, 1964), vol. 16, pp.  227–273. `<https://doi.org/10.1016/S0081-1947(08)60517-2>`_
+.. [#JensenMackintosh91] \J. Jensen and A. R. Mackintosh, Rare Earth Magnetism (Clarendon Press, 1991). `<https://www.fys.ku.dk/~jjensen/REM.htm>`_
+.. [#Judd63] \B. R. Judd, Operator Techniques in Atomic Spectroscopy (McGraw-Hill, 1963), reprinted (1998) by Princeton University Press.
+.. [#NewmanNg00] \D. J. Newman and B. K. C. Ng, Crystal Field Handbook (Cambridge University Press, 2000).
+.. [#SmithThornley66] \D. Smith and J. H. M. Thornley, Proc. Phys. Soc. 89, 779 (1966) `<https://doi.org/10.1088/0370-1328/89/4/301>`_
+.. [#Stevens52] \K. W. H. Stevens, Proc. Phys. Soc. A 65, 209 (1952). `<https://doi.org/10.1088/0370-1298/65/3/308>`_
+.. [#Wybourne65] \B. G. Wybourne, Spectroscopic Properties of Rare Earths (Interscience, New York, 1965).
 
 
 .. categories:: Concepts

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -155,14 +155,14 @@ If Abins is used as part of your data analysis routines, please cite the relevan
 References
 ----------
 
-.. [#Kohn1964] W. Kohn et al., *Inhomogeneous Electron Gas*, Phys. Rev. B {\bf 136}, 864 (1964).
+.. [#Kohn1964] \W. Kohn et al., *Inhomogeneous Electron Gas*, Phys. Rev. B {\bf 136}, 864 (1964).
 
-.. [#Howard1983] J. Howard, B.C. Boland, J. Tomkinson, *Intensities in inelastic neutron scattering spectra: a test of recent theory*, Chem. Phys. 77 (1983).
+.. [#Howard1983] \J. Howard, B.C. Boland, J. Tomkinson, *Intensities in inelastic neutron scattering spectra: a test of recent theory*, Chem. Phys. 77 (1983).
 
-.. [#Howard1983b] J. Howard and J. Tomkinson, *An analytical method for the calculation of the relative intensities of bending and stretching modes in inelastic neutron scattering spectra*, Chem. Phys. Letters 98 (1983).
+.. [#Howard1983b] \J. Howard and J. Tomkinson, *An analytical method for the calculation of the relative intensities of bending and stretching modes in inelastic neutron scattering spectra*, Chem. Phys. Letters 98 (1983).
 
-.. [#Mitchell] P. C H Mitchell, S. F. Parker, A. J. Ramirez-Cuesta, J. Tomkinson, *Vibrational Spectroscopy with Neutrons With Applications in Chemistry, Biology, Materials Science and Catalysis*, ISBN: 978-981-256-013-1
+.. [#Mitchell] \P. C H Mitchell, S. F. Parker, A. J. Ramirez-Cuesta, J. Tomkinson, *Vibrational Spectroscopy with Neutrons With Applications in Chemistry, Biology, Materials Science and Catalysis*, ISBN: 978-981-256-013-1
 
-.. [#Dymkowski2018] K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
+.. [#Dymkowski2018] \K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
 
 .. categories:: Concepts

--- a/docs/source/fitting/fitfunctions/ActivationK.rst
+++ b/docs/source/fitting/fitfunctions/ActivationK.rst
@@ -24,7 +24,7 @@ Alternatively use the `ActivationmeV <func-ActivationmeV>` fitting function when
 Examples
 --------
 
-An example of when this might be used is for examining the ion dynamics in flouride-containing polyatomic anion cathodes using muon spectroscopy [1].
+An example of when this might be used is for examining the ion dynamics in flouride-containing polyatomic anion cathodes using muon spectroscopy [1]_.
 
 
 
@@ -34,7 +34,7 @@ An example of when this might be used is for examining the ion dynamics in flour
 
 References
 ----------
-[1] Johnston, B. I., Baker, P. J. & Cussen, S. A. (2021). Ion dynamics in flouride-containing polyatomic anion cathodes by muon spectroscopy. Journal of Physics:Materials, Vol. 4 No. 4, `https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba <https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba>`_.
+.. [1] Johnston, B. I., Baker, P. J. & Cussen, S. A. (2021). Ion dynamics in flouride-containing polyatomic anion cathodes by muon spectroscopy. Journal of Physics:Materials, Vol. 4 No. 4, `https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba <https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba>`_.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/ActivationmeV.rst
+++ b/docs/source/fitting/fitfunctions/ActivationmeV.rst
@@ -25,7 +25,7 @@ Alternatively use the `ActivationK <func-ActivationK>` fitting function when fit
 Examples
 --------
 
-An example of when this might be used is for examining the ion dynamics in flouride-containing polyatomic anion cathodes using muon spectroscopy [1].
+An example of when this might be used is for examining the ion dynamics in flouride-containing polyatomic anion cathodes using muon spectroscopy [1]_.
 
 
 
@@ -35,7 +35,7 @@ An example of when this might be used is for examining the ion dynamics in flour
 
 References
 ----------
-[1] Johnston, B. I., Baker, P. J. & Cussen, S. A. (2021). Ion dynamics in flouride-containing polyatomic anion cathodes by muon spectroscopy. Journal of Physics:Materials, Vol. 4 No. 4, `https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba <https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba>`_.
+.. [1] Johnston, B. I., Baker, P. J. & Cussen, S. A. (2021). Ion dynamics in flouride-containing polyatomic anion cathodes by muon spectroscopy. Journal of Physics:Materials, Vol. 4 No. 4, `https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba <https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba>`_.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
+++ b/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
@@ -26,7 +26,7 @@ When fitting users should set :math:`T_c` as the temperature at which the peak o
 Examples
 --------
 
-An example of when this might be used is for examining the Chiral-like critical behaviour in antiferromagnet Cobalt Glycerolate[1] or in muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets[2].
+An example of when this might be used is for examining the Chiral-like critical behaviour in antiferromagnet Cobalt Glycerolate [1]_ or in muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets [2]_.
 
 
 .. attributes::
@@ -35,8 +35,9 @@ An example of when this might be used is for examining the Chiral-like critical 
 
 References
 ----------
-[1] Pratt, F.L, Baker, P.J., Blundell, S.J., Lancaster, T., Green, M.A., and Kurmoo, M. (2007). Chiral-Like Critical Behaviour in the Antiferromagnet Cobalt Glycerolate. Phys. Rev. Lett., Vol 99 Issue 1, 017202 `doi: 10.1103/PhysRevLett.99.017202 <https://doi.org/10.1103/PhysRevLett.99.017202>`_.
-[2] Pratt, F. et al (2009) Muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets. Physica B: Condensed Matter, Volume 404 Issues 5–7, pp585-589 `doi: 10.1016/j.physb.2008.11.123 <https://doi.org/10.1016/j.physb.2008.11.123>`_.
+
+.. [1] Pratt, F.L, Baker, P.J., Blundell, S.J., Lancaster, T., Green, M.A., and Kurmoo, M. (2007). Chiral-Like Critical Behaviour in the Antiferromagnet Cobalt Glycerolate. Phys. Rev. Lett., Vol 99 Issue 1, 017202 `doi: 10.1103/PhysRevLett.99.017202 <https://doi.org/10.1103/PhysRevLett.99.017202>`_.
+.. [2] Pratt, F. et al (2009) Muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets. Physica B: Condensed Matter, Volume 404 Issues 5–7, pp585-589 `doi: 10.1016/j.physb.2008.11.123 <https://doi.org/10.1016/j.physb.2008.11.123>`_.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/DecoupAsymPowderMagLong.rst
+++ b/docs/source/fitting/fitfunctions/DecoupAsymPowderMagLong.rst
@@ -25,7 +25,7 @@ For a rotating asymmetry use :ref:`DecoupAsymPowderMagRot<func-DecoupAsymPowderM
 Examples
 --------
 
-An example of when this might be used is for examining field dependence of :math:`\mu` SR signals in a polycrystalline magnet[1].
+An example of when this might be used is for examining field dependence of :math:`\mu` SR signals in a polycrystalline magnet [1]_.
 
 
 
@@ -35,7 +35,7 @@ An example of when this might be used is for examining field dependence of :math
 
 References
 ----------
-[1] Pratt, F.L. (2007). Field dependence of :math:`\mu` SR signals in a polycrystalline magnet. Journal of Physics:Condensed Matter, Vol. 19 No. 45, doi `10.1088/0953-8984/19/45/456207 <https://iopscience.iop.org/article/10.1088/0953-8984/19/45/456207>`_ .
+.. [1] Pratt, F.L. (2007). Field dependence of :math:`\mu` SR signals in a polycrystalline magnet. Journal of Physics:Condensed Matter, Vol. 19 No. 45, doi `10.1088/0953-8984/19/45/456207 <https://iopscience.iop.org/article/10.1088/0953-8984/19/45/456207>`_ .
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/DecoupAsymPowderMagRot.rst
+++ b/docs/source/fitting/fitfunctions/DecoupAsymPowderMagRot.rst
@@ -25,7 +25,7 @@ For a longitudinal polarization use :ref:`DecoupAsymPowderMagLong<func-DecoupAsy
 Examples
 --------
 
-An example of when this might be used is for examining field dependence of :math:`\mu` SR signals in a polycrystalline magnet[1].
+An example of when this might be used is for examining field dependence of :math:`\mu` SR signals in a polycrystalline magnet [1]_.
 
 
 
@@ -35,7 +35,7 @@ An example of when this might be used is for examining field dependence of :math
 
 References
 ----------
-[1] Pratt, F.L. (2007). Field dependence of :math:`\mu` SR signals in a polycrystalline magnet. Journal of Physics:Condensed Matter, Vol. 19 No. 45, doi:`10.1088/0953-8984/19/45/456207 <https://iopscience.iop.org/article/10.1088/0953-8984/19/45/456207>`_ .
+.. [1] Pratt, F.L. (2007). Field dependence of :math:`\mu` SR signals in a polycrystalline magnet. Journal of Physics:Condensed Matter, Vol. 19 No. 45, doi:`10.1088/0953-8984/19/45/456207 <https://iopscience.iop.org/article/10.1088/0953-8984/19/45/456207>`_ .
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/EISFDiffCylinder.rst
+++ b/docs/source/fitting/fitfunctions/EISFDiffCylinder.rst
@@ -30,7 +30,7 @@ in :math:`\theta` implements a powder average
 References
 ----------
 
-.. [1] A. J. Dianoux et al. `Mol. Phys. 46:1129-37, 1982 <https://doi.org/10.1080/00268978200101121>`__.
+.. [1] \A. J. Dianoux et al. `Mol. Phys. 46:1129-37, 1982 <https://doi.org/10.1080/00268978200101121>`__.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/EISFDiffSphere.rst
+++ b/docs/source/fitting/fitfunctions/EISFDiffSphere.rst
@@ -29,7 +29,7 @@ Related functions:
 References
 ----------
 
-.. [1] F. Volino and A. J. Dianoux, `Molecular Physics 41(2):271-279 <https://doi.org/10.1080/00268978000102761>`__.
+.. [1] \F. Volino and A. J. Dianoux, `Molecular Physics 41(2):271-279 <https://doi.org/10.1080/00268978000102761>`__.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/EISFDiffSphereAlkyl.rst
+++ b/docs/source/fitting/fitfunctions/EISFDiffSphereAlkyl.rst
@@ -42,7 +42,7 @@ Related functions:
 References
 ----------
 
-.. [1] V. K. Sharma, et al., `J. Phys. Chem. B 120(1):154-163 <http://pubs.acs.org/doi/abs/10.1021/acs.jpcb.5b10417>`__.
+.. [1] \V. K. Sharma, et al., `J. Phys. Chem. B 120(1):154-163 <http://pubs.acs.org/doi/abs/10.1021/acs.jpcb.5b10417>`__.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/ElasticIsoRotDiff.rst
+++ b/docs/source/fitting/fitfunctions/ElasticIsoRotDiff.rst
@@ -37,7 +37,7 @@ is expressed in terms of the :math:`j_l(z)`
 References
 ----------
 
-.. [1] M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
+.. [1] \M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/FickDiffusionSQE.rst
+++ b/docs/source/fitting/fitfunctions/FickDiffusionSQE.rst
@@ -32,7 +32,7 @@ where:
 References
 ----------
 
-.. [1] M. Bée, Chemical Physics 292, 121-141 (2003) <https://www.sciencedirect.com/science/article/abs/pii/S030101040300257X>
+.. [1] \M. Bée, Chemical Physics 292, 121-141 (2003) <https://www.sciencedirect.com/science/article/abs/pii/S030101040300257X>
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/GaussianComptonProfile.rst
+++ b/docs/source/fitting/fitfunctions/GaussianComptonProfile.rst
@@ -11,7 +11,7 @@ Description
 
 The GaussianComptonProfile function describes the Compton profile of a nucleus using a
 Gaussian approximation convoluted with an instrument resolution function,
-that is approximated by a Voigt function. The function approximates the Count rate, :math:`C(t)` as [1],
+that is approximated by a Voigt function. The function approximates the Count rate, :math:`C(t)` as [1]_,
 
 .. math::
     C(t) = \left[\frac{E_0I(E_0)}{q}\right](t) A_m J_M(y_M)\otimes R_M(t)  \label{a}
@@ -34,8 +34,8 @@ function.
 
 References
 ----------
-[1] Mayers J, Abdul-Redah T. The measurement of anomalous neutron inelastic cross-sections at electronvolt energy transfers.
-J Phys: Condens Matter 2004;16:4811–32. https://doi.org/10.1088/0953-8984/16/28/005
+
+.. [1] Mayers J, Abdul-Redah T. The measurement of anomalous neutron inelastic cross-sections at electronvolt energy transfers. J Phys: Condens Matter 2004;16:4811–32. https://doi.org/10.1088/0953-8984/16/28/005
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/GramCharlierComptonProfile.rst
+++ b/docs/source/fitting/fitfunctions/GramCharlierComptonProfile.rst
@@ -11,7 +11,7 @@ Description
 
 The GramCharlierComptonProfile function calculates the Compton profile of a nucleus using a
 Gram-Charlier approximation convoluted with an instrument resolution function.
-The Gram-Charlier expansion of the Neutron Compton profile, :math:`J(y)` is given by [1] as an
+The Gram-Charlier expansion of the Neutron Compton profile, :math:`J(y)` is given by [1]_ as an
 expansion of Hermite polynomials,
 
 .. math::
@@ -36,9 +36,8 @@ The instrument resolution, :math:`R_M`, is approximated by a :ref:`Voigt <func-V
 
 References
 ----------
-[1] Pantalei C, Pietropaolo A, Senesi R, Imberti S, Andreani C, Mayers J, et al.
-Proton Momentum Distribution of Liquid Water from Room Temperature to the Supercritical Phase.
-Phys Rev Lett 2008;100. https://doi.org/10.1103/physrevlett.100.177801.
+
+.. [1] Pantalei C, Pietropaolo A, Senesi R, Imberti S, Andreani C, Mayers J, et al. Proton Momentum Distribution of Liquid Water from Room Temperature to the Supercritical Phase. Phys Rev Lett 2008;100. https://doi.org/10.1103/physrevlett.100.177801.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/HallRoss.rst
+++ b/docs/source/fitting/fitfunctions/HallRoss.rst
@@ -34,7 +34,7 @@ Diffusion coefficient :math:`D = \frac{l^2}{2 \tau} \ \AA^2 ps^{-1}`.
 References
 ----------
 
-.. [1] P. L. Hall and D. K. Ross, Mol. Phys. 42, 673 (1981) <http://dx.doi.org/10.1080/00268978100100521>
+.. [1] \P. L. Hall and D. K. Ross, Mol. Phys. 42, 673 (1981) <http://dx.doi.org/10.1080/00268978100100521>
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/HallRossSQE.rst
+++ b/docs/source/fitting/fitfunctions/HallRossSQE.rst
@@ -39,7 +39,7 @@ Alternatively, units of :math:`HWHM` are :math:`\mu eV` if units of
 References
 ----------
 
-.. [1] P. L. Hall and D. K. Ross, Mol. Phys. 42, 673 (1981) <http://dx.doi.org/10.1080/00268978100100521>
+.. [1] \P. L. Hall and D. K. Ross, Mol. Phys. 42, 673 (1981) <http://dx.doi.org/10.1080/00268978100100521>
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/IkedaCarpenterPV.rst
+++ b/docs/source/fitting/fitfunctions/IkedaCarpenterPV.rst
@@ -80,7 +80,8 @@ of Ref[3].
 For a detailed derivation of the analytical Jacobian used by the implementation, see
 :ref:`func-IkedaCarpenterPV-derivative`.
 
-References:
+References
+----------
 
 #. S. Ikeda and J. M. Carpenter, `Nuclear Inst. and Meth. in Phys. Res.
    A239, 536 (1985) <http://dx.doi.org/10.1016/0168-9002(85)90033-6>`_

--- a/docs/source/fitting/fitfunctions/InelasticIsoRotDiff.rst
+++ b/docs/source/fitting/fitfunctions/InelasticIsoRotDiff.rst
@@ -41,7 +41,7 @@ for :math:`Q\cdot Radius<20`, a comfortable upper bound for the vast majority of
 References
 ----------
 
-.. [1] M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
+.. [1] \M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/IsoRotDiff.rst
+++ b/docs/source/fitting/fitfunctions/IsoRotDiff.rst
@@ -40,7 +40,7 @@ for :math:`Q\cdot Radius<20`, a comfortable upper bound for the vast majority of
 References
 ----------
 
-.. [1] M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
+.. [1] \M. Bee, "Quasielastic Neutron Scattering", Taylor & Francis, 1988.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/Meier.rst
+++ b/docs/source/fitting/fitfunctions/Meier.rst
@@ -9,7 +9,7 @@ Meier
 Description
 -----------
 
-Time dependence of the polarization function for a static muon interacting with nuclear spin [1].
+Time dependence of the polarization function for a static muon interacting with nuclear spin [1]_.
 
 .. math:: A(t)=\frac{A_0*G(t)*L(t)}{3}(2P_x+P_z)
 
@@ -59,7 +59,7 @@ and :math:`m` is the z-component of the total orbital quantum number.
 References
 ----------
 
-[1]  `P.H. Meier, HFI 17-19 427-434 (1984) <https://link.springer.com/content/pdf/10.1007%2FBF02064848.pdf>`_.
+.. [1]  `P.H. Meier, HFI 17-19 427-434 (1984) <https://link.springer.com/content/pdf/10.1007%2FBF02064848.pdf>`_.
 
 .. properties::
 

--- a/docs/source/fitting/fitfunctions/MsdGauss.rst
+++ b/docs/source/fitting/fitfunctions/MsdGauss.rst
@@ -26,7 +26,8 @@ corresponds to half of the MSD in a one-dimensional harmonic system [1].
 
 .. properties::
 
-**References**
+References
+----------
 
 1. Kurkal-Siebert, V. , Daniel, R. , Finney J. , Tehei, M. , Dunn, R. and Smith J. (2006) 'Enzyme hydration,
    activity and flexibility: A neutron scattering approach', *Journal of Non-Crystalline Solids*, Vol.352(42-49), pp.4387-4393

--- a/docs/source/fitting/fitfunctions/MultivariateGaussianComptonProfile.rst
+++ b/docs/source/fitting/fitfunctions/MultivariateGaussianComptonProfile.rst
@@ -62,7 +62,7 @@ correction expressed as:
 References
 ----------
 
-.. [1] G. Romanelli, `On the quantum contributions to phase transitions in Water probed by inelastic neutron scattering <https://epubs.stfc.ac.uk/work/12422430>`__
+.. [1] \G. Romanelli, `On the quantum contributions to phase transitions in Water probed by inelastic neutron scattering <https://epubs.stfc.ac.uk/work/12422430>`__
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/MuoniumDecouplingCurve.rst
+++ b/docs/source/fitting/fitfunctions/MuoniumDecouplingCurve.rst
@@ -24,7 +24,7 @@ The function models the repolarisation of isotropic muonium. The x axis should b
 Examples
 --------
 
-This has been used in examining the influence of strong magnetic field on the depolarizations of Muons[1] and in investigating the Paschen-Back Effect as a means of detecting Muonium[2].
+This has been used in examining the influence of strong magnetic field on the depolarizations of Muons [1]_ and in investigating the Paschen-Back Effect as a means of detecting Muonium [2]_.
 
 
 .. attributes::
@@ -33,8 +33,8 @@ This has been used in examining the influence of strong magnetic field on the de
 
 References
 ----------
-[1] Orearm J. and Harris, G. and Bierman, E. (1957) Influence of Strong Magnetic Field on Depolarization of Muons, Phys. Rev., Vol 107 Issue 1, 322-323 `doi: 10.1103/PhysRev.107.322 <https://doi.org/10.1103/PhysRev.107.322>`
-[2] Ferrell, R. A. and Chaos, F. (1957) Paschen-Back Effect as a Means of Detecting Muonium, Phys. Rev., Vol 107 Issue 5, 1322-1323 `doi: 10.1103/PhysRev.107.1322 <https://doi.org/10.1103/PhysRev.107.1322>`
+.. [1] Orearm J. and Harris, G. and Bierman, E. (1957) Influence of Strong Magnetic Field on Depolarization of Muons, Phys. Rev., Vol 107 Issue 1, 322-323 `doi: 10.1103/PhysRev.107.322 <https://doi.org/10.1103/PhysRev.107.322>`
+.. [2] Ferrell, R. A. and Chaos, F. (1957) Paschen-Back Effect as a Means of Detecting Muonium, Phys. Rev., Vol 107 Issue 5, 1322-1323 `doi: 10.1103/PhysRev.107.1322 <https://doi.org/10.1103/PhysRev.107.1322>`
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/NeutronBk2BkExpConvPVoigt.rst
+++ b/docs/source/fitting/fitfunctions/NeutronBk2BkExpConvPVoigt.rst
@@ -95,6 +95,7 @@ exponentially modelled neutron pulse goes from being exponentially
 rising to exponentially decaying.
 
 References
+^^^^^^^^^^
 
 1. Fullprof manual
 

--- a/docs/source/fitting/fitfunctions/PowerLaw.rst
+++ b/docs/source/fitting/fitfunctions/PowerLaw.rst
@@ -21,7 +21,7 @@ where:
 Examples
 --------
 
-An example of when this might be used is for spin relaxation modelling [1].
+An example of when this might be used is for spin relaxation modelling [1]_.
 
 
 
@@ -33,8 +33,8 @@ An example of when this might be used is for spin relaxation modelling [1].
 
 References
 ----------
-[1] D.E. MacLaughhlin, L.C. Gupta, D.W. Cooke, R.H. Heffner, M.Leon & M.E.Schillaci (1983). Evidence for Power-Law Spin-Correlation Decay from Muon Spin Relaxation in Ag Mn
-Spin-Glass. Phys. Rev. Lett., Vol 51 Issue 10, 927-930 `doi: 10.1103/PhysRevLett.51.927 <https://doi.org/10.1103/PhysRevLett.51.927>`_.
+
+.. [1] D.E. MacLaughhlin, L.C. Gupta, D.W. Cooke, R.H. Heffner, M.Leon & M.E.Schillaci (1983). Evidence for Power-Law Spin-Correlation Decay from Muon Spin Relaxation in Ag Mn Spin-Glass. Phys. Rev. Lett., Vol 51 Issue 10, 927-930 `doi: 10.1103/PhysRevLett.51.927 <https://doi.org/10.1103/PhysRevLett.51.927>`_.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/SmoothTransition.rst
+++ b/docs/source/fitting/fitfunctions/SmoothTransition.rst
@@ -25,7 +25,7 @@ This models a logistic function.
 Examples
 --------
 
-The logistic function has been used in modelling Covid-19 infection trajectory[1]. It has also been used for examining the muonium state of CdS at low temperatures[2].
+The logistic function has been used in modelling Covid-19 infection trajectory [1]_. It has also been used for examining the muonium state of CdS at low temperatures [2]_.
 
 
 .. attributes::
@@ -34,9 +34,9 @@ The logistic function has been used in modelling Covid-19 infection trajectory[1
 
 References
 ----------
-[1]Lee, Se Yoon et al. (2020) “Estimation of COVID-19 spread curves integrating global data and borrowing information.” PloS one vol. 15,7  `doi:10.1371/journal.pone.0236860 <https://doi.org/10.1371/journal.pone.0236860>`_.
 
-[2] Gil, J.M et al (1999). Novel Muonium State in CdS. Phys. Rev. Lett., Vol 83 Issue 25, 5294-5297 `doi: 10.1103/PhysRevLett.83.5294 <https://doi.org/10.1103/PhysRevLett.83.5294>`_.
+.. [1] Lee, Se Yoon et al. (2020) “Estimation of COVID-19 spread curves integrating global data and borrowing information.” PloS one vol. 15,7  `doi:10.1371/journal.pone.0236860 <https://doi.org/10.1371/journal.pone.0236860>`_.
+.. [2] Gil, J.M et al (1999). Novel Muonium State in CdS. Phys. Rev. Lett., Vol 83 Issue 25, 5294-5297 `doi: 10.1103/PhysRevLett.83.5294 <https://doi.org/10.1103/PhysRevLett.83.5294>`_.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/TeixeiraWater.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWater.rst
@@ -35,7 +35,7 @@ Alternatively, units of :math:`HWHM` are :math:`\mu eV` if units of
 References
 ----------
 
-.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+.. [1] \J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
@@ -38,7 +38,7 @@ Alternatively, units of :math:`\Gamma` are :math:`\mu eV` if units of
 References
 ----------
 
-.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+.. [1] \J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/TeixeiraWaterIqtFT.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWaterIqtFT.rst
@@ -39,7 +39,7 @@ Alternatively, units of :math:`\Gamma` are :math:`\mu eV` if units of
 References
 ----------
 
-.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+.. [1] \J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/TeixeiraWaterSQE.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWaterSQE.rst
@@ -34,7 +34,7 @@ dimensionality of the diffusion problem (:math:`N=3` for diffusion in a volume).
 References
 ----------
 
-.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+.. [1] \J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
 
 .. properties::
 

--- a/docs/source/fitting/fitfunctions/ThermalNeutronBk2BkExpConvPVoigt.rst
+++ b/docs/source/fitting/fitfunctions/ThermalNeutronBk2BkExpConvPVoigt.rst
@@ -84,6 +84,7 @@ exponentially modelled neutron pulse goes from being exponentially
 rising to exponentially decaying.
 
 References
+^^^^^^^^^^
 
 1. Fullprof manual
 

--- a/docs/source/interfaces/inelastic/Inelastic QENS Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic QENS Fitting.rst
@@ -188,8 +188,8 @@ single fit can be performed using the Fit Single Spectrum button underneath the
 preview plot. A simultaneous fit may be performed in a very similar fashion by changeing the Fit Type to Simultaneous
 and the clicking run.
 
-The :ref:`Peters model <func-MsdPeters>` [1] reduces to a :ref:`Gaussian <func-MsdGauss>` at large
-(towards infinity) beta. The :ref:`Yi Model <func-MsdYi>` [2] reduces to a :ref:`Gaussian <func-MsdGauss>` at sigma
+The :ref:`Peters model <func-MsdPeters>` [1]_ reduces to a :ref:`Gaussian <func-MsdGauss>` at large
+(towards infinity) beta. The :ref:`Yi Model <func-MsdYi>` [2]_ reduces to a :ref:`Gaussian <func-MsdGauss>` at sigma
 equal to zero.
 
 .. interface:: QENS Fitting
@@ -520,9 +520,10 @@ Acceptance Rate
 The FABADA minimizer can output a PDF group workspace when the PDF option is ticked. If this happens,
 then it is possible to plot this PDF data using the output options at the bottom of the tabs.
 
-**References**
+References
+----------
 
-1. Peters & Kneller, Journal of Chemical Physics, 139, 165102 (2013)
-2. Yi et al, J Phys Chem B 116, 5028 (2012)
+.. [1] Peters & Kneller, Journal of Chemical Physics, 139, 165102 (2013)
+.. [2] Yi et al, J Phys Chem B 116, 5028 (2012)
 
 .. categories:: Interfaces Inelastic


### PR DESCRIPTION
### Description of work
This PR fixes the misformation of citations references in docs as described in #41366. The issue has occured due to the misinterpretation of ordinary texts as enumerators as described [here](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#enumerated-lists:~:text=really%20smart%20dude.-,Caution!,-If%20a%20single) 

In addition, this PR has improved some of the malformed `References` blocks in the docs to include links and appear with proper citation numbers. Given below are some of the examples of such malformed Refecences:
- https://docs.mantidproject.org/nightly/algorithms/ProfileChiSquared1D-v1.html#references
- https://docs.mantidproject.org/nightly/algorithms/SaveGEMMAUDParamFile-v1.html#:~:text=details%20on%20this.-,References%3A,-%5BRonSmith%5D
- https://docs.mantidproject.org/nightly/concepts/CrystalField.html#references
- https://docs.mantidproject.org/nightly/interfaces/inelastic/Inelastic%20QENS%20Fitting.html#:~:text=of%20the%20tabs.-,References,-Peters%20%26%20Kneller%2C%20Journal


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41366. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

1. Build `docs-html` target and confirm there is no any build errors
2. Check the generated html artifacts from step (1) associated with the files changed in this PR 
3. The citations at each of the `References` section, should appear properly without any overlappings. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

Release notes were not added since the changes only apply to the existing docs.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
