### PR TITLE
Fix empty Instrument View in Windows standalone

### DIFF
--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -173,6 +173,16 @@ find $COPY_DIR -name *.pyc -delete
 # Delete extra DLLs
 rm -rf $COPY_DIR/bin/api-ms-win*.dll
 rm -rf $COPY_DIR/bin/libclang.dll
+# Remove Mesa's opengl32.dll (from mesalib, pulled in transitively by vtk-base
+# >=9.6 via viskores). Next to MantidWorkbench.exe it shadows the system OpenGL
+# driver and produces a black Instrument View. opengl32sw.dll (Qt's software
+# fallback) is kept. See https://github.com/mantidproject/mantid/issues/41735
+rm -f $COPY_DIR/bin/opengl32.dll
+# Drop the rest of the Mesa stack - orphaned once opengl32.dll is gone.
+rm -f $COPY_DIR/bin/libgallium_wgl.dll
+rm -f $COPY_DIR/bin/vulkan_dzn.dll
+rm -f $COPY_DIR/bin/vulkan_lvp.dll
+rm -f $COPY_DIR/bin/spirv_to_dxil.dll
 
 # Now package using NSIS
 echo "Packaging package via NSIS"


### PR DESCRIPTION
### Description of work
The Instrument View renders as a black viewport on the Windows standalone installer for v6.16. This PR fixes the rendering issue by removing the file that was breaking OpenGL.

Between v6.15 and v6.16, conda-forge bumped `vtk-base` from  9.5 to 9.6. VTK 9.6 added a transitive dependency on `viskores`, which on `win-64` hard-depends on `mesalib`. `mesalib` installs Mesa's Gallium WGL loader at `Library/bin/opengl32.dll`.

The standalone packaging script flattens every DLL from `Library/bin/` into the package's `bin/` directory, right next to `MantidWorkbench.exe`. On Windows, the executable's own directory is searched before `System32`, so Mesa's `opengl32.dll` ends up shadowing the system OpenGL DLL located in `System32`.

The Conda install isn't hit because `MantidWorkbench.exe` (and the Python launcher) live one directory level removed from `Library/bin/`, so DLL resolution still finds the system `opengl32.dll` first.

Closes #41735. 

### To test:
1- Remove the DLLs on your current 6.16 Windows installation, and the instrument viewer should work.
2- Check that the instrument viewer is working well in the unstable build: [![Build Status](https://builds.mantidproject.org/job/build_branch/1649/badge/icon)](https://builds.mantidproject.org/job/build_branch/1649/)

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
