### PR TITLE
WIP Parallel docs build

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -6,6 +6,10 @@ option(DOCS_SCREENSHOTS "If enabled include automatically generated screenshots 
 option(DOCS_PLOTDIRECTIVE "If enabled include plots generated with the plot directive. " OFF)
 option(SPHINX_WARNINGS_AS_ERRORS "non-zero exit if there are sphinx warnings" ON)
 option(SPHINX_FRESH_ENV "Don't use a saved environment, but rebuild it completely" ON)
+set(SPHINX_PARALLEL_JOBS
+    4
+    CACHE STRING "Set to 1 to disable parallel docs build"
+)
 
 # Build layout
 set(SPHINX_CONF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source)
@@ -40,6 +44,11 @@ if(SPHINX_FRESH_ENV)
 else()
   set(SPHINX_FRESH_ENV_FLAG "")
 endif()
+if(SPHINX_PARALLEL_JOBS GREATER 1)
+  set(SPHINX_PARALLEL_JOBS_FLAG "--jobs" ${SPHINX_PARALLEL_JOBS})
+else()
+  set(SPHINX_PARALLEL_JOBS_FLAG "")
+endif()
 
 # Add a sphinx build target to build documentation builder - Name of the sphinx builder: html, qthelp etc target_name -
 # Optional target name. Default=docs-${builder}
@@ -62,6 +71,7 @@ function(add_sphinx_build_target builder)
       ${SPHINX_KEEPGOING}
       ${SPHINX_WARNINGS_AS_ERRORS_FLAG}
       ${SPHINX_FRESH_ENV_FLAG}
+      ${SPHINX_PARALLEL_JOBS_FLAG}
       -b
       ${builder}
       -d

--- a/docs/sphinxext/mantiddoc/autodoc.py
+++ b/docs/sphinxext/mantiddoc/autodoc.py
@@ -40,3 +40,8 @@ def setup(app):
     # Define which methods are skipped when running autodoc
     # on a member
     app.connect("autodoc-skip-member", skip_member)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/algorithm.py
+++ b/docs/sphinxext/mantiddoc/directives/algorithm.py
@@ -135,3 +135,8 @@ def setup(app):
 
     # start framework manager to load plugins once
     FrameworkManager.Instance()
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/amalgamate.py
+++ b/docs/sphinxext/mantiddoc/directives/amalgamate.py
@@ -63,3 +63,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("amalgamate", CompilationDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/attributes.py
+++ b/docs/sphinxext/mantiddoc/directives/attributes.py
@@ -70,3 +70,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("attributes", AttributesDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -508,3 +508,8 @@ def setup(app):
 
     # connect document clean up to purge information about this page
     app.connect("env-purge-doc", purge_categories)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -117,3 +117,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("diagram", DiagramDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/docs/sphinxext/mantiddoc/directives/interface.py
@@ -123,3 +123,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("interface", InterfaceDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/properties.py
+++ b/docs/sphinxext/mantiddoc/directives/properties.py
@@ -273,3 +273,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("properties", PropertiesDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/relatedalgorithms.py
+++ b/docs/sphinxext/mantiddoc/directives/relatedalgorithms.py
@@ -59,3 +59,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("relatedalgorithms", RelatedalgorithmsDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -274,3 +274,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("sourcelink", SourceLinkDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/directives/summary.py
+++ b/docs/sphinxext/mantiddoc/directives/summary.py
@@ -33,3 +33,8 @@ def setup(app):
       app: The main Sphinx application object
     """
     app.add_directive("summary", SummaryDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -570,3 +570,8 @@ def setup(app):
     Connect the 'build-finished' event to the handler function.
     """
     app.connect("build-finished", doctest_to_xunit)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/sphinxext/mantiddoc/doctest.py
+++ b/docs/sphinxext/mantiddoc/doctest.py
@@ -559,3 +559,8 @@ def setup(app):
     Connect the 'build-finished' event to the handler function.
     """
     app.connect("build-finished", doctest_to_xunit)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
### Description of work

**This is not fully tested. While reviewing docs I have been experimenting with parallel sphinx builds to see if anything breaks.**

This adds a `SPHINX_PARALLEL_JOBS` cmake variable to control number of threads.

This is not perfect, but I've not found a better approach. It is unaware of the number of jobs you have requested from your make tool. CMake can't see the values that you pass to your make tool e.g. if you do `ninja -j8`. Also the parallelisation in sphinx is not visible to your make tool. E.g. `ninja -j8` may start the sphinx job at the same time as 7 other jobs.

Therefore `SPHINX_PARALLEL_JOBS` defaults to 4. High enough to get a useful speed up, but unlikely to cause problems on any system capable of running mantid builds.

This marks all the custom sphinx extensions as being safe for `parallel_read_safe` and `parallel_write_safe`. This is to needed to get the full benefit of parallel builds and to prevent a warning:
```
WARNING: the mantiddoc.directives.sourcelink extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```
Before merging each extension needs checking that it meets the requirements at https://www.sphinx-doc.org/en/master/extdev/index.html#ext-metadata . If not they either need fixing, or something will need to be done to prevent this warning from being treated as an error.

Windows is not supported https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

Closes #41608 

### To test:

Build a clean set of docs on a commit before this branch, note the time taken
```
git checkout 41608-parallel-docs~2
rm -rf docs/html/
ninja
time ninja docs-html
mv docs/html docs/html-main
```
switch to this branch
```
git switch 41608-parallel-docs
ninja
time ninja docs-html
```
check for any none trivial changes
```
diff -ru docs/html-main docs/html
```

For me it reduces doc build time from about 3:30 minutes to 1:30



<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
