### PR TITLE
Instrument View 2.0: Fix delete peaks bug

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -630,7 +630,7 @@ class FullInstrumentViewModel:
         )
         closest_peak_by_ws = []
         for ws_name in selected_peaks_workspaces:
-            peaks_by_detector = WorkspaceDetectorPeaks(ws_name).detector_peaks
+            peaks_by_detector = WorkspaceDetectorPeaks(ws_name, self.get_integration_units(), self.integration_limits).detector_peaks
             picked_detector_peaks = [p for p in peaks_by_detector if p.detector_id in self.picked_detector_ids]
             if len(picked_detector_peaks) == 0:
                 continue
@@ -650,7 +650,7 @@ class FullInstrumentViewModel:
 
     def delete_peaks_on_all_selected_detectors(self, selected_peaks_workspaces) -> None:
         for ws_name in selected_peaks_workspaces:
-            peaks_by_detector = WorkspaceDetectorPeaks(ws_name).detector_peaks
+            peaks_by_detector = WorkspaceDetectorPeaks(ws_name, self.get_integration_units(), self.integration_limits).detector_peaks
             picked_detector_peaks = [p for p in peaks_by_detector if p.detector_id in self.picked_detector_ids]
             if len(picked_detector_peaks) == 0:
                 continue

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -883,7 +883,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         ws2_wdp.detector_peaks = [
             DetectorPeaks([self._create_peak(100, 8), self._create_peak(200, 8)]),
         ]
-        mock_wdp_cls.side_effect = lambda name: {"ws1": ws1_wdp, "ws2": ws2_wdp}[name]
+        mock_wdp_cls.side_effect = lambda name, unit, limits: {"ws1": ws1_wdp, "ws2": ws2_wdp}[name]
         mock_ws1 = MagicMock()
         mock_ws2 = MagicMock()
         mock_ads.retrieve.side_effect = lambda name: {"ws1": mock_ws1, "ws2": mock_ws2}[name]
@@ -962,7 +962,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         ws1_wdp.detector_peaks = [DetectorPeaks([self._create_peak(201, 7, 2.5), self._create_peak(202, 7, 100.0)])]
         ws2_wdp = MagicMock()
         ws2_wdp.detector_peaks = [DetectorPeaks([self._create_peak(301, 7, 2.3), self._create_peak(302, 7, 50.0)])]
-        mock_wdp_cls.side_effect = lambda name: {"ws1": ws1_wdp, "ws2": ws2_wdp}[name]
+        mock_wdp_cls.side_effect = lambda name, unit, limits: {"ws1": ws1_wdp, "ws2": ws2_wdp}[name]
         mock_ws1 = MagicMock()
         mock_ws2 = MagicMock()
         mock_ads.retrieve.side_effect = lambda name: {"ws1": mock_ws1, "ws2": mock_ws2}[name]


### PR DESCRIPTION
### Description of work
This fixes a bug caused by missing arguments when initialising CreateDetectorTable. This probably happened as a result of some merge conflict resolution and went unoticed.


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. With a detector with peaks selected, click to delete all peaks
2. Delete individual peaks 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
