### PR TITLE
Add TexturePlanner exporter helper and test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(TEST_PY_FILES
     helpers/test/test_absorption.py helpers/test/test_detector_geometry.py helpers/test/test_workspace_manager.py
     helpers/test/test_plotter.py helpers/test/test_instrument.py helpers/test/test_orientation_table.py
-)
+    helpers/test/test_exporter.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -1,9 +1,14 @@
 # Tests for the Texture Planner interface
 
 set(TEST_PY_FILES
-    helpers/test/test_absorption.py helpers/test/test_detector_geometry.py helpers/test/test_workspace_manager.py
-    helpers/test/test_plotter.py helpers/test/test_instrument.py helpers/test/test_orientation_table.py
-    helpers/test/test_exporter.py)
+    helpers/test/test_absorption.py
+    helpers/test/test_detector_geometry.py
+    helpers/test/test_workspace_manager.py
+    helpers/test/test_plotter.py
+    helpers/test/test_instrument.py
+    helpers/test/test_orientation_table.py
+    helpers/test/test_exporter.py
+)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
@@ -1,0 +1,175 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import os
+import numpy as np
+
+from mantid.simpleapi import (
+    LoadEmptyInstrument,
+    SaveNexus,
+)
+from mantid.api import AnalysisDataService as ADS
+from mantid.kernel import logger
+from Engineering.texture.TextureUtils import convert_to_sscanss_frame
+from typing import Protocol, ValuesView, Generator
+from abc import abstractmethod
+from mantid.api import MatrixWorkspace
+from scipy.spatial.transform import Rotation
+
+
+class _WorkspaceManagerType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    updated_mesh_ws: MatrixWorkspace
+    WS_REFERENCE: str
+
+    @abstractmethod
+    def copy_sample_preserving_initial_rotation(self, source_ws: MatrixWorkspace, dest_ws: MatrixWorkspace) -> None:
+        pass
+
+
+class _InstrumentType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    @abstractmethod
+    def get_instrument(self) -> str:
+        pass
+
+
+class _OrientationType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    include: bool
+    select: bool
+    R: Rotation
+    transmission: np.ndarray | None
+
+
+class _OrientationTableType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    orientation_kwargs: dict
+
+    @abstractmethod
+    def values(self) -> ValuesView[_OrientationType]:
+        pass
+
+
+class _BaseModelType(Protocol):
+    """For the purpose of type hinting while this module is orphaned
+    Will be removed and replaced with actual model before final PR"""
+
+    workspaces: _WorkspaceManagerType
+    instrument: _InstrumentType
+    orientations: _OrientationTableType
+
+
+class OrientationExporter:
+    """Writes the currently-included orientations to disk in one of four formats.
+
+    Holds a back-reference to the TexturePlannerModel so it can pull the live
+    orientation table, init rotation, sample-mesh workspace, and instrument name
+    at write time.
+    """
+
+    def __init__(self, model: _BaseModelType):
+        self._model = model
+
+    def _included(self) -> Generator[_OrientationType, None, None]:
+        return (o for o in self._model.orientations.values() if o.include)
+
+    def output_as_sscanss(self, save_dir: str, filename: str) -> None:
+        header = ["xyz\n"]
+        lines = []
+        save_file = os.path.join(save_dir, filename + ".angles")
+        for orientation in self._included():
+            angs = convert_to_sscanss_frame(orientation.R.as_matrix())
+            lines.append(f"{np.round(angs[0], 2)}\t{np.round(angs[1], 2)}\t{np.round(angs[2], 2)}\n")
+        with open(save_file, "w") as f:
+            f.writelines(header + lines)
+        logger.notice(f"Orientation data written to '{save_file}' as Sscanss2 Angles")
+
+    def output_as_matrix(self, save_dir: str, filename: str) -> None:
+        lines = []
+        save_file = os.path.join(save_dir, filename + ".txt")
+        for orientation in self._included():
+            rot_mat = orientation.R.as_matrix().reshape(-1)
+            lines.append("\t".join(str(x) for x in rot_mat) + "\n")
+        with open(save_file, "w") as f:
+            f.writelines(lines)
+        logger.notice(f"Orientation data written to '{save_file}' as Rotation Matrices")
+
+    def output_as_euler(self, save_dir: str, filename: str) -> None:
+        axes = self._model.orientations.orientation_kwargs["Axes"]
+        senses = self._model.orientations.orientation_kwargs["Senses"].split(",")
+        lines = []
+        save_file = os.path.join(save_dir, filename + ".txt")
+        for orientation in self._included():
+            raw = orientation.R.as_euler(axes, degrees=True)
+            angle_strs = [str(np.round(float(sense) * raw[i], 2)) for i, sense in enumerate(senses)]
+            lines.append("\t".join(angle_strs) + "\n")
+        with open(save_file, "w") as f:
+            f.writelines(lines)
+        logger.notice(f"Orientation data written to '{save_file}' as Euler Angles with Scheme ({axes}) and Senses ({','.join(senses)})")
+
+    def output_transmission_weighting(self, save_dir: str, filename: str) -> None:
+        """Write one transmission-weighting value per included orientation.
+
+        For each included orientation we take the smallest transmission factor it produced, then
+        normalise those per-orientation minima against the largest value across all orientations,
+        so the least strongly absorbing orientation is 1.0 and the more absorbing ones are > 1.0
+        (i.e. they would need proportionally longer counting). Requires the transmission factors to
+        have been estimated (Estimate Transmission Values).
+        """
+        included = list(self._included())
+        per_orientation_min = []
+        for orientation in included:
+            transmission = orientation.transmission
+            if transmission is None or len(transmission) == 0:
+                logger.warning(
+                    "Transmission weighting export skipped: transmission values have not been estimated for all included orientations"
+                )
+                return
+            per_orientation_min.append(float(np.min(transmission)))
+        if not per_orientation_min:
+            logger.warning("Transmission weighting export skipped: no orientations are included")
+            return
+        if min(per_orientation_min) <= 0:
+            logger.warning(
+                "Transmission weighting export skipped: at least one included orientation has zero "
+                "transmission (sample likely outside the gauge volume)"
+            )
+            return
+        global_max = max(per_orientation_min)
+        save_file = os.path.join(save_dir, filename + "_transmission_weighting.txt")
+        with open(save_file, "w") as f:
+            f.writelines(f"{global_max / per_min}\n" for per_min in per_orientation_min)
+        logger.notice(f"Transmission weighting written to '{save_file}'")
+
+    def output_as_reference_workspace(self, save_dir, filename):
+        ref_wsname = self._model.workspaces.WS_REFERENCE
+        try:
+            self._build_reference_ws(ref_wsname)
+            save_file = os.path.join(save_dir, filename + ".nxs")
+            SaveNexus(InputWorkspace=ref_wsname, Filename=save_file)
+            logger.notice(f"Reference workspace saved to '{save_file}'")
+        finally:
+            if ADS.doesExist(ref_wsname):
+                ADS.remove(ref_wsname)
+
+    def _build_reference_ws(self, ref_wsname):
+        ref_ws = LoadEmptyInstrument(InstrumentName=self._model.instrument.get_instrument(), OutputWorkspace=ref_wsname)
+        # Source from updated_mesh_ws (always identity goniometer) rather than wsname (which carries
+        # the current orientation R on its goniometer). copy_sample_preserving_initial_rotation keeps
+        # the baked-in initial rotation - which a plain CopySample would strip from a CSG shape - and
+        # leaves the reference ws at an identity goniometer, i.e. already in its initial orientation
+        # ready to save.
+        self._model.workspaces.copy_sample_preserving_initial_rotation(self._model.workspaces.updated_mesh_ws, ref_ws)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
@@ -14,7 +14,7 @@ from mantid.simpleapi import (
 )
 from mantid.api import AnalysisDataService as ADS
 from mantid.kernel import logger
-from Engineering.texture.TextureUtils import convert_to_sscanss_frame
+from Engineering.texture.texture_helper import convert_to_sscanss_frame
 from typing import Protocol, ValuesView, Generator
 from abc import abstractmethod
 from mantid.api import MatrixWorkspace

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
@@ -1,0 +1,361 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+import numpy as np
+
+from unittest.mock import patch, MagicMock
+from scipy.spatial.transform import Rotation
+
+from mantidqtinterfaces.TexturePlanner.helpers.exporter import OrientationExporter
+
+file_path = "mantidqtinterfaces.TexturePlanner.helpers.exporter"
+
+WS_REFERENCE = "__texture_planning_reference_ws"
+
+
+def _make_orientation(R=None, include=True, transmission=None):
+    orient = MagicMock()
+    orient.R = R if R is not None else Rotation.identity()
+    orient.include = include
+    orient.transmission = transmission
+    return orient
+
+
+def _make_model(orientations=None, instr="ENGINX", axes="xyz", senses="1,1,1", init_R=None, updated_mesh_ws="neutral"):
+    model = MagicMock()
+    if orientations is None:
+        orientations = {0: _make_orientation()}
+    model.orientations.values.return_value = list(orientations.values())
+    model.instrument.get_instrument.return_value = instr
+    model.orientations.orientation_kwargs = {"Axes": axes, "Senses": senses}
+    model.workspaces.WS_REFERENCE = WS_REFERENCE
+    model.workspaces.updated_mesh_ws = updated_mesh_ws
+    model.workspaces.init_R = init_R if init_R is not None else Rotation.identity()
+    return model
+
+
+class TestOrientationExporter_Included(unittest.TestCase):
+    def test_filters_out_orientations_with_include_false(self):
+        kept = _make_orientation(include=True)
+        dropped = _make_orientation(include=False)
+        model = _make_model(orientations={0: kept, 1: dropped, 2: kept})
+        exp = OrientationExporter(model)
+
+        self.assertEqual(list(exp._included()), [kept, kept])
+
+
+@patch(file_path + ".logger")
+class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
+    def _run(self, model, filename="out"):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp = OrientationExporter(model)
+            exp.output_as_sscanss(tmp, filename)
+            save_file = os.path.join(tmp, filename + ".angles")
+            with open(save_file) as f:
+                return f.read(), save_file
+
+    @patch(file_path + ".convert_to_sscanss_frame")
+    def test_writes_header_and_one_line_per_orientation(self, mock_convert, mock_logger):
+        mock_convert.return_value = (10.0, 20.0, 30.0)
+        model = _make_model(orientations={0: _make_orientation(), 1: _make_orientation()})
+
+        content, _ = self._run(model)
+
+        lines = content.splitlines()
+        self.assertEqual(lines[0], "xyz")
+        self.assertEqual(len(lines), 1 + 2)
+        for line in lines[1:]:
+            self.assertEqual(line, "10.0\t20.0\t30.0")
+
+    @patch(file_path + ".convert_to_sscanss_frame")
+    def test_rounds_angles_to_two_decimals(self, mock_convert, mock_logger):
+        mock_convert.return_value = (1.23456, 2.34567, 3.45678)
+        model = _make_model()
+
+        content, _ = self._run(model)
+
+        self.assertIn("1.23\t2.35\t3.46", content)
+
+    @patch(file_path + ".convert_to_sscanss_frame")
+    def test_passes_rotation_matrix_to_convert(self, mock_convert, mock_logger):
+        mock_convert.return_value = (0.0, 0.0, 0.0)
+        R = Rotation.from_euler("x", 45, degrees=True)
+        model = _make_model(orientations={0: _make_orientation(R=R)})
+
+        self._run(model)
+
+        np.testing.assert_allclose(mock_convert.call_args.args[0], R.as_matrix())
+
+    @patch(file_path + ".convert_to_sscanss_frame")
+    def test_logs_notice_on_success(self, mock_convert, mock_logger):
+        mock_convert.return_value = (0.0, 0.0, 0.0)
+        model = _make_model()
+
+        _, save_file = self._run(model, filename="out")
+
+        mock_logger.notice.assert_called_once()
+        self.assertIn(save_file, mock_logger.notice.call_args.args[0])
+
+
+@patch(file_path + ".logger")
+class TestOrientationExporter_OutputAsMatrix(unittest.TestCase):
+    def _run(self, model, filename="out"):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp = OrientationExporter(model)
+            exp.output_as_matrix(tmp, filename)
+            save_file = os.path.join(tmp, filename + ".txt")
+            with open(save_file) as f:
+                return f.read(), save_file
+
+    def test_writes_9_tab_separated_values_per_line(self, mock_logger):
+        R = Rotation.identity()
+        model = _make_model(orientations={0: _make_orientation(R=R)})
+
+        content, _ = self._run(model)
+
+        line = content.splitlines()[0]
+        values = line.split("\t")
+        self.assertEqual(len(values), 9)
+        np.testing.assert_allclose([float(v) for v in values], np.eye(3).reshape(-1))
+
+    def test_writes_one_line_per_orientation(self, mock_logger):
+        model = _make_model(orientations={0: _make_orientation(), 1: _make_orientation()})
+
+        content, _ = self._run(model)
+
+        self.assertEqual(len(content.splitlines()), 2)
+
+    def test_logs_notice_with_save_file(self, mock_logger):
+        model = _make_model()
+
+        _, save_file = self._run(model)
+
+        mock_logger.notice.assert_called_once()
+        self.assertIn(save_file, mock_logger.notice.call_args.args[0])
+
+
+@patch(file_path + ".logger")
+class TestOrientationExporter_OutputAsEuler(unittest.TestCase):
+    def _run(self, model, filename="out"):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp = OrientationExporter(model)
+            exp.output_as_euler(tmp, filename)
+            save_file = os.path.join(tmp, filename + ".txt")
+            with open(save_file) as f:
+                return f.read(), save_file
+
+    def _make_orient_with_mock_R(self, euler_return):
+        orient = MagicMock()
+        orient.include = True
+        orient.R.as_euler.return_value = np.asarray(euler_return)
+        return orient
+
+    def test_uses_axes_from_orientation_kwargs(self, mock_logger):
+        orient = self._make_orient_with_mock_R([10.0, 20.0, 30.0])
+        model = _make_model(orientations={0: orient}, axes="zyx", senses="1,1,1")
+
+        self._run(model)
+
+        orient.R.as_euler.assert_called_once_with("zyx", degrees=True)
+
+    def test_applies_senses_per_axis(self, mock_logger):
+        orient = self._make_orient_with_mock_R([10.0, 20.0, 30.0])
+        model = _make_model(orientations={0: orient}, senses="1,-1,1")
+
+        content, _ = self._run(model)
+
+        values = content.splitlines()[0].split("\t")
+        self.assertEqual([float(v) for v in values], [10.0, -20.0, 30.0])
+
+    def test_writes_one_line_per_orientation(self, mock_logger):
+        orient = self._make_orient_with_mock_R([0.0, 0.0, 0.0])
+        model = _make_model(orientations={0: orient, 1: orient})
+
+        content, _ = self._run(model)
+
+        self.assertEqual(len(content.splitlines()), 2)
+
+
+@patch(file_path + ".logger")
+class TestOrientationExporter_OutputTransmissionWeighting(unittest.TestCase):
+    def _run(self, model, filename="out"):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp = OrientationExporter(model)
+            exp.output_transmission_weighting(tmp, filename)
+            save_file = os.path.join(tmp, filename + "_transmission_weighting.txt")
+            content = None
+            if os.path.exists(save_file):
+                with open(save_file) as f:
+                    content = f.read()
+            return content, save_file
+
+    def test_writes_one_row_per_included_orientation(self, mock_logger):
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.5, 0.8])),
+            1: _make_orientation(transmission=np.array([0.4, 0.9])),
+            2: _make_orientation(transmission=np.array([0.2, 0.6])),
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        self.assertEqual(len(content.splitlines()), 3)
+
+    def test_normalises_per_orientation_minima_against_the_largest(self, mock_logger):
+        # per-orientation minima: 0.5, 0.4, 0.2 -> largest is 0.5 -> weights 0.5/min
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.5, 0.8])),
+            1: _make_orientation(transmission=np.array([0.4, 0.9])),
+            2: _make_orientation(transmission=np.array([0.2, 0.6])),
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        weights = [float(line) for line in content.splitlines()]
+        np.testing.assert_allclose(weights, [0.5 / 0.5, 0.5 / 0.4, 0.5 / 0.2])
+
+    def test_least_absorbing_orientation_has_weight_one(self, mock_logger):
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.4])),
+            1: _make_orientation(transmission=np.array([0.7])),  # least absorbing
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        weights = [float(line) for line in content.splitlines()]
+        self.assertEqual(min(weights), 1.0)
+        self.assertTrue(all(w >= 1.0 for w in weights))
+
+    def test_excludes_orientations_with_include_false(self, mock_logger):
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.5]), include=True),
+            1: _make_orientation(transmission=np.array([0.1]), include=False),
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        # only the single included orientation contributes -> one row, normalised to itself
+        self.assertEqual(content.splitlines(), ["1.0"])
+
+    def test_skips_and_warns_when_transmission_missing(self, mock_logger):
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.5])),
+            1: _make_orientation(transmission=None),
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        self.assertIsNone(content)
+        mock_logger.warning.assert_called_once()
+        mock_logger.notice.assert_not_called()
+
+    def test_skips_and_warns_when_an_orientation_has_zero_transmission(self, mock_logger):
+        orientations = {
+            0: _make_orientation(transmission=np.array([0.5, 0.8])),
+            1: _make_orientation(transmission=np.array([0.0, 0.0])),  # outside gauge volume
+        }
+        model = _make_model(orientations=orientations)
+
+        content, _ = self._run(model)
+
+        self.assertIsNone(content)
+        mock_logger.warning.assert_called_once()
+
+    def test_logs_notice_with_save_file_on_success(self, mock_logger):
+        model = _make_model(orientations={0: _make_orientation(transmission=np.array([0.5]))})
+
+        _, save_file = self._run(model)
+
+        mock_logger.notice.assert_called_once()
+        self.assertIn(save_file, mock_logger.notice.call_args.args[0])
+
+
+@patch(file_path + ".LoadEmptyInstrument")
+class TestOrientationExporter_BuildReferenceWs(unittest.TestCase):
+    def test_loads_empty_instrument_into_reference_wsname(self, mock_load_instr):
+        model = _make_model(instr="ENGINX")
+        exp = OrientationExporter(model)
+
+        exp._build_reference_ws(WS_REFERENCE)
+
+        mock_load_instr.assert_called_once_with(InstrumentName="ENGINX", OutputWorkspace=WS_REFERENCE)
+
+    def test_copies_sample_preserving_initial_rotation_from_updated_mesh_ws(self, mock_load_instr):
+        model = _make_model(updated_mesh_ws="neutral")
+        exp = OrientationExporter(model)
+
+        exp._build_reference_ws(WS_REFERENCE)
+
+        # the reference ws keeps the sample's initial rotation (which a plain CopySample would strip
+        # from a CSG shape) via the shared workspace-manager helper, sourcing from the
+        # identity-goniometer neutral mesh ws and writing into the freshly loaded empty-instrument ws
+        model.workspaces.copy_sample_preserving_initial_rotation.assert_called_once_with("neutral", mock_load_instr.return_value)
+
+
+@patch(file_path + ".logger")
+@patch(file_path + ".ADS")
+@patch(file_path + ".SaveNexus")
+class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
+    def _make_exporter(self):
+        model = _make_model()
+        exp = OrientationExporter(model)
+        exp._build_reference_ws = MagicMock()
+        return exp
+
+    def test_orchestrates_build_then_save(self, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            exp.output_as_reference_workspace(tmp, "out")
+            expected_path = os.path.join(tmp, "out.nxs")
+
+            # _build_reference_ws now preserves the initial rotation itself (via the shared helper), so
+            # the orchestration is simply build-then-save
+            exp._build_reference_ws.assert_called_once_with(WS_REFERENCE)
+            mock_save.assert_called_once_with(InputWorkspace=WS_REFERENCE, Filename=expected_path)
+            mock_logger.notice.assert_called_once()
+
+    def test_removes_ref_ws_from_ads_when_it_exists(self, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+        mock_ads.doesExist.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            exp.output_as_reference_workspace(tmp, "out")
+
+        mock_ads.doesExist.assert_called_with(WS_REFERENCE)
+        mock_ads.remove.assert_called_once_with(WS_REFERENCE)
+
+    def test_does_not_remove_ref_ws_if_absent(self, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+        mock_ads.doesExist.return_value = False
+
+        with tempfile.TemporaryDirectory() as tmp:
+            exp.output_as_reference_workspace(tmp, "out")
+
+        mock_ads.remove.assert_not_called()
+
+    def test_cleans_up_ref_ws_even_when_build_raises(self, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+        exp._build_reference_ws.side_effect = RuntimeError("boom")
+        mock_ads.doesExist.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError):
+                exp.output_as_reference_workspace(tmp, "out")
+
+        mock_ads.remove.assert_called_once_with(WS_REFERENCE)
+        mock_save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
@@ -14,7 +14,7 @@ from scipy.spatial.transform import Rotation
 
 from mantidqtinterfaces.TexturePlanner.helpers.exporter import OrientationExporter
 
-file_path = "mantidqtinterfaces.TexturePlanner.helpers.exporter"
+FILE_PATH = "mantidqtinterfaces.TexturePlanner.helpers.exporter"
 
 WS_REFERENCE = "__texture_planning_reference_ws"
 
@@ -50,7 +50,7 @@ class TestOrientationExporter_Included(unittest.TestCase):
         self.assertEqual(list(exp._included()), [kept, kept])
 
 
-@patch(file_path + ".logger")
+@patch(FILE_PATH + ".logger")
 class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
     def _run(self, model, filename="out"):
         with tempfile.TemporaryDirectory() as tmp:
@@ -60,7 +60,7 @@ class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
             with open(save_file) as f:
                 return f.read(), save_file
 
-    @patch(file_path + ".convert_to_sscanss_frame")
+    @patch(FILE_PATH + ".convert_to_sscanss_frame")
     def test_writes_header_and_one_line_per_orientation(self, mock_convert, mock_logger):
         mock_convert.return_value = (10.0, 20.0, 30.0)
         model = _make_model(orientations={0: _make_orientation(), 1: _make_orientation()})
@@ -73,7 +73,7 @@ class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
         for line in lines[1:]:
             self.assertEqual(line, "10.0\t20.0\t30.0")
 
-    @patch(file_path + ".convert_to_sscanss_frame")
+    @patch(FILE_PATH + ".convert_to_sscanss_frame")
     def test_rounds_angles_to_two_decimals(self, mock_convert, mock_logger):
         mock_convert.return_value = (1.23456, 2.34567, 3.45678)
         model = _make_model()
@@ -82,7 +82,7 @@ class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
 
         self.assertIn("1.23\t2.35\t3.46", content)
 
-    @patch(file_path + ".convert_to_sscanss_frame")
+    @patch(FILE_PATH + ".convert_to_sscanss_frame")
     def test_passes_rotation_matrix_to_convert(self, mock_convert, mock_logger):
         mock_convert.return_value = (0.0, 0.0, 0.0)
         R = Rotation.from_euler("x", 45, degrees=True)
@@ -92,7 +92,7 @@ class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
 
         np.testing.assert_allclose(mock_convert.call_args.args[0], R.as_matrix())
 
-    @patch(file_path + ".convert_to_sscanss_frame")
+    @patch(FILE_PATH + ".convert_to_sscanss_frame")
     def test_logs_notice_on_success(self, mock_convert, mock_logger):
         mock_convert.return_value = (0.0, 0.0, 0.0)
         model = _make_model()
@@ -103,7 +103,7 @@ class TestOrientationExporter_OutputAsSscanss(unittest.TestCase):
         self.assertIn(save_file, mock_logger.notice.call_args.args[0])
 
 
-@patch(file_path + ".logger")
+@patch(FILE_PATH + ".logger")
 class TestOrientationExporter_OutputAsMatrix(unittest.TestCase):
     def _run(self, model, filename="out"):
         with tempfile.TemporaryDirectory() as tmp:
@@ -140,7 +140,7 @@ class TestOrientationExporter_OutputAsMatrix(unittest.TestCase):
         self.assertIn(save_file, mock_logger.notice.call_args.args[0])
 
 
-@patch(file_path + ".logger")
+@patch(FILE_PATH + ".logger")
 class TestOrientationExporter_OutputAsEuler(unittest.TestCase):
     def _run(self, model, filename="out"):
         with tempfile.TemporaryDirectory() as tmp:
@@ -182,7 +182,7 @@ class TestOrientationExporter_OutputAsEuler(unittest.TestCase):
         self.assertEqual(len(content.splitlines()), 2)
 
 
-@patch(file_path + ".logger")
+@patch(FILE_PATH + ".logger")
 class TestOrientationExporter_OutputTransmissionWeighting(unittest.TestCase):
     def _run(self, model, filename="out"):
         with tempfile.TemporaryDirectory() as tmp:
@@ -280,7 +280,7 @@ class TestOrientationExporter_OutputTransmissionWeighting(unittest.TestCase):
         self.assertIn(save_file, mock_logger.notice.call_args.args[0])
 
 
-@patch(file_path + ".LoadEmptyInstrument")
+@patch(FILE_PATH + ".LoadEmptyInstrument")
 class TestOrientationExporter_BuildReferenceWs(unittest.TestCase):
     def test_loads_empty_instrument_into_reference_wsname(self, mock_load_instr):
         model = _make_model(instr="ENGINX")
@@ -302,9 +302,9 @@ class TestOrientationExporter_BuildReferenceWs(unittest.TestCase):
         model.workspaces.copy_sample_preserving_initial_rotation.assert_called_once_with("neutral", mock_load_instr.return_value)
 
 
-@patch(file_path + ".logger")
-@patch(file_path + ".ADS")
-@patch(file_path + ".SaveNexus")
+@patch(FILE_PATH + ".logger")
+@patch(FILE_PATH + ".ADS")
+@patch(FILE_PATH + ".SaveNexus")
 class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
     def _make_exporter(self):
         model = _make_model()

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -548,6 +548,24 @@ def save_texture_ws_ascii(ws: str, save_dir: str, StoreInADS: bool = False) -> N
         SaveAscii(InputWorkspace=ascii_ws, Filename=path.join(save_dir, ws + ".txt"), Separator="Tab")
 
 
+def convert_to_sscanss_frame(rot_mat: np.ndarray) -> np.ndarray:
+    # Define M: matrix to convert vectors from XYZ to ZXY
+    M = np.array(
+        [
+            [0, 0, 1],  # X in ZXY = Z in XYZ
+            [1, 0, 0],  # Y in ZXY = X in XYZ
+            [0, 1, 0],  # Z in ZXY = Y in XYZ
+        ]
+    )
+
+    # Apply the similarity transform to express R in XYZ frame
+    r_xyz = Rotation.from_matrix(M @ rot_mat @ M.T)
+
+    # Now extract Euler angles in XYZ axes (extrinsic or intrinsic as needed)
+    # minus is because the sense of rotation is the other way in sscanss
+    return -r_xyz.as_euler("xyz", degrees=True)
+
+
 # --------------------------------------------------------------#
 ##### TexturePlanner shared math/workspace helpers ############
 # --------------------------------------------------------------#

--- a/scripts/test/Engineering/texture/test_texture_helper.py
+++ b/scripts/test/Engineering/texture/test_texture_helper.py
@@ -35,6 +35,7 @@ from Engineering.texture.texture_helper import (
     vec_string_to_norm_array,
     define_gauge_volume,
     get_scattering_centre,
+    convert_to_sscanss_frame,
 )
 import numpy as np
 from os import path
@@ -906,6 +907,46 @@ class TestGetScatteringCentre(unittest.TestCase):
 
         np.testing.assert_array_equal(out, [0.0, 0.0, 0.0])
         mock_logger.warning.assert_called_once()
+
+
+class TestConvertToSscanssFrame(unittest.TestCase):
+    def test_identity_maps_to_zero_angles(self):
+        out = convert_to_sscanss_frame(np.eye(3))
+        self.assertEqual(out.shape, (3,))
+        np.testing.assert_allclose(out, [0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_rotation_about_z_maps_to_negated_x_angle(self):
+        # M sends XYZ z-axis onto the sscanss x-axis, so a rotation about z becomes a
+        # rotation about x; the sense is flipped so the angle is negated.
+        theta = 30.0
+        rot = Rotation.from_euler("z", theta, degrees=True).as_matrix()
+        out = convert_to_sscanss_frame(rot)
+        np.testing.assert_allclose(out, [-theta, 0.0, 0.0], atol=1e-9)
+
+    def test_rotation_about_x_maps_to_negated_y_angle(self):
+        # XYZ x-axis maps onto the sscanss y-axis
+        theta = 45.0
+        rot = Rotation.from_euler("x", theta, degrees=True).as_matrix()
+        out = convert_to_sscanss_frame(rot)
+        np.testing.assert_allclose(out, [0.0, -theta, 0.0], atol=1e-9)
+
+    def test_rotation_about_y_maps_to_negated_z_angle(self):
+        # XYZ y-axis maps onto the sscanss z-axis
+        theta = 60.0
+        rot = Rotation.from_euler("y", theta, degrees=True).as_matrix()
+        out = convert_to_sscanss_frame(rot)
+        np.testing.assert_allclose(out, [0.0, 0.0, -theta], atol=1e-9)
+
+    def test_result_is_a_valid_rotation_roundtrip(self):
+        # the returned Euler angles must describe the same physical rotation expressed in
+        # the permuted, sign-flipped sscanss frame
+        rot = Rotation.from_euler("xyz", [10.0, 20.0, 30.0], degrees=True).as_matrix()
+        angles = convert_to_sscanss_frame(rot)
+
+        M = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+        recovered = Rotation.from_euler("xyz", -angles, degrees=True).as_matrix()
+        expected = M @ rot @ M.T
+        np.testing.assert_allclose(recovered, expected, atol=1e-9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

**This module handles the logic for exporting the experiment information to various file formats and for loading into the Engineering Diffraction Interface**

_Part of the model logic for the Texture Experiment Planning Interface as part of the Texture Analysis Epic._ 

_The plan is that the interface is written as Model-View-Presenter but the model is modularised into a series of smaller helper models which are either called directly from the presenter for stand alone functionality or interact with each other via a parent model (for which all helpers own a `._model` reference)._ 

_By doing this each of the helper models can be reviewed and merged independently to hopefully keep PR sizes manageable._ 

_For the purpose of both type hinting and reviewing some `Protocol` classes have been written to the top of each helper file giving some broader context for what will be required from other parts of the code. These will be removed in the final PR and replaced with type hinting the actual implemented classes._

For more full context you can see #40961 for the full interface.

### To test:

This won't be user facing until the final PR so I think there is limited testing that can be done. As a result, there will not be a release note either (unless reviewer feels strongly that there should be one)

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
