### PR TITLE
Add parameters to AlignAndFocusPowderSlim

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AlignAndFocusPowderSlim.h
@@ -12,6 +12,7 @@
 #include "MantidDataHandling/AlignAndFocusPowderSlim/SpectraProcessingData.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/TimeSplitter.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/TimeROI.h"
@@ -49,8 +50,9 @@ private:
   void initCalibrationConstants(API::MatrixWorkspace_sptr &wksp, const std::vector<double> &difc_focus);
   void initCalibrationConstantsFromCalWS(const std::vector<double> &difc_focus,
                                          const API::ITableWorkspace_sptr calibrationWS);
-  const API::ITableWorkspace_sptr loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
-                                              DataObjects::GroupingWorkspace_sptr &groupingWS);
+  void loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
+                   DataObjects::GroupingWorkspace_sptr &groupingWS, API::ITableWorkspace_sptr &calibrationWS,
+                   DataObjects::MaskWorkspace_sptr &maskWS);
   DataObjects::GroupingWorkspace_sptr loadGroupingFile(const API::MatrixWorkspace_sptr &wksp,
                                                        const std::string &filename);
   void initScaleAtSample(const API::MatrixWorkspace_sptr &wksp);
@@ -82,6 +84,8 @@ private:
 namespace PropertyNames {
 const std::string FILENAME("Filename");
 const std::string CAL_FILE("CalFileName");
+const std::string CAL_WKSP("CalibrationWorkspace");
+const std::string MASK_WKSP("MaskWorkspace");
 const std::string FILTER_TIMESTART("FilterByTimeStart");
 const std::string FILTER_TIMESTOP("FilterByTimeStop");
 const std::string GROUPING_WS("GroupingWorkspace");

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -181,6 +181,14 @@ void AlignAndFocusPowderSlim::init() {
   declareProperty(std::make_unique<FileProperty>(PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad, cal_exts),
                   "The .cal file containing the position correction factors. Either this or OffsetsWorkspace needs to "
                   "be specified.");
+  declareProperty(std::make_unique<WorkspaceProperty<API::ITableWorkspace>>(
+                      PropertyNames::CAL_WKSP, "", Direction::Input, API::PropertyMode::Optional),
+                  "Optional: A Workspace containing the calibration information. This takes precedence over the "
+                  "calibration from CalFileName.");
+  declareProperty(std::make_unique<WorkspaceProperty<DataObjects::MaskWorkspace>>(
+                      PropertyNames::MASK_WKSP, "", Direction::Input, API::PropertyMode::Optional),
+                  "Optional: A workspace giving which detectors are masked. This takes precedence over the mask "
+                  "from CalFileName.");
   const std::vector<std::string> grp_exts{".xml", ".h5", ".hd5", ".hdf", ".cal"};
   declareProperty(std::make_unique<FileProperty>(PropertyNames::GROUP_FILE, "", FileProperty::OptionalLoad, grp_exts),
                   "An optional file containing grouping information. Overrides grouping from CalFileName. "
@@ -366,11 +374,16 @@ void AlignAndFocusPowderSlim::exec() {
     groupingWS = this->loadGroupingFile(wksp, grp_filename);
   }
 
-  // load calibration file if provided
+  ITableWorkspace_sptr calibrationWS = this->getProperty(PropertyNames::CAL_WKSP);
+  MaskWorkspace_sptr maskWS = this->getProperty(PropertyNames::MASK_WKSP);
+
   const std::string cal_filename = getPropertyValue(PropertyNames::CAL_FILE);
-  ITableWorkspace_sptr calibrationWS;
   if (!cal_filename.empty()) {
-    calibrationWS = this->loadCalFile(wksp, cal_filename, groupingWS);
+    this->loadCalFile(wksp, cal_filename, groupingWS, calibrationWS, maskWS);
+  }
+
+  if (maskWS) {
+    m_masked = maskWS->getMaskedDetectors();
   }
 
   if (groupingWS) {
@@ -771,10 +784,20 @@ void AlignAndFocusPowderSlim::initCalibrationConstantsFromCalWS(const std::vecto
   }
 }
 
-const ITableWorkspace_sptr AlignAndFocusPowderSlim::loadCalFile(const API::Workspace_sptr &inputWS,
-                                                                const std::string &filename,
-                                                                GroupingWorkspace_sptr &groupingWS) {
+/**
+ * Load the calibration file, filling in only the workspaces (grouping, calibration, mask) that have not already been
+ * supplied. Supplied workspaces take precedence over the contents of the file.
+ */
+void AlignAndFocusPowderSlim::loadCalFile(const API::Workspace_sptr &inputWS, const std::string &filename,
+                                          GroupingWorkspace_sptr &groupingWS, ITableWorkspace_sptr &calibrationWS,
+                                          MaskWorkspace_sptr &maskWS) {
   const bool load_grouping = !groupingWS;
+  const bool load_calibration = !calibrationWS;
+  const bool load_mask = !maskWS;
+
+  // nothing left to load from the file
+  if (!load_grouping && !load_calibration && !load_mask)
+    return;
 
   auto alg = createChildAlgorithm("LoadDiffCal");
   alg->setPropertyValue("Filename", filename);
@@ -784,9 +807,9 @@ const ITableWorkspace_sptr AlignAndFocusPowderSlim::loadCalFile(const API::Works
     // intentionally do not supply the input workspace because h5 version can work without
     g_log.debug("Not supplying instrument information to LoadDifCal");
   }
-  alg->setProperty<bool>("MakeCalWorkspace", true);
+  alg->setProperty<bool>("MakeCalWorkspace", load_calibration);
   alg->setProperty<bool>("MakeGroupingWorkspace", load_grouping);
-  alg->setProperty<bool>("MakeMaskWorkspace", true);
+  alg->setProperty<bool>("MakeMaskWorkspace", load_mask);
   alg->setPropertyValue("WorkspaceName", "temp");
   alg->executeAsChildAlg();
 
@@ -794,14 +817,12 @@ const ITableWorkspace_sptr AlignAndFocusPowderSlim::loadCalFile(const API::Works
     g_log.debug() << "Loading grouping workspace from calibration file\n";
     groupingWS = alg->getProperty("OutputGroupingWorkspace");
   }
-
-  const ITableWorkspace_sptr calibrationWS = alg->getProperty("OutputCalWorkspace");
-
-  const MaskWorkspace_sptr maskWS = alg->getProperty("OutputMaskWorkspace");
-  m_masked = maskWS->getMaskedDetectors();
-  g_log.debug() << "Masked detectors: " << m_masked.size() << '\n';
-
-  return calibrationWS;
+  if (load_calibration) {
+    calibrationWS = alg->getProperty("OutputCalWorkspace");
+  }
+  if (load_mask) {
+    maskWS = alg->getProperty("OutputMaskWorkspace");
+  }
 }
 
 /**

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderSlimTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderSlimTest.py
@@ -12,6 +12,7 @@ from mantid.simpleapi import (
     PDLoadCharacterizations,
     MaskBins,
     CreateGroupingWorkspace,
+    LoadDiffCal,
 )
 
 
@@ -186,3 +187,69 @@ class VULCAN_compare_AlignAndFocusPowderFromFiles_with_RaggedBinning(systemtesti
 
     def validate(self):
         return (self.aafps, self.aafpff)
+
+
+class VULCAN_compare_CalFileName_to_InputWorkspaces(systemtesting.MantidSystemTest):
+    """
+    Compare the output of using the CalFileName to instead providing the CalibrationWorkspace, MaskWorkspace and GroupingWorkspace
+    """
+
+    data_file = "VULCAN_189186"
+    cal_file = "VULCAN_calibrate_2019_06_27.h5"
+
+    def requiredMemoryMB(self):
+        return 1024
+
+    def requiredFiles(self):
+        return [self.data_file, self.cal_file]
+
+    def runTest(self):
+        self.aafps = "AlignAndFocusPowderSlimTest_VULCAN_AAFPowderSlim"
+        self.aafps2 = "AlignAndFocusPowderSlimTest_VULCAN_AAFPowderSlim2"
+
+        L1 = 43.755
+        L2 = [2.0145, 2.0145, 2.0156]
+        Polar = [90, 90, 150]
+        Azimuthal = [180, 0, 0]
+
+        dmin = [0.306, 0.306, 0.22]
+        dmax = [2.0, 2.2, 2.0]
+        delta = [-0.001, -0.001, -0.0003]
+
+        AlignAndFocusPowderSlim(
+            Filename=self.data_file,
+            CalFileName=self.cal_file,
+            L1=L1,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            XMin=dmin,
+            XMax=dmax,
+            XDelta=delta,
+            OutputWorkspace=self.aafps,
+        )
+
+        # now repeat with input cal, mask and group workspaces instead of CalFileName. Should get the same result.
+        workspaces = LoadDiffCal("./ExternalData/Testing/Data/SystemTest/VULCAN_calibrate_2019_06_27.h5")
+
+        AlignAndFocusPowderSlim(
+            Filename=self.data_file,
+            CalibrationWorkspace=workspaces.OutputCalWorkspace,
+            MaskWorkspace=workspaces.OutputMaskWorkspace,
+            GroupingWorkspace=workspaces.OutputGroupingWorkspace,
+            L1=L1,
+            L2=L2,
+            Polar=Polar,
+            Azimuthal=Azimuthal,
+            XMin=dmin,
+            XMax=dmax,
+            XDelta=delta,
+            OutputWorkspace=self.aafps2,
+        )
+
+    def validateMethod(self):
+        self.tolerance = 1e-8
+        return "ValidateWorkspaceToWorkspace"
+
+    def validate(self):
+        return (self.aafps, self.aafps2)

--- a/docs/source/release/v6.17.0/Diffraction/Powder/New_features/41734.rst
+++ b/docs/source/release/v6.17.0/Diffraction/Powder/New_features/41734.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-AlignAndFocusPowderSlim` now accepts a ``CalibrationWorkspace`` and a ``MaskWorkspace``. When supplied, these take precedence over the corresponding information in ``CalFileName``.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

> To expand when AlignAndFocusPowderFromFiles can delegate work to AlignAndFocusPowderSlim, Add suppport to AAFPSlim for users to supply a CalibrationWorkspace and MaskWorkspace. The way that parameters interact and the logic will follow what is done in AAFP.


Closes [16688: Add parameters to AlignAndFocusPowderSlim](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/16688)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
```python
cal_file = "./ExternalData/Testing/Data/SystemTest/PG3_FERNS_d4832_2011_08_24.cal"
char_file = "./ExternalData/Testing/Data/SystemTest/PG3_characterization_2012_02_23-HR-ILL.txt"
data_file = "./ExternalData/Testing/Data/SystemTest/PG3_9829_event.nxs"
results = PDLoadCharacterizations(Filename=char_file, OutputWorkspace="characterizations")

AlignAndFocusPowderSlim(Filename=data_file,
                        OutputWorkspace="ws1",
                        CalFileName=cal_file,
                        L1=results.PrimaryFlightPath,
                        L2=results.L2,
                        Polar=results.Polar,
                        Azimuthal=results.Azimuthal)

# now try with input workspaces intead of CalFileName
w = LoadEventNexus(data_file, MetaDataOnly=True)
LoadDiffCal(cal_file, Workspacename="cal", InputWorkspace=w)

AlignAndFocusPowderSlim(Filename=data_file,
                        OutputWorkspace="ws2",
                        CalibrationWorkspace="cal_cal",
                        MaskWorkspace="cal_mask",
                        GroupingWorkspace="cal_group",
                        L1=results.PrimaryFlightPath,
                        L2=results.L2,
                        Polar=results.Polar,
                        Azimuthal=results.Azimuthal)

# should be the same
CompareWorkspaces("ws1", "ws2")
```
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
