### PR TITLE
Fix a couple of bugs in the new Instrument View

### DIFF
--- a/docs/source/release/v6.17.0/Workbench/InstrumentViewer/Bugfixes/41706.rst
+++ b/docs/source/release/v6.17.0/Workbench/InstrumentViewer/Bugfixes/41706.rst
@@ -1,0 +1,2 @@
+- In the new Instrument View, fixed a bug when overlaying a peaks workspace with more peaks than the number of detectors in the instrument. This could happen if viewing e.g. the result of ``ExtractSpectra``.
+- In the new Instrument View, fixed a bug with drawing workspaces where some detectors are not assigned to any spectra.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -94,10 +94,9 @@ class FullInstrumentViewModel:
         self._spherical_positions = np.transpose(np.vstack([r, theta, phi]))
         self._detector_positions_3d = detector_info_table.columnArray("Position")
         self._workspace_indices = detector_info_table.columnArray("Index")
-        self._spectrum_nos = detector_info_table.columnArray("Spectrum No")
         # Array of strings 'yes', 'no' and 'n/a'
         self._is_monitor = detector_info_table.columnArray("Monitor")
-        self._is_valid = self._is_monitor == "no"
+        self._is_valid = (self._is_monitor != "yes") & (self._workspace_indices != -1)
         self._component_idxs = np.arange(len(self._detector_ids))
         # TODO: Add masked column to detector table
         self._is_masked_in_ws = np.array([self._workspace.detectorInfo().isMasked(i) for i, _ in enumerate(self._detector_ids)])
@@ -156,10 +155,6 @@ class FullInstrumentViewModel:
         return self._detector_ids[self._is_masked & self._is_valid]
 
     @property
-    def spectrum_nos(self) -> np.ndarray:
-        return self._spectrum_nos[self.is_pickable]
-
-    @property
     def monitor_positions(self) -> np.ndarray:
         return self._monitor_positions
 
@@ -174,10 +169,6 @@ class FullInstrumentViewModel:
     @property
     def picked_detector_ids(self) -> np.ndarray:
         return self._detector_ids[self.is_pickable & self._detector_is_picked]
-
-    @property
-    def picked_spectrum_nos(self) -> np.ndarray:
-        return self._spectrum_nos[self.is_pickable & self._detector_is_picked]
 
     @property
     def picked_workspace_indices(self) -> np.ndarray:

--- a/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
@@ -37,7 +37,7 @@ class WorkspaceDetectorPeaks:
 
     def get_positions_and_labels(self, detector_positions, detector_ids) -> tuple[np.ndarray, list]:
         peaks_ids = np.array([p.detector_id for p in self.detector_peaks])
-        if len(peaks_ids) == 0:
+        if len(peaks_ids) == 0 or len(detector_ids) == 0:
             return np.array([]), []
 
         # Use argsort + searchsorted for fast lookup. Using np.where(np.isin) does not

--- a/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
@@ -46,6 +46,7 @@ class WorkspaceDetectorPeaks:
         sorter = np.argsort(detector_ids)
         sorted_detector_ids = detector_ids[sorter]
         positions = np.searchsorted(sorted_detector_ids, peaks_ids)
+        positions = np.clip(positions, 0, len(sorted_detector_ids) - 1)
         ordered_indices = sorter[positions]
         valid = sorted_detector_ids[positions] == peaks_ids
         ordered_indices = ordered_indices[valid]

--- a/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
@@ -80,6 +80,17 @@ class TestWorkspaceDetectorPeaks(unittest.TestCase):
         self.assertEqual([], x_values)
         self.assertEqual([], labels)
 
+    def test_get_positions_and_labels_peak_id_larger_than_all_detector_ids(self):
+        # Peak detector ID (999) is larger than every entry in detector_ids.
+        # np.searchsorted would return an out-of-bounds index; the valid mask must
+        # filter it out so the result is empty rather than raising an IndexError.
+        peak = Peak(999, 0, (1, 0, 0), 100, 10, 10, 10)
+        wdp = self._create_workspace_detector_peaks([DetectorPeaks([peak])])
+        detector_positions = np.array([[1, 1, 1], [2, 2, 2]])
+        detector_ids = np.array([1, 2])
+        positions, labels = wdp.get_positions_and_labels(detector_positions, detector_ids)
+        self.assertEqual(0, len(positions))
+
     @mock.patch("instrumentview.Peaks.WorkspaceDetectorPeaks.AnalysisDataService")
     def test_peaks_read_from_ads_workspace(self, peaks_mock_ads):
         test_detector_id = 4

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -75,7 +75,7 @@ class TestFullInstrumentViewModel(unittest.TestCase):
             "R": np.array([i for i in range(len(detector_ids))]),
             "Theta": np.array([i for i in range(len(detector_ids))]),
             "Phi": np.array([i for i in range(len(detector_ids))]),
-            "Index": np.array([i for i in range(len(detector_ids))]),
+            "Index": np.array([-1 if m == "n/a" else i for i, m in enumerate(monitors)]),
             "Monitor": monitors,
             "Spectrum No": spectrum_no,
         }
@@ -934,7 +934,6 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         """Selects and removes the closest peak within a single workspace."""
         mock_match_units.side_effect = lambda ws_from, idx, x_from, ws_to: x_from
         model, _ = self._setup_model([7])
-        model._spectrum_nos = np.array([7])
         model._detector_is_picked = [True]
         # Peaks at 1.0 (idx=100), 2.0 (idx=101), 10.0 (idx=102); click at 2.2 -> closest is 2.0
         ws1_wdp = MagicMock()
@@ -954,7 +953,6 @@ class TestFullInstrumentViewModel(unittest.TestCase):
         """Among multiple workspaces, chooses the peak with the smallest distance overall."""
         mock_match_units.side_effect = lambda ws_from, idx, x_from, ws_to: x_from
         model, _ = self._setup_model([1, 2, 3, 7])
-        model._spectrum_nos = np.array([1, 2, 3, 7])
         model._detector_is_picked = [False, False, False, True]
         # ws1 closest distance = |2.5 - 2.2| = 0.3 (peak_index=201)
         # ws2 closest distance = |2.3 - 2.2| = 0.1 (peak_index=301) -> ws2 should be chosen


### PR DESCRIPTION
Two problems fixed:

- If overlaying a peaks workspace where the number of peaks is greater than the number of valid detectors, there was an error. This could happen if the user extracted spectra from the original workspace, then overlaid the peaks workspace.
- Allow detectors that where the output from `CreateDetectorTable` is `n/a` for `Monitor`.  Check the workspace index for that detector, if it's -1 then it's no good.

### To test:

For the first problem:
```python
from mantid.simpleapi import *
import numpy as np

ws = Load('SXD23767')
peaks = FindSXPeaksConvolve(InputWorkspace=ws)
ws = ExtractSpectra(ws, StartWorkspaceIndex=10000, EndWorkspaceIndex = 11000)
```
Then plot `ws` in the new Instrument View and overlay `peaks`

For the second problem, see attached file: [BBY0082038.nxs.txt](https://github.com/user-attachments/files/29137282/BBY0082038.nxs.txt)



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
