### PR TITLE
Skip tests in case of database unavailability (release-next)

### DIFF
--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -129,7 +129,7 @@ class MantidORSODataset:
                     try:
                         future.result(timeout=5.0)
                     except concurrent.futures.TimeoutError:
-                        logger.error(f"The provided model description '{model}' could not be validated because of database unavalibility.")
+                        logger.error(f"The provided model description '{model}' could not be validated because of database unavailability.")
                         self._header = None
                         return
                     except:

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -246,11 +246,20 @@ class MantidORSODatasetTest(unittest.TestCase):
 
     @mock.patch("mantid.utils.reflectometry.orso_helper.logger.error")
     def test_create_mandatory_header_raises_error(self, mock_logger):
-        model_def = ["air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
+        model_def = ["air | Ni 100 | SiO2 0.5 | 02", "air | 25 [ Si 7 | Fe 7 ] | Si", "Si | SiO2 0.5 | wat:er"]
         for model in model_def:
             MantidORSODataset(None, None, None, None, None, None, None, model=model, validate=True)
+
+        error_messages = [call.args[0] for call in mock_logger.call_args_list]
+        if any("could not be validated because of database unavailability." in msg for msg in error_messages):
+            self.skipTest("ORSO database unavailable; validation could not be performed.")
+
         mock_logger.assert_has_calls(
             [
+                mock.call(
+                    "The provided model description 'air | Ni 100 | SiO2 0.5 | 02' contains an error. "
+                    "Please check that the string follows the correct ORSO format."
+                ),
                 mock.call(
                     "The provided model description 'air | 25 [ Si 7 | Fe 7 ] | Si' contains an error. "
                     "Please check that the string follows the correct ORSO format."
@@ -273,7 +282,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         MantidORSODataset(None, None, None, None, None, None, None, model="air", validate=True)
         error_logger.assert_has_calls(
             [
-                mock.call("The provided model description 'air' could not be validated because of database unavalibility."),
+                mock.call("The provided model description 'air' could not be validated because of database unavailability."),
             ]
         )
 


### PR DESCRIPTION
### Description of work
Put https://github.com/mantidproject/mantid/pull/41619 into release-next to avoid sporadic failures die to database connectivity issues.

### To test:
Tests should pass.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
