### PR TITLE
Replace/remove links to the forum in the docs

### DIFF
--- a/dev-docs/source/Communication.rst
+++ b/dev-docs/source/Communication.rst
@@ -15,7 +15,7 @@ Support
 -------
 
 * Email Mantid-help@mantidproject.org goes to a short list of developers, who create tickets and assign to others.
-* `Forum <http://forum.mantidproject.org/>`__ with discussions for general and technique help requests
+* `Github Discussions <https://github.com/mantidproject/mantid/discussions>`_ for general and technique help requests
 
 Meetings & other information
 ----------------------------

--- a/dev-docs/source/DeveloperAccounts.rst
+++ b/dev-docs/source/DeveloperAccounts.rst
@@ -23,7 +23,6 @@ Account Creation
 	+ Set up Git on your workstation; see `this guide <https://help.github.com/articles/set-up-git/>`__.
 	+ The Git workflow is described on the :ref:`GitWorkflow` page.
 - If based at ISIS, please sign up for a `User Facilities account <https://users.facilities.rl.ac.uk/>`__ that among other things, grants access to IDAaaS.
-- Sign up for an account on the **Mantid Help Forum**; follow `this link <https://forum.mantidproject.org/>`__. We recommend using your Github account to sign up on the forum!
 
 Introducing Yourself
 --------------------

--- a/dev-docs/source/UserSupport.rst
+++ b/dev-docs/source/UserSupport.rst
@@ -26,7 +26,7 @@ The main purpose of user support for the Mantid project, is to aide contact betw
 Bugs and Error Reports
 ----------------------
 
-1.	Users can report bugs via the `Mantid Help Forum <https://forum.mantidproject.org/>`_ or the `Mantid Help Email <mantid-help@mantidproject.org>`_, or from collected **Error Reports**. Currently this is a quick first contact with the team, but doesn't give much detail about the usage or unexpected error.
+1.	Users can report bugs via the `GitHub discussion page <https://github.com/mantidproject/mantid/discussions>`_, the `Mantid Help Email <mantid-help@mantidproject.org>`_, or from collected **Error Reports**. Currently this is a quick first contact with the team, but doesn't give much detail about the usage or unexpected error.
 2.	The bug is verified and reproduced by the support team.
 3.	The impact and importance are assessed by the support team member by contacting the users, instrument scientists, developers or project manager as appropriate.
 4.	A GitHub issue to resolve the problem is created if appropriate and/or workaround tested if possible.

--- a/docs/source/algorithms/Fit-v1.rst
+++ b/docs/source/algorithms/Fit-v1.rst
@@ -243,8 +243,7 @@ Currently only the following functions can be used in a fit with "Histogram" eva
 - :ref:`func-FlatBackground`
 - :ref:`func-LinearBackground`
 
-If any other functions need to be included in the list please leave a request at the
-`Forum <http://forum.mantidproject.org/>`_.
+If any other functions need to be included in the list please leave a request at mantid-help@mantidproject.org .
 
 
 Excluding data from fit

--- a/docs/source/deprecation.md
+++ b/docs/source/deprecation.md
@@ -36,7 +36,6 @@ To ensure users are aware of deprecated algorithms and other features
 
 When the code is being removed from the release that is being developed
 
-- Post to the [Mantid Forum](https://forum.mantidproject.org/)
 - E-mail the Mantid Announcements e-mail list (to join this list see our [Contact Us](https://www.mantidproject.org/contact) page.
 - Technical Working Group members will communicate the removal to the facilities they represent
 - A list of removed algorithms/features will be listed in the {ref}`release_notes` for that release

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,6 @@ This is the documentation for Mantid |release|.
   * :ref:`deprecation_policy`, our current policy for deprecating algorithms, interfaces and other parts of Mantid.
 
 **Other Help and Documentation:**
-    * A `forum <http://forum.mantidproject.org/>`_, to ask for help, report issues, and discuss with other Mantid users.
+    * `GitHub Discussion <https://github.com/mantidproject/mantid/discussions>`_, to ask for help, report issues, and discuss with other Mantid users.
     * A built in error-reporter. We really encourage you to use this, as it helps us to make Mantid more stable in future.
     * `Developer Documentation <http://developer.mantidproject.org/>`_

--- a/docs/source/release/v3.10.0/index.rst
+++ b/docs/source/release/v3.10.0/index.rst
@@ -23,7 +23,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -62,8 +62,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Aclosed
 

--- a/docs/source/release/v3.10.1/index.rst
+++ b/docs/source/release/v3.10.1/index.rst
@@ -46,6 +46,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.10.1

--- a/docs/source/release/v3.11.0/index.rst
+++ b/docs/source/release/v3.11.0/index.rst
@@ -24,7 +24,7 @@ time and effort helping us to make this another reliable version of Mantid.
 
 Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -60,8 +60,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Aclosed
 

--- a/docs/source/release/v3.12.0/index.rst
+++ b/docs/source/release/v3.12.0/index.rst
@@ -28,7 +28,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -65,8 +65,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+3.12"+is%3Amerged
 

--- a/docs/source/release/v3.12.1/index.rst
+++ b/docs/source/release/v3.12.1/index.rst
@@ -91,6 +91,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.12.1

--- a/docs/source/release/v3.13.0/index.rst
+++ b/docs/source/release/v3.13.0/index.rst
@@ -54,8 +54,6 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+3.13"+is%3Amerged
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.13.0

--- a/docs/source/release/v3.5.2/index.rst
+++ b/docs/source/release/v3.5.2/index.rst
@@ -38,6 +38,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.5.2

--- a/docs/source/release/v3.6.0/index.rst
+++ b/docs/source/release/v3.6.0/index.rst
@@ -27,7 +27,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -61,8 +61,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.6%22+is%3Aclosed
 

--- a/docs/source/release/v3.6.1/index.rst
+++ b/docs/source/release/v3.6.1/index.rst
@@ -50,6 +50,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.6.1

--- a/docs/source/release/v3.7.1/index.rst
+++ b/docs/source/release/v3.7.1/index.rst
@@ -23,7 +23,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -57,8 +57,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Aclosed
 

--- a/docs/source/release/v3.8.0/index.rst
+++ b/docs/source/release/v3.8.0/index.rst
@@ -21,7 +21,7 @@ has put a great effort into making all of these improvements as part of this Man
 Throughout the Mantid development, we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -59,8 +59,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Aclosed
 

--- a/docs/source/release/v3.9.0/index.rst
+++ b/docs/source/release/v3.9.0/index.rst
@@ -23,7 +23,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -65,8 +65,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Aclosed
 

--- a/docs/source/release/v3.9.1/index.rst
+++ b/docs/source/release/v3.9.1/index.rst
@@ -96,6 +96,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.9.1

--- a/docs/source/release/v3.9.2/index.rst
+++ b/docs/source/release/v3.9.2/index.rst
@@ -44,6 +44,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v3.9.2

--- a/docs/source/release/v4.0.0/index.rst
+++ b/docs/source/release/v4.0.0/index.rst
@@ -83,8 +83,6 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+4.0"+is%3Amerged
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v4.0.0

--- a/docs/source/release/v4.0.0/mantidworkbench.rst
+++ b/docs/source/release/v4.0.0/mantidworkbench.rst
@@ -70,7 +70,7 @@ Feedback
 
 We would be grateful of any feedback on the new interface to any of the usual means of communication:
 
-- there is a `forum thread <http://forum.mantidproject.org/t/mantid-4-0-workbench/463>`_ that can be used to report feedback
+- there is a forum thread that can be used to report feedback
 - the standard ``mantid-help`` mailing address
 - if you are at a facility then we are more than happy to come and have a chat.
 

--- a/docs/source/release/v4.1.0/index.rst
+++ b/docs/source/release/v4.1.0/index.rst
@@ -31,7 +31,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -85,8 +85,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release 4.1"+is%3Amerged
 

--- a/docs/source/release/v4.2.0/index.rst
+++ b/docs/source/release/v4.2.0/index.rst
@@ -31,7 +31,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -84,8 +84,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: http://download.mantidproject.org
-
-.. _forum: http://forum.mantidproject.org
 
 .. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease 4.2+is%3Amerged
 

--- a/docs/source/release/v5.0.0/index.rst
+++ b/docs/source/release/v5.0.0/index.rst
@@ -36,7 +36,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -88,8 +88,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release 5.0"+is%3Amerged
 

--- a/docs/source/release/v5.1.0/index.rst
+++ b/docs/source/release/v5.1.0/index.rst
@@ -30,7 +30,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -83,8 +83,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release Release 5.1"+is%3Amerged
 

--- a/docs/source/release/v5.1.0/mantidplot.rst
+++ b/docs/source/release/v5.1.0/mantidplot.rst
@@ -28,6 +28,6 @@ to workbench should be smooth and easy.
 **Workbench can even load all of the workspaces (although not the graphs) from a saved MantidPlot Project file
 if you want to transfer ongoing work.**
 
-If you run into any problems or have any questions please ask them on our `user forum <https://forum.mantidproject.org/>`_.
+If you run into any problems or have any questions please ask them on our forum.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.1/index.rst
+++ b/docs/source/release/v5.1.1/index.rst
@@ -80,6 +80,4 @@ Summary of impact
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v5.1.1

--- a/docs/source/release/v6.0.0/index.rst
+++ b/docs/source/release/v6.0.0/index.rst
@@ -36,7 +36,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world, you can also
@@ -85,8 +85,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.0%22+is%3Amerged
 

--- a/docs/source/release/v6.1.0/index.rst
+++ b/docs/source/release/v6.1.0/index.rst
@@ -34,7 +34,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -83,8 +83,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+6.1"+is%3Amerged
 

--- a/docs/source/release/v6.10.0/index.rst
+++ b/docs/source/release/v6.10.0/index.rst
@@ -58,7 +58,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -109,8 +109,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.10%22+is%3Amerged
 

--- a/docs/source/release/v6.11.0/index.rst
+++ b/docs/source/release/v6.11.0/index.rst
@@ -46,7 +46,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -97,8 +97,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.11%22+is%3Amerged
 

--- a/docs/source/release/v6.12.0/index.rst
+++ b/docs/source/release/v6.12.0/index.rst
@@ -34,7 +34,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -85,8 +85,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.12%22+is%3Amerged
 

--- a/docs/source/release/v6.13.0/index.rst
+++ b/docs/source/release/v6.13.0/index.rst
@@ -33,7 +33,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -84,8 +84,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.13%22+is%3Amerged
 

--- a/docs/source/release/v6.13.1/index.rst
+++ b/docs/source/release/v6.13.1/index.rst
@@ -34,6 +34,4 @@ Changes in this version
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.13.1

--- a/docs/source/release/v6.14.0/index.rst
+++ b/docs/source/release/v6.14.0/index.rst
@@ -31,7 +31,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -79,8 +79,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.14%22+is%3Amerged
 

--- a/docs/source/release/v6.15.0/index.rst
+++ b/docs/source/release/v6.15.0/index.rst
@@ -34,7 +34,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -84,8 +84,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.15%22+is%3Amerged
 

--- a/docs/source/release/v6.16.0/index.rst
+++ b/docs/source/release/v6.16.0/index.rst
@@ -29,7 +29,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -80,8 +80,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.16%22+is%3Amerged
 

--- a/docs/source/release/v6.2.0/index.rst
+++ b/docs/source/release/v6.2.0/index.rst
@@ -30,7 +30,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -79,8 +79,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+milestone%3A%22Release+6.2%22
 

--- a/docs/source/release/v6.3.0/index.rst
+++ b/docs/source/release/v6.3.0/index.rst
@@ -71,7 +71,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -120,8 +120,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+6.3"+is%3Amerged
 

--- a/docs/source/release/v6.4.0/index.rst
+++ b/docs/source/release/v6.4.0/index.rst
@@ -61,7 +61,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -110,8 +110,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.4%22+is%3Amerged
 

--- a/docs/source/release/v6.5.0/index.rst
+++ b/docs/source/release/v6.5.0/index.rst
@@ -37,7 +37,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -86,8 +86,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.5%22+is%3Amerged
 

--- a/docs/source/release/v6.6.0/index.rst
+++ b/docs/source/release/v6.6.0/index.rst
@@ -32,7 +32,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to sourceforge to mirror our download files around the world. You can also
@@ -81,8 +81,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.6%22+is%3Amerged
 

--- a/docs/source/release/v6.7.0/index.rst
+++ b/docs/source/release/v6.7.0/index.rst
@@ -34,7 +34,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -83,8 +83,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.7%22+is%3Amerged
 

--- a/docs/source/release/v6.8.0/index.rst
+++ b/docs/source/release/v6.8.0/index.rst
@@ -33,7 +33,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -82,8 +82,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.8%22+is%3Amerged
 

--- a/docs/source/release/v6.9.0/index.rst
+++ b/docs/source/release/v6.9.0/index.rst
@@ -30,7 +30,7 @@ time and effort helping us to make this another reliable version of Mantid.
 Throughout the Mantid project we put a lot of effort into ensuring
 Mantid is a robust and reliable product. Thank you to everyone that has
 reported any issues to us. Please keep on reporting any problems you
-have, or crashes that occur on our `forum`_.
+have, or crashes that occur on our forum.
 
 Installation packages can be found on our `download page`_
 which now links to the assets on our `GitHub release page`_, where you can also
@@ -81,8 +81,6 @@ Full Change Listings
 For a full list of all issues addressed during this release please see the `GitHub milestone`_.
 
 .. _download page: https://download.mantidproject.org
-
-.. _forum: https://forum.mantidproject.org
 
 .. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.9%22+is%3Amerged
 

--- a/docs/source/release/v6.9.1/index.rst
+++ b/docs/source/release/v6.9.1/index.rst
@@ -38,6 +38,4 @@ Changes in this version
 
 .. _download page: http://download.mantidproject.org
 
-.. _forum: http://forum.mantidproject.org
-
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.9.1

--- a/docs/source/tutorials/mantid_basic_course/useful/03_user_support.rst
+++ b/docs/source/tutorials/mantid_basic_course/useful/03_user_support.rst
@@ -12,13 +12,9 @@ Contact Us
 
 We are always keen for feedback, so if you have any suggestions for improving Mantid, then please contact us.
 
-1. Through the `Mantid Help Forum <https://forum.mantidproject.org/>`_. Report a problem or ask for help. Remember to tag an appropriate topic.
+1. Through the `GitHub Discussions <https://github.com/mantidproject/mantid/discussions>`_. Report a problem or ask for help. Remember to tag an appropriate topic.
 
-This is quickly accessible through the top Toolbar in Mantid "Help > Mantid Forum"
-
-.. figure:: /images/MantidHelpForum.png
-   :alt: Mantid Help Forum
-   :align: center
+This is quickly accessible through the top Toolbar in Mantid "Help > Mantid Discussion"
 
 2. Mantid Help email: mantid-help@mantidproject.org
 


### PR DESCRIPTION
As part of sunsetting the forum, modify the links in the documentation. 

There is no associated issue

### To test:

The docs builds should both pass

*This does not require release notes* because it is a minor documentation change.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
