### PR TITLE
Fix test reporter for fork PRs and inline test annotations

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -132,6 +132,8 @@ jobs:
 
   build-and-test:
     needs: [cppcheck, doxygen]
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -219,21 +221,21 @@ jobs:
           # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false true $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
 
-      - name: Unit test report (Linux)
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+      - name: Archive unit test output (Linux)
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.os == 'Linux' && failure() && steps.testunit.conclusion == 'failure' }}
         with:
-          check_name: "Unit test results (${{ matrix.os }})"
-          check_run: false
-          files: build/Testing/*unittest.xml
+          name: junit-unit-Linux
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/Testing/*unittest.xml
 
-      - name: Unit test report (Windows)
-        uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2
+      - name: Archive unit test output (Windows)
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.os == 'Windows' && failure() && steps.testunit.conclusion == 'failure' }}
         with:
-          check_name: "Unit test results (${{ matrix.os }})"
-          check_run: false
-          files: build/Testing/*unittest.xml
+          name: junit-unit-Windows
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/Testing/*unittest.xml
 
       - name: Run system tests
         if: ${{ matrix.os == 'Linux' && steps.changes.outputs.code_changes == 'true' }}
@@ -254,13 +256,20 @@ jobs:
           if-no-files-found: ignore
           path: ${{ github.workspace }}/build/**/*-mismatch.nxs
 
-      - name: System test report
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+      - name: Archive system test output
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.os == 'Linux' && failure() && steps.testsystem.conclusion == 'failure' }}
         with:
-          check_name: "System test results"
-          check_run: false
-          files: build/Testing/SystemTests/**/TEST-systemtests*.xml
+          name: junit-system
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/Testing/SystemTests/**/TEST-systemtests*.xml
+
+      - name: Upload event payload
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.os == 'Linux' && failure() && github.event_name == 'pull_request' }}
+        with:
+          name: event-file
+          path: ${{ github.event_path }}
 
       - name: Upload build and test log artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -1,0 +1,60 @@
+name: Publish PR test results
+
+on:
+  workflow_run:
+    workflows: ["PR Build and Test"]
+    types: [completed]
+
+permissions:
+  checks: write
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts
+
+      - name: Publish unit test results (Linux)
+        if: hashFiles('artifacts/junit-unit-Linux/*unittest.xml') != ''
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        with:
+          check_name: "Unit test results (Linux)"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          check_run_annotations: skipped tests
+          comment_mode: failures
+          files: artifacts/junit-unit-Linux/*unittest.xml
+
+      - name: Publish unit test results (Windows)
+        if: hashFiles('artifacts/junit-unit-Windows/*unittest.xml') != ''
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        with:
+          check_name: "Unit test results (Windows)"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          check_run_annotations: skipped tests
+          comment_mode: failures
+          files: artifacts/junit-unit-Windows/*unittest.xml
+
+      - name: Publish system test results (Linux)
+        if: hashFiles('artifacts/junit-system/**/TEST-systemtests*.xml') != ''
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        with:
+          check_name: "System test results (Linux)"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          check_run_annotations: skipped tests
+          comment_mode: failures
+          files: artifacts/junit-system/**/TEST-systemtests*.xml

--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled')
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v7


### PR DESCRIPTION
### Description of work
`EnricoMi/publish-unit-test-result-action` needs `checks: write` / `pull-requests: write`, but fork PRs get a read-only `GITHUB_TOKEN`, so the publish steps silently failed with no PR comment, no failed-test names, no inline source annotations.

This PR splits publishing into a separate `publish_test_results.yml` workflow triggered by `workflow_run` on completion of "PR Build and Test"; because `workflow_run` executes the publisher's YAML from the base repo's default branch with a write-scoped token, it works for fork PRs without the security risk of `pull_request_target`. The PR workflow now uploads JUnit XML and the GitHub event payload as artifacts when there is a failure instead of invoking EnricoMi directly. The publisher then downloads the artifacts and runs EnricoMi per category (Linux/Windows unit + Linux system) under minimum permissions, each step guarded by `hashFiles(...)` so only matrix entries that actually failed publish.

**Note**: that `workflow_run` reads the publisher YAML from the base repo's default branch, so fork-PR reporting activates only after this PR merges.

Closes #41093

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Verify that the comment summary and the test-result check runs behave as expected on my proof-of-concept PR in my fork: https://github.com/MohamedAlmaki/mantid/pull/8.
  2. Open a PR from a fork against this repository and confirm that the publisher comment and inline annotations appear correctly.
  3. Note that the publisher cannot be fully exercised against this repository until the workflow lands on `main` — `workflow_run` reads the publisher YAML from the base repo's default branch, so end-to-end verification before
  merge has to happen in my fork.


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
