### PR TITLE
Update AlignAndFocusPowderFromFiles to use new AlignAndFocusPowderSlim parameters

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -82,9 +82,7 @@ _SLIM_REQUIRED_PROPS = ["PrimaryFlightPath", "L2", "Polar"]
 # Properties that block use of AAFPSlim entirely
 _SLIM_BLOCKING_PROPS = [
     "AbsorptionWorkspace",
-    "CalibrationWorkspace",
     "OffsetsWorkspace",
-    "MaskWorkspace",
     "MaskBinTable",
     "ResampleX",
     "RemovePromptPulseWidth",
@@ -891,6 +889,12 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
             kwargs["GroupingWorkspace"] = self.getPropertyValue(GRP_WKSP)
         elif not self.getProperty(GROUP_FILE).isDefault:
             kwargs["GroupFilename"] = self.getPropertyValue(GROUP_FILE)
+
+        # calibration and mask workspaces take precedence over the contents of CalFileName in AAFPSlim
+        if not self.getProperty(CAL_WKSP).isDefault:
+            kwargs["CalibrationWorkspace"] = self.getPropertyValue(CAL_WKSP)
+        if not self.getProperty(MASK_WKSP).isDefault:
+            kwargs["MaskWorkspace"] = self.getPropertyValue(MASK_WKSP)
 
         # chunk size
         if not self.getProperty("MaxChunkSize").isDefault and self.chunkSize > 0.0:

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -277,6 +277,77 @@ class SavedNexusWithAllowSlimProcess(systemtesting.MantidSystemTest):
         return None
 
 
+def _slimAlgorithmRan(output_ws):
+    """Return True if AlignAndFocusPowderSlim appears anywhere in the history of *output_ws*.
+
+    AlignAndFocusPowderFromFiles records AlignAndFocusPowderSlim as a nested child when it
+    delegates to the fast path, so the history has to be searched recursively.
+    """
+
+    def _search(alg_history):
+        if alg_history.name() == "AlignAndFocusPowderSlim":
+            return True
+        for i in range(alg_history.childHistorySize()):
+            if _search(alg_history.getChildAlgorithmHistory(i)):
+                return True
+        return False
+
+    return any(_search(alg) for alg in mtd[output_ws].getHistory().getAlgorithmHistories())
+
+
+class AllowSlimProcessWithCalMask(systemtesting.MantidSystemTest):
+    """Verify that AlignAndFocusPowderFromFiles delegates to AlignAndFocusPowderSlim when using the CalibrationWorkspace and
+    MaskWorkspace inputs."""
+
+    cal_file = "PG3_FERNS_d4832_2011_08_24.cal"
+    data_file = "PG3_9829_event.nxs"
+
+    def cleanup(self):
+        return True
+
+    def requiredMemoryMB(self):
+        return 3 * 1024  # GiB
+
+    def requiredFiles(self):
+        return [self.cal_file, self.data_file]
+
+    def runTest(self):
+        input_ws = "cal_mask_slim_input"
+        output_ws = "cal_mask_slim_output"
+
+        # calibration table, mask and grouping workspaces all derived from the calibration file
+        LoadEventNexus(Filename=self.data_file, OutputWorkspace=input_ws, MetaDataOnly=True)
+        LoadDiffCal(Filename=self.cal_file, InputWorkspace=input_ws, WorkspaceName="PG3")
+
+        AlignAndFocusPowderFromFiles(
+            Filename=self.data_file,
+            OutputWorkspace=output_ws,
+            Params=(0.5, -0.004, 7),
+            Dspacing=True,
+            CalibrationWorkspace="PG3_cal",
+            MaskWorkspace="PG3_mask",
+            PrimaryFlightPath=60,
+            L2=3.18,
+            Polar=90,
+            Azimuthal=0,
+            PreserveEvents=False,
+            AllowSlimProcess=True,
+        )
+
+        self.assertTrue(AnalysisDataService.doesExist(output_ws), f"Expected output workspace '{output_ws}' to be created")
+        self.assertGreaterThan(mtd[output_ws].getNumberHistograms(), 0, "Expected output workspace to contain spectra")
+        self.assertTrue(
+            _slimAlgorithmRan(output_ws),
+            "Expected AlignAndFocusPowderFromFiles to delegate to AlignAndFocusPowderSlim, but it was not found in the history",
+        )
+
+    def validateMethod(self):
+        return None
+
+    def validate(self):
+        return None
+
+
 class CompressedCompare(systemtesting.MantidSystemTest):
     # this test is very similar to SNAPRedux.Simple
 

--- a/docs/source/release/v6.17.0/Diffraction/Powder/New_features/41734.rst
+++ b/docs/source/release/v6.17.0/Diffraction/Powder/New_features/41734.rst
@@ -1,1 +1,0 @@
-- :ref:`algm-AlignAndFocusPowderSlim` now accepts a ``CalibrationWorkspace`` and a ``MaskWorkspace``. When supplied, these take precedence over the corresponding information in ``CalFileName``.

--- a/docs/source/release/v7.0.0/Diffraction/Powder/New_features/41734.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Powder/New_features/41734.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-AlignAndFocusPowderSlim` now accepts a ``CalibrationWorkspace`` and a ``MaskWorkspace``. When supplied, these take precedence over the corresponding information in ``CalFileName``. :ref:`algm-AlignAndFocusPowderFromFiles` has been updated to pass these parameters to :ref:`algm-AlignAndFocusPowderSlim`.


### PR DESCRIPTION
### Description of work

This updates `AlignAndFocusPowderFromFiles` to use the new parameters added to `AlignAndFocusPowderSlim` in #41734


<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes [16688: Add parameters to AlignAndFocusPowderSlim](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/16688)

### To test:

Same as system test you can check that `AlignAndFocusPowderSlim` is executed
```python
cal_file = "PG3_FERNS_d4832_2011_08_24.cal"
data_file = "PG3_9829_event.nxs"

input_ws = "cal_mask_slim_input"
output_ws = "cal_mask_slim_output"

LoadEventNexus(Filename=data_file, OutputWorkspace=input_ws, MetaDataOnly=True)
LoadDiffCal(Filename=cal_file, InputWorkspace=input_ws, WorkspaceName="PG3")

AlignAndFocusPowderFromFiles(
            Filename=data_file,
            OutputWorkspace=output_ws,
            Params=(0.5, -0.004, 7),
            Dspacing=True,
            CalibrationWorkspace="PG3_cal",
            MaskWorkspace="PG3_mask",
            PrimaryFlightPath=60,
            L2=3.18,
            Polar=90,
            Azimuthal=0,
            PreserveEvents=False,
            AllowSlimProcess=True,
)
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
