### PR TITLE
Fix colour palette when using Qt6

### DIFF
--- a/qt/applications/workbench/workbench/app/workbench_process.py
+++ b/qt/applications/workbench/workbench/app/workbench_process.py
@@ -22,7 +22,7 @@ import mantid.kernel.environment as mtd_env
 plugins.setup_library_paths()
 
 from qtpy.QtGui import QIcon, QSurfaceFormat  # noqa: E402
-from qtpy.QtWidgets import QApplication  # noqa: E402
+from qtpy.QtWidgets import QApplication, QStyleFactory  # noqa: E402
 from qtpy.QtCore import QCoreApplication, Qt  # noqa: E402
 
 # Register the workbench Qt resources. This must happen before the QApplication is
@@ -62,6 +62,12 @@ def qapplication():
         argv[0] = APPNAME  # replace application name
 
         app = QApplication(argv)
+        # Under a desktop session (GNOME, xfce, ...) Qt's gtk3 platform theme maps the
+        # system GTK theme onto an incomplete palette, collapsing roles like Window/Base/
+        # Button into one colour and giving a washed-out look. Pin Fusion's standard palette
+        # for consistent, well-defined colours regardless of the desktop environment.
+        if mtd_env.is_linux():
+            app.setPalette(QStyleFactory.create("Fusion").standardPalette())
         app.setOrganizationName(ORGANIZATION)
         app.setOrganizationDomain(ORG_DOMAIN)
         app.setApplicationName(APPNAME)


### PR DESCRIPTION
### Description of work

While testing #41652 on a SNS analysis computers I discovered this issue.

Qt looks at the `DESKTOP_SESSION` and `XDG_CURRENT_DESKTOP` environment variables to determine what colours to use, trying to match the theme. It worked in Qt5 but just seems to fail in Qt6 resulting in everything having the same grey colour. This fixes the palette to the default one.

If you install the qt6 package build from #41652 you change see the difference by changing the environment variables

This has the broken palette
```
DESKTOP_SESSION=xfce XDG_CURRENT_DESKTOP=xfce mantidworkbench
```

This palette is good (because it doesn't recognise the desktop it just does the default)
```
DESKTOP_SESSION=something XDG_CURRENT_DESKTOP=something mantidworkbench
```

Broken palette:
<img width="513" height="409" alt="2026-06-19-123834_513x409_scrot" src="https://github.com/user-attachments/assets/df121fdd-fd84-4b61-ad4b-09f6f44d612f" />

Fixed palette:
<img width="513" height="409" alt="2026-06-19-123945_513x409_scrot" src="https://github.com/user-attachments/assets/15505032-62d7-4c59-bb3d-5ca97e537302" />

Ref #38415

### To test:

To build with Qt6 follow the test instructions from #41599 for the correct pixi environment and cmake options.

Running the workbench with different environment everything should now look correct.

*This does not require release notes* because it was only added this release.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
   <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
