### PR TITLE
Use `Diffraction.isis_powder` for `isis_powder` imports

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SaveGEMMAUDParamFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveGEMMAUDParamFile.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from mantid.api import mtd, AlgorithmFactory, FileAction, FileProperty, PythonAlgorithm, WorkspaceGroupProperty
 from mantid.kernel import logger, Direction, IntArrayProperty
-import isis_powder.gem_routines
+import Diffraction.isis_powder.gem_routines as gem_routines
 
 _MAUD_TEMPLATE_PATH = None
 
@@ -19,7 +19,7 @@ _MAUD_TEMPLATE_PATH = None
 def _maud_template_path():
     global _MAUD_TEMPLATE_PATH
     if _MAUD_TEMPLATE_PATH is None:
-        _MAUD_TEMPLATE_PATH = os.path.join(os.path.dirname(isis_powder.gem_routines.__file__), "maud_param_template.maud")
+        _MAUD_TEMPLATE_PATH = os.path.join(os.path.dirname(gem_routines.__file__), "maud_param_template.maud")
     return _MAUD_TEMPLATE_PATH
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScatteringTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScatteringTest.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 from mantid.simpleapi import TotScatCalculateSelfScattering
 from mantid.api import mtd
-from isis_powder import SampleDetails
+from Diffraction.isis_powder import SampleDetails
 from testhelpers import WorkspaceCreationHelper
 
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
@@ -11,7 +11,7 @@ import shutil
 import mantid.simpleapi as mantid
 from mantid import config
 
-from isis_powder import Gem, SampleDetails
+from Diffraction.isis_powder import Gem, SampleDetails
 
 DIRS = config["datasearch.directories"].split(";")
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderHRPDTest.py
@@ -13,7 +13,7 @@ import mantid.simpleapi as mantid
 from mantid import config
 from mantid.kernel import UnitConversion, DeltaEModeType
 
-from isis_powder import HRPD, SampleDetails
+from Diffraction.isis_powder import HRPD, SampleDetails
 
 
 DIRS = config["datasearch.directories"].split(";")

--- a/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
@@ -11,8 +11,8 @@ import shutil
 import mantid.simpleapi as mantid
 from mantid import config
 
-from isis_powder.osiris import Osiris
-from isis_powder.routines.sample_details import SampleDetails
+from Diffraction.isis_powder.osiris import Osiris
+from Diffraction.isis_powder.routines.sample_details import SampleDetails
 
 DIRS = config["datasearch.directories"].split(";")
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -11,7 +11,7 @@ import shutil
 import mantid.simpleapi as mantid
 from mantid import config
 
-from isis_powder import Pearl
+from Diffraction.isis_powder import Pearl
 
 DIRS = config["datasearch.directories"].split(";")
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -12,7 +12,7 @@ import shutil
 import mantid.simpleapi as mantid
 from mantid import config
 
-from isis_powder import Polaris, SampleDetails
+from Diffraction.isis_powder import Polaris, SampleDetails
 from mantid.api import AnalysisDataService
 
 DIRS = config["datasearch.directories"].split(";")

--- a/scripts/Diffraction/isis_powder/__init__.py
+++ b/scripts/Diffraction/isis_powder/__init__.py
@@ -6,13 +6,14 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # Disable unused import warnings. The import is for user convenience
 # Bring instruments into package namespace
-from .gem import Gem  # noqa: F401
-from .hrpd import HRPD  # noqa: F401
-from .pearl import Pearl  # noqa: F401
-from .polaris import Polaris  # noqa: F401
+from .gem import Gem
+from .hrpd import HRPD
+from .osiris import Osiris
+from .pearl import Pearl
+from .polaris import Polaris
 
 # Other useful classes
-from .routines.sample_details import SampleDetails  # noqa: F401
+from .routines.sample_details import SampleDetails
 
 # Prevent users using from import *
-__all__ = []
+__all__ = [Gem, HRPD, Osiris, Pearl, Polaris, SampleDetails]

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
-from isis_powder.routines import calibrate, focus, common, common_enums, common_output
+from Diffraction.isis_powder.routines import calibrate, focus, common, common_enums, common_output
 from mantid.kernel import config, logger
 import mantid.simpleapi as mantid
 

--- a/scripts/Diffraction/isis_powder/gem.py
+++ b/scripts/Diffraction/isis_powder/gem.py
@@ -6,9 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.gem_routines import gem_advanced_config, gem_algs, gem_param_mapping, gem_output, gem_calibration_algs
-from isis_powder.routines import absorb_corrections, common, instrument_settings, common_output
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.gem_routines import gem_advanced_config, gem_algs, gem_param_mapping, gem_output, gem_calibration_algs
+from Diffraction.isis_powder.routines import absorb_corrections, common, instrument_settings, common_output
 
 
 class Gem(AbstractInst):

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_advanced_config.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import copy
 
-from isis_powder.routines.common import ADVANCED_CONFIG as COMMON_ADVANCED_CONFIG
+from Diffraction.isis_powder.routines.common import ADVANCED_CONFIG as COMMON_ADVANCED_CONFIG
 
 
 absorption_correction_params = {

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
@@ -6,9 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
 
-from isis_powder.routines import absorb_corrections, common
-from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
-from isis_powder.gem_routines import gem_advanced_config
+from Diffraction.isis_powder.routines import absorb_corrections, common
+from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
+from Diffraction.isis_powder.gem_routines import gem_advanced_config
 
 
 def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering, is_vanadium, msevents):

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_calibration_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_calibration_algs.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import mantid.simpleapi as mantid
-import isis_powder.routines.common as common
-from isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
 
 
 def create_calibration(

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
@@ -4,10 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines.param_map_entry import ParamMapEntry
-from isis_powder.gem_routines.gem_enums import GEM_CHOPPER_MODES
-from isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
-from isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS, EMPTY_CAN_SUBTRACTION_METHOD
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.gem_routines.gem_enums import GEM_CHOPPER_MODES
+from Diffraction.isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS, EMPTY_CAN_SUBTRACTION_METHOD
 
 #                 Maps friendly user name (ext_name) -> script name (int_name)
 attr_mapping = [

--- a/scripts/Diffraction/isis_powder/hrpd.py
+++ b/scripts/Diffraction/isis_powder/hrpd.py
@@ -7,9 +7,9 @@
 import os
 import numpy as np
 
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.routines import absorb_corrections, common, instrument_settings
-from isis_powder.hrpd_routines import hrpd_advanced_config, hrpd_algs, hrpd_param_mapping
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.routines import absorb_corrections, common, instrument_settings
+from Diffraction.isis_powder.hrpd_routines import hrpd_advanced_config, hrpd_algs, hrpd_param_mapping
 
 import mantid.simpleapi as mantid
 from mantid.api import MultiDomainFunction, FunctionFactory

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.hrpd_routines.hrpd_enums import HRPD_TOF_WINDOWS
+from Diffraction.isis_powder.hrpd_routines.hrpd_enums import HRPD_TOF_WINDOWS
 
 absorption_correction_params = {
     "cylinder_sample_height": 2.0,

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
@@ -6,9 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
 
-from isis_powder.hrpd_routines import hrpd_advanced_config
-from isis_powder.routines import common, absorb_corrections, sample_details, common_enums
-from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
+from Diffraction.isis_powder.hrpd_routines import hrpd_advanced_config
+from Diffraction.isis_powder.routines import common, absorb_corrections, sample_details, common_enums
+from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
 
 
 def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering, msevents):

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
@@ -4,10 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.hrpd_routines.hrpd_enums import HRPD_MODES, HRPD_TOF_WINDOWS
-from isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
-from isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
-from isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.hrpd_routines.hrpd_enums import HRPD_MODES, HRPD_TOF_WINDOWS
+from Diffraction.isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
+from Diffraction.isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
 
 attr_mapping = [
     ParamMapEntry(ext_name="calibration_directory", int_name="calibration_dir"),

--- a/scripts/Diffraction/isis_powder/osiris.py
+++ b/scripts/Diffraction/isis_powder/osiris.py
@@ -5,9 +5,9 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.osiris_routines import osiris_advanced_config, osiris_algs, osiris_param_mapping
-from isis_powder.routines import instrument_settings, common_output, common, focus, absorb_corrections, common_enums
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.osiris_routines import osiris_advanced_config, osiris_algs, osiris_param_mapping
+from Diffraction.isis_powder.routines import instrument_settings, common_output, common, focus, absorb_corrections, common_enums
 import copy
 import mantid.simpleapi as mantid
 import os

--- a/scripts/Diffraction/isis_powder/osiris_routines/osiris_algs.py
+++ b/scripts/Diffraction/isis_powder/osiris_routines/osiris_algs.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-import isis_powder.routines.common as common
-from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
 import numpy as np
 from mantid.kernel import logger
 from mantid.simpleapi import (

--- a/scripts/Diffraction/isis_powder/osiris_routines/osiris_algs.py
+++ b/scripts/Diffraction/isis_powder/osiris_routines/osiris_algs.py
@@ -9,12 +9,7 @@ import Diffraction.isis_powder.routines.common as common
 from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
 import numpy as np
 from mantid.kernel import logger
-from mantid.simpleapi import (
-    RebinToWorkspace,
-    MergeRuns,
-    ConjoinSpectra,
-    CreateWorkspace,
-)
+import mantid.simpleapi as mantid
 from mantid.api import AnalysisDataService
 
 d_range_with_time = {
@@ -112,7 +107,7 @@ def rebin_and_sum(workspaces):
             rebinned_workspaces.append(workspace)
         else:
             rebinned_workspaces.append(
-                RebinToWorkspace(
+                mantid.RebinToWorkspace(
                     WorkspaceToRebin=workspace,
                     WorkspaceToMatch=smallest_ws,
                     OutputWorkspace="rebinned",
@@ -206,7 +201,7 @@ def _correct_drange_overlap(merged_ws, drange_sets):
 def merge_dspacing_runs(focussed_runs, drange_sets, run_number):
     if len(focussed_runs) == 1:
         input_workspaces_str = ",".join([ws.name() for ws in focussed_runs[0]])
-        ConjoinSpectra(InputWorkspaces=input_workspaces_str, OutputWorkspace="OSIRIS" + run_number + WORKSPACE_SUFFIX.MERGED)
+        mantid.ConjoinSpectra(InputWorkspaces=input_workspaces_str, OutputWorkspace="OSIRIS" + run_number + WORKSPACE_SUFFIX.MERGED)
 
         joined_spectra = AnalysisDataService["OSIRIS" + run_number + WORKSPACE_SUFFIX.MERGED]
         return [_correct_drange_overlap(joined_spectra, drange_sets)]
@@ -221,7 +216,9 @@ def merge_dspacing_runs(focussed_runs, drange_sets, run_number):
     # Group workspaces located at the same index
     matched_spectra = [list(spectra) for spectra in zip(*focussed_runs)]
     # Merge workspaces located at the same index
-    merged_spectra = [MergeRuns(InputWorkspaces=spectra, OutputWorkspace=f"merged_{idx}") for idx, spectra in enumerate(matched_spectra)]
+    merged_spectra = [
+        mantid.MergeRuns(InputWorkspaces=spectra, OutputWorkspace=f"merged_{idx}") for idx, spectra in enumerate(matched_spectra)
+    ]
 
     max_x_size = max([spectra.dataX(0).size for spectra in merged_spectra])
     max_y_size = max([spectra.dataY(0).size for spectra in merged_spectra])
@@ -241,7 +238,7 @@ def merge_dspacing_runs(focussed_runs, drange_sets, run_number):
             dataY = np.append(dataY, [0] * (max_y_size - dataY.size))
             dataE = np.append(dataE, [0] * (max_e_size - dataE.size))
 
-            merged_spectra[i] = CreateWorkspace(
+            merged_spectra[i] = mantid.CreateWorkspace(
                 NSpec=1,
                 DataX=dataX,
                 DataY=dataY,
@@ -253,7 +250,7 @@ def merge_dspacing_runs(focussed_runs, drange_sets, run_number):
             )
 
     input_workspaces_str = ",".join([ws.name() for ws in merged_spectra])
-    ConjoinSpectra(InputWorkspaces=input_workspaces_str, OutputWorkspace=output_name)
+    mantid.ConjoinSpectra(InputWorkspaces=input_workspaces_str, OutputWorkspace=output_name)
 
     common.remove_intermediate_workspace([ws for ws in merged_spectra])
 

--- a/scripts/Diffraction/isis_powder/osiris_routines/osiris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/osiris_routines/osiris_param_mapping.py
@@ -4,9 +4,9 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines.param_map_entry import ParamMapEntry
-from isis_powder.routines.common import PARAM_MAPPING
-from isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.routines.common import PARAM_MAPPING
+from Diffraction.isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
 
 
 # Maps friendly user name (ext_name) -> script name (int_name)

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -11,9 +11,15 @@ from ast import literal_eval
 import mantid.simpleapi as mantid
 from mantid.kernel import logger
 
-from isis_powder.routines import common, instrument_settings
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.pearl_routines import pearl_advanced_config, pearl_algs, pearl_calibration_algs, pearl_output, pearl_param_mapping
+from Diffraction.isis_powder.routines import common, instrument_settings
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.pearl_routines import (
+    pearl_advanced_config,
+    pearl_algs,
+    pearl_calibration_algs,
+    pearl_output,
+    pearl_param_mapping,
+)
 
 import copy
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -7,8 +7,8 @@
 import mantid.simpleapi as mantid
 from mantid.kernel import logger
 
-import isis_powder.routines.common as common
-from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
 import os
 
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_calibration_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_calibration_algs.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import mantid.simpleapi as mantid
-import isis_powder.routines.common as common
-from isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
 
 
 def create_calibration(

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -7,8 +7,8 @@
 import mantid.simpleapi as mantid
 from mantid.kernel import logger
 
-from isis_powder.routines.common_enums import WORKSPACE_UNITS
-from isis_powder.pearl_routines import pearl_algs
+from Diffraction.isis_powder.routines.common_enums import WORKSPACE_UNITS
+from Diffraction.isis_powder.pearl_routines import pearl_algs
 
 # This file generates the various outputs for the PEARL instruments and saves them to their respective files
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
@@ -4,10 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines.common import PARAM_MAPPING
-from isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
-from isis_powder.routines.param_map_entry import ParamMapEntry
-from isis_powder.pearl_routines.pearl_enums import PEARL_FOCUS_MODES, PEARL_TT_MODES
+from Diffraction.isis_powder.routines.common import PARAM_MAPPING
+from Diffraction.isis_powder.routines.common_enums import EMPTY_CAN_SUBTRACTION_METHOD
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.pearl_routines.pearl_enums import PEARL_FOCUS_MODES, PEARL_TT_MODES
 
 #                 Maps friendly user name (ext_name) -> script name (int_name)
 attr_mapping = [

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -6,9 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 
-from isis_powder.routines import absorb_corrections, common, instrument_settings
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.polaris_routines import polaris_advanced_config, polaris_algs, polaris_param_mapping
+from Diffraction.isis_powder.routines import absorb_corrections, common, instrument_settings
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.polaris_routines import polaris_advanced_config, polaris_algs, polaris_param_mapping
 from mantid.kernel import logger
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_advanced_config.py
@@ -9,7 +9,7 @@
 # into future versions of Mantid.
 import copy
 
-from isis_powder.routines.common import ADVANCED_CONFIG as COMMON_ADVANCED_CONFIG
+from Diffraction.isis_powder.routines.common import ADVANCED_CONFIG as COMMON_ADVANCED_CONFIG
 
 
 absorption_correction_params = {

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -11,9 +11,9 @@ from typing import Union
 import mantid.simpleapi as mantid
 from mantid.api import WorkspaceGroup, MatrixWorkspace
 from mantid.kernel import MaterialBuilder
-from isis_powder.routines import absorb_corrections, common
-from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
-from isis_powder.polaris_routines import polaris_advanced_config
+from Diffraction.isis_powder.routines import absorb_corrections, common
+from Diffraction.isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
+from Diffraction.isis_powder.polaris_routines import polaris_advanced_config
 
 
 def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering, is_vanadium, msevents):

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -4,10 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines.param_map_entry import ParamMapEntry
-from isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
-from isis_powder.routines.common_enums import INPUT_BATCHING, EMPTY_CAN_SUBTRACTION_METHOD, VAN_NORMALISATION_METHOD
-from isis_powder.polaris_routines.polaris_enums import POLARIS_CHOPPER_MODES
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.routines.common import PARAM_MAPPING as COMMON_PARAM_MAPPING
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING, EMPTY_CAN_SUBTRACTION_METHOD, VAN_NORMALISATION_METHOD
+from Diffraction.isis_powder.polaris_routines.polaris_enums import POLARIS_CHOPPER_MODES
 
 #                 Maps friendly user name (ext_name) -> script name (int_name)
 attr_mapping = [

--- a/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
+++ b/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
 
-from isis_powder.routines import common, common_enums, sample_details
+from Diffraction.isis_powder.routines import common, common_enums, sample_details
 
 
 def create_vanadium_sample_details_obj(config_dict):

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
 
-import isis_powder.routines.common as common
-from isis_powder.routines.common_enums import INPUT_BATCHING
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING
 
 
 def create_van(instrument, run_details, absorb, spline=True):

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -12,8 +12,8 @@ import mantid.kernel as kernel
 import mantid.simpleapi as mantid
 from mantid.api import AnalysisDataService, WorkspaceGroup, MatrixWorkspace
 from mantid.dataobjects import Workspace2D
-from isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
-from isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING, WORKSPACE_UNITS
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
 
 # Common param mapping entries
 PARAM_MAPPING = [

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -9,8 +9,8 @@ import mantid.simpleapi as mantid
 from mantid.kernel import logger
 from mantid.dataobjects import Workspace2D
 
-import isis_powder.routines.common as common
-from isis_powder.routines.common_enums import INPUT_BATCHING
+import Diffraction.isis_powder.routines.common as common
+from Diffraction.isis_powder.routines.common_enums import INPUT_BATCHING
 import math
 import numpy
 import os

--- a/scripts/Diffraction/isis_powder/routines/instrument_settings.py
+++ b/scripts/Diffraction/isis_powder/routines/instrument_settings.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines import yaml_parser
+from Diffraction.isis_powder.routines import yaml_parser
 import warnings
 
 

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines import common, yaml_parser
+from Diffraction.isis_powder.routines import common, yaml_parser
 import os
 
 

--- a/scripts/Diffraction/isis_powder/routines/sample_details.py
+++ b/scripts/Diffraction/isis_powder/routines/sample_details.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from isis_powder.routines import common
+from Diffraction.isis_powder.routines import common
 import math
 from mantid import logger
 

--- a/scripts/Diffraction/isis_powder/routines/yaml_parser.py
+++ b/scripts/Diffraction/isis_powder/routines/yaml_parser.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import yaml
-from isis_powder.routines import common as common
-from isis_powder.routines import yaml_sanity
+from Diffraction.isis_powder.routines import common as common
+from Diffraction.isis_powder.routines import yaml_sanity
 
 
 def get_run_dictionary(run_number_string, file_path):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbsorptionTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbsorptionTest.py
@@ -7,7 +7,7 @@
 import mantid.simpleapi as mantid
 import unittest
 
-from isis_powder.routines import absorb_corrections, SampleDetails
+from Diffraction.isis_powder.routines import absorb_corrections, SampleDetails
 
 
 class ISISPowderAbsorptionTest(unittest.TestCase):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
@@ -6,10 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid
 
-from isis_powder.abstract_inst import AbstractInst
-from isis_powder.routines.instrument_settings import InstrumentSettings
-from isis_powder.routines.param_map_entry import ParamMapEntry
-from isis_powder.routines import common, run_details, yaml_parser
+from Diffraction.isis_powder.abstract_inst import AbstractInst
+from Diffraction.isis_powder.routines.instrument_settings import InstrumentSettings
+from Diffraction.isis_powder.routines.param_map_entry import ParamMapEntry
+from Diffraction.isis_powder.routines import common, run_details, yaml_parser
 
 import os
 import random
@@ -238,11 +238,11 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height="height", width=-2)
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=True)
 
-    @patch("isis_powder.routines.common.remove_intermediate_workspace")
-    @patch("isis_powder.routines.common.keep_single_ws_unit")
-    @patch("isis_powder.abstract_inst.AbstractInst._output_focused_ws")
-    @patch("isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
-    @patch("isis_powder.abstract_inst.AbstractInst._get_run_details")
+    @patch("Diffraction.isis_powder.routines.common.remove_intermediate_workspace")
+    @patch("Diffraction.isis_powder.routines.common.keep_single_ws_unit")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._output_focused_ws")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._get_run_details")
     def test_output_focused_runs_individual_batch_mode(
         self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
     ):
@@ -256,11 +256,11 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
         expected_calls = [call(d_spacing_group=run, tof_group=run, unit_to_keep=None) for run in runs]
         mock_keep_unit.assert_has_calls(expected_calls)
 
-    @patch("isis_powder.routines.common.remove_intermediate_workspace")
-    @patch("isis_powder.routines.common.keep_single_ws_unit")
-    @patch("isis_powder.abstract_inst.AbstractInst._output_focused_ws")
-    @patch("isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
-    @patch("isis_powder.abstract_inst.AbstractInst._get_run_details")
+    @patch("Diffraction.isis_powder.routines.common.remove_intermediate_workspace")
+    @patch("Diffraction.isis_powder.routines.common.keep_single_ws_unit")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._output_focused_ws")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
+    @patch("Diffraction.isis_powder.abstract_inst.AbstractInst._get_run_details")
     def test_output_focused_runs_summed_batch_mode(
         self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
     ):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -7,7 +7,7 @@
 import mantid.simpleapi as mantid  # Have to import Mantid to setup paths
 import unittest
 
-from isis_powder.routines import common, common_enums
+from Diffraction.isis_powder.routines import common, common_enums
 
 
 class ISISPowderCommonTest(unittest.TestCase):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderFocusCropTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderFocusCropTest.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
-from isis_powder.routines import focus
+from Diffraction.isis_powder.routines import focus
 import unittest
 
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderGemOutputTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderGemOutputTest.py
@@ -11,7 +11,7 @@ import tempfile
 import shutil
 import warnings
 
-from isis_powder.gem_routines import gem_output
+from Diffraction.isis_powder.gem_routines import gem_output
 
 
 class ISISPowderGemOutputTest(unittest.TestCase):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderInstrumentSettingsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderInstrumentSettingsTest.py
@@ -7,7 +7,7 @@
 import unittest
 import warnings
 
-from isis_powder.routines import instrument_settings, param_map_entry
+from Diffraction.isis_powder.routines import instrument_settings, param_map_entry
 
 
 class ISISPowderInstrumentSettingsTest(unittest.TestCase):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderPearlTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderPearlTest.py
@@ -7,12 +7,12 @@
 import unittest
 from unittest.mock import patch, Mock
 import mantid.simpleapi as mantid  # noqa: F401 # runs .pth file to add scripts subdirectories
-from isis_powder.pearl import Pearl
-from isis_powder.pearl_routines import pearl_advanced_config
+from Diffraction.isis_powder.pearl import Pearl
+from Diffraction.isis_powder.pearl_routines import pearl_advanced_config
 
 
 class ISISPowderPearlTest(unittest.TestCase):
-    @patch("isis_powder.routines.focus.focus")
+    @patch("Diffraction.isis_powder.routines.focus.focus")
     def test_long_mode_on(self, mock_focus):
         def generate_long_mode_checker(expected_value):
             if expected_value:

--- a/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
@@ -12,8 +12,8 @@ import tempfile
 import unittest
 import warnings
 
-from isis_powder.routines import run_details
-from isis_powder.routines import common, yaml_parser
+from Diffraction.isis_powder.routines import run_details
+from Diffraction.isis_powder.routines import common, yaml_parser
 
 
 class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderSampleDetailsTest.py
@@ -8,7 +8,7 @@ import io
 import sys
 import unittest
 
-from isis_powder.routines import sample_details
+from Diffraction.isis_powder.routines import sample_details
 from mantid.simpleapi import SetSample, CreateSampleWorkspace
 
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderYamlParserTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderYamlParserTest.py
@@ -8,7 +8,7 @@ import tempfile
 import os
 import unittest
 import warnings
-from isis_powder.routines import yaml_parser
+from Diffraction.isis_powder.routines import yaml_parser
 
 
 class ISISPowderYamlParserTest(unittest.TestCase):


### PR DESCRIPTION
### Description of work

Issue is unhappy that the `from isis_powder` imports cannot be resolved by PyCharm as the link only exists at runtime. Now the imports are from `Diffraction.isis_powder` which satisfies pycharm. 

As well as getting rid of the "distracting" errors, you can now use the `Go To` features properly, which is helpful.

Closes #33388

### To test:

I think if the CI all passes and the changes look ok, nothing else should need testing 

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
