### PR TITLE
Fixed the initialisation of the `EMin` and `EMax` values on the Inelastic Data Processor Interface when a new workspace is loaded in the `Moments` tab 

### DIFF
--- a/docs/source/release/v6.17.0/Inelastic/Bugfixes/41507.rst
+++ b/docs/source/release/v6.17.0/Inelastic/Bugfixes/41507.rst
@@ -1,0 +1,1 @@
+- The :ref:`Moments<inelastic-moments>` tab now correctly sets the ``EMin`` and ``EMax`` value for the *MomentsModel* when plotting new data so that it is correctly propagated through to the :ref:`SofQWMoments <algm-SofQWMoments>` algorithm initialization.

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -75,6 +75,8 @@ void MomentsPresenter::plotNewData(std::string const &filename) {
   m_view->setPlotPropertyRange(range);
   m_view->setRangeSelector(range);
   m_view->replot();
+  m_model->setEMin(range.first);
+  m_model->setEMax(range.second);
 }
 
 /**


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41507. <!-- One line per closed issue. -->
The `EMin` and `EMax` values are now correctly initialised when a new workspace is loaded and a new plot is generated. This means that the `MomentsModel` now correctly propagates these values to the `SofQWMoments` algorithm initialisation. Before this change, `SofQWMoments` was being initialised with both `EMin` and `EMax` as zero (default values in MomentsModel). This resulted in an error being raised by  the `_CheckElimits` method in `SofQWMoments`.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
1) Open `Interfaces -> Inelastic -> Data Processor` and navigate to the **S(Q, w)** tab.
2) Follow the [instruction](https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html#isis-data) steps 1-7 to create a `_sqw` workspace.
3) Close the Interface.
4) Open `Interfaces -> Inelastic -> Data Processor` and navigate to the **Moments** tab.
5) Follow the [instruction](https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html#indirect-data) steps 1-4 and then jump to step 7.
6) Verify that no error is logged.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
