### PR TITLE
MultiFileNameParser don't regex if no digits

### DIFF
--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -355,6 +355,11 @@ void Parser::split() {
     base = base.substr(m_underscoreString.size(), base.size());
   }
 
+  // LIST requires at least one run number ([0-9]+) so a base with no digits
+  // can never match. Skip the expensive regex and fail fast.
+  if (base.find_first_of("0123456789") == std::string::npos)
+    throw std::runtime_error("There do not appear to be any runs present.");
+
   m_runString = getMatchingString("^" + Regexs::LIST, base);
 
   if (m_runString.size() != base.size()) {


### PR DESCRIPTION
### Description of work

Fixes a regression with trying to `Load` files beginning with an instrument name, but not describing a run.

Was discovered for the file `WISHPredictedSingleCrystalPeaks.nxs` in the system test data, but probably present for other files with the same pattern.  

The switch from `boost::regex` to `std::regex` caused load time to jump from 2s to around 100s.  This time is spent entirely trying to resolve the regex for a pattern like `WAND_123`, but without any numbers actually in it.

Refs:
PR https://github.com/mantidproject/mantid/pull/41623
Find as part of [EWM 16512](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16512)

### To test:

Build, and try to load the above-mentioned file.  Time it.  It should be closer to 2 or 3 seconds, and not like 100s.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
