### PR TITLE
Fixed a crash caused by incorrect skipping of unaltered `EventWorkspaces` when monitors are loaded and  `Save Altered Workspaces Only` is selected in the `Save Project as...` dialog

### DIFF
--- a/docs/source/release/v6.17.0/Workbench/Bugfixes/38655.rst
+++ b/docs/source/release/v6.17.0/Workbench/Bugfixes/38655.rst
@@ -1,1 +1,1 @@
-- The :menuselection:`File --> Save Project as...` dialog now correctly skips unmodified workspaces when ``Save Altered Workspaces Only`` is selected without resulting in mantid crashing.
+- The :menuselection:`File --> Save Project as...` dialog now correctly skips an unmodified :py:obj:`EventWorkspace <mantid.dataobjects.EventWorkspace>` when monitors are loaded and ``Save Altered Workspaces Only`` is selected without resulting in mantid crashing.

--- a/docs/source/release/v6.17.0/Workbench/Bugfixes/38655.rst
+++ b/docs/source/release/v6.17.0/Workbench/Bugfixes/38655.rst
@@ -1,0 +1,1 @@
+- The :menuselection:`File --> Save Project as...` dialog now correctly skips unmodified workspaces when ``Save Altered Workspaces Only`` is selected without resulting in mantid crashing.

--- a/qt/python/mantidqt/mantidqt/project/project.py
+++ b/qt/python/mantidqt/mantidqt/project/project.py
@@ -191,7 +191,7 @@ class Project(AnalysisDataServiceObserver):
         altered_workspace_names = []
         for ws in workspaces:
             history = ws.getHistory()
-            if not (history.size() == 1 and history.getAlgorithm(0).name() == "Load"):
+            if not (history.size() == 1 and history.getAlgorithmHistory(0).name() == "Load"):
                 altered_workspace_names.append(ws.name())
 
         return altered_workspace_names

--- a/qt/python/mantidqt/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/mantidqt/project/test/test_project.py
@@ -251,7 +251,7 @@ class ProjectTest(unittest.TestCase):
         unaltered_workspace_history = mock.Mock()
         unaltered_workspace.getHistory.return_value = unaltered_workspace_history
         unaltered_workspace_history.size.return_value = 1
-        unaltered_workspace_history.getAlgorithm(0).name.return_value = "Load"
+        unaltered_workspace_history.getAlgorithmHistory(0).name.return_value = "Load"
 
         # Create a mock altered workspaces with history length > 1.
         altered_workspace = mock.Mock()


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #38655. <!-- One line per closed issue. -->

The call to `getAlgorithm` is replaced with a call to `getAlgorithmHistory`. `getAlgorithm` will try to create an algorithm but `getAlgorithmHistory` will retrieve the history.
<img width="695" height="388" alt="image" src="https://github.com/user-attachments/assets/64f67f91-77a2-499f-b93b-46998d7c349c" />


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
Follow the same instructions as defined in the issue.

1) Load` CNCS_7860_event` from the training data (make sure to check `LoadMontiors` also)
2) Go to `File > Save Project as...`
3) Tick `Save Altered Workspaces Only`
4) Pick a new path for the project (choose a new name)
5) Click `OK`
6) Verify that no error is raised.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
