### PR TITLE
Nexus lazy descriptor

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -203,6 +203,7 @@ set(SRC_FILES
     src/SaveTBL.cpp
     src/SaveVTK.cpp
     src/ScaleInstrumentComponent.cpp
+    src/SemanticVersion.cpp
     src/SetBeam.cpp
     src/SetSample.cpp
     src/SetSampleMaterial.cpp
@@ -426,6 +427,7 @@ set(INC_FILES
     inc/MantidDataHandling/SaveTBL.h
     inc/MantidDataHandling/SaveVTK.h
     inc/MantidDataHandling/ScaleInstrumentComponent.h
+    inc/MantidDataHandling/SemanticVersion.h
     inc/MantidDataHandling/SetBeam.h
     inc/MantidDataHandling/SetSample.h
     inc/MantidDataHandling/SetSampleMaterial.h
@@ -639,6 +641,7 @@ set(TEST_FILES
     SaveStlTest.h
     SaveTBLTest.h
     ScaleInstrumentComponentTest.h
+    SemanticVersionTest.h
     SetBeamTest.h
     SetSampleMaterialTest.h
     SetSampleTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
@@ -95,7 +95,7 @@ private:
   void parse_version(const std::string &);
 
   // The full version
-  std::string m_version;
+  std::string m_version = "";
 
   // The major number
   std::uint32_t m_major = 0;

--- a/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
@@ -56,7 +56,7 @@ public:
   SemanticVersion(const std::string &);
 
   // Constructor from major, minor, patch and identifier;
-  SemanticVersion(std::uint32_t major = 0, std::uint32_t minor = 0, std::uint32_t patch = 0,
+  SemanticVersion(std::uint32_t major, std::uint32_t minor = 0, std::uint32_t patch = 0,
                   const std::string &prerelease = "", const std::string &build = "");
 
   // Destructor

--- a/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
@@ -1,0 +1,120 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2008 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <regex>
+#include <string>
+
+#include "MantidDataHandling/DllConfig.h"
+
+namespace Mantid {
+
+namespace DataHandling {
+
+namespace ILLNexus {
+
+/**
+ * @class SemanticVersion
+ * @brief Implementation of a SemVer parser.
+ *
+ * It supports th following formats :
+ * - X
+ * - X.Y
+ * - X.Y.Z
+ * - X.Y.Z-identifier
+ *
+ * The implementation is not strict in the sense that:
+ * - minor = 0 if absent
+ * - patch = 0 if absent
+ * - identifier = "" if absent
+ *
+ * so e.g.:
+ * - 3 --> major = 3, minor = 0, patch = 0, identifier = ""
+ * - 3.12 --> major = 3, minor = 12, patch = 0, identifier = ""
+ * - 3.12.3 --> major = 3, minor = 12, patch = 3, identifier = ""
+ * - 3.12.3-myid --> major = 3, minor = 12, patch = 3, identifier = "myid"
+ */
+class MANTID_DATAHANDLING_DLL SemanticVersion {
+
+public:
+  // The SemVer regex
+  static std::regex version_regex;
+
+  // Default constructor
+  SemanticVersion() = delete;
+
+  // Copy constructor
+  SemanticVersion(const SemanticVersion &other) = default;
+
+  // Constructor from string
+  SemanticVersion(const std::string &);
+
+  // Constructor from major, minor, patch and identifier;
+  SemanticVersion(std::uint32_t major = 0, std::uint32_t minor = 0, std::uint32_t patch = 0,
+                  const std::string &prerelease = "", const std::string &build = "");
+
+  // Destructor
+  ~SemanticVersion() = default;
+
+  // Assignment operators
+  SemanticVersion &operator=(const SemanticVersion &other) = default;
+
+  // Equality operator
+  bool operator==(const SemanticVersion &other) const;
+
+  // Comparison operators
+  std::strong_ordering operator<=>(const SemanticVersion &other) const;
+  std::strong_ordering operator<=>(const std::string &versionStr) const;
+
+  // Returns the build
+  const std::string &getBuild() const;
+
+  // Returns the major version
+  std::uint32_t getMajor() const;
+
+  // Returns the minor version
+  std::uint32_t getMinor() const;
+
+  // Returns the patch version
+  std::uint32_t getPatch() const;
+
+  // Returns the prerelease
+  const std::string &getPrerelease() const;
+
+  // Returns the version
+  const std::string &getVersion() const;
+
+private:
+  // Proceeds to the internal validation of the version
+  void parse_version(const std::string &);
+
+  // The full version
+  std::string m_version;
+
+  // The major number
+  std::uint32_t m_major = 0;
+
+  // The minor number
+  std::uint32_t m_minor = 0;
+
+  // The patch number
+  std::uint32_t m_patch = 0;
+
+  // The prerelease
+  std::string m_prerelease = "";
+
+  // The build
+  std::string m_build = "";
+};
+
+} // end namespace ILLNexus
+
+} // end namespace DataHandling
+
+} // end namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SemanticVersion.h
@@ -6,12 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidDataHandling/DllConfig.h"
+
 #include <compare>
 #include <cstdint>
 #include <regex>
 #include <string>
-
-#include "MantidDataHandling/DllConfig.h"
 
 namespace Mantid {
 

--- a/Framework/DataHandling/src/SemanticVersion.cpp
+++ b/Framework/DataHandling/src/SemanticVersion.cpp
@@ -95,24 +95,30 @@ void SemanticVersion::parse_version(const std::string &version) {
   std::uint32_t value = 0;
 
   std::string_view sv = m[1].str();
-  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
-  if (ec != std::errc())
-    throw std::runtime_error(std::format("Invalid major revision number: {}", m[1].str()));
+  {
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+    if (ec != std::errc())
+      throw std::runtime_error(std::format("Invalid major revision number: {}", m[1].str()));
+  }
   m_major = value;
 
   if (m[2].matched) {
     sv = m[2].str();
-    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
-    if (ec != std::errc())
-      throw std::runtime_error(std::format("Invalid minor revision number: {}", m[2].str()));
+    {
+      auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+      if (ec != std::errc())
+        throw std::runtime_error(std::format("Invalid minor revision number: {}", m[2].str()));
+    }
     m_minor = value;
   }
 
   if (m[3].matched) {
     sv = m[3].str();
-    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
-    if (ec != std::errc())
-      throw std::runtime_error(std::format("Invalid minor revision number: {}", m[3].str()));
+    {
+      auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+      if (ec != std::errc())
+        throw std::runtime_error(std::format("Invalid minor revision number: {}", m[3].str()));
+    }
     m_patch = value;
   }
 

--- a/Framework/DataHandling/src/SemanticVersion.cpp
+++ b/Framework/DataHandling/src/SemanticVersion.cpp
@@ -35,10 +35,7 @@ std::string trim(std::string s) {
 std::regex
     SemanticVersion::version_regex(R"(^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$)");
 
-SemanticVersion::SemanticVersion(const std::string &version) {
-  parse_version(version);
-  m_version = version;
-}
+SemanticVersion::SemanticVersion(const std::string &version) : m_version(version) { parse_version(version); }
 
 SemanticVersion::SemanticVersion(std::uint32_t major, std::uint32_t minor, std::uint32_t patch,
                                  const std::string &prerelease, const std::string &build)

--- a/Framework/DataHandling/src/SemanticVersion.cpp
+++ b/Framework/DataHandling/src/SemanticVersion.cpp
@@ -1,0 +1,132 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataHandling/SemanticVersion.h"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <cstddef>
+#include <format>
+#include <stdexcept>
+
+namespace Mantid {
+
+namespace DataHandling {
+
+namespace ILLNexus {
+
+namespace {
+
+std::string trim(std::string s) {
+  auto not_space = [](unsigned char c) { return !std::isspace(c); };
+
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+  s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+
+  return s;
+}
+
+} // namespace
+
+std::regex
+    SemanticVersion::version_regex(R"(^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$)");
+
+SemanticVersion::SemanticVersion(const std::string &version) {
+  parse_version(version);
+  m_version = version;
+}
+
+SemanticVersion::SemanticVersion(std::uint32_t major, std::uint32_t minor, std::uint32_t patch,
+                                 const std::string &prerelease, const std::string &build)
+    : m_major(major), m_minor(minor), m_patch(patch), m_prerelease(trim(prerelease)), m_build(trim(build)) {
+  m_version = std::format("{}.{}.{}", major, minor, patch);
+  if (!m_prerelease.empty())
+    m_version = std::format("{}-{}", m_version, m_prerelease);
+
+  if (!m_build.empty())
+    m_version = std::format("{}+{}", m_version, m_build);
+}
+
+bool SemanticVersion::operator==(const SemanticVersion &other) const {
+  return (m_major == other.m_major) && (m_minor == other.m_minor) && (m_patch == other.m_patch) &&
+         (m_prerelease == other.m_prerelease);
+}
+
+std::strong_ordering SemanticVersion::operator<=>(const SemanticVersion &other) const {
+  if (auto cmp = m_major <=> other.m_major; cmp != 0)
+    return cmp;
+
+  if (auto cmp = m_minor <=> other.m_minor; cmp != 0)
+    return cmp;
+
+  if (auto cmp = m_patch <=> other.m_patch; cmp != 0)
+    return cmp;
+
+  // According SemVer the build is not used to differentiate two versions so the comparison is stopped at the prerelease
+  return m_prerelease <=> other.m_prerelease;
+}
+
+std::strong_ordering SemanticVersion::operator<=>(const std::string &otherVersionStr) const {
+  return *this <=> SemanticVersion(otherVersionStr);
+}
+
+const std::string &SemanticVersion::getBuild() const { return m_build; }
+
+std::uint32_t SemanticVersion::getMajor() const { return m_major; }
+
+std::uint32_t SemanticVersion::getMinor() const { return m_minor; }
+
+std::uint32_t SemanticVersion::getPatch() const { return m_patch; }
+
+const std::string &SemanticVersion::getPrerelease() const { return m_prerelease; }
+
+const std::string &SemanticVersion::getVersion() const { return m_version; }
+
+void SemanticVersion::parse_version(const std::string &version) {
+
+  std::smatch m;
+  if (!std::regex_match(version, m, version_regex))
+    throw std::runtime_error(std::format("Invalid version: {}", version));
+
+  std::uint32_t value = 0;
+
+  std::string_view sv = m[1].str();
+  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+  if (ec != std::errc())
+    throw std::runtime_error(std::format("Invalid major revision number: {}", m[1].str()));
+  m_major = value;
+
+  if (m[2].matched) {
+    sv = m[2].str();
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+    if (ec != std::errc())
+      throw std::runtime_error(std::format("Invalid minor revision number: {}", m[2].str()));
+    m_minor = value;
+  }
+
+  if (m[3].matched) {
+    sv = m[3].str();
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+    if (ec != std::errc())
+      throw std::runtime_error(std::format("Invalid minor revision number: {}", m[3].str()));
+    m_patch = value;
+  }
+
+  // No need to trim the match, covered by the regex
+  if (m[4].matched)
+    m_prerelease = m[4].str();
+
+  // No need to trim the match, covered by the regex
+  if (m[5].matched)
+    m_build = m[5].str();
+}
+
+} // end namespace ILLNexus
+
+} // end namespace DataHandling
+
+} // end namespace Mantid

--- a/Framework/DataHandling/src/SemanticVersion.cpp
+++ b/Framework/DataHandling/src/SemanticVersion.cpp
@@ -21,6 +21,7 @@ namespace ILLNexus {
 
 namespace {
 
+// trimming spaces
 std::string trim(std::string s) {
   auto not_space = [](unsigned char c) { return !std::isspace(c); };
 
@@ -35,11 +36,28 @@ std::string trim(std::string s) {
 std::regex
     SemanticVersion::version_regex(R"(^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$)");
 
+/** Constructor using a full version string
+ *
+ * The version string is parsed and separated into major, minor, patch, etc.
+ *
+ * @param version The full version string
+
+ * @throw std::runtime_error if parsing fails
+ */
 SemanticVersion::SemanticVersion(const std::string &version) : m_version(version) { parse_version(version); }
 
+/** Constructor using the full version string from the indidual major, minor, patch, etc. values
+ *
+ * @param major Major number of the release
+ * @param minor Minor number of the release
+ * @param patch patch number
+ * @param prerelease pre-release string
+ * @param build build id string
+ */
 SemanticVersion::SemanticVersion(std::uint32_t major, std::uint32_t minor, std::uint32_t patch,
                                  const std::string &prerelease, const std::string &build)
     : m_major(major), m_minor(minor), m_patch(patch), m_prerelease(trim(prerelease)), m_build(trim(build)) {
+  // cppcheck-suppress useInitializationList
   m_version = std::format("{}.{}.{}", major, minor, patch);
   if (!m_prerelease.empty())
     m_version = std::format("{}-{}", m_version, m_prerelease);
@@ -48,11 +66,21 @@ SemanticVersion::SemanticVersion(std::uint32_t major, std::uint32_t minor, std::
     m_version = std::format("{}+{}", m_version, m_build);
 }
 
+/** Check if two versions are equivalent
+ *
+ * the build string is not considered
+ */
 bool SemanticVersion::operator==(const SemanticVersion &other) const {
   return (m_major == other.m_major) && (m_minor == other.m_minor) && (m_patch == other.m_patch) &&
          (m_prerelease == other.m_prerelease);
 }
 
+/** Comparison operator
+ *
+ * the build string is not considered
+ *
+ * @param other Other SemanticVersion class
+ */
 std::strong_ordering SemanticVersion::operator<=>(const SemanticVersion &other) const {
   if (auto cmp = m_major <=> other.m_major; cmp != 0)
     return cmp;
@@ -67,6 +95,12 @@ std::strong_ordering SemanticVersion::operator<=>(const SemanticVersion &other) 
   return m_prerelease <=> other.m_prerelease;
 }
 
+/** Comparison operator
+ *
+ * the build string is not considered
+ *
+ * @param otherVersionStr other version string
+ */
 std::strong_ordering SemanticVersion::operator<=>(const std::string &otherVersionStr) const {
   return *this <=> SemanticVersion(otherVersionStr);
 }
@@ -83,6 +117,10 @@ const std::string &SemanticVersion::getPrerelease() const { return m_prerelease;
 
 const std::string &SemanticVersion::getVersion() const { return m_version; }
 
+/** Check and split the version string into major, minor, patch, etc.
+ *
+ * @param version full version string
+ */
 void SemanticVersion::parse_version(const std::string &version) {
 
   std::smatch m;

--- a/Framework/DataHandling/test/SemanticVersionTest.h
+++ b/Framework/DataHandling/test/SemanticVersionTest.h
@@ -1,0 +1,169 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <stdexcept>
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataHandling/SemanticVersion.h"
+
+using Mantid::DataHandling::ILLNexus::SemanticVersion;
+
+class SemanticVersionTest : public CxxTest::TestSuite {
+public:
+  static SemanticVersionTest *createSuite() { return new SemanticVersionTest(); }
+  static void destroySuite(SemanticVersionTest *suite) { delete suite; }
+
+  SemanticVersionTest() = default;
+
+  //---------------------------------------------------------------------------------------------
+  void testMajor() {
+
+    SemanticVersion version("3");
+
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 0);
+    TS_ASSERT_EQUALS(version.getPatch(), 0);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+  }
+
+  void testMajorMinor() {
+
+    SemanticVersion version("4.2");
+
+    TS_ASSERT_EQUALS(version.getMajor(), 4);
+    TS_ASSERT_EQUALS(version.getMinor(), 2);
+    TS_ASSERT_EQUALS(version.getPatch(), 0);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+  }
+
+  void testMajorMinorPatch() {
+
+    SemanticVersion version("6.3.1");
+
+    TS_ASSERT_EQUALS(version.getMajor(), 6);
+    TS_ASSERT_EQUALS(version.getMinor(), 3);
+    TS_ASSERT_EQUALS(version.getPatch(), 1);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+  }
+
+  void testMajorMinorPatchPrerelease() {
+
+    SemanticVersion version("7.0.6-alpha1");
+
+    TS_ASSERT_EQUALS(version.getMajor(), 7);
+    TS_ASSERT_EQUALS(version.getMinor(), 0);
+    TS_ASSERT_EQUALS(version.getPatch(), 6);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "alpha1");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+  }
+
+  void testMajorMinorPatchPrereleaseBuild() {
+
+    SemanticVersion version("8.2.4-rc2+commit5367c8");
+
+    TS_ASSERT_EQUALS(version.getMajor(), 8);
+    TS_ASSERT_EQUALS(version.getMinor(), 2);
+    TS_ASSERT_EQUALS(version.getPatch(), 4);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "rc2");
+    TS_ASSERT_EQUALS(version.getBuild(), "commit5367c8");
+  }
+
+  void testInvalidVersion() {
+    // Major which is not an integer
+    TS_ASSERT_THROWS(SemanticVersion("x"), const std::runtime_error &);
+    // Minor which is not an integer
+    TS_ASSERT_THROWS(SemanticVersion("3.x"), const std::runtime_error &);
+    // Patch which is not an integer
+    TS_ASSERT_THROWS(SemanticVersion("3.2.x"), const std::runtime_error &);
+
+    // Major with negative integer
+    TS_ASSERT_THROWS(SemanticVersion("-2"), const std::runtime_error &);
+    // Minor with negative integer
+    TS_ASSERT_THROWS(SemanticVersion("3.-2"), const std::runtime_error &);
+    // Patch with negative integer
+    TS_ASSERT_THROWS(SemanticVersion("3.2.-1"), const std::runtime_error &);
+
+    // Invalid prerelease
+    TS_ASSERT_THROWS(SemanticVersion("3.2.1rc3"), const std::runtime_error &);
+    // Prerelease with spaces
+    TS_ASSERT_THROWS(SemanticVersion("3.2.1- rc3 "), const std::runtime_error &);
+
+    // Build with spaces
+    TS_ASSERT_THROWS(SemanticVersion("3.2.1-rc2+ commit1234f5"), const std::runtime_error &);
+  }
+
+  void testCTOR() {
+    SemanticVersion version(4, 5, 7, "rc2", "sha12b4g6");
+    TS_ASSERT_EQUALS(version.getMajor(), 4);
+    TS_ASSERT_EQUALS(version.getMinor(), 5);
+    TS_ASSERT_EQUALS(version.getPatch(), 7);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "rc2");
+    TS_ASSERT_EQUALS(version.getBuild(), "sha12b4g6");
+
+    version = SemanticVersion(3);
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 0);
+    TS_ASSERT_EQUALS(version.getPatch(), 0);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+
+    version = SemanticVersion(3, 12);
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 12);
+    TS_ASSERT_EQUALS(version.getPatch(), 0);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+
+    version = SemanticVersion(3, 11, 3);
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 11);
+    TS_ASSERT_EQUALS(version.getPatch(), 3);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+
+    version = SemanticVersion(3, 10, 4, "alpha2");
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 10);
+    TS_ASSERT_EQUALS(version.getPatch(), 4);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "alpha2");
+    TS_ASSERT_EQUALS(version.getBuild(), "");
+
+    version = SemanticVersion(3, 10, 4, "alpha2", "c12g4d3");
+    TS_ASSERT_EQUALS(version.getMajor(), 3);
+    TS_ASSERT_EQUALS(version.getMinor(), 10);
+    TS_ASSERT_EQUALS(version.getPatch(), 4);
+    TS_ASSERT_EQUALS(version.getPrerelease(), "alpha2");
+    TS_ASSERT_EQUALS(version.getBuild(), "c12g4d3");
+  }
+
+  void testComparison() {
+    SemanticVersion version1("7.0.6");
+    SemanticVersion version2("8.1.3");
+    TS_ASSERT(version1 < version2);
+
+    version1 = SemanticVersion("8.0.6");
+    version2 = SemanticVersion("8.1.3");
+    TS_ASSERT(version1 < version2);
+
+    version1 = SemanticVersion("8.1.2");
+    version2 = SemanticVersion("8.1.7");
+    TS_ASSERT(version1 < version2);
+
+    version1 = SemanticVersion("8.1.2-rc1");
+    version2 = SemanticVersion("8.1.7-rc3");
+    TS_ASSERT(version1 < version2);
+
+    version1 = SemanticVersion("8.1.7-rc1+sha45f7e6");
+    version2 = SemanticVersion("8.1.7-rc1+sha7b87d3");
+    TS_ASSERT(version1 == version2);
+  }
+};

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -35,12 +35,12 @@ class MANTID_NEXUS_DLL NexusDescriptorLazy {
 
 public:
   enum class CacheReturnStatus_t {
-    FOUND,
-    CACHED,
-    DATASET_NOT_FOUND,
-    WRONG_TYPE,
-    ERROR,
-    UNSET,
+    NXFOUND,
+    NXCACHED,
+    NXDATASET_NOT_FOUND,
+    NXWRONG_TYPE,
+    NXERROR,
+    NXUNSET,
   };
 
   using CacheValue_t = std::variant<float, double, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -16,12 +16,16 @@
 #include <shared_mutex>
 #include <string>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include <H5Cpp.h>
 
 namespace Mantid {
 namespace Nexus {
+
+using CacheValue =
+    std::variant<float, double, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, std::string>;
 
 template <typename T>
 concept entryTypes = std::integral<T> || std::floating_point<T> || std::same_as<T, std::string>;
@@ -104,6 +108,7 @@ public:
   bool isEntry(std::string const &entryName) const;
 
   template <entryTypes T> bool checkEntry(const std::string &entryName, const T &value) const;
+  template <typename T> std::optional<std::reference_wrapper<const T>> getCached(const std::string &key) const;
 
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(std::string const &classType) const;
@@ -152,6 +157,8 @@ private:
 
   /// the set of non-existent entries that have been checked
   mutable std::unordered_set<std::string> m_allMisses;
+
+  mutable std::map<std::string, CacheValue> m_readEntries;
 };
 
 template <>
@@ -200,20 +207,39 @@ template <> inline hid_t getH5NativeType<int64_t>() { return H5T_NATIVE_INT64; }
 
 template <> inline hid_t getH5NativeType<uint64_t>() { return H5T_NATIVE_UINT64; }
 
+template <typename T>
+std::optional<std::reference_wrapper<const T>> NexusDescriptorLazy::getCached(const std::string &key) const {
+  auto it = m_readEntries.find(key);
+  if (it == m_readEntries.end())
+    return std::nullopt;
+
+  if (auto ptr = std::get_if<T>(&it->second))
+    return std::cref(*ptr);
+
+  return std::nullopt;
+}
+
 template <entryTypes T> bool NexusDescriptorLazy::checkEntry(const std::string &entryName, const T &value) const {
 
+  // Checks if the entry is cached and if so compare the value with the cached one
+  auto cachedValueOpt = getCached<T>(entryName);
+  if (cachedValueOpt) {
+    T cachedValue = cachedValueOpt.value().get();
+    if constexpr (std::same_as<T, std::string>) {
+      return cachedValue == value;
+    } else {
+      if constexpr (std::floating_point<T>)
+        return std::fabs(cachedValue - value) < 1e-12;
+      else
+        return cachedValue == value;
+    }
+  }
+
+  // Otherwise fetch if possible the entry and performs the comparison
   if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
     return false;
 
   UniqueID<&H5Dclose> entryID(H5Dopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
-
-  // The entry must be a scalar
-  // hid_t dataspace = H5Dget_space(entryID.get());
-  // int ndims = H5Sget_simple_extent_ndims(dataspace);
-  // if (ndims != 0) {
-  //   H5Sclose(dataspace);
-  //   return false;
-  // }
 
   hid_t datatype = H5Dget_type(entryID.get());
 
@@ -274,6 +300,9 @@ template <entryTypes T> bool NexusDescriptorLazy::checkEntry(const std::string &
 
     if (buffer.size() != 1)
       return false;
+
+    // Update the cache
+    m_readEntries[entryName] = value;
 
     if constexpr (std::floating_point<T>)
       return std::fabs(buffer[0] - value) < 1e-12;

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -11,10 +11,12 @@
 
 #include <cmath>
 #include <concepts>
+#include <format>
 #include <map>
 #include <optional>
 #include <shared_mutex>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <variant>
 #include <vector>
@@ -24,9 +26,6 @@
 namespace Mantid {
 namespace Nexus {
 
-using CacheValue =
-    std::variant<float, double, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, std::string>;
-
 template <typename T>
 concept entryTypes = std::integral<T> || std::floating_point<T> || std::same_as<T, std::string>;
 
@@ -35,6 +34,18 @@ template <typename T> hid_t getH5NativeType();
 class MANTID_NEXUS_DLL NexusDescriptorLazy {
 
 public:
+  enum class CacheReturnStatus_t {
+    FOUND,
+    CACHED,
+    DATASET_NOT_FOUND,
+    WRONG_TYPE,
+    ERROR,
+    UNSET,
+  };
+
+  using CacheValue_t = std::variant<float, double, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
+                                    uint64_t, std::string, CacheReturnStatus_t>;
+
   /**
    * Unique constructor
    * @param filename input HDF5 Nexus file name
@@ -107,8 +118,14 @@ public:
    */
   bool isEntry(std::string const &entryName) const;
 
-  template <entryTypes T> bool checkEntry(const std::string &entryName, const T &value) const;
-  template <typename T> std::optional<std::reference_wrapper<const T>> getCached(const std::string &key) const;
+  /**
+   * @brief Gets the value of an entry in the Nexus file.
+   * Only single values are returned, either numeric or strings.
+   * @param entryName full address for an entry name
+   * @return pair<value, status> where value is valid only if the return status is FOUND or CACHED
+   */
+  template <typename T>
+  std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t> getEntryValue(const std::string &entryName) const;
 
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(std::string const &classType) const;
@@ -130,6 +147,8 @@ private:
   std::map<std::string, std::string> initAllEntries();
   void loadGroups(std::map<std::string, std::string> &allEntries, std::string const &address, unsigned int depth,
                   const unsigned int maxDepth);
+
+  const CacheValue_t _getEntryValue(const std::string &entryName) const;
 
   /** Nexus HDF5 file name */
   std::string const m_filename;
@@ -158,158 +177,9 @@ private:
   /// the set of non-existent entries that have been checked
   mutable std::unordered_set<std::string> m_allMisses;
 
-  mutable std::map<std::string, CacheValue> m_readEntries;
+  /// the map of all read entry values that have been checked
+  mutable std::map<std::string, CacheValue_t> m_readEntries;
 };
-
-template <>
-inline bool NexusDescriptorLazy::checkEntry<std::string>(const std::string &entryName, const std::string &value) const {
-  if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
-    return false;
-
-  UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
-  hid_t datatype = H5Dget_type(entryID.get());
-
-  if (H5Tget_class(datatype) == H5T_STRING) {
-    if (H5Tis_variable_str(datatype)) {
-      char *rdata = nullptr;
-      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
-      const std::string s(rdata);
-      H5free_memory(rdata);
-      return s == value;
-    } else {
-      size_t size = H5Tget_size(datatype);
-      std::vector<char> buffer(size + 1, '\0');
-      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
-      const std::string s(buffer.data());
-      return s == value;
-    }
-  }
-  return false;
-}
-
-template <> inline hid_t getH5NativeType<float>() { return H5T_NATIVE_FLOAT; }
-
-template <> inline hid_t getH5NativeType<double>() { return H5T_NATIVE_DOUBLE; }
-
-template <> inline hid_t getH5NativeType<int8_t>() { return H5T_NATIVE_INT8; }
-
-template <> inline hid_t getH5NativeType<uint8_t>() { return H5T_NATIVE_UINT8; }
-
-template <> inline hid_t getH5NativeType<int16_t>() { return H5T_NATIVE_INT16; }
-
-template <> inline hid_t getH5NativeType<uint16_t>() { return H5T_NATIVE_UINT16; }
-
-template <> inline hid_t getH5NativeType<int32_t>() { return H5T_NATIVE_INT32; }
-
-template <> inline hid_t getH5NativeType<uint32_t>() { return H5T_NATIVE_UINT32; }
-
-template <> inline hid_t getH5NativeType<int64_t>() { return H5T_NATIVE_INT64; }
-
-template <> inline hid_t getH5NativeType<uint64_t>() { return H5T_NATIVE_UINT64; }
-
-template <typename T>
-std::optional<std::reference_wrapper<const T>> NexusDescriptorLazy::getCached(const std::string &key) const {
-  auto it = m_readEntries.find(key);
-  if (it == m_readEntries.end())
-    return std::nullopt;
-
-  if (auto ptr = std::get_if<T>(&it->second))
-    return std::cref(*ptr);
-
-  return std::nullopt;
-}
-
-template <entryTypes T> bool NexusDescriptorLazy::checkEntry(const std::string &entryName, const T &value) const {
-
-  // Checks if the entry is cached and if so compare the value with the cached one
-  auto cachedValueOpt = getCached<T>(entryName);
-  if (cachedValueOpt) {
-    T cachedValue = cachedValueOpt.value().get();
-    if constexpr (std::same_as<T, std::string>) {
-      return cachedValue == value;
-    } else {
-      if constexpr (std::floating_point<T>)
-        return std::fabs(cachedValue - value) < 1e-12;
-      else
-        return cachedValue == value;
-    }
-  }
-
-  // Otherwise fetch if possible the entry and performs the comparison
-  if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
-    return false;
-
-  UniqueID<&H5Dclose> entryID(H5Dopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
-
-  hid_t datatype = H5Dget_type(entryID.get());
-
-  // Case of a string (fixed or variable length) type
-  if constexpr (std::same_as<T, std::string>) {
-
-    if (H5Tget_class(datatype) != H5T_STRING)
-      return false;
-
-    // Variable-length string
-    if (H5Tis_variable_str(datatype)) {
-
-      char *rdata = nullptr;
-      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
-
-      std::string s(rdata);
-      H5free_memory(rdata);
-      return s == value;
-
-      // Fixed-length string
-    } else {
-
-      size_t size = H5Tget_size(datatype);
-      std::vector<char> buffer(size + 1, '\0');
-
-      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
-
-      std::string s(buffer.data());
-      return s == value;
-    }
-    // Numeric type
-  } else {
-
-    if (H5Tget_class(datatype) != H5T_FLOAT && H5Tget_class(datatype) != H5T_INTEGER)
-      return false;
-
-    hid_t dataspace = H5Dget_space(entryID.get());
-    int ndims = H5Sget_simple_extent_ndims(dataspace);
-
-    // The ndims < 0 is for case when an error occured while fetching the dims
-    if (ndims < 0 || ndims > 1) {
-      H5Sclose(dataspace);
-      return false;
-    }
-
-    hsize_t size = 1;
-    hsize_t dims[1] = {1};
-
-    if (ndims == 1) {
-      H5Sget_simple_extent_dims(dataspace, dims, nullptr);
-      size = dims[0];
-    }
-    H5Sclose(dataspace);
-
-    // Read the entry
-    std::vector<T> buffer(size);
-    H5Dread(entryID.get(), getH5NativeType<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
-
-    if (buffer.size() != 1)
-      return false;
-
-    // Update the cache
-    m_readEntries[entryName] = value;
-
-    if constexpr (std::floating_point<T>)
-      return std::fabs(buffer[0] - value) < 1e-12;
-    else
-      return buffer[0] == value;
-  }
-}
 
 } // namespace Nexus
 } // namespace Mantid

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -9,14 +9,24 @@
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexus/UniqueID.h"
 
+#include <cmath>
+#include <concepts>
 #include <map>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
+#include <H5Cpp.h>
+
 namespace Mantid {
 namespace Nexus {
+
+template <typename T>
+concept entryTypes = std::integral<T> || std::floating_point<T> || std::same_as<T, std::string>;
+
+template <typename T> hid_t getH5NativeType();
 
 class MANTID_NEXUS_DLL NexusDescriptorLazy {
 
@@ -93,6 +103,8 @@ public:
    */
   bool isEntry(std::string const &entryName) const;
 
+  template <entryTypes T> bool checkEntry(const std::string &entryName, const T &value) const;
+
   /// Query if a given type exists somewhere in the file
   bool classTypeExists(std::string const &classType) const;
 
@@ -141,6 +153,134 @@ private:
   /// the set of non-existent entries that have been checked
   mutable std::unordered_set<std::string> m_allMisses;
 };
+
+template <>
+inline bool NexusDescriptorLazy::checkEntry<std::string>(const std::string &entryName, const std::string &value) const {
+  if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
+    return false;
+
+  UniqueID<&H5Oclose> entryID(H5Oopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
+  hid_t datatype = H5Dget_type(entryID.get());
+
+  if (H5Tget_class(datatype) == H5T_STRING) {
+    if (H5Tis_variable_str(datatype)) {
+      char *rdata = nullptr;
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
+      const std::string s(rdata);
+      H5free_memory(rdata);
+      return s == value;
+    } else {
+      size_t size = H5Tget_size(datatype);
+      std::vector<char> buffer(size + 1, '\0');
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+      const std::string s(buffer.data());
+      return s == value;
+    }
+  }
+  return false;
+}
+
+template <> inline hid_t getH5NativeType<float>() { return H5T_NATIVE_FLOAT; }
+
+template <> inline hid_t getH5NativeType<double>() { return H5T_NATIVE_DOUBLE; }
+
+template <> inline hid_t getH5NativeType<int8_t>() { return H5T_NATIVE_INT8; }
+
+template <> inline hid_t getH5NativeType<uint8_t>() { return H5T_NATIVE_UINT8; }
+
+template <> inline hid_t getH5NativeType<int16_t>() { return H5T_NATIVE_INT16; }
+
+template <> inline hid_t getH5NativeType<uint16_t>() { return H5T_NATIVE_UINT16; }
+
+template <> inline hid_t getH5NativeType<int32_t>() { return H5T_NATIVE_INT32; }
+
+template <> inline hid_t getH5NativeType<uint32_t>() { return H5T_NATIVE_UINT32; }
+
+template <> inline hid_t getH5NativeType<int64_t>() { return H5T_NATIVE_INT64; }
+
+template <> inline hid_t getH5NativeType<uint64_t>() { return H5T_NATIVE_UINT64; }
+
+template <entryTypes T> bool NexusDescriptorLazy::checkEntry(const std::string &entryName, const T &value) const {
+
+  if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
+    return false;
+
+  UniqueID<&H5Dclose> entryID(H5Dopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
+
+  // The entry must be a scalar
+  // hid_t dataspace = H5Dget_space(entryID.get());
+  // int ndims = H5Sget_simple_extent_ndims(dataspace);
+  // if (ndims != 0) {
+  //   H5Sclose(dataspace);
+  //   return false;
+  // }
+
+  hid_t datatype = H5Dget_type(entryID.get());
+
+  // Case of a string (fixed or variable length) type
+  if constexpr (std::same_as<T, std::string>) {
+
+    if (H5Tget_class(datatype) != H5T_STRING)
+      return false;
+
+    // Variable-length string
+    if (H5Tis_variable_str(datatype)) {
+
+      char *rdata = nullptr;
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
+
+      std::string s(rdata);
+      H5free_memory(rdata);
+      return s == value;
+
+      // Fixed-length string
+    } else {
+
+      size_t size = H5Tget_size(datatype);
+      std::vector<char> buffer(size + 1, '\0');
+
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+      std::string s(buffer.data());
+      return s == value;
+    }
+    // Numeric type
+  } else {
+
+    if (H5Tget_class(datatype) != H5T_FLOAT && H5Tget_class(datatype) != H5T_INTEGER)
+      return false;
+
+    hid_t dataspace = H5Dget_space(entryID.get());
+    int ndims = H5Sget_simple_extent_ndims(dataspace);
+
+    // The ndims < 0 is for case when an error occured while fetching the dims
+    if (ndims < 0 || ndims > 1) {
+      H5Sclose(dataspace);
+      return false;
+    }
+
+    hsize_t size = 1;
+    hsize_t dims[1] = {1};
+
+    if (ndims == 1) {
+      H5Sget_simple_extent_dims(dataspace, dims, nullptr);
+      size = dims[0];
+    }
+    H5Sclose(dataspace);
+
+    // Read the entry
+    std::vector<T> buffer(size);
+    H5Dread(entryID.get(), getH5NativeType<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+    if (buffer.size() != 1)
+      return false;
+
+    if constexpr (std::floating_point<T>)
+      return std::fabs(buffer[0] - value) < 1e-12;
+    else
+      return buffer[0] == value;
+  }
+}
 
 } // namespace Nexus
 } // namespace Mantid

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -10,7 +10,6 @@
 #include "MantidNexus/UniqueID.h"
 
 #include <concepts>
-#include <format>
 #include <map>
 #include <shared_mutex>
 #include <string>

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -9,14 +9,11 @@
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexus/UniqueID.h"
 
-#include <cmath>
 #include <concepts>
 #include <format>
 #include <map>
-#include <optional>
 #include <shared_mutex>
 #include <string>
-#include <tuple>
 #include <unordered_set>
 #include <variant>
 #include <vector>

--- a/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusDescriptorLazy.h
@@ -17,8 +17,6 @@
 #include <variant>
 #include <vector>
 
-#include <H5Cpp.h>
-
 namespace Mantid {
 namespace Nexus {
 

--- a/Framework/Nexus/src/.#NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/.#NexusDescriptorLazy.cpp
@@ -1,0 +1,1 @@
+shervin@nourbakhshport2.6097:1786772493

--- a/Framework/Nexus/src/.#NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/.#NexusDescriptorLazy.cpp
@@ -1,1 +1,0 @@
-shervin@nourbakhshport2.6097:1786772493

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -17,7 +17,6 @@
 #include <cstdlib> // malloc, calloc
 #include <cstring> // strcpy
 #include <filesystem>
-#include <iostream>
 #include <map>
 #include <stdexcept> // std::invalid_argument
 #include <unordered_set>
@@ -192,7 +191,7 @@ void NexusDescriptorLazy::loadGroups(std::map<std::string, std::string> &allEntr
   H5Gget_num_objs(groupID.get(), &numObjs);
   for (hsize_t i = 0; i < numObjs; i++) {
     H5G_obj_t type = H5Gget_objtype_by_idx(groupID, i);
-    ssize_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
+    size_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
     if (name_len <= 0)
       continue;
     std::string memberName(name_len, 'X');                              // fill with X for obvious errors
@@ -263,5 +262,120 @@ std::map<std::string, std::string> NexusDescriptorLazy::initAllEntries() {
   // rely on move semantics for single return
   return allEntries;
 }
+
+using CRS_t = NexusDescriptorLazy::CacheReturnStatus_t;
+
+const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(const std::string &entryName) const {
+  // Otherwise fetch if possible the entry and performs the comparison
+  if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
+    return CRS_t::DATASET_NOT_FOUND;
+
+  UniqueID<&H5Dclose> entryID(H5Dopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
+
+  hid_t datatype = H5Dget_type(entryID.get());
+
+  // Case of a string (fixed or variable length) type
+
+  if (H5Tget_class(datatype) == H5T_STRING) {
+
+    // Variable-length string
+    if (H5Tis_variable_str(datatype)) {
+
+      char *rdata = nullptr;
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata);
+
+      std::string s(rdata);
+      H5free_memory(rdata);
+
+      return s; // return std::string
+
+      // Fixed-length string
+    } else {
+
+      size_t size = H5Tget_size(datatype);
+      std::vector<char> buffer(size + 1, '\0');
+
+      H5Dread(entryID.get(), datatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+      std::string s(buffer.data());
+      return s; // return std::string
+    }
+    // Numeric type
+  } else {
+    if (H5Tget_class(datatype) != H5T_FLOAT && H5Tget_class(datatype) != H5T_INTEGER)
+      return CRS_t::WRONG_TYPE;
+
+    hid_t dataspace = H5Dget_space(entryID.get());
+    int ndims = H5Sget_simple_extent_ndims(dataspace);
+
+    // The ndims < 0 is for case when an error occured while fetching the dims
+    if (ndims < 0 || ndims > 1) {
+      H5Sclose(dataspace);
+      return CRS_t::ERROR;
+    }
+    hsize_t size = 1;
+    hsize_t dims[1] = {1};
+
+    // if (ndims == 1) { // ensured by the previous if
+    H5Sget_simple_extent_dims(dataspace, dims, nullptr);
+    size = dims[0];
+    //}
+    H5Sclose(dataspace);
+
+    // what about unsigned int?
+    if (H5Tget_class(datatype) == H5T_FLOAT) {
+      // Read the entry
+      std::vector<float> buffer(size);
+      H5Dread(entryID.get(), H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+      if (buffer.size() != 1)
+        return CRS_t::ERROR;
+      else
+        return buffer[0];
+    } else if (H5Tget_class(datatype) == H5T_INTEGER) {
+      // Read the entry
+      std::vector<int> buffer(size);
+      H5Dread(entryID.get(), H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+      if (buffer.size() != 1)
+        return CRS_t::ERROR;
+      else
+        return buffer[0];
+    }
+
+  } // else numeric
+
+  return CRS_t::ERROR;
+}
+
+template <typename T>
+std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t>
+NexusDescriptorLazy::getEntryValue(const std::string &entryName) const {
+
+  T value = T{};
+  NexusDescriptorLazy::CacheReturnStatus_t returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::CACHED;
+  // Checks if the entry is cached and if so compare the value with the cached one
+  auto it = m_readEntries.find(entryName);
+  if (it == m_readEntries.end()) {
+    auto result = _getEntryValue(entryName);
+
+    std::tie(it, std::ignore) = m_readEntries.insert(std::pair{entryName, result});
+    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::FOUND;
+  }
+
+  // value not found or not available
+  if (auto ptr = std::get_if<NexusDescriptorLazy::CacheReturnStatus_t>(&it->second))
+    returnStatus = *ptr;
+  else if (auto ptr = std::get_if<T>(&it->second))
+    value = *ptr;
+  else
+    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE;
+
+  // the value type is wrong
+  return std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t>{value, returnStatus};
+}
+
+template std::pair<std::string, NexusDescriptorLazy::CacheReturnStatus_t>
+NexusDescriptorLazy::getEntryValue<std::string>(const std::string &) const;
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -375,13 +375,13 @@ NexusDescriptorLazy::getEntryValue(const std::string &entryName) const {
   return std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t>{value, returnStatus};
 }
 
-template std::pair<std::string, NexusDescriptorLazy::CacheReturnStatus_t>
+template MANTID_NEXUS_DLL std::pair<std::string, NexusDescriptorLazy::CacheReturnStatus_t>
 NexusDescriptorLazy::getEntryValue<std::string>(const std::string &) const;
 
-template std::pair<int, NexusDescriptorLazy::CacheReturnStatus_t>
+template MANTID_NEXUS_DLL std::pair<int, NexusDescriptorLazy::CacheReturnStatus_t>
 NexusDescriptorLazy::getEntryValue<int>(const std::string &) const;
 
-template std::pair<float, NexusDescriptorLazy::CacheReturnStatus_t>
+template MANTID_NEXUS_DLL std::pair<float, NexusDescriptorLazy::CacheReturnStatus_t>
 NexusDescriptorLazy::getEntryValue<float>(const std::string &) const;
 
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -268,7 +268,7 @@ using CRS_t = NexusDescriptorLazy::CacheReturnStatus_t;
 const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(const std::string &entryName) const {
   // Otherwise fetch if possible the entry and performs the comparison
   if (H5Oexists_by_name(m_fileID, entryName.c_str(), H5P_DEFAULT) <= 0)
-    return CRS_t::DATASET_NOT_FOUND;
+    return CRS_t::NXDATASET_NOT_FOUND;
 
   UniqueID<&H5Dclose> entryID(H5Dopen(m_fileID, entryName.c_str(), H5P_DEFAULT));
 
@@ -303,7 +303,7 @@ const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(cons
     // Numeric type
   } else {
     if (H5Tget_class(datatype) != H5T_FLOAT && H5Tget_class(datatype) != H5T_INTEGER)
-      return CRS_t::WRONG_TYPE;
+      return CRS_t::NXWRONG_TYPE;
 
     hid_t dataspace = H5Dget_space(entryID.get());
     int ndims = H5Sget_simple_extent_ndims(dataspace);
@@ -311,7 +311,7 @@ const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(cons
     // The ndims < 0 is for case when an error occured while fetching the dims
     if (ndims < 0 || ndims > 1) {
       H5Sclose(dataspace);
-      return CRS_t::ERROR;
+      return CRS_t::NXERROR;
     }
     hsize_t size = 1;
     hsize_t dims[1] = {1};
@@ -329,7 +329,7 @@ const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(cons
       H5Dread(entryID.get(), H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
 
       if (buffer.size() != 1)
-        return CRS_t::ERROR;
+        return CRS_t::NXERROR;
       else
         return buffer[0];
     } else if (H5Tget_class(datatype) == H5T_INTEGER) {
@@ -338,14 +338,14 @@ const NexusDescriptorLazy::CacheValue_t NexusDescriptorLazy::_getEntryValue(cons
       H5Dread(entryID.get(), H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
 
       if (buffer.size() != 1)
-        return CRS_t::ERROR;
+        return CRS_t::NXERROR;
       else
         return buffer[0];
     }
 
   } // else numeric
 
-  return CRS_t::ERROR;
+  return CRS_t::NXERROR;
 }
 
 template <typename T>
@@ -353,14 +353,14 @@ std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t>
 NexusDescriptorLazy::getEntryValue(const std::string &entryName) const {
 
   T value = T{};
-  NexusDescriptorLazy::CacheReturnStatus_t returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::CACHED;
+  NexusDescriptorLazy::CacheReturnStatus_t returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::NXCACHED;
   // Checks if the entry is cached and if so compare the value with the cached one
   auto it = m_readEntries.find(entryName);
   if (it == m_readEntries.end()) {
     auto result = _getEntryValue(entryName);
 
     std::tie(it, std::ignore) = m_readEntries.insert(std::pair{entryName, result});
-    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::FOUND;
+    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::NXFOUND;
   }
 
   // value not found or not available
@@ -369,7 +369,7 @@ NexusDescriptorLazy::getEntryValue(const std::string &entryName) const {
   else if (auto ptr = std::get_if<T>(&it->second))
     value = *ptr;
   else
-    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE;
+    returnStatus = NexusDescriptorLazy::CacheReturnStatus_t::NXWRONG_TYPE;
 
   // the value type is wrong
   return std::pair<T, NexusDescriptorLazy::CacheReturnStatus_t>{value, returnStatus};

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -11,13 +11,13 @@
 #include "MantidNexus/UniqueID.h"
 
 #include "MantidNexus/NexusFile_fwd.h"
-#include <H5Cpp.h>
 #include <hdf5.h>
 
 #include <algorithm>
 #include <cstdlib> // malloc, calloc
 #include <cstring> // strcpy
 #include <filesystem>
+#include <iostream>
 #include <map>
 #include <stdexcept> // std::invalid_argument
 #include <unordered_set>

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -192,7 +192,7 @@ void NexusDescriptorLazy::loadGroups(std::map<std::string, std::string> &allEntr
   for (hsize_t i = 0; i < numObjs; i++) {
     H5G_obj_t type = H5Gget_objtype_by_idx(groupID, i);
     size_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
-    if (name_len <= 0)
+    if (name_len == 0)
       continue;
     std::string memberName(name_len, 'X');                              // fill with X for obvious errors
     H5Gget_objname_by_idx(groupID, i, memberName.data(), name_len + 1); // +1 for null terminator,

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -378,4 +378,10 @@ NexusDescriptorLazy::getEntryValue(const std::string &entryName) const {
 template std::pair<std::string, NexusDescriptorLazy::CacheReturnStatus_t>
 NexusDescriptorLazy::getEntryValue<std::string>(const std::string &) const;
 
+template std::pair<int, NexusDescriptorLazy::CacheReturnStatus_t>
+NexusDescriptorLazy::getEntryValue<int>(const std::string &) const;
+
+template std::pair<float, NexusDescriptorLazy::CacheReturnStatus_t>
+NexusDescriptorLazy::getEntryValue<float>(const std::string &) const;
+
 } // namespace Mantid::Nexus

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -191,8 +191,8 @@ void NexusDescriptorLazy::loadGroups(std::map<std::string, std::string> &allEntr
   H5Gget_num_objs(groupID.get(), &numObjs);
   for (hsize_t i = 0; i < numObjs; i++) {
     H5G_obj_t type = H5Gget_objtype_by_idx(groupID, i);
-    size_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
-    if (name_len == 0)
+    ssize_t name_len = H5Gget_objname_by_idx(groupID, i, nullptr, 0);
+    if (name_len <= 0)
       continue;
     std::string memberName(name_len, 'X');                              // fill with X for obvious errors
     H5Gget_objname_by_idx(groupID, i, memberName.data(), name_len + 1); // +1 for null terminator,

--- a/Framework/Nexus/src/NexusDescriptorLazy.cpp
+++ b/Framework/Nexus/src/NexusDescriptorLazy.cpp
@@ -11,6 +11,7 @@
 #include "MantidNexus/UniqueID.h"
 
 #include "MantidNexus/NexusFile_fwd.h"
+#include <H5Cpp.h>
 #include <hdf5.h>
 
 #include <algorithm>

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -143,29 +143,29 @@ public:
 
     {
       auto v = descriptor.getEntryValue<std::string>("/entry/instrument/not_a_data");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::DATASET_NOT_FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXDATASET_NOT_FOUND)
     }
     {
       auto v = descriptor.getEntryValue<std::string>("/entry/entry_identifier");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXFOUND)
       TS_ASSERT_EQUALS(v.first, "89157")
     }
     {
       auto v = descriptor.getEntryValue<int>("/entry/entry_identifier");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXWRONG_TYPE)
     }
     {
       auto v = descriptor.getEntryValue<float>("/entry/duration");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXFOUND)
       TS_ASSERT_DELTA(v.first, 7200.01, 1e-2)
 
       auto v2 = descriptor.getEntryValue<float>("/entry/duration");
-      TS_ASSERT_EQUALS(v2.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::CACHED)
+      TS_ASSERT_EQUALS(v2.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXCACHED)
       TS_ASSERT_DELTA(v2.first, 7200.01, 1e-2)
     }
     {
       auto v = descriptor.getEntryValue<int>("/entry/duration");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::NXWRONG_TYPE)
     }
   }
 

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -136,6 +136,39 @@ public:
     TS_ASSERT(descriptor.isEntry("/MDHistoWorkspace", "NXentry"));
   }
 
+  void test_getEntryValue() {
+    std::cout << "\nTesting getEntryValue in NexusDescriptorLazy" << std::endl;
+    const std::string filename = NexusTest::getFullPath("EQSANS_89157.nxs.h5");
+    Mantid::Nexus::NexusDescriptorLazy descriptor(filename);
+
+    {
+      auto v = descriptor.getEntryValue<std::string>("/entry/instrument/not_a_data");
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::DATASET_NOT_FOUND)
+    }
+    {
+      auto v = descriptor.getEntryValue<std::string>("/entry/entry_identifier");
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::FOUND)
+      TS_ASSERT_EQUALS(v.first, "89157")
+    }
+    {
+      auto v = descriptor.getEntryValue<int>("/entry/entry_identifier");
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::WRONG_TYPE)
+    }
+    {
+      auto v = descriptor.getEntryValue<float>("/entry/duration");
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::FOUND)
+      TS_ASSERT_DELTA(v.first, 7200.01, 1e-2)
+
+      auto v2 = descriptor.getEntryValue<float>("/entry/duration");
+      TS_ASSERT_EQUALS(v2.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::CACHED)
+      TS_ASSERT_DELTA(v2.first, 7200.01, 1e-2)
+    }
+    {
+      auto v = descriptor.getEntryValue<int>("/entry/duration");
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::WRONG_TYPE)
+    }
+  }
+
   void test_threadSafety() {
     constexpr int NUM_THREAD{5}; // number of threads to spawn
 

--- a/Framework/Nexus/test/NexusDescriptorLazyTest.h
+++ b/Framework/Nexus/test/NexusDescriptorLazyTest.h
@@ -143,29 +143,29 @@ public:
 
     {
       auto v = descriptor.getEntryValue<std::string>("/entry/instrument/not_a_data");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::DATASET_NOT_FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::DATASET_NOT_FOUND)
     }
     {
       auto v = descriptor.getEntryValue<std::string>("/entry/entry_identifier");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::FOUND)
       TS_ASSERT_EQUALS(v.first, "89157")
     }
     {
       auto v = descriptor.getEntryValue<int>("/entry/entry_identifier");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::WRONG_TYPE)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE)
     }
     {
       auto v = descriptor.getEntryValue<float>("/entry/duration");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::FOUND)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::FOUND)
       TS_ASSERT_DELTA(v.first, 7200.01, 1e-2)
 
       auto v2 = descriptor.getEntryValue<float>("/entry/duration");
-      TS_ASSERT_EQUALS(v2.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::CACHED)
+      TS_ASSERT_EQUALS(v2.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::CACHED)
       TS_ASSERT_DELTA(v2.first, 7200.01, 1e-2)
     }
     {
       auto v = descriptor.getEntryValue<int>("/entry/duration");
-      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::cacheReturnStatus_t::WRONG_TYPE)
+      TS_ASSERT_EQUALS(v.second, Mantid::Nexus::NexusDescriptorLazy::CacheReturnStatus_t::WRONG_TYPE)
     }
   }
 


### PR DESCRIPTION
Here's the merge request for Mantid.
Code from @eurydice76 

## Need

At the ILL, Nexus files have a version number, in order to describe their evolution for a single instrument. When choosing the right loader of a given Nexus file, the usage of an instrument name and version number is more efficient and clear. There is a clear benefit in further developments and maintenance on the long term if using this strategy instead of obscure rules on the structure of a file.

## The issue

The possibility to read the value of an address in the Nexus file is not provided by the current NexusDescriptorLazy class. An access to the file in the confidence method would have a big impact on the Load algorithm performance.

## The proposed solution

The current merge request provides an additional method for this class that includes the boiler plate of reading simple string, int and float fields from a nexus file with a caching mechanism. This limits the reading overhead to the first request. In order to deal with versioning numbers, a helper class SemanticVersion is also provided to simplify the usage in the loaders.

Here's an exammple of use in the loader confidence method:

```
std::string instrumentName;
NexusDescriptorLazy::CacheReturnStatus_t status = NexusDescriptorLazy::CacheReturnStatus_t::UNSET;
std::tie(instrumentName, status) = descriptor.getEntryValue<std::string>("/entry0/instrument/name");
if ((status == NexusDescriptorLazy::CacheReturnStatus_t::FOUND ||
        status == NexusDescriptorLazy::CacheReturnStatus_t::CACHED) == false)
     return 0; // no instrument/name in entry0

std::string nexusVersion;
std::tie(nexusVersion, status) =
    descriptor.getEntryValue<std::string>(std::format("/entry0/{}/NexusProfile/version", instrumentName));
if ((status == NexusDescriptorLazy::CacheReturnStatus_t::FOUND ||
        status == NexusDescriptorLazy::CacheReturnStatus_t::CACHED) == false)
     return 0; // no nexus version in NexusProfile

SemanticVersion version(nexusVersion);
if ((status == NexusDescriptorLazy::CacheReturnStatus_t::FOUND ||
     status == NexusDescriptorLazy::CacheReturnStatus_t::CACHED) &&
     instrumentName == "D20" &&
     version.getMajor() >= 10)
     return 80;
return 0;
```

### Todo
- [x] Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- [x] Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- [x] Are appropriately scoped unit and/or system tests provided?
- [ ] Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- [x] Has the relevant (user and developer) documentation been added/updated?
- [x] If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

