### PR TITLE
Fix mdgridbox boundary event

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
@@ -213,6 +213,8 @@ private:
   /// size of each sub-box (the one this GridBox can be split into) in
   /// correspondent direction
   double m_SubBoxSize[nd];
+  /// Precomputed reciprocal of m_SubBoxSize; replaces division with multiplication in calculateChildIndex
+  double m_SubBoxSizeInv[nd];
 
   /// How many boxes in the boxes vector? This is just to avoid boxes.size()
   /// calls.

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
@@ -9,7 +9,6 @@
 #include "MantidDataObjects/MDEvent.h"
 #include "MantidDataObjects/MDGridBox.h"
 #include "MantidKernel/FunctionTask.h"
-#include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Task.h"
 #include "MantidKernel/ThreadPool.h"
@@ -18,6 +17,7 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Utils.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include <algorithm>
 #include <boost/math/special_functions/round.hpp>
 #include <optional>
 #include <ostream>
@@ -181,6 +181,7 @@ TMDE(MDGridBox)::MDGridBox(const MDGridBox<MDE, nd> &other, Mantid::API::BoxCont
     split[d] = other.split[d];
     splitCumul[d] = other.splitCumul[d];
     m_SubBoxSize[d] = other.m_SubBoxSize[d];
+    m_SubBoxSizeInv[d] = other.m_SubBoxSizeInv[d];
   }
   // Copy all the boxes
   m_Children.clear();
@@ -230,6 +231,7 @@ TMDE(size_t MDGridBox)::computeSizesFromSplit() {
     tot *= split[d];
     // Length of the side of a box in this dimension
     m_SubBoxSize[d] = static_cast<double>(this->extents[d].getSize()) / static_cast<double>(split[d]);
+    m_SubBoxSizeInv[d] = 1.0 / m_SubBoxSize[d];
     // Accumulate the squared diagonal length.
     diagSum += m_SubBoxSize[d] * m_SubBoxSize[d];
   }
@@ -1730,15 +1732,9 @@ TMDE(size_t MDGridBox)::calculateChildIndex(const MDE &event) const {
     // Accumulate the index
     const auto coordinate = event.getCenter(d);
     const auto offset = coordinate - this->extents[d].getMin();
-    auto childIndex = static_cast<int>(offset / m_SubBoxSize[d]);
-    if (childIndex == static_cast<int>(split[d]) && coordinate <= this->extents[d].getMax()) {
-      static Kernel::Logger mdGridBoxLog("MDGridBox");
-      mdGridBoxLog.debug() << "MDGridBox::calculateChildIndex clamping upper-boundary event: dimension=" << d
-                           << ", coordinate=" << coordinate << ", min=" << this->extents[d].getMin()
-                           << ", max=" << this->extents[d].getMax() << ", subBoxSize=" << m_SubBoxSize[d]
-                           << ", raw child index=" << childIndex << ", clamped child index=" << (split[d] - 1) << '\n';
-      childIndex = static_cast<int>(split[d] - 1);
-    }
+    const int splitD = static_cast<int>(split[d]);
+    // FP rounding can place a boundary event one index past the last valid child
+    const auto childIndex = std::min(static_cast<int>(offset * m_SubBoxSizeInv[d]), splitD - 1);
     cindex += childIndex * splitCumul[d];
   }
   return cindex;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
@@ -17,7 +17,6 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Utils.h"
 #include "MantidKernel/WarningSuppressions.h"
-#include <algorithm>
 #include <boost/math/special_functions/round.hpp>
 #include <optional>
 #include <ostream>
@@ -1733,8 +1732,10 @@ TMDE(size_t MDGridBox)::calculateChildIndex(const MDE &event) const {
     const auto coordinate = event.getCenter(d);
     const auto offset = coordinate - this->extents[d].getMin();
     const int splitD = static_cast<int>(split[d]);
-    // FP rounding can place a boundary event one index past the last valid child
-    const auto childIndex = std::min(static_cast<int>(offset * m_SubBoxSizeInv[d]), splitD - 1);
+    // clamp to splitD-1: FP rounding can place an in-box coordinate one slot past the last valid child
+    auto childIndex = static_cast<int>(offset * m_SubBoxSizeInv[d]);
+    if (childIndex == splitD && coordinate <= this->extents[d].getMax())
+      childIndex = splitD - 1;
     cindex += childIndex * splitCumul[d];
   }
   return cindex;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.hxx
@@ -9,6 +9,7 @@
 #include "MantidDataObjects/MDEvent.h"
 #include "MantidDataObjects/MDGridBox.h"
 #include "MantidKernel/FunctionTask.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Task.h"
 #include "MantidKernel/ThreadPool.h"
@@ -1727,8 +1728,18 @@ TMDE(size_t MDGridBox)::calculateChildIndex(const MDE &event) const {
   size_t cindex(0);
   for (size_t d = 0; d < nd; d++) {
     // Accumulate the index
-    auto offset = event.getCenter(d) - this->extents[d].getMin();
-    cindex += static_cast<int>(offset / (m_SubBoxSize[d])) * splitCumul[d];
+    const auto coordinate = event.getCenter(d);
+    const auto offset = coordinate - this->extents[d].getMin();
+    auto childIndex = static_cast<int>(offset / m_SubBoxSize[d]);
+    if (childIndex == static_cast<int>(split[d]) && coordinate <= this->extents[d].getMax()) {
+      static Kernel::Logger mdGridBoxLog("MDGridBox");
+      mdGridBoxLog.debug() << "MDGridBox::calculateChildIndex clamping upper-boundary event: dimension=" << d
+                           << ", coordinate=" << coordinate << ", min=" << this->extents[d].getMin()
+                           << ", max=" << this->extents[d].getMax() << ", subBoxSize=" << m_SubBoxSize[d]
+                           << ", raw child index=" << childIndex << ", clamped child index=" << (split[d] - 1) << '\n';
+      childIndex = static_cast<int>(split[d] - 1);
+    }
+    cindex += childIndex * splitCumul[d];
   }
   return cindex;
 }

--- a/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Framework/DataObjects/test/MDGridBoxTest.h
@@ -1005,6 +1005,29 @@ public:
     BoxController *const bcc = b0->getBoxController();
     delete b0;
     delete bcc;
+
+    // Corner case: preserve events already assigned to a child MDBox when they
+    // lie exactly on that child box's upper boundary during serial splitting.
+    gbox_t *boundaryBox = MDEventsTestHelper::makeMDGridBox<2>();
+    boundaryBox->getBoxController()->setSplitThreshold(1);
+    boundaryBox->getBoxController()->setMaxDepth(2);
+
+    auto *boundaryChild = dynamic_cast<box_t *>(boundaryBox->getChild(0));
+    TS_ASSERT(boundaryChild);
+    for (size_t i = 0; i < 2; ++i) {
+      // Insert directly into child 0 so the event is already assigned to this
+      // MDBox when it splits. The point lies on child 0's upper y boundary.
+      coord_t centers[2] = {0.5f, 1.0f};
+      TS_ASSERT_EQUALS(boundaryChild->addEvent(MDLeanEvent<2>(2.0, 2.0, centers)), 1);
+    }
+
+    boundaryBox->splitAllIfNeeded(nullptr);
+    boundaryBox->refreshCache(nullptr);
+    TS_ASSERT_EQUALS(boundaryBox->getNPoints(), 2);
+
+    BoxController *const boundaryBc = boundaryBox->getBoxController();
+    delete boundaryBox;
+    delete boundaryBc;
   }
 
   //------------------------------------------------------------------------------------------------
@@ -1013,6 +1036,7 @@ public:
    */
   void test_splitAllIfNeeded_usingThreadPool() {
     using gbox_t = MDGridBox<MDLeanEvent<2>, 2>;
+    using box_t = MDBox<MDLeanEvent<2>, 2>;
     using ibox_t = MDBoxBase<MDLeanEvent<2>, 2>;
 
     gbox_t *b = MDEventsTestHelper::makeMDGridBox<2>();
@@ -1062,6 +1086,32 @@ public:
     BoxController *const bcc = b->getBoxController();
     delete b;
     delete bcc;
+
+    // Corner case: preserve events already assigned to a child MDBox when they
+    // lie exactly on that child box's upper boundary during threaded splitting.
+    gbox_t *boundaryBox = MDEventsTestHelper::makeMDGridBox<2>();
+    boundaryBox->getBoxController()->setSplitThreshold(1);
+    boundaryBox->getBoxController()->setMaxDepth(2);
+
+    auto *boundaryChild = dynamic_cast<box_t *>(boundaryBox->getChild(0));
+    TS_ASSERT(boundaryChild);
+    for (size_t i = 0; i < 2; ++i) {
+      // Insert directly into child 0 so the event is already assigned to this
+      // MDBox when it splits. The point lies on child 0's upper y boundary.
+      coord_t centers[2] = {0.5f, 1.0f};
+      TS_ASSERT_EQUALS(boundaryChild->addEvent(MDLeanEvent<2>(2.0, 2.0, centers)), 1);
+    }
+
+    ThreadSchedulerFIFO *boundaryTs = new ThreadSchedulerFIFO();
+    ThreadPool boundaryTp(boundaryTs);
+    boundaryBox->splitAllIfNeeded(boundaryTs);
+    boundaryTp.joinAll();
+    boundaryBox->refreshCache(nullptr);
+    TS_ASSERT_EQUALS(boundaryBox->getNPoints(), 2);
+
+    BoxController *const boundaryBc = boundaryBox->getBoxController();
+    delete boundaryBox;
+    delete boundaryBc;
   }
 
   //------------------------------------------------------------------------------------------------

--- a/docs/source/release/v7.0.0/Framework/Data_Objects/Bugfixes/41770.rst
+++ b/docs/source/release/v7.0.0/Framework/Data_Objects/Bugfixes/41770.rst
@@ -1,0 +1,1 @@
+- Fixed a boundary-condition bug in ``MDGridBox`` splitting where events exactly on a child box's upper boundary could be dropped during serial or threaded splitting.


### PR DESCRIPTION
### Description of work

This PR addresses a boundary-condition bug in `MDGridBox` event splitting where events lying exactly on a child box’s upper boundary can compute an out-of-range child index and be dropped during (serial and threaded) splitting.

**Changes:**
- Clamp per-dimension child index in `MDGridBox::calculateChildIndex` to keep upper-boundary events within the valid child range.
- Add two unit-test cases covering the corner case for both serial splitting and threaded splitting.

Companion to #41795

### To test:
Run the following script in the workbench after building Mantid from either `main` or `ornl-next`:
```python
HB3AAdjustSampleNorm(
    Filename="HB3A_exp0724_scan0182.nxs",
    VanadiumFile="HB3A_exp0722_scan0220.nxs",
    NormaliseBy="None",
    NormalizeData=False,
    OutputType="Q-sample events",
    MergeInputs=False,
    OutputWorkspace="data",
    OutputNormalizationWorkspace="norm",
)
HB3AAdjustSampleNorm(
    Filename="HB3A_exp0724_scan0182.nxs",
    VanadiumFile="HB3A_exp0722_scan0220.nxs",
    NormaliseBy="None",
    NormalizeData=False,
    OutputType="Q-sample events",
    MinValues=[-1000, -1000, -1000],
    MaxValues=[1000, 1000, 1000],
    MergeInputs=False,
    OutputWorkspace="data2",
    OutputNormalizationWorkspace= "norm2",
)
```
You will need to also run `ninja UnitTestData`, then add `<build_dir>/ExternalData/Testing/Data/UnitTest/` to the list of Mantid search directories so that the input files are readily available for Mantid to find them. Verify workspace `norm` has 96,724,247 events and `norm2` has 96,724,232 events. In both cases the correct number of events is 96,724,248.

Now rerun the script on a build of Mantid from this feature branch, and verify the correct number of events for both workspaces. Also, you may want to record the execution time of the calls to the algorithm (they'll show up as log messages). This way you can ascertain the changes don't impact execution time.
<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
