### PR TITLE
Formally deprecate pre-`Histogram` methods `readX`, `dataX` and friends

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -106,11 +106,22 @@ public:
   const HistogramX &x() const { return *m_x; }
   const HistogramY &y() const { return *m_y; }
   const HistogramE &e() const { return *m_e; }
-  const HistogramDx &dx() const { return *m_dx; }
+  // Dx is optional and, unlike X/Y/E, is not guaranteed to have been set. Lazily initialize it to
+  // zeros on first access, consistent with the legacy dataDx()/readDx() accessors below, which have
+  // always behaved this way (see the comment on the legacy Dx interface further down).
+  const HistogramDx &dx() const {
+    if (!m_dx)
+      m_dx = Kernel::make_cow<HistogramDx>(size(), 0.0);
+    return *m_dx;
+  }
   HistogramX &mutableX() & { return m_x.access(); }
   HistogramY &mutableY() & { return m_y.access(); }
   HistogramE &mutableE() & { return m_e.access(); }
-  HistogramDx &mutableDx() & { return m_dx.access(); }
+  HistogramDx &mutableDx() & {
+    if (!m_dx)
+      m_dx = Kernel::make_cow<HistogramDx>(size(), 0.0);
+    return m_dx.access();
+  }
 
   Kernel::cow_ptr<HistogramX> sharedX() const { return m_x; }
   Kernel::cow_ptr<HistogramY> sharedY() const { return m_y; }

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -905,6 +905,22 @@ public:
     TS_ASSERT_THROWS(hist.setSharedE(data2), const std::logic_error &);
   }
 
+  void test_dx_triggers_creation() {
+    Histogram hist(Points(2));
+    TS_ASSERT_THROWS_NOTHING(hist.dx());
+    TS_ASSERT_EQUALS(hist.dx().size(), 2);
+    TS_ASSERT_EQUALS(hist.dx()[0], 0.0);
+    TS_ASSERT_EQUALS(hist.dx()[1], 0.0);
+  }
+
+  void test_mutableDx_triggers_creation() {
+    Histogram hist(Points(2));
+    TS_ASSERT_THROWS_NOTHING(hist.mutableDx());
+    TS_ASSERT_EQUALS(hist.mutableDx().size(), 2);
+    TS_ASSERT_EQUALS(hist.mutableDx()[0], 0.0);
+    TS_ASSERT_EQUALS(hist.mutableDx()[1], 0.0);
+  }
+
   void test_setPointStandardDeviations_point_data() {
     Histogram hist(Points(2));
     TS_ASSERT_THROWS_NOTHING(hist.setPointStandardDeviations(std::vector<double>{1.0, 2.0}));

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -604,7 +604,9 @@ void export_MatrixWorkspace() {
       .def("e", &eData, return_readonly_numpy(), args("self", "workspaceIndex"),
            "Creates a read-only numpy wrapper around the E data at the given index")
       .def("dx", &dxData, return_readonly_numpy(), args("self", "workspaceIndex"),
-           "Creates a read-only numpy wrapper around the Dx data at the given index")
+           "Creates a read-only numpy wrapper around the Dx data at the given index. "
+           "If :class:`~mantid.api.MatrixWorkspace.hasDx` is False for this index, "
+           "the Dx data is first initialized to zeros.")
       .def("readX", &readXDeprecated, (arg("self"), arg("workspaceIndex")), return_readonly_numpy(),
            "Creates a read-only numpy wrapper "
            "around the original X data at the "
@@ -641,7 +643,9 @@ void export_MatrixWorkspace() {
            "Raises a RuntimeError for :class:`~mantid.api.IEventWorkspace`, since "
            "non-const access to E data is not possible for event data.")
       .def("mutableDx", &mutableDxData, return_readwrite_numpy(), args("self", "workspaceIndex"),
-           "Creates a writable numpy wrapper around the Dx data at the given index")
+           "Creates a writable numpy wrapper around the Dx data at the given index. "
+           "If :class:`~mantid.api.MatrixWorkspace.hasDx` is False for this index, "
+           "the Dx data is first initialized to zeros.")
       .def("dataX", &dataXDeprecated, return_readwrite_numpy(), args("self", "workspaceIndex"),
            "Creates a writable numpy wrapper around the original X data at the "
            "given index (deprecated, use "

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -136,6 +136,145 @@ list getSpectrumNumbers(const MatrixWorkspace &self) {
 }
 
 /**
+ * The following xData/yData/eData/dxData and mutableXData/mutableYData/mutableEData/mutableDxData
+ * functions expose MatrixWorkspace::x/y/e/dx and MatrixWorkspace::mutableX/mutableY/mutableE/mutableDx
+ * to Python. HistogramX/Y/E/Dx are not std::vector<double> themselves, so we go via rawData() to
+ * obtain the plain vector that the numpy return-value policies require. For the mutable variants,
+ * calling the mutable*() accessor first still triggers the copy-on-write detach; the numpy wrapper
+ * is made writable by the WrapReadWrite return-value policy used at the .def() call site, not by
+ * the const-ness of this function's return type (mutableRawData() is intentionally protected).
+ */
+const Mantid::MantidVec &xData(MatrixWorkspace &self, const size_t index) { return self.x(index).rawData(); }
+const Mantid::MantidVec &yData(MatrixWorkspace &self, const size_t index) { return self.y(index).rawData(); }
+const Mantid::MantidVec &eData(MatrixWorkspace &self, const size_t index) { return self.e(index).rawData(); }
+const Mantid::MantidVec &dxData(MatrixWorkspace &self, const size_t index) { return self.dx(index).rawData(); }
+
+const Mantid::MantidVec &mutableXData(MatrixWorkspace &self, const size_t index) {
+  return self.mutableX(index).rawData();
+}
+const Mantid::MantidVec &mutableYData(MatrixWorkspace &self, const size_t index) {
+  return self.mutableY(index).rawData();
+}
+const Mantid::MantidVec &mutableEData(MatrixWorkspace &self, const size_t index) {
+  return self.mutableE(index).rawData();
+}
+const Mantid::MantidVec &mutableDxData(MatrixWorkspace &self, const size_t index) {
+  return self.mutableDx(index).rawData();
+}
+
+/**
+ * Adds a deprecation warning to the readX call to warn about using x instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns xData(self, index)
+ */
+const Mantid::MantidVec &readXDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.readX()` is deprecated in Mantid 7.0, use `MatrixWorkspace.x()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return xData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the readY call to warn about using y instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns yData(self, index)
+ */
+const Mantid::MantidVec &readYDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.readY()` is deprecated in Mantid 7.0, use `MatrixWorkspace.y()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return yData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the readE call to warn about using e instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns eData(self, index)
+ */
+const Mantid::MantidVec &readEDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.readE()` is deprecated in Mantid 7.0, use `MatrixWorkspace.e()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return eData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the readDx call to warn about using dx instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns dxData(self, index)
+ */
+const Mantid::MantidVec &readDxDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.readDx()` is deprecated in Mantid 7.0, use `MatrixWorkspace.dx()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return dxData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the dataX call to warn about using mutableX instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns mutableXData(self, index)
+ */
+const Mantid::MantidVec &dataXDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.dataX()` is deprecated in Mantid 7.0, use `MatrixWorkspace.mutableX()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return mutableXData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the dataY call to warn about using mutableY instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns mutableYData(self, index)
+ */
+const Mantid::MantidVec &dataYDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.dataY()` is deprecated in Mantid 7.0, use `MatrixWorkspace.mutableY()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return mutableYData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the dataE call to warn about using mutableE instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns mutableEData(self, index)
+ */
+const Mantid::MantidVec &dataEDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.dataE()` is deprecated in Mantid 7.0, use `MatrixWorkspace.mutableE()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return mutableEData(self, index);
+}
+
+/**
+ * Adds a deprecation warning to the dataDx call to warn about using mutableDx instead
+ * @param self A reference to the calling object
+ * @param index The workspace index to retrieve
+ * @returns mutableDxData(self, index)
+ */
+const Mantid::MantidVec &dataDxDeprecated(MatrixWorkspace &self, const size_t index) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.dataDx()` is deprecated in Mantid 7.0, use `MatrixWorkspace.mutableDx()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  return mutableDxData(self, index);
+}
+
+/**
  * Set the X values from an python array-style object
  * @param self :: A reference to the calling object
  * @param wsIndex :: The workspace index for the spectrum to set
@@ -458,39 +597,67 @@ void export_MatrixWorkspace() {
 
       //--------------------------------------- Read spectrum data
       //-------------------------
-      .def("readX", &MatrixWorkspace::readX, (arg("self"), arg("workspaceIndex")), return_readonly_numpy(),
+      .def("x", &xData, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "Creates a read-only numpy wrapper around the X data at the given index")
+      .def("y", &yData, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "Creates a read-only numpy wrapper around the Y data at the given index")
+      .def("e", &eData, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "Creates a read-only numpy wrapper around the E data at the given index")
+      .def("dx", &dxData, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "Creates a read-only numpy wrapper around the Dx data at the given index")
+      .def("readX", &readXDeprecated, (arg("self"), arg("workspaceIndex")), return_readonly_numpy(),
            "Creates a read-only numpy wrapper "
            "around the original X data at the "
-           "given index")
-      .def("readY", &MatrixWorkspace::readY, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.x` instead)")
+      .def("readY", &readYDeprecated, return_readonly_numpy(), args("self", "workspaceIndex"),
            "Creates a read-only numpy wrapper "
            "around the original Y data at the "
-           "given index")
-      .def("readE", &MatrixWorkspace::readE, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.y` instead)")
+      .def("readE", &readEDeprecated, return_readonly_numpy(), args("self", "workspaceIndex"),
            "Creates a read-only numpy wrapper "
            "around the original E data at the "
-           "given index")
-      .def("readDx", &MatrixWorkspace::readDx, return_readonly_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.e` instead)")
+      .def("readDx", &readDxDeprecated, return_readonly_numpy(), args("self", "workspaceIndex"),
            "Creates a read-only numpy wrapper "
            "around the original Dx data at the "
-           "given index")
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.dx` instead)")
       .def("hasDx", &MatrixWorkspace::hasDx, args("self", "workspaceIndex"),
            "Returns True if the spectrum uses the DX (X Error) array, else "
            "False.")
       //--------------------------------------- Write spectrum data
       //------------------------
-      .def("dataX", (data_modifier)&MatrixWorkspace::dataX, return_readwrite_numpy(), args("self", "workspaceIndex"),
+      .def("mutableX", &mutableXData, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the X data at the given index")
+      .def("mutableY", &mutableYData, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the Y data at the given index. "
+           "Raises a RuntimeError for :class:`~mantid.api.IEventWorkspace`, since "
+           "non-const access to Y data is not possible for event data.")
+      .def("mutableE", &mutableEData, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the E data at the given index. "
+           "Raises a RuntimeError for :class:`~mantid.api.IEventWorkspace`, since "
+           "non-const access to E data is not possible for event data.")
+      .def("mutableDx", &mutableDxData, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the Dx data at the given index")
+      .def("dataX", &dataXDeprecated, return_readwrite_numpy(), args("self", "workspaceIndex"),
            "Creates a writable numpy wrapper around the original X data at the "
-           "given index")
-      .def("dataY", (data_modifier)&MatrixWorkspace::dataY, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.mutableX` instead)")
+      .def("dataY", &dataYDeprecated, return_readwrite_numpy(), args("self", "workspaceIndex"),
            "Creates a writable numpy wrapper around the original Y data at the "
-           "given index")
-      .def("dataE", (data_modifier)&MatrixWorkspace::dataE, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.mutableY` instead)")
+      .def("dataE", &dataEDeprecated, return_readwrite_numpy(), args("self", "workspaceIndex"),
            "Creates a writable numpy wrapper around the original E data at the "
-           "given index")
-      .def("dataDx", (data_modifier)&MatrixWorkspace::dataDx, return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.mutableE` instead)")
+      .def("dataDx", &dataDxDeprecated, return_readwrite_numpy(), args("self", "workspaceIndex"),
            "Creates a writable numpy wrapper around the original Dx data at "
-           "the given index")
+           "the given index (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.mutableDx` instead)")
       .def("setX", &setXFromPyObject, args("self", "workspaceIndex", "x"),
            "Set X values from a python list or numpy array. It performs a "
            "simple copy into the array.")

--- a/Framework/PythonInterface/plugins/algorithms/SavePlot1DAsJson.py
+++ b/Framework/PythonInterface/plugins/algorithms/SavePlot1DAsJson.py
@@ -93,10 +93,10 @@ class SavePlot1DAsJson(PythonAlgorithm):
             # or title?
             # title = "%s - spectrum %d" % (workspace.getTitle(), spectrum_no)
             arr = [
-                list(workspace.readX(i)),
-                list(workspace.readY(i)),
-                list(workspace.readE(i)),
-                list(workspace.readDx(i)),
+                list(workspace.x(i)),
+                list(workspace.y(i)),
+                list(workspace.e(i)),
+                list(workspace.dx(i)),
             ]
             serialized["data"][spectrum_no] = arr
             continue

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -147,15 +147,15 @@ class LoadWANDGroupingTest(unittest.TestCase):
         self.assertEqual(int(y_values.min()), 1)
 
         # Spot-check: workspace index 0  → pixel (x=0, y=0) → group 1
-        self.assertEqual(int(grp_ws.readY(0)[0]), 1)
+        self.assertEqual(int(grp_ws.y(0)[0]), 1)
         # Spot-check: workspace index 1  → pixel (x=0, y=1) → group 1  (same 2×2 block as index 0)
-        self.assertEqual(int(grp_ws.readY(1)[0]), 1)
+        self.assertEqual(int(grp_ws.y(1)[0]), 1)
         # Spot-check: workspace index 2  → pixel (x=0, y=2) → group 2  (next 2×2 block along y)
-        self.assertEqual(int(grp_ws.readY(2)[0]), 2)
+        self.assertEqual(int(grp_ws.y(2)[0]), 2)
         # Spot-check: workspace index 512 → pixel (x=1, y=0) → shares 2×2 block with index 0 → group 1
-        self.assertEqual(int(grp_ws.readY(512)[0]), 1)
+        self.assertEqual(int(grp_ws.y(512)[0]), 1)
         # Spot-check: workspace index 1024 → pixel (x=2, y=0) → first group of x_idx=1 row → group (512//2)+1 = 257
-        self.assertEqual(int(grp_ws.readY(1024)[0]), (self.N_COLS // grouping) + 1)
+        self.assertEqual(int(grp_ws.y(1024)[0]), (self.N_COLS // grouping) + 1)
 
         # detector ID stored
         self.assertEqual(grp_ws.getSpectrum(0).getDetectorIDs()[0], 0)
@@ -168,7 +168,7 @@ class LoadWANDGroupingTest(unittest.TestCase):
         self.assertEqual(len(detectorID), expected_groups)
         self.assertEqual(len(detectorID), len(twotheta))
         # each stored detector ID maps to a valid group (det_id == workspace index for WAND)
-        self.assertTrue(all(grp_ws.readY(int(d))[0] >= 1 for d in detectorID))
+        self.assertTrue(all(grp_ws.y(int(d))[0] >= 1 for d in detectorID))
 
         ws.delete()
         grp_ws.delete()
@@ -276,9 +276,9 @@ class LoadWANDOutputNormalizationTest(unittest.TestCase):
         self.assertEqual(grouping_workspace.getNumberHistograms(), LoadWANDGroupingTest.N_ROWS * LoadWANDGroupingTest.N_COLS)
         self.assertEqual(int(y_values.min()), 1)
         self.assertEqual(int(y_values.max()), expected_groups)
-        self.assertEqual(int(grouping_workspace.readY(0)[0]), 1)
-        self.assertEqual(int(grouping_workspace.readY(grouping)[0]), 2)
-        self.assertEqual(int(grouping_workspace.readY(grouping * 512)[0]), (LoadWANDGroupingTest.N_COLS // grouping) + 1)
+        self.assertEqual(int(grouping_workspace.y(0)[0]), 1)
+        self.assertEqual(int(grouping_workspace.y(grouping)[0]), 2)
+        self.assertEqual(int(grouping_workspace.y(grouping * 512)[0]), (LoadWANDGroupingTest.N_COLS // grouping) + 1)
 
     def test_output_normalization_workspace_for_counts(self):
         data = normalization = None

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SavePlot1DAsJsonTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SavePlot1DAsJsonTest.py
@@ -26,7 +26,9 @@ class SavePlot1DAsJsonTest(unittest.TestCase):
         alg_test = run_algorithm("SavePlot1DAsJson", InputWorkspace=datawsname, JsonFilename=out_path)
         # executed?
         self.assertTrue(alg_test.isExecuted())
-        # Verify ....
+        # Verify .... JsonFilename is a FileProperty, so its resolved value is the actual
+        # location the file was saved to (relative to defaultsave.directory if not absolute)
+        out_path = alg_test.getPropertyValue("JsonFilename")
         d = json.load(open(out_path))[datawsname]
         self.assertEqual(d["type"], "point")
         self._checkData(d, E, intensity, err, dE=dQ)
@@ -44,7 +46,9 @@ class SavePlot1DAsJsonTest(unittest.TestCase):
         alg_test = run_algorithm("SavePlot1DAsJson", InputWorkspace=datawsname, JsonFilename=out_path)
         # Executed?
         self.assertTrue(alg_test.isExecuted())
-        # Verify ....
+        # Verify .... JsonFilename is a FileProperty, so its resolved value is the actual
+        # location the file was saved to (relative to defaultsave.directory if not absolute)
+        out_path = alg_test.getPropertyValue("JsonFilename")
         d = json.load(open(out_path))[datawsname]
         self._checkData(d, E, intensity, err)
         # test overwrite
@@ -62,7 +66,9 @@ class SavePlot1DAsJsonTest(unittest.TestCase):
         alg_test = run_algorithm("SavePlot1DAsJson", InputWorkspace=datawsname, JsonFilename=out_path)
         # executed?
         self.assertTrue(alg_test.isExecuted())
-        # Verify ....
+        # Verify .... JsonFilename is a FileProperty, so its resolved value is the actual
+        # location the file was saved to (relative to defaultsave.directory if not absolute)
+        out_path = alg_test.getPropertyValue("JsonFilename")
         d = json.load(open(out_path))[datawsname]
         self._checkData(d, E, intensity_1, err)
         self._checkData(d, E, intensity_2, err2, ID="2")
@@ -80,7 +86,9 @@ class SavePlot1DAsJsonTest(unittest.TestCase):
         alg_test = run_algorithm("SavePlot1DAsJson", InputWorkspace=datawsname, JsonFilename=out_path, PlotName=plotname)
         # executed?
         self.assertTrue(alg_test.isExecuted())
-        # Verify ....
+        # Verify .... JsonFilename is a FileProperty, so its resolved value is the actual
+        # location the file was saved to (relative to defaultsave.directory if not absolute)
+        out_path = alg_test.getPropertyValue("JsonFilename")
         d = json.load(open(out_path))[plotname]
         self._checkData(d, E, intensity, err)
         # Delete the output file

--- a/docs/source/algorithms/CalculatePlaczekPlotP1.py
+++ b/docs/source/algorithms/CalculatePlaczekPlotP1.py
@@ -29,11 +29,11 @@ ConvertUnits(InputWorkspace="NOM_P1", OutputWorkspace="NOM_P1", Target="Momentum
 
 # plot
 outws = mtd["NOM_P1"]
-x = np.array(outws.readX(0))
+x = np.array(outws.x(0))
 x = 0.5 * (x[1:] + x[:-1])
 fig, ax1 = plt.subplots(1)
 for i in range(6):
-    y = np.array(outws.readY(i))
+    y = np.array(outws.y(i))
     ax1.plot(x, y, label=f"P1:Spec{i}")
 ax1.set_xlabel(r"q($\AA^{-1}$)")
 ax1.set_xlim([0.1, 15])

--- a/docs/source/algorithms/CalculatePlaczekPlotP2.py
+++ b/docs/source/algorithms/CalculatePlaczekPlotP2.py
@@ -28,11 +28,11 @@ ConvertUnits(InputWorkspace="NOM_P2", OutputWorkspace="NOM_P2", Target="Momentum
 
 # plot
 outws = mtd["NOM_P2"]
-x = np.array(outws.readX(0))
+x = np.array(outws.x(0))
 x = 0.5 * (x[1:] + x[:-1])
 fig, ax1 = plt.subplots(1)
 for i in range(6):
-    y = np.array(outws.readY(i))
+    y = np.array(outws.y(i))
     ax1.plot(x, y, label=f"P1+P2:Spec{i}")
 ax1.set_xlabel(r"q($\AA^{-1}$)")
 ax1.set_xlim([0.1, 15])

--- a/docs/source/release/v7.0.0/Framework/Python/Deprecated/41801.rst
+++ b/docs/source/release/v7.0.0/Framework/Python/Deprecated/41801.rst
@@ -1,0 +1,22 @@
+- :class:`~mantid.api.MatrixWorkspace` now exposes
+  the preferred ``Histogram`` data accessors to python:
+  ``x()``, ``y()``, ``e()``, ``dx()`` (read-only numpy wrappers) and
+  ``mutableX()``, ``mutableY()``, ``mutableE()``, ``mutableDx()``
+  (writable numpy wrappers). These replace the legacy ``readX()``/``readY()``/``readE()``/``readDx()``
+  and ``dataX()``/``dataY()``/``dataE()``/``dataDx()`` methods,
+  which are now deprecated and emit a ``DeprecationWarning`` naming the replacement,
+  but continue to work and return the same data.
+  See the :ref:`HistogramData` concept page for more information on the ``Histogram`` data model.
+- ``dx()``/``mutableDx()`` behave the same way ``readDx()``/``dataDx()`` always have:
+  if no Dx (x-error) data has been set on the spectrum, it is first initialized to zeros,
+  so these methods are always safe to call.
+- The deprecation warnings above are emitted via
+  `PyErr_Warn(PyExc_DeprecationWarning, ...) <https://docs.python.org/3/c-api/exceptions.html#c.PyExc_DeprecationWarning>`__,
+  equivalent to ``warnings.warn(message, DeprecationWarning)``,
+  and follow Python's standard warnings filtering:
+  by default they are printed only for deprecated calls made directly from a user script
+  or interactive session (``__main__``), once per call site,
+  while calls from inside imported modules are silent.
+  Run Python with ``-W default`` (or use ``warnings.simplefilter("default")``) to surface
+  every occurrence, or ``error`` in place of ``default`` to raise them as exceptions
+  when hunting call sites in tests or CI.

--- a/scripts/LargeScaleStructures/data_stitching.py
+++ b/scripts/LargeScaleStructures/data_stitching.py
@@ -217,8 +217,8 @@ class DataSet(object):
         points
         """
         if self.is_loaded():
-            x = mtd[self._ws_name].readX(0)
-            y = mtd[self._ws_name].readY(0)
+            x = mtd[self._ws_name].x(0)
+            y = mtd[self._ws_name].y(0)
             xmin = x[0]
             xmax = x[len(x) - 1]
 
@@ -281,7 +281,7 @@ class DataSet(object):
         self.load()
 
         # Keep track of dQ
-        dq = mtd[self._ws_name].readDx(0)
+        dq = mtd[self._ws_name].dx(0)
 
         Scale(InputWorkspace=self._ws_name, OutputWorkspace=self._ws_scaled, Operation="Multiply", Factor=self._scale)
 
@@ -291,10 +291,10 @@ class DataSet(object):
             dq_scaled[i] = dq[i]
 
         if xmin is not None and xmax is not None:
-            x = mtd[self._ws_scaled].readX(0)
+            x = mtd[self._ws_scaled].x(0)
             dx = dq_scaled
-            y = mtd[self._ws_scaled].readY(0)
-            e = mtd[self._ws_scaled].readE(0)
+            y = mtd[self._ws_scaled].y(0)
+            e = mtd[self._ws_scaled].e(0)
 
             x_trim = []
             dx_trim = []
@@ -362,7 +362,7 @@ class DataSet(object):
                 point_data_ws = "%s_" % self._ws_name
                 ConvertToPointData(InputWorkspace=self._ws_name, OutputWorkspace=point_data_ws)
                 # Copy over the resolution
-                dq_original = mtd[self._ws_name].readDx(0)
+                dq_original = mtd[self._ws_name].dx(0)
                 dq_points = mtd[point_data_ws].dataDx(0)
                 for i in range(len(dq_points)):
                     dq_points[i] = dq_original[i]
@@ -371,11 +371,11 @@ class DataSet(object):
             self._ws_scaled = self._ws_name + "_scaled"
             if update_range:
                 self._restricted_range = restricted_range
-                self._xmin = min(mtd[self._ws_name].readX(0))
-                self._xmax = max(mtd[self._ws_name].readX(0))
+                self._xmin = min(mtd[self._ws_name].x(0))
+                self._xmax = max(mtd[self._ws_name].x(0))
                 if restricted_range:
-                    y = mtd[self._ws_name].readY(0)
-                    x = mtd[self._ws_name].readX(0)
+                    y = mtd[self._ws_name].y(0)
+                    x = mtd[self._ws_name].x(0)
 
                     for i in range(len(y)):
                         if y[i] != 0.0:
@@ -386,7 +386,7 @@ class DataSet(object):
                             self._xmax = x[i]
                             break
 
-            self._npts = len(mtd[self._ws_name].readY(0))
+            self._npts = len(mtd[self._ws_name].y(0))
             self._last_applied_scale = 1.0
 
     def scale_to_unity(self, xmin=None, xmax=None):
@@ -394,9 +394,9 @@ class DataSet(object):
         Compute a scaling factor for which the average of the
         data is 1 in the specified region
         """
-        x = mtd[self._ws_name].readX(0)
-        y = mtd[self._ws_name].readY(0)
-        e = mtd[self._ws_name].readE(0)
+        x = mtd[self._ws_name].x(0)
+        y = mtd[self._ws_name].y(0)
+        e = mtd[self._ws_name].e(0)
         sum_cts = 0.0
         sum_err = 0.0
         for i in range(len(y)):
@@ -422,9 +422,9 @@ class DataSet(object):
         if xmax is None:
             xmax = self._xmax
 
-        x = mtd[self._ws_name].readX(0)
-        y = mtd[self._ws_name].readY(0)
-        e = mtd[self._ws_name].readE(0)
+        x = mtd[self._ws_name].x(0)
+        y = mtd[self._ws_name].y(0)
+        e = mtd[self._ws_name].e(0)
 
         is_histo = len(x) == len(y) + 1
         if not is_histo and len(x) != len(y):


### PR DESCRIPTION
### Description of work

According to code comments inside `MatrixWorkspace.h` and `Histogram.h` and other files, the following methods have been "deprecated" for at least a decade:
- `readX()`
- `dataX()`
- `setX()`

plus the analogs for `Y`, `E`, and `Dx`.

However, the deprecation "strategy" there was to leave a little note inside the source code.

This is the beginning of work to actually deprecate, by raising a deprecation warning inside the python binding.  When a user tries to run one of these methods, they will now see a deprecation warning, and their call will instead be rerouted to the correct `x()` or `mutableX()` methods.

Because `dx()` and `mutableDx()` were in scope, and yet were not really complete, this added a guard on `Histogram::dx()` so make sure the pointer exists before use, and if not initializes it with all zeroes.  Otherwise, segfaults are possible.

While fixing the above error, test failures led to a minor refactor in a test to use the user's config to lookup a file, rather than assuming the save path.  Also, a few places of `readX()` were replaced with `x()` in attempting to debug a test failure.

Related to:
[EWM 16825](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16825)

### To test:

Build, load data into a matrix workspace, and try to use the `readX()` and etc. methods.

Calls should succeed, but will log a warning (make sure logger is at least at WARN level)

**This does not need release notes because** it is the first in a long set of PRs to handle this change, the last of which will receive the release notes.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
