### PR TITLE
Skip code build on doc only PRs only

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -116,17 +116,19 @@ pushd $WORKSPACE
 # install pixi if not already installed
 install_pixi "$WORKSPACE"
 
-# For a docs only change, don't need code build (doc targets include the code targets that they need)
-if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
-    ENABLE_BUILD_CODE=false
-    ENABLE_UNIT_TESTS=false
-    ENABLE_SYSTEM_TESTS=false
-elif ${SCRIPT_DIR}/../check_for_changes dev-docs-only; then
-    ENABLE_BUILD_CODE=false
-    ENABLE_UNIT_TESTS=false
-    ENABLE_SYSTEM_TESTS=false
-    ENABLE_DOC_TESTS=false
-    ENABLE_DOCS=false
+# For a PR that only changes docs, don't need code build (doc targets include the code targets that they need)
+if [[ ${JOB_NAME} == *pull_requests* ]]; then
+  if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
+      ENABLE_BUILD_CODE=false
+      ENABLE_UNIT_TESTS=false
+      ENABLE_SYSTEM_TESTS=false
+  elif ${SCRIPT_DIR}/../check_for_changes dev-docs-only; then
+      ENABLE_BUILD_CODE=false
+      ENABLE_UNIT_TESTS=false
+      ENABLE_SYSTEM_TESTS=false
+      ENABLE_DOC_TESTS=false
+      ENABLE_DOCS=false
+  fi
 fi
 
 # Remake the directory for the test logs.

--- a/docs/source/algorithms/ExportGeometry-v1.rst
+++ b/docs/source/algorithms/ExportGeometry-v1.rst
@@ -13,7 +13,7 @@ Description
 This algorithm is intended to write out portions of an instrument's
 geometry in the :ref:`Instrument Definition File <InstrumentDefinitionFile>`
 xml format. The resulting file is meant to be copied by-hand into a
-geometry file, the output is not a useable IDF as written.
+geometry file, the output is not a usable IDF as written.
 
 The main use of this algorithm is if the instrument geometry is
 calibrated in mantid, this algorithm can be used to help get the


### PR DESCRIPTION
### Description of work

The previous fix caused a problem for nightly run in the case where the most recent commit was a doc only change. The optimisation of skipping the code build should only happen on PRs

Closes #41467

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
Ensure that this build runs the tests and passes:
 [![Build Status](https://builds.mantidproject.org/job/build_branch/1630/badge/icon)](https://builds.mantidproject.org/job/build_branch/1630/) 
 
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
