### PR TITLE
Fix `LoadWANDSCD` normalization scale for "Counts" and update tests w…

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -484,7 +484,7 @@ class LoadWANDSCD(PythonAlgorithm):
         DeleteWorkspace(norm_replicated)
         # find the scale
         if normalize_by == "counts":
-            scale = norm.getSignalArray().mean()
+            scale = 1.0 / norm.getSignalArray().mean()
             self.getLogger().information("scale counts = {}".format(int(scale)))
         elif normalize_by == "monitor":
             scale = np.array(data.getExperimentInfo(0).run().getProperty("monitor_count").value)

--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -485,7 +485,7 @@ class LoadWANDSCD(PythonAlgorithm):
         # find the scale
         if normalize_by == "counts":
             scale = 1.0 / norm.getSignalArray().mean()
-            self.getLogger().information("scale counts = {}".format(int(scale)))
+            self.getLogger().information("scale counts = {}".format(scale))
         elif normalize_by == "monitor":
             scale = np.array(data.getExperimentInfo(0).run().getProperty("monitor_count").value)
             scale /= norm.getExperimentInfo(0).run().getProperty("monitor_count").value[0]

--- a/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
+++ b/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
@@ -24,10 +24,10 @@ class LoadWANDSCDTest(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), 0.0, 5)
         #
         LoadWANDTest_ws = LoadWANDSCD(Filename="HB2C_7000.nxs.h5,HB2C_7001.nxs.h5", VanadiumWorkspace=van, NormalizedBy="Counts")
-        ref_val = 0.0112
-        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
-        ref_err = 2.29376e-05
-        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 5)
+        ref_val = 7.0
+        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 2)
+        ref_err = 8.96
+        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 2)
         #
         LoadWANDTest_ws = LoadWANDSCD(Filename="HB2C_7000.nxs.h5,HB2C_7001.nxs.h5", VanadiumWorkspace=van, NormalizedBy="Time")
         ref_val = 0.29363296439511044

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -17,17 +17,6 @@ it is crucial to have the correct instrument attached to the first run.
 In addition the s1 (omega rotation), duration, run_number and monitor count is read from every
 file and included in the logs of the OutputWorkspace.
 
-During a recent feature expansion, normalization can be optionally performed in the same process
-provided that the necessary Vanadium data is specified.
-By default, the algorithm will try to locate the Vanadium data using IPTS and run number.
-If failed, it will check the Vanadium filename entry to see if the data can be loaded directly
-from file.
-If neither is provided, the algorithm will try to check if the Vanadium data is provided as a
-workspace in memory.
-Currently there are three normalization scheme supported: by Count, by Monitor and by Time.
-If None is selected, no normalization will be performed and all normalization related properties
-will be ignored (on the GUI end, they will be disabled instead).
-
 If the "HB2C:CS:CrystalAlign:UBMatrix" property exists and apply goniometer tilt is true,
 it will be converted into the OrientedLattice on the OutputWorkspace.
 The goniometer tilts (sgu and sgl) are combined into the UB Matrix so that only omega (s1) needs to
@@ -40,8 +29,32 @@ usage and speed up the later reduction steps.
 In most cases you will not see a difference in reduced data with 4x4 pixel grouping.
 Also, both input data and the Vanadium data will share the same grouping scheme.
 
-The loaded workspace is designed to be the input to
-:ref:`algm-ConvertWANDSCDtoQ`.
+The loaded workspace is designed to be the input to :ref:`algm-ConvertWANDSCDtoQ`.
+
+Normalization
+=============
+
+Normalization can be performed while loading the data if the necessary Vanadium data is specified.
+By default, the algorithm will try to locate the Vanadium data using IPTS and run number.
+If that is not specified, it will check the Vanadium filename entry to see if the data can be
+loaded directly from file. If neither is provided, the algorithm will try to use Vanadium data
+provided as a workspace in memory. When a Vanadium source is provided, the data is divided by the
+Vanadium signal and then scaled according to the ``NormalizedBy`` option. If no Vanadium source is
+provided, no normalization is performed.
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``NormalizedBy``
+     - Final result
+   * - ``None``
+     - ``sample_signal / vanadium_signal``
+   * - ``Counts``
+     - ``sample_signal / (vanadium_signal / mean_vanadium_signal)``
+   * - ``Monitor``
+     - ``(sample_signal / sample_monitor_count) / (vanadium_signal / vanadium_monitor_count)``
+   * - ``Time``
+     - ``(sample_signal / sample_duration) / (vanadium_signal / vanadium_duration)``
 
 Usage
 -----

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -32,7 +32,7 @@ Also, both input data and the Vanadium data will share the same grouping scheme.
 The loaded workspace is designed to be the input to :ref:`algm-ConvertWANDSCDtoQ`.
 
 Normalization
-=============
+-------------
 
 Normalization can be performed while loading the data if the necessary Vanadium data is specified.
 By default, the algorithm will try to locate the Vanadium data using IPTS and run number.

--- a/docs/source/release/v6.17.0/Diffraction/Single_Crystal/Bugfixes/41646.rst
+++ b/docs/source/release/v6.17.0/Diffraction/Single_Crystal/Bugfixes/41646.rst
@@ -1,0 +1,1 @@
+- Fixed the ``Counts`` vanadium normalization option in :ref:`algm-LoadWANDSCD` so detector counts are scaled by the mean vanadium signal when applying the vanadium correction.


### PR DESCRIPTION
### Description of work

This PR corrects the normalization scaling in the LoadWANDSCD Python algorithm when NormalizedBy="Counts", and updates the corresponding system test reference values to match the new behavior.

Companion to PR #41647 
Implements EWM [16583](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16583)

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
