### PR TITLE
Deprecate quasielasticbayes

### DIFF
--- a/Framework/PythonInterface/mantid/utils/deprecator.py
+++ b/Framework/PythonInterface/mantid/utils/deprecator.py
@@ -55,7 +55,7 @@ def deprecated_algorithm(new_name, deprecation_date):  # decorator factory
     def decorator_instance(cls):
         depr_msg = f'Algorithm "{cls.__name__}" is deprecated since {deprecation_date}.'
         if new_name:
-            depr_msg += ' Use "{new_name}" instead'
+            depr_msg += f' Use "{new_name}" instead'
         raise_msg = 'Configuration "algorithms.deprecated" set to raise upon use of any deprecated algorithm'
 
         cls_category = cls.category

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -22,6 +22,7 @@ from mantid.api import (
 )
 from mantid.kernel import StringListValidator, Direction
 import mantid.simpleapi as s_api
+from mantid.utils.deprecator import deprecated_algorithm
 from mantid import config, logger
 from IndirectCommon import (
     check_analysers_or_e_fixed,
@@ -45,6 +46,7 @@ def _calculate_eisf(
     return eisf, eisf_error
 
 
+@deprecated_algorithm("BayesQuasi", "2026-06-22")
 class BayesQuasi(PythonAlgorithm):
     _program = None
     _samWS = None

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -8,11 +8,13 @@
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceGroupProperty, Progress
 from mantid.kernel import StringListValidator, Direction
 import mantid.simpleapi as s_api
+from mantid.utils.deprecator import deprecated_algorithm
 from mantid import config, logger
 import os
 import numpy as np
 
 
+@deprecated_algorithm("BayesStretch2", "2026-06-22")
 class BayesStretch(PythonAlgorithm):
     _sam_name = None
     _sam_ws = None

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
+from mantid.kernel import ConfigService
 from mantid.simpleapi import BayesQuasi, CreateWorkspace, DeleteWorkspace, Load
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from plugins.algorithms.WorkflowAlgorithms.BayesQuasi import _calculate_eisf
@@ -28,11 +29,15 @@ class BayesQuasiTest(unittest.TestCase):
         self._resnorm_ws = Load(Filename="irs26173_graphite002_ResNorm.nxs", OutputWorkspace="irs26173_graphite002_ResNorm")
         self._num_bins = self._sample_ws.blocksize()
         self._num_hists = self._sample_ws.getNumberHistograms()
+        config_service = ConfigService.Instance()
+        self._original_deprecation_setting = config_service["algorithms.deprecated"]
+        config_service["algorithms.deprecated"] = "Log"
 
     def tearDown(self):
         """
         Remove workspaces from ADS.
         """
+        ConfigService.Instance()["algorithms.deprecated"] = self._original_deprecation_setting
         DeleteWorkspace(self._sample_ws)
         DeleteWorkspace(self._res_ws)
         DeleteWorkspace(self._resnorm_ws)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.api import WorkspaceGroup
+from mantid.kernel import ConfigService
 from mantid.simpleapi import BayesStretch, DeleteWorkspace, Load
 
 
@@ -20,6 +21,9 @@ class BayesStretchTest(unittest.TestCase):
         self._res_ws = Load(Filename="irs26173_graphite002_res.nxs", OutputWorkspace="__BayesStretchTest_Resolution")
         self._sample_ws = Load(Filename="irs26176_graphite002_red.nxs", OutputWorkspace="__BayesStretchTest_Sample")
         self._num_hists = self._sample_ws.getNumberHistograms()
+        config = ConfigService.Instance()
+        self._original_deprectation_setting = config["algorithms.deprecated"]
+        config["algorithms.deprecated"] = "Log"
 
     def tearDown(self):
         """
@@ -27,6 +31,7 @@ class BayesStretchTest(unittest.TestCase):
         """
         DeleteWorkspace(self._sample_ws)
         DeleteWorkspace(self._res_ws)
+        ConfigService.Instance()["algorithms.deprecated"] = self._original_deprectation_setting
 
     # ----------------------------------Algorithm tests----------------------------------------
 

--- a/Testing/SystemTests/tests/framework/BayesQuasiTest.py
+++ b/Testing/SystemTests/tests/framework/BayesQuasiTest.py
@@ -26,6 +26,7 @@ class BayesQuasiTest(MantidSystemTest):
         return platform == "darwin"
 
     def runTest(self):
+        config["algorithms.deprecated"] = "Log"
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
         Load(Filename=f"{self._sample_name}.nxs", OutputWorkspace=self._sample_name, LoadHistory=False)

--- a/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
@@ -36,6 +36,7 @@ class QLresTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         prefix = "rt_"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
@@ -86,6 +87,7 @@ class QuestTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
 
@@ -125,6 +127,7 @@ class QSeTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
         e_min = -0.5
@@ -169,6 +172,7 @@ class QLDataTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_red"
         e_min = -0.5
@@ -219,6 +223,7 @@ class QLResNormTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
         rsname = "irs26173_graphite002_ResNorm"
@@ -273,6 +278,7 @@ class QLWidthTest(systemtesting.MantidSystemTest):
     def runTest(self):
         workdir = tempfile.mkdtemp(prefix="bayes_")
         config["defaultsave.directory"] = workdir
+        config["algorithms.deprecated"] = "Log"
         prefix = "wt_"
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"

--- a/docs/source/algorithms/BayesQuasi-v1.rst
+++ b/docs/source/algorithms/BayesQuasi-v1.rst
@@ -10,6 +10,8 @@
 Description
 -----------
 
+This algorithm has been deprecated in favour of :ref:`algm-BayesQuasi2`
+
 The model that is being fitted is that of a \delta-function (elastic component) of amplitude A(0)
 and Lorentzians of amplitude A(j) and HWHM W(j) where j=1,2,3. The whole function is then convolved
 with the resolution function. The -function and Lorentzians are intrinsically normalised to unity
@@ -33,7 +35,7 @@ Usage
 
 **Example - BayesQuasi**
 
-.. testcode:: BayesQuasiExample
+.. code-block:: python
 
     # Load in test data
     sampleWs = Load('irs26176_graphite002_red.nxs')

--- a/docs/source/algorithms/BayesStretch-v1.rst
+++ b/docs/source/algorithms/BayesStretch-v1.rst
@@ -9,6 +9,8 @@
 Description
 -----------
 
+This algorithm has been deprecated in favour of :ref:`algm-BayesStretch2`
+
 This is a variation of the stretched exponential option of
 :ref:`Quasi <algm-BayesQuasi>`. For each spectrum a fit is performed
 for a grid of :math:`\beta` and :math:`\sigma` values. The distribution of goodness of fit values
@@ -22,7 +24,7 @@ Usage
 
 **Example - BayesStretch**
 
-.. testcode:: BayesStretchExample
+.. code-block:: python
 
     # Load in test data
     sample_ws = Load('irs26176_graphite002_red.nxs')

--- a/docs/source/release/v6.16.0/direct_geometry.rst
+++ b/docs/source/release/v6.16.0/direct_geometry.rst
@@ -9,6 +9,7 @@ New features
 ############
 - (`#41309 <https://github.com/mantidproject/mantid/pull/41309>`_) In :ref:`DGS Planner <dgsplanner-ref>`, the minimal value for the Incident Energy has been lowered from 1.0 to 0.1 meV.
 - (`#41305 <https://github.com/mantidproject/mantid/pull/41305>`_) CNCS has a new parameter file to update the calculation of T0 offset.
+- (`#41432 <https://github.com/mantidproject/mantid/pull/41432>`_) :ref:`LoadPLNnxs <algm-LoadPLNnxs>` now supports loading ANSTO PELICAN data collected with the AESS framework.
 
 MSlice
 ------

--- a/docs/source/release/v6.16.0/inelastic.rst
+++ b/docs/source/release/v6.16.0/inelastic.rst
@@ -6,6 +6,12 @@ New Features
 ------------
 - (`#41228 <https://github.com/mantidproject/mantid/pull/41228>`_) The :ref:`Absorption Corrections<absorption_corrections>` tab now has an improved UI which displays existing elements better and adds new features.
 
+Deprecated
+----------
+- (`#TBC <https://github.com/mantidproject/mantid/pull/TBC>`_) This release will be the final version to include ``quasielasticbayes`` support.
+  The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` now uses ``quickbayes`` (the new python library) by default.
+  In the next release the option to use ``quasielasticbayes`` will be removed.
+  The :ref:`algm-BayesQuasi` and :ref:`algm-BayesStretch` algorithms (based on ``quasielasticbayes``) have been deprecated in favour of the ``quickbayes`` replacements, :ref:`algm-BayesQuasi2` and :ref:`algm-BayesStretch2`, respectively.
 
 Bugfixes
 --------

--- a/docs/source/release/v6.16.0/inelastic.rst
+++ b/docs/source/release/v6.16.0/inelastic.rst
@@ -8,7 +8,7 @@ New Features
 
 Deprecated
 ----------
-- (`#TBC <https://github.com/mantidproject/mantid/pull/TBC>`_) This release will be the final version to include ``quasielasticbayes`` support.
+- (`#41712 <https://github.com/mantidproject/mantid/pull/41712>`_) This release will be the final version to include ``quasielasticbayes`` support.
   The :ref:`Bayes Fitting interface <interface-inelastic-bayes-fitting>` now uses ``quickbayes`` (the new python library) by default.
   In the next release the option to use ``quasielasticbayes`` will be removed.
   The :ref:`algm-BayesQuasi` and :ref:`algm-BayesStretch` algorithms (based on ``quasielasticbayes``) have been deprecated in favour of the ``quickbayes`` replacements, :ref:`algm-BayesQuasi2` and :ref:`algm-BayesStretch2`, respectively.

--- a/docs/source/release/v6.17.0/Direct_Geometry/General/New_features/41432.rst
+++ b/docs/source/release/v6.17.0/Direct_Geometry/General/New_features/41432.rst
@@ -1,1 +1,0 @@
-- :ref:`LoadPLNnxs <algm-LoadPLNnxs>` supports loading ANSTO PELICAN data collected with the AESS framework.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -19,7 +19,7 @@ DECLARE_SUBWINDOW(BayesFitting)
 
 BayesFitting::BayesFitting(QWidget *parent)
     : InelasticInterface(parent), m_changeObserver(*this, &BayesFitting::handleDirectoryChange),
-      m_backend(BayesBackendType::QUASI_ELASTIC_BAYES) {
+      m_backend(BayesBackendType::QUICK_BAYES) {
   m_uiForm.setupUi(this);
   m_uiForm.pbSettings->setIcon(Settings::icon());
   setBackend(backendToQStr.at(m_backend));
@@ -129,9 +129,7 @@ void BayesFitting::setBackend(const QString &text) {
     m_uiForm.backendChoice->setToolTip("Old Fortran library");
   } else if (text == backendToQStr.at(BayesBackendType::QUICK_BAYES)) {
     newBackend = BayesBackendType::QUICK_BAYES;
-    m_uiForm.warningLabel->setText(
-        "Warning: the process to establish confidence in quickbayes (new Python library)\n"
-        "is ongoing. Please feedback any issues you encounter to the Mantid development team.");
+    m_uiForm.warningLabel->setText("");
     m_uiForm.backendChoice->setToolTip("New Python library");
   }
   if (newBackend != m_backend) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.ui
@@ -105,12 +105,12 @@
         </property>
         <item>
          <property name="text">
-          <string>quasielasticbayes</string>
+          <string>quickbayes</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>quickbayes</string>
+          <string>quasielasticbayes</string>
          </property>
         </item>
        </widget>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -9,7 +9,7 @@
 namespace MantidQt::CustomInterfaces {
 
 BayesFittingTab::BayesFittingTab(QWidget *parent, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner)
-    : InelasticTab(parent), m_propTree(new QtTreePropertyBrowser()), m_useQuickBayes(false) {
+    : InelasticTab(parent), m_propTree(new QtTreePropertyBrowser()), m_useQuickBayes(true) {
 
   m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
   // Temporary until all Bayes Fitting tabs are refactored as MVP

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.h
@@ -87,7 +87,7 @@ class QuasiView final : public QWidget, public IQuasiView {
   Q_OBJECT
 
 public:
-  QuasiView(QWidget *parent = nullptr, bool useQuickBayes = false);
+  QuasiView(QWidget *parent = nullptr, bool useQuickBayes = true);
   ~QuasiView() override = default;
 
   void subscribe(IQuasiPresenter *presenter) override;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchModel.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchModel.h
@@ -33,7 +33,7 @@ public:
   MantidQt::API::IConfiguredAlgorithm_sptr stretchAlgorithm(const StretchRunData &algParams,
                                                             const std::string &fitWorkspaceName,
                                                             const std::string &contourWorkspaceNames,
-                                                            const bool useQuickBayes = false) const override;
+                                                            const bool useQuickBayes = true) const override;
 
   API::IConfiguredAlgorithm_sptr setupSaveAlgorithm(const std::string &wsName) const override;
 };

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.h
@@ -66,7 +66,7 @@ public:
 class MANTIDQT_INELASTIC_DLL StretchView : public QWidget, public IStretchView {
   Q_OBJECT
 public:
-  explicit StretchView(QWidget *parent = nullptr, bool useQuickBayes = false);
+  explicit StretchView(QWidget *parent = nullptr, bool useQuickBayes = true);
   ~StretchView() override = default;
 
   void subscribePresenter(IStretchViewSubscriber *presenter) override;

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
@@ -149,11 +149,11 @@ public:
   void test_notifyBackendChanged_calls_view() {
     EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
 
     EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
   }
 
   void test_notifyBackendChanged_alters_the_model_call() {

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/QuasiPresenterTest.h
@@ -149,11 +149,11 @@ public:
   void test_notifyBackendChanged_calls_view() {
     EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
 
     EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
   }
 
   void test_notifyBackendChanged_alters_the_model_call() {

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchModelTest.h
@@ -170,7 +170,7 @@ public:
     params.sequentialFit = true;
     params.sampleBinning = 1;
 
-    auto configuredAlgorithm = m_model->stretchAlgorithm(params, "fit_ws", "contour_ws");
+    auto configuredAlgorithm = m_model->stretchAlgorithm(params, "fit_ws", "contour_ws", false);
 
     TS_ASSERT_EQUALS("BayesStretch", configuredAlgorithm->algorithm()->name());
 

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -118,13 +118,13 @@ public:
 
     auto const cutIndex = runData.sampleName.find_last_of("_");
     auto const baseName = runData.sampleName.substr(0, cutIndex);
-    auto fitWorkspaceName = baseName + "_Stretch_Fit_QuasiElasticBayes";
-    auto contourWorkspaceName = baseName + "_Stretch_Contour_QuasiElasticBayes";
+    auto fitWorkspaceName = baseName + "_Stretch_Fit_QuickBayes";
+    auto contourWorkspaceName = baseName + "_Stretch_Contour_QuickBayes";
 
     ads.addOrReplace(fitWorkspaceName, m_workspace);
     ads.addOrReplace(contourWorkspaceName, m_workspace);
 
-    ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
+    ON_CALL(*m_view, getRunData(true)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_view, setPlotADSEnabled(false)).Times(1);
 
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, _)).Times(1);
@@ -143,11 +143,11 @@ public:
   void test_notifyBackendChanged_calls_view() {
     EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
 
     EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
   }
 
   void test_notifyBackendChanged_changes_stretchAlgorithm_call() {
@@ -157,14 +157,14 @@ public:
     ON_CALL(*m_view, getRunData(true)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
     m_presenter->handleRun();
 
     EXPECT_CALL(*m_view, getRunData(false)).Times(1);
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, false)).Times(1);
     ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
     m_presenter->handleRun();
   }
 

--- a/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/BayesFitting/StretchPresenterTest.h
@@ -143,11 +143,11 @@ public:
   void test_notifyBackendChanged_calls_view() {
     EXPECT_CALL(*m_view, updateBackend(true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
 
     EXPECT_CALL(*m_view, updateBackend(false)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
   }
 
   void test_notifyBackendChanged_changes_stretchAlgorithm_call() {
@@ -157,14 +157,14 @@ public:
     ON_CALL(*m_view, getRunData(true)).WillByDefault(Return(runData));
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, true)).Times(1);
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
     m_presenter->handleRun();
 
     EXPECT_CALL(*m_view, getRunData(false)).Times(1);
     EXPECT_CALL(*m_model, stretchAlgorithm(_, _, _, false)).Times(1);
     ON_CALL(*m_view, getRunData(false)).WillByDefault(Return(runData));
 
-    m_presenter->notifyBackendChanged(BayesBackendType::QUASI_ELASTIC_BAYES);
+    m_presenter->notifyBackendChanged(BayesBackendType::QUICK_BAYES);
     m_presenter->handleRun();
   }
 


### PR DESCRIPTION
### Description of work
Formally deprecate algorithms that use the fortran-based quasielasticbayes package. We think the quasielasticbayes package might be a considerable blocker to moving to Qt6 in the next release, so we need to give users advance warning in case we can no longer support it. PR includes:

- A fix to `deprecator.py`, which was missing an `f` in an f-string (whoops!)
- Added a stray release note that was in 6.17.0 by mistake
- Deprecation added to release notes
- Algorithms deprecated and linked to replacements
- Made quickbayes the default backend for the algorithms used in the Inelastic Bayes Fitting interface
- Added deprecation message to the algorithm docs for algorithms using quasielasticbayes
- Converted testcode directives to plain code blocks because deprecated algorithms raise, which fails the doctest.

### To test:
1. Install the test package:
`mamba install -c mantid-test/label/quickbayes-default-fix mantidworkbench`
2. Open the Inelastic Bayes Fitting interface and verify that quickbayes is the default backend (there is a combo box at the bottom).
3. Run the example [here](https://docs.mantidproject.org/nightly/algorithms/BayesQuasi-v1.html#usage) and verify that the algorithm deprecation message is displayed. Data for this example can be found in the [ISIS sample data](https://sourceforge.net/projects/mantid/files/Sample%20Data/SampleData-ISIS.zip/download) (you may have to change one of the file names in the example to match what's in the sample data).
4. Verify that deprecation text in the algorithm docs link to the correct places.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
