### PR TITLE
Add conda packaging job to pr workflow

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          path: source
 
       - uses: dorny/paths-filter@v4
         id: changes
@@ -62,7 +64,7 @@ jobs:
         if: ${{ steps.changes.outputs.code_changes == 'true' }}
         run: |
           rm -rf ${GITHUB_WORKSPACE}/conda-bld
-          bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
 
       - name: Upload conda packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -70,15 +70,15 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: conda_packages
-          if-no-files-found: ignore
-          path: ${GITHUB_WORKSPACE}/conda-bld/**/*.conda
+          if-no-files-found: error
+          path: ${{ github.workspace }}/conda-bld/**/*.conda
 
       - name: Upload conda environment logs
         uses: actions/upload-artifact@v7
         with:
           name: env_logs
-          if-no-files-found: ignore
-          path: ${GITHUB_WORKSPACE}/conda-bld/env_logs/*.txt
+          if-no-files-found: warn
+          path: ${{ github.workspace }}/**/env_logs/*/*.txt
 
   build-and-test:
     needs: [doxygen]

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -35,6 +35,48 @@ jobs:
         name: Build doxygen
         if: ${{ steps.changes.outputs.doxygen == 'true' }}
 
+  conda-packaging-linux:
+    needs: [doxygen]
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - Linux
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+
+      - name: Build conda packages
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          rm -rf ${GITHUB_WORKSPACE}/conda-bld
+          bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
+
+      - name: Upload conda packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda_packages
+          if-no-files-found: ignore
+          path: ${GITHUB_WORKSPACE}/conda-bld/**/*.conda
+
+      - name: Upload conda environment logs
+        uses: actions/upload-artifact@v7
+        with:
+          name: env_logs
+          if-no-files-found: ignore
+          path: ${GITHUB_WORKSPACE}/conda-bld/env_logs/*.txt
 
   build-and-test:
     needs: [doxygen]

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 100
+          fetch-tags: true
           path: source
 
       - uses: dorny/paths-filter@v4


### PR DESCRIPTION
### Description of work

Add the conda packaging job to the github actions build and test pr workflow. This is with the aim to replace the jenkins job (can be switched off after this pr is merged)

Closes #41100

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

New job runs and the packages and env logs are archived

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
