### PR TITLE
Fix coverity warnings refl

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -121,6 +121,9 @@ public:
       }
     }
 
+    if constexpr (DependentVars < 2)
+      return covariance;
+
     // Preserve supplied dependent variances on the diagonal. Only dependent-dependent off-diagonal terms are inferred.
     for (size_t depA = 0; depA < DependentVars; ++depA) {
       const size_t depAIndex = IndependentVars + depA;

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -473,7 +473,7 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::postReductionProcessing(con
   } else {
     g_log.error("NRCalculateSlitResolution failed. Workspace in Q will not be "
                 "rebinned. Please provide dQ/Q.");
-    binnedWS = IvsQC;
+    binnedWS = std::move(IvsQC);
   }
   return binnedWS;
 }
@@ -906,7 +906,7 @@ ReflectometryReductionOneAuto3::processGroupMembers(const Algorithm::WorkspaceVe
       allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder));
     }
   }
-  return {.rroOutputs = allRROOutputs, .outputNames = allOutputNames};
+  return {.rroOutputs = std::move(allRROOutputs), .outputNames = std::move(allOutputNames)};
 }
 
 std::vector<std::string> ReflectometryReductionOneAuto3::getTaskExecutionOrder(const bool reduced,

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -646,7 +646,7 @@ void ReflectometryReductionOneAuto3::determineCorrectionAlgorithm(const Instrume
   } else {
     corrProps.type = "None";
   }
-  m_correctionProperties = corrProps;
+  m_correctionProperties = std::move(corrProps);
 }
 
 /** Set algorithmic correction properties
@@ -900,10 +900,10 @@ ReflectometryReductionOneAuto3::processGroupMembers(const Algorithm::WorkspaceVe
     if (reduced) {
       const auto &origProcessingInstructions = getPropertyValue("ProcessingInstructions");
       setPropertyValue("ProcessingInstructions", convertToSpectrumNumber("0", matrixWs));
-      allRROOutputs.push_back(performCoreReduction(matrixWs, taskOrder, false));
+      allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder, false));
       setPropertyValue("ProcessingInstructions", origProcessingInstructions);
     } else {
-      allRROOutputs.push_back(performCoreReduction(matrixWs, taskOrder));
+      allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder));
     }
   }
   return {.rroOutputs = allRROOutputs, .outputNames = allOutputNames};

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -17,6 +17,7 @@
 #include "MantidQtWidgets/Common/IMessageHandler.h"
 #include "Reduction/RowExceptions.h"
 #include <memory>
+#include <stdexcept>
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Batch Presenter");
@@ -44,7 +45,7 @@ BatchPresenter::BatchPresenter(
     std::unique_ptr<IExperimentPresenter> experimentPresenter,
     std::unique_ptr<IInstrumentPresenter> instrumentPresenter, std::unique_ptr<ISavePresenter> savePresenter,
     std::unique_ptr<IPreviewPresenter> previewPresenter, MantidQt::MantidWidgets::IMessageHandler *messageHandler)
-    : m_view(view), m_model(std::move(model)), m_mainPresenter(), m_runsPresenter(std::move(runsPresenter)),
+    : m_view(view), m_model(std::move(model)), m_mainPresenter(nullptr), m_runsPresenter(std::move(runsPresenter)),
       m_eventPresenter(std::move(eventPresenter)), m_experimentPresenter(std::move(experimentPresenter)),
       m_instrumentPresenter(std::move(instrumentPresenter)), m_savePresenter(std::move(savePresenter)),
       m_previewPresenter(std::move(previewPresenter)), m_unsavedBatchFlag(false), m_jobRunner(std::move(jobRunner)),
@@ -72,6 +73,13 @@ BatchPresenter::BatchPresenter(
  */
 void BatchPresenter::acceptMainPresenter(IMainWindowPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IMainWindowPresenter &BatchPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("BatchPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 std::string BatchPresenter::initInstrumentList(const std::string &selectedInstrument) {
   return m_runsPresenter->initInstrumentList(selectedInstrument);
 }
@@ -79,7 +87,7 @@ std::string BatchPresenter::initInstrumentList(const std::string &selectedInstru
 bool BatchPresenter::requestClose() const { return true; }
 
 void BatchPresenter::notifyChangeInstrumentRequested(const std::string &instrumentName) {
-  m_mainPresenter->notifyChangeInstrumentRequested(instrumentName);
+  mainPresenter().notifyChangeInstrumentRequested(instrumentName);
 }
 
 void BatchPresenter::notifyInstrumentChanged(const std::string &instrumentName) {
@@ -88,7 +96,7 @@ void BatchPresenter::notifyInstrumentChanged(const std::string &instrumentName) 
   m_instrumentPresenter->notifyInstrumentChanged(instrumentName);
 }
 
-void BatchPresenter::notifyUpdateInstrumentRequested() { m_mainPresenter->notifyUpdateInstrumentRequested(); }
+void BatchPresenter::notifyUpdateInstrumentRequested() { mainPresenter().notifyUpdateInstrumentRequested(); }
 
 void BatchPresenter::notifySettingsChanged() { settingsChanged(); }
 
@@ -188,8 +196,8 @@ void BatchPresenter::resumeReduction() {
   m_jobManager->notifyReductionResumed();
   // Get the algorithms to process
   auto algorithms = m_jobManager->getAlgorithms();
-  if (algorithms.size() < 1 || (m_jobManager->getProcessAll() && m_mainPresenter->isProcessAllPrevented()) ||
-      (m_jobManager->getProcessPartial() && m_mainPresenter->isProcessPartialGroupPrevented())) {
+  if (algorithms.size() < 1 || (m_jobManager->getProcessAll() && mainPresenter().isProcessAllPrevented()) ||
+      (m_jobManager->getProcessPartial() && mainPresenter().isProcessPartialGroupPrevented())) {
     notifyReductionPaused();
     return;
   }
@@ -206,7 +214,7 @@ void BatchPresenter::notifyReductionResumed() {
   m_experimentPresenter->notifyReductionResumed();
   m_instrumentPresenter->notifyReductionResumed();
   m_runsPresenter->notifyReductionResumed();
-  m_mainPresenter->notifyAnyBatchReductionResumed();
+  mainPresenter().notifyAnyBatchReductionResumed();
 }
 
 void BatchPresenter::pauseReduction() { m_jobRunner->cancelAlgorithmQueue(); }
@@ -221,7 +229,7 @@ void BatchPresenter::notifyReductionPaused() {
   m_experimentPresenter->notifyReductionPaused();
   m_instrumentPresenter->notifyReductionPaused();
   m_runsPresenter->notifyReductionPaused();
-  m_mainPresenter->notifyAnyBatchReductionPaused();
+  mainPresenter().notifyAnyBatchReductionPaused();
   // If autoreducing, notify
   if (isAutoreducing())
     notifyAutoreductionCompleted();
@@ -255,7 +263,7 @@ void BatchPresenter::notifyAutoreductionResumed() {
   m_runsPresenter->notifyAutoreductionResumed();
 
   m_runsPresenter->notifyRowStateChanged();
-  m_mainPresenter->notifyAnyBatchAutoreductionResumed();
+  mainPresenter().notifyAnyBatchAutoreductionResumed();
 }
 
 void BatchPresenter::pauseAutoreduction() {
@@ -276,7 +284,7 @@ void BatchPresenter::notifyAutoreductionPaused() {
   m_instrumentPresenter->notifyAutoreductionPaused();
   m_runsPresenter->notifyAutoreductionPaused();
 
-  m_mainPresenter->notifyAnyBatchAutoreductionPaused();
+  mainPresenter().notifyAnyBatchAutoreductionPaused();
 }
 
 void BatchPresenter::autoreductionCompleted() {
@@ -303,9 +311,9 @@ void BatchPresenter::notifyRunsTransferred() {
   m_runsPresenter->notifyRowModelChanged();
 }
 
-Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
+Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return mainPresenter().instrument(); }
 
-std::string BatchPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }
+std::string BatchPresenter::instrumentName() const { return mainPresenter().instrumentName(); }
 
 void BatchPresenter::settingsChanged() {
   setBatchUnsaved();
@@ -331,19 +339,19 @@ bool BatchPresenter::isAutoreducing() const { return m_jobManager->isAutoreducin
    * i.e. whether we are polling for new runs
    * @return : Bool on whether data is being processed
    */
-bool BatchPresenter::isAnyBatchProcessing() const { return m_mainPresenter->isAnyBatchProcessing(); }
+bool BatchPresenter::isAnyBatchProcessing() const { return mainPresenter().isAnyBatchProcessing(); }
 
 /**
    Checks whether or not autoprocessing is currently running in any batch
    * i.e. whether we are polling for new runs
    * @return : Bool on whether data is being autoprocessed
    */
-bool BatchPresenter::isAnyBatchAutoreducing() const { return m_mainPresenter->isAnyBatchAutoreducing(); }
+bool BatchPresenter::isAnyBatchAutoreducing() const { return mainPresenter().isAnyBatchAutoreducing(); }
 
-bool BatchPresenter::isOverwriteBatchPrevented() const { return m_mainPresenter->isOverwriteBatchPrevented(this); }
+bool BatchPresenter::isOverwriteBatchPrevented() const { return mainPresenter().isOverwriteBatchPrevented(this); }
 
 bool BatchPresenter::discardChanges(std::string const &message) const {
-  return m_mainPresenter->discardChanges(message);
+  return mainPresenter().discardChanges(message);
 }
 
 /** Returns whether there are any unsaved changes in the current batch */
@@ -429,7 +437,7 @@ std::optional<ProcessingInstructions> BatchPresenter::getMatchingROIDetectorIDsF
 }
 
 std::string BatchPresenter::getBatchState(const std::vector<std::string> &jsonKey) const {
-  return m_mainPresenter->encodeBatchToStr(jsonKey);
+  return mainPresenter().encodeBatchToStr(jsonKey);
 }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -45,7 +45,7 @@ BatchPresenter::BatchPresenter(
     std::unique_ptr<IExperimentPresenter> experimentPresenter,
     std::unique_ptr<IInstrumentPresenter> instrumentPresenter, std::unique_ptr<ISavePresenter> savePresenter,
     std::unique_ptr<IPreviewPresenter> previewPresenter, MantidQt::MantidWidgets::IMessageHandler *messageHandler)
-    : m_view(view), m_model(std::move(model)), m_mainPresenter(nullptr), m_runsPresenter(std::move(runsPresenter)),
+    : m_view(view), m_model(std::move(model)), m_runsPresenter(std::move(runsPresenter)),
       m_eventPresenter(std::move(eventPresenter)), m_experimentPresenter(std::move(experimentPresenter)),
       m_instrumentPresenter(std::move(instrumentPresenter)), m_savePresenter(std::move(savePresenter)),
       m_previewPresenter(std::move(previewPresenter)), m_unsavedBatchFlag(false), m_jobRunner(std::move(jobRunner)),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -106,6 +106,8 @@ public:
   void clearADSHandle() override;
 
 private:
+  IMainWindowPresenter &mainPresenter() const;
+
   bool startBatch(std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> algorithms);
   void resumeReduction();
   void notifyReductionResumed();
@@ -119,7 +121,7 @@ private:
 
   IBatchView *m_view;
   std::unique_ptr<IBatch> m_model;
-  IMainWindowPresenter *m_mainPresenter;
+  IMainWindowPresenter *m_mainPresenter{nullptr};
   std::unique_ptr<IRunsPresenter> m_runsPresenter;
   std::unique_ptr<IEventPresenter> m_eventPresenter;
   std::unique_ptr<IExperimentPresenter> m_experimentPresenter;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -51,7 +51,7 @@ std::vector<std::string> suffixesFromFirstInputWorkspaceGroup(Group const &group
     if (!row)
       continue;
 
-    auto const groupWSName = row->reducedWorkspaceNames().iVsQ();
+    auto const &groupWSName = row->reducedWorkspaceNames().iVsQ();
     if (!ads.doesExist(groupWSName))
       continue;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -68,7 +68,7 @@ void Decoder::decodeBatch(const IMainWindowView *mwv, int batchIndex, const QMap
   auto runsPresenter = dynamic_cast<RunsPresenter *>(batchPresenter->m_runsPresenter.get());
   auto runsTablePresenter = dynamic_cast<RunsTablePresenter *>(runsPresenter->m_tablePresenter.get());
   auto reductionJobs = &runsTablePresenter->m_model.m_reductionJobs;
-  auto destinationPrecision = batchPresenter->m_mainPresenter->roundPrecision();
+  auto destinationPrecision = batchPresenter->mainPresenter().roundPrecision();
   auto searcher = dynamic_cast<QtCatalogSearcher *>(runsPresenter->m_searcher.get());
   // We must do the Runs tab first because this sets the instrument, which
   // other settings may need to be correct. There is also a notification to set

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -11,6 +11,7 @@
 #include "IEventView.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include <boost/algorithm/string.hpp>
+#include <stdexcept>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -23,40 +24,47 @@ EventPresenter::EventPresenter(IEventView *view) : m_view(view), m_sliceType(Sli
 
 void EventPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IBatchPresenter &EventPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("EventPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 Slicing const &EventPresenter::slicing() const { return m_slicing; }
 
 void EventPresenter::notifyUniformSliceCountChanged(int) {
   if (m_sliceType == SliceType::UniformEven) {
     setUniformSlicingByNumberOfSlicesFromView();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
   }
 }
 
 void EventPresenter::notifyUniformSecondsChanged(double) {
   if (m_sliceType == SliceType::Uniform) {
     setUniformSlicingByTimeFromView();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
   }
 }
 
 void EventPresenter::notifyCustomSliceValuesChanged(std::string) {
   if (m_sliceType == SliceType::Custom) {
     setCustomSlicingFromView();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
   }
 }
 
 void EventPresenter::notifyLogSliceBreakpointsChanged(std::string) {
   if (m_sliceType == SliceType::LogValue) {
     setLogValueSlicingFromView();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
   }
 }
 
 void EventPresenter::notifyLogBlockNameChanged(std::string) {
   if (m_sliceType == SliceType::LogValue) {
     setLogValueSlicingFromView();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
   }
 }
 
@@ -65,7 +73,7 @@ void EventPresenter::notifySliceTypeChanged(SliceType newSliceType) {
   m_view->enableSliceType(newSliceType);
   m_sliceType = newSliceType;
   setSlicingFromView();
-  m_mainPresenter->notifySettingsChanged();
+  mainPresenter().notifySettingsChanged();
 }
 
 /** Tells the view to update the enabled/disabled state of all relevant
@@ -150,7 +158,7 @@ void EventPresenter::setSlicingFromView() {
 
 GNU_DIAG_ON("maybe-uninitialized")
 
-bool EventPresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool EventPresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool EventPresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool EventPresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
@@ -40,8 +40,9 @@ public:
   Slicing const &slicing() const override;
 
 private:
-  IBatchPresenter *m_mainPresenter;
+  IBatchPresenter *m_mainPresenter{nullptr};
   Slicing m_slicing;
+  IBatchPresenter &mainPresenter() const;
   void setUniformSlicingByNumberOfSlicesFromView();
   void setUniformSlicingByTimeFromView();
   void setCustomSlicingFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -12,6 +12,7 @@
 #include "Reduction/ParseReflectometryStrings.h"
 #include "Reduction/PreviewRow.h"
 #include "Reduction/RowExceptions.h"
+#include <stdexcept>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 // unnamed namespace
@@ -29,17 +30,24 @@ ExperimentPresenter::ExperimentPresenter(IExperimentView *view, Experiment exper
 
 void ExperimentPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IBatchPresenter &ExperimentPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("ExperimentPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 Experiment const &ExperimentPresenter::experiment() const { return m_model; }
 
 void ExperimentPresenter::notifySettingsChanged() {
   updateModelFromView();
   showValidationResult();
-  m_mainPresenter->notifySettingsChanged();
+  mainPresenter().notifySettingsChanged();
 }
 
 void ExperimentPresenter::notifyRestoreDefaultsRequested() {
   // Trigger a reload of the instrument to get up-to-date settings.
-  m_mainPresenter->notifyUpdateInstrumentRequested();
+  mainPresenter().notifyUpdateInstrumentRequested();
   restoreDefaults();
 }
 
@@ -68,12 +76,12 @@ void ExperimentPresenter::notifyRemoveLookupRowRequested(int index) {
 void ExperimentPresenter::notifyLookupRowChanged(int /*row*/, int /*column*/) {
   updateModelFromView();
   showValidationResult();
-  m_mainPresenter->notifySettingsChanged();
+  mainPresenter().notifySettingsChanged();
 }
 
-bool ExperimentPresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool ExperimentPresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool ExperimentPresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool ExperimentPresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 
 /** Tells the view to update the enabled/disabled state of all relevant
  * widgets based on whether processing is in progress or not.
@@ -133,7 +141,7 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
 
     m_model.updateLookupRow(std::move(lookupRowCopy), m_thetaTolerance);
     updateViewFromModel();
-    m_mainPresenter->notifySettingsChanged();
+    mainPresenter().notifySettingsChanged();
     g_log.information("Updated experiment settings applied from preview.");
   } else {
     throw RowNotFoundException("There is no row with angle matching '" + std::to_string(previewRow.theta()) +
@@ -148,7 +156,7 @@ void ExperimentPresenter::updateLookupRowProcessingInstructions(PreviewRow const
 }
 
 void ExperimentPresenter::restoreDefaults() {
-  auto const instrument = m_mainPresenter->instrument();
+  auto const instrument = mainPresenter().instrument();
   try {
     m_model = m_experimentDefaults->get(instrument);
   } catch (std::invalid_argument &ex) {
@@ -242,7 +250,7 @@ void ExperimentPresenter::updatePolarizationCorrectionEnabledState() {
   // We could generalise which instruments polarization corrections are
   // applicable for but for now it's not worth it, so just hard code the
   // instrument names.
-  auto const &instrumentName = m_mainPresenter->instrumentName();
+  auto const &instrumentName = mainPresenter().instrumentName();
   if (instrumentName == "INTER" || instrumentName == "SURF") {
     m_view->setPolarizationCorrectionOption("None");
     m_view->disablePolarizationCorrections();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -75,8 +75,9 @@ protected:
   std::unique_ptr<IExperimentOptionDefaults> m_experimentDefaults;
 
 private:
-  IBatchPresenter *m_mainPresenter;
+  IBatchPresenter *m_mainPresenter{nullptr};
 
+  IBatchPresenter &mainPresenter() const;
   ExperimentValidationResult validateExperimentFromView();
   BackgroundSubtraction backgroundSubtractionFromView();
   PolarizationCorrections polarizationCorrectionsFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -9,6 +9,7 @@
 #include "InstrumentOptionDefaults.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include <ostream>
+#include <stdexcept>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -33,14 +34,21 @@ InstrumentPresenter::InstrumentPresenter(IInstrumentView *view, Instrument instr
 
 void InstrumentPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IBatchPresenter &InstrumentPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("InstrumentPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 void InstrumentPresenter::notifySettingsChanged() {
   updateModelFromView();
-  m_mainPresenter->notifySettingsChanged();
+  mainPresenter().notifySettingsChanged();
 }
 
 void InstrumentPresenter::notifyRestoreDefaultsRequested() {
   // Trigger a reload of the instrument to get up-to-date settings.
-  m_mainPresenter->notifyUpdateInstrumentRequested();
+  mainPresenter().notifyUpdateInstrumentRequested();
   restoreDefaults();
 }
 
@@ -53,9 +61,9 @@ void InstrumentPresenter::notifyBrowseToCalibrationFileRequested() {
 
 Instrument const &InstrumentPresenter::instrument() const { return m_model; }
 
-bool InstrumentPresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool InstrumentPresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool InstrumentPresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool InstrumentPresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 
 /** Tells the view to update the enabled/disabled state of all widgets
  * depending on whether they are currently applicable or not
@@ -119,7 +127,7 @@ void InstrumentPresenter::notifyInstrumentChanged(std::string const &instrumentN
 }
 
 void InstrumentPresenter::restoreDefaults() {
-  auto const instr = m_mainPresenter->instrument();
+  auto const instr = mainPresenter().instrument();
   try {
     m_model = m_instrumentDefaults->get(instr);
   } catch (std::invalid_argument &ex) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -53,10 +53,11 @@ protected:
 private:
   IInstrumentView *m_view;
   Instrument m_model;
-  IBatchPresenter *m_mainPresenter;
+  IBatchPresenter *m_mainPresenter{nullptr};
   IFileHandler *m_fileHandler;
   IReflMessageHandler *m_messageHandler;
 
+  IBatchPresenter &mainPresenter() const;
   std::optional<RangeInLambda> wavelengthRangeFromView();
   std::optional<RangeInLambda> monitorBackgroundRangeFromView();
   std::optional<RangeInLambda> monitorIntegralRangeFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -19,6 +19,7 @@
 #include "ROIType.h"
 #include "Reduction/RowExceptions.h"
 #include <memory>
+#include <stdexcept>
 
 using Mantid::API::MatrixWorkspace_sptr;
 using MantidQt::MantidWidgets::AxisID;
@@ -70,6 +71,13 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
 
 void PreviewPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IBatchPresenter &PreviewPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("PreviewPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 void PreviewPresenter::notifyReductionResumed() { updateWidgetEnabledState(); }
 
 void PreviewPresenter::notifyReductionPaused() { updateWidgetEnabledState(); }
@@ -81,7 +89,7 @@ void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState();
 void PreviewPresenter::notifySetYAxisSymlogChanged() { updatePlotAxes(); }
 
 void PreviewPresenter::updateWidgetEnabledState() {
-  if (m_mainPresenter->isProcessing() || m_mainPresenter->isAutoreducing()) {
+  if (mainPresenter().isProcessing() || mainPresenter().isAutoreducing()) {
     m_view->disableMainWidget();
   } else {
     m_view->enableMainWidget();
@@ -260,7 +268,7 @@ void PreviewPresenter::notifyLinePlotExportAdsRequested() { m_model->exportReduc
 
 void PreviewPresenter::notifyApplyRequested() {
   try {
-    m_mainPresenter->notifyPreviewApplyRequested();
+    mainPresenter().notifyPreviewApplyRequested();
   } catch (InvalidTableException const &ex) {
     std::ostringstream msg;
     msg << "Could not update Experiment Settings: ";
@@ -292,7 +300,7 @@ void PreviewPresenter::plotRegionSelector() {
 
   // If there are matching experiment settings already then add region selectors to
   // display these on the plot
-  auto const roiMap = m_mainPresenter->getMatchingProcessingInstructionsForPreviewRow();
+  auto const roiMap = mainPresenter().getMatchingProcessingInstructionsForPreviewRow();
   if (!roiMap.empty()) {
     clearRegionSelector();
   }
@@ -334,7 +342,7 @@ void PreviewPresenter::runSumBanks(bool const addExistingROIsToPlot) {
   // Ensure the angle is up to date so that we can check for matching experiment settings lookup rows
   m_model->setTheta(m_view->getAngle());
 
-  auto const &expSettingsDetectorROI = m_mainPresenter->getMatchingROIDetectorIDsForPreviewRow();
+  auto const &expSettingsDetectorROI = mainPresenter().getMatchingROIDetectorIDsForPreviewRow();
   if (m_plotExistingROIs) {
     auto const selectedDetectorsOnPlot = m_dockedWidgets->getSelectedDetectorIDs();
     if (selectedDetectorsOnPlot.empty()) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -110,6 +110,7 @@ private:
   bool m_plotExistingROIs = false;
 
   void updateWidgetEnabledState();
+  IBatchPresenter &mainPresenter() const;
   void updateSelectedRegionInModelFromView();
   void updateRegionSelectorWorkspace();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -50,8 +50,8 @@ RunsPresenter::RunsPresenter(IRunsView *mainView, ProgressableView *progressable
                              IFileHandler *fileHandler)
     : m_runNotifier(std::make_unique<CatalogRunNotifier>(mainView)),
       m_searcher(std::make_unique<QtCatalogSearcher>(mainView)), m_view(mainView), m_progressView(progressableView),
-      m_mainPresenter(nullptr), m_messageHandler(messageHandler), m_fileHandler(fileHandler),
-      m_instruments(std::move(instruments)), m_thetaTolerance(thetaTolerance), m_tableUnsaved{false} {
+      m_messageHandler(messageHandler), m_fileHandler(fileHandler), m_instruments(std::move(instruments)),
+      m_thetaTolerance(thetaTolerance), m_tableUnsaved{false} {
 
   assert(m_view != nullptr);
   m_view->subscribe(this);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -18,6 +18,7 @@
 #include "QtCatalogSearcher.h"
 
 #include <algorithm>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -71,6 +72,13 @@ RunsPresenter::~RunsPresenter() {
  * @param mainPresenter :: [input] A main presenter
  */
 void RunsPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
+
+IBatchPresenter &RunsPresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("RunsPresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
 
 /** Initialise the list of available instruments.
  * @param selectedInstrument : Optional name of an instrument to try and select from the list.
@@ -136,7 +144,7 @@ void RunsPresenter::notifyChangeInstrumentRequested() {
   if (changeInstrumentPrevented(newName))
     m_view->setSearchInstrument(instrumentName());
   else
-    m_mainPresenter->notifyChangeInstrumentRequested(newName);
+    mainPresenter().notifyChangeInstrumentRequested(newName);
 }
 
 void RunsPresenter::notifyExportSearchResults() const {
@@ -172,17 +180,17 @@ bool RunsPresenter::notifyChangeInstrumentRequested(std::string const &instrumen
   if (changeInstrumentPrevented(instrumentName))
     return false;
 
-  m_mainPresenter->notifyChangeInstrumentRequested(instrumentName);
+  mainPresenter().notifyChangeInstrumentRequested(instrumentName);
   return true;
 }
 
-void RunsPresenter::notifyResumeReductionRequested() { m_mainPresenter->notifyResumeReductionRequested(); }
+void RunsPresenter::notifyResumeReductionRequested() { mainPresenter().notifyResumeReductionRequested(); }
 
-void RunsPresenter::notifyPauseReductionRequested() { m_mainPresenter->notifyPauseReductionRequested(); }
+void RunsPresenter::notifyPauseReductionRequested() { mainPresenter().notifyPauseReductionRequested(); }
 
-void RunsPresenter::notifyResumeAutoreductionRequested() { m_mainPresenter->notifyResumeAutoreductionRequested(); }
+void RunsPresenter::notifyResumeAutoreductionRequested() { mainPresenter().notifyResumeAutoreductionRequested(); }
 
-void RunsPresenter::notifyPauseAutoreductionRequested() { m_mainPresenter->notifyPauseAutoreductionRequested(); }
+void RunsPresenter::notifyPauseAutoreductionRequested() { mainPresenter().notifyPauseAutoreductionRequested(); }
 
 void RunsPresenter::notifyStartMonitor() { startMonitor(); }
 
@@ -315,14 +323,14 @@ void RunsPresenter::notifyInstrumentChanged(std::string const &instrumentName) {
   tablePresenter()->notifyInstrumentChanged(instrumentName);
 }
 
-std::string RunsPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }
+std::string RunsPresenter::instrumentName() const { return mainPresenter().instrumentName(); }
 
 void RunsPresenter::notifyTableChanged() { m_tableUnsaved = true; }
 
-void RunsPresenter::notifyRowContentChanged(Row &changedRow) { m_mainPresenter->notifyRowContentChanged(changedRow); }
+void RunsPresenter::notifyRowContentChanged(Row &changedRow) { mainPresenter().notifyRowContentChanged(changedRow); }
 
 void RunsPresenter::notifyGroupNameChanged(Group &changedGroup) {
-  m_mainPresenter->notifyGroupNameChanged(changedGroup);
+  mainPresenter().notifyGroupNameChanged(changedGroup);
 }
 
 void RunsPresenter::settingsChanged() { tablePresenter()->settingsChanged(); }
@@ -382,16 +390,16 @@ void RunsPresenter::autoreduceNewRuns() {
   if (rowsToTransfer.size() > 0)
     transfer(rowsToTransfer, TransferMatch::Strict);
 
-  m_mainPresenter->notifyResumeReductionRequested();
+  mainPresenter().notifyResumeReductionRequested();
 }
 
-bool RunsPresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool RunsPresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool RunsPresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool RunsPresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 
-bool RunsPresenter::isAnyBatchProcessing() const { return m_mainPresenter->isAnyBatchProcessing(); }
+bool RunsPresenter::isAnyBatchProcessing() const { return mainPresenter().isAnyBatchProcessing(); }
 
-bool RunsPresenter::isAnyBatchAutoreducing() const { return m_mainPresenter->isAnyBatchAutoreducing(); }
+bool RunsPresenter::isAnyBatchAutoreducing() const { return mainPresenter().isAnyBatchAutoreducing(); }
 
 bool RunsPresenter::changeInstrumentPrevented(std::string const &newName) const {
   return newName != instrumentName() && overwriteSearchResultsPrevented();
@@ -400,20 +408,19 @@ bool RunsPresenter::changeInstrumentPrevented(std::string const &newName) const 
 bool RunsPresenter::hasUnsavedChanges() const { return m_tableUnsaved || m_searcher->hasUnsavedChanges(); }
 
 bool RunsPresenter::overwriteSearchResultsAndTablePrevented() const {
-  return hasUnsavedChanges() &&
-         !m_mainPresenter->discardChanges("This will cause unsaved changes in the search results "
-                                          "and main table to be lost. Continue?");
+  return hasUnsavedChanges() && !mainPresenter().discardChanges("This will cause unsaved changes in the search results "
+                                                                "and main table to be lost. Continue?");
 }
 
 bool RunsPresenter::overwriteTablePrevented() const {
-  return m_tableUnsaved && !m_mainPresenter->discardChanges("This will cause unsaved changes in "
-                                                            "the table to be lost. Continue?");
+  return m_tableUnsaved && !mainPresenter().discardChanges("This will cause unsaved changes in "
+                                                           "the table to be lost. Continue?");
 }
 
 bool RunsPresenter::overwriteSearchResultsPrevented() const {
   return m_searcher->hasUnsavedChanges() &&
-         !m_mainPresenter->discardChanges("This will cause unsaved changes in the search results to be "
-                                          "lost. Continue?");
+         !mainPresenter().discardChanges("This will cause unsaved changes in the search results to be "
+                                         "lost. Continue?");
 }
 
 bool RunsPresenter::searchInProgress() const { return m_searcher->searchInProgress(); }
@@ -422,11 +429,7 @@ SearchCriteria RunsPresenter::searchCriteria() const {
   return SearchCriteria{m_view->getSearchInstrument(), m_view->getSearchCycle(), m_view->getSearchString()};
 }
 
-int RunsPresenter::percentComplete() const {
-  if (!m_mainPresenter)
-    return 0;
-  return m_mainPresenter->percentComplete();
-}
+int RunsPresenter::percentComplete() const { return mainPresenter().percentComplete(); }
 
 void RunsPresenter::setRoundPrecision(int &precision) { m_tablePresenter->setTablePrecision(precision); }
 
@@ -487,7 +490,7 @@ void RunsPresenter::transfer(const std::set<int> &rowsToTransfer, const Transfer
     }
 
     tablePresenter()->mergeAdditionalJobs(jobs);
-    m_mainPresenter->notifyRunsTransferred();
+    mainPresenter().notifyRunsTransferred();
   }
 }
 
@@ -518,8 +521,8 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
-  auto options = m_mainPresenter->rowProcessingPropertiesDefault();
-  auto experimentState = m_mainPresenter->getBatchState({"experimentView", "perAngleDefaults", "rows"});
+  auto options = mainPresenter().rowProcessingPropertiesDefault();
+  auto experimentState = mainPresenter().getBatchState({"experimentView", "perAngleDefaults", "rows"});
 
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -429,7 +429,11 @@ SearchCriteria RunsPresenter::searchCriteria() const {
   return SearchCriteria{m_view->getSearchInstrument(), m_view->getSearchCycle(), m_view->getSearchString()};
 }
 
-int RunsPresenter::percentComplete() const { return mainPresenter().percentComplete(); }
+int RunsPresenter::percentComplete() const {
+  if (!m_mainPresenter)
+    return 0;
+  return m_mainPresenter->percentComplete();
+}
 
 void RunsPresenter::setRoundPrecision(int &precision) { m_tablePresenter->setTablePrecision(precision); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -140,7 +140,7 @@ private:
   /// The progress view
   ProgressableView *m_progressView;
   /// The main presenter
-  IBatchPresenter *m_mainPresenter;
+  IBatchPresenter *m_mainPresenter{nullptr};
   /// The message reporting implementation
   IReflMessageHandler *m_messageHandler;
   /// The file handler

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -180,6 +180,8 @@ private:
 
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 
+  IBatchPresenter &mainPresenter() const;
+
   void handleError(const std::string &message, const std::exception &e);
   void handleError(const std::string &message);
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -14,6 +14,7 @@
 #include <boost/range/algorithm/fill.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/regex.hpp>
+#include <stdexcept>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -138,6 +139,13 @@ void RunsTablePresenter::appendRowAndGroup() {
 
 void RunsTablePresenter::acceptMainPresenter(IRunsPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IRunsPresenter &RunsTablePresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("RunsTablePresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 RunsTable const &RunsTablePresenter::runsTable() const { return m_model; }
 
 RunsTable &RunsTablePresenter::mutableRunsTable() { return m_model; }
@@ -205,9 +213,9 @@ void RunsTablePresenter::removeGroupsFromModel(std::vector<int> const &groupIndi
     removeGroup(m_model.mutableReductionJobs(), *it);
 }
 
-void RunsTablePresenter::notifyResumeReductionRequested() { m_mainPresenter->notifyResumeReductionRequested(); }
+void RunsTablePresenter::notifyResumeReductionRequested() { mainPresenter().notifyResumeReductionRequested(); }
 
-void RunsTablePresenter::notifyPauseReductionRequested() { m_mainPresenter->notifyPauseReductionRequested(); }
+void RunsTablePresenter::notifyPauseReductionRequested() { mainPresenter().notifyPauseReductionRequested(); }
 
 void RunsTablePresenter::notifyInsertRowRequested() {
   if (isProcessing() || isAutoreducing())
@@ -236,8 +244,8 @@ void RunsTablePresenter::notifyFilterChanged(std::string const &filterString) {
 void RunsTablePresenter::notifyChangeInstrumentRequested() {
   auto const instrumentName = m_view->getInstrumentName();
   // If the instrument cannot be changed, revert to the original
-  if (!m_mainPresenter->notifyChangeInstrumentRequested(instrumentName))
-    m_view->setInstrumentName(m_mainPresenter->instrumentName());
+  if (!mainPresenter().notifyChangeInstrumentRequested(instrumentName))
+    m_view->setInstrumentName(mainPresenter().instrumentName());
 }
 
 void RunsTablePresenter::notifyFilterReset() { m_view->resetFilterBox(); }
@@ -460,7 +468,7 @@ void RunsTablePresenter::updateGroupName(MantidWidgets::Batch::RowLocation const
     cell.setContentText(oldValue);
     m_view->jobs().setCellAt(itemIndex, column, cell);
   }
-  m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[groupIndex]);
+  mainPresenter().notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[groupIndex]);
   notifyRowModelChanged();
 }
 
@@ -478,7 +486,7 @@ void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const 
   updateRow(m_model.mutableReductionJobs(), groupIndex, rowIndex, rowValidationResult.validElseNone());
   if (rowValidationResult.isValid()) {
     showAllCellsOnRowAsValid(itemIndex);
-    m_mainPresenter->notifyRowContentChanged(
+    mainPresenter().notifyRowContentChanged(
         m_model.mutableReductionJobs().mutableGroups()[groupIndex].mutableRows()[rowIndex].value());
     Item const &row = m_model.reductionJobs().groups()[groupIndex].rows()[rowIndex].value();
     notifyRowModelChanged(row);
@@ -747,9 +755,9 @@ void RunsTablePresenter::setRowStylingForItem(MantidWidgets::Batch::RowLocation 
   };
 }
 
-void RunsTablePresenter::updateProgressBar() { m_view->setProgress(m_mainPresenter->percentComplete()); }
+void RunsTablePresenter::updateProgressBar() { m_view->setProgress(mainPresenter().percentComplete()); }
 
-void RunsTablePresenter::notifyTableChanged() { m_mainPresenter->notifyTableChanged(); }
+void RunsTablePresenter::notifyTableChanged() { mainPresenter().notifyTableChanged(); }
 
 void RunsTablePresenter::notifyRowStateChanged() {
   updateProgressBar();
@@ -813,13 +821,13 @@ void RunsTablePresenter::notifyRowModelChanged(std::optional<std::reference_wrap
   m_jobViewUpdater.rowModified(groupOf(location), rowOf(location), row);
 }
 
-bool RunsTablePresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool RunsTablePresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool RunsTablePresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool RunsTablePresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 
-bool RunsTablePresenter::isAnyBatchProcessing() const { return m_mainPresenter->isAnyBatchProcessing(); }
+bool RunsTablePresenter::isAnyBatchProcessing() const { return mainPresenter().isAnyBatchProcessing(); }
 
-bool RunsTablePresenter::isAnyBatchAutoreducing() const { return m_mainPresenter->isAnyBatchAutoreducing(); }
+bool RunsTablePresenter::isAnyBatchAutoreducing() const { return mainPresenter().isAnyBatchAutoreducing(); }
 
 void RunsTablePresenter::notifyPlotSelectedPressed() {
   std::vector<std::string> workspaces;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -141,6 +141,8 @@ private:
 
   void notifyTableChanged();
 
+  IRunsPresenter &mainPresenter() const;
+
   bool isProcessing() const;
   bool isAutoreducing() const;
   bool isAnyBatchProcessing() const;
@@ -152,7 +154,7 @@ private:
   RunsTable m_model;
   Clipboard m_clipboard;
   JobsViewUpdater m_jobViewUpdater;
-  IRunsPresenter *m_mainPresenter;
+  IRunsPresenter *m_mainPresenter{nullptr};
   const IPlotter &m_plotter;
 
   friend class Encoder;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -28,8 +28,7 @@ using namespace Mantid::API;
  * @param view :: The view we are handling
  */
 SavePresenter::SavePresenter(ISaveView *view, std::unique_ptr<IFileSaver> saver)
-    : m_mainPresenter(nullptr), m_view(view), m_saver(std::move(saver)), m_shouldAutosave(false),
-      m_shouldSaveIndividualRows(false) {
+    : m_view(view), m_saver(std::move(saver)), m_shouldAutosave(false), m_shouldSaveIndividualRows(false) {
 
   m_view->subscribe(this);
   populateWorkspaceList();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -17,6 +17,7 @@
 #include "Poco/File.h"
 
 #include <boost/regex.hpp>
+#include <stdexcept>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -40,8 +41,15 @@ SavePresenter::SavePresenter(ISaveView *view, std::unique_ptr<IFileSaver> saver)
 
 void SavePresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
+IBatchPresenter &SavePresenter::mainPresenter() const {
+  if (!m_mainPresenter) {
+    throw std::runtime_error("SavePresenter does not have a main presenter.");
+  }
+  return *m_mainPresenter;
+}
+
 void SavePresenter::notifySettingsChanged() {
-  m_mainPresenter->setBatchUnsaved();
+  mainPresenter().setBatchUnsaved();
   updateWidgetEnabledState();
 }
 
@@ -59,9 +67,9 @@ void SavePresenter::notifyAutosaveEnabled() { enableAutosave(); }
 
 void SavePresenter::notifySavePathChanged() { onSavePathChanged(); }
 
-bool SavePresenter::isProcessing() const { return m_mainPresenter->isProcessing(); }
+bool SavePresenter::isProcessing() const { return mainPresenter().isProcessing(); }
 
-bool SavePresenter::isAutoreducing() const { return m_mainPresenter->isAutoreducing(); }
+bool SavePresenter::isAutoreducing() const { return mainPresenter().isAutoreducing(); }
 
 namespace {
 bool isORSOFormat(const NamedFormat &fileFormat) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -52,7 +52,7 @@ public:
   void notifySavePathChanged() override;
 
 private:
-  IBatchPresenter *m_mainPresenter;
+  IBatchPresenter *m_mainPresenter{nullptr};
   IBatchPresenter &mainPresenter() const;
   bool isValidSaveDirectory(std::string const &directory);
   void onSavePathChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -53,6 +53,7 @@ public:
 
 private:
   IBatchPresenter *m_mainPresenter;
+  IBatchPresenter &mainPresenter() const;
   bool isValidSaveDirectory(std::string const &directory);
   void onSavePathChanged();
   void warnInvalidSaveDirectory();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -73,7 +73,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(makeModel(), false);
-    TS_ASSERT_THROWS(presenter->instrumentName(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter->instrumentName(), std::runtime_error const &e, std::string(e.what()),
+                            "BatchPresenter does not have a main presenter.");
   }
 
   void testMainPresenterUpdatedWhenChangeInstrumentRequested() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -71,6 +71,11 @@ public:
     TS_ASSERT_EQUALS(presenter->initInstrumentList(selectedInstrument), selectedInstrument);
   }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(makeModel(), false);
+    TS_ASSERT_THROWS(presenter->instrumentName(), std::runtime_error const &);
+  }
+
   void testMainPresenterUpdatedWhenChangeInstrumentRequested() {
     auto presenter = makePresenter(makeModel());
     auto const instrument = std::string("POLREF");
@@ -703,7 +708,8 @@ private:
 
   std::unique_ptr<MockBatch> makeMockModel() { return std::make_unique<MockBatch>(); }
 
-  std::unique_ptr<BatchPresenterFriend> makePresenter(std::unique_ptr<IBatch> batchModel) {
+  std::unique_ptr<BatchPresenterFriend> makePresenter(std::unique_ptr<IBatch> batchModel,
+                                                      bool const acceptMainPresenter = true) {
     // Create pointers to the child presenters and pass them into the batch
     auto runsPresenter = std::make_unique<NiceMock<MockRunsPresenter>>();
     auto eventPresenter = std::make_unique<NiceMock<MockEventPresenter>>();
@@ -725,7 +731,9 @@ private:
         &m_view, std::move(batchModel), std::move(jobRunner), std::move(runsPresenter), std::move(eventPresenter),
         std::move(experimentPresenter), std::move(instrumentPresenter), std::move(savePresenter),
         std::move(previewPresenter), &m_messageHandler);
-    presenter->acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter->acceptMainPresenter(&m_mainPresenter);
+    }
     // Replace the constructed job runner with a mock
     m_jobManager = new NiceMock<MockBatchJobManager>();
     presenter->m_jobManager.reset(m_jobManager);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
@@ -44,6 +44,11 @@ public:
     TS_ASSERT(isNoSlicing(presenter.slicing()));
   }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(false);
+    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+  }
+
   void testInitializesWithStateFromViewWhenChangingToUniformSlicingByTime() {
     auto presenter = makePresenter();
     auto const secondsPerSlice = 10.0;
@@ -208,9 +213,11 @@ private:
   NiceMock<MockEventView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;
 
-  EventPresenter makePresenter() {
+  EventPresenter makePresenter(bool const acceptMainPresenter = true) {
     auto presenter = EventPresenter(&m_view);
-    presenter.acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter.acceptMainPresenter(&m_mainPresenter);
+    }
     return presenter;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
@@ -46,7 +46,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(false);
-    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifyReductionResumed(), std::runtime_error const &e, std::string(e.what()),
+                            "EventPresenter does not have a main presenter.");
   }
 
   void testInitializesWithStateFromViewWhenChangingToUniformSlicingByTime() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -603,6 +603,11 @@ public:
     presenter.notifySettingsChanged();
   }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(makeDefaults(), makeEmptyExperiment(), false);
+    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+  }
+
   void testChangingLookupRowNotifiesMainPresenter() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
@@ -988,12 +993,14 @@ private:
 
   ExperimentPresenter makePresenter(
       std::unique_ptr<IExperimentOptionDefaults> defaultOptions = std::make_unique<MockExperimentOptionDefaults>(),
-      Experiment experiment = makeEmptyExperiment()) {
+      Experiment experiment = makeEmptyExperiment(), bool const acceptMainPresenter = true) {
     // The presenter gets values from the view on construction so the view must
     // return something sensible
     auto presenter = ExperimentPresenter(&m_view, std::move(experiment), m_thetaTolerance, &m_fileHandler,
                                          std::move(defaultOptions));
-    presenter.acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter.acceptMainPresenter(&m_mainPresenter);
+    }
     return presenter;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -605,7 +605,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(makeDefaults(), makeEmptyExperiment(), false);
-    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifyReductionResumed(), std::runtime_error const &e, std::string(e.what()),
+                            "ExperimentPresenter does not have a main presenter.");
   }
 
   void testChangingLookupRowNotifiesMainPresenter() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -50,7 +50,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(std::make_unique<MockInstrumentOptionDefaults>(), false);
-    TS_ASSERT_THROWS(presenter.notifySettingsChanged(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifySettingsChanged(), std::runtime_error const &e, std::string(e.what()),
+                            "InstrumentPresenter does not have a main presenter.");
   }
 
   void testSetValidWavelengthRange() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -48,6 +48,11 @@ public:
     auto presenter = makePresenter();
   }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(std::make_unique<MockInstrumentOptionDefaults>(), false);
+    TS_ASSERT_THROWS(presenter.notifySettingsChanged(), std::runtime_error const &);
+  }
+
   void testSetValidWavelengthRange() {
     auto const range = RangeInLambda(1.5, 14);
     runTestForValidWavelengthRange(range, range);
@@ -369,10 +374,13 @@ private:
   }
 
   InstrumentPresenter makePresenter(
-      std::unique_ptr<IInstrumentOptionDefaults> defaultOptions = std::make_unique<MockInstrumentOptionDefaults>()) {
+      std::unique_ptr<IInstrumentOptionDefaults> defaultOptions = std::make_unique<MockInstrumentOptionDefaults>(),
+      bool const acceptMainPresenter = true) {
     auto presenter = InstrumentPresenter(&m_view, ModelCreationHelper::makeEmptyInstrument(), &m_fileHandler,
                                          &m_messageHandler, std::move(defaultOptions));
-    presenter.acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter.acceptMainPresenter(&m_mainPresenter);
+    }
     return presenter;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -75,7 +75,8 @@ public:
   void test_throws_when_main_presenter_has_not_been_accepted() {
     auto mockView = makeView();
     auto presenter = PreviewPresenter(packDeps(mockView.get()));
-    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifyReductionResumed(), std::runtime_error const &e, std::string(e.what()),
+                            "PreviewPresenter does not have a main presenter.");
   }
 
   void test_notify_load_workspace_requested_does_not_load_from_file_if_in_ads() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -72,6 +72,12 @@ public:
     presenter.notifyLoadWorkspaceRequested();
   }
 
+  void test_throws_when_main_presenter_has_not_been_accepted() {
+    auto mockView = makeView();
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    TS_ASSERT_THROWS(presenter.notifyReductionResumed(), std::runtime_error const &);
+  }
+
   void test_notify_load_workspace_requested_does_not_load_from_file_if_in_ads() {
     auto mockModel = makeModel();
     auto mockView = makeView();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -61,9 +61,9 @@ public:
   static RunsPresenterTest *createSuite() { return new RunsPresenterTest(); }
   static void destroySuite(RunsPresenterTest *suite) { delete suite; }
 
-  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+  void testPercentCompleteWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(false);
-    TS_ASSERT_THROWS(presenter->percentComplete(), std::runtime_error const &);
+    TS_ASSERT_EQUALS(presenter->percentComplete(), 0);
   }
 
   RunsPresenterTest()

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -61,6 +61,11 @@ public:
   static RunsPresenterTest *createSuite() { return new RunsPresenterTest(); }
   static void destroySuite(RunsPresenterTest *suite) { delete suite; }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(false);
+    TS_ASSERT_THROWS(presenter->percentComplete(), std::runtime_error const &);
+  }
+
   RunsPresenterTest()
       : m_thetaTolerance(0.01), m_instruments{"INTER", "SURF", "CRISP", "POLREF", "OFFSPEC"},
         m_runsTable(m_instruments, m_thetaTolerance, ReductionJobs()), m_searchString("test search string"),
@@ -833,7 +838,7 @@ private:
                         fileHandler) {}
   };
 
-  std::shared_ptr<RunsPresenterFriend> makePresenter() {
+  std::shared_ptr<RunsPresenterFriend> makePresenter(bool const acceptMainPresenter = true) {
     Plotter plotter;
 
     auto makeRunsTablePresenter = RunsTablePresenterFactory(m_instruments, m_thetaTolerance, std::move(plotter));
@@ -841,7 +846,9 @@ private:
         std::make_shared<RunsPresenterFriend>(&m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
                                               m_instruments, &m_messageHandler, &m_fileHandler);
 
-    presenter->acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter->acceptMainPresenter(&m_mainPresenter);
+    }
     presenter->m_tablePresenter.reset(new NiceMock<MockRunsTablePresenter>());
     m_runsTablePresenter = dynamic_cast<NiceMock<MockRunsTablePresenter> *>(presenter->m_tablePresenter.get());
     presenter->m_runNotifier.reset(new NiceMock<MockRunNotifier>());

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
@@ -38,6 +38,11 @@ public:
 
   static void destroySuite(RunsTablePresenterProcessingTest *suite) { delete suite; }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenterWithoutMainPresenter(m_view);
+    TS_ASSERT_THROWS(presenter.notifyResumeReductionRequested(), std::runtime_error const &);
+  }
+
   void testResumeReductionNotifiesParent() {
     auto presenter = makePresenter(m_view, ReductionJobs());
     EXPECT_CALL(m_mainPresenter, notifyResumeReductionRequested()).Times(1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
@@ -40,7 +40,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenterWithoutMainPresenter(m_view);
-    TS_ASSERT_THROWS(presenter.notifyResumeReductionRequested(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifyResumeReductionRequested(), std::runtime_error const &e,
+                            std::string(e.what()), "RunsTablePresenter does not have a main presenter.");
   }
 
   void testResumeReductionNotifiesParent() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
@@ -72,6 +72,10 @@ public:
     return presenter;
   }
 
+  RunsTablePresenter makePresenterWithoutMainPresenter(IRunsTableView &view) {
+    return RunsTablePresenter(&view, {}, 0.01, ReductionJobs(), m_plotter);
+  }
+
   Group &getGroup(RunsTablePresenter &presenter, int groupIndex) {
     auto &reductionJobs = presenter.mutableRunsTable().mutableReductionJobs();
     auto &group = reductionJobs.mutableGroups()[groupIndex];

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
@@ -55,7 +55,8 @@ public:
 
   void testThrowsWhenMainPresenterHasNotBeenAccepted() {
     auto presenter = makePresenter(false);
-    TS_ASSERT_THROWS(presenter.notifySettingsChanged(), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(presenter.notifySettingsChanged(), std::runtime_error const &e, std::string(e.what()),
+                            "SavePresenter does not have a main presenter.");
   }
 
   void testSetWorkspaceListOnConstruction() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
@@ -53,6 +53,11 @@ public:
     auto presenter = makePresenter();
   }
 
+  void testThrowsWhenMainPresenterHasNotBeenAccepted() {
+    auto presenter = makePresenter(false);
+    TS_ASSERT_THROWS(presenter.notifySettingsChanged(), std::runtime_error const &);
+  }
+
   void testSetWorkspaceListOnConstruction() {
     auto workspaceNames = createWorkspaces();
     expectSetWorkspaceListFromADS(workspaceNames);
@@ -525,11 +530,13 @@ public:
   }
 
 private:
-  SavePresenter makePresenter() {
+  SavePresenter makePresenter(bool const acceptMainPresenter = true) {
     auto FileSaver = std::make_unique<NiceMock<MockFileSaver>>();
     m_fileSaver = FileSaver.get();
     auto presenter = SavePresenter(&m_view, std::move(FileSaver));
-    presenter.acceptMainPresenter(&m_mainPresenter);
+    if (acceptMainPresenter) {
+      presenter.acceptMainPresenter(&m_mainPresenter);
+    }
     return presenter;
   }
 

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -493,12 +493,8 @@ void QtTreePropertyBrowserPrivate::propertyInserted(QtBrowserItem *index, const 
   QTreeWidgetItem *afterItem = m_indexToItem.value(afterIndex);
   QTreeWidgetItem *parentItem = m_indexToItem.value(index->parent());
 
-  QTreeWidgetItem *newItem = nullptr;
-  if (parentItem) {
-    newItem = new QTreeWidgetItem(parentItem, afterItem);
-  } else {
-    newItem = new QTreeWidgetItem(m_treeWidget, afterItem);
-  }
+  QTreeWidgetItem *newItem =
+      (parentItem) ? new QTreeWidgetItem(parentItem, afterItem) : new QTreeWidgetItem(m_treeWidget, afterItem);
   m_itemToIndex[newItem] = index;
   m_indexToItem[index] = newItem;
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41723

Fixes coverity warnings flagged after a recent refactor of a number of the Reflectometry algorithms.

Many of the issues are preexisting, a couple are new.

Fixes include:
- using `std::move` to avoid copies in a few places.
- adding explicit definition as `nullptr` and a guard to the access of the main presenter raw pointer in certain reflectometry GUI classes. The main presenter is set after object instantiation as part of a factory method.
- Added an early exit to a reflectometry helper class used to generate covariance matrix - for certain template parameter values part of the code was unreachable.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
