### PR TITLE
Output normalization workspace in LoadWANDSCD

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -85,14 +85,19 @@ class LoadWANDSCD(PythonAlgorithm):
         )
         # normalization method
         self.declareProperty(
-            "NormalizedBy", "None", StringListValidator(["None", "Counts", "Monitor", "Time"]), "Normalize to Counts, Monitor, Time."
+            "NormalizedBy",
+            "None",
+            StringListValidator(["None", "Counts", "Monitor", "Time"]),
+            doc="Normalization flux. Valid options are Counts, Monitor, and Time.",
         )
+        self.declareProperty("NormalizeData", True, "When False, skip normalization even if vanadium data is provided.")
         # group normalization properties
         self.setPropertyGroup("VanadiumIPTS", "Normalization")
         self.setPropertyGroup("VanadiumRunNumber", "Normalization")
         self.setPropertyGroup("VanadiumFile", "Normalization")
         self.setPropertyGroup("VanadiumWorkspace", "Normalization")
         self.setPropertyGroup("NormalizedBy", "Normalization")
+        self.setPropertyGroup("NormalizeData", "Normalization")
 
         # Grouping info
         self.declareProperty(
@@ -108,15 +113,22 @@ class LoadWANDSCD(PythonAlgorithm):
 
         # Output workspace/data info
         self.declareProperty(
-            WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output), "Output Workspace"
+            WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output),
+            doc="signal for each pixel and run index. May be normalized by flux and vanadium signal.",
         )
-
+        self.declareProperty(
+            WorkspaceProperty("OutputNormalizationWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
+            doc="Optional: output the normalization workspace containing the product of flux and vanadium signal "
+            "for each pixel and run index.",
+        )
         self.declareProperty(
             WorkspaceProperty("OutputGroupingWorkspace", "", optional=PropertyMode.Optional, direction=Direction.Output),
             doc="Optional: output GroupingWorkspace mapping every detector's workspace index to its group ID. "
             "Only produced when Grouping is '2x2' or '4x4'.",
         )
-        self.setPropertyGroup("OutputGroupingWorkspace", "Grouping")
+        self.setPropertyGroup("OutputWorkspace", "Outputs")
+        self.setPropertyGroup("OutputNormalizationWorkspace", "Outputs")
+        self.setPropertyGroup("OutputGroupingWorkspace", "Outputs")
 
     def validateInputs(self):
         issues = dict()
@@ -149,29 +161,22 @@ class LoadWANDSCD(PythonAlgorithm):
         # load and group
         data, grouping_ws = self.load_and_group(runs, create_grouping_ws=create_grouping_ws)
 
-        # check if normalization need to be performed
-        # NOTE: the normalization will be skipped if no information regarding Vanadium is provided
-        skipNormalization = (
+        # check if any normalization work needs to be performed
+        noVanadium = (
             self.getProperty("VanadiumIPTS").isDefault
             and self.getProperty("VanadiumRunNumber").isDefault
             and self.getProperty("VanadiumFile").isDefault
             and self.getProperty("VanadiumWorkspace").isDefault
         )
-        if skipNormalization:
-            self.log().warning("No Vanadium data provided, skip normalization")
+        if noVanadium:
+            self.log().warning("No Vanadium data provided, skip any normalization-related work")
         else:
-            # attempt to get the vanadium via file
-            van_filename = self.get_va_filename()
-            if van_filename is None:
-                # try to load from memory
-                norm = self.getProperty("VanadiumWorkspace").value
+            norm = self.normalization_workspace(data, self.getProperty("NormalizedBy").value.lower())
+            if self.getProperty("NormalizeData").value:
+                data = DivideMD(LHSWorkspace=data, RHSWorkspace=norm)
+            if not self.getProperty("OutputNormalizationWorkspace").isDefault:
+                self.setProperty("OutputNormalizationWorkspace", norm)
             else:
-                norm, _ = self.load_and_group([van_filename])
-            # normalize
-            data = self.normalize(data, norm, self.getProperty("NormalizedBy").value.lower())
-            # cleanup
-            # NOTE: if va is read from memory, we will keep it in case we need it later
-            if van_filename is not None:
                 DeleteWorkspace(norm)
 
         # setup output
@@ -468,41 +473,57 @@ class LoadWANDSCD(PythonAlgorithm):
 
         return grouping_ws
 
-    def normalize(
+    def normalization_workspace(
         self,
         data: IMDHistoWorkspace,
-        norm: IMDHistoWorkspace,
         normalize_by: str,
     ) -> IMDHistoWorkspace:
-        """
-        Normalize the given data with given Va normalization workspace
-        """
-        # prep
-        norm_replicated = ReplicateMD(ShapeWorkspace=data, DataWorkspace=norm)
-        data = DivideMD(LHSWorkspace=data, RHSWorkspace=norm_replicated)
-        # reduce memory footprint
-        DeleteWorkspace(norm_replicated)
-        # find the scale
-        if normalize_by == "counts":
-            scale = 1.0 / norm.getSignalArray().mean()
-            self.getLogger().information("scale counts = {}".format(scale))
-        elif normalize_by == "monitor":
-            scale = np.array(data.getExperimentInfo(0).run().getProperty("monitor_count").value)
-            scale /= norm.getExperimentInfo(0).run().getProperty("monitor_count").value[0]
-            self.getLogger().information("scale monitor = {}".format(scale))
-        elif normalize_by == "time":
-            scale = np.array(data.getExperimentInfo(0).run().getProperty("duration").value)
-            scale /= norm.getExperimentInfo(0).run().getProperty("duration").value[0]
-            self.getLogger().information("van time = {}".format(scale))
-        elif normalize_by == "none":
-            scale = 1
+        van_filename = self.get_va_filename()  # attempt to get the vanadium via file
+        if van_filename is None:
+            norm = self.getProperty("VanadiumWorkspace").value  # try to load from memory
         else:
-            raise RuntimeError(f"Unknown normalization method: {normalize_by}!")
-        # exec
-        data.setSignalArray(data.getSignalArray() / scale)
-        data.setErrorSquaredArray(data.getErrorSquaredArray() / scale**2)
-        # return
-        return data
+            norm, _ = self.load_and_group([van_filename])
+
+        # Cast Vanadium into an MDHistoWorkspace of dimensions (pixel_x, pixel_y, data's run_index)
+        # Very important: normMD inherits the sample logs and experiment info from `data`,
+        # because ReplicateMD clones `data`.
+        normMD = ReplicateMD(ShapeWorkspace=data, DataWorkspace=norm)
+
+        def replicate_normalization_log(log_name: str) -> None:
+            """
+            Replace the selected normMD flux log values with the single Vanadium flux value,
+            preserving normMD timestamps so the log still follows the sample run index.
+            """
+            norm_log = norm.getExperimentInfo(0).run().getProperty(log_name)
+            normMD_run = normMD.getExperimentInfo(0).run()
+            normMD_log = normMD_run.getProperty(log_name)
+            values = np.full(len(normMD_log.value), norm_log.value[0])
+            add_time_series_property(log_name, normMD_run, normMD_log.times, values)
+            normMD_run.getProperty(log_name).units = norm_log.units
+
+        # find the flux ratio
+        if normalize_by == "counts":
+            flux_ratio = 1.0 / norm.getSignalArray().mean()
+            self.getLogger().information("flux ratio by counts = {}".format(flux_ratio))
+        elif normalize_by == "monitor":
+            flux_ratio = np.array(data.getExperimentInfo(0).run().getProperty("monitor_count").value)
+            flux_ratio /= norm.getExperimentInfo(0).run().getProperty("monitor_count").value[0]
+            replicate_normalization_log("monitor_count")
+            self.getLogger().information("flux ratio by monitor = {}".format(flux_ratio))
+        elif normalize_by == "time":
+            flux_ratio = np.array(data.getExperimentInfo(0).run().getProperty("duration").value)
+            flux_ratio /= norm.getExperimentInfo(0).run().getProperty("duration").value[0]
+            replicate_normalization_log("duration")
+            self.getLogger().information("flux ratio by time = {}".format(flux_ratio))
+        elif normalize_by == "none":
+            flux_ratio = 1
+        else:
+            raise RuntimeError(f"Unknown flux selection: {normalize_by}!")
+        normMD.setSignalArray(normMD.getSignalArray() * flux_ratio)
+        normMD.setErrorSquaredArray(normMD.getErrorSquaredArray() * flux_ratio**2)
+        if van_filename is not None:
+            DeleteWorkspace(norm)
+        return normMD
 
 
 def add_time_series_property(name, run, times, values):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.dataobjects import GroupingWorkspace
-from mantid.simpleapi import LoadWANDSCD
+from mantid.simpleapi import AddSampleLog, CreateMDHistoWorkspace, LoadEmptyInstrument, LoadWANDSCD
 import unittest
 import numpy as np
 
@@ -121,7 +121,7 @@ class LoadWANDApplyGoniometerTiltTest(unittest.TestCase):
         LoadWANDTest_ws.delete()
 
 
-class LoadWANDGrouping(unittest.TestCase):
+class LoadWANDGroupingTest(unittest.TestCase):
     # Full detector grid dimensions for WAND (HB2C)
     N_ROWS = 480 * 8  # 3840
     N_COLS = 512
@@ -196,6 +196,229 @@ class LoadWANDGrouping(unittest.TestCase):
         """Requesting OutputGroupingWorkspace while Grouping='None' must raise."""
         with self.assertRaises(Exception):
             LoadWANDSCD("HB2C_475936.nxs.h5", Grouping="None", OutputGroupingWorkspace="should_fail")
+
+
+class LoadWANDOutputNormalizationTest(unittest.TestCase):
+    DATA_FILES = "HB2C_7000.nxs.h5,HB2C_7001.nxs.h5"
+    VANADIUM_SIGNAL = 25.0
+    VANADIUM_MONITOR = 420.0
+    VANADIUM_DURATION = 42.0
+    SAMPLE_MONITOR = np.array([907880.0, 908651.0])
+    SAMPLE_DURATION = np.array([40.05, 40.05])
+
+    @classmethod
+    def setUpClass(cls):
+        cls.vanadium = cls._create_vanadium_workspace()
+        cls.vanadium_2x2 = cls._create_vanadium_workspace(grouping="2x2")
+        cls.vanadium_4x4 = cls._create_vanadium_workspace(grouping="4x4")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._delete_workspaces(cls.vanadium, cls.vanadium_2x2, cls.vanadium_4x4)
+
+    @classmethod
+    def _create_vanadium_workspace(cls, grouping="None"):
+        grouping_factor = {"None": 1, "2x2": 2, "4x4": 4}[grouping]
+        grouping_label = grouping.lower().replace("x", "")
+        x_bins = LoadWANDGroupingTest.N_ROWS // grouping_factor
+        y_bins = LoadWANDGroupingTest.N_COLS // grouping_factor
+        signal = np.full(y_bins * x_bins, cls.VANADIUM_SIGNAL)
+        vanadium = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents=f"0.5,{y_bins + 0.5},0.5,{x_bins + 0.5}",
+            SignalInput=signal,
+            ErrorInput=np.sqrt(signal),
+            NumberOfBins=f"{y_bins},{x_bins}",
+            Names="y,x",
+            Units="bin,bin",
+            OutputWorkspace=f"vanadium_normalization_input_{grouping_label}",
+        )
+        hb2c = LoadEmptyInstrument(
+            InstrumentName="HB2C",
+            OutputWorkspace=f"vanadium_normalization_source_{grouping_label}",
+        )
+        vanadium.addExperimentInfo(hb2c)
+        hb2c.delete()
+        AddSampleLog(
+            vanadium,
+            LogName="monitor_count",
+            LogText=str(cls.VANADIUM_MONITOR),
+            LogType="Number Series",
+            NumberType="Double",
+        )
+        AddSampleLog(
+            vanadium,
+            LogName="duration",
+            LogText=str(cls.VANADIUM_DURATION),
+            LogType="Number Series",
+            NumberType="Double",
+        )
+        return vanadium
+
+    @staticmethod
+    def _delete_workspaces(*workspaces):
+        for workspace in workspaces:
+            if workspace is not None:
+                workspace.delete()
+
+    def _assert_workspace_dimensions(self, workspace, expected_y_bins, expected_x_bins, expected_scan_bins):
+        self.assertEqual(workspace.getDimension(0).name, "y")
+        self.assertEqual(workspace.getDimension(0).getNBins(), expected_y_bins)
+        self.assertEqual(workspace.getDimension(1).name, "x")
+        self.assertEqual(workspace.getDimension(1).getNBins(), expected_x_bins)
+        self.assertEqual(workspace.getDimension(2).name, "scanIndex")
+        self.assertEqual(workspace.getDimension(2).getNBins(), expected_scan_bins)
+
+    def _assert_grouping_workspace(self, grouping_workspace, grouping):
+        expected_groups = (LoadWANDGroupingTest.N_ROWS // grouping) * (LoadWANDGroupingTest.N_COLS // grouping)
+        y_values = grouping_workspace.extractY().flatten()
+        self.assertIsInstance(grouping_workspace, GroupingWorkspace)
+        self.assertEqual(grouping_workspace.getNumberHistograms(), LoadWANDGroupingTest.N_ROWS * LoadWANDGroupingTest.N_COLS)
+        self.assertEqual(int(y_values.min()), 1)
+        self.assertEqual(int(y_values.max()), expected_groups)
+        self.assertEqual(int(grouping_workspace.readY(0)[0]), 1)
+        self.assertEqual(int(grouping_workspace.readY(grouping)[0]), 2)
+        self.assertEqual(int(grouping_workspace.readY(grouping * 512)[0]), (LoadWANDGroupingTest.N_COLS // grouping) + 1)
+
+    def test_output_normalization_workspace_for_counts(self):
+        data = normalization = None
+        try:
+            data, normalization = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="counts_data",
+                VanadiumWorkspace=self.vanadium,
+                NormalizedBy="Counts",
+                NormalizeData=True,
+                OutputNormalizationWorkspace="counts_normalization",
+            )
+
+            np.testing.assert_allclose(normalization.getSignalArray(), 1.0)
+            np.testing.assert_allclose(normalization.getErrorSquaredArray(), 1.0 / self.VANADIUM_SIGNAL)
+            self.assertEqual(normalization.getSignalArray().shape, data.getSignalArray().shape)
+            self._assert_workspace_dimensions(normalization, 512, 3840, 2)
+        finally:
+            self._delete_workspaces(data, normalization)
+
+    def test_output_normalization_workspace_for_monitor(self):
+        data = normalization = None
+        try:
+            data, normalization = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="monitor_data",
+                VanadiumWorkspace=self.vanadium,
+                NormalizedBy="Monitor",
+                NormalizeData=True,
+                OutputNormalizationWorkspace="monitor_normalization",
+            )
+
+            expected_signal = self.VANADIUM_SIGNAL * self.SAMPLE_MONITOR / self.VANADIUM_MONITOR
+            for scan_index, expected in enumerate(expected_signal):
+                np.testing.assert_allclose(normalization.getSignalArray()[..., scan_index], expected)
+
+            normalization_monitor = normalization.getExperimentInfo(0).run().getProperty("monitor_count")
+            np.testing.assert_allclose(normalization_monitor.value, np.full(len(self.SAMPLE_MONITOR), self.VANADIUM_MONITOR))
+            self.assertEqual(normalization_monitor.units, self.vanadium.getExperimentInfo(0).run().getProperty("monitor_count").units)
+        finally:
+            self._delete_workspaces(data, normalization)
+
+    def test_output_normalization_workspace_for_time(self):
+        data = normalization = None
+        try:
+            data, normalization = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="time_data",
+                VanadiumWorkspace=self.vanadium,
+                NormalizedBy="Time",
+                NormalizeData=True,
+                OutputNormalizationWorkspace="time_normalization",
+            )
+
+            expected_signal = self.VANADIUM_SIGNAL * self.SAMPLE_DURATION / self.VANADIUM_DURATION
+            for scan_index, expected in enumerate(expected_signal):
+                np.testing.assert_allclose(normalization.getSignalArray()[..., scan_index], expected)
+
+            normalization_duration = normalization.getExperimentInfo(0).run().getProperty("duration")
+            np.testing.assert_allclose(normalization_duration.value, np.full(len(self.SAMPLE_DURATION), self.VANADIUM_DURATION))
+            self.assertEqual(normalization_duration.units, self.vanadium.getExperimentInfo(0).run().getProperty("duration").units)
+        finally:
+            self._delete_workspaces(data, normalization)
+
+    def test_output_normalization_workspace_for_none(self):
+        data = normalization = None
+        try:
+            data, normalization = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="none_data",
+                VanadiumWorkspace=self.vanadium,
+                NormalizedBy="None",
+                NormalizeData=True,
+                OutputNormalizationWorkspace="none_normalization",
+            )
+
+            np.testing.assert_allclose(normalization.getSignalArray(), self.VANADIUM_SIGNAL)
+            np.testing.assert_allclose(normalization.getErrorSquaredArray(), self.VANADIUM_SIGNAL)
+            self.assertEqual(normalization.getSignalArray().shape, data.getSignalArray().shape)
+        finally:
+            self._delete_workspaces(data, normalization)
+
+    def test_normalize_data_false_still_outputs_normalization_workspace(self):
+        data = normalization = None
+        try:
+            data, normalization = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="normalize_data_false_data",
+                VanadiumWorkspace=self.vanadium,
+                NormalizedBy="None",
+                NormalizeData=False,
+                OutputNormalizationWorkspace="normalize_data_false_normalization",
+            )
+
+            self.assertEqual(data.getSignalArray().max(), 7)
+            np.testing.assert_allclose(normalization.getSignalArray(), self.VANADIUM_SIGNAL)
+        finally:
+            self._delete_workspaces(data, normalization)
+
+    def test_output_normalization_and_grouping_workspaces_for_2x2_grouping(self):
+        data = normalization = grouping = None
+        try:
+            data, normalization, grouping = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="data_2x2",
+                Grouping="2x2",
+                VanadiumWorkspace=self.vanadium_2x2,
+                NormalizedBy="Counts",
+                NormalizeData=True,
+                OutputGroupingWorkspace="grouping_2x2",
+                OutputNormalizationWorkspace="normalization_2x2",
+            )
+
+            np.testing.assert_allclose(normalization.getSignalArray(), 1.0)
+            self.assertEqual(normalization.getSignalArray().shape, data.getSignalArray().shape)
+            self._assert_workspace_dimensions(normalization, 256, 1920, 2)
+            self._assert_grouping_workspace(grouping, 2)
+        finally:
+            self._delete_workspaces(data, grouping, normalization)
+
+    def test_output_normalization_and_grouping_workspaces_for_4x4_grouping(self):
+        data = normalization = grouping = None
+        try:
+            data, normalization, grouping = LoadWANDSCD(
+                self.DATA_FILES,
+                OutputWorkspace="data_4x4",
+                Grouping="4x4",
+                VanadiumWorkspace=self.vanadium_4x4,
+                NormalizedBy="Counts",
+                NormalizeData=True,
+                OutputGroupingWorkspace="grouping_4x4",
+                OutputNormalizationWorkspace="normalization_4x4",
+            )
+
+            np.testing.assert_allclose(normalization.getSignalArray(), 1.0)
+            self.assertEqual(normalization.getSignalArray().shape, data.getSignalArray().shape)
+            self._assert_workspace_dimensions(normalization, 128, 960, 2)
+            self._assert_grouping_workspace(grouping, 4)
+        finally:
+            self._delete_workspaces(data, grouping, normalization)
 
 
 if __name__ == "__main__":

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -17,6 +17,17 @@ it is crucial to have the correct instrument attached to the first run.
 In addition the s1 (omega rotation), duration, run_number and monitor count is read from every
 file and included in the logs of the OutputWorkspace.
 
+During a recent feature expansion, normalization can be optionally performed in the same process
+provided that the necessary Vanadium data is specified.
+By default, the algorithm will try to locate the Vanadium data using IPTS and run number.
+If failed, it will check the Vanadium filename entry to see if the data can be loaded directly
+from file.
+If neither is provided, the algorithm will try to check if the Vanadium data is provided as a
+workspace in memory.
+Currently there are three normalization scheme supported: by Count, by Monitor and by Time.
+If None is selected, no normalization will be performed and all normalization related properties
+will be ignored (on the GUI end, they will be disabled instead).
+
 If the "HB2C:CS:CrystalAlign:UBMatrix" property exists and apply goniometer tilt is true,
 it will be converted into the OrientedLattice on the OutputWorkspace.
 The goniometer tilts (sgu and sgl) are combined into the UB Matrix so that only omega (s1) needs to

--- a/docs/source/algorithms/LoadWANDSCD-v1.rst
+++ b/docs/source/algorithms/LoadWANDSCD-v1.rst
@@ -9,24 +9,37 @@
 Description
 -----------
 
-This algorithm will load a series of runs into a MDHistoWorkspace that
-has dimensions x and y detector pixels vs scanIndex.
-The scanIndex is the omega rotation of the sample.
+This algorithm will load a series of runs into a MDHistoWorkspace that has dimensions x and y detector pixels
+vs scanIndex. The scanIndex is the omega rotation of the sample.
 The instrument attached to the OutputWorkspace is directly copied from the FIRST run, therefore
 it is crucial to have the correct instrument attached to the first run.
 In addition the s1 (omega rotation), duration, run_number and monitor count is read from every
 file and included in the logs of the OutputWorkspace.
 
-During a recent feature expansion, normalization can be optionally performed in the same process
-provided that the necessary Vanadium data is specified.
+Normalization can be optionally performed in the same process, provided that the necessary Vanadium data is specified.
+There's also the posibility of not normalizing the data but saving the normalization workspace
+alongside the main data workspace for later use in MDNorm.
+
 By default, the algorithm will try to locate the Vanadium data using IPTS and run number.
-If failed, it will check the Vanadium filename entry to see if the data can be loaded directly
-from file.
-If neither is provided, the algorithm will try to check if the Vanadium data is provided as a
-workspace in memory.
-Currently there are three normalization scheme supported: by Count, by Monitor and by Time.
-If None is selected, no normalization will be performed and all normalization related properties
-will be ignored (on the GUI end, they will be disabled instead).
+If failed, it will check the Vanadium filename entry to see if the data can be loaded directly from file.
+If neither is provided, the algorithm will try to check if the Vanadium data is provided as a workspace in memory.
+
+Option ``NormalizedBy`` selects the data-to-Vanadium flux ratio as:
+
+- ``Monitor``: ratio of data to Vanadium monitor counts.
+- ``Time``: ratio of data to Vanadium duration.
+- ``Counts``: 1.0 / mean Vanadium signal.
+- ``None``: 1.0
+
+If option ``NormalizeData`` is ``True``, a normalization workspace is constructed and then divided from the data:
+
+.. code-block:: python
+
+    normalization_workspace = flux_ratio * vanadium_signal
+    normalized_data = sample_signal / normalization_workspace
+
+If a workspace name is provided in ``OutputNormalizationWorkspace``,
+then ``normalization_workspace`` will be saved, irrespective of the value of ``NormalizeData``.
 
 If the "HB2C:CS:CrystalAlign:UBMatrix" property exists and apply goniometer tilt is true,
 it will be converted into the OrientedLattice on the OutputWorkspace.
@@ -41,31 +54,6 @@ In most cases you will not see a difference in reduced data with 4x4 pixel group
 Also, both input data and the Vanadium data will share the same grouping scheme.
 
 The loaded workspace is designed to be the input to :ref:`algm-ConvertWANDSCDtoQ`.
-
-Normalization
--------------
-
-Normalization can be performed while loading the data if the necessary Vanadium data is specified.
-By default, the algorithm will try to locate the Vanadium data using IPTS and run number.
-If that is not specified, it will check the Vanadium filename entry to see if the data can be
-loaded directly from file. If neither is provided, the algorithm will try to use Vanadium data
-provided as a workspace in memory. When a Vanadium source is provided, the data is divided by the
-Vanadium signal and then scaled according to the ``NormalizedBy`` option. If no Vanadium source is
-provided, no normalization is performed.
-
-.. list-table::
-   :header-rows: 1
-
-   * - ``NormalizedBy``
-     - Final result
-   * - ``None``
-     - ``sample_signal / vanadium_signal``
-   * - ``Counts``
-     - ``sample_signal / (vanadium_signal / mean_vanadium_signal)``
-   * - ``Monitor``
-     - ``(sample_signal / sample_monitor_count) / (vanadium_signal / vanadium_monitor_count)``
-   * - ``Time``
-     - ``(sample_signal / sample_duration) / (vanadium_signal / vanadium_duration)``
 
 Usage
 -----
@@ -95,18 +83,7 @@ Output:
     Sample: a 1.0, b 1.0, c 1.0; alpha 90, beta 90, gamma 90
 
 
-**Load data and Vanadium at the same time**
-
-.. code-block:: python
-
-    data = LoadWANDSCD(
-        IPTS=7776, RunNumbers='26640-27944',
-        VanadiumIPTS=7776, VanadiumRunNumber=26509,
-        NormalizedBy='Monitor',
-        )
-
-
-**Load multiple data file**
+**Load multiple data files**
 
 .. code-block:: python
 
@@ -139,6 +116,82 @@ Output:
     monitor_count = [44571,44598,44567,44869,44453,44238,44611,44120,44762,44658]
     duration = [2.05,2.05,2.03333,2.05,2.03333,2.03333,2.05,2.01667,2.05,2.05]
     run_number = [26640,26641,26642,26643,26644,26645,26646,26647,26648,26649]
+
+
+**Load data and Vanadium, normalize data**
+
+.. code-block:: python
+
+    data = LoadWANDSCD(
+        IPTS=7776, RunNumbers='26640-26700',
+        VanadiumIPTS=7776, VanadiumRunNumber=26509,
+        NormalizedBy='Monitor', NormalizeData=True
+        )
+
+
+**Load data and Vanadium. Don't normalize the output data but output the normalization workspace**
+
+.. code-block:: python
+
+    data, norm = LoadWANDSCD(
+        IPTS=7776, RunNumbers='26640-26700',
+        VanadiumIPTS=7776, VanadiumRunNumber=26509,
+        NormalizedBy='Monitor', NormalizeData=False,
+        Grouping="4x4", OutputNormalizationWorkspace='norm'
+        )
+    print(repr(norm.id()))
+    print([norm.getDimension(i).getNBins() for i in range(norm.getNumDims())])
+
+Output:
+
+.. code-block:: none
+
+    'MDHistoWorkspace'
+    [128, 960, 61]
+
+
+**Load data and Vanadium. Normalize the output data and output the grouping workspace**
+
+.. code-block:: python
+
+    data = LoadWANDSCD(
+        IPTS=7776, RunNumbers='26640-26700',
+        VanadiumIPTS=7776, VanadiumRunNumber=26509,
+        Grouping='2x2',
+        NormalizedBy='Monitor', NormalizeData=True,
+        OutputGroupingWorkspace='grouping'
+        )
+    grouping = mtd['grouping']
+    print(int(grouping.readY(255)[0]))
+
+Output:
+
+.. code-block:: none
+
+    128
+
+
+**Load data and Vanadium. Don't normalize the output data and output the normalization and grouping workspaces**
+
+.. code-block:: python
+
+    data, norm, grouping = LoadWANDSCD(
+        IPTS=7776, RunNumbers='26640-26700',
+        VanadiumIPTS=7776, VanadiumRunNumber=26509,
+        Grouping='2x2',
+        NormalizedBy='Monitor', NormalizeData=False,
+        OutputNormalizationWorkspace='norm',
+        OutputGroupingWorkspace='grouping'
+        )
+    print([norm.getDimension(i).getNBins() for i in range(norm.getNumDims())])
+    print(int(grouping.readY(255)[0]))
+
+Output:
+
+.. code-block:: none
+
+    [256, 1920, 61]
+    128
 
 
 **Load with different grouping comparing memory usage**


### PR DESCRIPTION
### Description of work

This change is a step towards the goal of using `MDNorm` for normalizing monochromatic single-crystal data. Here we produce a normalizing `MDHistoWorkspace` with same dimensions and binning as the data `MDHistoworkspace`.

In the future:
- the normalizing workspace will be converted to an `MDEventWorkspace` (`Q_lab`), same as the data.
- both data and normalizing will be `MDEventWorkspace` workspaces, both fed to `MDNorm`.
- `MDNorm` will `RebinMD` both workspaces to User's desired specifications, and divide them.

Companion to #41667
Implements EWM [16590](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16590)

### To test:

```
from mantid.simpleapi import *
# Output signal and normalization workspace
data, norm, grouping = LoadWANDSCD(
    IPTS=7776, RunNumbers='26640-26700',
    VanadiumIPTS=7776, VanadiumRunNumber=26509,
    Grouping='4x4',
    NormalizedBy='Monitor', NormalizeData=False,
    OutputNormalizationWorkspace='norm'
    )
# normalization can be carried out later. Here we verify data and norm have same dimensions and binning
data = DivideMD(LHSWorkspace=data, RHSWorkspace=norm)
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
