### PR TITLE
Cherry-pick to `ornl-next`: Fix error causes by clearing axes before removing a related artist

### DIFF
--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -14,6 +14,13 @@ from matplotlib.patches import PathPatch
 MARKER_SENSITIVITY = 5
 
 
+def _remove_marker_patch(patch):
+    try:
+        patch.remove()
+    except (ValueError, NotImplementedError):
+        pass
+
+
 class HorizontalMarker(QObject):
     """
     An interactive marker displayed as a horizontal line.
@@ -71,10 +78,7 @@ class HorizontalMarker(QObject):
         """
         Remove this marker from the canvas.
         """
-        try:
-            self.patch.remove()
-        except ValueError:
-            pass
+        _remove_marker_patch(self.patch)
 
     def redraw(self):
         """
@@ -257,7 +261,7 @@ class VerticalMarker(QObject):
         """
         Remove this marker from the canvas.
         """
-        self.patch.remove()
+        _remove_marker_patch(self.patch)
 
     def redraw(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -161,7 +161,6 @@ class ColorbarWidget(QWidget):
         Adds axes to the figure. If axes already exist then these are removed and replaced with new ones.
         """
         if self.ax:
-            self.ax.clear()
             self.canvas.figure.delaxes(self.ax)
         self.ax = self.canvas.figure.add_axes([0.0, 0.02, 0.2, 0.97])
 


### PR DESCRIPTION
### Description of work

This is a cherry pick of PR #41529 to fix the same error in `ornl-next`.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
