### PR TITLE
Updated `SaveDaveGrp` to optionally save `Q` values when the `ToQsInQENSData` flag is set

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveDaveGrp.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveDaveGrp.h
@@ -43,6 +43,7 @@ public:
   const std::string category() const override { return "DataHandling\\Text;Inelastic\\DataHandling"; }
   /// Algorithm's aliases
   const std::string alias() const override { return "SaveDASC"; }
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   /// Initialise the properties

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -31,7 +31,7 @@ void SaveDaveGrp::init() {
                         "Transform all energy units from milli eV to micro eV");
   this->declareProperty(
       std::make_unique<Kernel::PropertyWithValue<bool>>("ToQsInQENSData", false, Kernel::Direction::Input),
-      "Transform the spectrum numbers to q values");
+      "Transform the spectrum numbers to Q values");
 }
 
 /** Execute the algorithm.
@@ -50,7 +50,7 @@ void SaveDaveGrp::exec() {
   if (xcaption.length() == 0)
     xcaption = "X";
   if (ycaption.length() == 0 || ycaption == "Spectrum")
-    ycaption = toQsInQENSData ? "q" : "Y";
+    ycaption = toQsInQENSData ? "Q" : "Y";
 
   std::string filename = getProperty("Filename");
   std::ofstream file(filename.c_str());

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -45,8 +45,8 @@ void SaveDaveGrp::exec() {
     throw std::invalid_argument("Either the number of bins or the number of histograms is 0");
   std::string xcaption = ws->getAxis(0)->unit()->caption();
   std::string ycaption = ws->getAxis(1)->unit()->caption();
-  bool toQsInQENSData = getProperty("ToQsInQENSData");
-  ;
+  const bool toQsInQENSData = getProperty("ToQsInQENSData");
+
   if (xcaption.length() == 0)
     xcaption = "X";
   if (ycaption.length() == 0 || ycaption == "Spectrum")

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -42,10 +42,11 @@ void SaveDaveGrp::exec() {
     throw std::invalid_argument("Either the number of bins or the number of histograms is 0");
   std::string xcaption = ws->getAxis(0)->unit()->caption();
   std::string ycaption = ws->getAxis(1)->unit()->caption();
+  bool toQsInQENSData = (ycaption != "q");
   if (xcaption.length() == 0)
     xcaption = "X";
   if (ycaption.length() == 0 || ycaption == "Spectrum")
-    ycaption = "Y";
+    ycaption = "q";
 
   std::string filename = getProperty("Filename");
   std::ofstream file(filename.c_str());
@@ -86,7 +87,16 @@ void SaveDaveGrp::exec() {
     yunit = "micro eV";
   file << "# " << ycaption << " (" << yunit << ") values\n";
   double yvalue;
-  if ((*ws->getAxis(1)).length() == (nSpectra + 1)) {
+  if (toQsInQENSData) {
+    auto qsInQENSData = createChildAlgorithm("GetQsInQENSData");
+    qsInQENSData->initialize();
+    qsInQENSData->setProperty("InputWorkspace", ws->getName());
+    qsInQENSData->execute();
+    std::vector<double> qvalues = qsInQENSData->getProperty("Qvalues");
+    for (const auto &qvalue : qvalues) {
+      file << qvalue << '\n';
+    }
+  } else if ((*ws->getAxis(1)).length() == (nSpectra + 1)) {
     for (std::size_t i = 0; i < nSpectra; i++) {
       yvalue = 0.5 * (((*ws->getAxis(1))(i)) + ((*ws->getAxis(1))(i + 1)));
       if (yToMicroeV)

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -34,6 +34,18 @@ void SaveDaveGrp::init() {
       "Transform the spectrum numbers to Q values");
 }
 
+std::map<std::string, std::string> SaveDaveGrp::validateInputs() {
+  std::map<std::string, std::string> result;
+
+  const bool toMicroEV = getProperty("ToMicroEV");
+  const bool toQsInQENSData = getProperty("ToQsInQENSData");
+  if (toMicroEV && toQsInQENSData) {
+    result["ToQsInQENSData"] = "'ToMicroEV' and 'ToQsInQENSData' can't be set to True at the same time."
+                               "Set 'ToQsInQENSData' to False";
+  }
+  return result;
+}
+
 /** Execute the algorithm.
  */
 void SaveDaveGrp::exec() {

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -29,6 +29,9 @@ void SaveDaveGrp::init() {
                         "A DAVE grouped data format file that will be created");
   this->declareProperty(std::make_unique<Kernel::PropertyWithValue<bool>>("ToMicroEV", false, Kernel::Direction::Input),
                         "Transform all energy units from milli eV to micro eV");
+  this->declareProperty(
+      std::make_unique<Kernel::PropertyWithValue<bool>>("ToQsInQENSData", false, Kernel::Direction::Input),
+      "Transform the spectrum numbers to q values");
 }
 
 /** Execute the algorithm.
@@ -42,11 +45,12 @@ void SaveDaveGrp::exec() {
     throw std::invalid_argument("Either the number of bins or the number of histograms is 0");
   std::string xcaption = ws->getAxis(0)->unit()->caption();
   std::string ycaption = ws->getAxis(1)->unit()->caption();
-  bool toQsInQENSData = (ycaption != "q");
+  bool toQsInQENSData = getProperty("ToQsInQENSData");
+  ;
   if (xcaption.length() == 0)
     xcaption = "X";
   if (ycaption.length() == 0 || ycaption == "Spectrum")
-    ycaption = "q";
+    ycaption = toQsInQENSData ? "q" : "Y";
 
   std::string filename = getProperty("Filename");
   std::ofstream file(filename.c_str());

--- a/Framework/DataHandling/test/SaveDaveGrpTest.h
+++ b/Framework/DataHandling/test/SaveDaveGrpTest.h
@@ -272,6 +272,7 @@ public:
     TS_ASSERT_EQUALS(dataStore.doesExist(outws), true);
 
     TS_ASSERT_THROWS_NOTHING(saver->setPropertyValue("InputWorkspace", outws));
+    TS_ASSERT_THROWS_NOTHING(saver->setProperty("ToMicroEV", false));
     TS_ASSERT_THROWS_NOTHING(saver->setProperty("ToQsInQENSData", true));
     std::string outputFile("testSaveDaveGrp4.grp");
     TS_ASSERT_THROWS_NOTHING(saver->setPropertyValue("Filename", outputFile));
@@ -308,6 +309,17 @@ public:
     AnalysisDataService::Instance().remove(outws);
     if (std::filesystem::exists(outputFile))
       std::filesystem::remove(outputFile);
+  }
+
+  void test_validate_inputs() {
+    saver->setProperty("ToMicroEV", true);
+    saver->setProperty("ToQsInQENSData", true);
+    auto errors = saver->validateInputs();
+
+    TS_ASSERT_EQUALS(errors.size(), 1);
+    TS_ASSERT_EQUALS(
+        errors["ToQsInQENSData"],
+        "\'ToMicroEV\' and \'ToQsInQENSData\' can\'t be set to True at the same time.Set \'ToQsInQENSData\' to False");
   }
 
 private:

--- a/Framework/DataHandling/test/SaveDaveGrpTest.h
+++ b/Framework/DataHandling/test/SaveDaveGrpTest.h
@@ -303,6 +303,7 @@ public:
       getline(testfile, line);
       getline(testfile, line);
       TS_ASSERT_EQUALS(line, "# q () values");
+      testfile.close();
     }
     AnalysisDataService::Instance().remove(outws);
     if (std::filesystem::exists(outputFile))

--- a/Framework/DataHandling/test/SaveDaveGrpTest.h
+++ b/Framework/DataHandling/test/SaveDaveGrpTest.h
@@ -44,7 +44,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(saver->initialize());
     TS_ASSERT(saver->isInitialized());
 
-    TS_ASSERT_EQUALS(static_cast<int>(saver->getProperties().size()), 3);
+    TS_ASSERT_EQUALS(static_cast<int>(saver->getProperties().size()), 4);
   }
 
   void test_exec() {
@@ -252,6 +252,57 @@ public:
       getline(testfile, line);
       TS_ASSERT_EQUALS(line, "0 0");
       testfile.close();
+    }
+    AnalysisDataService::Instance().remove(outws);
+    if (std::filesystem::exists(outputFile))
+      std::filesystem::remove(outputFile);
+  }
+
+  void test_exec_event_q() {
+    LoadEventNexus ld;
+    ld.initialize();
+    std::string outws("CNCS");
+    ld.setPropertyValue("Filename", "CNCS_7860_event.nxs");
+    ld.setPropertyValue("OutputWorkspace", outws);
+    ld.setPropertyValue("Precount", "0");
+    ld.setProperty("NumberOfBins", 1);
+    ld.execute();
+    TS_ASSERT(ld.isExecuted());
+    AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
+    TS_ASSERT_EQUALS(dataStore.doesExist(outws), true);
+
+    TS_ASSERT_THROWS_NOTHING(saver->setPropertyValue("InputWorkspace", outws));
+    TS_ASSERT_THROWS_NOTHING(saver->setProperty("ToQsInQENSData", true));
+    std::string outputFile("testSaveDaveGrp4.grp");
+    TS_ASSERT_THROWS_NOTHING(saver->setPropertyValue("Filename", outputFile));
+    outputFile = saver->getPropertyValue("Filename"); // get absolute path
+
+    TS_ASSERT_THROWS_NOTHING(saver->execute());
+    TS_ASSERT(saver->isExecuted());
+
+    TS_ASSERT(std::filesystem::exists(outputFile));
+    // check the content of the file
+    std::ifstream testfile;
+    testfile.open(outputFile.c_str());
+    TS_ASSERT(testfile.is_open());
+    if (testfile.is_open()) {
+      std::string line;
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "# Number of Time-of-flight values");
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "1"); // only one bin
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "# Number of q values");
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "51200");
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "# Time-of-flight (microsecond) values");
+      double d;
+      testfile >> d;
+      TS_ASSERT_DELTA(d, 52496.4, 1);
+      getline(testfile, line);
+      getline(testfile, line);
+      TS_ASSERT_EQUALS(line, "# q () values");
     }
     AnalysisDataService::Instance().remove(outws);
     if (std::filesystem::exists(outputFile))

--- a/Framework/DataHandling/test/SaveDaveGrpTest.h
+++ b/Framework/DataHandling/test/SaveDaveGrpTest.h
@@ -292,7 +292,7 @@ public:
       getline(testfile, line);
       TS_ASSERT_EQUALS(line, "1"); // only one bin
       getline(testfile, line);
-      TS_ASSERT_EQUALS(line, "# Number of q values");
+      TS_ASSERT_EQUALS(line, "# Number of Q values");
       getline(testfile, line);
       TS_ASSERT_EQUALS(line, "51200");
       getline(testfile, line);
@@ -302,7 +302,7 @@ public:
       TS_ASSERT_DELTA(d, 52496.4, 1);
       getline(testfile, line);
       getline(testfile, line);
-      TS_ASSERT_EQUALS(line, "# q () values");
+      TS_ASSERT_EQUALS(line, "# Q () values");
       testfile.close();
     }
     AnalysisDataService::Instance().remove(outws);

--- a/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
+++ b/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
@@ -1,1 +1,1 @@
-- :ref:`algm-SaveDaveGrp` algorithm now optionally converts the spectrum numbers into ``q`` values using :ref:`algm-GetQsInQENSData` when creating the ``.grp`` file.
+- :ref:`algm-SaveDaveGrp` algorithm now optionally converts the spectrum numbers into ``Q`` values using :ref:`algm-GetQsInQENSData` when creating the ``.grp`` file.

--- a/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
+++ b/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-SaveDaveGrp` algorithm now automatically converts the spectrum numbers into ``q`` values using :ref:`algm-GetQsInQENSData` when creating the ``.grp`` file.

--- a/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
+++ b/docs/source/release/v6.17.0/Framework/Algorithms/Bugfixes/41428.rst
@@ -1,1 +1,1 @@
-- :ref:`algm-SaveDaveGrp` algorithm now automatically converts the spectrum numbers into ``q`` values using :ref:`algm-GetQsInQENSData` when creating the ``.grp`` file.
+- :ref:`algm-SaveDaveGrp` algorithm now optionally converts the spectrum numbers into ``q`` values using :ref:`algm-GetQsInQENSData` when creating the ``.grp`` file.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41428. <!-- One line per closed issue. -->
Saves the `Q` values when the `ToQsInQENSData` value is set to `True` in `SaveDaveGrp`.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) Run the following script.
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import os

ws = Load("CNCS_7860_event.nxs")
ws = ConvertUnits(ws, Target="DeltaE", EMode="Direct", EFixed=3.0)
ws = Rebin(ws, Params=[-3,0.01,3], PreserveEvents=False)

savefile = os.path.join(config["default.savedirectory"], "CNCS_7860_sqw.grp")
SaveDaveGrp(ws, Filename=savefile, ToQsInQENSData=True)

```
2) Verify that `Q` values are in the `.grp` file instead of the spectrum numbers (1,2,3...).
<img width="753" height="789" alt="image" src="https://github.com/user-attachments/assets/22871ade-2e0c-4edf-9f93-4a64f463fade" />



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
