### PR TITLE
Updated HFIRPowderReduction to have option to overwrite IDF

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -89,7 +89,9 @@ public:
 
   /// Version
   int version() const override { return 1; };
-  const std::vector<std::string> seeAlso() const override { return {"LoadISISNexus", "LoadEventAndCompress"}; }
+  const std::vector<std::string> seeAlso() const override {
+    return {"LoadISISNexus", "LoadEventAndCompress", "LoadEventAsWorkspace2D"};
+  }
 
   /// Category
   const std::string category() const override { return "DataHandling\\Nexus"; }

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -55,9 +55,8 @@ from mantid.simpleapi import (
     SaveNexus,
     Load,
     LoadWAND,
+    LoadEventAsWorkspace2D,
     LoadInstrument,
-    CreateWorkspace,
-    LoadNexusLogs,
     AddSampleLog,
 )
 import h5py
@@ -68,11 +67,6 @@ logger = Logger(__name__)
 
 
 class HFIRPowderReduction(DataProcessorAlgorithm):
-    MIDAS_NUM_BANKS = 7
-    MIDAS_TUBES_PER_BANK = 16
-    MIDAS_PIXELS_PER_TUBE = 512
-    MIDAS_TOTAL_PIXELS = MIDAS_NUM_BANKS * MIDAS_TUBES_PER_BANK * MIDAS_PIXELS_PER_TUBE  # 57344
-
     def name(self):
         return "HFIRPowderReduction"
 
@@ -116,6 +110,11 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         # Reduction UI properties
         # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty("Instrument", "", StringListValidator(["", "MIDAS", "WAND^2"]), "HB2 Instrument")
+        self.declareProperty(
+            FileProperty(name="IDFFilename", defaultValue="", action=FileAction.OptionalLoad, extensions=[".xml"]),
+            doc="Optional instrument definition file (IDF). If provided, it overrides the instrument geometry "
+            "that would otherwise be determined by the sample file.",
+        )
         # TODO: This field fields below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(
             "Wavelength",
@@ -820,43 +819,41 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             logger.warning("MaskAngle is not set.")
 
     def _loadMIDASData(self, filename, ws):
-        # Check if the file has the expected fields
-        with h5py.File(filename, "r") as f:
-            has_entry_fields = (
-                "/entry/monitor1/total_counts" in f
-                and "/entry/duration" in f
-                and "/entry/run_number" in f
-                and all(f"/entry/bank{b + 1}_events/event_id" in f for b in range(self.MIDAS_NUM_BANKS))
-            )
+        # MIDAS raw event files are integrated during load (no event workspace is needed),
+        # mirroring LoadWAND. LoadEventAsWorkspace2D performs the bank discovery and
+        # per-pixel integration in C++; fall back to the generic loader for processed /
+        # histogram files that it cannot read.
+        idf = self.getProperty("IDFFilename").value
+        wavelength = self.getProperty("Wavelength").value
 
-        if not has_entry_fields:
-            # Fall back to the generic MIDAS loader
+        try:
+            LoadEventAsWorkspace2D(
+                Filename=filename,
+                OutputWorkspace=ws,
+                # The X axis is unused downstream (ConvertSpectrumAxis operates on the
+                # spectrum axis), but XWidth*XCenter must be non-zero, so set them
+                # explicitly rather than relying on wavelength/wavelength_spread logs.
+                XCenter=wavelength,
+                XWidth=0.01,
+                Units="Wavelength",
+                # LoadNexusInstrumentXML defaults to True, so the geometry (and hence the
+                # spectrum count and event->pixel binning) comes from the file's embedded
+                # IDF. A user-supplied IDF is overlaid afterwards via LoadInstrument.
+                EnableLogging=False,
+            )
+        except RuntimeError:
+            logger.warning(f"LoadEventAsWorkspace2D failed for {filename}, falling back to generic Load")
             self._load_MIDAS(filename, ws)
             return
 
-        data = np.zeros(self.MIDAS_TOTAL_PIXELS, dtype=np.int64)
+        # Normalization needs these logs (gd_prtn_chrg for Monitor, duration for Time).
+        # LoadEventAsWorkspace2D is WAND-agnostic and does not set the monitor-style logs,
+        # so add them here. run_number is set by LoadEventAsWorkspace2D's metadata loading.
         with h5py.File(filename, "r") as f:
             monitor_count = f["/entry/monitor1/total_counts"][0]
             duration = f["/entry/duration"][0]
-            run_number = f["/entry/run_number"][0]
-            for b in range(self.MIDAS_NUM_BANKS):
-                data += np.bincount(
-                    f["/entry/bank" + str(b + 1) + "_events/event_id"][()],
-                    minlength=self.MIDAS_TOTAL_PIXELS,
-                )
-        CreateWorkspace(
-            DataX=[0, 1],
-            DataY=data,
-            DataE=np.sqrt(data),
-            UnitX="Empty",
-            YUnitLabel="Counts",
-            NSpec=self.MIDAS_TOTAL_PIXELS,
-            OutputWorkspace="__tmp_load",
-            EnableLogging=False,
-        )
-        LoadNexusLogs("__tmp_load", Filename=filename, EnableLogging=False)
         AddSampleLog(
-            "__tmp_load",
+            ws,
             LogName="monitor_count",
             LogType="Number",
             NumberType="Double",
@@ -864,31 +861,28 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             EnableLogging=False,
         )
         AddSampleLog(
-            "__tmp_load",
+            ws,
             LogName="gd_prtn_chrg",
             LogType="Number",
             NumberType="Double",
             LogText=str(monitor_count),
             EnableLogging=False,
         )
-        AddSampleLog("__tmp_load", LogName="run_number", LogText=str(run_number), EnableLogging=False)
         AddSampleLog(
-            "__tmp_load",
+            ws,
             LogName="duration",
             LogType="Number",
-            LogText=str(duration),
             NumberType="Double",
+            LogText=str(duration),
             EnableLogging=False,
         )
 
-        # Use the modified IDF that supports simulated data until we get real MIDAS data
-        # LoadInstrument("__tmp_load", InstrumentName="MIDAS", RewriteSpectraMap=True, EnableLogging=False)
-        LoadInstrument("__tmp_load", Filename="/SNS/users/nxw/mccode_fixed.xml", RewriteSpectraMap=True, EnableLogging=False)
+        # A user-supplied IDF overrides the geometry embedded in the sample file.
+        if idf:
+            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=True, EnableLogging=False)
         # Masking is not used yet, but will be added back later
         # if self.getProperty("ApplyMask").value:
-        #     MaskBTP("__tmp_load", Pixel="1,2,511,512", EnableLogging=False)
-
-        RenameWorkspace("__tmp_load", ws, EnableLogging=False)
+        #     MaskBTP(ws, Pixel="1,2,511,512", EnableLogging=False)
 
     def PyExec(self):
         """
@@ -1045,9 +1039,11 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
 
     def _load_MIDAS(self, filename, ws):
         Load(Filename=filename, OutputWorkspace=ws, EnableLogging=False)
-        if not isinstance(ws, WorkspaceGroup):
-            # This is a temp fix for using simulated MIDAS data
-            LoadInstrument(ws, Filename="/SNS/users/nxw/mccode_fixed.xml", RewriteSpectraMap=True)
+        # By default the instrument geometry comes from the loaded sample file. Only override it
+        # when the user supplies an IDF (and the loaded workspace is not a group).
+        idf = self.getProperty("IDFFilename").value
+        if idf and not isinstance(mtd[ws], WorkspaceGroup):
+            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=True)
 
     def _load_WAND_Data(self, filename, ws):
         grouping = self.getProperty("Grouping").value
@@ -1057,6 +1053,13 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         except RuntimeError:
             logger.warning(f"LoadWAND failed for {filename}, falling back to generic Load")
             Load(Filename=filename, OutputWorkspace=ws, EnableLogging=False)
+
+        # A user-supplied IDF overrides the geometry loaded above. Use RewriteSpectraMap=False
+        # so the (possibly grouped) spectrum->detector mapping that LoadWAND built is preserved
+        # and only the instrument geometry is replaced.
+        idf = self.getProperty("IDFFilename").value
+        if idf and not isinstance(mtd[ws], WorkspaceGroup):
+            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=False, EnableLogging=False)
 
     def _general_load_data(self, data_type):
         instrument = self.getProperty("Instrument").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -818,18 +818,17 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         if self.getProperty("MaskAngle").value == Property.EMPTY_DBL:
             logger.warning("MaskAngle is not set.")
 
-    def _loadMIDASData(self, filename, ws):
+    def _loadMIDASData(self, filename, wsname):
         # MIDAS raw event files are integrated during load (no event workspace is needed),
         # mirroring LoadWAND. LoadEventAsWorkspace2D performs the bank discovery and
         # per-pixel integration in C++; fall back to the generic loader for processed /
         # histogram files that it cannot read.
-        idf = self.getProperty("IDFFilename").value
         wavelength = self.getProperty("Wavelength").value
 
         try:
             LoadEventAsWorkspace2D(
                 Filename=filename,
-                OutputWorkspace=ws,
+                OutputWorkspace=wsname,
                 # The X axis is unused downstream (ConvertSpectrumAxis operates on the
                 # spectrum axis), but XWidth*XCenter must be non-zero, so set them
                 # explicitly rather than relying on wavelength/wavelength_spread logs.
@@ -843,7 +842,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             )
         except RuntimeError:
             logger.warning(f"LoadEventAsWorkspace2D failed for {filename}, falling back to generic Load")
-            self._load_MIDAS(filename, ws)
+            self._load_MIDAS(filename, wsname)
             return
 
         # Normalization needs these logs (gd_prtn_chrg for Monitor, duration for Time).
@@ -853,7 +852,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             monitor_count = f["/entry/monitor1/total_counts"][0]
             duration = f["/entry/duration"][0]
         AddSampleLog(
-            ws,
+            wsname,
             LogName="monitor_count",
             LogType="Number",
             NumberType="Double",
@@ -861,7 +860,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             EnableLogging=False,
         )
         AddSampleLog(
-            ws,
+            wsname,
             LogName="gd_prtn_chrg",
             LogType="Number",
             NumberType="Double",
@@ -869,7 +868,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             EnableLogging=False,
         )
         AddSampleLog(
-            ws,
+            wsname,
             LogName="duration",
             LogType="Number",
             NumberType="Double",
@@ -878,11 +877,10 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         )
 
         # A user-supplied IDF overrides the geometry embedded in the sample file.
-        if idf:
-            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=True, EnableLogging=False)
+        self._load_IDF_if_supplied(wsname, rewrite_spectra_map=True)
         # Masking is not used yet, but will be added back later
         # if self.getProperty("ApplyMask").value:
-        #     MaskBTP(ws, Pixel="1,2,511,512", EnableLogging=False)
+        #     MaskBTP(wsname, Pixel="1,2,511,512", EnableLogging=False)
 
     def PyExec(self):
         """
@@ -1037,29 +1035,48 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         # Update the list with potentially renamed workspace
         sample_workspaces[index] = ws_name
 
-    def _load_MIDAS(self, filename, ws):
-        Load(Filename=filename, OutputWorkspace=ws, EnableLogging=False)
-        # By default the instrument geometry comes from the loaded sample file. Only override it
-        # when the user supplies an IDF (and the loaded workspace is not a group).
-        idf = self.getProperty("IDFFilename").value
-        if idf and not isinstance(mtd[ws], WorkspaceGroup):
-            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=True)
+    def _load_IDF_if_supplied(self, wsname, rewrite_spectra_map):
+        """Overlay a user-supplied IDF onto the loaded workspace, if one was provided.
 
-    def _load_WAND_Data(self, filename, ws):
+        Does nothing when no IDFFilename is set. LoadInstrument cannot operate on a
+        WorkspaceGroup directly, so group members are handled individually.
+
+        rewrite_spectra_map is passed through to LoadInstrument's RewriteSpectraMap: True
+        rebuilds the spectrum->detector mapping from the new geometry, False preserves an
+        existing (e.g. grouped) mapping and only replaces the geometry.
+        """
+        idf = self.getProperty("IDFFilename").value
+        if not idf:
+            return
+        workspace = mtd[wsname]
+        names = workspace.getNames() if isinstance(workspace, WorkspaceGroup) else [wsname]
+        for name in names:
+            LoadInstrument(name, Filename=idf, RewriteSpectraMap=rewrite_spectra_map, EnableLogging=False)
+
+    def _load_MIDAS(self, filename, wsname):
+        """Fallback MIDAS loader for files LoadEventAsWorkspace2D cannot read.
+
+        _loadMIDASData is the primary path; it calls this when LoadEventAsWorkspace2D
+        raises (e.g. processed / histogram files that are not raw event data). Uses the
+        generic Load algorithm, which handles those formats.
+        """
+        Load(Filename=filename, OutputWorkspace=wsname, EnableLogging=False)
+        # A user-supplied IDF overrides the geometry that came from the loaded sample file.
+        self._load_IDF_if_supplied(wsname, rewrite_spectra_map=True)
+
+    def _load_WAND_Data(self, filename, wsname):
         grouping = self.getProperty("Grouping").value
         apply_mask = self.getProperty("ApplyMask").value
         try:
-            LoadWAND(Filename=filename, OutputWorkspace=ws, Grouping=grouping, ApplyMask=apply_mask, EnableLogging=False)
+            LoadWAND(Filename=filename, OutputWorkspace=wsname, Grouping=grouping, ApplyMask=apply_mask, EnableLogging=False)
         except RuntimeError:
             logger.warning(f"LoadWAND failed for {filename}, falling back to generic Load")
-            Load(Filename=filename, OutputWorkspace=ws, EnableLogging=False)
+            Load(Filename=filename, OutputWorkspace=wsname, EnableLogging=False)
 
         # A user-supplied IDF overrides the geometry loaded above. Use RewriteSpectraMap=False
         # so the (possibly grouped) spectrum->detector mapping that LoadWAND built is preserved
         # and only the instrument geometry is replaced.
-        idf = self.getProperty("IDFFilename").value
-        if idf and not isinstance(mtd[ws], WorkspaceGroup):
-            LoadInstrument(ws, Filename=idf, RewriteSpectraMap=False, EnableLogging=False)
+        self._load_IDF_if_supplied(wsname, rewrite_spectra_map=False)
 
     def _general_load_data(self, data_type):
         instrument = self.getProperty("Instrument").value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -2123,5 +2123,79 @@ class SampleAbsorptionCorrectionTests(unittest.TestCase):
         self.assertLess(fnorm, 10000)
 
 
+# A minimal but valid instrument definition file with a distinctive name. When applied via the
+# IDFFilename property, the loaded workspace's instrument name becomes this file's basename.
+_CUSTOM_IDF = """<?xml version='1.0' encoding='UTF-8'?>
+<instrument name="CUSTOM_IDF" valid-from="1900-01-31 23:59:59" valid-to="2100-01-31 23:59:59" last-modified="2020-01-01 00:00:00">
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+    </reference-frame>
+  </defaults>
+  <component type="moderator"><location z="-5.0"/></component>
+  <type is="Source" name="moderator"/>
+  <component type="sample-position"><location y="0.0" x="0.0" z="0.0"/></component>
+  <type is="SamplePos" name="sample-position"/>
+  <component type="detector-bank" idlist="dets"><location/></component>
+  <type name="detector-bank">
+    <component type="pixel"><location y="0.0" x="0.707" z="0.707"/></component>
+  </type>
+  <type is="detector" name="pixel">
+    <cylinder id="cyl-approx">
+      <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+      <axis y="1.0" x="0.0" z="0.0"/>
+      <radius val="0.0127"/>
+      <height val="0.1"/>
+    </cylinder>
+    <algebra val="cyl-approx"/>
+  </type>
+  <idlist idname="dets"><id start="1" end="1"/></idlist>
+</instrument>
+"""
+
+
+class IDFOverrideTests(unittest.TestCase):
+    """Tests for the optional IDFFilename property that overrides the instrument geometry.
+
+    When IDFFilename is supplied, the loaders overlay it with LoadInstrument, which sets the
+    workspace's instrument name to the IDF file's basename. Each test verifies the override by
+    checking the loaded workspace has the custom instrument rather than the default WAND/MIDAS one.
+    """
+
+    def setUp(self):
+        self._test_dir = tempfile.mkdtemp()
+        self._idf = os.path.join(self._test_dir, "My_Custom_IDF.xml")
+        with open(self._idf, "w") as f:
+            f.write(_CUSTOM_IDF)
+
+    def tearDown(self):
+        shutil.rmtree(self._test_dir, ignore_errors=True)
+        for name in list(mtd.getObjectNames()):
+            if mtd.doesExist(name):
+                mtd.remove(name)
+
+    def test_wand_uses_custom_idf(self):
+        algo = _create_algo(Instrument="WAND^2", IDFFilename=self._idf)
+        algo._load_WAND_Data("HB2C_7000.nxs.h5", "test_wand_custom_idf")
+        instrument_name = mtd["test_wand_custom_idf"].getInstrument().getName()
+        self.assertEqual(instrument_name, os.path.basename(self._idf))
+
+    def test_midas_uses_custom_idf(self):
+        # Save a small workspace as the MIDAS sample file. _loadMIDASData falls back to the
+        # generic loader for this (non-event) file, which then applies the custom IDF.
+        CreateSampleWorkspace(NumBanks=1, BankPixelWidth=4, BinWidth=20000, OutputWorkspace="_midas_sample")
+        midas_file = os.path.join(self._test_dir, "midas_sample.nxs")
+        SaveNexusESS(mtd["_midas_sample"], Filename=midas_file)
+
+        algo = _create_algo(Instrument="MIDAS", Wavelength=2.5, IDFFilename=self._idf)
+        algo._loadMIDASData(midas_file, "test_midas_custom_idf")
+        instrument_name = mtd["test_midas_custom_idf"].getInstrument().getName()
+        self.assertEqual(instrument_name, os.path.basename(self._idf))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/algorithms/HFIRPowderReduction-v1.rst
+++ b/docs/source/algorithms/HFIRPowderReduction-v1.rst
@@ -15,6 +15,9 @@ specified either as a list of files or as an IPTS number and a list of run numbe
 Reducing WAND^2 data with HFIRPowderReduction is very similar to using :ref:`algm-WANDPowderReduction`, but with some differences in the input parameters,
 and reduction steps are slightly modified.
 
+By default the instrument geometry is determined by the sample file. An instrument definition file (IDF) can
+optionally be supplied through the ``IDFFilename`` property to override the geometry used by the sample file.
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41757.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41757.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-HFIRPowderReduction` now has an ``IDFFilename`` property to optionally override the instrument geometry from the sample file, and loads MIDAS data with :ref:`algm-LoadEventAsWorkspace2D`.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
This work adds an option to HFIRPowderReduction to let the user specify the IDF if they don't want to use the one given inside the sample being reduced. Loading MIDAS data within HFIRPowderReduction has also been updated to use LoadEventAs2DWorkspace to simplify/reduce some of the loading logic needed to load MIDAS data. Lastly LoadEventNexus has been updated to include LoadEventAs2DWorkspace in the See Also list.

EWM Item [16691](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16691)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run the following script (CHANGE THE OutputDirectory FIELD TO SOMETHING YOU HAVE ACCESS TO):

```python
from mantid.simpleapi import *

HFIRPowderReduction(SampleFilename='/HFIR/NOWX/IPTS-0000/nexus/NOWX_12727.nxs.h5', Instrument='MIDAS', IDFFilename='/SNS/users/nxw/mccode_fixed.xml', Wavelength=1.54, VanadiumDiameter=1, DoAttenuationCorrection=True, DoMultipleScatteringCorrection=True, AbsoluteIntensityUnits=True, SampleChemicalFormula='Tm', SampleCrystalDensity=1, SampleDiameter=1, SampleHeight=3, XMin='1', XMax='180', NormaliseBy='Time', OutputWorkspace='WANDfixed', OutputDirectory='/SNS/users/8l2/HFIRPowderReductionOutput')
```
This generates a result with a modified IDF. Now rerun the same script, but delete the IDFFilename field and rename the OutputWorkspace so the original result does not get overwritten. When you click the dropdown button on each workspace in the workspace browser, you should be able to see that the listed instrument is different.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
