### PR TITLE
Expose getXmlText to python

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -59,6 +59,9 @@ void export_Instrument() {
       .def("getDefaultView", &Instrument::getDefaultView, arg("self"), return_value_policy<copy_const_reference>(),
            "Return the name of the preferred view in instrument view.")
 
+      .def("getXmlText", &Instrument::getXmlText, arg("self"), return_value_policy<copy_const_reference>(),
+           "Return the instrument XML.")
+
       .def("getNumberDetectors", &Instrument::getNumberDetectors,
            Instrument_getNumberDetectors((arg("self"), arg("skipMonitors") = false)))
 

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -58,6 +58,12 @@ class InstrumentTest(unittest.TestCase):
         # put the filename back to what it was
         inst.setFilename(NAME_ORIG)
 
+    def test_getXmlText(self):
+        inst = self.__testws.getInstrument()
+        xml_text = inst.getXmlText()
+        self.assertIsInstance(xml_text, str)
+        self.assertEqual(xml_text, "Fake XML")
+
     def test_ValidDates(self):
         inst = self.__testws.getInstrument()
         valid_from = inst.getValidFromDate()

--- a/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
@@ -44,6 +44,7 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace, bool includeMonito
     physicalPixel->setPos(0.0, ypos, detZPos);
     instrument->add(physicalPixel);
     instrument->markAsDetector(physicalPixel);
+    instrument->setXmlText("Fake XML");
     workspace.getSpectrum(i).setDetectorID(physicalPixel->getID());
   }
 

--- a/docs/source/release/v6.17.0/Framework/Python/New_features/instrumentXML.rst
+++ b/docs/source/release/v6.17.0/Framework/Python/New_features/instrumentXML.rst
@@ -1,0 +1,1 @@
+- ``Instrument`` now has ``getXmlText`` exposed to python.


### PR DESCRIPTION
### Description of work
Expose getXMLText to python. This allows users to see the IDF used
**Report to:** M. Guthrie


### To test:
* Load any raw Nexus file from ipython, with a handle `w`
* run `w.getInstrument().getXmlText()`

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
