### PR TITLE
Stability improvements in continuous rotation operations

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWS.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWS.h
@@ -73,7 +73,6 @@ private:
       m_Goniometer.setRotationAngle(m_GonioIndex[axIdx], logval);
     }
     m_tmpRot = m_Goniometer.getR() * m_Wtransf;
-    m_tmpRot.Invert();
     m_QConverter->updateRotMat(m_tmpRot.getVector());
     return true;
   }

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
@@ -12,8 +12,6 @@
 
 #include "MantidKernel/DeltaEMode.h"
 
-#include <boost/scoped_ptr.hpp>
-
 namespace Mantid {
 namespace MDAlgorithms {
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
@@ -53,7 +53,7 @@ private:
   void exec() override;
   void init() override;
   /// progress reporter
-  boost::scoped_ptr<API::Progress> m_Progress;
+  std::unique_ptr<API::Progress> m_Progress;
 
   void setupFileBackend(const std::string &filebackPath, const API::IMDEventWorkspace_sptr &outputWS);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfInterface.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfInterface.h
@@ -206,8 +206,8 @@ public:
    * Updates the internal rotation matrix for classes which support this
    */
   virtual void updateRotMat(const std::vector<double> &newMat) { UNUSED_ARG(newMat); }
-
   virtual std::pair<coord_t, coord_t> getDimBounds(size_t dim) const = 0;
+  virtual void setInvertRot(bool isInvert) { UNUSED_ARG(isInvert); }
 };
 
 using MDTransf_sptr = std::shared_ptr<MDTransfInterface>;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -78,7 +78,7 @@ public:
   void setInvertRot(bool isInvert) override { m_invertRot = isInvert; }
 
 protected:
-  void calcMatrixCoordLinSys(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
+  void calcMatrixCoordLinSys(double qx, double qy, double qz, std::array<coord_t, 3> &Coord) const;
   //  directions to the detectors
   double m_ex, m_ey, m_ez;
   // the matrix which transforms the neutron momentums from laboratory to
@@ -113,13 +113,15 @@ protected:
   // untill Mantid masks spectra by 0 instead of NaNs, when switched to NaN-s --
   // remove
   int *m_pDetMasks;
-  bool m_invertRot; // whether rot matrix is not inverted prior to solving q
+  bool m_invertRot; // whether rot matrix requires inverting prior to solving q
 
 private:
   /// how to transform workspace data in elastic case
   inline bool calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord) const;
   /// how to transform workspace data in inelastic case
   inline bool calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> &Coord) const;
+  //// matrix coordinate transformation of q
+  inline bool applyCoordTransf(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -75,8 +75,10 @@ public:
 
   void updateRotMat(const std::vector<double> &newMat) override { m_RotMat = newMat; }
   std::pair<coord_t, coord_t> getDimBounds(size_t dim) const override;
+  void setInvertRot(bool isInvert) override { m_invertRot = isInvert; }
 
 protected:
+  void calcMatrixCoordLinSys(const std::vector<double> &q, std::vector<coord_t> &Coord) const;
   //  directions to the detectors
   double m_ex, m_ey, m_ez;
   // the matrix which transforms the neutron momentums from laboratory to
@@ -111,6 +113,7 @@ protected:
   // untill Mantid masks spectra by 0 instead of NaNs, when switched to NaN-s --
   // remove
   int *m_pDetMasks;
+  bool m_invertRot; // whether rot matrix is not inverted prior to solving q
 
 private:
   /// how to transform workspace data in elastic case

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -78,7 +78,7 @@ public:
   void setInvertRot(bool isInvert) override { m_invertRot = isInvert; }
 
 protected:
-  void calcMatrixCoordLinSys(const std::vector<double> &q, std::vector<coord_t> &Coord) const;
+  void calcMatrixCoordLinSys(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
   //  directions to the detectors
   double m_ex, m_ey, m_ez;
   // the matrix which transforms the neutron momentums from laboratory to
@@ -117,9 +117,9 @@ protected:
 
 private:
   /// how to transform workspace data in elastic case
-  inline bool calcMatrixCoordElastic(const double &k0, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoordInelastic(const double &deltaE, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> &Coord) const;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -117,9 +117,9 @@ protected:
 
 private:
   /// how to transform workspace data in elastic case
-  inline bool calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoordElastic(const double k0, std::vector<coord_t> &Coord) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoordInelastic(const double deltaE, std::vector<coord_t> &Coord) const;
   //// matrix coordinate transformation of q
   inline bool applyCoordTransf(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
 };

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -80,9 +80,10 @@ protected:
 
 private:
   /// how to transform workspace data in elastic case
-  inline bool calcMatrixCoord3DElastic(double k0, std::vector<coord_t> &Coord, double &signal, double &errSq) const;
+  inline bool calcMatrixCoord3DElastic(const double k0, std::vector<coord_t> &Coord, double &signal,
+                                       double &errSq) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoord3DInelastic(double deltaE, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoord3DInelastic(const double deltaE, std::vector<coord_t> &Coord) const;
   inline bool calcMatrixCoord3D(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
 };
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -80,10 +80,10 @@ protected:
 
 private:
   /// how to transform workspace data in elastic case
-  inline bool calcMatrixCoord3DElastic(const double &k0, std::vector<coord_t> &Coord, double &signal,
-                                       double &errSq) const;
+  inline bool calcMatrixCoord3DElastic(double k0, std::vector<coord_t> &Coord, double &signal, double &errSq) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoord3DInelastic(const double &deltaE, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoord3DInelastic(double deltaE, std::vector<coord_t> &Coord) const;
+  inline bool calcMatrixCoord3D(double qx, double qy, double qz, std::vector<coord_t> &Coord) const;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -206,8 +206,12 @@ void ConvToMDEventsWS::appendEventsFromInputWS(API::Progress *pProgress, const A
     // tp constructor)
     pProgress->resetNumSteps(m_NSpectra, 0, 1);
   }
-  Kernel::ThreadPool tp(ts, nThreads, new API::Progress(*pProgress));
+  Kernel::ThreadPool tp(ts, nThreads, new API::Progress());
   //<<<--  Thread control stuff
+
+  // for continuous rotation, algorithm takes much longer. We increase report rate for QOL usage.
+  const bool frequentReport = !m_GonioIndex.empty();
+  const int div = 500;
 
   size_t eventsAdded = 0;
   for (size_t wi = 0; wi < m_NSpectra; wi++) {
@@ -215,6 +219,11 @@ void ConvToMDEventsWS::appendEventsFromInputWS(API::Progress *pProgress, const A
     size_t nConverted = conversionChunk(wi);
     eventsAdded += nConverted;
     nEventsInWS += nConverted;
+
+    if (frequentReport && wi % div == 0) {
+      pProgress->report(static_cast<int>(wi));
+    }
+
     // Keep a running total of how many events we've added
     if (bc->shouldSplitBoxes(nEventsInWS, eventsAdded, lastNumBoxes)) {
       if (runMultithreaded) {
@@ -230,7 +239,7 @@ void ConvToMDEventsWS::appendEventsFromInputWS(API::Progress *pProgress, const A
       // Count the new # of boxes.
       lastNumBoxes = m_OutWSWrapper->pWorkspace()->getBoxController()->getTotalNumMDBoxes();
       eventsAdded = 0;
-      pProgress->report(wi);
+      pProgress->report(static_cast<int>(wi));
     }
   }
   // Do a final splitting of everything

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -150,14 +150,16 @@ size_t ConvToMDEventsWS::initialize(const MDWSDescription &WSD, std::shared_ptr<
         m_GonioIndex.push_back(n);
       }
     }
-
     const auto &dimNames = WSD.getDimNames();
     for (auto it = dimNames.cbegin() + m_NMatrixDimensions; it != dimNames.cend(); ++it) {
       m_Logs.push_back(
           std::unique_ptr<Kernel::TimeSeriesProperty<double>>(run.getTimeSeriesProperty<double>(*it)->clone()));
       m_extraDimBounds.push_back(m_QConverter->getDimBounds(it - dimNames.cbegin()));
     }
-    m_tmpRot = Kernel::DblMatrix(3, 3);
+    if (!m_GonioIndex.empty()) {
+      m_tmpRot = Kernel::DblMatrix(3, 3);
+      m_QConverter->setInvertRot(true);
+    }
   }
 
   return numSpec;

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -292,7 +292,7 @@ void ConvertToMD::exec() {
   copyMetaData(spws);
 
   // progress reporter
-  m_Progress.reset(new API::Progress(this, 0.0, 1.0, n_steps));
+  m_Progress = std::make_unique<Progress>(this, 0.0, 1.0, n_steps);
 
   g_log.information() << " conversion started\n";
   // DO THE JOB:

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -152,7 +152,7 @@ bool MDTransfModQ::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
 * transfer and put them into initial positions (0 and 1) in the Coord vector
 *
 *@param   deltaE input energy transfer
-*@param   &Coord  vector of MD coordinates with filled in momentum and energy
+*@param   Coord  vector of MD coordinates with filled in momentum and energy
 transfer
 
 *@return   true if all momentum and energy are within the limits requested by
@@ -161,7 +161,7 @@ the algorithm and false otherwise.
 * it also uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method.    */
-bool MDTransfModQ::calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> &Coord) const {
+bool MDTransfModQ::calcMatrixCoordInelastic(const double deltaE, std::vector<coord_t> &Coord) const {
   if (deltaE < m_DimMin[1] || deltaE >= m_DimMax[1])
     return false;
   Coord[1] = static_cast<coord_t>(deltaE);
@@ -186,7 +186,7 @@ bool MDTransfModQ::calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> 
 * put it into specified (0) position in the Coord vector
 *
 *@param    k0   module of input momentum
-*@param   &Coord  vector of MD coordinates with filled in momentum and energy
+*@param   Coord  vector of MD coordinates with filled in momentum and energy
 transfer
 
 *@return   true if momentum is within the limits requested by the algorithm and
@@ -195,7 +195,7 @@ false otherwise.
 * it uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method. */
-bool MDTransfModQ::calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord) const {
+bool MDTransfModQ::calcMatrixCoordElastic(const double k0, std::vector<coord_t> &Coord) const {
   double qx = -m_ex * k0;
   double qy = -m_ey * k0;
   double qz = (1 - m_ez) * k0;

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -179,25 +179,7 @@ bool MDTransfModQ::calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> 
     qy = -m_ey * m_kFixed;
     qz = kInitial - m_ez * m_kFixed;
   }
-
-  std::vector<coord_t> Q(3);
-  if (m_invertRot) {
-    calcMatrixCoordLinSys(qx, qy, qz, Q);
-  } else {
-    // transformation matrix has to be here for "Crystal AS Powder conversion
-    // mode, further specialization possible if "powder" mode defined"
-    Q[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-    Q[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-    Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
-  }
-
-  const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
-  if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
-    return false;
-  }
-  Coord[0] = sqrt(Qsq);
-
-  return true;
+  return applyCoordTransf(qx, qy, qz, Coord);
 }
 /** function calculates workspace-dependent coordinates in elastic case.
 * Namely, it calculates module of Momentum transfer
@@ -217,24 +199,9 @@ bool MDTransfModQ::calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord
   double qx = -m_ex * k0;
   double qy = -m_ey * k0;
   double qz = (1 - m_ez) * k0;
-
-  std::vector<coord_t> Q(3);
-  if (m_invertRot) {
-    calcMatrixCoordLinSys(qx, qy, qz, Q);
-  } else {
-    // transformation matrix has to be here for "Crystal AS Powder conversion
-    // mode, further specialization possible if "powder" mode defined"
-    Q[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-    Q[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-    Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
-  }
-  const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
-  if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
-    return false;
-  }
-  Coord[0] = sqrt(Qsq);
-  return true;
+  return applyCoordTransf(qx, qy, qz, Coord);
 }
+
 /** method returns the vector of input coordinates values where the transformed
  *coordinates reach its extremum values in Q or dE
  * direction.
@@ -424,7 +391,28 @@ void MDTransfModQ::setDisplayNormalization(Mantid::API::IMDWorkspace_sptr mdWork
   setter(mdWorkspace, underlyingWorkspace, isQ, m_Emode);
 }
 
-void MDTransfModQ::calcMatrixCoordLinSys(double qx, double qy, double qz, std::vector<coord_t> &Coord) const {
+bool MDTransfModQ::applyCoordTransf(double qx, double qy, double qz, std::vector<coord_t> &Coord) const {
+  std::array<coord_t, 3> Q{};
+  if (m_invertRot) {
+    calcMatrixCoordLinSys(qx, qy, qz, Q);
+  } else {
+    // transformation matrix has to be here for "Crystal AS Powder conversion
+    // mode, further specialization possible if "powder" mode defined"
+    Q[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+    Q[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
+    Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  }
+
+  const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
+  if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
+    return false;
+  }
+  Coord[0] = sqrt(Qsq);
+
+  return true;
+}
+
+void MDTransfModQ::calcMatrixCoordLinSys(double qx, double qy, double qz, std::array<coord_t, 3> &Coord) const {
   // For some computations, e.g. continuous rotation in ConvToMDEventsWS, the rotation matrix
   // has to be recomputed multiple times, so it is not inverted prior to calculating the coordinates.
   // Deferring to a linear system solution here makes it slightly more efficient and stable.

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -427,8 +427,8 @@ void MDTransfModQ::calcMatrixCoordLinSys(const std::vector<double> &q, std::vect
   // has to be recomputed multiple times, so it is not inverted prior to calculating the coordinates.
   // Deferring to a linear system solution here makes it slightly more efficient and stable.
   Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> map_rm(m_RotMat.data());
-  const Eigen::Vector3d qs = {q[0], q[1], q[2]};
-  const Eigen::PartialPivLU<Eigen::Matrix3d> lu(map_rm);
+  const Eigen::Vector3d qs(q[0], q[1], q[2]);
+  const Eigen::PartialPivLU<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> lu(map_rm);
   Eigen::Vector3d coords = lu.solve(qs);
 
   Coord[0] = static_cast<coord_t>(coords[0]);

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -407,7 +407,7 @@ bool MDTransfModQ::applyCoordTransf(double qx, double qy, double qz, std::vector
   if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
     return false;
   }
-  Coord[0] = sqrt(Qsq);
+  Coord[0] = static_cast<coord_t>(std::sqrt(Qsq));
 
   return true;
 }

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -161,7 +161,7 @@ the algorithm and false otherwise.
 * it also uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method.    */
-bool MDTransfModQ::calcMatrixCoordInelastic(const double &deltaE, std::vector<coord_t> &Coord) const {
+bool MDTransfModQ::calcMatrixCoordInelastic(double deltaE, std::vector<coord_t> &Coord) const {
   if (deltaE < m_DimMin[1] || deltaE >= m_DimMax[1])
     return false;
   Coord[1] = static_cast<coord_t>(deltaE);
@@ -182,7 +182,7 @@ bool MDTransfModQ::calcMatrixCoordInelastic(const double &deltaE, std::vector<co
 
   std::vector<coord_t> Q(3);
   if (m_invertRot) {
-    calcMatrixCoordLinSys({qx, qy, qz}, Q);
+    calcMatrixCoordLinSys(qx, qy, qz, Q);
   } else {
     // transformation matrix has to be here for "Crystal AS Powder conversion
     // mode, further specialization possible if "powder" mode defined"
@@ -192,8 +192,9 @@ bool MDTransfModQ::calcMatrixCoordInelastic(const double &deltaE, std::vector<co
   }
 
   const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
-  if (Qsq < m_DimMin[0] || Qsq >= m_DimMax[0])
+  if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
     return false;
+  }
   Coord[0] = sqrt(Qsq);
 
   return true;
@@ -212,14 +213,14 @@ false otherwise.
 * it uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method. */
-bool MDTransfModQ::calcMatrixCoordElastic(const double &k0, std::vector<coord_t> &Coord) const {
+bool MDTransfModQ::calcMatrixCoordElastic(double k0, std::vector<coord_t> &Coord) const {
   double qx = -m_ex * k0;
   double qy = -m_ey * k0;
   double qz = (1 - m_ez) * k0;
 
   std::vector<coord_t> Q(3);
   if (m_invertRot) {
-    calcMatrixCoordLinSys({qx, qy, qz}, Q);
+    calcMatrixCoordLinSys(qx, qy, qz, Q);
   } else {
     // transformation matrix has to be here for "Crystal AS Powder conversion
     // mode, further specialization possible if "powder" mode defined"
@@ -228,8 +229,9 @@ bool MDTransfModQ::calcMatrixCoordElastic(const double &k0, std::vector<coord_t>
     Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
   }
   const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
-  if (Qsq < m_DimMin[0] || Qsq >= m_DimMax[0])
+  if (Qsq < static_cast<coord_t>(m_DimMin[0]) || Qsq >= static_cast<coord_t>(m_DimMax[0])) {
     return false;
+  }
   Coord[0] = sqrt(Qsq);
   return true;
 }
@@ -422,12 +424,12 @@ void MDTransfModQ::setDisplayNormalization(Mantid::API::IMDWorkspace_sptr mdWork
   setter(mdWorkspace, underlyingWorkspace, isQ, m_Emode);
 }
 
-void MDTransfModQ::calcMatrixCoordLinSys(const std::vector<double> &q, std::vector<coord_t> &Coord) const {
+void MDTransfModQ::calcMatrixCoordLinSys(double qx, double qy, double qz, std::vector<coord_t> &Coord) const {
   // For some computations, e.g. continuous rotation in ConvToMDEventsWS, the rotation matrix
   // has to be recomputed multiple times, so it is not inverted prior to calculating the coordinates.
   // Deferring to a linear system solution here makes it slightly more efficient and stable.
   Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> map_rm(m_RotMat.data());
-  const Eigen::Vector3d qs(q[0], q[1], q[2]);
+  const Eigen::Vector3d qs(qx, qy, qz);
   const Eigen::PartialPivLU<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> lu(map_rm);
   Eigen::Vector3d coords = lu.solve(qs);
 

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -5,8 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidMDAlgorithms/MDTransfModQ.h"
+#include "Eigen/Core"
+#include "Eigen/Dense"
 #include "MantidKernel/RegistrationHelper.h"
 #include "MantidMDAlgorithms/DisplayNormalizationSetter.h"
+
 namespace Mantid::MDAlgorithms {
 // register the class, whith conversion factory under ModQ name
 // clang-format off
@@ -177,16 +180,21 @@ bool MDTransfModQ::calcMatrixCoordInelastic(const double &deltaE, std::vector<co
     qz = kInitial - m_ez * m_kFixed;
   }
 
-  // transformation matrix has to be here for "Crystal AS Powder conversion
-  // mode, further specialization possible if "powder" mode defined"
-  double Qx = (m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-  double Qy = (m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-  double Qz = (m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  std::vector<coord_t> Q(3);
+  if (m_invertRot) {
+    calcMatrixCoordLinSys({qx, qy, qz}, Q);
+  } else {
+    // transformation matrix has to be here for "Crystal AS Powder conversion
+    // mode, further specialization possible if "powder" mode defined"
+    Q[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+    Q[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
+    Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  }
 
-  double Qsq = Qx * Qx + Qy * Qy + Qz * Qz;
+  const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
   if (Qsq < m_DimMin[0] || Qsq >= m_DimMax[0])
     return false;
-  Coord[0] = static_cast<coord_t>(sqrt(Qsq));
+  Coord[0] = sqrt(Qsq);
 
   return true;
 }
@@ -205,20 +213,24 @@ false otherwise.
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method. */
 bool MDTransfModQ::calcMatrixCoordElastic(const double &k0, std::vector<coord_t> &Coord) const {
-
   double qx = -m_ex * k0;
   double qy = -m_ey * k0;
   double qz = (1 - m_ez) * k0;
-  // transformation matrix has to be here for "Crystal AS Powder mode, further
-  // specialization possible if powder mode is defined "
-  double Qx = (m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-  double Qy = (m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-  double Qz = (m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
 
-  double Qsq = Qx * Qx + Qy * Qy + Qz * Qz;
+  std::vector<coord_t> Q(3);
+  if (m_invertRot) {
+    calcMatrixCoordLinSys({qx, qy, qz}, Q);
+  } else {
+    // transformation matrix has to be here for "Crystal AS Powder conversion
+    // mode, further specialization possible if "powder" mode defined"
+    Q[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+    Q[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
+    Q[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  }
+  const auto Qsq = Q[0] * Q[0] + Q[1] * Q[1] + Q[2] * Q[2];
   if (Qsq < m_DimMin[0] || Qsq >= m_DimMax[0])
     return false;
-  Coord[0] = static_cast<coord_t>(sqrt(Qsq));
+  Coord[0] = sqrt(Qsq);
   return true;
 }
 /** method returns the vector of input coordinates values where the transformed
@@ -386,7 +398,7 @@ MDTransfModQ::MDTransfModQ()
     : m_ex(0), m_ey(0), m_ez(1), m_DetDirecton(nullptr), //,m_NMatrixDim(-1)
       m_NMatrixDim(0),                                   // uninitialized
       m_Emode(Kernel::DeltaEMode::Undefined),            // uninitialized
-      m_kFixed(1.), m_eFixed(1.), m_pEfixedArray(nullptr), m_pDetMasks(nullptr) {}
+      m_kFixed(1.), m_eFixed(1.), m_pEfixedArray(nullptr), m_pDetMasks(nullptr), m_invertRot(false) {}
 
 /**
  * @param dim dimension index for which to check bounds.
@@ -408,6 +420,20 @@ void MDTransfModQ::setDisplayNormalization(Mantid::API::IMDWorkspace_sptr mdWork
   DisplayNormalizationSetter setter;
   auto isQ = true;
   setter(mdWorkspace, underlyingWorkspace, isQ, m_Emode);
+}
+
+void MDTransfModQ::calcMatrixCoordLinSys(const std::vector<double> &q, std::vector<coord_t> &Coord) const {
+  // For some computations, e.g. continuous rotation in ConvToMDEventsWS, the rotation matrix
+  // has to be recomputed multiple times, so it is not inverted prior to calculating the coordinates.
+  // Deferring to a linear system solution here makes it slightly more efficient and stable.
+  Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> map_rm(m_RotMat.data());
+  const Eigen::Vector3d qs = {q[0], q[1], q[2]};
+  const Eigen::PartialPivLU<Eigen::Matrix3d> lu(map_rm);
+  Eigen::Vector3d coords = lu.solve(qs);
+
+  Coord[0] = static_cast<coord_t>(coords[0]);
+  Coord[1] = static_cast<coord_t>(coords[1]);
+  Coord[2] = static_cast<coord_t>(coords[2]);
 }
 
 } // namespace Mantid::MDAlgorithms

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -295,7 +295,7 @@ std::vector<std::string> MDTransfQ3D::outputUnitID(Kernel::DeltaEMode::Type dEmo
 }
 
 bool MDTransfQ3D::calcMatrixCoord3D(double qx, double qy, double qz, std::vector<coord_t> &Coord) const {
-  std::vector<coord_t> coord(3);
+  std::array<coord_t, 3> coord{};
   if (m_invertRot) {
     calcMatrixCoordLinSys(qx, qy, qz, coord);
   }

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -57,7 +57,7 @@ bool MDTransfQ3D::calcMatrixCoord(const double &deltaEOrK0, std::vector<coord_t>
 * transfer and put them into initial positions (0 and 1) in the Coord vector
 *
 *@param   deltaE   input energy transfer
-*@param   &Coord  vector of MD coordinates with filled in momentum and energy
+*@param   Coord  vector of MD coordinates with filled in momentum and energy
 transfer
 
 *@return   true if all momentum and energy are within the limits requested by
@@ -70,7 +70,6 @@ bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double &deltaE, std::vector<c
   Coord[3] = static_cast<coord_t>(deltaE);
   if (Coord[3] < m_DimMin[3] || Coord[3] >= m_DimMax[3])
     return false;
-
   // x,y,z refer to internal coordinate system where Z is the beam direction
   double qx{0.0}, qy{0.0}, qz{0.0};
   if (m_Emode == Kernel::DeltaEMode::Direct) {
@@ -91,14 +90,18 @@ bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double &deltaE, std::vector<c
     qz = -qz;
   }
 
-  Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+  if (m_invertRot) {
+    calcMatrixCoordLinSys({qx, qy, qz}, Coord);
+  } else {
+    Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+    Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
+    Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  }
 
   if (Coord[0] < m_DimMin[0] || Coord[0] >= m_DimMax[0])
     return false;
-  Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
   if (Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1])
     return false;
-  Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
   if (Coord[2] < m_DimMin[2] || Coord[2] >= m_DimMax[2])
     return false;
 
@@ -113,7 +116,7 @@ bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double &deltaE, std::vector<c
 * put it into specified (0) position in the Coord vector
 *
 *@param   k0   module of input momentum
-*@param   &Coord  vector of MD coordinates with filled in momentum and energy
+*@param   Coord  vector of MD coordinates with filled in momentum and energy
 transfer
 *@param   signal signal
 *@param   errSq error squared
@@ -136,17 +139,20 @@ bool MDTransfQ3D::calcMatrixCoord3DElastic(const double &k0, std::vector<coord_t
     qz = -qz;
   }
 
+  if (m_invertRot) {
+    calcMatrixCoordLinSys({qx, qy, qz}, Coord);
+  } else {
+    Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
+    Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
+    Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  }
+
   // Dimension limits have to be converted to coord_t, otherwise floating point
   // error will cause valid events to be discarded.
-  Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
   if (Coord[0] < static_cast<coord_t>(m_DimMin[0]) || Coord[0] >= static_cast<coord_t>(m_DimMax[0]))
     return false;
-
-  Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
   if (Coord[1] < static_cast<coord_t>(m_DimMin[1]) || Coord[1] >= static_cast<coord_t>(m_DimMax[1]))
     return false;
-
-  Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
   if (Coord[2] < static_cast<coord_t>(m_DimMin[2]) || Coord[2] >= static_cast<coord_t>(m_DimMax[2]))
     return false;
 

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -9,6 +9,7 @@
 #include "MantidKernel/RegistrationHelper.h"
 
 namespace Mantid::MDAlgorithms {
+
 // register the class, whith conversion factory under Q3D name
 DECLARE_MD_TRANSFID(MDTransfQ3D, Q3D)
 
@@ -66,7 +67,7 @@ the algorithm and false otherwise.
 * it also uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method.    */
-bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double &deltaE, std::vector<coord_t> &Coord) const {
+bool MDTransfQ3D::calcMatrixCoord3DInelastic(double deltaE, std::vector<coord_t> &Coord) const {
   Coord[3] = static_cast<coord_t>(deltaE);
   if (Coord[3] < m_DimMin[3] || Coord[3] >= m_DimMax[3])
     return false;
@@ -90,25 +91,7 @@ bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double &deltaE, std::vector<c
     qz = -qz;
   }
 
-  if (m_invertRot) {
-    calcMatrixCoordLinSys({qx, qy, qz}, Coord);
-  } else {
-    Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-    Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-    Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
-  }
-
-  if (Coord[0] < m_DimMin[0] || Coord[0] >= m_DimMax[0])
-    return false;
-  if (Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1])
-    return false;
-  if (Coord[2] < m_DimMin[2] || Coord[2] >= m_DimMax[2])
-    return false;
-
-  if (std::sqrt(Coord[0] * Coord[0] + Coord[1] * Coord[1] + Coord[2] * Coord[2]) < m_AbsMin)
-    return false;
-
-  return true;
+  return calcMatrixCoord3D(qx, qy, qz, Coord);
 }
 
 /** function calculates workspace-dependent coordinates in elastic case.
@@ -127,7 +110,7 @@ false otherwise.
 * it uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method. */
-bool MDTransfQ3D::calcMatrixCoord3DElastic(const double &k0, std::vector<coord_t> &Coord, double &signal,
+bool MDTransfQ3D::calcMatrixCoord3DElastic(double k0, std::vector<coord_t> &Coord, double &signal,
                                            double &errSq) const {
 
   double qx = -m_ex * k0;
@@ -139,35 +122,17 @@ bool MDTransfQ3D::calcMatrixCoord3DElastic(const double &k0, std::vector<coord_t
     qz = -qz;
   }
 
-  if (m_invertRot) {
-    calcMatrixCoordLinSys({qx, qy, qz}, Coord);
-  } else {
-    Coord[0] = static_cast<coord_t>(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
-    Coord[1] = static_cast<coord_t>(m_RotMat[3] * qx + m_RotMat[4] * qy + m_RotMat[5] * qz);
-    Coord[2] = static_cast<coord_t>(m_RotMat[6] * qx + m_RotMat[7] * qy + m_RotMat[8] * qz);
+  if (calcMatrixCoord3D(qx, qy, qz, Coord)) {
+    /*Apply Lorentz corrections if necessary */
+    if (m_isLorentzCorrected) {
+      double kdash = k0 / (2 * M_PI);
+      double correct = m_SinThetaSq * kdash * kdash * kdash * kdash;
+      signal *= correct;
+      errSq *= (correct * correct);
+    }
+    return true;
   }
-
-  // Dimension limits have to be converted to coord_t, otherwise floating point
-  // error will cause valid events to be discarded.
-  if (Coord[0] < static_cast<coord_t>(m_DimMin[0]) || Coord[0] >= static_cast<coord_t>(m_DimMax[0]))
-    return false;
-  if (Coord[1] < static_cast<coord_t>(m_DimMin[1]) || Coord[1] >= static_cast<coord_t>(m_DimMax[1]))
-    return false;
-  if (Coord[2] < static_cast<coord_t>(m_DimMin[2]) || Coord[2] >= static_cast<coord_t>(m_DimMax[2]))
-    return false;
-
-  if (std::sqrt(Coord[0] * Coord[0] + Coord[1] * Coord[1] + Coord[2] * Coord[2]) < m_AbsMin)
-    return false;
-
-  /*Apply Lorentz corrections if necessary */
-  if (m_isLorentzCorrected) {
-    double kdash = k0 / (2 * M_PI);
-    double correct = m_SinThetaSq * kdash * kdash * kdash * kdash;
-    signal *= correct;
-    errSq *= (correct * correct);
-  }
-
-  return true;
+  return false;
 }
 
 std::vector<double> MDTransfQ3D::getExtremumPoints(const double xMin, const double xMax, size_t det_num) const {
@@ -327,6 +292,30 @@ std::vector<std::string> MDTransfQ3D::outputUnitID(Kernel::DeltaEMode::Type dEmo
   UnitID[1] = kUnits;
   UnitID[2] = kUnits;
   return UnitID;
+}
+
+bool MDTransfQ3D::calcMatrixCoord3D(double qx, double qy, double qz, std::vector<coord_t> &Coord) const {
+  std::vector<coord_t> coord(3);
+  if (m_invertRot) {
+    calcMatrixCoordLinSys(qx, qy, qz, coord);
+  }
+  // Dimension limits have to be converted to coord_t, otherwise floating point
+  // error will cause valid events to be discarded.
+  for (auto i = 0; i < 3; i++) {
+    Coord[i] =
+        m_invertRot
+            ? coord[i]
+            : static_cast<coord_t>(m_RotMat[3 * i + 0] * qx + m_RotMat[3 * i + 1] * qy + m_RotMat[3 * i + 2] * qz);
+    if (Coord[i] < static_cast<coord_t>(m_DimMin[i]) || Coord[i] >= static_cast<coord_t>(m_DimMax[i])) {
+      return false;
+    }
+  }
+
+  if (std::sqrt(Coord[0] * Coord[0] + Coord[1] * Coord[1] + Coord[2] * Coord[2]) < m_AbsMin) {
+    return false;
+  }
+
+  return true;
 }
 
 /// constructor;

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -67,7 +67,7 @@ the algorithm and false otherwise.
 * it also uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method.    */
-bool MDTransfQ3D::calcMatrixCoord3DInelastic(double deltaE, std::vector<coord_t> &Coord) const {
+bool MDTransfQ3D::calcMatrixCoord3DInelastic(const double deltaE, std::vector<coord_t> &Coord) const {
   Coord[3] = static_cast<coord_t>(deltaE);
   if (Coord[3] < m_DimMin[3] || Coord[3] >= m_DimMax[3])
     return false;
@@ -110,7 +110,7 @@ false otherwise.
 * it uses preprocessed detectors positions, which are calculated by
 PreprocessDetectors algorithm and set up by
 * calcYDepCoordinates(std::vector<coord_t> &Coord,size_t i) method. */
-bool MDTransfQ3D::calcMatrixCoord3DElastic(double k0, std::vector<coord_t> &Coord, double &signal,
+bool MDTransfQ3D::calcMatrixCoord3DElastic(const double k0, std::vector<coord_t> &Coord, double &signal,
                                            double &errSq) const {
 
   double qx = -m_ex * k0;

--- a/Framework/MDAlgorithms/test/MDTransfModQTest.h
+++ b/Framework/MDAlgorithms/test/MDTransfModQTest.h
@@ -135,25 +135,64 @@ public:
     return result;
   }
 
+  void testMatrixLinSys() {
+    MDTransfModQ ModQTransf;
+    MDWSDescription WSDescr(2);
+    auto ws2D = prepareWsForMDTransfModQ(ModQTransf, WSDescr, false);
+
+    const double deltaE{1};
+    double signal{1.0}, error{1.0};
+
+    std::vector<coord_t> Q{0.0, 1.0};
+    Mantid::Kernel::DblMatrix mat = std::vector<double>({1, 0, 0.5, 0, 1, 0, 1, 0, 1});
+    ModQTransf.updateRotMat(mat.getVector());
+    ModQTransf.calcYDepCoordinates(Q, 0);
+    ModQTransf.calcMatrixCoord(deltaE, Q, signal, error);
+
+    mat.Invert();
+    ModQTransf.updateRotMat(mat.getVector());
+    ModQTransf.setInvertRot(true);
+    std::vector<coord_t> Q2{0.0, 1.0};
+    ModQTransf.calcMatrixCoord(deltaE, Q2, signal, error);
+
+    TS_ASSERT_DELTA(Q[0], Q2[0], 1e-5);
+    TS_ASSERT_DELTA(Q[1], Q2[1], 1e-5);
+  }
+
   void testExtremums() {
     MDTransfModQ ModQTransf;
+    MDWSDescription WSDescr(4);
+    auto ws2Dbig = prepareWsForMDTransfModQ(ModQTransf, WSDescr, true);
 
-    size_t nDims = 4;
+    auto convResult = checkMinMaxRangesCorrect(WSDescr, ws2Dbig, ModQTransf);
+    TSM_ASSERT_EQUALS(convResult, 0, convResult.size());
+    // Check if the correct display normalization is set
+    auto mdEventWorkspace = Mantid::DataObjects::MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
+    ModQTransf.setDisplayNormalization(mdEventWorkspace, ws2Dbig);
+    TSM_ASSERT_EQUALS("Should be set to number events normalization", mdEventWorkspace->displayNormalization(),
+                      Mantid::API::VolumeNormalization);
+    TSM_ASSERT_EQUALS("Should be set to number events normalization", mdEventWorkspace->displayNormalizationHisto(),
+                      Mantid::API::NumEventsNormalization);
+  }
+
+  API::MatrixWorkspace_sptr prepareWsForMDTransfModQ(MDTransfModQ &ModQTransf, MDWSDescription &WSDescr,
+                                                     bool addExtraDims) {
+    auto nDims = WSDescr.nDimensions();
     std::vector<double> L2, polar, azimuthal;
     WorkspaceCreationHelper::create2DAngles(L2, polar, azimuthal);
-
-    MDWSDescription WSDescr(static_cast<unsigned int>(nDims));
     std::string QMode = ModQTransf.transfID();
     std::string dEMode = Kernel::DeltaEMode::asString(Kernel::DeltaEMode::Direct);
-    std::vector<std::string> dimPropNames(2, "T");
-    dimPropNames[1] = "Ei";
+    std::vector<std::string> dimPropNames;
 
     auto ws2Dbig = WorkspaceCreationHelper::createProcessedInelasticWS(L2, polar, azimuthal, 100, -11, 9.9, 10);
 
     ws2Dbig->mutableRun().mutableGoniometer().setRotationAngle(0, 20);
-    // add workspace energy
-    ws2Dbig->mutableRun().addProperty("Ei", 13., "meV", true);
-    ws2Dbig->mutableRun().addProperty("T", 70., "K", true);
+    if (addExtraDims) {
+      dimPropNames = {"T", "Ei"};
+      // add workspace energy
+      ws2Dbig->mutableRun().addProperty("Ei", 13., "meV", true);
+      ws2Dbig->mutableRun().addProperty("T", 70., "K", true);
+    }
 
     WSDescr.buildFromMatrixWS(ws2Dbig, QMode, dEMode, dimPropNames);
 
@@ -172,25 +211,19 @@ public:
     ppDets_alg->execute();
     WSDescr.m_PreprDetTable = ppDets_alg->getProperty("OutputWorkspace");
     TSM_ASSERT_THROWS_NOTHING("should initialize properly: ", ModQTransf.initialize(WSDescr));
-    std::vector<coord_t> coord(4);
-    TSM_ASSERT("Generic coordinates should be in range, so should be true ", ModQTransf.calcGenericVariables(coord, 4));
-    TSM_ASSERT_DELTA("3th Generic coordinates should be temperature ", 70, coord[2], 2.e-8);
-    TSM_ASSERT_DELTA("4th Generic coordinates should be Ei ", 13, coord[3], 2.e-8);
 
-    TSM_ASSERT(" Y-dependent coordinates should be in range so it should be true: ",
-               ModQTransf.calcYDepCoordinates(coord, 0));
+    if (addExtraDims) {
+      std::vector<coord_t> coord(4);
+      TSM_ASSERT("Generic coordinates should be in range, so should be true ",
+                 ModQTransf.calcGenericVariables(coord, 4));
+      TSM_ASSERT_DELTA("3th Generic coordinates should be temperature ", 70, coord[2], 2.e-8);
+      TSM_ASSERT_DELTA("4th Generic coordinates should be Ei ", 13, coord[3], 2.e-8);
 
-    auto convResult = checkMinMaxRangesCorrect(WSDescr, ws2Dbig, ModQTransf);
+      TSM_ASSERT(" Y-dependent coordinates should be in range so it should be true: ",
+                 ModQTransf.calcYDepCoordinates(coord, 0));
+    }
 
-    TSM_ASSERT_EQUALS(convResult, 0, convResult.size());
-
-    // Check if the correct display normalization is set
-    auto mdEventWorkspace = Mantid::DataObjects::MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
-    ModQTransf.setDisplayNormalization(mdEventWorkspace, ws2Dbig);
-    TSM_ASSERT_EQUALS("Should be set to number events normalization", mdEventWorkspace->displayNormalization(),
-                      Mantid::API::VolumeNormalization);
-    TSM_ASSERT_EQUALS("Should be set to number events normalization", mdEventWorkspace->displayNormalizationHisto(),
-                      Mantid::API::NumEventsNormalization);
+    return ws2Dbig;
   }
 
   MDTransfModQTest() {

--- a/docs/source/algorithms/ConvertToMDMinMaxLocal-v1.rst
+++ b/docs/source/algorithms/ConvertToMDMinMaxLocal-v1.rst
@@ -63,7 +63,7 @@ Usage
 
     MD workspace limits:
     |Q|_min:   0.299713, dE_min: -50.000000
-    |Q|_max:  11.102851, dE_max:  50.000000
+    |Q|_max:  11.102852, dE_max:  50.000000
 
 **Example -- Find min-max values for Q3D transformation, while converting TOF to energy transfer :**
 


### PR DESCRIPTION
### Description of work

This PR works on some improvements discussed in Continuous Rotation MD PR: #41402 

In particular: 

- When having to correct for continuous rotation in ConvertToMDEvent class, it is necessary to invert the rotation matrix  multiple times prior to calculating the Q coordinates, in this PR this operation is deferred to the plugins classes (MDTransfModQ and MDTransfQ3D) and instead of inverting the matrix, the Q coordinates are extracted using the LU solver from the Eigen classes. It is slightly faster and more stable than directly inverting the matrix.
- Progress bar of ConvertToMD was a `boost::scoped_ptr`, I have changed to `std::unique_ptr` to homogenize with Mantid's codebase.
- Progress bar did not show much updates in ConvertToMD algorithms, which is not so much of a problem when the algorithm takes about 2-3 seconds, but in the case of continuous rotation it may take up to 20-30 s. Therefore, as a quality of life feature, in continuous rotation the progress bar will update every 500 processed events, which gives a more traceable sense of progress to the algorithm. Additionally, a small bug has been fixed, as the pointer to the progress bar was being sent to the ThreadPool processor and scrambling the progress of the algorithm in the bar. 

Test have been added, and no release notes, as it is a modification to an unreleased feature. 


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41545 #41573  <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
