### PR TITLE
Add NumberDensityUnit to POLARIS total scattering workflow

### DIFF
--- a/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41672.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41672.rst
@@ -1,0 +1,1 @@
+- :ref:`ISIS Powder SampleDetails <isis-powder-diffraction-sampleDetails-ref>` now accepts a ``number_density_units`` argument which can be set appropriately to fix issues where total scattering ``S(Q)-1`` does not tend to 0 at high Q when number density has been provided as: formula units per volume (see :ref:`number_density_unit_sampleDetails_isis-powder-diffraction-ref`).

--- a/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
+++ b/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
@@ -247,8 +247,10 @@ Example Input:
 number_density
 ^^^^^^^^^^^^^^
 This parameter defines the number density of the property.
+By default it should be given in units of atoms per cubic angstrom. Optionally this unit can be changed using
+:ref:`number_density_unit_sampleDetails_isis-powder-diffraction-ref`.
 When :ref:`chemical_formula_sampleDetails_isis-powder-diffraction-ref`
-defines an element this can automatically be calculated by Mantid.
+defines a sole element this can automatically be calculated by Mantid.
 
 This value is used to convert between different PDF types in `Polaris.create_total_scattering_pdf`.
 
@@ -290,6 +292,21 @@ Example Input:
 ..  code-block:: python
 
     sample_obj.set_material(number_density=0.231, packing_fraction=0.5, ...)
+
+
+.. _number_density_unit_sampleDetails_isis-powder-diffraction-ref:
+
+number_density_unit
+^^^^^^^^^^^^^^^^^^^
+This defines the units of the provided :ref:`number_density_sampleDetails_isis-powder-diffraction-ref`. By default it is
+``"Atoms"`` (i.e. atoms per cubic angstrom) but :ref:`SetSampleMaterial<algm-SetSampleMaterial>`
+also accepts ``"Formula Units"`` (i.e. formula units per cubic angstrom) so this can be used as well.
+
+Example Input:
+
+..  code-block:: python
+
+    sample_obj.set_material(..., number_density_unit="Formula Units", ...)
 
 
 .. _set_material_properties_sampleDetails_isis-powder-diffraction-ref:

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
@@ -58,6 +58,8 @@ def calculate_slab_absorb_corrections(ws_to_correct, sample_details_obj):
     material_json = {"ChemicalFormula": material.chemical_formula}
     if material.number_density:
         material_json["SampleNumberDensity"] = material.number_density
+        # Honour the unit the density was supplied in so a formula-unit density is converted to atoms
+        material_json["NumberDensityUnit"] = material.number_density_unit
     if material.absorption_cross_section:
         material_json["AttenuationXSection"] = material.absorption_cross_section
     if material.scattering_cross_section:

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -138,12 +138,14 @@ def generate_ts_pdf(
     if debug:
         s_of_q_minus_one = mantid.CloneWorkspace(InputWorkspace=focused_ws)
 
+    # rho0 should be the per-atom number density
+    number_density_in_atoms = sample_details.material_object.get_number_density_in_atoms()
     pdf_kwargs = {
         "InputSofQType": "S(Q)-1",
         "PDFType": pdf_type,
         "Filter": lorch_filter,
         "DeltaR": delta_r,
-        "rho0": sample_details.material_object.number_density,
+        "rho0": number_density_in_atoms,
     }
     if r_lims is not None:
         pdf_kwargs.update({"RMin": r_lims[0], "RMax": r_lims[-1]})
@@ -151,7 +153,7 @@ def generate_ts_pdf(
         pdf_output = _merge_banks(focused_ws, pdf_kwargs, freq_params, q_lims, stitch_points, stitch_lims, overlap_width)
     else:
         for ws in focused_ws:
-            fast_fourier_filter(ws, rho0=sample_details.material_object.number_density, freq_params=freq_params)
+            fast_fourier_filter(ws, rho0=number_density_in_atoms, freq_params=freq_params)
         pdf_output = mantid.PDFFourierTransform(Inputworkspace="focused_ws", **pdf_kwargs)
         pdf_output = mantid.RebinToWorkspace(WorkspaceToRebin=pdf_output, WorkspaceToMatch=pdf_output[4], PreserveEvents=True)
     if not per_detector and not debug:

--- a/scripts/Diffraction/isis_powder/routines/sample_details.py
+++ b/scripts/Diffraction/isis_powder/routines/sample_details.py
@@ -305,7 +305,7 @@ class _Material(object):
         self.number_density_effective = number_density_effective
 
         self.packing_fraction = packing_fraction
-        self.number_density_unit = _normalise_number_density_unit(number_density_unit)
+        self.number_density_unit = _validate_number_density_unit(number_density_unit)
 
         # Advanced material properties
         self.absorption_cross_section = None
@@ -503,20 +503,15 @@ class _FlatPlateHolder(object):
         }
 
 
-def _normalise_number_density_unit(number_density_unit):
+def _validate_number_density_unit(number_density_unit):
     """
-    Convert a user-supplied number density unit to the exact strings accepted by SetSample's
-    NumberDensityUnit property ("Atoms" or "Formula Units"). Defaults to "Atoms" when not supplied,
-    to match legacy and default behaviour.
+    Confirm that the provided string for number density unit is a permitted string
     """
     if number_density_unit is None:
         return "Atoms"
-    normalised = str(number_density_unit).strip().lower().replace("_", " ")
-    if normalised in ("atoms", "atom"):
-        return "Atoms"
-    if normalised in ("formula units", "formula unit", "formulaunits"):
-        return "Formula Units"
-    raise ValueError(f"Invalid number_density_unit '{number_density_unit}'. Allowed values are 'Atoms' or 'Formula Units'.")
+    if number_density_unit not in ("Atoms", "Formula Units"):
+        raise ValueError(f"Invalid number_density_unit '{number_density_unit}'. Allowed values are 'Atoms' or 'Formula Units'.")
+    return number_density_unit
 
 
 def _check_value_is_physical(property_name, value):

--- a/scripts/Diffraction/isis_powder/routines/sample_details.py
+++ b/scripts/Diffraction/isis_powder/routines/sample_details.py
@@ -7,6 +7,7 @@
 from Diffraction.isis_powder.routines import common
 import math
 from mantid import logger
+from mantid.kernel import MaterialBuilder, NumberDensityUnit
 
 property_err_string = "The following sample property was not passed as an argument: {}"
 
@@ -49,6 +50,7 @@ class SampleDetails(object):
         number_density = common.dictionary_key_helper(dictionary=kwargs, key="number_density", throws=False)
         number_density_effective = common.dictionary_key_helper(dictionary=kwargs, key="number_density_effective", throws=False)
         packing_fraction = common.dictionary_key_helper(dictionary=kwargs, key="packing_fraction", throws=False)
+        number_density_unit = common.dictionary_key_helper(dictionary=kwargs, key="number_density_unit", throws=False)
 
         if self.material_object is not None:
             self.print_sample_details()
@@ -63,6 +65,7 @@ class SampleDetails(object):
             number_density=number_density,
             number_density_effective=number_density_effective,
             packing_fraction=packing_fraction,
+            number_density_unit=number_density_unit,
         )
 
     def set_container(self, **kwargs):
@@ -74,6 +77,7 @@ class SampleDetails(object):
         number_density = common.dictionary_key_helper(dictionary=kwargs, key="number_density", throws=False)
         number_density_effective = common.dictionary_key_helper(dictionary=kwargs, key="number_density_effective", throws=False)
         packing_fraction = common.dictionary_key_helper(dictionary=kwargs, key="packing_fraction", throws=False)
+        number_density_unit = common.dictionary_key_helper(dictionary=kwargs, key="number_density_unit", throws=False)
         if self.container_material_object is not None:
             self.print_container_details()
             raise RuntimeError(
@@ -85,6 +89,7 @@ class SampleDetails(object):
             number_density=number_density,
             number_density_effective=number_density_effective,
             packing_fraction=packing_fraction,
+            number_density_unit=number_density_unit,
         )
         if self._shape_type.capitalize() == "Cylinder":
             self._container_shape = _HollowCylinder(
@@ -240,6 +245,8 @@ class SampleDetails(object):
             material_json["NumberDensity"] = self.material_object.number_density
         if self.material_object.number_density_effective:
             material_json["EffectiveNumberDensity"] = self.material_object.number_density_effective
+        if self.material_object.number_density_unit:
+            material_json["NumberDensityUnit"] = self.material_object.number_density_unit
         if self.material_object.packing_fraction:
             material_json["PackingFraction"] = self.material_object.packing_fraction
         if self.material_object.absorption_cross_section:
@@ -261,6 +268,8 @@ class SampleDetails(object):
                 container_material_json["NumberDensity"] = self.container_material_object.number_density
             if self.container_material_object.number_density_effective:
                 container_material_json["EffectiveNumberDensity"] = self.container_material_object.number_density_effective
+            if self.container_material_object.number_density_unit:
+                container_material_json["NumberDensityUnit"] = self.container_material_object.number_density_unit
             if self.container_material_object.packing_fraction:
                 container_material_json["PackingFraction"] = self.container_material_object.packing_fraction
             if self.container_material_object.absorption_cross_section:
@@ -273,7 +282,9 @@ class SampleDetails(object):
 
 
 class _Material(object):
-    def __init__(self, chemical_formula, number_density=None, number_density_effective=None, packing_fraction=None):
+    def __init__(
+        self, chemical_formula, number_density=None, number_density_effective=None, packing_fraction=None, number_density_unit=None
+    ):
         self.chemical_formula = chemical_formula
         # If it is not an element Mantid requires us to provide the number density
         # which is required for absorption corrections.
@@ -294,6 +305,7 @@ class _Material(object):
         self.number_density_effective = number_density_effective
 
         self.packing_fraction = packing_fraction
+        self.number_density_unit = _normalise_number_density_unit(number_density_unit)
 
         # Advanced material properties
         self.absorption_cross_section = None
@@ -302,13 +314,38 @@ class _Material(object):
         # Internal flags so we are only allowed to set the material properties once
         self._is_material_props_set = False
 
+    def get_number_density_in_atoms(self):
+        """
+        Return the number density in atoms / Angstrom^3, converting from formula units if necessary.
+        This is the convention expected by quantities such as rho0 in PDFFourierTransform.
+        Returns None if no (non-effective) number density was supplied.
+        """
+        if self.number_density is None:
+            return None
+        if self.number_density_unit == "Formula Units":
+            return self.number_density * self._atoms_per_formula_unit()
+        return self.number_density
+
+    def _atoms_per_formula_unit(self):
+        # Build the material with a number density of 1 formula unit / Angstrom^3; Mantid then stores the
+        # number density in atoms, so the resulting value is the number of atoms per formula unit.
+        builder = (
+            MaterialBuilder().setFormula(self.chemical_formula).setNumberDensity(1.0).setNumberDensityUnit(NumberDensityUnit.FormulaUnits)
+        )
+        try:
+            material = builder.build()
+            return material.numberDensity
+        except RuntimeError:
+            logger.error(f"Unable to work out the number of atoms per formula unit for {self.chemical_formula}")
+            return
+
     def print_material(self):
         print("Material properties:")
         print("------------------------")
         print("Chemical formula: {}".format(self.chemical_formula))
 
-        if self.number_density:
-            print("Number Density: {}".format(self.number_density))
+        if self.number_density and self.number_density_unit:
+            print(f"Number Density (units: {self.number_density_unit}/Volume): {self.number_density}")
         if self.number_density_effective:
             print("Effective Number Density: {}".format(self.number_density_effective))
         if not self.number_density and not self.number_density_effective:
@@ -464,6 +501,22 @@ class _FlatPlateHolder(object):
             "FrontThick": self.front_thick,
             "BackThick": self.back_thick,
         }
+
+
+def _normalise_number_density_unit(number_density_unit):
+    """
+    Convert a user-supplied number density unit to the exact strings accepted by SetSample's
+    NumberDensityUnit property ("Atoms" or "Formula Units"). Defaults to "Atoms" when not supplied,
+    to match legacy and default behaviour.
+    """
+    if number_density_unit is None:
+        return "Atoms"
+    normalised = str(number_density_unit).strip().lower().replace("_", " ")
+    if normalised in ("atoms", "atom"):
+        return "Atoms"
+    if normalised in ("formula units", "formula unit", "formulaunits"):
+        return "Formula Units"
+    raise ValueError(f"Invalid number_density_unit '{number_density_unit}'. Allowed values are 'Atoms' or 'Formula Units'.")
 
 
 def _check_value_is_physical(property_name, value):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
@@ -584,26 +584,26 @@ class ISISPowderSampleDetailsTest(unittest.TestCase):
                 ContainerMaterial=sample_details_object.generate_container_material(),
             )
 
-    def test_normalise_number_density_unit(self):
+    def test_validate_number_density_unit(self):
         # Defaults to Atoms when not supplied (historic / Mantid default behaviour)
-        self.assertEqual(sample_details._normalise_number_density_unit(None), "Atoms")
-        # Canonical values pass through
-        self.assertEqual(sample_details._normalise_number_density_unit("Atoms"), "Atoms")
-        self.assertEqual(sample_details._normalise_number_density_unit("Formula Units"), "Formula Units")
-        # Case-insensitive and underscore-tolerant, normalised to the strings SetSample accepts
-        self.assertEqual(sample_details._normalise_number_density_unit("atoms"), "Atoms")
-        self.assertEqual(sample_details._normalise_number_density_unit("formula_units"), "Formula Units")
-        self.assertEqual(sample_details._normalise_number_density_unit("FORMULA UNITS"), "Formula Units")
-        # Anything else is rejected
-        with self.assertRaisesRegex(ValueError, "Invalid number_density_unit"):
-            sample_details._normalise_number_density_unit("kg")
+        self.assertEqual(sample_details._validate_number_density_unit(None), "Atoms")
+
+        bad_inputs = ("atoms", "formula_units", "those cheeky little guys", "FormulaUnits")
+        good_inputs = ("Atoms", "Formula Units")
+        for bad_input in bad_inputs:
+            with self.subTest(bad_input=bad_input):
+                with self.assertRaisesRegex(ValueError, "Invalid number_density_unit"):
+                    sample_details._validate_number_density_unit(bad_input)
+        for good_input in good_inputs:
+            with self.subTest(good_input=good_input):
+                self.assertEqual(sample_details._validate_number_density_unit(good_input), good_input)
 
     def test_material_constructor_number_density_unit(self):
         # Defaults to Atoms
         material_default = sample_details._Material(chemical_formula="Si", number_density=1.0)
         self.assertEqual(material_default.number_density_unit, "Atoms")
         # Stores the normalised value when supplied
-        material_formula_units = sample_details._Material(chemical_formula="Si O2", number_density=1.0, number_density_unit="formula units")
+        material_formula_units = sample_details._Material(chemical_formula="Si O2", number_density=1.0, number_density_unit="Formula Units")
         self.assertEqual(material_formula_units.number_density_unit, "Formula Units")
         # An invalid unit raises on construction
         with self.assertRaisesRegex(ValueError, "Invalid number_density_unit"):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
@@ -276,7 +276,7 @@ class ISISPowderSampleDetailsTest(unittest.TestCase):
             sample_details_obj.print_sample_details()
             captured_std_out_material_set = std_out_buffer.getvalue()
             self.assertRegex(captured_std_out_material_set, "Chemical formula: " + chemical_formula_two)
-            self.assertRegex(captured_std_out_material_set, "Number Density: " + str(expected_number_density))
+            self.assertRegex(captured_std_out_material_set, r"Number Density \(units: Atoms/Volume\): " + str(expected_number_density))
 
             # Test with no material properties set - we can reuse buffer from previous test
             self.assertRegex(captured_std_out_material_default, "Absorption cross section: Calculated by Mantid")
@@ -380,7 +380,13 @@ class ISISPowderSampleDetailsTest(unittest.TestCase):
         # Run test
         result = sample_details_obj.generate_sample_material()
         # Validate
-        expected = {"ChemicalFormula": "Si", "NumberDensity": 1.5, "AttenuationXSection": 123.0, "ScatteringXSection": 456.0}
+        expected = {
+            "ChemicalFormula": "Si",
+            "NumberDensity": 1.5,
+            "AttenuationXSection": 123.0,
+            "ScatteringXSection": 456.0,
+            "NumberDensityUnit": "Atoms",
+        }
         self.assertEqual(result, expected)
 
     def test_generate_geometry_cylinder(self):
@@ -577,6 +583,49 @@ class ISISPowderSampleDetailsTest(unittest.TestCase):
                 ContainerGeometry=sample_details_object.generate_container_geometry(),
                 ContainerMaterial=sample_details_object.generate_container_material(),
             )
+
+    def test_normalise_number_density_unit(self):
+        # Defaults to Atoms when not supplied (historic / Mantid default behaviour)
+        self.assertEqual(sample_details._normalise_number_density_unit(None), "Atoms")
+        # Canonical values pass through
+        self.assertEqual(sample_details._normalise_number_density_unit("Atoms"), "Atoms")
+        self.assertEqual(sample_details._normalise_number_density_unit("Formula Units"), "Formula Units")
+        # Case-insensitive and underscore-tolerant, normalised to the strings SetSample accepts
+        self.assertEqual(sample_details._normalise_number_density_unit("atoms"), "Atoms")
+        self.assertEqual(sample_details._normalise_number_density_unit("formula_units"), "Formula Units")
+        self.assertEqual(sample_details._normalise_number_density_unit("FORMULA UNITS"), "Formula Units")
+        # Anything else is rejected
+        with self.assertRaisesRegex(ValueError, "Invalid number_density_unit"):
+            sample_details._normalise_number_density_unit("kg")
+
+    def test_material_constructor_number_density_unit(self):
+        # Defaults to Atoms
+        material_default = sample_details._Material(chemical_formula="Si", number_density=1.0)
+        self.assertEqual(material_default.number_density_unit, "Atoms")
+        # Stores the normalised value when supplied
+        material_formula_units = sample_details._Material(chemical_formula="Si O2", number_density=1.0, number_density_unit="formula units")
+        self.assertEqual(material_formula_units.number_density_unit, "Formula Units")
+        # An invalid unit raises on construction
+        with self.assertRaisesRegex(ValueError, "Invalid number_density_unit"):
+            sample_details._Material(chemical_formula="Si", number_density=1.0, number_density_unit="bad")
+
+    def test_get_number_density_in_atoms(self):
+        # Atoms: returned unchanged
+        material_atoms = sample_details._Material(chemical_formula="Si O2", number_density=2.0)
+        self.assertEqual(material_atoms.get_number_density_in_atoms(), 2.0)
+        # Formula Units: converted using atoms-per-formula-unit (Si O2 -> 3 atoms per formula unit)
+        material_formula_units = sample_details._Material(chemical_formula="Si O2", number_density=2.0, number_density_unit="Formula Units")
+        self.assertAlmostEqual(material_formula_units.get_number_density_in_atoms(), 6.0)
+        # No (non-effective) number density set -> None
+        material_none = sample_details._Material(chemical_formula="Si")
+        self.assertIsNone(material_none.get_number_density_in_atoms())
+
+    def test_generate_sample_material_formula_units(self):
+        sample_details_obj = sample_details.SampleDetails(height=1.0, radius=1.0, center=[0.0, 0.0, 0.0])
+        sample_details_obj.set_material(chemical_formula="Si O2", number_density=1.5, number_density_unit="Formula Units")
+        result = sample_details_obj.generate_sample_material()
+        expected = {"ChemicalFormula": "Si O2", "NumberDensity": 1.5, "NumberDensityUnit": "Formula Units"}
+        self.assertEqual(result, expected)
 
 
 def get_std_out_buffer_obj():


### PR DESCRIPTION
### Description of work

Currently, when calculating `S(Q)-1` for total scattering on POLARIS the user must provide the sample material, eg:

```
sam = SampleDetails(height=4.0,radius=0.29855,center=[0,0,0],shape='cylinder')
sam.set_material(chemical_formula='Ba-Ti-O3',
                 number_density=0.0155,
                 packing_fraction=0.41155,
)
```

It is not necessarily clear to the user what the units of `number_density` should be, and one crystallographic standard that might be assumed is that it is formula units per volume. Mantid does support such a definition of material, however, it requires setting `NumberDensityUnit = "FormulaUnit"` rather than the default: `"Atoms"`. This option has previously not been exposed through `SampleDetails`, so `number_density` has been necessarily assuming the provided value is atoms per volume.

Defining this incorrectly results in a incorrect normalisation of `S(Q)` and so the `S(Q)-1` does not tend the high Q to 0, rather to `(Z-1).sig_tot/sig_coh`.

Here I have added the option to set `number_density_unit` on `SampleDetails` and have this internally handle the conversion to atoms per volume for relevant normalisations

Previously a subtraction option has been added to enforce this behaviour with a linear subtraction #40639. Below I show the comparison of:
- the correctly defined units (`_form_units`)
- the incorrectly defined units (`_bad_atoms_units`)
- the incorrectly defined units with `enforce_high_q_to_1 = True` (`_subtraction_fudge`)

**S(Q) -1:**

<img width="837" height="375" alt="image" src="https://github.com/user-attachments/assets/ffef7278-2c77-4f54-86c0-c723dd530f3e" />

<img width="831" height="375" alt="image" src="https://github.com/user-attachments/assets/2d8ba725-6f0e-4d35-b67a-732fef2db6ac" />

**g(r):**

<img width="594" height="316" alt="image" src="https://github.com/user-attachments/assets/a2e7f316-79c9-4246-81cc-153031d6bc88" />

<img width="596" height="321" alt="image" src="https://github.com/user-attachments/assets/5c507806-36ad-409a-8876-b17ed1557f1e" />

From what I can tell the low Q region seems reasonably good, so I am not sure if this sufficiently addresses some of the issues raised in #40646 #40647 (from what I can tell those use `PDFFourierTransform` directly rather than `polaris_object.create_total_scattering_pdf` so not sure on the comparison)


(There is also one external usage of the material_json on HRPD which I have added reading of `number_density_unit` to - I don't suppose it matters as HRPD is no more)

Closes #40566

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Use the scripts and discussion in https://github.com/mantidproject/mantid/issues/40566#issuecomment-3749247422 and reproduce the results, with baseline tending to approx 9.  (I would rather the reviewer also follows these steps rather than providing my files as it would be good to validate that I applied the example scripts correctly)

- Add `number_density_unit = "formula_unit"` to `sam.set_material` and the baseline should tend to approx 0

- Check docs updates look correct

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
