### PR TITLE
Updated the code snippets in the plotting section and also added doctests to verify expected behaviour

### DIFF
--- a/docs/source/release/v6.17.0/Framework/Python/Bugfixes/40018.rst
+++ b/docs/source/release/v6.17.0/Framework/Python/Bugfixes/40018.rst
@@ -1,0 +1,1 @@
+- The :ref:`01_basic_plot_scripting` and :ref:`02_scripting_plots` documentation has been updated to automate the testing of the :ref:`pim_plotting` section instead of relying on manually testing the code snippets.

--- a/docs/source/release/v6.17.0/Framework/Python/Bugfixes/40018.rst
+++ b/docs/source/release/v6.17.0/Framework/Python/Bugfixes/40018.rst
@@ -1,1 +1,0 @@
-- The :ref:`01_basic_plot_scripting` and :ref:`02_scripting_plots` documentation has been updated to automate the testing of the :ref:`pim_plotting` section instead of relying on manually testing the code snippets.

--- a/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
+++ b/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
@@ -139,7 +139,7 @@ Please note especially the shortcuts `k` and `l`, which are useful for quickly s
 
 * :ref:`02_scripting_plots`
 * :ref:`plotting`
-* `Matplotlib Keyboard Shortcuts <https://matplotlib.org/3.1.1/users/navigation_toolbar.html#navigation-keyboard-shortcuts>`_
+* `Matplotlib Keyboard Shortcuts <https://matplotlib.org/stable/users/explain/figure/interactive.html#navigation-keyboard-shortcuts>`_
 
 .. |FigureOptionsGear.png| image:: /images/FigureOptionsGear.png
    :width: 150px

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -283,7 +283,8 @@ Output:
     from mantid.simpleapi import *
     import matplotlib.pyplot as plt
 
-    data = Load('MARI27691_sqw.nxs')
+    data = Load('164198.nxs')
+    data=ExtractSpectra(data, XMin=470, XMax=490, StartWorkspaceIndex=260, EndWorkspaceIndex=270)
 
     fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
     ax.plot_wireframe(data, color='green')

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -19,23 +19,68 @@ Right-clicking a workspace from the Workspaces Toolbox and selecting **Show Data
 
 Right clicking on a row or a column allows a plot of that spectrum or time bin, which can also be achieved in Python using the `plotSpectrum()` or `plotBin()` functions, e.g.
 
-.. code-block:: python
+.. testcode:: PlottingWithoutErrorBars
+
+    from matplotlib.container import ErrorbarContainer
 
     RawData = Load("MAR11015")
 
     graph_spec = plotSpectrum(RawData, 0)
     graph_time = plotBin(RawData, 0)
 
+    # Verify no errorbars added to plots
+    graph_spec_has_errorbars = any(isinstance(c, ErrorbarContainer) for c in graph_spec.axes[0].containers)
+    graph_time_has_errorbars = any(isinstance(c, ErrorbarContainer) for c in graph_time.axes[0].containers)
+
+    print(f"The spectrum graph contains errorbars - {graph_spec_has_errorbars}")
+    print(f"The time-of-flight graph contains errorbars - {graph_time_has_errorbars}")
+
+Output:
+
+.. testoutput:: PlottingWithoutErrorBars
+
+    The spectrum graph contains errorbars - False
+    The time-of-flight graph contains errorbars - False
+
+.. testcleanup:: PlottingWithoutErrorBars
+
+    DeleteWorkspace("RawData")
+
+
 To include error bars on a plot, there is an extra argument that can be set to 'True' to enable them, e.g.
 
-.. code-block:: python
+.. testcode:: PlottingWithErrorBars
+
+    from matplotlib.container import ErrorbarContainer
+
+    RawData = Load("MAR11015")
 
     graph_spec = plotSpectrum(RawData, 0, error_bars=True)
     graph_time = plotBin(RawData, 0, error_bars=True)
 
+    # Verify errorbars added to plots
+    graph_spec_has_errorbars = any(isinstance(c, ErrorbarContainer) for c in graph_spec.axes[0].containers)
+    graph_time_has_errorbars = any(isinstance(c, ErrorbarContainer) for c in graph_time.axes[0].containers)
+
+    print(f"The spectrum graph contains errorbars - {graph_spec_has_errorbars}")
+    print(f"The time-of-flight graph contains errorbars - {graph_time_has_errorbars}")
+
+Output:
+
+.. testoutput:: PlottingWithErrorBars
+
+    The spectrum graph contains errorbars - True
+    The time-of-flight graph contains errorbars - True
+
+.. testcleanup:: PlottingWithErrorBars
+
+    DeleteWorkspace("RawData")
+
 For setting scales, axis titles, plot titles etc. you can use:
 
-.. code-block:: python
+.. testcode:: AddingScalesAndTitlesToPlots
+
+    import matplotlib.pyplot as plt
 
     RawData = Load("MAR11015")
     plotSpectrum(RawData,1, error_bars=True)
@@ -49,7 +94,8 @@ For setting scales, axis titles, plot titles etc. you can use:
     axes.set_xlim(0,5000)
     axes.set_ylim(0.001,1500)
 
-    #C hange the y-axis label
+    # Change the labels
+    axes.set_xlabel(r'Time-of-flight ($\mu s$)')
     axes.set_ylabel(r'Counts ($\mu s$)$^{-1}$')
 
     # Add legend entries
@@ -58,33 +104,84 @@ For setting scales, axis titles, plot titles etc. you can use:
     # Give the graph a modest title
     plt.title("My Wonderful Plot", fontsize=20)
 
+    # Verify the scale, legend, axis limits and labels
+    print(f"The yscale is - {axes.get_yscale()}")
+    print(f"The x-limits are - [{float(axes.get_xlim()[0])}, {float(axes.get_xlim()[1])}]")
+    print(f"The y-limits are - [{float(axes.get_ylim()[0])}, {float(axes.get_ylim()[1])}]")
+    print(f"The x-axis label is - {axes.get_xlabel()}")
+    print(f"The y-axis label is - {axes.get_ylabel()}")
+    print(f"The plot title is - {axes.get_title()}")
+    print(f"The plot legend is - {axes.get_legend().get_texts()[0].get_text()}")
+
+Output:
+
+.. testoutput:: AddingScalesAndTitlesToPlots
+
+    The yscale is - log
+    The x-limits are - [0.0, 5000.0]
+    The y-limits are - [0.001, 1500.0]
+    The x-axis label is - Time-of-flight ($\mu s$)
+    The y-axis label is - Counts ($\mu s$)$^{-1}$
+    The plot title is - My Wonderful Plot
+    The plot legend is - Good Line
+
+.. testcleanup:: AddingScalesAndTitlesToPlots
+
+    DeleteWorkspace("RawData")
+
 Multiple workspaces/spectra can be plotted by providing lists within the `plotSpectrum()` or `plotBin()` functions, e.g.
 
-.. code-block:: python
+.. testoutput:: PlotMultipleSpectrums
+
+    RawData1 = Load("MAR11015")
+    RawData2 = Load("MAR11060")
 
     # Plot multiple spectra from a single workspace
-    plotSpectrum(RawData, [0,1,3])
-
-    # Here you need to load files into RawData1 and RawData2 before the next two commands
+    graph_spec1 = plotSpectrum(RawData1, [0,1,3])
 
     # Plot a spectrum from different workspaces
-    plotSpectrum([RawData1,RawData2], 0)
+    graph_spec2 = plotSpectrum([RawData1,RawData2], 0)
 
     # Plot multiple spectra across multiple workspaces
-    plotSpectrum([RawData1,RawData2], [0,1,3])
+    graph_spec3 = plotSpectrum([RawData1,RawData2], [0,1,3])
+
+    # Verify the number of spectrums in plots
+    print(f"The graph_spec1 plot contains {len(graph_spec1.axes[0].lines)} spectrums")
+    print(f"The graph_spec2 plot contains {len(graph_spec2.axes[0].lines)} spectrums")
+    print(f"The graph_spec3 plot contains {len(graph_spec3.axes[0].lines)} spectrums")
+
+Output:
+
+.. testoutput:: PlotMultipleSpectrums
+
+    The graph_spec1 plot contains 3 spectrums
+    The graph_spec2 plot contains 2 spectrums
+    The graph_spec3 plot contains 6 spectrums
 
 To overplot on the same window:
 
-.. code-block:: python
+.. testcode:: OverPlottingWithTwoSpectrums
 
     RawData = Load("MAR11015")
 
-    # Assign original plot to a window called graph_spce
+    # Assign original plot to a window called graph_spec
     graph_spec = plotSpectrum(RawData, 0)
 
     # Overplot on that window, without clearing it
     plotSpectrum(RawData, 1, window=graph_spec, clearWindow=False)
 
+    # Verify the number of spectrums in plot
+    print(f"The plot contains {len(graph_spec.axes[0].lines)} spectrums")
+
+Output:
+
+.. testoutput:: OverPlottingWithTwoSpectrums
+
+    The plot contains 2 spectrums
+
+.. testcleanup:: OverPlottingWithTwoSpectrums
+
+    DeleteWorkspace("RawData")
 
 2D Colourfill and Contour Plots
 ===============================
@@ -186,9 +283,7 @@ To overplot on the same window:
     from mantid.simpleapi import *
     import matplotlib.pyplot as plt
 
-    # This file can be found in the Usage Examples folder, available
-    # here https://www.mantidproject.org/installation/index#sample-data
-    data = Load('PG3_733.nxs')
+    data = Load('MARI27691_sqw.nxs')
 
     fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
     ax.plot_wireframe(data, color='green')

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -131,7 +131,7 @@ Output:
 
 Multiple workspaces/spectra can be plotted by providing lists within the `plotSpectrum()` or `plotBin()` functions, e.g.
 
-.. testcode:: PlotMultipleSpectrums
+.. testcode:: PlotMultipleSpectra
 
     RawData1 = Load("MAR11015")
     RawData2 = Load("MAR11060")
@@ -152,13 +152,13 @@ Multiple workspaces/spectra can be plotted by providing lists within the `plotSp
 
 Output:
 
-.. testoutput:: PlotMultipleSpectrums
+.. testoutput:: PlotMultipleSpectra
 
     The graph_spec1 plot contains 3 spectrums
     The graph_spec2 plot contains 2 spectrums
     The graph_spec3 plot contains 6 spectrums
 
-.. testcleanup:: PlotMultipleSpectrums
+.. testcleanup:: PlotMultipleSpectra
 
     DeleteWorkspace(RawData1)
     DeleteWorkspace(RawData2)

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -165,7 +165,7 @@ Output:
 
 To overplot on the same window:
 
-.. testcode:: OverPlottingWithTwoSpectrums
+.. testcode:: OverPlottingWithTwoSpectra
 
     RawData = Load("MAR11015")
 
@@ -180,11 +180,11 @@ To overplot on the same window:
 
 Output:
 
-.. testoutput:: OverPlottingWithTwoSpectrums
+.. testoutput:: OverPlottingWithTwoSpectra
 
     The plot contains 2 spectrums
 
-.. testcleanup:: OverPlottingWithTwoSpectrums
+.. testcleanup:: OverPlottingWithTwoSpectra
 
     DeleteWorkspace("RawData")
 

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -145,18 +145,18 @@ Multiple workspaces/spectra can be plotted by providing lists within the `plotSp
     # Plot multiple spectra across multiple workspaces
     graph_spec3 = plotSpectrum([RawData1,RawData2], [0,1,3])
 
-    # Verify the number of spectrums in plots
-    print(f"The graph_spec1 plot contains {len(graph_spec1.axes[0].lines)} spectrums")
-    print(f"The graph_spec2 plot contains {len(graph_spec2.axes[0].lines)} spectrums")
-    print(f"The graph_spec3 plot contains {len(graph_spec3.axes[0].lines)} spectrums")
+    # Verify the number of spectra in plots
+    print(f"The graph_spec1 plot contains {len(graph_spec1.axes[0].lines)} spectra")
+    print(f"The graph_spec2 plot contains {len(graph_spec2.axes[0].lines)} spectra")
+    print(f"The graph_spec3 plot contains {len(graph_spec3.axes[0].lines)} spectra")
 
 Output:
 
 .. testoutput:: PlotMultipleSpectra
 
-    The graph_spec1 plot contains 3 spectrums
-    The graph_spec2 plot contains 2 spectrums
-    The graph_spec3 plot contains 6 spectrums
+    The graph_spec1 plot contains 3 spectra
+    The graph_spec2 plot contains 2 spectra
+    The graph_spec3 plot contains 6 spectra
 
 .. testcleanup:: PlotMultipleSpectra
 
@@ -175,14 +175,14 @@ To overplot on the same window:
     # Overplot on that window, without clearing it
     plotSpectrum(RawData, 1, window=graph_spec, clearWindow=False)
 
-    # Verify the number of spectrums in plot
-    print(f"The plot contains {len(graph_spec.axes[0].lines)} spectrums")
+    # Verify the number of spectra in plot
+    print(f"The plot contains {len(graph_spec.axes[0].lines)} spectra")
 
 Output:
 
 .. testoutput:: OverPlottingWithTwoSpectra
 
-    The plot contains 2 spectrums
+    The plot contains 2 spectra
 
 .. testcleanup:: OverPlottingWithTwoSpectra
 

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -83,7 +83,7 @@ For setting scales, axis titles, plot titles etc. you can use:
     import matplotlib.pyplot as plt
 
     RawData = Load("MAR11015")
-    plotSpectrum(RawData,1, error_bars=True)
+    plotSpectrum(RawData, 1, error_bars=True)
 
     # Get current axes of the graph
     fig, axes = plt.gcf(), plt.gca()
@@ -157,10 +157,12 @@ Output:
     The graph_spec1 plot contains 3 spectrums
     The graph_spec2 plot contains 2 spectrums
     The graph_spec3 plot contains 6 spectrums
+
 .. testcleanup:: PlotMultipleSpectrums
 
     DeleteWorkspace(RawData1)
     DeleteWorkspace(RawData2)
+
 To overplot on the same window:
 
 .. testcode:: OverPlottingWithTwoSpectrums

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -131,7 +131,7 @@ Output:
 
 Multiple workspaces/spectra can be plotted by providing lists within the `plotSpectrum()` or `plotBin()` functions, e.g.
 
-.. testoutput:: PlotMultipleSpectrums
+.. testcode:: PlotMultipleSpectrums
 
     RawData1 = Load("MAR11015")
     RawData2 = Load("MAR11060")
@@ -157,7 +157,10 @@ Output:
     The graph_spec1 plot contains 3 spectrums
     The graph_spec2 plot contains 2 spectrums
     The graph_spec3 plot contains 6 spectrums
+.. testcleanup:: PlotMultipleSpectrums
 
+    DeleteWorkspace(RawData1)
+    DeleteWorkspace(RawData2)
 To overplot on the same window:
 
 .. testcode:: OverPlottingWithTwoSpectrums

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -12,24 +12,28 @@ General
 
 Required imports:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     from mantid.simpleapi import *
     import matplotlib.pyplot as plt
 
 Access a workspace,loaded in the Workspace Toolbox, inside a script:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
-    ws = mtd['ws']
+    # For example
+    # ws = mtd['ws']
 
-    #or you could use:
-    from mantid.api import AnalysisDataService as ADS
-    ws = ADS.retrieve('ws')
+    # or you could use:
+    # from mantid.api import AnalysisDataService as ADS
+    # ws = ADS.retrieve('ws')
+
+    # or import it directly
+    ws = Load('MAR11060')
 
 Create a Figure and access its Axes for plotting:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
 
@@ -37,33 +41,33 @@ Create a Figure and access its Axes for plotting:
 
 **Actually plot** the 1st spectrum of the workspace "ws" and control `many options <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.axes.Axes.plot.html>`_:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     axes.plot(ws, specNum=1, color='red', label='spec 1 - ws', linewidth=1.0, linestyle='--', drawstyle='steps', marker = 'x')
 
 Add a `legend <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.legend.html>`_ containing the plotted data labels:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
-    plt.legend()
+    axes.legend()
 
 Adjust the `scale to logarithmic <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.yscale.html>`_, or the `axis limits <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.set_xlim.html>`_:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     axes.set_yscale('log')
-    axes.set_xlim(0.0, 80.)
+    axes.set_xlim(0.0, 800.)
     # x and y can be swapped to alter the other axis
 
 Add a title:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     axes.set_title("My Wonderful Plot", fontsize=20, verticalalignment='bottom')
 
 Add axis labels:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     axes.set_xlabel(r'Time-of-flight ($\mu s$)'), axes.set_ylabel(r'Counts ($\mu s$)$^{-1}$')
 
@@ -73,9 +77,9 @@ Plotting with Errorbars
 
 Simply use "`errorbar <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.errorbar.html>`_" instead of "plot":
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
-    axes.errorbar(ws, specNum=3, capsize=2.0, label='spec 3', linewidth=1.0)
+    axes.errorbar(ws, specNum=1, capsize=2.0, label='spec 3', linewidth=1.0)
 
 
 Tick Marks and Grid lines
@@ -83,7 +87,7 @@ Tick Marks and Grid lines
 
 Add `minor tick marks <https://matplotlib.org/3.2.1/gallery/ticks_and_spines/major_minor_demo.html>`_, here to the x-axis:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     from matplotlib.ticker import (MultipleLocator, AutoMinorLocator)
     axes.xaxis.set_minor_locator(MultipleLocator(5)) # minor ticks every 5 units
@@ -91,19 +95,19 @@ Add `minor tick marks <https://matplotlib.org/3.2.1/gallery/ticks_and_spines/maj
 
 Edit `tick options <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.tick_params.html>`_ such as direction in/out:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
    axes.tick_params(which='minor', width = 0.5, length=4, color='b', direction='in', top='on')
 
 Even add `gridlines <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.grid.html>`_ :
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
    axes.grid(True, which = 'both', axis = 'both') # major/minor, x/y
 
 Notice how `gridlines are linked to the axis ticks <https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.tick_params.html>`_:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
     axes.tick_params(which='minor', grid_color='r', grid_alpha=0.5)
     axes.tick_params(which='major', grid_color='b')
@@ -124,7 +128,7 @@ Note that the fonts available is system dependent - and you can `find available 
 
 Alternatively, you can set a title or label to have certain `font properties <https://matplotlib.org/3.1.1/api/text_api.html#matplotlib.text.Text>`_:
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
    axes.set_xlabel(r'Time-of-flight ($\mu s$)', fontsize = 12, fontstyle = 'italic', fontweight = 'bold', fontfamily='serif')
 
@@ -133,23 +137,35 @@ Subplots and Inset plots
 
 Create a `tiled plot <https://matplotlib.org/devdocs/gallery/subplots_axes_and_figures/subplots_demo.html>`_ (subplot)
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
-    fig, axes = plt.subplots(ncols=2, nrows=2, subplot_kw={'projection': 'mantid'})
+    multi_fig, multi_axes = plt.subplots(ncols=2, nrows=2, subplot_kw={'projection': 'mantid'})
     # You've created 2x2 arrangement of plots, now plot in them:
-    axes[0][0].plot(ws, specNum=1)
-    axes[0][1].plot(ws, specNum=2)
-    axes[1][0].plot(ws, specNum=3)
-    axes[1][1].plot(ws, specNum=5)
+    multi_axes[0][0].plot(ws, specNum=1)
+    multi_axes[0][1].plot(ws, specNum=2)
+    multi_axes[1][0].plot(ws, specNum=3)
+    multi_axes[1][1].plot(ws, specNum=5)
     #for subplots it is useful to include the following line
     plt.tight_layout()
 
 Add an `inset plot using the mantid projection <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.figure.Figure.html?highlight=add_axes#matplotlib.figure.Figure.add_axes>`_ (`without it <https://matplotlib.org/3.1.1/api/_as_gen/mpl_toolkits.axes_grid1.inset_locator.inset_axes.html>`_ ):
 
-.. code-block:: python
+.. testcode:: MantidPlottingExample
 
-    ax_sub = fig.add_axes([0.50, 0.50, 0.3, 0.25],projection='mantid') #[left, bottom, width, height]
-    ax_sub.plot(ws, specNum=5)
+    ax_sub = multi_fig.add_axes([0.50, 0.50, 0.3, 0.25],projection='mantid') #[left, bottom, width, height]
+    ax_sub.plot(ws, specNum=6)
+
+    print("Mantid plotting example ran successfully")
+
+Output:
+
+.. testoutput:: MantidPlottingExample
+
+    Mantid plotting example ran successfully
+
+.. testcleanup:: MantidPlottingExample
+
+    DeleteWorkspace(ws)
 
 
 Generate a Script

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -4,7 +4,7 @@
 Formatting Plots with a script
 ==============================
 
-**Sometimes the easiest way to find out how to control part of a plot with Matplotlib is to search online for their** `documentation <https://matplotlib.org/3.2.1/index.html>`_ **! Below are some useful commands and a handful of links**
+**Sometimes the easiest way to find out how to control part of a plot with Matplotlib is to search online for their** `documentation <https://matplotlib.org/3.10.9/index.html>`_ **! Below are some useful commands and a handful of links**
 
 
 General
@@ -183,7 +183,7 @@ Useful links
 For further info, including code for producing 2D colorfill plots see:
 
 * `Mantid Plotting Examples <https://docs.mantidproject.org/nightly/plotting/index.html>`_
-* `Matplotlib Gallery <https://matplotlib.org/3.1.1/gallery/index.html>`_
+* `Matplotlib Gallery <https://matplotlib.org/3.10.9/gallery/index.html>`_
 * `Mantid Script Plotting <https://docs.mantidproject.org/nightly/api/python/mantid/plots/index.html>`_
 
 
@@ -238,7 +238,7 @@ Example Script
 
 * :ref:`plotting`
 * :ref:`06_formatting_plots`
-* `Matplotlib Keyboard Shortcuts <https://matplotlib.org/3.1.1/users/navigation_toolbar.html#navigation-keyboard-shortcuts>`_
+* `Matplotlib Keyboard Shortcuts <https://matplotlib.org/stable/users/explain/figure/interactive.html#navigation-keyboard-shortcuts>`_
 
 .. |GenerateAScript.png| image:: /images/GenerateAScript.png
    :width: 30px

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -126,7 +126,7 @@ Alter the `font <https://matplotlib.org/3.10.8/users/explain/text/usetex.html>`_
 
 Note that the fonts available is system dependent - and you can `find available fonts here <http://jonathansoma.com/lede/data-studio/matplotlib/list-all-fonts-available-in-matplotlib-plus-samples/>`_ .
 
-Alternatively, you can set a title or label to have certain `font properties <https://matplotlib.org/3.1.1/api/text_api.html#matplotlib.text.Text>`_:
+Alternatively, you can set a title or label to have certain `font properties <https://matplotlib.org/3.10.9/api/text_api.html#matplotlib.text.Text>`_:
 
 .. testcode:: MantidPlottingExample
 

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -148,7 +148,7 @@ Create a `tiled plot <https://matplotlib.org/devdocs/gallery/subplots_axes_and_f
     #for subplots it is useful to include the following line
     plt.tight_layout()
 
-Add an `inset plot using the mantid projection <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.figure.Figure.html?highlight=add_axes#matplotlib.figure.Figure.add_axes>`_ (`without it <https://matplotlib.org/3.1.1/api/_as_gen/mpl_toolkits.axes_grid1.inset_locator.inset_axes.html>`_ ):
+Add an `inset plot using the mantid projection <https://matplotlib.org/3.10.9/api/_as_gen/matplotlib.figure.Figure.add_axes.html>`_ (`without it <https://matplotlib.org/3.10.9/api/_as_gen/mpl_toolkits.axes_grid1.inset_locator.inset_axes.html>`_ ):
 
 .. testcode:: MantidPlottingExample
 

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -14,7 +14,7 @@ Required imports:
 
 .. testcode:: MantidPlottingExample
 
-    from mantid.simpleapi import *
+    from mantid.simpleapi import Load
     import matplotlib.pyplot as plt
 
 Access a workspace,loaded in the Workspace Toolbox, inside a script:
@@ -132,38 +132,56 @@ Alternatively, you can set a title or label to have certain `font properties <ht
 
    axes.set_xlabel(r'Time-of-flight ($\mu s$)', fontsize = 12, fontstyle = 'italic', fontweight = 'bold', fontfamily='serif')
 
-Subplots and Inset plots
-========================
-
-Create a `tiled plot <https://matplotlib.org/devdocs/gallery/subplots_axes_and_figures/subplots_demo.html>`_ (subplot)
-
-.. testcode:: MantidPlottingExample
-
-    multi_fig, multi_axes = plt.subplots(ncols=2, nrows=2, subplot_kw={'projection': 'mantid'})
-    # You've created 2x2 arrangement of plots, now plot in them:
-    multi_axes[0][0].plot(ws, specNum=1)
-    multi_axes[0][1].plot(ws, specNum=2)
-    multi_axes[1][0].plot(ws, specNum=3)
-    multi_axes[1][1].plot(ws, specNum=5)
-    #for subplots it is useful to include the following line
-    plt.tight_layout()
-
-Add an `inset plot using the mantid projection <https://matplotlib.org/3.10.9/api/_as_gen/matplotlib.figure.Figure.add_axes.html>`_ (`without it <https://matplotlib.org/3.10.9/api/_as_gen/mpl_toolkits.axes_grid1.inset_locator.inset_axes.html>`_ ):
-
-.. testcode:: MantidPlottingExample
-
-    ax_sub = multi_fig.add_axes([0.50, 0.50, 0.3, 0.25],projection='mantid') #[left, bottom, width, height]
-    ax_sub.plot(ws, specNum=6)
-
-    print("Mantid plotting example ran successfully")
+   print("Plotting example ran successfully")
 
 Output:
 
 .. testoutput:: MantidPlottingExample
 
-    Mantid plotting example ran successfully
+    Plotting example ran successfully
 
 .. testcleanup:: MantidPlottingExample
+
+    DeleteWorkspace(ws)
+
+
+Subplots and Inset plots
+========================
+
+Create a `tiled plot <https://matplotlib.org/devdocs/gallery/subplots_axes_and_figures/subplots_demo.html>`_ (subplot)
+
+.. testcode:: MantidSubplotExample
+
+    from mantid.simpleapi import Load
+    import matplotlib.pyplot as plt
+
+    ws = Load('MAR11060')
+
+    fig, axes = plt.subplots(ncols=2, nrows=2, subplot_kw={'projection': 'mantid'})
+    # You've created 2x2 arrangement of plots, now plot in them:
+    axes[0][0].plot(ws, specNum=1)
+    axes[0][1].plot(ws, specNum=2)
+    axes[1][0].plot(ws, specNum=3)
+    axes[1][1].plot(ws, specNum=5)
+    #for subplots it is useful to include the following line
+    plt.tight_layout()
+
+Add an `inset plot using the mantid projection <https://matplotlib.org/3.10.9/api/_as_gen/matplotlib.figure.Figure.add_axes.html>`_ (`without it <https://matplotlib.org/3.10.9/api/_as_gen/mpl_toolkits.axes_grid1.inset_locator.inset_axes.html>`_ ):
+
+.. testcode:: MantidSubplotExample
+
+    ax_sub = fig.add_axes([0.50, 0.50, 0.3, 0.25],projection='mantid') #[left, bottom, width, height]
+    ax_sub.plot(ws, specNum=6)
+
+    print("Subplots and Inset example ran successfully")
+
+Output:
+
+.. testoutput:: MantidSubplotExample
+
+    Subplots and Inset example ran successfully
+
+.. testcleanup:: MantidSubplotExample
 
     DeleteWorkspace(ws)
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40018. <!-- One line per closed issue. -->

The code snippets in the [Plotting with Python](https://docs.mantidproject.org/nightly/tutorials/python_in_mantid/plotting/index.html) section are now tested **automatically** in the `Conda: linux docs build` CI.  I would recommend the manual testing of this section can be shortened to just a visual inspection of the three pages in this section. 

This is because the other snippets (like the ones shown below) are the source code used to create the images of the various types of plot (eg. 2D Colourfill, Contour Plots, 3D Surface and Wireframe Plots)
<img width="760" height="802" alt="image" src="https://github.com/user-attachments/assets/dfd8400e-346b-4ffd-99ad-c1072db61535" />

There is no point of copy pasting these snippets into Mantid to verify that the plot generated matches because it would **always** be the same.

**Note** - Some of the changes recommended in the original issue are out of date and that is why those changes have not been made.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Build the docs using `pixi run cmake --build . --target docs-html`.
2) Navigate to `mantid/build/docs/html/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.html`
3) And verify that the following section is now different from the [online](https://docs.mantidproject.org/nightly/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.html#d-surface-and-wireframe-plots) version shown on the left.
<img width="350" height="350" alt="Screenshot 2026-06-11 at 11 25 59 am" src="https://github.com/user-attachments/assets/70a70420-0662-4f16-8b25-513ff261d7ae" />

<img width="350" height="350" alt="image" src="https://github.com/user-attachments/assets/9fe7163b-2986-447a-8fd5-668d40ae2e45" />

4) The doctests pass if the `Conda: linux docs build` CI passes. However, the tests can be run locally using the [instructions](https://developer.mantidproject.org/Standards/AlgorithmUsageExamples.html#running-the-tests) but it is not required. Running the test locally will create extraneous files in the default save directory due to improper test clean up.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
