### PR TITLE
Change references to forum to email or discussions

### DIFF
--- a/Framework/API/src/NotebookWriter.cpp
+++ b/Framework/API/src/NotebookWriter.cpp
@@ -114,8 +114,8 @@ void NotebookWriter::headerComment() {
                              "* [IPython Notebook "
                              "Documentation](http://ipython.org/ipython-doc/stable/notebook/)\n"
                              "* [matplotlib Documentation](http://matplotlib.org/contents.html)\n\n"
-                             "Help requests and bug reports should be submitted to the [Mantid forum.]"
-                             "(http://forum.mantidproject.org)"));
+                             "Help requests and bug reports should be submitted to [mantid-help]"
+                             "(mailto:mantid-help@mantidproject.org)."));
 
   markdownCell(strings);
 }

--- a/Framework/Algorithms/test/NormaliseByDetectorTest.h
+++ b/Framework/Algorithms/test/NormaliseByDetectorTest.h
@@ -307,7 +307,7 @@ public:
   }
 
   void test_formula_not_specified_doesnt_throw() {
-    // If we don't specify wavelength, then we assume the forumlas are working
+    // If we don't specify wavelength, then we assume the formulas are working
     // in terms of wavelength.
     MatrixWorkspace_sptr inputWS2 = create_workspace_with_fitting_functions("");
     do_test_doesnt_throw_on_execution(inputWS2);

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -317,7 +317,7 @@ class MainWindow(QMainWindow):
         action_algorithm_descriptions = create_action(self, "Algorithm Descriptions", on_triggered=self.open_algorithm_descriptions_help)
         action_mantid_concepts = create_action(self, "Mantid Concepts", on_triggered=self.open_mantid_concepts_help)
         action_mantid_homepage = create_action(self, "Mantid Homepage", on_triggered=self.open_mantid_homepage)
-        action_mantid_forum = create_action(self, "Mantid Forum", on_triggered=self.open_mantid_forum)
+        action_mantid_discussion = create_action(self, "Mantid Discussion", on_triggered=self.open_mantid_discussion)
         action_support_email = create_action(self, "Email mantid-help@mantidproject.org", on_triggered=self.mantidhelp_mailto)
         action_about = create_action(self, "About Mantid Workbench", on_triggered=self.open_about)
 
@@ -327,7 +327,7 @@ class MainWindow(QMainWindow):
             action_algorithm_descriptions,
             None,
             action_mantid_homepage,
-            action_mantid_forum,
+            action_mantid_discussion,
             action_support_email,
             None,
             action_about,
@@ -680,8 +680,8 @@ class MainWindow(QMainWindow):
     def open_mantid_homepage(self):
         self.interface_manager.showWebPage("https://www.mantidproject.org")
 
-    def open_mantid_forum(self):
-        self.interface_manager.showWebPage("https://forum.mantidproject.org/")
+    def open_mantid_discussion(self):
+        self.interface_manager.showWebPage("https://github.com/mantidproject/mantid/discussions")
 
     def mantidhelp_mailto(self):
         self.interface_manager.showWebPage("mailto:mantid-help@mantidproject.org")

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -153,7 +153,7 @@ class MainWindowTest(unittest.TestCase):
             "Algorithm Descriptions",
             None,
             "Mantid Homepage",
-            "Mantid Forum",
+            "Mantid Discussion",
             "Email mantid-help@mantidproject.org",
             None,
             "About Mantid Workbench",

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -55,7 +55,7 @@ DefaultTrans = True
 # CommandInterfaceStateDirector global instance
 # ----------------------------------------------------------------------------------------------------------------------
 director = CommandInterfaceStateDirector(SANSFacility.ISIS)
-_plot_missing_str = "Plotting is not implemented for workbench yet, please contact us via the forum:\nhttps://forum.mantidproject.org/"
+_plot_missing_str = "Plotting is not implemented for workbench yet, please contact us via \nmantid-help@mantidproject.org"
 
 
 def deprecated(obj):

--- a/tools/release_generator/patch.py
+++ b/tools/release_generator/patch.py
@@ -47,7 +47,7 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
+.. _discussion: https://github.com/mantidproject/mantid/discussions
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v{version}
 """

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -40,7 +40,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our `discussion`_.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -92,7 +92,7 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _download page: https://download.mantidproject.org
 
-.. _forum: https://forum.mantidproject.org
+.. _discussion: https://github.com/mantidproject/mantid/discussions
 
 .. _GitHub milestone: {milestone_link}
 


### PR DESCRIPTION
The mantid forum will be shut down soon. This moves references to appropriate replacements. Some are to the discussions page, and some to the mantid-help email address.

There is no associated issue.

### To test:

In principle, build and click on the couple of links.

*This does not require release notes* because it is completing a news item.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
