### PR TITLE
Add TexturePlanner plotter helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/show_sample_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/show_sample/show_sample_model.py
@@ -12,17 +12,18 @@ from typing import Sequence
 from mantid.kernel import logger
 from mantidqt.plotting import sample_shape
 from Engineering.common.texture_sample_viewer import get_scaled_intrinsic_sample_directions_in_lab_frame, get_xml_mesh, is_valid_mesh
+from matplotlib.figure import Figure
 
 
 class ShowSampleModel(object):
-    def __init__(self, inc_gauge_vol: bool = False, fix_axes_to_sample: bool = True):
-        self.ws_name = None
+    def __init__(self, inc_gauge_vol: bool = False, fix_axes_to_sample: bool = True, ws_name: str | None = None, fig: Figure | None = None):
+        self.ws_name = ws_name
         self.include_gauge_vol = inc_gauge_vol
         self.fix_axes_to_sample = fix_axes_to_sample
         self.gauge_vol_str = ""
-        self.fig = None
+        self.fig = fig
 
-    def set_ws_name(self, ws_name: str) -> None:
+    def set_ws_name(self, ws_name: str | None) -> None:
         self.ws_name = ws_name
 
     def set_fix_axes_to_sample(self, fix_axes: bool) -> None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Tests for the Texture Planner interface
 
 set(TEST_PY_FILES helpers/test/test_absorption.py helpers/test/test_detector_geometry.py
-                  helpers/test/test_workspace_manager.py
+                  helpers/test/test_workspace_manager.py helpers/test/test_plotter.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -63,13 +63,12 @@ class AbsorptionCalculator:
         }
 
     def calc_for_index(self, index: int) -> None:
-        m = self._model
-        wsm = m.workspaces
+        wsm = self._model.workspaces
         # create a workspace to run the absorption calculation on
         mc_ws = self._create_mc_ws(wsm)
 
         # extract goniometer for run index
-        R = m.orientations[index].R
+        R = self._model.orientations[index].R
 
         # set sample state (orientated shape, material and gauge volume) for run index
         self._set_mc_sample_state(wsm, mc_ws, R)
@@ -79,11 +78,11 @@ class AbsorptionCalculator:
             transmission = read_attenuation_coefficient_at_value(
                 wsm.WS_MC_OUTPUT, wsm.attenuation_kwargs["point"], wsm.attenuation_kwargs["unit"]
             )
-            transmission = [transmission[spec_ind] for spec_ind in m.geometry.spec_inds]
+            transmission = [transmission[spec_ind] for spec_ind in self._model.geometry.spec_inds]
         except RuntimeError:
             logger.warning("MonteCarloAbsorption has failed, sample is assumed to be outside the gauge volume ")
-            transmission = [0] * len(m.geometry.spec_inds)
-        m.orientations.set_transmission_at_index(transmission, index)
+            transmission = [0] * len(self._model.geometry.spec_inds)
+        self._model.orientations.set_transmission_at_index(transmission, index)
 
     @staticmethod
     def _create_mc_ws(wsm: _WorkspaceManagerType) -> MatrixWorkspace:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -1,0 +1,295 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
+
+from mantidqt.plotting.sample_shape import plot_sample_only
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.show_sample.show_sample_model import ShowSampleModel
+from Engineering.texture.texture_helper import (
+    azim_proj_xy,
+    get_alpha_beta_from_cart,
+    ring,
+    ster_proj_xy,
+)
+from typing import Protocol, ValuesView, List, ItemsView
+from abc import abstractmethod
+from mantid.api import MatrixWorkspace
+from scipy.spatial.transform import Rotation
+
+
+class _WorkspaceManagerType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    ws: MatrixWorkspace
+    ungrouped_ws: MatrixWorkspace
+    updated_mesh_ws: MatrixWorkspace
+    wsname: str
+    gauge_volume_str: str
+    scattering_centre: np.ndarray
+
+    @abstractmethod
+    def copy_sample_preserving_initial_rotation(self, source_ws: MatrixWorkspace, dest_ws: MatrixWorkspace) -> None:
+        pass
+
+
+class _InstrumentType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    @abstractmethod
+    def get_grouping_path(self) -> str:
+        pass
+
+
+class _OrientationType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    include: bool
+    select: bool
+    R: Rotation
+    transmission: np.ndarray | None
+    gRs: List[Rotation]
+    pf_points: np.ndarray | None
+
+
+class _OrientationTableType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    @abstractmethod
+    def values(self) -> ValuesView[_OrientationType]:
+        pass
+
+    @abstractmethod
+    def items(self) -> ItemsView[int, _OrientationType]:
+        pass
+
+    @abstractmethod
+    def __getitem__(self, index: int) -> _OrientationType:
+        pass
+
+
+class _GeometryType(Protocol):
+    detQs_lab: np.ndarray
+    det_k: np.ndarray
+
+
+class _BaseModelType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    workspaces: _WorkspaceManagerType
+    instrument: _InstrumentType
+    orientations: _OrientationTableType
+    geometry: _GeometryType
+
+    gonio_index: int
+    ax_transform: np.ndarray
+    dir_names: List[str]
+    projection: str
+    plot_transmission: bool
+
+
+class TexturePlotter:
+    """Renders the lab-frame 3D scene and the 2D pole-figure projection.
+
+    Reads model state at draw time (workspace, detector Qs, sample mesh,
+    orientation table, visualisation settings) via back-reference.
+    """
+
+    def __init__(self, model: _BaseModelType):
+        self._model = model
+        # visual / rendering config owned by the plotter (the colour/label constants plus the
+        # visualisation toggles the settings dialog writes to)
+        self.gon_colors = ("hotpink", "orange", "purple", "goldenrod", "plum", "saddlebrown")
+        self.dir_cols = ("red", "green", "blue")
+        self.vis_settings = {"directions": True, "goniometers": True, "incident": True, "ks": True, "scattered": False}
+        # when True the transmission plot colour scale spans the data range; otherwise it is fixed to [0, 1]
+        self.transmission_use_data_range = False
+        self._transmission_cax = None
+
+    def update_plot(
+        self, vecs: List[np.ndarray], senses: List[float], angles: List[float], fig: Figure, lab_ax: Axes, proj_ax: Axes, current_index: int
+    ) -> None:
+        m = self._model
+        lab_ax.clear()
+        proj_ax.clear()
+
+        orientation = m.orientations[current_index]
+        gRs = orientation.gRs
+        R = orientation.R
+        n_gon = len(gRs)
+
+        m.workspaces.ws.run().getGoniometer().setR(R.as_matrix())
+
+        shape_mesh = m.workspaces.updated_mesh_ws.sample().getShape().getMesh().copy()
+        extent = (np.linalg.norm(shape_mesh, axis=(1, 2)).max() / 2) * 1.2
+        rot_mesh = R.apply(shape_mesh.reshape((-1, 3))).reshape(shape_mesh.shape)
+
+        scat_centre = m.workspaces.scattering_centre
+
+        g_vecs = self._draw_goniometers(lab_ax, vecs, senses, angles, gRs, n_gon, extent)
+        self._draw_sample_and_axes(fig, lab_ax, rot_mesh, extent, n_gon, scat_centre)
+        self._draw_beam_and_detectors(lab_ax, scat_centre, extent, n_gon)
+        lab_ax.set_axis_off()
+
+        g_pole_xy = self._project_goniometer_poles(R, g_vecs)
+        self._draw_pole_figure(proj_ax, g_pole_xy, current_index)
+        self._decorate_pole_figure(proj_ax)
+
+        fig.canvas.draw_idle()
+        proj_ax.figure.canvas.draw_idle()
+
+    def _draw_goniometers(
+        self,
+        lab_ax: Axes,
+        vecs: List[np.ndarray],
+        senses: List[float],
+        angles: List[float],
+        gRs: List[Rotation],
+        n_gon: int,
+        extent: float,
+    ) -> List[np.ndarray | int]:
+        m = self._model
+        g_vecs = []
+        for i, vec in enumerate(vecs):
+            gR = gRs[i]
+            g_vec = gR.apply(vec)
+            g_vecs.append(g_vec)
+
+            gon_scale = (1 + ((n_gon - i) / 2)) * extent
+            _ring_res = 360
+            gon_ring = gR.apply(ring(vec, gon_scale, res=_ring_res).T).T
+
+            angle = angles[i] * senses[i]
+            if angle <= 0:
+                gon_ring = np.flip(gon_ring, axis=1)  # reverse the ring if the angle is negative
+            pos_ind = int(np.abs(angle) / 360 * _ring_res)
+
+            if self.vis_settings["goniometers"]:
+                lab_ax.plot(*gon_ring[:, : pos_ind + 1], color=self.gon_colors[i])
+                lab_ax.plot(*gon_ring[:, pos_ind:], color="grey")
+                lab_ax.quiver(
+                    *np.zeros(3),
+                    *g_vec * extent * 2,
+                    color=self.gon_colors[i],
+                    ls=("-", "--")[int(i != m.gonio_index)],
+                    label=f"Axis {i}",
+                )
+        if self.vis_settings["goniometers"]:
+            lab_ax.legend()
+        return g_vecs
+
+    def _draw_sample_and_axes(
+        self, fig: Figure, lab_ax: Axes, rot_mesh: np.ndarray, extent: float, n_gon: int, scat_centre: np.ndarray
+    ) -> None:
+        m = self._model
+        sample_model = ShowSampleModel()
+        sample_model.fig = fig
+        sample_model.ws_name = m.workspaces.wsname
+        sample_model.gauge_vol_str = m.workspaces.gauge_volume_str
+        fig.sca(lab_ax)
+        plot_sample_only(fig, rot_mesh, 0.5, "grey")
+        if self.vis_settings["directions"]:
+            sample_model.plot_sample_directions(m.ax_transform, m.dir_names, scat_centre=scat_centre)
+        lim = extent * n_gon / 1.5
+        lab_ax.set_xlim([-lim, lim])
+        lab_ax.set_ylim([-lim, lim])
+        lab_ax.set_zlim([-lim, lim])
+        lab_ax.set_aspect("equal")
+        if m.workspaces.gauge_volume_str:
+            sample_model.plot_gauge_vol()
+
+    def _draw_beam_and_detectors(self, lab_ax: Axes, scat_centre: np.ndarray, extent: float, n_gon: int) -> None:
+        m = self._model
+        comp_info = m.workspaces.ws.componentInfo()
+        ki = scat_centre - np.array(comp_info.sourcePosition())
+        ki = (ki / np.linalg.norm(ki)) * extent * n_gon / 0.75
+        if self.vis_settings["incident"]:
+            lab_ax.quiver(*(-ki), *ki, arrow_length_ratio=0.05, color="black", alpha=0.25)
+
+        if self.vis_settings["ks"]:
+            self._draw_quiver_bundle(lab_ax, m.geometry.detQs_lab, scat_centre, extent, "dodgerblue", linestyle="--")
+        if self.vis_settings["scattered"]:
+            self._draw_quiver_bundle(lab_ax, np.asarray(m.geometry.det_k), scat_centre, extent, "grey")
+
+    @staticmethod
+    def _draw_quiver_bundle(
+        lab_ax: Axes, dirs: np.ndarray, scat_centre: np.ndarray, extent: float, tip_color: str, linestyle: str = "-"
+    ) -> None:
+        scaled = dirs * (1.25 * extent)
+        tips = scaled + scat_centre[None, :]
+        n = len(scaled)
+        lab_ax.quiver(
+            np.ones(n) * scat_centre[0],
+            np.ones(n) * scat_centre[1],
+            np.ones(n) * scat_centre[2],
+            scaled[:, 0],
+            scaled[:, 1],
+            scaled[:, 2],
+            arrow_length_ratio=0.05,
+            color="grey",
+            alpha=0.25,
+            linestyle=linestyle,
+        )
+        lab_ax.scatter(tips[:, 0], tips[:, 1], tips[:, 2], color=tip_color, s=2)
+
+    def _project_goniometer_poles(self, R: Rotation, g_vecs: List[np.ndarray | int]) -> np.ndarray:
+        m = self._model
+        g_pole = R.inv().apply(np.array(g_vecs)) @ m.ax_transform
+        cart_g_pole = get_alpha_beta_from_cart(g_pole.T)
+        return ster_proj_xy(*cart_g_pole.T) if m.projection == "ster" else azim_proj_xy(*cart_g_pole.T)
+
+    def _draw_pole_figure(self, proj_ax: Axes, g_pole_xy: np.ndarray, current_index: int) -> None:
+        m = self._model
+        if self._transmission_cax is not None:
+            self._transmission_cax.remove()
+            self._transmission_cax = None
+        for i, gP in enumerate(g_pole_xy):
+            pc = self.gon_colors[i]
+            fc = "None" if i != m.gonio_index else pc
+            if np.isclose(np.linalg.norm(gP), 1):
+                proj_ax.plot((gP[1], -gP[1]), (gP[0], -gP[0]), color=pc, ls=("-", "--")[int(i != m.gonio_index)])
+            else:
+                proj_ax.scatter(gP[1], gP[0], s=30, edgecolor=pc, facecolor=fc)
+
+        if not m.plot_transmission:
+            for i, orientation in m.orientations.items():
+                if orientation.include:
+                    pf_xy = orientation.pf_points
+                    if i == current_index:
+                        proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, c="dodgerblue")
+                    else:
+                        proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="dodgerblue")
+                elif i == current_index:
+                    pf_xy = orientation.pf_points
+                    proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="grey", alpha=0.5)
+        else:
+            included = [o for o in m.orientations.values() if o.include]
+            all_pf_xy = np.concatenate([o.pf_points for o in included], axis=0)
+            all_transmissions = np.concatenate([o.transmission for o in included], axis=0)
+            clim_kwargs = {} if self.transmission_use_data_range else {"vmin": 0, "vmax": 1}
+            scatt = proj_ax.scatter(all_pf_xy[:, 1], all_pf_xy[:, 0], s=20, c=all_transmissions, cmap="jet", **clim_kwargs)
+            self._transmission_cax = proj_ax.inset_axes([0.9, 0.15, 0.05, 0.7])
+            proj_ax.figure.colorbar(scatt, cax=self._transmission_cax)
+
+    def _decorate_pole_figure(self, proj_ax: Axes) -> None:
+        m = self._model
+        proj_ax.set_aspect("equal")
+        proj_ax.set_xlim(-1.5, 1.5)
+        proj_ax.set_ylim(-1.5, 1.5)
+        for i, bv in enumerate(np.eye(2)):
+            proj_ax.quiver(*np.array((-1, -1)), *bv, color=self.dir_cols[-1 + i], scale=5)
+        proj_ax.add_patch(plt.Circle((0, 0), 1, color="grey", fill=False, linestyle="-"))
+        proj_ax.annotate(m.dir_names[0], (-0.95, -0.8))
+        proj_ax.annotate(m.dir_names[2], (-0.8, -0.95))
+        proj_ax.set_axis_off()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -120,22 +120,21 @@ class TexturePlotter:
     def update_plot(
         self, vecs: List[np.ndarray], senses: List[float], angles: List[float], fig: Figure, lab_ax: Axes, proj_ax: Axes, current_index: int
     ) -> None:
-        m = self._model
         lab_ax.clear()
         proj_ax.clear()
 
-        orientation = m.orientations[current_index]
+        orientation = self._model.orientations[current_index]
         gRs = orientation.gRs
         R = orientation.R
         n_gon = len(gRs)
 
-        m.workspaces.ws.run().getGoniometer().setR(R.as_matrix())
+        self._model.workspaces.ws.run().getGoniometer().setR(R.as_matrix())
 
-        shape_mesh = m.workspaces.updated_mesh_ws.sample().getShape().getMesh().copy()
+        shape_mesh = self._model.workspaces.updated_mesh_ws.sample().getShape().getMesh().copy()
         extent = (np.linalg.norm(shape_mesh, axis=(1, 2)).max() / 2) * 1.2
         rot_mesh = R.apply(shape_mesh.reshape((-1, 3))).reshape(shape_mesh.shape)
 
-        scat_centre = m.workspaces.scattering_centre
+        scat_centre = self._model.workspaces.scattering_centre
 
         g_vecs = self._draw_goniometers(lab_ax, vecs, senses, angles, gRs, n_gon, extent)
         self._draw_sample_and_axes(fig, lab_ax, rot_mesh, extent, n_gon, scat_centre)
@@ -159,7 +158,6 @@ class TexturePlotter:
         n_gon: int,
         extent: float,
     ) -> List[np.ndarray | int]:
-        m = self._model
         g_vecs = []
         for i, vec in enumerate(vecs):
             gR = gRs[i]
@@ -182,7 +180,7 @@ class TexturePlotter:
                     *np.zeros(3),
                     *g_vec * extent * 2,
                     color=self.gon_colors[i],
-                    ls=("-", "--")[int(i != m.gonio_index)],
+                    ls=("-", "--")[int(i != self._model.gonio_index)],
                     label=f"Axis {i}",
                 )
         if self.vis_settings["goniometers"]:
@@ -192,35 +190,33 @@ class TexturePlotter:
     def _draw_sample_and_axes(
         self, fig: Figure, lab_ax: Axes, rot_mesh: np.ndarray, extent: float, n_gon: int, scat_centre: np.ndarray
     ) -> None:
-        m = self._model
         sample_model = ShowSampleModel()
         sample_model.fig = fig
-        sample_model.ws_name = m.workspaces.wsname
-        sample_model.gauge_vol_str = m.workspaces.gauge_volume_str
+        sample_model.ws_name = self._model.workspaces.wsname
+        sample_model.gauge_vol_str = self._model.workspaces.gauge_volume_str
         fig.sca(lab_ax)
         plot_sample_only(fig, rot_mesh, 0.5, "grey")
         if self.vis_settings["directions"]:
-            sample_model.plot_sample_directions(m.ax_transform, m.dir_names, scat_centre=scat_centre)
+            sample_model.plot_sample_directions(self._model.ax_transform, self._model.dir_names, scat_centre=scat_centre)
         lim = extent * n_gon / 1.5
         lab_ax.set_xlim([-lim, lim])
         lab_ax.set_ylim([-lim, lim])
         lab_ax.set_zlim([-lim, lim])
         lab_ax.set_aspect("equal")
-        if m.workspaces.gauge_volume_str:
+        if self._model.workspaces.gauge_volume_str:
             sample_model.plot_gauge_vol()
 
     def _draw_beam_and_detectors(self, lab_ax: Axes, scat_centre: np.ndarray, extent: float, n_gon: int) -> None:
-        m = self._model
-        comp_info = m.workspaces.ws.componentInfo()
+        comp_info = self._model.workspaces.ws.componentInfo()
         ki = scat_centre - np.array(comp_info.sourcePosition())
         ki = (ki / np.linalg.norm(ki)) * extent * n_gon / 0.75
         if self.vis_settings["incident"]:
             lab_ax.quiver(*(-ki), *ki, arrow_length_ratio=0.05, color="black", alpha=0.25)
 
         if self.vis_settings["ks"]:
-            self._draw_quiver_bundle(lab_ax, m.geometry.detQs_lab, scat_centre, extent, "dodgerblue", linestyle="--")
+            self._draw_quiver_bundle(lab_ax, self._model.geometry.detQs_lab, scat_centre, extent, "dodgerblue", linestyle="--")
         if self.vis_settings["scattered"]:
-            self._draw_quiver_bundle(lab_ax, np.asarray(m.geometry.det_k), scat_centre, extent, "grey")
+            self._draw_quiver_bundle(lab_ax, np.asarray(self._model.geometry.det_k), scat_centre, extent, "grey")
 
     @staticmethod
     def _draw_quiver_bundle(
@@ -244,26 +240,24 @@ class TexturePlotter:
         lab_ax.scatter(tips[:, 0], tips[:, 1], tips[:, 2], color=tip_color, s=2)
 
     def _project_goniometer_poles(self, R: Rotation, g_vecs: List[np.ndarray | int]) -> np.ndarray:
-        m = self._model
-        g_pole = R.inv().apply(np.array(g_vecs)) @ m.ax_transform
+        g_pole = R.inv().apply(np.array(g_vecs)) @ self._model.ax_transform
         cart_g_pole = get_alpha_beta_from_cart(g_pole.T)
-        return ster_proj_xy(*cart_g_pole.T) if m.projection == "ster" else azim_proj_xy(*cart_g_pole.T)
+        return ster_proj_xy(*cart_g_pole.T) if self._model.projection == "ster" else azim_proj_xy(*cart_g_pole.T)
 
     def _draw_pole_figure(self, proj_ax: Axes, g_pole_xy: np.ndarray, current_index: int) -> None:
-        m = self._model
         if self._transmission_cax is not None:
             self._transmission_cax.remove()
             self._transmission_cax = None
         for i, gP in enumerate(g_pole_xy):
             pc = self.gon_colors[i]
-            fc = "None" if i != m.gonio_index else pc
+            fc = "None" if i != self._model.gonio_index else pc
             if np.isclose(np.linalg.norm(gP), 1):
-                proj_ax.plot((gP[1], -gP[1]), (gP[0], -gP[0]), color=pc, ls=("-", "--")[int(i != m.gonio_index)])
+                proj_ax.plot((gP[1], -gP[1]), (gP[0], -gP[0]), color=pc, ls=("-", "--")[int(i != self._model.gonio_index)])
             else:
                 proj_ax.scatter(gP[1], gP[0], s=30, edgecolor=pc, facecolor=fc)
 
-        if not m.plot_transmission:
-            for i, orientation in m.orientations.items():
+        if not self._model.plot_transmission:
+            for i, orientation in self._model.orientations.items():
                 if orientation.include:
                     pf_xy = orientation.pf_points
                     if i == current_index:
@@ -274,7 +268,7 @@ class TexturePlotter:
                     pf_xy = orientation.pf_points
                     proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="grey", alpha=0.5)
         else:
-            included = [o for o in m.orientations.values() if o.include]
+            included = [o for o in self._model.orientations.values() if o.include]
             all_pf_xy = np.concatenate([o.pf_points for o in included], axis=0)
             all_transmissions = np.concatenate([o.transmission for o in included], axis=0)
             clim_kwargs = {} if self.transmission_use_data_range else {"vmin": 0, "vmax": 1}
@@ -283,13 +277,12 @@ class TexturePlotter:
             proj_ax.figure.colorbar(scatt, cax=self._transmission_cax)
 
     def _decorate_pole_figure(self, proj_ax: Axes) -> None:
-        m = self._model
         proj_ax.set_aspect("equal")
         proj_ax.set_xlim(-1.5, 1.5)
         proj_ax.set_ylim(-1.5, 1.5)
         for i, bv in enumerate(np.eye(2)):
             proj_ax.quiver(*np.array((-1, -1)), *bv, color=self.dir_cols[-1 + i], scale=5)
         proj_ax.add_patch(plt.Circle((0, 0), 1, color="grey", fill=False, linestyle="-"))
-        proj_ax.annotate(m.dir_names[0], (-0.95, -0.8))
-        proj_ax.annotate(m.dir_names[2], (-0.8, -0.95))
+        proj_ax.annotate(self._model.dir_names[0], (-0.95, -0.8))
+        proj_ax.annotate(self._model.dir_names[2], (-0.8, -0.95))
         proj_ax.set_axis_off()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -196,11 +196,8 @@ class TexturePlotter:
         plot_sample_only(fig, rot_mesh, 0.5, "grey")
         if self.vis_settings["directions"]:
             sample_model.plot_sample_directions(self._model.ax_transform, self._model.dir_names, scat_centre=scat_centre)
-        lim = extent * n_gon / 1.5
-        lab_ax.set_xlim([-lim, lim])
-        lab_ax.set_ylim([-lim, lim])
-        lab_ax.set_zlim([-lim, lim])
-        lab_ax.set_aspect("equal")
+        lim = [-(abs_lim := extent * n_gon / 1.5), abs_lim]
+        lab_ax.set(xlim=lim, ylim=lim, zlim=lim, aspect="equal")
         if self._model.workspaces.gauge_volume_str:
             sample_model.plot_gauge_vol()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -18,10 +18,11 @@ from Engineering.texture.texture_helper import (
     ring,
     ster_proj_xy,
 )
-from typing import Protocol, ValuesView, List, ItemsView
+from typing import Protocol, ValuesView, List, ItemsView, Tuple
 from abc import abstractmethod
 from mantid.api import MatrixWorkspace
 from scipy.spatial.transform import Rotation
+from dataclasses import dataclass
 
 
 class _WorkspaceManagerType(Protocol):
@@ -99,6 +100,25 @@ class _BaseModelType(Protocol):
     plot_transmission: bool
 
 
+@dataclass
+class PlotProperties:
+    sample_vec_scaler: float = 1.2
+    num_points_in_ring: int = 360
+    sample_opacity: float = 0.5
+    sample_colour: str = "grey"
+    goniometer_axis_scale: float = 2
+    diffraction_vector_scale: float = 1.33
+    arrow_head_size: float = 0.05
+    cbar_inset_location: Tuple[float, float, float, float] = (0.9, 0.15, 0.05, 0.7)
+    pf_ax_lims: Tuple[float, float] = (-1.5, 1.5)
+    d1_name_loc: Tuple[float, float] = (-0.95, -0.8)
+    d2_name_loc: Tuple[float, float] = (-0.8, -0.95)
+
+    def goniometer_plot_scales(self, n_gon: int, current_index: int, sample_size_scaler: float) -> float:
+        # get the scaler for the current_index goniometer in a progression of decreasing scales for n_goniometers
+        return (1 + ((n_gon - current_index) / 2)) * sample_size_scaler
+
+
 class TexturePlotter:
     """Renders the lab-frame 3D scene and the 2D pole-figure projection.
 
@@ -116,35 +136,45 @@ class TexturePlotter:
         # when True the transmission plot colour scale spans the data range; otherwise it is fixed to [0, 1]
         self.transmission_use_data_range = False
         self._transmission_cax = None
+        self._plot_properties = PlotProperties()
 
     def update_plot(
         self, vecs: List[np.ndarray], senses: List[float], angles: List[float], fig: Figure, lab_ax: Axes, proj_ax: Axes, current_index: int
     ) -> None:
+        # Easier to rebuild whole plot rather than updating individual artists
         lab_ax.clear()
         proj_ax.clear()
 
+        # pull the orientation information
         orientation = self._model.orientations[current_index]
         gRs = orientation.gRs
         R = orientation.R
         n_gon = len(gRs)
-
-        self._model.workspaces.ws.run().getGoniometer().setR(R.as_matrix())
-
-        shape_mesh = self._model.workspaces.updated_mesh_ws.sample().getShape().getMesh().copy()
-        extent = (np.linalg.norm(shape_mesh, axis=(1, 2)).max() / 2) * 1.2
-        rot_mesh = R.apply(shape_mesh.reshape((-1, 3))).reshape(shape_mesh.shape)
-
+        # and the location of the scattering centre
         scat_centre = self._model.workspaces.scattering_centre
 
+        # set the goniometer on the workspace
+        self._model.workspaces.ws.run().getGoniometer().setR(R.as_matrix())
+
+        # get a copy of the unrotated and rotated sample shape mesh
+        shape_mesh = self._model.workspaces.updated_mesh_ws.sample().getShape().getMesh().copy()
+        rot_mesh = R.apply(shape_mesh.reshape((-1, 3))).reshape(shape_mesh.shape)
+
+        # calculate a scaling value that is based on how far the furthest vertex of the sample mesh is from the origin
+        extent = (np.linalg.norm(shape_mesh, axis=(1, 2)).max() / 2) * self._plot_properties.sample_vec_scaler
+
+        # draw the lab frame
         g_vecs = self._draw_goniometers(lab_ax, vecs, senses, angles, gRs, n_gon, extent)
         self._draw_sample_and_axes(fig, lab_ax, rot_mesh, extent, n_gon, scat_centre)
         self._draw_beam_and_detectors(lab_ax, scat_centre, extent, n_gon)
         lab_ax.set_axis_off()
 
+        # draw the pole figure plot
         g_pole_xy = self._project_goniometer_poles(R, g_vecs)
         self._draw_pole_figure(proj_ax, g_pole_xy, current_index)
         self._decorate_pole_figure(proj_ax)
 
+        # ensure the plots are updated
         fig.canvas.draw_idle()
         proj_ax.figure.canvas.draw_idle()
 
@@ -158,27 +188,40 @@ class TexturePlotter:
         n_gon: int,
         extent: float,
     ) -> List[np.ndarray | int]:
+
+        # iterate through the goniometers and draw them to the lab frame
         g_vecs = []
         for i, vec in enumerate(vecs):
+            # get the rotation matrix corresponding to all the goniometer transformations beneath this one
             gR = gRs[i]
+            # apply the rotation to the axis of this goniometer
             g_vec = gR.apply(vec)
             g_vecs.append(g_vec)
 
-            gon_scale = (1 + ((n_gon - i) / 2)) * extent
-            _ring_res = 360
+            # calculate appropriate scaling values so each goniometer sits inside those it depends on
+            gon_scale = self._plot_properties.goniometer_plot_scales(n_gon, i, extent)
+            # read the number of points to use for the goniometer ring rendering
+            _ring_res = self._plot_properties.num_points_in_ring
+
+            # apply the transformation of the outer goniometers on the ring render
             gon_ring = gR.apply(ring(vec, gon_scale, res=_ring_res).T).T
 
+            # calculate which way round the ring points should be ordered
             angle = angles[i] * senses[i]
             if angle <= 0:
                 gon_ring = np.flip(gon_ring, axis=1)  # reverse the ring if the angle is negative
+            # find the nearest index of point in the ring so the coloured section can be drawn to the correct arc
             pos_ind = int(np.abs(angle) / 360 * _ring_res)
 
+            # plot the goniometer coloured section (corresponding to the angle rotated through),
+            # the uncoloured section (corresponding to the remaining rotation of the goniometer), and
+            # the goniometer axis
             if self.vis_settings["goniometers"]:
                 lab_ax.plot(*gon_ring[:, : pos_ind + 1], color=self.gon_colors[i])
                 lab_ax.plot(*gon_ring[:, pos_ind:], color="grey")
                 lab_ax.quiver(
                     *np.zeros(3),
-                    *g_vec * extent * 2,
+                    *g_vec * extent * self._plot_properties.goniometer_axis_scale,
                     color=self.gon_colors[i],
                     ls=("-", "--")[int(i != self._model.gonio_index)],
                     label=f"Axis {i}",
@@ -190,36 +233,54 @@ class TexturePlotter:
     def _draw_sample_and_axes(
         self, fig: Figure, lab_ax: Axes, rot_mesh: np.ndarray, extent: float, n_gon: int, scat_centre: np.ndarray
     ) -> None:
-        sample_model = ShowSampleModel(fig=fig, ws_name=self._model.workspaces.wsname)
-        sample_model.set_gauge_vol_str(self._model.workspaces.gauge_volume_str)
+        # set current axis of fig to lab frame
         fig.sca(lab_ax)
-        plot_sample_only(fig, rot_mesh, 0.5, "grey")
-        if self.vis_settings["directions"]:
-            sample_model.plot_sample_directions(self._model.ax_transform, self._model.dir_names, scat_centre=scat_centre)
-        lim = [-(abs_lim := extent * n_gon / 1.5), abs_lim]
-        lab_ax.set(xlim=lim, ylim=lim, zlim=lim, aspect="equal")
+        # plot the sample mesh
+        plot_sample_only(fig, rot_mesh, self._plot_properties.sample_opacity, self._plot_properties.sample_colour)
+
+        # get a show sample model helper class for plotting the sample direction vectors + gauge volume
+        sample_model = ShowSampleModel(fig=fig, ws_name=self._model.workspaces.wsname)
+        # set the current gauge volume
+        sample_model.set_gauge_vol_str(self._model.workspaces.gauge_volume_str)
+
+        # if there is a gauge volume, plot it
         if self._model.workspaces.gauge_volume_str:
             sample_model.plot_gauge_vol()
 
+        # if the setting want the sample directions plotted, plot them
+        if self.vis_settings["directions"]:
+            sample_model.plot_sample_directions(self._model.ax_transform, self._model.dir_names, scat_centre=scat_centre)
+
+        # scale the lab frame
+        lim = [-(abs_lim := extent * n_gon / 1.5), abs_lim]
+        lab_ax.set(xlim=lim, ylim=lim, zlim=lim, aspect="equal")
+
     def _draw_beam_and_detectors(self, lab_ax: Axes, scat_centre: np.ndarray, extent: float, n_gon: int) -> None:
+        # get the screen space positions for the beam direction arrow
         comp_info = self._model.workspaces.ws.componentInfo()
         ki = scat_centre - np.array(comp_info.sourcePosition())
-        ki = (ki / np.linalg.norm(ki)) * extent * n_gon / 0.75
-        if self.vis_settings["incident"]:
-            lab_ax.quiver(*(-ki), *ki, arrow_length_ratio=0.05, color="black", alpha=0.25)
+        ki = (ki / np.linalg.norm(ki)) * extent * n_gon * self._plot_properties.diffraction_vector_scale
 
+        # if the incident beam is desired, plot it
+        if self.vis_settings["incident"]:
+            lab_ax.quiver(*(-ki), *ki, arrow_length_ratio=self._plot_properties.arrow_head_size, color="black", alpha=0.25)
+
+        # if the diffraction vectors are desired, plot them
         if self.vis_settings["ks"]:
             self._draw_quiver_bundle(lab_ax, self._model.geometry.detQs_lab, scat_centre, extent, "dodgerblue", linestyle="--")
+        # if the detector positions are desired, plot them
         if self.vis_settings["scattered"]:
             self._draw_quiver_bundle(lab_ax, np.asarray(self._model.geometry.det_k), scat_centre, extent, "grey")
 
-    @staticmethod
     def _draw_quiver_bundle(
-        lab_ax: Axes, dirs: np.ndarray, scat_centre: np.ndarray, extent: float, tip_color: str, linestyle: str = "-"
+        self, lab_ax: Axes, dirs: np.ndarray, scat_centre: np.ndarray, extent: float, tip_color: str, linestyle: str = "-"
     ) -> None:
+        # get screen space positions of the provided vectors
         scaled = dirs * (1.25 * extent)
         tips = scaled + scat_centre[None, :]
         n = len(scaled)
+
+        # plot the arrows
         lab_ax.quiver(
             np.ones(n) * scat_centre[0],
             np.ones(n) * scat_centre[1],
@@ -227,11 +288,12 @@ class TexturePlotter:
             scaled[:, 0],
             scaled[:, 1],
             scaled[:, 2],
-            arrow_length_ratio=0.05,
+            arrow_length_ratio=self._plot_properties.arrow_head_size,
             color="grey",
             alpha=0.25,
             linestyle=linestyle,
         )
+        # plot the points at the end of the arrows
         lab_ax.scatter(tips[:, 0], tips[:, 1], tips[:, 2], color=tip_color, s=2)
 
     def _project_goniometer_poles(self, R: Rotation, g_vecs: List[np.ndarray | int]) -> np.ndarray:
@@ -240,44 +302,63 @@ class TexturePlotter:
         return ster_proj_xy(*cart_g_pole.T) if self._model.projection == "ster" else azim_proj_xy(*cart_g_pole.T)
 
     def _draw_pole_figure(self, proj_ax: Axes, g_pole_xy: np.ndarray, current_index: int) -> None:
+        # update the transmission colour bar
         if self._transmission_cax is not None:
             self._transmission_cax.remove()
             self._transmission_cax = None
+
+        # plot the goniometers onto the figure
         for i, gP in enumerate(g_pole_xy):
             pc = self.gon_colors[i]
             fc = "None" if i != self._model.gonio_index else pc
+            # if the point is approximately on the edge of the pole figure circle, plot a line instead
             if np.isclose(np.linalg.norm(gP), 1):
                 proj_ax.plot((gP[1], -gP[1]), (gP[0], -gP[0]), color=pc, ls=("-", "--")[int(i != self._model.gonio_index)])
             else:
                 proj_ax.scatter(gP[1], gP[0], s=30, edgecolor=pc, facecolor=fc)
 
+        # if there aren't transmission values
         if not self._model.plot_transmission:
+            # go through all the orientations
             for i, orientation in self._model.orientations.items():
+                if orientation.pf_points is None:
+                    continue
                 if orientation.include:
                     pf_xy = orientation.pf_points
+                    # plot current selected orientation with full circles
                     if i == current_index:
                         proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, c="dodgerblue")
+                    # plot all other orientations as just edges
                     else:
                         proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="dodgerblue")
+                # if the current selected orientation is not set to be included plot it as a grey edge
                 elif i == current_index:
                     pf_xy = orientation.pf_points
                     proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="grey", alpha=0.5)
+        # if there are transmission values to be plotted
         else:
-            included = [o for o in self._model.orientations.values() if o.include]
+            # get the included runs
+            included = [
+                o for o in self._model.orientations.values() if o.include and o.pf_points is not None and o.transmission is not None
+            ]
+            if not included:
+                return
+            # get the locations of the included points
             all_pf_xy = np.concatenate([o.pf_points for o in included], axis=0)
+            # get the values of the included points
             all_transmissions = np.concatenate([o.transmission for o in included], axis=0)
+            # constrain the cmap range if desired
             clim_kwargs = {} if self.transmission_use_data_range else {"vmin": 0, "vmax": 1}
+            # plot the points
             scatt = proj_ax.scatter(all_pf_xy[:, 1], all_pf_xy[:, 0], s=20, c=all_transmissions, cmap="jet", **clim_kwargs)
-            self._transmission_cax = proj_ax.inset_axes([0.9, 0.15, 0.05, 0.7])
+            self._transmission_cax = proj_ax.inset_axes(self._plot_properties.cbar_inset_location)
             proj_ax.figure.colorbar(scatt, cax=self._transmission_cax)
 
     def _decorate_pole_figure(self, proj_ax: Axes) -> None:
-        proj_ax.set_aspect("equal")
-        proj_ax.set_xlim(-1.5, 1.5)
-        proj_ax.set_ylim(-1.5, 1.5)
+        proj_ax.set(xlim=self._plot_properties.pf_ax_lims, ylim=self._plot_properties.pf_ax_lims, aspect="equal")
         for i, bv in enumerate(np.eye(2)):
             proj_ax.quiver(*np.array((-1, -1)), *bv, color=self.dir_cols[-1 + i], scale=5)
         proj_ax.add_patch(plt.Circle((0, 0), 1, color="grey", fill=False, linestyle="-"))
-        proj_ax.annotate(self._model.dir_names[0], (-0.95, -0.8))
-        proj_ax.annotate(self._model.dir_names[2], (-0.8, -0.95))
+        proj_ax.annotate(self._model.dir_names[0], self._plot_properties.d1_name_loc)
+        proj_ax.annotate(self._model.dir_names[2], self._plot_properties.d2_name_loc)
         proj_ax.set_axis_off()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -190,10 +190,8 @@ class TexturePlotter:
     def _draw_sample_and_axes(
         self, fig: Figure, lab_ax: Axes, rot_mesh: np.ndarray, extent: float, n_gon: int, scat_centre: np.ndarray
     ) -> None:
-        sample_model = ShowSampleModel()
-        sample_model.fig = fig
-        sample_model.ws_name = self._model.workspaces.wsname
-        sample_model.gauge_vol_str = self._model.workspaces.gauge_volume_str
+        sample_model = ShowSampleModel(fig=fig, ws_name=self._model.workspaces.wsname)
+        sample_model.set_gauge_vol_str(self._model.workspaces.gauge_volume_str)
         fig.sca(lab_ax)
         plot_sample_only(fig, rot_mesh, 0.5, "grey")
         if self.vis_settings["directions"]:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
@@ -1,0 +1,615 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+
+from unittest.mock import patch, MagicMock, call
+from scipy.spatial.transform import Rotation
+
+from mantidqtinterfaces.TexturePlanner.helpers.plotter import TexturePlotter
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.plotter"
+
+
+def _make_model(
+    vis_settings=None,
+    gon_colors=None,
+    dir_cols=None,
+    dir_names=None,
+    ax_transform=None,
+    projection="ster",
+    gonio_index=0,
+    plot_transmission=False,
+    transmission_use_data_range=False,
+    orientations=None,
+    detQs_lab=None,
+    det_k=None,
+    source_position=(-1.0, 0.0, 0.0),
+    scattering_centre=(0.0, 0.0, 0.0),
+    gauge_volume_str=None,
+):
+    model = MagicMock()
+    model.vis_settings = vis_settings or {
+        "goniometers": True,
+        "directions": True,
+        "incident": True,
+        "ks": True,
+        "scattered": True,
+    }
+    model.gon_colors = gon_colors or ["red", "green", "blue"]
+    model.dir_cols = dir_cols or ["c1", "c2", "c3"]
+    model.dir_names = dir_names or ["RD", "ND", "TD"]
+    model.ax_transform = np.eye(3) if ax_transform is None else ax_transform
+    model.projection = projection
+    model.gonio_index = gonio_index
+    model.plot_transmission = plot_transmission
+    model.transmission_use_data_range = transmission_use_data_range
+    if orientations is None:
+        orient = MagicMock()
+        orient.gRs = [Rotation.identity()]
+        orient.R = Rotation.identity()
+        orient.include = True
+        orient.pf_points = np.array([[0.1, 0.2], [0.3, 0.4]])
+        orient.transmission = np.array([0.5, 0.7])
+        orientations = {0: orient}
+    model.orientations = MagicMock()
+    model.orientations.__getitem__.side_effect = lambda i: orientations[i]
+    model.orientations.items.return_value = list(orientations.items())
+    model.orientations.values.return_value = list(orientations.values())
+    model.geometry.detQs_lab = np.array([[1.0, 0.0, 0.0]]) if detQs_lab is None else detQs_lab
+    model.geometry.det_k = np.array([[0.0, 1.0, 0.0]]) if det_k is None else det_k
+    model.workspaces.ws.componentInfo.return_value.sourcePosition.return_value = list(source_position)
+    model.workspaces.scattering_centre = np.asarray(scattering_centre, dtype=float)
+    model.workspaces.wsname = "ws_name"
+    model.workspaces.gauge_volume_str = gauge_volume_str
+    return model
+
+
+def _make_plotter(model):
+    # the plotter now owns its visual config (colours + vis toggles); mirror the values the test set
+    # on the model mock so tests can keep configuring behaviour through _make_model(...)
+    plotter = TexturePlotter(model)
+    plotter.vis_settings = model.vis_settings
+    plotter.gon_colors = model.gon_colors
+    plotter.dir_cols = model.dir_cols
+    plotter.transmission_use_data_range = model.transmission_use_data_range
+    return plotter
+
+
+class TestTexturePlotter_UpdatePlot(unittest.TestCase):
+    @patch(file_path + ".plot_sample_only")
+    @patch(file_path + ".ShowSampleModel")
+    def test_orchestrates_helpers_in_order(self, mock_show_sample, mock_plot_sample):
+        model = _make_model()
+        # stub the internal helpers so we only verify orchestration
+        plotter = _make_plotter(model)
+        plotter._draw_goniometers = MagicMock(return_value=[np.array([1.0, 0.0, 0.0])])
+        plotter._draw_sample_and_axes = MagicMock()
+        plotter._draw_beam_and_detectors = MagicMock()
+        plotter._project_goniometer_poles = MagicMock(return_value=np.array([[0.1, 0.2]]))
+        plotter._draw_pole_figure = MagicMock()
+        plotter._decorate_pole_figure = MagicMock()
+
+        # fake mesh on updated_mesh_ws
+        mesh = np.ones((2, 3, 3))
+        model.workspaces.updated_mesh_ws.sample.return_value.getShape.return_value.getMesh.return_value = mesh
+
+        fig = MagicMock()
+        lab_ax = MagicMock()
+        proj_ax = MagicMock()
+
+        plotter.update_plot([(1, 0, 0)], [1], [10.0], fig, lab_ax, proj_ax, 0)
+
+        lab_ax.clear.assert_called_once_with()
+        proj_ax.clear.assert_called_once_with()
+        # _draw_goniometers receives (lab_ax, vecs, senses, angles, gRs, n_gon, extent)
+        gon_args = plotter._draw_goniometers.call_args.args
+        self.assertIs(gon_args[0], lab_ax)
+        self.assertEqual(gon_args[1:4], ([(1, 0, 0)], [1], [10.0]))
+        # _draw_sample_and_axes receives (fig, lab_ax, rot_mesh, extent, n_gon, scat_centre)
+        sample_args = plotter._draw_sample_and_axes.call_args.args
+        self.assertIs(sample_args[0], fig)
+        self.assertIs(sample_args[1], lab_ax)
+        # _draw_beam_and_detectors receives (lab_ax, scat_centre, extent, n_gon)
+        beam_args = plotter._draw_beam_and_detectors.call_args.args
+        self.assertIs(beam_args[0], lab_ax)
+        # _project_goniometer_poles receives (R, g_vecs)
+        proj_args = plotter._project_goniometer_poles.call_args.args
+        np.testing.assert_allclose(proj_args[0].as_matrix(), np.eye(3))
+        plotter._draw_pole_figure.assert_called_once_with(proj_ax, plotter._project_goniometer_poles.return_value, 0)
+        plotter._decorate_pole_figure.assert_called_once_with(proj_ax)
+        lab_ax.set_axis_off.assert_called_once_with()
+        fig.canvas.draw_idle.assert_called_once_with()
+        proj_ax.figure.canvas.draw_idle.assert_called_once_with()
+
+    @patch(file_path + ".plot_sample_only")
+    @patch(file_path + ".ShowSampleModel")
+    def test_applies_orientation_R_to_workspace_goniometer(self, mock_show_sample, mock_plot_sample):
+        R = Rotation.from_euler("z", 45, degrees=True)
+        orient = MagicMock()
+        orient.gRs = [Rotation.identity()]
+        orient.R = R
+        orient.include = True
+        orient.pf_points = np.array([[0.0, 0.0]])
+        model = _make_model(orientations={0: orient})
+        gonio = MagicMock()
+        model.workspaces.ws.run.return_value.getGoniometer.return_value = gonio
+        model.workspaces.updated_mesh_ws.sample.return_value.getShape.return_value.getMesh.return_value = np.ones((2, 3, 3))
+
+        plotter = _make_plotter(model)
+        plotter._draw_goniometers = MagicMock(return_value=[np.array([1.0, 0.0, 0.0])])
+        plotter._draw_sample_and_axes = MagicMock()
+        plotter._draw_beam_and_detectors = MagicMock()
+        plotter._project_goniometer_poles = MagicMock(return_value=np.array([[0.0, 0.0]]))
+        plotter._draw_pole_figure = MagicMock()
+        plotter._decorate_pole_figure = MagicMock()
+
+        plotter.update_plot([], [], [], MagicMock(), MagicMock(), MagicMock(), 0)
+
+        self.assertEqual(len(gonio.setR.call_args_list), 1)
+        np.testing.assert_allclose(gonio.setR.call_args.args[0], R.as_matrix())
+
+
+@patch(file_path + ".ring")
+class TestTexturePlotter_DrawGoniometers(unittest.TestCase):
+    def _stub_ring(self, mock_ring):
+        # ring returns shape (3, res); the code transposes / applies and reverses
+        mock_ring.return_value = np.tile(np.arange(360.0), (3, 1))
+
+    def test_skipped_entirely_when_goniometers_vis_off(self, mock_ring):
+        self._stub_ring(mock_ring)
+        model = _make_model(vis_settings={"goniometers": False, "directions": True, "incident": True, "ks": True, "scattered": True})
+        plotter = _make_plotter(model)
+        lab_ax = MagicMock()
+
+        g_vecs = plotter._draw_goniometers(lab_ax, [(1.0, 0.0, 0.0)], [1], [0.0], [Rotation.identity()], 1, 1.0)
+
+        lab_ax.plot.assert_not_called()
+        lab_ax.quiver.assert_not_called()
+        lab_ax.legend.assert_not_called()
+        # g_vecs still computed even when vis is off
+        self.assertEqual(len(g_vecs), 1)
+
+    def test_draws_two_segments_and_quiver_per_axis_when_visible(self, mock_ring):
+        self._stub_ring(mock_ring)
+        model = _make_model()
+        plotter = _make_plotter(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_goniometers(
+            lab_ax,
+            [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+            [1, 1],
+            [45.0, 90.0],
+            [Rotation.identity(), Rotation.identity()],
+            n_gon=2,
+            extent=1.0,
+        )
+
+        # 2 ring segments per axis * 2 axes = 4 plot calls; colors alternate per-axis-colour then "grey"
+        plot_colors = [c.kwargs["color"] for c in lab_ax.plot.call_args_list]
+        self.assertEqual(plot_colors, ["red", "grey", "green", "grey"])
+        # one quiver per axis
+        quiver_colors = [c.kwargs["color"] for c in lab_ax.quiver.call_args_list]
+        quiver_labels = [c.kwargs["label"] for c in lab_ax.quiver.call_args_list]
+        self.assertEqual(quiver_colors, ["red", "green"])
+        self.assertEqual(quiver_labels, ["Axis 0", "Axis 1"])
+        lab_ax.legend.assert_called_once_with()
+
+    def test_quiver_linestyle_solid_for_active_axis_dashed_for_others(self, mock_ring):
+        self._stub_ring(mock_ring)
+        model = _make_model(gonio_index=1)
+        plotter = _make_plotter(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_goniometers(
+            lab_ax,
+            [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+            [1, 1],
+            [10.0, 10.0],
+            [Rotation.identity(), Rotation.identity()],
+            n_gon=2,
+            extent=1.0,
+        )
+
+        linestyles = [c.kwargs["ls"] for c in lab_ax.quiver.call_args_list]
+        self.assertEqual(linestyles, ["--", "-"])
+        labels = [c.kwargs["label"] for c in lab_ax.quiver.call_args_list]
+        self.assertEqual(labels, ["Axis 0", "Axis 1"])
+
+    def test_returns_one_g_vec_per_input_vec(self, mock_ring):
+        self._stub_ring(mock_ring)
+        model = _make_model()
+        plotter = _make_plotter(model)
+
+        g_vecs = plotter._draw_goniometers(
+            MagicMock(),
+            [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)],
+            [1, 1, 1],
+            [0.0, 0.0, 0.0],
+            [Rotation.identity()] * 3,
+            n_gon=3,
+            extent=1.0,
+        )
+
+        self.assertEqual(len(g_vecs), 3)
+
+
+@patch(file_path + ".plot_sample_only")
+@patch(file_path + ".ShowSampleModel")
+class TestTexturePlotter_DrawSampleAndAxes(unittest.TestCase):
+    def test_calls_plot_sample_only_with_grey_alpha(self, mock_show_sample, mock_plot_sample):
+        model = _make_model()
+        plotter = _make_plotter(model)
+        fig = MagicMock()
+        lab_ax = MagicMock()
+        rot_mesh = np.ones((2, 3, 3))
+
+        plotter._draw_sample_and_axes(fig, lab_ax, rot_mesh, extent=1.0, n_gon=2, scat_centre=np.zeros(3))
+
+        fig.sca.assert_called_once_with(lab_ax)
+        mock_plot_sample.assert_called_once_with(fig, rot_mesh, 0.5, "grey")
+
+    def test_sets_axis_limits_and_aspect_from_extent_and_n_gon(self, mock_show_sample, mock_plot_sample):
+        model = _make_model()
+        plotter = _make_plotter(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_sample_and_axes(MagicMock(), lab_ax, np.ones((2, 3, 3)), extent=3.0, n_gon=2, scat_centre=np.zeros(3))
+
+        lim = 3.0 * 2 / 1.5
+        lab_ax.set_xlim.assert_called_once_with([-lim, lim])
+        lab_ax.set_ylim.assert_called_once_with([-lim, lim])
+        lab_ax.set_zlim.assert_called_once_with([-lim, lim])
+        lab_ax.set_aspect.assert_called_once_with("equal")
+
+    def test_plot_sample_directions_called_only_when_directions_vis_on(self, mock_show_sample, mock_plot_sample):
+        sample_model = MagicMock()
+        mock_show_sample.return_value = sample_model
+        model = _make_model(vis_settings={"goniometers": True, "directions": False, "incident": True, "ks": True, "scattered": True})
+        plotter = _make_plotter(model)
+
+        plotter._draw_sample_and_axes(MagicMock(), MagicMock(), np.ones((2, 3, 3)), extent=1.0, n_gon=1, scat_centre=np.zeros(3))
+
+        sample_model.plot_sample_directions.assert_not_called()
+
+    def test_plot_gauge_vol_called_when_gauge_volume_str_set(self, mock_show_sample, mock_plot_sample):
+        sample_model = MagicMock()
+        mock_show_sample.return_value = sample_model
+        model = _make_model(gauge_volume_str="<gv/>")
+        plotter = _make_plotter(model)
+
+        plotter._draw_sample_and_axes(MagicMock(), MagicMock(), np.ones((2, 3, 3)), extent=1.0, n_gon=1, scat_centre=np.zeros(3))
+
+        sample_model.plot_gauge_vol.assert_called_once_with()
+
+    def test_plot_gauge_vol_skipped_when_no_gauge_volume_str(self, mock_show_sample, mock_plot_sample):
+        sample_model = MagicMock()
+        mock_show_sample.return_value = sample_model
+        model = _make_model(gauge_volume_str=None)
+        plotter = _make_plotter(model)
+
+        plotter._draw_sample_and_axes(MagicMock(), MagicMock(), np.ones((2, 3, 3)), extent=1.0, n_gon=1, scat_centre=np.zeros(3))
+
+        sample_model.plot_gauge_vol.assert_not_called()
+
+
+class TestTexturePlotter_DrawBeamAndDetectors(unittest.TestCase):
+    def _make_plotter_with_stubbed_quiver_bundle(self, model):
+        plotter = _make_plotter(model)
+        plotter._draw_quiver_bundle = MagicMock()
+        return plotter
+
+    def test_incident_beam_drawn_only_when_vis_incident_on(self):
+        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": True, "ks": False, "scattered": False})
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
+
+        # incident-beam quiver should be the single call, with these styling kwargs
+        self.assertEqual(len(lab_ax.quiver.call_args_list), 1)
+        kw = lab_ax.quiver.call_args.kwargs
+        self.assertEqual(kw["color"], "black")
+        self.assertEqual(kw["alpha"], 0.25)
+        self.assertEqual(kw["arrow_length_ratio"], 0.05)
+
+    def test_incident_beam_skipped_when_vis_incident_off(self):
+        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": False})
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
+
+        lab_ax.quiver.assert_not_called()
+
+    def test_ks_bundle_drawn_when_vis_ks_on(self):
+        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": True, "scattered": False})
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        lab_ax = MagicMock()
+        scat_centre = np.zeros(3)
+
+        plotter._draw_beam_and_detectors(lab_ax, scat_centre, extent=2.0, n_gon=1)
+
+        self.assertEqual(len(plotter._draw_quiver_bundle.call_args_list), 1)
+        args = plotter._draw_quiver_bundle.call_args
+        self.assertIs(args.args[0], lab_ax)
+        np.testing.assert_array_equal(args.args[1], model.geometry.detQs_lab)
+        np.testing.assert_array_equal(args.args[2], scat_centre)
+        self.assertEqual(args.args[3], 2.0)
+        self.assertEqual(args.args[4], "dodgerblue")
+        self.assertEqual(args.kwargs, {"linestyle": "--"})
+
+    def test_scattered_bundle_drawn_when_vis_scattered_on(self):
+        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": True})
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        lab_ax = MagicMock()
+
+        plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
+
+        self.assertEqual(len(plotter._draw_quiver_bundle.call_args_list), 1)
+        args = plotter._draw_quiver_bundle.call_args
+        self.assertIs(args.args[0], lab_ax)
+        np.testing.assert_array_equal(args.args[1], np.asarray(model.geometry.det_k))
+        self.assertEqual(args.args[3], 1.0)
+        self.assertEqual(args.args[4], "grey")
+        self.assertEqual(args.kwargs, {})
+
+
+class TestTexturePlotter_DrawQuiverBundle(unittest.TestCase):
+    def test_calls_quiver_with_n_arrows_from_scattering_centre(self):
+        lab_ax = MagicMock()
+        dirs = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        scat_centre = np.array([10.0, 20.0, 30.0])
+
+        TexturePlotter._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
+
+        args = lab_ax.quiver.call_args.args
+        np.testing.assert_array_equal(args[0], np.array([10.0, 10.0]))
+        np.testing.assert_array_equal(args[1], np.array([20.0, 20.0]))
+        np.testing.assert_array_equal(args[2], np.array([30.0, 30.0]))
+        # arrow vectors scaled by 1.25 * extent
+        np.testing.assert_allclose(args[3], dirs[:, 0] * 2.5)
+        np.testing.assert_allclose(args[4], dirs[:, 1] * 2.5)
+        np.testing.assert_allclose(args[5], dirs[:, 2] * 2.5)
+
+    def test_passes_linestyle_through_to_quiver(self):
+        lab_ax = MagicMock()
+        TexturePlotter._draw_quiver_bundle(lab_ax, np.array([[1.0, 0.0, 0.0]]), np.zeros(3), extent=1.0, tip_color="red", linestyle="--")
+
+        self.assertEqual(lab_ax.quiver.call_args.kwargs["linestyle"], "--")
+
+    def test_scatters_tips_with_tip_color(self):
+        lab_ax = MagicMock()
+        dirs = np.array([[1.0, 0.0, 0.0]])
+        scat_centre = np.zeros(3)
+
+        TexturePlotter._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
+
+        # tips = dirs * 1.25 * extent + scat_centre = [[2.5, 0, 0]]
+        scatter_args = lab_ax.scatter.call_args
+        np.testing.assert_allclose(scatter_args.args[0], np.array([2.5]))
+        np.testing.assert_allclose(scatter_args.args[1], np.array([0.0]))
+        np.testing.assert_allclose(scatter_args.args[2], np.array([0.0]))
+        self.assertEqual(scatter_args.kwargs, {"color": "red", "s": 2})
+
+
+@patch(file_path + ".azim_proj_xy")
+@patch(file_path + ".ster_proj_xy")
+@patch(file_path + ".get_alpha_beta_from_cart")
+class TestTexturePlotter_ProjectGoniometerPoles(unittest.TestCase):
+    def test_uses_stereographic_projection_when_projection_is_ster(self, mock_alpha_beta, mock_ster, mock_azim):
+        mock_alpha_beta.return_value = np.array([[0.1, 0.2], [0.3, 0.4]])
+        mock_ster.return_value = "ster_result"
+        model = _make_model(projection="ster")
+        plotter = _make_plotter(model)
+
+        result = plotter._project_goniometer_poles(Rotation.identity(), [np.array([1.0, 0.0, 0.0])])
+
+        self.assertEqual(result, "ster_result")
+        # ster_proj_xy is called with the two columns of get_alpha_beta_from_cart's transposed return
+        ster_args = mock_ster.call_args.args
+        np.testing.assert_allclose(ster_args[0], np.array([0.1, 0.3]))
+        np.testing.assert_allclose(ster_args[1], np.array([0.2, 0.4]))
+        mock_azim.assert_not_called()
+
+    def test_uses_azimuthal_projection_when_projection_is_not_ster(self, mock_alpha_beta, mock_ster, mock_azim):
+        mock_alpha_beta.return_value = np.array([[0.1, 0.2], [0.3, 0.4]])
+        mock_azim.return_value = "azim_result"
+        model = _make_model(projection="azim")
+        plotter = _make_plotter(model)
+
+        result = plotter._project_goniometer_poles(Rotation.identity(), [np.array([1.0, 0.0, 0.0])])
+
+        self.assertEqual(result, "azim_result")
+        azim_args = mock_azim.call_args.args
+        np.testing.assert_allclose(azim_args[0], np.array([0.1, 0.3]))
+        np.testing.assert_allclose(azim_args[1], np.array([0.2, 0.4]))
+        mock_ster.assert_not_called()
+
+
+class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
+    def test_goniometer_pole_on_unit_circle_draws_line_segment(self):
+        model = _make_model(gonio_index=0)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+        # a pole exactly on the unit circle (norm == 1) -> line
+        g_pole_xy = [np.array([1.0, 0.0])]
+
+        plotter._draw_pole_figure(proj_ax, g_pole_xy, current_index=0)
+
+        self.assertTrue(any(call_ for call_ in proj_ax.plot.call_args_list))
+
+    def test_goniometer_pole_inside_unit_circle_draws_scatter(self):
+        model = _make_model(gonio_index=0)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+        g_pole_xy = [np.array([0.1, 0.0])]  # norm < 1
+
+        plotter._draw_pole_figure(proj_ax, g_pole_xy, current_index=0)
+
+        proj_ax.scatter.assert_any_call(0.0, 0.1, s=30, edgecolor="red", facecolor="red")
+
+    def test_goniometer_pole_inactive_axis_uses_no_fill(self):
+        model = _make_model(gonio_index=0)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+        # first pole active (index 0 == gonio_index); second pole inactive
+        g_pole_xy = [np.array([0.1, 0.0]), np.array([0.0, 0.2])]
+
+        plotter._draw_pole_figure(proj_ax, g_pole_xy, current_index=0)
+
+        # inactive axis gets facecolor "None"
+        self.assertIn(
+            call(0.2, 0.0, s=30, edgecolor="green", facecolor="None"),
+            proj_ax.scatter.call_args_list,
+        )
+
+    def test_included_orientation_draws_pf_points_with_filled_color_for_current(self):
+        orient = MagicMock()
+        orient.include = True
+        orient.pf_points = np.array([[0.1, 0.2]])
+        model = _make_model(orientations={0: orient}, plot_transmission=False)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        proj_ax.scatter.assert_any_call(np.array([0.2]), np.array([0.1]), s=20, c="dodgerblue")
+
+    def test_included_orientation_draws_open_circles_when_not_current(self):
+        cur = MagicMock()
+        cur.include = True
+        cur.pf_points = np.array([[0.0, 0.0]])
+        other = MagicMock()
+        other.include = True
+        other.pf_points = np.array([[0.1, 0.2]])
+        model = _make_model(orientations={0: cur, 1: other}, plot_transmission=False)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        proj_ax.scatter.assert_any_call(np.array([0.2]), np.array([0.1]), s=20, facecolor="None", edgecolor="dodgerblue")
+
+    def test_excluded_current_orientation_drawn_in_grey(self):
+        orient = MagicMock()
+        orient.include = False
+        orient.pf_points = np.array([[0.1, 0.2]])
+        model = _make_model(orientations={0: orient}, plot_transmission=False)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        proj_ax.scatter.assert_any_call(np.array([0.2]), np.array([0.1]), s=20, facecolor="None", edgecolor="grey", alpha=0.5)
+
+    def test_transmission_mode_aggregates_included_and_adds_colorbar(self):
+        a = MagicMock()
+        a.include = True
+        a.pf_points = np.array([[0.1, 0.2]])
+        a.transmission = np.array([0.3])
+        b = MagicMock()
+        b.include = True
+        b.pf_points = np.array([[0.3, 0.4]])
+        b.transmission = np.array([0.7])
+        excluded = MagicMock()
+        excluded.include = False
+        model = _make_model(orientations={0: a, 1: b, 2: excluded}, plot_transmission=True)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+        scatt_obj = MagicMock()
+        proj_ax.scatter.return_value = scatt_obj
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        scatter_call = proj_ax.scatter.call_args
+        np.testing.assert_array_equal(scatter_call.args[0], np.array([0.2, 0.4]))
+        np.testing.assert_array_equal(scatter_call.args[1], np.array([0.1, 0.3]))
+        np.testing.assert_array_equal(scatter_call.kwargs["c"], np.array([0.3, 0.7]))
+        self.assertEqual(scatter_call.kwargs["vmin"], 0)
+        self.assertEqual(scatter_call.kwargs["vmax"], 1)
+        self.assertEqual(scatter_call.kwargs["cmap"], "jet")
+        proj_ax.inset_axes.assert_called_once_with([0.9, 0.15, 0.05, 0.7])
+        proj_ax.figure.colorbar.assert_called_once_with(scatt_obj, cax=proj_ax.inset_axes.return_value)
+
+    def test_transmission_mode_uses_data_range_when_enabled(self):
+        a = MagicMock()
+        a.include = True
+        a.pf_points = np.array([[0.1, 0.2]])
+        a.transmission = np.array([0.3])
+        model = _make_model(orientations={0: a}, plot_transmission=True, transmission_use_data_range=True)
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        scatter_call = proj_ax.scatter.call_args
+        self.assertNotIn("vmin", scatter_call.kwargs)
+        self.assertNotIn("vmax", scatter_call.kwargs)
+        self.assertEqual(scatter_call.kwargs["cmap"], "jet")
+
+
+@patch(file_path + ".plt")
+class TestTexturePlotter_DecoratePoleFigure(unittest.TestCase):
+    def test_sets_aspect_limits_and_axis_off(self, mock_plt):
+        model = _make_model()
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._decorate_pole_figure(proj_ax)
+
+        proj_ax.set_aspect.assert_called_once_with("equal")
+        proj_ax.set_xlim.assert_called_once_with(-1.5, 1.5)
+        proj_ax.set_ylim.assert_called_once_with(-1.5, 1.5)
+        proj_ax.set_axis_off.assert_called_once_with()
+
+    def test_draws_two_basis_quivers(self, mock_plt):
+        model = _make_model(dir_cols=["a", "b", "c"])
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._decorate_pole_figure(proj_ax)
+
+        self.assertEqual(
+            proj_ax.quiver.call_args_list,
+            [
+                call(-1, -1, 1, 0, color="c", scale=5),
+                call(-1, -1, 0, 1, color="a", scale=5),
+            ],
+        )
+
+    def test_adds_unit_circle_patch(self, mock_plt):
+        model = _make_model()
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+        circle = MagicMock()
+        mock_plt.Circle.return_value = circle
+
+        plotter._decorate_pole_figure(proj_ax)
+
+        mock_plt.Circle.assert_called_once_with((0, 0), 1, color="grey", fill=False, linestyle="-")
+        proj_ax.add_patch.assert_called_once_with(circle)
+
+    def test_annotates_with_first_and_third_dir_names(self, mock_plt):
+        model = _make_model(dir_names=["A", "B", "C"])
+        plotter = _make_plotter(model)
+        proj_ax = MagicMock()
+
+        plotter._decorate_pole_figure(proj_ax)
+
+        self.assertEqual(
+            proj_ax.annotate.call_args_list,
+            [
+                call("A", (-0.95, -0.8)),
+                call("C", (-0.8, -0.95)),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
@@ -16,15 +16,11 @@ file_path = "mantidqtinterfaces.TexturePlanner.helpers.plotter"
 
 
 def _make_model(
-    vis_settings=None,
-    gon_colors=None,
-    dir_cols=None,
     dir_names=None,
     ax_transform=None,
     projection="ster",
     gonio_index=0,
     plot_transmission=False,
-    transmission_use_data_range=False,
     orientations=None,
     detQs_lab=None,
     det_k=None,
@@ -32,22 +28,14 @@ def _make_model(
     scattering_centre=(0.0, 0.0, 0.0),
     gauge_volume_str=None,
 ):
+    # NB: the plotter owns its visual config (vis toggles + colours + transmission clim); those are
+    # configured on the plotter itself via _make_plotter(...), not on the model.
     model = MagicMock()
-    model.vis_settings = vis_settings or {
-        "goniometers": True,
-        "directions": True,
-        "incident": True,
-        "ks": True,
-        "scattered": True,
-    }
-    model.gon_colors = gon_colors or ["red", "green", "blue"]
-    model.dir_cols = dir_cols or ["c1", "c2", "c3"]
     model.dir_names = dir_names or ["RD", "ND", "TD"]
     model.ax_transform = np.eye(3) if ax_transform is None else ax_transform
     model.projection = projection
     model.gonio_index = gonio_index
     model.plot_transmission = plot_transmission
-    model.transmission_use_data_range = transmission_use_data_range
     if orientations is None:
         orient = MagicMock()
         orient.gRs = [Rotation.identity()]
@@ -69,14 +57,19 @@ def _make_model(
     return model
 
 
-def _make_plotter(model):
-    # the plotter now owns its visual config (colours + vis toggles); mirror the values the test set
-    # on the model mock so tests can keep configuring behaviour through _make_model(...)
+def _make_plotter(model, *, vis_settings=None, gon_colors=None, dir_cols=None, transmission_use_data_range=None):
+    # the plotter owns its visual config; by default we leave the constructor defaults in place so
+    # __init__ wiring is actually exercised. Tests that intentionally drive a specific config pass
+    # the relevant override(s), which are applied on top of the real defaults.
     plotter = TexturePlotter(model)
-    plotter.vis_settings = model.vis_settings
-    plotter.gon_colors = model.gon_colors
-    plotter.dir_cols = model.dir_cols
-    plotter.transmission_use_data_range = model.transmission_use_data_range
+    if vis_settings is not None:
+        plotter.vis_settings = vis_settings
+    if gon_colors is not None:
+        plotter.gon_colors = gon_colors
+    if dir_cols is not None:
+        plotter.dir_cols = dir_cols
+    if transmission_use_data_range is not None:
+        plotter.transmission_use_data_range = transmission_use_data_range
     return plotter
 
 
@@ -162,8 +155,10 @@ class TestTexturePlotter_DrawGoniometers(unittest.TestCase):
 
     def test_skipped_entirely_when_goniometers_vis_off(self, mock_ring):
         self._stub_ring(mock_ring)
-        model = _make_model(vis_settings={"goniometers": False, "directions": True, "incident": True, "ks": True, "scattered": True})
-        plotter = _make_plotter(model)
+        model = _make_model()
+        plotter = _make_plotter(
+            model, vis_settings={"goniometers": False, "directions": True, "incident": True, "ks": True, "scattered": True}
+        )
         lab_ax = MagicMock()
 
         g_vecs = plotter._draw_goniometers(lab_ax, [(1.0, 0.0, 0.0)], [1], [0.0], [Rotation.identity()], 1, 1.0)
@@ -177,7 +172,7 @@ class TestTexturePlotter_DrawGoniometers(unittest.TestCase):
     def test_draws_two_segments_and_quiver_per_axis_when_visible(self, mock_ring):
         self._stub_ring(mock_ring)
         model = _make_model()
-        plotter = _make_plotter(model)
+        plotter = _make_plotter(model, gon_colors=["red", "green", "blue"])
         lab_ax = MagicMock()
 
         plotter._draw_goniometers(
@@ -262,16 +257,15 @@ class TestTexturePlotter_DrawSampleAndAxes(unittest.TestCase):
         plotter._draw_sample_and_axes(MagicMock(), lab_ax, np.ones((2, 3, 3)), extent=3.0, n_gon=2, scat_centre=np.zeros(3))
 
         lim = 3.0 * 2 / 1.5
-        lab_ax.set_xlim.assert_called_once_with([-lim, lim])
-        lab_ax.set_ylim.assert_called_once_with([-lim, lim])
-        lab_ax.set_zlim.assert_called_once_with([-lim, lim])
-        lab_ax.set_aspect.assert_called_once_with("equal")
+        lab_ax.set.assert_called_once_with(xlim=[-lim, lim], ylim=[-lim, lim], zlim=[-lim, lim], aspect="equal")
 
     def test_plot_sample_directions_called_only_when_directions_vis_on(self, mock_show_sample, mock_plot_sample):
         sample_model = MagicMock()
         mock_show_sample.return_value = sample_model
-        model = _make_model(vis_settings={"goniometers": True, "directions": False, "incident": True, "ks": True, "scattered": True})
-        plotter = _make_plotter(model)
+        model = _make_model()
+        plotter = _make_plotter(
+            model, vis_settings={"goniometers": True, "directions": False, "incident": True, "ks": True, "scattered": True}
+        )
 
         plotter._draw_sample_and_axes(MagicMock(), MagicMock(), np.ones((2, 3, 3)), extent=1.0, n_gon=1, scat_centre=np.zeros(3))
 
@@ -299,14 +293,15 @@ class TestTexturePlotter_DrawSampleAndAxes(unittest.TestCase):
 
 
 class TestTexturePlotter_DrawBeamAndDetectors(unittest.TestCase):
-    def _make_plotter_with_stubbed_quiver_bundle(self, model):
-        plotter = _make_plotter(model)
+    def _make_plotter_with_stubbed_quiver_bundle(self, model, vis_settings):
+        plotter = _make_plotter(model, vis_settings=vis_settings)
         plotter._draw_quiver_bundle = MagicMock()
         return plotter
 
     def test_incident_beam_drawn_only_when_vis_incident_on(self):
-        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": True, "ks": False, "scattered": False})
-        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        model = _make_model()
+        vis_settings = {"goniometers": True, "directions": True, "incident": True, "ks": False, "scattered": False}
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model, vis_settings)
         lab_ax = MagicMock()
 
         plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
@@ -319,8 +314,9 @@ class TestTexturePlotter_DrawBeamAndDetectors(unittest.TestCase):
         self.assertEqual(kw["arrow_length_ratio"], 0.05)
 
     def test_incident_beam_skipped_when_vis_incident_off(self):
-        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": False})
-        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        model = _make_model()
+        vis_settings = {"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": False}
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model, vis_settings)
         lab_ax = MagicMock()
 
         plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
@@ -328,8 +324,9 @@ class TestTexturePlotter_DrawBeamAndDetectors(unittest.TestCase):
         lab_ax.quiver.assert_not_called()
 
     def test_ks_bundle_drawn_when_vis_ks_on(self):
-        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": True, "scattered": False})
-        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        model = _make_model()
+        vis_settings = {"goniometers": True, "directions": True, "incident": False, "ks": True, "scattered": False}
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model, vis_settings)
         lab_ax = MagicMock()
         scat_centre = np.zeros(3)
 
@@ -345,8 +342,9 @@ class TestTexturePlotter_DrawBeamAndDetectors(unittest.TestCase):
         self.assertEqual(args.kwargs, {"linestyle": "--"})
 
     def test_scattered_bundle_drawn_when_vis_scattered_on(self):
-        model = _make_model(vis_settings={"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": True})
-        plotter = self._make_plotter_with_stubbed_quiver_bundle(model)
+        model = _make_model()
+        vis_settings = {"goniometers": True, "directions": True, "incident": False, "ks": False, "scattered": True}
+        plotter = self._make_plotter_with_stubbed_quiver_bundle(model, vis_settings)
         lab_ax = MagicMock()
 
         plotter._draw_beam_and_detectors(lab_ax, np.zeros(3), extent=1.0, n_gon=1)
@@ -366,7 +364,7 @@ class TestTexturePlotter_DrawQuiverBundle(unittest.TestCase):
         dirs = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
         scat_centre = np.array([10.0, 20.0, 30.0])
 
-        TexturePlotter._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
+        _make_plotter(_make_model())._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
 
         args = lab_ax.quiver.call_args.args
         np.testing.assert_array_equal(args[0], np.array([10.0, 10.0]))
@@ -379,7 +377,9 @@ class TestTexturePlotter_DrawQuiverBundle(unittest.TestCase):
 
     def test_passes_linestyle_through_to_quiver(self):
         lab_ax = MagicMock()
-        TexturePlotter._draw_quiver_bundle(lab_ax, np.array([[1.0, 0.0, 0.0]]), np.zeros(3), extent=1.0, tip_color="red", linestyle="--")
+        _make_plotter(_make_model())._draw_quiver_bundle(
+            lab_ax, np.array([[1.0, 0.0, 0.0]]), np.zeros(3), extent=1.0, tip_color="red", linestyle="--"
+        )
 
         self.assertEqual(lab_ax.quiver.call_args.kwargs["linestyle"], "--")
 
@@ -388,7 +388,7 @@ class TestTexturePlotter_DrawQuiverBundle(unittest.TestCase):
         dirs = np.array([[1.0, 0.0, 0.0]])
         scat_centre = np.zeros(3)
 
-        TexturePlotter._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
+        _make_plotter(_make_model())._draw_quiver_bundle(lab_ax, dirs, scat_centre, extent=2.0, tip_color="red")
 
         # tips = dirs * 1.25 * extent + scat_centre = [[2.5, 0, 0]]
         scatter_args = lab_ax.scatter.call_args
@@ -446,7 +446,7 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
 
     def test_goniometer_pole_inside_unit_circle_draws_scatter(self):
         model = _make_model(gonio_index=0)
-        plotter = _make_plotter(model)
+        plotter = _make_plotter(model, gon_colors=["red", "green", "blue"])
         proj_ax = MagicMock()
         g_pole_xy = [np.array([0.1, 0.0])]  # norm < 1
 
@@ -456,7 +456,7 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
 
     def test_goniometer_pole_inactive_axis_uses_no_fill(self):
         model = _make_model(gonio_index=0)
-        plotter = _make_plotter(model)
+        plotter = _make_plotter(model, gon_colors=["red", "green", "blue"])
         proj_ax = MagicMock()
         # first pole active (index 0 == gonio_index); second pole inactive
         g_pole_xy = [np.array([0.1, 0.0]), np.array([0.0, 0.2])]
@@ -534,7 +534,7 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
         self.assertEqual(scatter_call.kwargs["vmin"], 0)
         self.assertEqual(scatter_call.kwargs["vmax"], 1)
         self.assertEqual(scatter_call.kwargs["cmap"], "jet")
-        proj_ax.inset_axes.assert_called_once_with([0.9, 0.15, 0.05, 0.7])
+        proj_ax.inset_axes.assert_called_once_with((0.9, 0.15, 0.05, 0.7))
         proj_ax.figure.colorbar.assert_called_once_with(scatt_obj, cax=proj_ax.inset_axes.return_value)
 
     def test_transmission_mode_uses_data_range_when_enabled(self):
@@ -542,8 +542,8 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
         a.include = True
         a.pf_points = np.array([[0.1, 0.2]])
         a.transmission = np.array([0.3])
-        model = _make_model(orientations={0: a}, plot_transmission=True, transmission_use_data_range=True)
-        plotter = _make_plotter(model)
+        model = _make_model(orientations={0: a}, plot_transmission=True)
+        plotter = _make_plotter(model, transmission_use_data_range=True)
         proj_ax = MagicMock()
 
         plotter._draw_pole_figure(proj_ax, [], current_index=0)
@@ -563,14 +563,12 @@ class TestTexturePlotter_DecoratePoleFigure(unittest.TestCase):
 
         plotter._decorate_pole_figure(proj_ax)
 
-        proj_ax.set_aspect.assert_called_once_with("equal")
-        proj_ax.set_xlim.assert_called_once_with(-1.5, 1.5)
-        proj_ax.set_ylim.assert_called_once_with(-1.5, 1.5)
+        proj_ax.set.assert_called_once_with(xlim=(-1.5, 1.5), ylim=(-1.5, 1.5), aspect="equal")
         proj_ax.set_axis_off.assert_called_once_with()
 
     def test_draws_two_basis_quivers(self, mock_plt):
-        model = _make_model(dir_cols=["a", "b", "c"])
-        plotter = _make_plotter(model)
+        model = _make_model()
+        plotter = _make_plotter(model, dir_cols=["a", "b", "c"])
         proj_ax = MagicMock()
 
         plotter._decorate_pole_figure(proj_ax)


### PR DESCRIPTION
### Description of work

**This module handles the logic for plotting both the lab visualisation and the pole figure visualisations for the interface**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)
<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
