### PR TITLE
Add TexturePlanner workspace_manager helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Tests for the Texture Planner interface
 
-set(TEST_PY_FILES helpers/test/test_absorption.py
-                  helpers/test/test_detector_geometry.py
-                  helpers/test/test_workspace_manager.py)
+set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py
+                  helpers/test/test_workspace_manager.py
+)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Tests for the Texture Planner interface
 
-set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py)
+set(TEST_PY_FILES helpers/test/test_absorption.py
+                  helpers/test/test_detector_geometry.py
+                  helpers/test/test_workspace_manager.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -1,0 +1,741 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+import numpy as np
+
+from unittest.mock import patch, MagicMock, call
+from scipy.spatial.transform import Rotation
+
+from mantidqtinterfaces.TexturePlanner.helpers.workspace_manager import WorkspaceManager
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.workspace_manager"
+
+COPY_KWARGS = dict(CopyName=False, CopyEnvironment=False, CopyLattice=False)
+COPY_MATERIAL_KWARGS = dict(CopyName=False, CopyMaterial=True, CopyShape=False, CopyEnvironment=False, CopyLattice=False)
+
+
+def _make_manager(instr="ENGINX"):
+    model = MagicMock()
+    model.instrument.get_instrument.return_value = instr
+    return WorkspaceManager(model)
+
+
+class TestWorkspaceManager_Init(unittest.TestCase):
+    def test_default_attributes(self):
+        wm = _make_manager("ENGINX")
+
+        self.assertEqual(wm.wsname, wm.WS_DATA)
+        self.assertEqual(wm.ungrouped_wsname, wm.WS_UNGROUPED)
+        self.assertIsNone(wm.ws)
+        self.assertIsNone(wm.ungrouped_ws)
+        self.assertIsNone(wm.mesh_ws)
+        self.assertIsNone(wm.updated_mesh_ws)
+        self.assertIsNone(wm.material_ws)
+        self.assertIsNone(wm.gauge_volume_str)
+        self.assertEqual(wm.offset, (0, 0, 0))
+        np.testing.assert_array_equal(wm.init_R.as_matrix(), np.eye(3))
+        self.assertEqual(wm.attenuation_kwargs, {"point": 1.5, "unit": "dSpacing"})
+        self.assertEqual(
+            wm.stl_kwargs,
+            {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": "0", "TranslationVector": "0,0,0"},
+        )
+
+    def test_instr_property_reads_from_model(self):
+        wm = _make_manager("IMAT")
+        self.assertEqual(wm.instr, "IMAT")
+
+    def test_workspace_names_are_suffixed_from_class_base_names(self):
+        # each owned name shadows its class constant with an instance-unique suffix so several
+        # planner windows can be open at once without colliding on the ADS
+        wm = _make_manager()
+        for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS:
+            base = getattr(WorkspaceManager, attr)
+            self.assertTrue(getattr(wm, attr).startswith(base + "_"))
+
+    def test_two_managers_get_distinct_workspace_names(self):
+        wm1 = _make_manager()
+        wm2 = _make_manager()
+        for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS:
+            self.assertNotEqual(getattr(wm1, attr), getattr(wm2, attr))
+
+    @patch(file_path + ".get_scattering_centre")
+    def test_scattering_centre_property_delegates_to_helper(self, mock_gsc):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        mock_gsc.return_value = (1.0, 2.0, 3.0)
+
+        self.assertEqual(wm.scattering_centre, (1.0, 2.0, 3.0))
+        mock_gsc.assert_called_once_with(wm.ws)
+
+
+@patch(file_path + ".ADS")
+class TestWorkspaceManager_Cleanup(unittest.TestCase):
+    def test_removes_every_owned_ws_that_exists(self, mock_ads):
+        wm = _make_manager()
+        mock_ads.doesExist.return_value = True
+
+        wm.cleanup()
+
+        removed = [c.args[0] for c in mock_ads.remove.call_args_list]
+        expected = [getattr(wm, attr) for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS]
+        self.assertEqual(removed, expected)
+
+    def test_skips_owned_ws_that_do_not_exist(self, mock_ads):
+        wm = _make_manager()
+        mock_ads.doesExist.return_value = False
+
+        wm.cleanup()
+
+        mock_ads.remove.assert_not_called()
+
+
+@patch(file_path + ".define_gauge_volume")
+@patch(file_path + ".CloneWorkspace")
+class TestWorkspaceManager_UpdateWorkspace(unittest.TestCase):
+    def _make_manager_with_mock_model(self):
+        wm = _make_manager("ENGINX")
+        wm._init_wss = MagicMock()
+        wm._update_existing_wss = MagicMock()
+        wm.set_material = MagicMock()
+        return wm
+
+    def test_delegates_to_init_and_seeds_material_when_no_existing_ws(self, mock_clone, mock_define_gv):
+        wm = self._make_manager_with_mock_model()
+        wm.ws = None
+
+        wm.update_ws()
+
+        wm._init_wss.assert_called_once_with()
+        wm._update_existing_wss.assert_not_called()
+        # brand-new workspaces have no material, so the default is seeded
+        wm.set_material.assert_called_once_with()
+
+    def test_delegates_to_update_and_preserves_material_when_ws_exists(self, mock_clone, mock_define_gv):
+        wm = self._make_manager_with_mock_model()
+        wm.ws = MagicMock()
+
+        wm.update_ws()
+
+        wm._update_existing_wss.assert_called_once_with()
+        wm._init_wss.assert_not_called()
+        # _update_existing_wss copies the (possibly user-set) material onto the new workspaces, so
+        # update_ws must not reset it
+        wm.set_material.assert_not_called()
+
+    def test_clones_ungrouped_from_ws(self, mock_clone, mock_define_gv):
+        wm = self._make_manager_with_mock_model()
+        wm.ws = MagicMock()
+        mock_clone.return_value = "ungrouped"
+
+        wm.update_ws()
+
+        mock_clone.assert_called_once_with(InputWorkspace=wm.ws, OutputWorkspace=wm.WS_UNGROUPED)
+        self.assertEqual(wm.ungrouped_ws, "ungrouped")
+
+    def test_does_not_define_gauge_volume_when_unset(self, mock_clone, mock_define_gv):
+        wm = self._make_manager_with_mock_model()
+        wm.gauge_volume_str = None
+
+        wm.update_ws()
+
+        mock_define_gv.assert_not_called()
+
+    def test_defines_gauge_volume_when_set(self, mock_clone, mock_define_gv):
+        wm = self._make_manager_with_mock_model()
+        wm.ws = MagicMock()
+        wm.gauge_volume_str = "<xml/>"
+
+        wm.update_ws()
+
+        mock_define_gv.assert_called_once_with(wm.ws, "<xml/>")
+
+
+@patch(file_path + ".SetSampleMaterial")
+@patch(file_path + ".SetSampleShape")
+@patch(file_path + ".CloneWorkspace")
+@patch(file_path + ".CreateSimulationWorkspace")
+class TestWorkspaceManager_InitWss(unittest.TestCase):
+    def test_creates_sim_workspace_with_expected_args(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        sim_ws = MagicMock()
+        sim_ws.getNumberHistograms.return_value = 0
+        mock_create_sim.return_value = sim_ws
+
+        wm._init_wss()
+
+        mock_create_sim.assert_called_once_with(
+            Instrument="ENGINX",
+            BinParams="0,0.1,5",
+            OutputWorkspace=wm.WS_DATA,
+            UnitX="dSpacing",
+        )
+        self.assertIs(wm.ws, sim_ws)
+
+    def test_fills_y_with_ones_for_each_histogram(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        sim_ws = MagicMock()
+        sim_ws.getNumberHistograms.return_value = 3
+        sim_ws.readY.return_value = np.zeros(4)
+        mock_create_sim.return_value = sim_ws
+
+        wm._init_wss()
+
+        # numpy arrays inside mock.call don't compare cleanly with ==, so check each call explicitly
+        spec_indices = [c.args[0] for c in sim_ws.setY.call_args_list]
+        self.assertEqual(spec_indices, [0, 1, 2])
+        for c in sim_ws.setY.call_args_list:
+            np.testing.assert_array_equal(c.args[1], np.ones(4))
+
+    def test_clones_mesh_neutral_and_material_from_sim_ws(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        sim_ws = MagicMock()
+        sim_ws.getNumberHistograms.return_value = 0
+        mock_create_sim.return_value = sim_ws
+        mock_clone.side_effect = ["mesh", "neutral", "material"]
+
+        wm._init_wss()
+
+        self.assertEqual(
+            mock_clone.call_args_list,
+            [
+                call(InputWorkspace=sim_ws, OutputWorkspace=wm.WS_MESH_RAW),
+                call(InputWorkspace=sim_ws, OutputWorkspace=wm.WS_MESH_NEUTRAL),
+                # material holder is cloned from the (cube-shaped) mesh ws so it owns a shape
+                call(InputWorkspace="mesh", OutputWorkspace=wm.WS_MATERIAL),
+            ],
+        )
+        self.assertEqual(wm.mesh_ws, "mesh")
+        self.assertEqual(wm.updated_mesh_ws, "neutral")
+        self.assertEqual(wm.material_ws, "material")
+
+    def test_seeds_material_holder_with_default(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        sim_ws = MagicMock()
+        sim_ws.getNumberHistograms.return_value = 0
+        mock_create_sim.return_value = sim_ws
+        mock_clone.side_effect = ["mesh", "neutral", "material"]
+
+        wm._init_wss()
+
+        mock_set_mat.assert_called_once_with("material", WorkspaceManager.DEFAULT_MATERIAL)
+
+    def test_sets_default_cube_shape_on_all_three_wss(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        sim_ws = MagicMock()
+        sim_ws.getNumberHistograms.return_value = 0
+        mock_create_sim.return_value = sim_ws
+        mock_clone.side_effect = ["mesh", "neutral", "material"]
+
+        wm._init_wss()
+
+        targets = [c.args[0] for c in mock_set_shape.call_args_list]
+        self.assertEqual(targets, [sim_ws, "mesh", "neutral"])
+        # All three receive the same XML cube string
+        xml_args = {c.args[1] for c in mock_set_shape.call_args_list}
+        self.assertEqual(len(xml_args), 1)
+
+
+class TestWorkspaceManager_UpdateExistingWss(unittest.TestCase):
+    def test_rebuilds_three_wss_via_create_new_helper(self):
+        wm = _make_manager("ENGINX")
+        wm.ws = "old_ws"
+        wm.mesh_ws = "old_mesh"
+        wm.updated_mesh_ws = "old_neutral"
+        wm._create_new_ws_with_copied_sample = MagicMock(side_effect=["new_ws", "new_mesh", "new_neutral"])
+
+        wm._update_existing_wss()
+
+        # ws and updated_mesh_ws hold the initial shape rotation and must preserve it across the
+        # instrument switch; the raw mesh_ws is un-rotated and is copied as-is
+        self.assertEqual(
+            wm._create_new_ws_with_copied_sample.call_args_list,
+            [
+                call(wm.WS_DATA, "old_ws", clone=True, preserve_initial_rotation=True),
+                call(wm.WS_MESH_RAW, "old_mesh", clone=True),
+                call(wm.WS_MESH_NEUTRAL, "old_neutral", clone=True, preserve_initial_rotation=True),
+            ],
+        )
+        self.assertEqual(wm.ws, "new_ws")
+        self.assertEqual(wm.mesh_ws, "new_mesh")
+        self.assertEqual(wm.updated_mesh_ws, "new_neutral")
+
+
+@patch(file_path + ".ADS")
+@patch(file_path + ".CopySample")
+@patch(file_path + ".CreateSimulationWorkspace")
+@patch(file_path + ".CloneWorkspace")
+class TestWorkspaceManager_CreateNewWsWithCopiedSample(unittest.TestCase):
+    def test_clone_true_clones_sample_into_shape_tmp(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        wm = _make_manager("ENGINX")
+        sample = MagicMock(name="sample")
+        mock_clone.return_value = "shape_tmp"
+        mock_create_sim.return_value = "new_ws"
+        mock_ads.doesExist.return_value = True
+
+        wm._create_new_ws_with_copied_sample("dest_ws", sample, clone=True)
+
+        mock_clone.assert_called_once_with(InputWorkspace=sample, OutputWorkspace=wm._SHAPE_TMP)
+
+    def test_clone_true_copies_from_shape_tmp_into_new_ws(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        wm = _make_manager("ENGINX")
+        mock_clone.return_value = "shape_tmp"
+        mock_create_sim.return_value = "new_ws"
+        mock_ads.doesExist.return_value = True
+
+        result = wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+
+        mock_create_sim.assert_called_once_with(Instrument="ENGINX", BinParams="0,0.1,5", OutputWorkspace="dest_ws", UnitX="dSpacing")
+        mock_copy.assert_called_once_with(InputWorkspace="shape_tmp", OutputWorkspace="dest_ws", **COPY_KWARGS)
+        self.assertEqual(result, "new_ws")
+
+    def test_clone_true_removes_shape_tmp_when_it_exists(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        wm = _make_manager("ENGINX")
+        mock_clone.return_value = "shape_tmp"
+        mock_ads.doesExist.return_value = True
+
+        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+
+        mock_ads.doesExist.assert_called_once_with(wm._SHAPE_TMP)
+        mock_ads.remove.assert_called_once_with(wm._SHAPE_TMP)
+
+    def test_clone_true_skips_remove_if_shape_tmp_missing(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        wm = _make_manager("ENGINX")
+        mock_ads.doesExist.return_value = False
+
+        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+
+        mock_ads.remove.assert_not_called()
+
+    def test_clone_false_copies_directly_from_sample(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        wm = _make_manager("ENGINX")
+        sample = MagicMock(name="sample")
+        mock_create_sim.return_value = "new_ws"
+
+        result = wm._create_new_ws_with_copied_sample("dest_ws", sample, clone=False)
+
+        mock_clone.assert_not_called()
+        mock_copy.assert_called_once_with(InputWorkspace=sample, OutputWorkspace="dest_ws", **COPY_KWARGS)
+        mock_ads.remove.assert_not_called()
+        self.assertEqual(result, "new_ws")
+
+    def test_preserve_initial_rotation_delegates_to_preserving_copy(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+        # when asked to preserve init_R, the bare CopySample is bypassed in favour of the helper that
+        # re-bakes init_R onto the destination (a plain CopySample drops it for a CSG shape)
+        wm = _make_manager("ENGINX")
+        mock_clone.return_value = "shape_tmp"
+        mock_create_sim.return_value = "new_ws"
+        wm.copy_sample_preserving_initial_rotation = MagicMock()
+
+        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True, preserve_initial_rotation=True)
+
+        wm.copy_sample_preserving_initial_rotation.assert_called_once_with("shape_tmp", "new_ws")
+        mock_copy.assert_not_called()
+
+
+@patch(file_path + ".CopySample")
+class TestWorkspaceManager_CopySamplePreservingInitialRotation(unittest.TestCase):
+    @staticmethod
+    def _ws_with_shape(shape_type_name):
+        ws = MagicMock()
+        ws.sample.return_value.getShape.return_value = type(shape_type_name, (), {})()
+        return ws
+
+    def test_csg_source_bakes_init_R_onto_destination_then_restores_identity(self, mock_copy):
+        wm = _make_manager()
+        wm.init_R = Rotation.from_euler("x", 30, degrees=True)
+        source = self._ws_with_shape("CSGObject")
+        dest = MagicMock()
+        gonio = dest.run.return_value.getGoniometer.return_value
+
+        wm.copy_sample_preserving_initial_rotation(source, dest)
+
+        # CopySample overwrites a CSG shape's <goniometer> tag with the destination's run goniometer,
+        # so the destination must carry init_R while the sample is copied...
+        set_matrices = [c.args[0] for c in gonio.setR.call_args_list]
+        self.assertEqual(len(set_matrices), 2)
+        np.testing.assert_allclose(set_matrices[0], wm.init_R.as_matrix())
+        # ...then be restored to identity so init_R lives in the shape, not the run goniometer
+        np.testing.assert_array_equal(set_matrices[1], np.eye(3))
+        mock_copy.assert_called_once_with(InputWorkspace=source, OutputWorkspace=dest, **COPY_KWARGS)
+
+    def test_mesh_source_keeps_destination_at_identity(self, mock_copy):
+        # a MeshObject already holds init_R in its vertices, which CopySample re-rotates by the
+        # destination goniometer; leaving it at identity avoids applying init_R a second time
+        wm = _make_manager()
+        wm.init_R = Rotation.from_euler("x", 30, degrees=True)
+        source = self._ws_with_shape("MeshObject")
+        dest = MagicMock()
+        gonio = dest.run.return_value.getGoniometer.return_value
+
+        wm.copy_sample_preserving_initial_rotation(source, dest)
+
+        for c in gonio.setR.call_args_list:
+            np.testing.assert_array_equal(c.args[0], np.eye(3))
+
+
+@patch(file_path + ".CopySample")
+class TestWorkspaceManager_SetMaterial(unittest.TestCase):
+    def test_copies_material_holder_onto_ws_mesh_and_updated_mesh(self, mock_copy):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.material_ws = "material"
+        wm.ungrouped_ws = None
+
+        wm.set_material()
+
+        self.assertEqual(
+            mock_copy.call_args_list,
+            [
+                call(InputWorkspace="material", OutputWorkspace="ws", **COPY_MATERIAL_KWARGS),
+                call(InputWorkspace="material", OutputWorkspace="mesh", **COPY_MATERIAL_KWARGS),
+                call(InputWorkspace="material", OutputWorkspace="neutral", **COPY_MATERIAL_KWARGS),
+            ],
+        )
+
+    def test_also_applies_to_ungrouped_when_present(self, mock_copy):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.material_ws = "material"
+        wm.ungrouped_ws = "ungrouped"
+
+        wm.set_material()
+
+        targets = [c.kwargs["OutputWorkspace"] for c in mock_copy.call_args_list]
+        self.assertEqual(targets, ["ws", "mesh", "neutral", "ungrouped"])
+
+
+@patch(file_path + ".CopySample")
+class TestWorkspaceManager_PropagateMaterial(unittest.TestCase):
+    def test_captures_ground_truth_then_copies_to_other_wss(self, mock_copy):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.material_ws = "material"
+        wm.ungrouped_ws = "ungrouped"
+
+        wm.propagate_material()
+
+        self.assertEqual(
+            mock_copy.call_args_list,
+            [
+                # the just-set material on the raw mesh ws becomes the new ground truth
+                call(InputWorkspace="mesh", OutputWorkspace="material", **COPY_MATERIAL_KWARGS),
+                call(InputWorkspace="mesh", OutputWorkspace="ws", **COPY_MATERIAL_KWARGS),
+                call(InputWorkspace="mesh", OutputWorkspace="neutral", **COPY_MATERIAL_KWARGS),
+                call(InputWorkspace="mesh", OutputWorkspace="ungrouped", **COPY_MATERIAL_KWARGS),
+            ],
+        )
+
+    def test_skips_ungrouped_when_absent(self, mock_copy):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.material_ws = "material"
+        wm.ungrouped_ws = None
+
+        wm.propagate_material()
+
+        targets = [c.kwargs["OutputWorkspace"] for c in mock_copy.call_args_list]
+        self.assertEqual(targets, ["material", "ws", "neutral"])
+
+
+class TestWorkspaceManager_GetMaterialName(unittest.TestCase):
+    def test_returns_name_from_material_ws_sample_material(self):
+        wm = _make_manager()
+        wm.material_ws = MagicMock()
+        wm.material_ws.sample.return_value.getMaterial.return_value.name.return_value = "Al2O3"
+
+        self.assertEqual(wm.get_material_name(), "Al2O3")
+
+    def test_returns_empty_string_when_unavailable(self):
+        wm = _make_manager()
+        wm.material_ws = None
+
+        self.assertEqual(wm.get_material_name(), "")
+
+
+@patch(file_path + ".SetSampleMaterial")
+@patch(file_path + ".LoadSampleShape")
+class TestWorkspaceManager_LoadStl(unittest.TestCase):
+    def test_loads_stl_into_all_three_wss_with_stl_kwargs(self, mock_load_shape, mock_set_mat):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.set_material = MagicMock()
+
+        wm.load_stl("file.stl")
+
+        expected = [
+            call(InputWorkspace="ws", Filename="file.stl", OutputWorkspace="ws", **wm.stl_kwargs),
+            call(InputWorkspace="mesh", Filename="file.stl", OutputWorkspace="mesh", **wm.stl_kwargs),
+            call(InputWorkspace="neutral", Filename="file.stl", OutputWorkspace="neutral", **wm.stl_kwargs),
+        ]
+        self.assertEqual(mock_load_shape.call_args_list, expected)
+
+    def test_reapplies_material_after_loading_stl(self, mock_load_shape, mock_set_mat):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.ungrouped_ws = None
+        wm.set_material = MagicMock()
+
+        wm.load_stl("file.stl")
+
+        # loading a shape wipes the material off the shape object; set_material re-applies the
+        # ground-truth material (preserving its full definition, e.g. number/mass density)
+        wm.set_material.assert_called_once_with()
+
+
+@patch(file_path + ".SetSampleMaterial")
+@patch(file_path + ".SetSampleShape")
+class TestWorkspaceManager_LoadXml(unittest.TestCase):
+    def _write_tmp_xml(self, content):
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False) as f:
+            f.write(content)
+            return f.name
+
+    def test_sets_xml_shape_on_all_three_wss(self, mock_set_shape, mock_set_mat):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.set_material = MagicMock()
+        fname = self._write_tmp_xml("<cube/>")
+        try:
+            wm.load_xml(fname)
+        finally:
+            os.unlink(fname)
+
+        self.assertEqual(
+            mock_set_shape.call_args_list,
+            [
+                call("ws", "<cube/>"),
+                call("mesh", "<cube/>"),
+                call("neutral", "<cube/>"),
+            ],
+        )
+
+    def test_reapplies_material_after_loading_xml(self, mock_set_shape, mock_set_mat):
+        wm = _make_manager()
+        wm.ws = "ws"
+        wm.mesh_ws = "mesh"
+        wm.updated_mesh_ws = "neutral"
+        wm.ungrouped_ws = None
+        wm.set_material = MagicMock()
+        fname = self._write_tmp_xml("<cube/>")
+        try:
+            wm.load_xml(fname)
+        finally:
+            os.unlink(fname)
+
+        # loading a shape wipes the material off the shape object; set_material re-applies the
+        # ground-truth material (preserving its full definition, e.g. number/mass density)
+        wm.set_material.assert_called_once_with()
+
+
+@patch(file_path + ".TranslateSampleShape")
+class TestWorkspaceManager_TranslateShape(unittest.TestCase):
+    def test_skips_when_all_zero(self, mock_translate):
+        WorkspaceManager.translate_shape("ws", 0.0, 0.0, 0.0)
+        mock_translate.assert_not_called()
+
+    def test_translates_when_x_nonzero(self, mock_translate):
+        WorkspaceManager.translate_shape("ws", 1.0, 0.0, 0.0)
+        mock_translate.assert_called_once_with(InputWorkspace="ws", TranslationVector="1.0,0.0,0.0")
+
+    def test_translates_when_all_nonzero(self, mock_translate):
+        WorkspaceManager.translate_shape("ws", 1.0, 2.0, 3.0)
+        mock_translate.assert_called_once_with(InputWorkspace="ws", TranslationVector="1.0,2.0,3.0")
+
+
+class TestWorkspaceManager_AllRotsZero(unittest.TestCase):
+    def test_true_for_zero(self):
+        self.assertTrue(WorkspaceManager._all_rots_zero(0, 0, 0))
+
+    def test_true_for_near_zero(self):
+        self.assertTrue(WorkspaceManager._all_rots_zero(1e-12, -1e-12, 0))
+
+    def test_false_when_x_nonzero(self):
+        self.assertFalse(WorkspaceManager._all_rots_zero(1.0, 0, 0))
+
+    def test_false_when_y_nonzero(self):
+        self.assertFalse(WorkspaceManager._all_rots_zero(0, 1.0, 0))
+
+    def test_false_when_z_nonzero(self):
+        self.assertFalse(WorkspaceManager._all_rots_zero(0, 0, 1.0))
+
+
+@patch(file_path + ".RotateSampleShape")
+class TestWorkspaceManager_RotateSamplesByInitialGoniometer(unittest.TestCase):
+    def test_returns_none_and_no_rotate_when_identity(self, mock_rotate):
+        wm = _make_manager()
+        wm.init_R = Rotation.identity()
+
+        self.assertIsNone(wm.rotate_samples_by_initial_goniometer())
+        mock_rotate.assert_not_called()
+
+    def test_rotates_ws_and_updated_mesh_with_axis_angle_string(self, mock_rotate):
+        wm = _make_manager()
+        wm.updated_mesh_ws = "neutral"
+        wm.init_R = Rotation.from_euler("x", 90, degrees=True)
+
+        wm.rotate_samples_by_initial_goniometer()
+
+        targets = [c.args[0] for c in mock_rotate.call_args_list]
+        self.assertEqual(targets, [wm.WS_DATA, "neutral"])
+        for c in mock_rotate.call_args_list:
+            parts = c.args[1].split(",")
+            self.assertAlmostEqual(float(parts[0]), 90.0)
+            np.testing.assert_allclose([float(parts[1]), float(parts[2]), float(parts[3])], [1.0, 0.0, 0.0], atol=1e-12)
+            self.assertEqual(parts[4], "1")
+
+
+@patch(file_path + ".ADS")
+@patch(file_path + ".CopySample")
+class TestWorkspaceManager_UpdateInitialShape(unittest.TestCase):
+    def _make_wm_with_ws(self):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        gonio = MagicMock()
+        wm.ws.run.return_value.getGoniometer.return_value = gonio
+        wm.mesh_ws = MagicMock()
+        wm.updated_mesh_ws = "neutral"
+        wm._create_new_ws_with_copied_sample = MagicMock(return_value="tmp_ws")
+        wm.translate_shape = MagicMock()
+        wm.rotate_samples_by_initial_goniometer = MagicMock()
+        return wm, gonio
+
+    def test_creates_tmp_ws_from_mesh(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        wm._create_new_ws_with_copied_sample.assert_called_once_with(wm.WS_TMP, wm.mesh_ws)
+
+    def test_stores_offset_and_translates_tmp_ws(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 1.0, 2.0, 3.0)
+
+        self.assertEqual(wm.offset, (1.0, 2.0, 3.0))
+        wm.translate_shape.assert_called_once_with("tmp_ws", 1.0, 2.0, 3.0)
+
+    def test_resets_goniometer_to_identity_before_copy(self, mock_copy, mock_ads):
+        wm, gonio = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        gonio.setR.assert_called_once()
+        np.testing.assert_array_equal(gonio.setR.call_args.args[0], np.eye(3))
+
+    def test_copies_tmp_into_ws_and_updated_mesh(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        self.assertEqual(
+            mock_copy.call_args_list,
+            [
+                call(InputWorkspace="tmp_ws", OutputWorkspace=wm.WS_DATA, **COPY_KWARGS),
+                call(InputWorkspace="tmp_ws", OutputWorkspace="neutral", **COPY_KWARGS),
+            ],
+        )
+
+    def test_zero_rotation_sets_init_R_identity_and_skips_rotate(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        np.testing.assert_array_equal(wm.init_R.as_matrix(), np.eye(3))
+        wm.rotate_samples_by_initial_goniometer.assert_not_called()
+
+    def test_nonzero_rotation_sets_init_R_from_euler_and_rotates(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(90.0, 45.0, 30.0, 0.0, 0.0, 0.0)
+
+        expected = Rotation.from_euler("xyz", (90.0, 45.0, 30.0), degrees=True)
+        np.testing.assert_allclose(wm.init_R.as_matrix(), expected.as_matrix())
+        wm.rotate_samples_by_initial_goniometer.assert_called_once_with()
+
+    def test_tmp_workspace_always_removed(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+
+        wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        mock_ads.remove.assert_called_once_with(wm.WS_TMP)
+
+    def test_tmp_workspace_removed_even_when_copy_raises(self, mock_copy, mock_ads):
+        wm, _ = self._make_wm_with_ws()
+        mock_copy.side_effect = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        mock_ads.remove.assert_called_once_with(wm.WS_TMP)
+
+
+@patch(file_path + ".DeleteLog")
+@patch(file_path + ".define_gauge_volume")
+@patch(file_path + ".get_gauge_vol_str")
+class TestWorkspaceManager_SetGaugeVolumeStr(unittest.TestCase):
+    def test_stores_str_from_helper(self, mock_get_str, mock_define_gv, mock_delete_log):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        mock_get_str.return_value = "<xml/>"
+
+        wm.set_gauge_volume_str("preset", "custom")
+
+        mock_get_str.assert_called_once_with("preset", "custom")
+        self.assertEqual(wm.gauge_volume_str, "<xml/>")
+
+    def test_nonempty_str_defines_gauge_volume(self, mock_get_str, mock_define_gv, mock_delete_log):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        mock_get_str.return_value = "<xml/>"
+
+        wm.set_gauge_volume_str("preset", "custom")
+
+        mock_define_gv.assert_called_once_with(wm.ws, "<xml/>")
+        mock_delete_log.assert_not_called()
+
+    def test_empty_str_with_existing_property_deletes_log(self, mock_get_str, mock_define_gv, mock_delete_log):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        wm.ws.run.return_value.hasProperty.return_value = True
+        mock_get_str.return_value = None
+
+        wm.set_gauge_volume_str("preset", "custom")
+
+        self.assertIsNone(wm.gauge_volume_str)
+        mock_define_gv.assert_not_called()
+        mock_delete_log.assert_called_once_with(Workspace=wm.ws, Name="GaugeVolume")
+
+    def test_empty_str_without_property_does_nothing(self, mock_get_str, mock_define_gv, mock_delete_log):
+        wm = _make_manager()
+        wm.ws = MagicMock()
+        wm.ws.run.return_value.hasProperty.return_value = False
+        mock_get_str.return_value = ""
+
+        wm.set_gauge_volume_str("preset", "custom")
+
+        mock_define_gv.assert_not_called()
+        mock_delete_log.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -43,7 +43,7 @@ class TestWorkspaceManager_Init(unittest.TestCase):
         self.assertEqual(wm.attenuation_kwargs, {"point": 1.5, "unit": "dSpacing"})
         self.assertEqual(
             wm.stl_kwargs,
-            {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": "0", "TranslationVector": "0,0,0"},
+            {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": 0, "TranslationVector": "0,0,0"},
         )
 
     def test_instr_property_reads_from_model(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -50,19 +50,18 @@ class TestWorkspaceManager_Init(unittest.TestCase):
         wm = _make_manager("IMAT")
         self.assertEqual(wm.instr, "IMAT")
 
-    def test_workspace_names_are_suffixed_from_class_base_names(self):
-        # each owned name shadows its class constant with an instance-unique suffix so several
-        # planner windows can be open at once without colliding on the ADS
+    def test_workspace_names_carry_an_instance_unique_suffix(self):
+        # every owned name gets an instance-unique suffix so several planner windows can be open at
+        # once without colliding on the ADS
         wm = _make_manager()
-        for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS:
-            base = getattr(WorkspaceManager, attr)
-            self.assertTrue(getattr(wm, attr).startswith(base + "_"))
+        for name in wm._owned_ws_names:
+            self.assertRegex(name, r"^__.+_[0-9a-f]{8}$")
 
     def test_two_managers_get_distinct_workspace_names(self):
         wm1 = _make_manager()
         wm2 = _make_manager()
-        for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS:
-            self.assertNotEqual(getattr(wm1, attr), getattr(wm2, attr))
+        for name1, name2 in zip(wm1._owned_ws_names, wm2._owned_ws_names):
+            self.assertNotEqual(name1, name2)
 
     @patch(file_path + ".get_scattering_centre")
     def test_scattering_centre_property_delegates_to_helper(self, mock_gsc):
@@ -83,8 +82,7 @@ class TestWorkspaceManager_Cleanup(unittest.TestCase):
         wm.cleanup()
 
         removed = [c.args[0] for c in mock_ads.remove.call_args_list]
-        expected = [getattr(wm, attr) for attr in WorkspaceManager._OWNED_WS_NAME_ATTRS]
-        self.assertEqual(removed, expected)
+        self.assertEqual(removed, list(wm._owned_ws_names))
 
     def test_skips_owned_ws_that_do_not_exist(self, mock_ads):
         wm = _make_manager()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -1,0 +1,335 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from uuid import uuid4
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from mantid.simpleapi import (
+    CloneWorkspace,
+    CopySample,
+    CreateSimulationWorkspace,
+    DeleteLog,
+    LoadSampleShape,
+    RotateSampleShape,
+    SetSampleMaterial,
+    SetSampleShape,
+    TranslateSampleShape,
+)
+from mantid.api import AnalysisDataService as ADS, MatrixWorkspace
+from Engineering.common.xml_shapes import get_cube_xml
+from Engineering.texture.texture_helper import define_gauge_volume, get_gauge_vol_str, get_scattering_centre
+from typing import Any, Protocol
+
+
+class _BaseModelType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    orientations: Any
+    instrument: Any
+    geometry: Any
+
+
+class WorkspaceManager:
+    """Owns the workspaces (data, ungrouped, mesh, mesh-neutral, instrument)
+    and the operations that mutate sample shape / material / gauge volume on
+    them. Reads instrument name from the parent model via a back-reference.
+    """
+
+    # Workspace names used by the planner. All start with "__" so the ADS treats them as hidden.
+    # Each holds a distinct view of the sample needed by a specific consumer:
+    #   WS_DATA          live workspace driving plots/exports: holds the translated shape with init_R
+    #                    baked into its XML goniometer tag, and carries the current orientation R on
+    #                    its run goniometer. Read by get_scattering_centre, GroupDetectors, etc.
+    #   WS_UNGROUPED     pre-group clone of WS_DATA; detector_geometry re-runs GroupDetectors against
+    #                    this whenever the group pattern changes (can't ungroup an already-grouped ws).
+    #   WS_MESH_RAW      pristine sample (no init_R, no translation, identity goniometer). Source of
+    #                    truth for absorption (which composes R*init_R itself) and for rebuilding
+    #                    WS_DATA in update_initial_shape.
+    #   WS_MESH_NEUTRAL  init_R baked in, no translation, identity goniometer. Used by the plotter
+    #                    (which applies R itself to the mesh vertices) and by the reference-ws export.
+    #   WS_REFERENCE     transient name for output_as_reference_workspace; created and removed inside
+    #                    the export call, never persists across calls.
+    #   WS_MC_INPUT      per-orientation MonteCarloAbsorption input. Rebuilt each calc_for_index with
+    #                    R*init_R baked into the shape and identity goniometer.
+    #   WS_MC_OUTPUT     MonteCarloAbsorption output (transmission factors).
+    #   WS_TMP           transient name for update_initial_shape's working copy; removed in finally.
+    #   WS_MATERIAL      dedicated holder for the ground-truth sample material. Its shape is never
+    #                    reloaded, so it survives shape changes and lets set_material re-apply the
+    #                    full material (formula + number/mass density) via CopySample rather than a
+    #                    lossy formula-only round-trip through SetSampleMaterial.
+    WS_DATA = "__texture_planning_ws"
+    WS_UNGROUPED = "__texture_planning_ws_ungrouped"
+    WS_MESH_RAW = "__texture_planning_raw_sample_mesh"
+    WS_MESH_NEUTRAL = "__texture_planning_neutral_sample_mesh"
+    WS_MATERIAL = "__texture_planning_material"
+    WS_REFERENCE = "__texture_planning_reference_ws"
+    WS_MC_INPUT = "__mc_ws"
+    WS_MC_OUTPUT = "__abs_ws"
+    WS_TMP = "__tmp_ws"
+    _SHAPE_TMP = "__shape_ws"
+
+    # The class constants above are base names. Each instance shadows them with per-instance copies
+    # carrying a unique suffix (see __init__) so that several planner windows open at once don't
+    # collide on the ADS. Listed here once so __init__ can suffix them and cleanup() can remove them.
+    _OWNED_WS_NAME_ATTRS = (
+        "WS_DATA",
+        "WS_UNGROUPED",
+        "WS_MESH_RAW",
+        "WS_MESH_NEUTRAL",
+        "WS_MATERIAL",
+        "WS_REFERENCE",
+        "WS_MC_INPUT",
+        "WS_MC_OUTPUT",
+        "WS_TMP",
+        "_SHAPE_TMP",
+    )
+
+    DEFAULT_MATERIAL = "Fe"
+
+    def __init__(self, model: _BaseModelType):
+        self._model = model
+        # Several planner windows can be open simultaneously, so suffix every workspace name with a
+        # token unique to this instance.
+        self._suffix = f"_{uuid4().hex[:8]}"
+        for attr in self._OWNED_WS_NAME_ATTRS:
+            setattr(self, attr, getattr(self, attr) + self._suffix)
+        self.wsname = self.WS_DATA
+        self.ungrouped_wsname = self.WS_UNGROUPED
+        self.ws = None  # holds the translated shape with init_R
+        # baked in and current orientation R on its run goniometer
+        self.ungrouped_ws = None  # ungrouped clone of self.ws for changing groups quickly
+        self.mesh_ws = None  # pristine sample (no init_R, no translation, identity goniometer)
+        # reference for absorption and for rebuilding WS_DATA when initial shape is updated.
+        self.updated_mesh_ws = None  # sample with init_R baked in, no translation, identity goniometer
+        # Used by the plotter and by the reference-ws export.
+        self.material_ws = None  # ground-truth material holder; never has its shape reloaded
+        self.init_R = Rotation.identity()
+        self.offset = (0, 0, 0)
+        self.gauge_volume_str = None
+        # stl_settings
+        self.stl_kwargs = {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": "0", "TranslationVector": "0,0,0"}
+        # attenuation-point settings read by AbsorptionCalculator. The material itself lives on
+        # material_ws (the ground truth), not here.
+        self.attenuation_kwargs = {"point": 1.5, "unit": "dSpacing"}
+
+    def cleanup(self) -> None:
+        """Remove every workspace this instance owns from the ADS. Called when the planner window
+        closes so the (hidden) workspaces don't accumulate across open/close cycles now that their
+        names are unique per instance."""
+        for attr in self._OWNED_WS_NAME_ATTRS:
+            wsname = getattr(self, attr)
+            if ADS.doesExist(wsname):
+                ADS.remove(wsname)
+
+    @property
+    def instr(self) -> str:
+        return self._model.instrument.get_instrument()
+
+    @property
+    def scattering_centre(self) -> np.ndarray:
+        return get_scattering_centre(self.ws)
+
+    def update_ws(self) -> None:
+        if self.ws:
+            # rebuilding for a new instrument: _update_existing_wss copies the sample (including
+            # whatever material the user set via the SetSampleMaterial dialog) onto the new
+            # workspaces, so we must not reset the material here
+            self._update_existing_wss()
+        else:
+            # brand-new workspaces have no material; seed the default so absorption works out of the box
+            self._init_wss()
+            self.set_material()
+        self.ungrouped_ws = CloneWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ungrouped_wsname)
+        if self.gauge_volume_str:
+            define_gauge_volume(self.ws, self.gauge_volume_str)
+
+    def _update_existing_wss(self) -> None:
+        # ws and updated_mesh_ws carry the user's initial shape rotation (init_R); it must survive the
+        # instrument switch, but a plain CopySample drops it for a CSG shape (see
+        # copy_sample_preserving_initial_rotation), so preserve it explicitly. mesh_ws is the pristine,
+        # un-rotated sample and is copied as-is.
+        ws = self._create_new_ws_with_copied_sample(self.wsname, self.ws, clone=True, preserve_initial_rotation=True)
+        mesh_ws = self._create_new_ws_with_copied_sample(self.WS_MESH_RAW, self.mesh_ws, clone=True)
+        updated_mesh_ws = self._create_new_ws_with_copied_sample(
+            self.WS_MESH_NEUTRAL, self.updated_mesh_ws, clone=True, preserve_initial_rotation=True
+        )
+        self.ws = ws
+        self.mesh_ws = mesh_ws
+        self.updated_mesh_ws = updated_mesh_ws
+
+    def _init_wss(self) -> None:
+        ws = CreateSimulationWorkspace(Instrument=self.instr, BinParams="0,0.1,5", OutputWorkspace=self.wsname, UnitX="dSpacing")
+        for ispec in range(ws.getNumberHistograms()):
+            ws.setY(ispec, np.ones_like(ws.readY(ispec)))
+        mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_RAW)
+        updated_mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_NEUTRAL)
+        self.ws = ws
+        self.mesh_ws = mesh_ws
+        self.updated_mesh_ws = updated_mesh_ws
+        self._set_default_shape_on_wss()
+        # ground-truth material holder, seeded with the default. Cloned after the default shape is
+        # set so it owns a shape to hang the material on. set_material copies from here, so the
+        # default is applied to the other wss in the brand-new branch of update_ws.
+        self.material_ws = CloneWorkspace(InputWorkspace=self.mesh_ws, OutputWorkspace=self.WS_MATERIAL)
+        SetSampleMaterial(self.material_ws, self.DEFAULT_MATERIAL)
+
+    def _set_default_shape_on_wss(self) -> None:
+        SetSampleShape(self.ws, get_cube_xml("default_cube", 0.01))
+        SetSampleShape(self.mesh_ws, get_cube_xml("default_cube", 0.01))
+        SetSampleShape(self.updated_mesh_ws, get_cube_xml("default_cube", 0.01))
+
+    @staticmethod
+    def _copy_material(source: MatrixWorkspace, target: MatrixWorkspace) -> None:
+        # copy only the material (not shape/orientation/etc.), preserving its full definition
+        # including the number/mass density
+        CopySample(
+            InputWorkspace=source,
+            OutputWorkspace=target,
+            CopyName=False,
+            CopyMaterial=True,
+            CopyShape=False,
+            CopyEnvironment=False,
+            CopyLattice=False,
+        )
+
+    def set_material(self) -> None:
+        """Apply the ground-truth material (material_ws) onto the shape workspaces"""
+        targets = [self.ws, self.mesh_ws, self.updated_mesh_ws]
+        if self.ungrouped_ws is not None:
+            targets.append(self.ungrouped_ws)
+        for target in targets:
+            self._copy_material(self.material_ws, target)
+
+    def get_material_name(self) -> str:
+        """Chemical formula / name of the ground-truth material. Returns "" when no material is set."""
+        try:
+            return self.material_ws.sample().getMaterial().name()
+        except (AttributeError, RuntimeError):
+            return ""
+
+    def propagate_material(self) -> None:
+        """Share the material the user just set via the SetSampleMaterial dialog (which only writes to
+        WS_MESH_RAW) with the other workspaces. The raw mesh ws becomes the new ground truth, so it is
+        captured onto material_ws as well, ensuring later shape reloads re-apply this exact material."""
+        self._copy_material(self.mesh_ws, self.material_ws)
+        targets = [self.ws, self.updated_mesh_ws]
+        if self.ungrouped_ws is not None:
+            targets.append(self.ungrouped_ws)
+        for target in targets:
+            self._copy_material(self.mesh_ws, target)
+
+    def load_stl(self, stl_file: str) -> None:
+        LoadSampleShape(InputWorkspace=self.ws, Filename=stl_file, OutputWorkspace=self.ws, **self.stl_kwargs)
+        LoadSampleShape(InputWorkspace=self.mesh_ws, Filename=stl_file, OutputWorkspace=self.mesh_ws, **self.stl_kwargs)
+        LoadSampleShape(InputWorkspace=self.updated_mesh_ws, Filename=stl_file, OutputWorkspace=self.updated_mesh_ws, **self.stl_kwargs)
+        self.set_material()
+
+    def load_xml(self, xml_file: str) -> None:
+        with open(xml_file, "r") as f:
+            xml_string = f.read()
+        SetSampleShape(self.ws, xml_string)
+        SetSampleShape(self.mesh_ws, xml_string)
+        SetSampleShape(self.updated_mesh_ws, xml_string)
+        self.set_material()
+
+    @staticmethod
+    def translate_shape(ws: MatrixWorkspace, x_pos: float | int, y_pos: float | int, z_pos: float | int) -> None:
+        if not (x_pos == 0.0 and y_pos == 0.0 and z_pos == 0.0):
+            TranslateSampleShape(InputWorkspace=ws, TranslationVector=f"{x_pos},{y_pos},{z_pos}")
+
+    def update_initial_shape(
+        self, x_rot: float | int, y_rot: float | int, z_rot: float | int, x_pos: float | int, y_pos: float | int, z_pos: float | int
+    ) -> None:
+        _tmp_ws = self._create_new_ws_with_copied_sample(self.WS_TMP, self.mesh_ws)
+        self.offset = (x_pos, y_pos, z_pos)
+        self.translate_shape(_tmp_ws, *self.offset)
+
+        try:
+            # CopySample bakes the destination workspace's current goniometer R into the new
+            # shape's XML (see CopySample::copyParameters -> addGoniometerTag), and the plotter
+            # leaves a non-identity R on self.ws on every redraw.
+            #
+            # Reset to identity *before* the CopySamples so the shape we hand on carries only init_R
+            self.ws.run().getGoniometer().setR(np.eye(3))
+            CopySample(InputWorkspace=_tmp_ws, OutputWorkspace=self.wsname, CopyName=False, CopyEnvironment=False, CopyLattice=False)
+            CopySample(
+                InputWorkspace=_tmp_ws, OutputWorkspace=self.updated_mesh_ws, CopyName=False, CopyEnvironment=False, CopyLattice=False
+            )
+
+            if self._all_rots_zero(x_rot, y_rot, z_rot):
+                self.init_R = Rotation.identity()
+
+            else:
+                self.init_R = Rotation.from_euler("xyz", (x_rot, y_rot, z_rot), degrees=True)
+                self.rotate_samples_by_initial_goniometer()
+        finally:
+            # guard so a failure before the temp ws was created does not mask the original error
+            if ADS.doesExist(self.WS_TMP):
+                ADS.remove(self.WS_TMP)
+
+    @staticmethod
+    def _all_rots_zero(x_rot: float | int, y_rot: float | int, z_rot: float | int) -> bool:
+        return np.isclose(x_rot, 0) and np.isclose(y_rot, 0) and np.isclose(z_rot, 0)
+
+    def rotate_samples_by_initial_goniometer(self) -> None:
+        rot_vec = self.init_R.as_rotvec(degrees=True)
+        ang = np.linalg.norm(rot_vec)
+        if ang == 0:
+            return None
+        vec = rot_vec / ang
+
+        RotateSampleShape(self.wsname, f"{ang},{vec[0]},{vec[1]},{vec[2]},1")
+        RotateSampleShape(self.updated_mesh_ws, f"{ang},{vec[0]},{vec[1]},{vec[2]},1")
+
+    def set_gauge_volume_str(self, preset: str | None, custom: str | None) -> None:
+        self.gauge_volume_str = get_gauge_vol_str(preset, custom)
+        if self.gauge_volume_str:
+            define_gauge_volume(self.ws, self.gauge_volume_str)
+        elif self.ws.run().hasProperty("GaugeVolume"):
+            DeleteLog(Workspace=self.ws, Name="GaugeVolume")
+
+    def _create_new_ws_with_copied_sample(
+        self, new_wsname: str, sample_to_copy: MatrixWorkspace, clone: bool = False, preserve_initial_rotation: bool = False
+    ) -> MatrixWorkspace:
+        if clone:
+            shape_ws = CloneWorkspace(InputWorkspace=sample_to_copy, OutputWorkspace=self._SHAPE_TMP)
+        else:
+            shape_ws = sample_to_copy
+        try:
+            new_ws = CreateSimulationWorkspace(Instrument=self.instr, BinParams="0,0.1,5", OutputWorkspace=new_wsname, UnitX="dSpacing")
+            if preserve_initial_rotation:
+                self.copy_sample_preserving_initial_rotation(shape_ws, new_ws)
+            else:
+                CopySample(InputWorkspace=shape_ws, OutputWorkspace=new_wsname, CopyName=False, CopyEnvironment=False, CopyLattice=False)
+        finally:
+            if clone and ADS.doesExist(self._SHAPE_TMP):
+                ADS.remove(self._SHAPE_TMP)
+        return new_ws
+
+    @staticmethod
+    def _shape_is_mesh(ws: MatrixWorkspace) -> bool:
+        # a loaded STL becomes a MeshObject; the default cube and a loaded CSG xml are CSGObjects.
+        return type(ws.sample().getShape()).__name__ == "MeshObject"
+
+    def copy_sample_preserving_initial_rotation(self, source_ws: MatrixWorkspace, dest_ws: MatrixWorkspace) -> None:
+        """CopySample source_ws's sample onto dest_ws while keeping source_ws's baked-in initial
+        shape rotation (init_R).
+
+        CopySample re-bakes the *destination* workspace's run goniometer into the copied shape: for a
+        CSG shape it overwrites the <goniometer> tag that holds init_R (so a copy into an
+        identity-goniometer workspace silently strips init_R), while for a MeshObject it rotates the
+        vertices that already hold init_R. So the destination must carry init_R for a CSG shape, and
+        stay at identity for a mesh (otherwise init_R would be applied a second time). The destination
+        goniometer is only a vehicle for re-baking init_R into the shape, so it is restored to
+        identity afterwards - init_R must live in the shape, never in the run goniometer."""
+        gonio_R = np.eye(3) if self._shape_is_mesh(source_ws) else self.init_R.as_matrix()
+        dest_ws.run().getGoniometer().setR(gonio_R)
+        CopySample(InputWorkspace=source_ws, OutputWorkspace=dest_ws, CopyName=False, CopyEnvironment=False, CopyLattice=False)
+        dest_ws.run().getGoniometer().setR(np.eye(3))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -42,64 +42,60 @@ class WorkspaceManager:
     them. Reads instrument name from the parent model via a back-reference.
     """
 
-    # Workspace names used by the planner. All start with "__" so the ADS treats them as hidden.
-    # Each holds a distinct view of the sample needed by a specific consumer:
-    #   WS_DATA          live workspace driving plots/exports: holds the translated shape with init_R
-    #                    baked into its XML goniometer tag, and carries the current orientation R on
-    #                    its run goniometer. Read by get_scattering_centre, GroupDetectors, etc.
-    #   WS_UNGROUPED     pre-group clone of WS_DATA; detector_geometry re-runs GroupDetectors against
-    #                    this whenever the group pattern changes (can't ungroup an already-grouped ws).
-    #   WS_MESH_RAW      pristine sample (no init_R, no translation, identity goniometer). Source of
-    #                    truth for absorption (which composes R*init_R itself) and for rebuilding
-    #                    WS_DATA in update_initial_shape.
-    #   WS_MESH_NEUTRAL  init_R baked in, no translation, identity goniometer. Used by the plotter
-    #                    (which applies R itself to the mesh vertices) and by the reference-ws export.
-    #   WS_REFERENCE     transient name for output_as_reference_workspace; created and removed inside
-    #                    the export call, never persists across calls.
-    #   WS_MC_INPUT      per-orientation MonteCarloAbsorption input. Rebuilt each calc_for_index with
-    #                    R*init_R baked into the shape and identity goniometer.
-    #   WS_MC_OUTPUT     MonteCarloAbsorption output (transmission factors).
-    #   WS_TMP           transient name for update_initial_shape's working copy; removed in finally.
-    #   WS_MATERIAL      dedicated holder for the ground-truth sample material. Its shape is never
-    #                    reloaded, so it survives shape changes and lets set_material re-apply the
-    #                    full material (formula + number/mass density) via CopySample rather than a
-    #                    lossy formula-only round-trip through SetSampleMaterial.
-    WS_DATA = "__texture_planning_ws"
-    WS_UNGROUPED = "__texture_planning_ws_ungrouped"
-    WS_MESH_RAW = "__texture_planning_raw_sample_mesh"
-    WS_MESH_NEUTRAL = "__texture_planning_neutral_sample_mesh"
-    WS_MATERIAL = "__texture_planning_material"
-    WS_REFERENCE = "__texture_planning_reference_ws"
-    WS_MC_INPUT = "__mc_ws"
-    WS_MC_OUTPUT = "__abs_ws"
-    WS_TMP = "__tmp_ws"
-    _SHAPE_TMP = "__shape_ws"
-
-    # The class constants above are base names. Each instance shadows them with per-instance copies
-    # carrying a unique suffix (see __init__) so that several planner windows open at once don't
-    # collide on the ADS. Listed here once so __init__ can suffix them and cleanup() can remove them.
-    _OWNED_WS_NAME_ATTRS = (
-        "WS_DATA",
-        "WS_UNGROUPED",
-        "WS_MESH_RAW",
-        "WS_MESH_NEUTRAL",
-        "WS_MATERIAL",
-        "WS_REFERENCE",
-        "WS_MC_INPUT",
-        "WS_MC_OUTPUT",
-        "WS_TMP",
-        "_SHAPE_TMP",
-    )
-
     DEFAULT_MATERIAL = "Fe"
 
     def __init__(self, model: _BaseModelType):
         self._model = model
-        # Several planner windows can be open simultaneously, so suffix every workspace name with a
-        # token unique to this instance.
-        self._suffix = f"_{uuid4().hex[:8]}"
-        for attr in self._OWNED_WS_NAME_ATTRS:
-            setattr(self, attr, getattr(self, attr) + self._suffix)
+        # Workspace names used by the planner
+        # Several planner windows could be open simultaneously, so every name carries a token unique to
+        # this instance and no two managers collide on the ADS. Each holds a distinct view of the
+        # sample needed by a specific consumer:
+        #   WS_DATA          live workspace driving plots/exports: holds the translated shape with
+        #                    init_R baked into its XML goniometer tag, and carries the current
+        #                    orientation R on its run goniometer. Read by get_scattering_centre,
+        #                    GroupDetectors, etc.
+        #   WS_UNGROUPED     pre-group clone of WS_DATA; detector_geometry re-runs GroupDetectors
+        #                    against this whenever the group pattern changes (slow to ungroup an
+        #                    already-grouped ws).
+        #   WS_MESH_RAW      pristine sample (no init_R, no translation, identity goniometer). Source
+        #                    of truth for absorption (which composes R*init_R itself) and for
+        #                    rebuilding WS_DATA in update_initial_shape.
+        #   WS_MESH_NEUTRAL  init_R baked in, no translation, identity goniometer. Used by the plotter
+        #                    (which applies R itself to the mesh vertices) and by the reference-ws export.
+        #   WS_REFERENCE     transient name for output_as_reference_workspace; created and removed inside
+        #                    the export call, never persists across calls.
+        #   WS_MC_INPUT      per-orientation MonteCarloAbsorption input. Rebuilt each calc_for_index with
+        #                    R*init_R baked into the shape and identity goniometer.
+        #   WS_MC_OUTPUT     MonteCarloAbsorption output (transmission factors).
+        #   WS_TMP           transient name for update_initial_shape's working copy; removed in finally.
+        #   WS_MATERIAL      dedicated holder for the ground-truth sample material. Its shape is never
+        #                    reloaded, so it survives shape changes and lets set_material re-apply the
+        #                    full material (formula + number/mass density) via CopySample rather than a
+        #                    round-trip through SetSampleMaterial.
+        suffix = f"_{uuid4().hex[:8]}"
+        self.WS_DATA = "__texture_planning_ws" + suffix
+        self.WS_UNGROUPED = "__texture_planning_ws_ungrouped" + suffix
+        self.WS_MESH_RAW = "__texture_planning_raw_sample_mesh" + suffix
+        self.WS_MESH_NEUTRAL = "__texture_planning_neutral_sample_mesh" + suffix
+        self.WS_MATERIAL = "__texture_planning_material" + suffix
+        self.WS_REFERENCE = "__texture_planning_reference_ws" + suffix
+        self.WS_MC_INPUT = "__mc_ws" + suffix
+        self.WS_MC_OUTPUT = "__abs_ws" + suffix
+        self.WS_TMP = "__tmp_ws" + suffix
+        self._SHAPE_TMP = "__shape_ws" + suffix
+        # Every workspace this instance owns, so cleanup() can remove them all from the ADS.
+        self._owned_ws_names = (
+            self.WS_DATA,
+            self.WS_UNGROUPED,
+            self.WS_MESH_RAW,
+            self.WS_MESH_NEUTRAL,
+            self.WS_MATERIAL,
+            self.WS_REFERENCE,
+            self.WS_MC_INPUT,
+            self.WS_MC_OUTPUT,
+            self.WS_TMP,
+            self._SHAPE_TMP,
+        )
         self.wsname = self.WS_DATA
         self.ungrouped_wsname = self.WS_UNGROUPED
         self.ws = None  # holds the translated shape with init_R
@@ -123,8 +119,7 @@ class WorkspaceManager:
         """Remove every workspace this instance owns from the ADS. Called when the planner window
         closes so the (hidden) workspaces don't accumulate across open/close cycles now that their
         names are unique per instance."""
-        for attr in self._OWNED_WS_NAME_ATTRS:
-            wsname = getattr(self, attr)
+        for wsname in self._owned_ws_names:
             if ADS.doesExist(wsname):
                 ADS.remove(wsname)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -114,7 +114,7 @@ class WorkspaceManager:
         self.offset = (0, 0, 0)
         self.gauge_volume_str = None
         # stl_settings
-        self.stl_kwargs = {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": "0", "TranslationVector": "0,0,0"}
+        self.stl_kwargs = {"Scale": "cm", "XDegrees": 0, "YDegrees": 0, "ZDegrees": 0, "TranslationVector": "0,0,0"}
         # attenuation-point settings read by AbsorptionCalculator. The material itself lives on
         # material_ws (the ground truth), not here.
         self.attenuation_kwargs = {"point": 1.5, "unit": "dSpacing"}


### PR DESCRIPTION
### Description of work

**This module handles the logic for handling the underlying hidden workspaces which the interface uses to keep track of the experimental settings. It is the largest and probably the messiest of the modules but I think all of the workspaces are required to hold different ground truth states and allow for interactive user modification (e.g. to dynamically translate the sample we need a workspace with a ground truth of the un-translated sample)**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
