### PR TITLE
Fix Coverity Warning in `ParatemeterMap::getRecursiveFittingParameter`

### DIFF
--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -958,9 +958,13 @@ Parameter_sptr ParameterMap::getRecursiveFittingParameter(const IComponent *comp
   if (!comp || m_map.empty())
     return Parameter_sptr();
 
-  std::shared_ptr<const IComponent> compInFocus(comp, NoDeleting());
-  while (compInFocus != nullptr) {
-    const ComponentID id = compInFocus->getComponentID();
+  // Walk up the component tree using a raw pointer. Wrapping the externally-owned
+  // component in a shared_ptr (even with NoDeleting) makes Coverity flag it as being
+  // managed by two smart pointers; the parent shared_ptr keeps each level alive.
+  const IComponent *current = comp;
+  std::shared_ptr<const IComponent> parent;
+  while (current != nullptr) {
+    const ComponentID id = current->getComponentID();
     auto it_found = m_map.find(id);
     if (it_found != m_map.end()) {
       auto itrs = m_map.equal_range(id);
@@ -977,7 +981,8 @@ Parameter_sptr ParameterMap::getRecursiveFittingParameter(const IComponent *comp
         }
       }
     }
-    compInFocus = compInFocus->getParent();
+    parent = current->getParent();
+    current = parent.get();
   }
   return Parameter_sptr();
 }


### PR DESCRIPTION
### Description of work
Fixes Coverity warning:  
```
*** CID 1660165:         Memory - corruptions  (MULTIPLE_INIT_SMART_PTRS)
/home/docker/actions-runner/_work/mantid/mantid/Framework/API/src/IFunction.cpp: 1237             in Mantid::API::IFunction::setMatrixWorkspace(std::shared_ptr<const Mantid::API::MatrixWorkspace>, unsigned long, double, double)()
1231     
1232         for (size_t i = 0; i < nParams(); i++) {
1233           if (!isExplicitlySet(i)) {
1234             // Use the fitting-function-aware lookup: two functions on the same component can declare a
1235             // parameter with the same short name (e.g. Bk2BkExpConvPV:Gamma and IkedaCarpenterPV:Gamma).
1236             // The plain getRecursive() short-circuits on the first match and would pick the wrong one.
>>>     CID 1660165:         Memory - corruptions  (MULTIPLE_INIT_SMART_PTRS)
>>>     Function "getRecursiveFittingParameter" sets a smart pointer with "detectorPtr", but it is already managed by another smart pointer.
1237             Geometry::Parameter_sptr param =
1238                 paramMap.getRecursiveFittingParameter(detectorPtr, parameterName(i), this->name());
1239             if (!param) {
1240               // Fall back for IDFs that omit the function prefix (no embedded function name to match).
1241               param = paramMap.getRecursive(detectorPtr, parameterName(i), "fitting");
1242             }
```

### To test:

passes CI

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
