### PR TITLE
Add TexturePlanner orientation_table helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py
                   helpers/test/test_workspace_manager.py helpers/test/test_plotter.py helpers/test/test_instrument.py
-)
+                  helpers/test/test_orientation_table.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,8 +1,9 @@
 # Tests for the Texture Planner interface
 
-set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py
-                  helpers/test/test_workspace_manager.py helpers/test/test_plotter.py helpers/test/test_instrument.py
-                  helpers/test/test_orientation_table.py)
+set(TEST_PY_FILES
+    helpers/test/test_absorption.py helpers/test/test_detector_geometry.py helpers/test/test_workspace_manager.py
+    helpers/test/test_plotter.py helpers/test/test_instrument.py helpers/test/test_orientation_table.py
+)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
@@ -1,0 +1,258 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from collections.abc import KeysView, ValuesView, ItemsView
+
+import numpy as np
+from dataclasses import dataclass, field
+from typing import List, Tuple, Sequence
+from scipy.spatial.transform import Rotation
+from mantid.kernel import logger
+from Engineering.texture.texture_helper import vec_string_to_norm_array
+
+
+MAX_GONIOMETERS = 6
+_DEFAULT_GONIO_STRING = "0,1.0,0.0,0.0,-1"  # angle=0, vec=(1,0,0), sense=-1
+
+
+@dataclass
+class Orientation:
+    """One row in the orientation table: goniometer settings, the resulting
+    rotation(s), inclusion/selection flags, and any cached projection / MC results."""
+
+    gonio_strings: List[str] = field(default_factory=lambda: [_DEFAULT_GONIO_STRING] * MAX_GONIOMETERS)
+    gRs: List[Rotation] = field(default_factory=lambda: [Rotation.identity()])
+    R: Rotation = field(default_factory=Rotation.identity)
+    include: bool = True
+    select: bool = True
+    pf_points: np.ndarray | None = None
+    transmission: np.ndarray | None = None
+
+    def copy(self) -> "Orientation":
+        return Orientation(
+            gonio_strings=list(self.gonio_strings),
+            gRs=list(self.gRs),
+            R=self.R,
+            include=self.include,
+            select=self.select,
+            pf_points=self.pf_points,
+            transmission=self.transmission,
+        )
+
+
+class OrientationTable:
+    """The list of saved orientations and operations on them (add / select /
+    include / delete / load-from-file / goniometer-string IO).
+
+    Holds the table-level state (saved_orientations, orientation_index,
+    n_gonio) and the Euler goniometer convention (orientation_kwargs) used when
+    loading orientation files.
+    """
+
+    # Returned by load_orientation_file when the file is not in Euler-angles format
+    # (matrix format, or an error path). Falls back to a 3-axis (YXY) goniometer view.
+    _DEFAULT_NUM_AXES = 3
+
+    def __init__(self):
+        # Euler goniometer convention used when loading orientation files (Axes scheme + Senses).
+        self.orientation_kwargs = {"Axes": "YXY", "Senses": "-1,-1,-1"}
+        self.sense_vals = {"Clockwise": -1, "Counterclockwise": 1}  # mantid convention
+        self.sense_names = {"-1": "Clockwise", "1": "Counterclockwise"}
+        self.axis_dict = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}
+        self.n_gonio = 2
+        self.orientation_index = 0
+        self.saved_orientations = {0: self._make_default_orientation()}
+
+    # dict-like access ---------------------------------------------------
+    def __getitem__(self, index: int) -> Orientation:
+        return self.saved_orientations[index]
+
+    def keys(self) -> KeysView:
+        return self.saved_orientations.keys()
+
+    def values(self) -> ValuesView:
+        return self.saved_orientations.values()
+
+    def items(self) -> ItemsView:
+        return self.saved_orientations.items()
+
+    # index / count ------------------------------------------------------
+    def get_orientation_index(self) -> int:
+        return self.orientation_index
+
+    def set_orientation_index(self, index: int) -> None:
+        self.orientation_index = index
+
+    def get_num_orientations(self) -> int:
+        return len(self.saved_orientations.keys())
+
+    def get_table_info(self) -> List[List[str | bool]]:
+        return [[list(v.gonio_strings), v.include, v.select] for v in self.saved_orientations.values()]
+
+    def set_n_gonio(self, val: int) -> None:
+        self.n_gonio = val
+
+    # setting values from elsewhere ---------------------------------------
+
+    def set_transmission_at_index(self, transmission: np.ndarray, index: int) -> None:
+        self.saved_orientations[index].transmission = transmission
+
+    # rotation maths -----------------------------------------------------
+    def calc_gRs(
+        self, vecs: List[Tuple[int | float, int | float, int | float]], senses: List[int | float], angles: List[int | float]
+    ) -> Tuple[List[Rotation], Rotation]:
+        gRs = [Rotation.identity()]
+        R = Rotation.identity()
+        for i, vec in enumerate(vecs):
+            sense = senses[i]
+            r_step = Rotation.from_davenport(vec, "extrinsic", sense * angles[i], degrees=True)
+            R = R * r_step
+            gRs.append(R)
+        return gRs, R
+
+    def update_gRs(
+        self,
+        vecs: List[Tuple[int | float, int | float, int | float]],
+        senses: List[int | float],
+        angles: List[int | float],
+        current_index: int,
+    ) -> None:
+        gRs, R = self.calc_gRs(vecs, senses, angles)
+        self.saved_orientations[current_index].gRs = gRs
+        self.saved_orientations[current_index].R = R
+
+    # selection / inclusion / delete ------------------------------------
+    def update_selected(self, selected_inds: Sequence[int]) -> None:
+        for k, v in self.saved_orientations.items():
+            v.select = k in selected_inds
+
+    def update_included(self, included_inds: Sequence[int]) -> None:
+        for k, v in self.saved_orientations.items():
+            v.include = k in included_inds
+
+    def select_all(self) -> None:
+        for v in self.saved_orientations.values():
+            v.select = True
+
+    def deselect_all(self) -> None:
+        for v in self.saved_orientations.values():
+            v.select = False
+
+    def delete_selected(self) -> None:
+        to_keep = [k for k, v in self.saved_orientations.items() if not v.select]
+        if len(to_keep) == 0:
+            self.saved_orientations = {0: self._make_default_orientation()}
+        else:
+            self.saved_orientations = {i: self.saved_orientations[k] for i, k in enumerate(to_keep)}
+        new_orientation_index = to_keep.index(self.orientation_index) if self.orientation_index in to_keep else 0
+        self.set_orientation_index(new_orientation_index)
+
+    def add_orientation(self) -> None:
+        # create a new orientation, initially just as a copy of the current orientation
+        self.saved_orientations[self.get_num_orientations()] = self.saved_orientations[self.orientation_index].copy()
+
+    # defaults / goniometer string IO -----------------------------------
+    def _make_default_orientation(self) -> Orientation:
+        vecs = [(1, 0, 0)] * MAX_GONIOMETERS
+        senses = [-1] * MAX_GONIOMETERS
+        angles = [0.0] * MAX_GONIOMETERS
+        gRs, R = self.calc_gRs(vecs[: self.n_gonio], senses[: self.n_gonio], angles[: self.n_gonio])
+        gonio_strings = [self.get_goniometer_string(vecs[i], senses[i], angles[i]) for i in range(MAX_GONIOMETERS)]
+        return Orientation(gonio_strings=gonio_strings, gRs=gRs, R=R)
+
+    @staticmethod
+    def get_goniometer_string(vec: Tuple[int | float, int | float, int | float], sense: int | float, angle: int | float) -> str:
+        return f"{angle},{np.round(vec[0], 3)},{np.round(vec[1], 3)},{np.round(vec[2], 3)},{sense}"
+
+    def update_gonio_string(
+        self, vecs: List[Tuple[int | float, int | float, int | float]], senses: List[int | float], angles: List[int | float], index: int
+    ) -> None:
+        orientation = self.saved_orientations[index]
+        for i, vec in enumerate(vecs):
+            orientation.gonio_strings[i] = self.get_goniometer_string(vec, senses[i], angles[i])
+        for i in range(len(vecs), MAX_GONIOMETERS):
+            orientation.gonio_strings[i] = self.get_goniometer_string((1, 0, 0), 1, 0)
+
+    def read_goniometer_string(self, goniometer_string: str) -> Tuple[str, float, float]:
+        angle, v1, v2, v3, sense = goniometer_string.split(",")
+        return f"{v1},{v2},{v3}", self.sense_names[sense], float(angle)
+
+    def get_goniometer_values(self, index: int) -> Tuple[List[str], List[int | float], List[int | float]]:
+        info = self.saved_orientations[index]
+        vecs, senses, angles = [], [], []
+        for gonio_string in info.gonio_strings:
+            vec, sense, angle = self.read_goniometer_string(gonio_string)
+            vecs.append(vec)
+            senses.append(sense)
+            angles.append(angle)
+        return vecs, senses, angles
+
+    # file loaders -------------------------------------------------------
+    def load_orientation_file(self, txt_file: str) -> int:
+        """Load orientations from a whitespace/comma-separated text file."""
+        logger.notice("Loading Orientations from file")
+        with open(txt_file, "r") as f:
+            goniometer_strings = [line.strip().replace("\t", ",") for line in f]
+            goniometer_lists = [[float(x) for x in gs.split(",")] for gs in goniometer_strings]
+        if len(goniometer_lists) == 0:
+            logger.warning("No orientations found in file provided")
+            return self._DEFAULT_NUM_AXES
+        num_entries = len(goniometer_lists[0])
+        is_matrix_format = num_entries > 6
+        if is_matrix_format:
+            self._load_matrix_orientations(goniometer_lists)
+            return self._DEFAULT_NUM_AXES
+        return self._load_euler_orientations(goniometer_lists, num_entries)
+
+    def _load_matrix_orientations(self, goniometer_lists: List[List[float]]) -> None:
+        vecs = [(0, 1, 0), (1, 0, 0), (0, 1, 0)]
+        senses = [1, 1, 1]
+        for goniometer_list in goniometer_lists:
+            R_mat = np.asarray(goniometer_list[:9]).reshape((3, 3))
+            R = Rotation.from_matrix(R_mat)
+            # the YXY decomposition is only used to populate the displayed goniometer fields
+            display_angles = np.round(R.as_euler("YXY", degrees=True), 2)
+            self.add_orientation()
+            new_index = self.get_num_orientations() - 1
+            self.update_gonio_string(vecs, senses, display_angles, new_index)
+            self.update_gRs(vecs, senses, display_angles, new_index)
+            # preserve the exact input matrix so projection / export stay faithful to the file
+            self.saved_orientations[new_index].R = R
+
+    def _load_euler_orientations(self, goniometer_lists: List[List[float]], num_entries: int) -> int:
+        axes = self.orientation_kwargs["Axes"]
+        senses = self.orientation_kwargs["Senses"].split(",")
+        num_ax, num_senses = len(axes), len(senses)
+        errors = []
+        if num_entries != num_ax:
+            errors.append(f"Number of Angles ({num_entries}) does not match number of goniometer axes ({num_ax})")
+        if num_entries != num_senses:
+            errors.append(f"Number of Angles ({num_entries}) does not match number of goniometer senses ({num_senses})")
+        if errors:
+            logger.error("\n".join(errors) + "\n")
+            return self._DEFAULT_NUM_AXES
+        vecs = [self.axis_dict[ax.lower()] for ax in axes]
+        sense_ints = [int(sense) for sense in senses]
+        for angles in goniometer_lists:
+            self.add_orientation()
+            new_index = self.get_num_orientations() - 1
+            # the file angles are the source of truth; use them unrounded for both the displayed
+            # string and the rotation so the two cannot disagree
+            self.update_gonio_string(vecs, sense_ints, angles, new_index)
+            self.update_gRs(vecs, sense_ints, angles, new_index)
+        return num_ax
+
+    # helpers for converting view fields into typed values --------------
+    def get_vecs(self, all_vec_strings: List[str], num_gonios: int) -> List[np.ndarray]:
+        vec_strings = all_vec_strings[:num_gonios]
+        return [vec_string_to_norm_array(vec_string) for vec_string in vec_strings]
+
+    def get_senses(self, senses: List[str], num_gonios: int) -> List[float]:
+        return [self.sense_vals[x] for x in senses[:num_gonios]]
+
+    @staticmethod
+    def get_angles(angles: List[str], num_gonios: int) -> List[float]:
+        return [float(x) for x in angles[:num_gonios]]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
@@ -103,6 +103,7 @@ class OrientationTable:
 
     # rotation maths -----------------------------------------------------
     def calc_gRs(self, vecs: List[Tuple[float, float, float]], senses: List[float], angles: List[float]) -> Tuple[List[Rotation], Rotation]:
+        self._validate_gR_data(vecs, senses, angles)  # throws an error if these lists have become different lengths
         gRs = [Rotation.identity()]
         R = Rotation.identity()
         for i, vec in enumerate(vecs):
@@ -173,6 +174,7 @@ class OrientationTable:
         return f"{angle},{np.round(vec[0], 3)},{np.round(vec[1], 3)},{np.round(vec[2], 3)},{sense}"
 
     def update_gonio_string(self, vecs: List[Tuple[float, float, float]], senses: List[float], angles: List[float], index: int) -> None:
+        self._validate_gR_data(vecs, senses, angles)  # throws an error if these lists have become different lengths
         orientation = self.saved_orientations[index]
         for i, vec in enumerate(vecs):
             orientation.gonio_strings[i] = self.get_goniometer_string(vec, senses[i], angles[i])
@@ -261,3 +263,10 @@ class OrientationTable:
     @staticmethod
     def get_angles(angles: List[str], num_gonios: int) -> List[float]:
         return [float(x) for x in angles[:num_gonios]]
+
+    # validation helper
+
+    @staticmethod
+    def _validate_gR_data(vecs, senses, angles) -> None:
+        if len({len(vecs), len(senses), len(angles)}) != 1:
+            raise ValueError(f"Goniometer data lists have unequal lengths: vecs={len(vecs)}, senses={len(senses)}, angles={len(angles)}")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/orientation_table.py
@@ -12,6 +12,7 @@ from typing import List, Tuple, Sequence
 from scipy.spatial.transform import Rotation
 from mantid.kernel import logger
 from Engineering.texture.texture_helper import vec_string_to_norm_array
+import re
 
 
 MAX_GONIOMETERS = 6
@@ -38,8 +39,8 @@ class Orientation:
             R=self.R,
             include=self.include,
             select=self.select,
-            pf_points=self.pf_points,
-            transmission=self.transmission,
+            pf_points=None if self.pf_points is None else self.pf_points.copy(),
+            transmission=None if self.transmission is None else self.transmission.copy(),
         )
 
 
@@ -101,9 +102,7 @@ class OrientationTable:
         self.saved_orientations[index].transmission = transmission
 
     # rotation maths -----------------------------------------------------
-    def calc_gRs(
-        self, vecs: List[Tuple[int | float, int | float, int | float]], senses: List[int | float], angles: List[int | float]
-    ) -> Tuple[List[Rotation], Rotation]:
+    def calc_gRs(self, vecs: List[Tuple[float, float, float]], senses: List[float], angles: List[float]) -> Tuple[List[Rotation], Rotation]:
         gRs = [Rotation.identity()]
         R = Rotation.identity()
         for i, vec in enumerate(vecs):
@@ -115,14 +114,17 @@ class OrientationTable:
 
     def update_gRs(
         self,
-        vecs: List[Tuple[int | float, int | float, int | float]],
-        senses: List[int | float],
-        angles: List[int | float],
+        vecs: List[Tuple[float, float, float]],
+        senses: List[float],
+        angles: List[float],
         current_index: int,
     ) -> None:
         gRs, R = self.calc_gRs(vecs, senses, angles)
-        self.saved_orientations[current_index].gRs = gRs
-        self.saved_orientations[current_index].R = R
+        orientation = self.saved_orientations[current_index]
+        orientation.gRs = gRs
+        orientation.R = R
+        orientation.pf_points = None
+        orientation.transmission = None
 
     # selection / inclusion / delete ------------------------------------
     def update_selected(self, selected_inds: Sequence[int]) -> None:
@@ -164,12 +166,13 @@ class OrientationTable:
         return Orientation(gonio_strings=gonio_strings, gRs=gRs, R=R)
 
     @staticmethod
-    def get_goniometer_string(vec: Tuple[int | float, int | float, int | float], sense: int | float, angle: int | float) -> str:
+    def get_goniometer_string(vec: Tuple[float, float, float], sense: float, angle: float) -> str:
+        sense = int(float(sense))
+        if sense not in (-1, 1):
+            raise ValueError(f"Invalid goniometer sense: {sense}")
         return f"{angle},{np.round(vec[0], 3)},{np.round(vec[1], 3)},{np.round(vec[2], 3)},{sense}"
 
-    def update_gonio_string(
-        self, vecs: List[Tuple[int | float, int | float, int | float]], senses: List[int | float], angles: List[int | float], index: int
-    ) -> None:
+    def update_gonio_string(self, vecs: List[Tuple[float, float, float]], senses: List[float], angles: List[float], index: int) -> None:
         orientation = self.saved_orientations[index]
         for i, vec in enumerate(vecs):
             orientation.gonio_strings[i] = self.get_goniometer_string(vec, senses[i], angles[i])
@@ -178,9 +181,10 @@ class OrientationTable:
 
     def read_goniometer_string(self, goniometer_string: str) -> Tuple[str, float, float]:
         angle, v1, v2, v3, sense = goniometer_string.split(",")
-        return f"{v1},{v2},{v3}", self.sense_names[sense], float(angle)
+        sense_key = str(int(float(sense)))
+        return f"{v1},{v2},{v3}", self.sense_names[sense_key], float(angle)
 
-    def get_goniometer_values(self, index: int) -> Tuple[List[str], List[int | float], List[int | float]]:
+    def get_goniometer_values(self, index: int) -> Tuple[List[str], List[float], List[float]]:
         info = self.saved_orientations[index]
         vecs, senses, angles = [], [], []
         for gonio_string in info.gonio_strings:
@@ -196,7 +200,7 @@ class OrientationTable:
         logger.notice("Loading Orientations from file")
         with open(txt_file, "r") as f:
             goniometer_strings = [line.strip().replace("\t", ",") for line in f]
-            goniometer_lists = [[float(x) for x in gs.split(",")] for gs in goniometer_strings]
+            goniometer_lists = [[float(x) for x in re.split(r"[\s,]+", gs) if x] for gs in goniometer_strings]
         if len(goniometer_lists) == 0:
             logger.warning("No orientations found in file provided")
             return self._DEFAULT_NUM_AXES
@@ -214,11 +218,12 @@ class OrientationTable:
             R_mat = np.asarray(goniometer_list[:9]).reshape((3, 3))
             R = Rotation.from_matrix(R_mat)
             # the YXY decomposition is only used to populate the displayed goniometer fields
-            display_angles = np.round(R.as_euler("YXY", degrees=True), 2)
+            euler_angles = R.as_euler("YXY", degrees=True)
+            display_angles = np.round(euler_angles, 2)
             self.add_orientation()
             new_index = self.get_num_orientations() - 1
             self.update_gonio_string(vecs, senses, display_angles, new_index)
-            self.update_gRs(vecs, senses, display_angles, new_index)
+            self.update_gRs(vecs, senses, euler_angles, new_index)
             # preserve the exact input matrix so projection / export stay faithful to the file
             self.saved_orientations[new_index].R = R
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
@@ -1,0 +1,423 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+import numpy as np
+
+from unittest.mock import patch, call
+from scipy.spatial.transform import Rotation
+
+from mantidqtinterfaces.TexturePlanner.helpers.orientation_table import (
+    MAX_GONIOMETERS,
+    Orientation,
+    OrientationTable,
+    _DEFAULT_GONIO_STRING,
+)
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.orientation_table"
+
+
+def _make_table(axes="xyz", senses="1,1,1"):
+    table = OrientationTable()
+    table.orientation_kwargs = {"Axes": axes, "Senses": senses}
+    return table
+
+
+class TestOrientation_Copy(unittest.TestCase):
+    def test_copy_returns_independent_lists(self):
+        original = Orientation(
+            gonio_strings=["a", "b", "c"],
+            gRs=[Rotation.identity()],
+            R=Rotation.identity(),
+            include=False,
+            select=True,
+            pf_points=np.array([1.0, 2.0]),
+            transmission=np.array([0.5]),
+        )
+
+        clone = original.copy()
+        clone.gonio_strings[0] = "modified"
+        clone.gRs.append(Rotation.identity())
+
+        self.assertEqual(original.gonio_strings, ["a", "b", "c"])
+        self.assertEqual(len(original.gRs), 1)
+
+    def test_copy_preserves_scalar_and_array_fields(self):
+        pf = np.array([1.0, 2.0])
+        original = Orientation(include=False, select=True, pf_points=pf, transmission=None)
+
+        clone = original.copy()
+
+        self.assertFalse(clone.include)
+        self.assertTrue(clone.select)
+        self.assertIs(clone.pf_points, pf)
+        self.assertIsNone(clone.transmission)
+
+
+class TestOrientationTable_Init(unittest.TestCase):
+    def test_default_attributes(self):
+        tab = _make_table()
+
+        self.assertEqual(tab.sense_vals, {"Clockwise": -1, "Counterclockwise": 1})
+        self.assertEqual(tab.sense_names, {"-1": "Clockwise", "1": "Counterclockwise"})
+        self.assertEqual(tab.axis_dict, {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)})
+        self.assertEqual(tab.n_gonio, 2)
+        self.assertEqual(tab.orientation_index, 0)
+
+    def test_starts_with_one_default_orientation(self):
+        tab = _make_table()
+
+        self.assertEqual(list(tab.saved_orientations.keys()), [0])
+        self.assertIsInstance(tab.saved_orientations[0], Orientation)
+
+
+class TestOrientationTable_DictAccess(unittest.TestCase):
+    def test_getitem_returns_saved_orientation(self):
+        tab = _make_table()
+        self.assertIs(tab[0], tab.saved_orientations[0])
+
+    def test_keys_values_items(self):
+        tab = _make_table()
+        self.assertEqual(list(tab.keys()), [0])
+        self.assertEqual(list(tab.values()), [tab.saved_orientations[0]])
+        self.assertEqual(list(tab.items()), [(0, tab.saved_orientations[0])])
+
+
+class TestOrientationTable_IndexAndCount(unittest.TestCase):
+    def test_get_and_set_orientation_index(self):
+        tab = _make_table()
+        tab.set_orientation_index(5)
+        self.assertEqual(tab.get_orientation_index(), 5)
+
+    def test_get_num_orientations(self):
+        tab = _make_table()
+        self.assertEqual(tab.get_num_orientations(), 1)
+        tab.add_orientation()
+        self.assertEqual(tab.get_num_orientations(), 2)
+
+    def test_set_n_gonio(self):
+        tab = _make_table()
+        tab.set_n_gonio(4)
+        self.assertEqual(tab.n_gonio, 4)
+
+
+class TestOrientationTable_GetTableInfo(unittest.TestCase):
+    def test_returns_gonio_strings_include_select_per_orientation(self):
+        tab = _make_table()
+        tab.add_orientation()
+        tab[0].include = True
+        tab[0].select = False
+        tab[1].include = False
+        tab[1].select = True
+
+        info = tab.get_table_info()
+
+        self.assertEqual(len(info), 2)
+        self.assertEqual(info[0][1:], [True, False])
+        self.assertEqual(info[1][1:], [False, True])
+        self.assertEqual(info[0][0], list(tab[0].gonio_strings))
+
+
+class TestOrientationTable_SetTransmissionAtIndex(unittest.TestCase):
+    def test_assigns_transmission_to_correct_orientation(self):
+        tab = _make_table()
+        tab.add_orientation()
+        transmission = np.array([0.1, 0.2, 0.3])
+
+        tab.set_transmission_at_index(transmission, 1)
+
+        np.testing.assert_array_equal(tab[1].transmission, transmission)
+        self.assertIsNone(tab[0].transmission)
+
+
+class TestOrientationTable_CalcGRs(unittest.TestCase):
+    def test_returns_identity_for_zero_angles(self):
+        tab = _make_table()
+
+        gRs, R = tab.calc_gRs([(1, 0, 0), (0, 1, 0)], [1, 1], [0.0, 0.0])
+
+        self.assertEqual(len(gRs), 3)
+        for g in gRs:
+            np.testing.assert_allclose(g.as_matrix(), np.eye(3))
+        np.testing.assert_allclose(R.as_matrix(), np.eye(3))
+
+    def test_composes_rotations_in_order_and_applies_sense(self):
+        tab = _make_table()
+
+        gRs, R = tab.calc_gRs([(1, 0, 0)], [-1], [90.0])
+
+        # Davenport extrinsic about x by -1 * 90 = -90 degrees
+        expected = Rotation.from_euler("x", -90, degrees=True)
+        np.testing.assert_allclose(R.as_matrix(), expected.as_matrix(), atol=1e-12)
+        np.testing.assert_allclose(gRs[1].as_matrix(), expected.as_matrix(), atol=1e-12)
+        np.testing.assert_allclose(gRs[0].as_matrix(), np.eye(3))
+
+
+class TestOrientationTable_UpdateGRs(unittest.TestCase):
+    def test_assigns_gRs_and_R_onto_orientation_at_index(self):
+        tab = _make_table()
+        tab.add_orientation()
+
+        tab.update_gRs([(1, 0, 0)], [1], [45.0], 1)
+
+        expected = Rotation.from_euler("x", 45, degrees=True)
+        np.testing.assert_allclose(tab[1].R.as_matrix(), expected.as_matrix(), atol=1e-12)
+        self.assertEqual(len(tab[1].gRs), 2)
+        # untouched orientation unchanged
+        np.testing.assert_allclose(tab[0].R.as_matrix(), np.eye(3))
+
+
+class TestOrientationTable_SelectionAndInclusion(unittest.TestCase):
+    def setUp(self):
+        self.tab = _make_table()
+        self.tab.add_orientation()
+        self.tab.add_orientation()  # three orientations at 0,1,2
+
+    def test_update_selected_sets_select_only_for_listed_indices(self):
+        self.tab.update_selected([0, 2])
+
+        self.assertTrue(self.tab[0].select)
+        self.assertFalse(self.tab[1].select)
+        self.assertTrue(self.tab[2].select)
+
+    def test_update_included_sets_include_only_for_listed_indices(self):
+        self.tab.update_included([1])
+
+        self.assertFalse(self.tab[0].include)
+        self.assertTrue(self.tab[1].include)
+        self.assertFalse(self.tab[2].include)
+
+    def test_select_all(self):
+        for v in self.tab.values():
+            v.select = False
+
+        self.tab.select_all()
+
+        self.assertTrue(all(v.select for v in self.tab.values()))
+
+    def test_deselect_all(self):
+        for v in self.tab.values():
+            v.select = True
+
+        self.tab.deselect_all()
+
+        self.assertFalse(any(v.select for v in self.tab.values()))
+
+
+class TestOrientationTable_DeleteSelected(unittest.TestCase):
+    def test_keeps_only_unselected_and_reindexes(self):
+        tab = _make_table()
+        tab.add_orientation()
+        tab.add_orientation()  # 0,1,2
+        kept_0 = tab[0]
+        kept_2 = tab[2]
+        tab[0].select = False
+        tab[1].select = True
+        tab[2].select = False
+
+        tab.delete_selected()
+
+        self.assertEqual(list(tab.keys()), [0, 1])
+        self.assertIs(tab[0], kept_0)
+        self.assertIs(tab[1], kept_2)
+
+    def test_resets_to_default_when_all_selected(self):
+        tab = _make_table()
+        tab.add_orientation()
+        for v in tab.values():
+            v.select = True
+
+        tab.delete_selected()
+
+        self.assertEqual(list(tab.keys()), [0])
+        self.assertEqual(tab.get_orientation_index(), 0)
+
+    def test_orientation_index_kept_when_pointing_at_surviving_row(self):
+        tab = _make_table()
+        tab.add_orientation()
+        tab.add_orientation()  # 0,1,2
+        tab[0].select = True
+        tab[1].select = False
+        tab[2].select = False
+        tab.set_orientation_index(2)  # row at old index 2 survives at new index 1
+
+        tab.delete_selected()
+
+        self.assertEqual(tab.get_orientation_index(), 1)
+
+    def test_orientation_index_reset_to_zero_when_pointing_at_deleted_row(self):
+        tab = _make_table()
+        tab.add_orientation()
+        tab.add_orientation()
+        tab[0].select = False
+        tab[1].select = True  # delete row 1
+        tab[2].select = False
+        tab.set_orientation_index(1)
+
+        tab.delete_selected()
+
+        self.assertEqual(tab.get_orientation_index(), 0)
+
+
+class TestOrientationTable_AddOrientation(unittest.TestCase):
+    def test_appends_a_copy_of_current_orientation(self):
+        tab = _make_table()
+        tab[0].include = False
+        tab[0].gonio_strings[0] = "modified"
+
+        tab.add_orientation()
+
+        self.assertEqual(list(tab.keys()), [0, 1])
+        self.assertFalse(tab[1].include)
+        self.assertEqual(tab[1].gonio_strings[0], "modified")
+        self.assertIsNot(tab[1], tab[0])
+        # list is copied → mutating one shouldn't affect the other
+        tab[1].gonio_strings[0] = "diverged"
+        self.assertEqual(tab[0].gonio_strings[0], "modified")
+
+
+class TestOrientationTable_GoniometerStringIO(unittest.TestCase):
+    def test_get_goniometer_string_formats_with_three_dp_vector(self):
+        s = OrientationTable.get_goniometer_string((1.23456, 0.0, 0.0), -1, 45.0)
+        self.assertEqual(s, "45.0,1.235,0.0,0.0,-1")
+
+    def test_read_goniometer_string_inverse_format(self):
+        tab = _make_table()
+
+        vec, sense_name, angle = tab.read_goniometer_string("45.0,1.0,0.0,0.0,-1")
+
+        self.assertEqual(vec, "1.0,0.0,0.0")
+        self.assertEqual(sense_name, "Clockwise")
+        self.assertEqual(angle, 45.0)
+
+    def test_update_gonio_string_writes_supplied_then_pads_with_identity(self):
+        tab = _make_table()
+
+        tab.update_gonio_string([(0, 1, 0)], [-1], [90.0], 0)
+
+        self.assertEqual(tab[0].gonio_strings[0], "90.0,0,1,0,-1")
+        for s in tab[0].gonio_strings[1:]:
+            # padding uses (1,0,0), sense=1, angle=0
+            self.assertEqual(s, "0,1,0,0,1")
+
+    def test_get_goniometer_values_round_trips_default_strings(self):
+        tab = _make_table()
+        tab[0].gonio_strings = [
+            "30.0,1.0,0.0,0.0,1",
+            "45.0,0.0,1.0,0.0,-1",
+        ] + [_DEFAULT_GONIO_STRING] * (MAX_GONIOMETERS - 2)
+
+        vecs, senses, angles = tab.get_goniometer_values(0)
+
+        self.assertEqual(vecs[0], "1.0,0.0,0.0")
+        self.assertEqual(vecs[1], "0.0,1.0,0.0")
+        self.assertEqual(senses[0], "Counterclockwise")
+        self.assertEqual(senses[1], "Clockwise")
+        self.assertEqual(angles[:2], [30.0, 45.0])
+        self.assertEqual(len(vecs), MAX_GONIOMETERS)
+
+
+class TestOrientationTable_MakeDefaultOrientation(unittest.TestCase):
+    def test_pads_gonio_strings_to_max_goniometers(self):
+        tab = _make_table()
+        default = tab._make_default_orientation()
+
+        self.assertEqual(len(default.gonio_strings), MAX_GONIOMETERS)
+        for s in default.gonio_strings:
+            self.assertEqual(s, "0.0,1,0,0,-1")
+
+    def test_uses_identity_for_R_and_first_two_gRs(self):
+        tab = _make_table()
+        default = tab._make_default_orientation()
+
+        np.testing.assert_allclose(default.R.as_matrix(), np.eye(3))
+        self.assertEqual(len(default.gRs), tab.n_gonio + 1)
+
+
+@patch(file_path + ".logger")
+class TestOrientationTable_LoadOrientationFile(unittest.TestCase):
+    def _write_tmp(self, content):
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+            f.write(content)
+            return f.name
+
+    def test_empty_file_returns_default_num_axes_and_warns(self, mock_logger):
+        tab = _make_table()
+        fname = self._write_tmp("")
+        try:
+            result = tab.load_orientation_file(fname)
+        finally:
+            os.unlink(fname)
+
+        self.assertEqual(result, OrientationTable._DEFAULT_NUM_AXES)
+        mock_logger.warning.assert_called_once()
+
+    def test_matrix_format_returns_default_num_axes_and_adds_orientations(self, mock_logger):
+        tab = _make_table()
+        # 9 numbers → matrix format. Identity matrix.
+        identity_line = "\t".join(["1", "0", "0", "0", "1", "0", "0", "0", "1"])
+        fname = self._write_tmp(identity_line + "\n" + identity_line + "\n")
+        try:
+            result = tab.load_orientation_file(fname)
+        finally:
+            os.unlink(fname)
+
+        self.assertEqual(result, OrientationTable._DEFAULT_NUM_AXES)
+        # initial default + 2 added
+        self.assertEqual(tab.get_num_orientations(), 3)
+
+    def test_euler_format_returns_num_angles_and_adds_orientations(self, mock_logger):
+        tab = _make_table(axes="xyz", senses="1,1,1")
+        fname = self._write_tmp("10,20,30\n40,50,60\n")
+        try:
+            result = tab.load_orientation_file(fname)
+        finally:
+            os.unlink(fname)
+
+        self.assertEqual(result, 3)
+        self.assertEqual(tab.get_num_orientations(), 3)
+
+    def test_euler_format_logs_error_and_returns_default_on_axis_count_mismatch(self, mock_logger):
+        tab = _make_table(axes="xy", senses="1,1")  # 2 axes
+        fname = self._write_tmp("10,20,30\n")  # 3 angles
+        try:
+            result = tab.load_orientation_file(fname)
+        finally:
+            os.unlink(fname)
+
+        self.assertEqual(result, OrientationTable._DEFAULT_NUM_AXES)
+        mock_logger.error.assert_called_once()
+        # No new orientations added on error
+        self.assertEqual(tab.get_num_orientations(), 1)
+
+
+class TestOrientationTable_FieldHelpers(unittest.TestCase):
+    @patch(file_path + ".vec_string_to_norm_array")
+    def test_get_vecs_normalises_first_n_vec_strings(self, mock_norm):
+        tab = _make_table()
+        mock_norm.side_effect = lambda s: f"norm({s})"
+
+        result = tab.get_vecs(["a", "b", "c", "d"], 2)
+
+        self.assertEqual(result, ["norm(a)", "norm(b)"])
+        self.assertEqual(mock_norm.call_args_list, [call("a"), call("b")])
+
+    def test_get_senses_converts_sense_names_via_sense_vals(self):
+        tab = _make_table()
+
+        result = tab.get_senses(["Clockwise", "Counterclockwise", "Clockwise"], 2)
+
+        self.assertEqual(result, [-1, 1])
+
+    def test_get_angles_converts_to_float_and_truncates(self):
+        result = OrientationTable.get_angles(["1.0", "2", "3.5", "4"], 3)
+        self.assertEqual(result, [1.0, 2.0, 3.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
@@ -55,7 +55,9 @@ class TestOrientation_Copy(unittest.TestCase):
 
         self.assertFalse(clone.include)
         self.assertTrue(clone.select)
-        self.assertIs(clone.pf_points, pf)
+        # we want the arrays to carry the same values but be different objects
+        np.testing.assert_array_equal(clone.pf_points, pf)
+        self.assertIsNot(clone.pf_points, pf)
         self.assertIsNone(clone.transmission)
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
@@ -19,7 +19,7 @@ from mantidqtinterfaces.TexturePlanner.helpers.orientation_table import (
     _DEFAULT_GONIO_STRING,
 )
 
-file_path = "mantidqtinterfaces.TexturePlanner.helpers.orientation_table"
+FILE_PATH = "mantidqtinterfaces.TexturePlanner.helpers.orientation_table"
 
 
 def _make_table(axes="xyz", senses="1,1,1"):
@@ -341,7 +341,7 @@ class TestOrientationTable_MakeDefaultOrientation(unittest.TestCase):
         self.assertEqual(len(default.gRs), tab.n_gonio + 1)
 
 
-@patch(file_path + ".logger")
+@patch(FILE_PATH + ".logger")
 class TestOrientationTable_LoadOrientationFile(unittest.TestCase):
     def _write_tmp(self, content):
         with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
@@ -399,7 +399,7 @@ class TestOrientationTable_LoadOrientationFile(unittest.TestCase):
 
 
 class TestOrientationTable_FieldHelpers(unittest.TestCase):
-    @patch(file_path + ".vec_string_to_norm_array")
+    @patch(FILE_PATH + ".vec_string_to_norm_array")
     def test_get_vecs_normalises_first_n_vec_strings(self, mock_norm):
         tab = _make_table()
         mock_norm.side_effect = lambda s: f"norm({s})"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_orientation_table.py
@@ -421,5 +421,16 @@ class TestOrientationTable_FieldHelpers(unittest.TestCase):
         self.assertEqual(result, [1.0, 2.0, 3.5])
 
 
+class TestOrientationTable_GoniometerDataValidator(unittest.TestCase):
+    def test_validate_gR_data_logs_error_when_unequal_len_inputs(self):
+        tab = _make_table()
+        with self.assertRaisesRegex(ValueError, "Goniometer data lists have unequal lengths:"):
+            tab._validate_gR_data([(1, 0, 0), (0, 1, 0)], [1, -1], [0, 90, 360])
+
+    def test_validate_gR_data_logs_no_error_when_valid(self):
+        tab = _make_table()
+        self.assertIsNone(tab._validate_gR_data([(1, 0, 0), (0, 1, 0)], [1, 1], [-45, 45]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work

**This module handles the logic for handling the different experimental sample orientations and the logic for table in the interface for displaying them**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)
<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
