### PR TITLE
Fixed sliceviewer not showing data in non-orthogonal view when L is selected as one of projection axes

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/SliceViewer/Bugfixes/39593.rst
+++ b/docs/source/release/v7.0.0/Workbench/SliceViewer/Bugfixes/39593.rst
@@ -1,0 +1,1 @@
+- Fixed an issue of :ref:`SliceViewer <sliceviewer>` not showing data in non-orthogonal view when L is selected as one of the project axes by setting proper limits for the axes.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -13,6 +13,7 @@ from mantidqt.widgets.sliceviewer.views.dataview import SliceViewerDataView
 from mantidqt.widgets.sliceviewer.views.dataviewsubscriber import IDataViewSubscriber
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.presenters.masking import Masking
+import numpy as np
 
 
 class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
@@ -44,9 +45,11 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         """
         if auto_transform and self._data_view.nonorthogonal_mode:
             to_display = self._data_view.nonortho_transform.tr
-            xmin_p, ymin_p = to_display(xlim[0], ylim[0])
-            xmax_p, ymax_p = to_display(xlim[1], ylim[1])
-            xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
+            x = np.array([xlim[0], xlim[0], xlim[1], xlim[1]])
+            y = np.array([ylim[0], ylim[1], ylim[0], ylim[1]])
+            x_p, y_p = to_display(x, y)
+            xlim = (float(np.min(x_p)), float(np.max(x_p)))
+            ylim = (float(np.min(y_p)), float(np.max(y_p)))
 
         self._data_view.set_axes_limits(xlim, ylim)
         self.data_limits_changed()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -123,6 +123,24 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
 
         new_plot_mock.assert_not_called()
 
+    def test_set_axes_limits_transforms_all_four_corners_for_nonorthogonal_view(self):
+        data_view_mock = mock.Mock()
+        data_view_mock.nonorthogonal_mode = True
+
+        class Transform:
+            def tr(self, x, y):
+                return x + 2 * y, 3 * y
+
+        data_view_mock.nonortho_transform = Transform()
+        data_view_mock.set_axes_limits = mock.Mock()
+        presenter = SliceViewerBasePresenterShim(None, model=mock.Mock(), data_view=data_view_mock)
+        presenter.new_plot = mock.Mock()
+
+        presenter.set_axes_limits((-1, 1), (-2, 2))
+
+        data_view_mock.set_axes_limits.assert_called_once_with((-5.0, 5.0), (-6.0, 6.0))
+        presenter.new_plot.assert_called_once()
+
     def test_request_to_show_all_data_sets_correct_limits_on_view_MD(self):
         model_mock = mock.Mock()
         data_view_mock = mock.Mock()


### PR DESCRIPTION
### Description of work
This PR fixes an issue in Sliceviewer not showing data in non-orthogonal view when L is selected as one of the projectsion axes. 

The issue was due to setting incorrect limits for the X and Y axes to show the data as was fixed by selecting limits by comparing the corresponding transformed values for the 4 corners or the orthoganal view.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #39593. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Code review.
2. run the below code snippet
```python
Load(Filename='SXD23767.raw', OutputWorkspace='SXD23767')
FindSXPeaks(InputWorkspace='SXD23767', PeakFindingStrategy='AllPeaks', AbsoluteBackground=3.25, ResolutionStrategy='AbsoluteResolution', XResolution=0.10000000000000001, PhiResolution=2, TwoThetaResolution=2, MinNBinsPerPeak=2, OutputWorkspace='peaks')
FindUBUsingFFT(PeaksWorkspace='peaks', MinD=1, MaxD=20)
CopySample(InputWorkspace='peaks', OutputWorkspace='SXD23767', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputWorkspace='SXD23767_HKL', OneEventPerBin=False, OutputDimensions='HKL')
```
3. open `SXD23767_HKL` in sliceviewer
4. select L as one of the project axes
5. click non-orthogonal view
6. Data should be visible


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
