### PR TITLE
Fix crash in `TextureUtils` for RaggedWorkspaces

### DIFF
--- a/docs/source/concepts/TextureAnalysis.rst
+++ b/docs/source/concepts/TextureAnalysis.rst
@@ -564,7 +564,7 @@ If using a standard grouping, no ``grouping_filepath`` or ``prm_filepath`` is re
       bank_focus_dir = os.path.join(root_dir, "Focus", "CombinedFiles")
 
       # get grouping directory name
-      calib_info = CalibrationInfo(group = GROUP(grouping))
+      calib_info = CalibrationInfo(group = GROUP(grouping), instrument = instr)
       if groupingfile_path:
          calib_info.set_grouping_file(groupingfile_path)
       elif prm_path:
@@ -646,7 +646,7 @@ Additionally to fitting the peak, the table will also contain a numerical integr
    # find and load peaks
 
    # get grouping directory name
-   calib_info = CalibrationInfo(group = GROUP(grouping))
+   calib_info = CalibrationInfo(group = GROUP(grouping), instrument = instr)
    if groupingfile_path:
       calib_info.set_grouping_file(groupingfile_path)
    elif prm_path:

--- a/scripts/Engineering/common/instrument_config.py
+++ b/scripts/Engineering/common/instrument_config.py
@@ -54,6 +54,7 @@ class IMAT_GROUP(Enum):
 # if a new instrument is added, add its config key to this list and group to groups (used for tests)
 SUPPORTED_INSTRUMENTS = ("ENGINX", "IMAT")
 GROUPS = (ENGINX_GROUP, IMAT_GROUP)
+PSEUDONYMS = {"ENGIN-X": "ENGINX"}
 
 
 @dataclass(frozen=True)
@@ -227,6 +228,7 @@ def get_instr_config(instrument: Optional[str]) -> Optional[InstrumentConfig]:
     if instrument is None:
         return None
     key = instrument.upper()
+    key = PSEUDONYMS.get(key, key)
     if key not in CONFIGS:
         raise RuntimeError(f"No instrument config registered for instrument='{instrument}'")
     return CONFIGS[key]

--- a/scripts/Engineering/texture/TextureUtils.py
+++ b/scripts/Engineering/texture/TextureUtils.py
@@ -9,7 +9,7 @@ from os import path, scandir
 from Engineering.texture.correction.correction_model import TextureCorrectionModel
 from Engineering.texture.polefigure.polefigure_model import TextureProjection
 from mantid.simpleapi import SaveNexus, logger, CreateEmptyTableWorkspace, Fit
-from mantid.simpleapi import ConvertUnits, Rebunch, Rebin, SumSpectra, AppendSpectra, CloneWorkspace, CropWorkspace, Load
+from mantid.simpleapi import ConvertUnits, Rebunch, Rebin, SumSpectra, AppendSpectra, CloneWorkspace, CropWorkspaceRagged, Load
 from pathlib import Path
 from Engineering.EnginX import EnginX
 from Engineering.IMAT import IMAT
@@ -288,18 +288,17 @@ def validate_abs_corr_inputs(
 
 
 def crop_and_rebin(ws, out_ws, lower, upper, rebin_params):
-    CropWorkspace(ws, lower, upper, OutputWorkspace="__tmp_peak_window")
+    CropWorkspaceRagged(ws, lower, upper, OutputWorkspace="__tmp_peak_window")
     Rebin("__tmp_peak_window", rebin_params, OutputWorkspace=out_ws)
 
 
 def _get_max_bin(ws):
-    xdat = ws.extractX()
-    return np.diff(xdat, axis=1).max()
+    return max(np.diff(ws.readX(i)).max() for i in range(ws.getNumberHistograms()))
 
 
 def crop_wss_and_combine(wss, peak, lower, upper, output):
     cropped_rebinned_wss = [f"rebin_ws_{peak}_0"]
-    peak_window_ws = CropWorkspace(wss[0], lower, upper, OutputWorkspace="__peak_window_crop")
+    peak_window_ws = CropWorkspaceRagged(wss[0], lower, upper, OutputWorkspace="__peak_window_crop")
     rebin_params = (lower, _get_max_bin(peak_window_ws), upper)
     Rebin("__peak_window_crop", rebin_params, OutputWorkspace=f"rebin_ws_{peak}_0")
     CloneWorkspace(InputWorkspace=f"rebin_ws_{peak}_0", OutputWorkspace=f"rebin_ws_{peak}")
@@ -663,7 +662,6 @@ def fit_all_peaks(
     # we will then fix the amount this can change in the individual fits
 
     x0_lims, all_cropped_rebinned_wss = fit_initial_summed_spectra(wss, peaks, peak_window, fit_kwargs.copy(), peak_func_name)
-
     for iws, wsname in enumerate(wss):
         # notice user how far through the fitting they are (useful if any fits fail)
         logger.notice(f"Fitting Workspace: {wsname} ({iws + 1}/{len(wss)})")

--- a/scripts/test/Engineering/texture/test_TextureUtils.py
+++ b/scripts/test/Engineering/texture/test_TextureUtils.py
@@ -327,7 +327,7 @@ class TextureUtilsFittingUtilsTests(unittest.TestCase):
         self.assertEqual(bg0["A0"], 2.0)
 
     @patch(f"{texture_utils_path}.Rebin")
-    @patch(f"{texture_utils_path}.CropWorkspace")
+    @patch(f"{texture_utils_path}.CropWorkspaceRagged")
     def test_crop_and_rebin(self, mock_crop, mock_rebin):
         # inputs
         ws = "ws1"
@@ -346,7 +346,7 @@ class TextureUtilsFittingUtilsTests(unittest.TestCase):
     @patch(f"{texture_utils_path}.CloneWorkspace")
     @patch(f"{texture_utils_path}.Rebin")
     @patch(f"{texture_utils_path}._get_max_bin")
-    @patch(f"{texture_utils_path}.CropWorkspace")
+    @patch(f"{texture_utils_path}.CropWorkspaceRagged")
     @patch(f"{texture_utils_path}.crop_and_rebin")
     def test_crop_wss_and_combine(self, mock_crop_and_rebin, mock_crop, mock_max_bin, mock_rebin, mock_clone, mock_append, mock_sum):
         # inputs


### PR DESCRIPTION
### Description of work

Perhaps related to #40039 and or #41242 it is now possible for focused ENGINX data to produce ragged workspaces with custom groupings being used.

This is currently not well handled by either `CropWorkspace` or `extractX`, it is unclear whether it is one or both causing the crash as it is a bit flaky and I am trying to get this fixed quickly.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

I am currently testing this with every script I have to make sure it doesn't break anything else. 

I will look into improving the System Test coverage after release to try and work out why this wasn't identified by CI (I think current tests only check the grouped by bank pathway which happens to be symmetric and so not ragged)

As it causes problems in the script I think it will be possible to fix the issues through the python api, perhaps quite heavy handedly 

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
