### PR TITLE
Speed up component tree creation in new Instrument View

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/InstrumentViewer/New_features/41754.rst
+++ b/docs/source/release/v7.0.0/Workbench/InstrumentViewer/New_features/41754.rst
@@ -1,0 +1,1 @@
+- Sped up new Instrument View by creating the component tree lazily, i.e. only when a component in the tree is expanded. This will give a speed-up of a few seconds for large instruments.

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -304,10 +304,10 @@ class WorkspaceWidget(PluginWidget):
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
             if ws.getInstrument().getName():
                 try:
-                    window = FullInstrumentViewWindow(parent=parent, off_screen=off_screen)
-                    window.show()
+                    self._instrument_view_window = FullInstrumentViewWindow(parent=parent, off_screen=off_screen)
+                    self._instrument_view_window.show()
                     model = FullInstrumentViewModel(ws)
-                    FullInstrumentViewPresenter(window.get_instrument_view_widget(), model)
+                    FullInstrumentViewPresenter(self._instrument_view_window.get_instrument_view_widget(), model)
                     logger.warning(
                         "This Instrument View interface is available for testing purposes and evaluation, but is still "
                         "under active development. There may be bugs, and several features from the older Instrument View "

--- a/qt/python/instrumentview/instrumentview/ComponentTreeModel.py
+++ b/qt/python/instrumentview/instrumentview/ComponentTreeModel.py
@@ -7,31 +7,25 @@
 
 from mantid.dataobjects import Workspace2D
 
-from dataclasses import dataclass
 import numpy as np
-
-
-@dataclass
-class Node:
-    name: str
-    component_index: int
-    children: list["Node"]
 
 
 class ComponentTreeModel:
     def __init__(self, workspace: Workspace2D) -> None:
         self._component_info = workspace.componentInfo()
-        self.tree = self._create_tree()
 
-    def _create_tree(self) -> Node:
-        root = int(self._component_info.root())
-        children = self._create_children(root)
-        return Node(self._component_info.name(root), root, children)
+    def root_index(self) -> int:
+        return int(self._component_info.root())
 
-    def _create_children(self, component_index: int) -> list[Node]:
+    def root_name(self) -> str:
+        return self._component_info.name(self.root_index())
+
+    def get_children(self, component_index: int) -> list[tuple[str, int]]:
         children = self._component_info.children(component_index)
-        children_nodes = [Node(self._component_info.name(int(child)), int(child), self._create_children(int(child))) for child in children]
-        return children_nodes
+        return [(self._component_info.name(int(c)), int(c)) for c in children]
+
+    def has_children(self, component_index: int) -> bool:
+        return len(self._component_info.children(component_index)) > 0
 
     def get_all_sub_component_indices(self, component_indices: list[int]) -> np.ndarray:
         if len(component_indices) == 0:

--- a/qt/python/instrumentview/instrumentview/ComponentTreePresenter.py
+++ b/qt/python/instrumentview/instrumentview/ComponentTreePresenter.py
@@ -6,13 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from instrumentview.ComponentTreeView import ComponentTreeView
-from instrumentview.ComponentTreeModel import ComponentTreeModel, Node
+from instrumentview.ComponentTreeModel import ComponentTreeModel
+from qtpy.QtCore import Qt
 from qtpy.QtGui import QStandardItemModel, QStandardItem
 from typing import Callable
 import numpy as np
 
+_COMPONENT_INDEX_ROLE = Qt.UserRole + 1
+
 
 class ComponentTreePresenter:
+    _PLACEHOLDER_TEXT = "##placeholder##"
+
     def __init__(
         self, view: ComponentTreeView, model: ComponentTreeModel, on_tree_selection_callback: Callable[[np.ndarray], None]
     ) -> None:
@@ -21,29 +26,40 @@ class ComponentTreePresenter:
         self._on_tree_selection_callback = on_tree_selection_callback
         self._q_model = QStandardItemModel()
         self._q_model.setHorizontalHeaderLabels(["Component Tree"])
-        root = self._q_model.invisibleRootItem()
-        parent = self._add_children_to_parent(self._model.tree, None)
-        root.appendRow(parent)
+        root_idx = self._model.root_index()
+        root_item = self._create_q_item(self._model.root_name(), root_idx)
+        self._add_placeholder_if_has_children(root_item)
+        self._q_model.invisibleRootItem().appendRow(root_item)
 
     @property
     def model_for_qt_tree(self) -> QStandardItemModel:
         return self._q_model
 
-    def _add_children_to_parent(self, node: Node, parent: QStandardItem | None) -> QStandardItem:
-        if parent is None:
-            parent = self._create_q_item_from_node(node)
-        for child in node.children:
-            q_child = self._create_q_item_from_node(child)
-            parent.appendRow(q_child)
-            self._add_children_to_parent(child, q_child)
-        return parent
-
-    def _create_q_item_from_node(self, node: Node) -> QStandardItem:
-        item = QStandardItem(node.name)
-        item.component_index = node.component_index
+    def _create_q_item(self, name: str, component_index: int) -> QStandardItem:
+        item = QStandardItem(name)
+        item.setData(component_index, _COMPONENT_INDEX_ROLE)
         return item
 
+    def _create_placeholder(self) -> QStandardItem:
+        item = QStandardItem(self._PLACEHOLDER_TEXT)
+        item.setData(-1, _COMPONENT_INDEX_ROLE)
+        return item
+
+    def _add_placeholder_if_has_children(self, item: QStandardItem) -> None:
+        if self._model.has_children(item.data(_COMPONENT_INDEX_ROLE)):
+            item.appendRow(self._create_placeholder())
+
+    def on_item_expanded(self, item: QStandardItem) -> None:
+        """Populate children of item on first expansion (lazy loading)."""
+        if item.rowCount() == 1 and item.child(0).text() == self._PLACEHOLDER_TEXT:
+            item.removeRow(0)
+            component_index = item.data(_COMPONENT_INDEX_ROLE)
+            for name, child_idx in self._model.get_children(component_index):
+                child_item = self._create_q_item(name, child_idx)
+                self._add_placeholder_if_has_children(child_item)
+                item.appendRow(child_item)
+
     def on_selection_changed(self, q_items: list[QStandardItem]) -> None:
-        component_indices = [item.component_index for item in q_items]
+        component_indices = [item.data(_COMPONENT_INDEX_ROLE) for item in q_items if item.data(_COMPONENT_INDEX_ROLE) != -1]
         all_selected_component_indices = self._model.get_all_sub_component_indices(component_indices)
         self._on_tree_selection_callback(all_selected_component_indices)

--- a/qt/python/instrumentview/instrumentview/ComponentTreeView.py
+++ b/qt/python/instrumentview/instrumentview/ComponentTreeView.py
@@ -6,19 +6,29 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from qtpy.QtWidgets import QTreeView
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 class ComponentTreeView(QTreeView):
     def subscribe_presenter(self, presenter) -> None:
+        QAppThreadCall(self._subscribe_presenter)(presenter)
+
+    def _subscribe_presenter(self, presenter) -> None:
         self._presenter = presenter
         self.setModel(self._presenter.model_for_qt_tree)
         self.selectionModel().selectionChanged.connect(self.on_selection_changed)
         self.expanded.connect(self.on_item_expanded)
 
     def on_item_expanded(self, index) -> None:
+        QAppThreadCall(self._on_item_expanded)(index)
+
+    def _on_item_expanded(self, index) -> None:
         item = self.model().itemFromIndex(index)
         self._presenter.on_item_expanded(item)
 
-    def on_selection_changed(self, _selected, _deselected):
+    def on_selection_changed(self, selected, deselected) -> None:
+        QAppThreadCall(self._on_selection_changed)(selected, deselected)
+
+    def _on_selection_changed(self, _selected, _deselected):
         items = [self.model().itemFromIndex(index) for index in self.selectionModel().selectedIndexes()]
         self._presenter.on_selection_changed(items)

--- a/qt/python/instrumentview/instrumentview/ComponentTreeView.py
+++ b/qt/python/instrumentview/instrumentview/ComponentTreeView.py
@@ -7,15 +7,17 @@
 
 from qtpy.QtWidgets import QTreeView
 
-from mantidqt.utils.qt.qappthreadcall import run_on_qapp_thread
 
-
-@run_on_qapp_thread()
 class ComponentTreeView(QTreeView):
     def subscribe_presenter(self, presenter) -> None:
         self._presenter = presenter
         self.setModel(self._presenter.model_for_qt_tree)
         self.selectionModel().selectionChanged.connect(self.on_selection_changed)
+        self.expanded.connect(self.on_item_expanded)
+
+    def on_item_expanded(self, index) -> None:
+        item = self.model().itemFromIndex(index)
+        self._presenter.on_item_expanded(item)
 
     def on_selection_changed(self, _selected, _deselected):
         items = [self.model().itemFromIndex(index) for index in self.selectionModel().selectedIndexes()]

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -661,6 +661,7 @@ class FullInstrumentViewPresenter:
             del self._ads_observer
         if hasattr(self, "_callback_queue"):
             self._callback_queue.put(self._callback_stop_sentinel)
+        self._model = None
 
     def on_sliders_unit_selected(self, value) -> None:
         self._model.set_integration_units(self._UNIT_OPTIONS[value])

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -145,7 +145,6 @@ class CheckBoxWithColourLabel(QCheckBox):
         return QIcon(pixmap)
 
 
-@run_on_qapp_thread()
 class FullInstrumentViewWindow(QMainWindow):
     """View for the Instrument View window. Contains the 3D view, the projection view, boxes showing information about the selected
     detector, and a line plot of selected detector(s)"""

--- a/qt/python/instrumentview/instrumentview/test/test_component_tree_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_component_tree_model.py
@@ -38,32 +38,35 @@ class TestComponentTreeModel(unittest.TestCase):
             3: np.array([3]),
         }[idx]
 
-        # Create model
         self.model = ComponentTreeModel(self.workspace)
 
     # ---------------------------
 
-    def test_tree_root_created_correctly(self):
-        """Root node should be created with correct name and index."""
-        root = self.model.tree
-        self.assertEqual(root.name, "root")
-        self.assertEqual(root.component_index, 0)
-        self.assertEqual(len(root.children), 2)
+    def test_root_index(self):
+        self.assertEqual(self.model.root_index(), 0)
 
-    def test_children_created_correctly(self):
-        """Tree should contain correct children and grandchildren."""
-        root = self.model.tree
-        child1 = root.children[0]
-        child2 = root.children[1]
+    def test_root_name(self):
+        self.assertEqual(self.model.root_name(), "root")
 
-        self.assertEqual(child1.name, "child1")
-        self.assertEqual(child1.component_index, 1)
-        self.assertEqual(len(child1.children), 1)
-        self.assertEqual(child1.children[0].name, "grandchild")
+    def test_get_children_returns_name_index_tuples(self):
+        children = self.model.get_children(0)
+        self.assertEqual(children, [("child1", 1), ("child2", 2)])
 
-        self.assertEqual(child2.name, "child2")
-        self.assertEqual(child2.component_index, 2)
-        self.assertEqual(len(child2.children), 0)
+    def test_get_children_grandchildren(self):
+        children = self.model.get_children(1)
+        self.assertEqual(children, [("grandchild", 3)])
+
+    def test_get_children_leaf_returns_empty(self):
+        self.assertEqual(self.model.get_children(2), [])
+        self.assertEqual(self.model.get_children(3), [])
+
+    def test_has_children_returns_true_for_non_leaves(self):
+        self.assertTrue(self.model.has_children(0))
+        self.assertTrue(self.model.has_children(1))
+
+    def test_has_children_returns_false_for_leaves(self):
+        self.assertFalse(self.model.has_children(2))
+        self.assertFalse(self.model.has_children(3))
 
     # ---------------------------
 

--- a/qt/python/instrumentview/instrumentview/test/test_component_tree_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_component_tree_presenter.py
@@ -5,8 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from instrumentview.ComponentTreePresenter import ComponentTreePresenter
-from instrumentview.ComponentTreeModel import Node
+from instrumentview.ComponentTreePresenter import ComponentTreePresenter, _COMPONENT_INDEX_ROLE
 
 from qtpy.QtGui import QStandardItem
 import numpy as np
@@ -16,57 +15,71 @@ from unittest.mock import MagicMock
 
 class TestComponentTreePresenter(unittest.TestCase):
     def setUp(self):
-        # Build test tree:
-        # root
-        #  ├── child1
-        #  └── child2
-        self.root = Node("root", 0, children=[Node("child1", 1, []), Node("child2", 2, [])])
+        # Tree structure:
+        # root (0)
+        #  ├── child1 (1)  -- no children
+        #  └── child2 (2)  -- no children
 
         self.model = MagicMock()
-        self.model.tree = self.root
+        self.model.root_index.return_value = 0
+        self.model.root_name.return_value = "root"
+        self.model.has_children.side_effect = lambda idx: {0: True, 1: False, 2: False}.get(idx, False)
+        self.model.get_children.side_effect = lambda idx: {
+            0: [("child1", 1), ("child2", 2)],
+            1: [],
+            2: [],
+        }[idx]
         self.model.get_all_sub_component_indices = MagicMock(return_value=np.array([10, 20]))
 
         self.view = MagicMock()
         self.callback = MagicMock()
         self.presenter = ComponentTreePresenter(self.view, self.model, self.callback)
 
-    def test_constructor_builds_qt_tree_model(self):
-        """Constructor should create a QStandardItemModel with the correct root structure."""
+    def test_constructor_builds_root_with_placeholder(self):
+        """Constructor should build only the root node plus a placeholder for lazy loading."""
         q_model = self.presenter.model_for_qt_tree
         root_item = q_model.invisibleRootItem().child(0)
         self.assertIsNotNone(root_item)
         self.assertEqual(root_item.text(), "root")
-        self.assertEqual(root_item.component_index, 0)
+        self.assertEqual(root_item.data(_COMPONENT_INDEX_ROLE), 0)
+        # Root has children, so it should have exactly one placeholder child
+        self.assertEqual(root_item.rowCount(), 1)
+        self.assertEqual(root_item.child(0).text(), ComponentTreePresenter._PLACEHOLDER_TEXT)
+
+    def test_on_item_expanded_replaces_placeholder_with_children(self):
+        """Expanding the root should replace the placeholder with real children."""
+        root_item = self.presenter._q_model.invisibleRootItem().child(0)
+        self.presenter.on_item_expanded(root_item)
+
         self.assertEqual(root_item.rowCount(), 2)
         self.assertEqual(root_item.child(0).text(), "child1")
-        self.assertEqual(root_item.child(0).component_index, 1)
+        self.assertEqual(root_item.child(0).data(_COMPONENT_INDEX_ROLE), 1)
         self.assertEqual(root_item.child(1).text(), "child2")
-        self.assertEqual(root_item.child(1).component_index, 2)
+        self.assertEqual(root_item.child(1).data(_COMPONENT_INDEX_ROLE), 2)
 
-    def test_create_q_item_from_node(self):
-        """_create_q_item_from_node should set name and component_index."""
-        node = Node("testnode", 42, [])
-        item = self.presenter._create_q_item_from_node(node)
+    def test_on_item_expanded_leaf_children_have_no_placeholder(self):
+        """Children with no sub-children should not receive a placeholder."""
+        root_item = self.presenter._q_model.invisibleRootItem().child(0)
+        self.presenter.on_item_expanded(root_item)
 
-        self.assertIsInstance(item, QStandardItem)
-        self.assertEqual(item.text(), "testnode")
-        self.assertEqual(item.component_index, 42)
+        self.assertEqual(root_item.child(0).rowCount(), 0)
+        self.assertEqual(root_item.child(1).rowCount(), 0)
 
-    def test_add_children_to_parent_creates_hierarchy(self):
-        """_add_children_to_parent should recursively build QStandardItem hierarchy."""
-        q_root = self.presenter._add_children_to_parent(self.root, None)
+    def test_on_item_expanded_is_idempotent(self):
+        """Expanding an already-expanded node should not reload children."""
+        root_item = self.presenter._q_model.invisibleRootItem().child(0)
+        self.presenter.on_item_expanded(root_item)
+        self.presenter.on_item_expanded(root_item)  # second expand should be a no-op
 
-        self.assertEqual(q_root.text(), "root")
-        self.assertEqual(q_root.rowCount(), 2)
-        self.assertEqual(q_root.child(0).text(), "child1")
-        self.assertEqual(q_root.child(1).text(), "child2")
+        self.model.get_children.assert_called_once_with(0)
+        self.assertEqual(root_item.rowCount(), 2)
 
     def test_on_selection_changed_calls_callback_with_indices(self):
         """on_selection_changed should gather component indices and call callback."""
         mock_item1 = MagicMock()
-        mock_item1.component_index = 5
+        mock_item1.data.return_value = 5
         mock_item2 = MagicMock()
-        mock_item2.component_index = 6
+        mock_item2.data.return_value = 6
 
         self.presenter.on_selection_changed([mock_item1, mock_item2])
         self.model.get_all_sub_component_indices.assert_called_once_with([5, 6])
@@ -80,6 +93,16 @@ class TestComponentTreePresenter(unittest.TestCase):
         self.model.get_all_sub_component_indices.assert_called_once_with([])
         args, _ = self.callback.call_args
         np.testing.assert_array_equal(args[0], np.array([10, 20]))
+
+    def test_on_selection_changed_ignores_placeholder_items(self):
+        """Placeholder items (component_index == -1) must not be passed to the model."""
+        placeholder = QStandardItem(ComponentTreePresenter._PLACEHOLDER_TEXT)
+        placeholder.setData(-1, _COMPONENT_INDEX_ROLE)
+        real_item = MagicMock()
+        real_item.data.return_value = 3
+
+        self.presenter.on_selection_changed([placeholder, real_item])
+        self.model.get_all_sub_component_indices.assert_called_once_with([3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lazy load the component tree in the new Instrument View, which will give a significant speed up when loading large instruments. The tree will now only load the children of a node when it is expanded. This converts the method from O(N) to O(1) for the initial load of the tree, shaving off a few seconds.

I also fixed a bug caused by nothing holding onto a reference to the Instrument View when opening it with the right-click context menu. The parent [here](https://github.com/mantidproject/mantid/blob/f41283b281b8d6aae96054b42254b5c77d9f4e94/qt/applications/workbench/workbench/plugins/workspacewidget.py#L303) can be `None`, so then the window can be garbage collected randomly. Instead we keep the reference and make sure to remove the model on closing.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Check the component tree tab is working, should expand correctly. The old Instrument View also has a component tree for comparison.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
