### PR TITLE
Introduced nightly publishing branch as a github actions variable BRANCH_TO_PUBLISH

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: benelan/milestone-action@v3
         with:
-          farthest: false      # false = use current milestone by due date
+          # When the target branch == vars.BRANCH_TO_PUBLISH, set the current milestone. Otherwise set the next milestone
+          farthest: ${{ github.base_ref != vars.BRANCH_TO_PUBLISH }}
           overwrite: false     # don't overwrite if milestone already exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -10,8 +10,7 @@ on:
     - cron: 0 6 * * *
 
 env:
-  # change this between main and release-next
-  UPDATE_BRANCH: release-next
+  UPDATE_BRANCH: ${{ vars.BRANCH_TO_PUBLISH }}
 
 jobs:
   pixi-update-lockfile:

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -435,6 +435,7 @@ Code Freeze
   <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__. This will
   set the value of the Jenkins global property ``BRANCH_TO_PUBLISH`` to ``release-next``,
   which will re-enable package publishing for the ``release-next`` nightly pipeline.
+* Set the value of the `github actions variable <https://github.com/mantidproject/mantid/settings/variables/actions>`__ ``BRANCH_TO_PUBLISH`` to ``release-next``. This will set the target branch used by `github workflow <https://github.com/mantidproject/mantid/blob/main/.github/workflows/update-pixi-lockfile.yml>`__ for updating pixi lock file. And the same variable is also used to `determine the milestone <https://github.com/mantidproject/mantid/blob/main/.github/workflows/add-milestone.yml>`__ for pull requests without an assigned milestone.
 * Check the state of all open pull requests for this milestone and decide which
   should be kept for the release, liaise with the Release Manager on this. Move any
   pull requests not targeted for this release out of the milestone, and then change
@@ -571,6 +572,7 @@ Anaconda channel.
 *  Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__ Jenkins job.
    This will set the value of the Jenkins global property ``BRANCH_TO_PUBLISH`` to ``main``, which will re-enable package
    publishing for the ``main`` nightly pipeline.
+*  Set the value of the `github actions variable <https://github.com/mantidproject/mantid/settings/variables/actions>`__ ``BRANCH_TO_PUBLISH`` back to ``main``.
 
 **Generate DOI**
 


### PR DESCRIPTION
### Description of work

This pull request introduces a new [github actions variable](https://github.com/mantidproject/mantid/settings/variables/actions) `BRANCH_TO_PUBLISH` and updated two existing github actions workflows as below to consume it.

1. The workflow to determine the target branch for updating pixi lockfile
2. The workflow to set a milestone for pull requests without a milestone.

In addition this PR updates the [Release checklist documentation](https://developer.mantidproject.org/ReleaseChecklist.html) with the instructions on when and how to set this new github actions variable by the technical release manager.

Closes https://github.com/mantidproject/mantid/issues/41454.

### To test:

1. Code review
2. Cherry pick these changes( git cherry-pick https://github.com/mantidproject/mantid/commit/2a152201549b1edc7cdcb1a151aeca60380265bc ) or branch off from this feature branch(41454_gh_actions_branch_variable)
3. Create a dummy PR without a milestone targetting main branch.
4. When the BRANCH_TO_PUBLISH variable and the target branch of your pr do not match, the milestone of your PR should get the next milestone(i.e: Release 6.17).
5. Create another dummy PR without a milestone targetting release-next branch.
6. When the BRANCH_TO_PUBLISH variable and the target branch of your pr match, the milestone of the PR should get the current milestone (i.e Release 6.16)
7. After testing close those PRs.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
