### PR TITLE
Enable MDNorm to handle workspaces created with ConvertToMD with UseLogTimes

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDBase.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDBase.h
@@ -48,7 +48,7 @@ public:
      (if such conversion is necessary) */
   UnitsConversionHelper &getUnitConversionHelper() { return m_UnitConversion; }
   // This value is used by ConvertToMD to set a property as a flag for BinMD/MDNorm
-  std::vector<std::string> getLogTimesName() { return m_useLogTimesName; }
+  std::vector<std::string> getTimeLogsName() { return m_timeLogsName; }
 
 protected:
   // pointer to input matrix workspace;
@@ -88,7 +88,7 @@ protected:
   Mantid::Kernel::SpecialCoordinateSystem m_coordinateSystem;
   /// Flag to use log values corresponding to event pulse time instead of average values
   bool m_useLogTimes;
-  std::vector<std::string> m_useLogTimesName;
+  std::vector<std::string> m_timeLogsName;
 
 private:
   /** internal function which do one peace of work, which should be performed by

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDBase.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDBase.h
@@ -47,6 +47,8 @@ public:
      units to the units, used by appropriate MD transformation
      (if such conversion is necessary) */
   UnitsConversionHelper &getUnitConversionHelper() { return m_UnitConversion; }
+  // This value is used by ConvertToMD to set a property as a flag for BinMD/MDNorm
+  std::vector<std::string> getLogTimesName() { return m_useLogTimesName; }
 
 protected:
   // pointer to input matrix workspace;
@@ -86,6 +88,7 @@ protected:
   Mantid::Kernel::SpecialCoordinateSystem m_coordinateSystem;
   /// Flag to use log values corresponding to event pulse time instead of average values
   bool m_useLogTimes;
+  std::vector<std::string> m_useLogTimesName;
 
 private:
   /** internal function which do one peace of work, which should be performed by

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -26,8 +26,10 @@ public:
   const std::vector<std::string> seeAlso() const override { return {"MDNormSCD", "MDNormSCDPreprocessIncoherent"}; }
   const std::string category() const override;
   const std::string summary() const override;
-  static constexpr double CHARGEBINSIZE = 1.0; // Proton charge bin size in uA.hr for useLogTimes normalization
-  static constexpr double GONIOBINSTEP = 0.25; // Bin size in angle in degrees for useLogTimes normalization
+  static constexpr double CHARGEBINSIZE = 1.0;    // Proton charge bin size in uA.hr for useLogTimes normalization
+  static constexpr double GONIOBINSTEP = 0.25;    // Bin size in angle in degrees for useLogTimes normalization
+  static constexpr double MINPROTONCHARGE = 0.1;  // Proton charge below which an angle will be ignored as no data
+  static constexpr double STATIONARYANGLIM = 0.1; // Angle size (degrees) below which a gonio is considered stationary
 
 private:
   void init() override;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -39,6 +39,7 @@ private:
   std::vector<coord_t> getValuesFromOtherDimensions(bool &skipNormalization, uint16_t expInfoIndex = 0) const;
   Kernel::Matrix<coord_t> findIntergratedDimensions(const std::vector<coord_t> &otherDimValues,
                                                     bool &skipNormalization);
+  void initializeLogTimes();
   void cacheDimensionXValues();
   void calculateNormalization(const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
                               uint16_t expInfoIndex);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -43,6 +43,9 @@ private:
   void cacheDimensionXValues();
   void calculateNormalization(const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
                               uint16_t expInfoIndex);
+  void calculateNormInner(const API::SpectrumInfo &spectrumInfo, const double protonCharge,
+                          const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
+                          std::pair<double, double> progval);
 
   void calculateIntersections(std::vector<std::array<double, 4>> &intersections, const double theta, const double phi);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -45,9 +45,10 @@ private:
   void cacheDimensionXValues();
   void calculateNormalization(const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
                               uint16_t expInfoIndex);
+  void calculateNormContinuous(const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
+                               uint16_t expInfoIndex);
   void calculateNormInner(const API::SpectrumInfo &spectrumInfo, const double protonCharge,
-                          const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans,
-                          std::pair<double, double> progval);
+                          const std::vector<coord_t> &otherValues, const Kernel::Matrix<coord_t> &affineTrans);
 
   void calculateIntersections(std::vector<std::array<double, 4>> &intersections, const double theta, const double phi);
 
@@ -77,6 +78,8 @@ private:
   bool m_accumulate{false};
   /// number of experiment infos
   uint16_t m_numExptInfos;
+  /// Progress bar
+  std::unique_ptr<API::Progress> m_progress;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -26,6 +26,8 @@ public:
   const std::vector<std::string> seeAlso() const override { return {"MDNormSCD", "MDNormSCDPreprocessIncoherent"}; }
   const std::string category() const override;
   const std::string summary() const override;
+  static constexpr double CHARGEBINSIZE = 1.0; // Proton charge bin size in uA.hr for useLogTimes normalization
+  static constexpr double GONIOBINSTEP = 0.25; // Bin size in angle in degrees for useLogTimes normalization
 
 private:
   void init() override;

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -148,7 +148,7 @@ size_t ConvToMDEventsWS::initialize(const MDWSDescription &WSD, std::shared_ptr<
         m_Logs.push_back(
             std::unique_ptr<Kernel::TimeSeriesProperty<double>>(run.getTimeSeriesProperty<double>(ax.name)->clone()));
         m_GonioIndex.push_back(n);
-        m_useLogTimesName.push_back(ax.name);
+        m_timeLogsName.push_back(ax.name);
       }
     }
     const auto &dimNames = WSD.getDimNames();

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -148,6 +148,7 @@ size_t ConvToMDEventsWS::initialize(const MDWSDescription &WSD, std::shared_ptr<
         m_Logs.push_back(
             std::unique_ptr<Kernel::TimeSeriesProperty<double>>(run.getTimeSeriesProperty<double>(ax.name)->clone()));
         m_GonioIndex.push_back(n);
+        m_useLogTimesName.push_back(ax.name);
       }
     }
     const auto &dimNames = WSD.getDimNames();

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -310,6 +310,10 @@ void ConvertToMD::exec() {
     savemd->executeAsChildAlg();
   }
 
+  if (std::vector<std::string> logname = m_Convertor->getLogTimesName(); logname.size() > 0) {
+    spws->getExperimentInfo(0)->mutableRun().addProperty("useLogTimes", logname, true);
+  }
+
   // JOB COMPLETED:
   setProperty("OutputWorkspace", std::dynamic_pointer_cast<IMDEventWorkspace>(spws));
   // free the algorithm from the responsibility for the target workspace to

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -310,10 +310,11 @@ void ConvertToMD::exec() {
     savemd->executeAsChildAlg();
   }
 
-  if (std::vector<std::string> logname = m_Convertor->getLogTimesName(); logname.size() > 0) {
+  if (const auto logname = m_Convertor->getTimeLogsName(); logname.size() > 0) {
     std::string singlestring;
+    singlestring.reserve(2 * logname.size());
     for (auto string : logname) {
-      singlestring += string + ",";
+      singlestring.append(string).append(1, ',');
     }
     singlestring.pop_back();
     spws->getExperimentInfo(0)->mutableRun().addProperty("useLogTimes", singlestring, true);

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -311,7 +311,12 @@ void ConvertToMD::exec() {
   }
 
   if (std::vector<std::string> logname = m_Convertor->getLogTimesName(); logname.size() > 0) {
-    spws->getExperimentInfo(0)->mutableRun().addProperty("useLogTimes", logname, true);
+    std::string singlestring;
+    for (auto string : logname) {
+      singlestring += string + ",";
+    }
+    singlestring.pop_back();
+    spws->getExperimentInfo(0)->mutableRun().addProperty("useLogTimes", singlestring, true);
   }
 
   // JOB COMPLETED:

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -225,16 +225,18 @@ std::string MDNormDirectSC::inputEnergyMode() const {
   const auto &hist = m_inputWS->getHistory();
   const size_t nalgs = hist.size();
   const auto &lastAlgHist = hist.getAlgorithmHistory(nalgs - 1);
-  const auto &penultimateAlgHist = hist.getAlgorithmHistory(nalgs - 2);
 
   std::string emode;
   if (lastAlgHist->name() == "ConvertToMD") {
-    emode = lastAlgHist->getPropertyValue("dEAnalysisMode");
-  } else if ((lastAlgHist->name() == "Load" || lastAlgHist->name() == "LoadMD") &&
-             penultimateAlgHist->name() == "ConvertToMD") {
     // get dEAnalysisMode
-    emode = penultimateAlgHist->getPropertyValue("dEAnalysisMode");
+    emode = lastAlgHist->getPropertyValue("dEAnalysisMode");
   } else {
+    if ((lastAlgHist->name() == "Load" || lastAlgHist->name() == "LoadMD") && nalgs > 1) {
+      const auto &penultimateAlgHist = hist.getAlgorithmHistory(nalgs - 2);
+      if (penultimateAlgHist->name() == "ConvertToMD") {
+        return penultimateAlgHist->getPropertyValue("dEAnalysisMode");
+      }
+    }
     throw std::invalid_argument("The last algorithm in the history of the "
                                 "input workspace is not ConvertToMD");
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -89,6 +89,8 @@ void MDNormDirectSC::init() {
   solidAngleValidator->add<InstrumentValidator>();
   solidAngleValidator->add<CommonBinsValidator>();
 
+  m_progress = std::make_unique<API::Progress>();
+
   declareProperty(std::make_unique<WorkspaceProperty<>>("SolidAngleWorkspace", "", Direction::Input,
                                                         PropertyMode::Optional, solidAngleValidator),
                   "An input workspace containing integrated vanadium (a measure of the "
@@ -135,6 +137,11 @@ void MDNormDirectSC::exec() {
   m_numExptInfos = outputWS->getNumExperimentInfo();
   // loop over all experiment infos
   for (uint16_t expInfoIndex = 0; expInfoIndex < m_numExptInfos; expInfoIndex++) {
+    const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
+    if (!currentExptInfo.run().hasProperty("RUBW_MATRIX")) {
+      throw std::runtime_error("Wokspace does not contain a log entry for the RUBW matrix."
+                               "Cannot continue.");
+    }
     // Check for other dimensions if we could measure anything in the original
     // data
     bool skipNormalization = false;
@@ -143,7 +150,11 @@ void MDNormDirectSC::exec() {
     cacheDimensionXValues();
 
     if (!skipNormalization) {
-      calculateNormalization(otherValues, affineTrans, expInfoIndex);
+      if (currentExptInfo.run().hasProperty("useLogTimes")) {
+        calculateNormContinuous(otherValues, affineTrans, expInfoIndex);
+      } else {
+        calculateNormalization(otherValues, affineTrans, expInfoIndex);
+      }
     } else {
       g_log.warning("Binning limits are outside the limits of the MDWorkspace. "
                     "Not applying normalization.");
@@ -436,116 +447,123 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
   const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
   const auto &spectrumInfo = currentExptInfo.spectrumInfo();
   auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
-  if (!rubwLog) {
-    throw std::runtime_error("Wokspace does not contain a log entry for the RUBW matrix."
-                             "Cannot continue.");
-  }
+  int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
   Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
-  if (currentExptInfo.run().hasProperty("useLogTimes")) {
-    // MDEventWS was created with the "useLogTimes" option: should be only a single expInfo, but
-    // gonios vary with time - we now coarse-bin it to compute the normalisation.
-    const Run &run = currentExptInfo.run();
-    if (!run.hasProperty(LOG_CHARGE_NAME)) {
-      throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
+  m_rubw = currentExptInfo.run().getGoniometerMatrix() * rubwValue;
+  m_rubw.Invert();
+  const double protonCharge = currentExptInfo.run().getProtonCharge();
+
+  double progStep = 0.7 / m_numExptInfos;
+  m_progress->resetNumSteps(ndets, 0.3 + progStep * expInfoIndex, 0.3 + progStep * (expInfoIndex + 1.));
+  calculateNormInner(spectrumInfo, protonCharge, otherValues, affineTrans);
+}
+
+/**
+ * Computes the normalization for the input workspace for the case of a continous rotation
+ * @param otherValues non HKLE dimensions
+ * @param affineTrans affine matrix
+ * @param expInfoIndex current experiment info index
+ */
+void MDNormDirectSC::calculateNormContinuous(const std::vector<coord_t> &otherValues,
+                                             const Kernel::Matrix<coord_t> &affineTrans, uint16_t expInfoIndex) {
+  using VectorDoubleProperty = Kernel::PropertyWithValue<std::vector<double>>;
+  const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
+  const auto &spectrumInfo = currentExptInfo.spectrumInfo();
+  auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
+  int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
+  Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
+  // MDEventWS was created with the "useLogTimes" option: should be only a single expInfo, but
+  // gonios vary with time - we now coarse-bin it to compute the normalisation.
+  const Run &run = currentExptInfo.run();
+  if (!run.hasProperty(LOG_CHARGE_NAME)) {
+    throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
+  }
+  double normfac = run.hasProperty("NormalizationFactor")
+                       ? (*dynamic_cast<Kernel::PropertyWithValue<double> *>(run.getProperty("NormalizationFactor")))()
+                       : 1.0;
+  std::vector<std::string> lognames;
+  std::istringstream tosplit;
+  tosplit.str((*dynamic_cast<PropertyWithValue<std::string> *>(run.getProperty("useLogTimes")))());
+  for (std::string item; std::getline(tosplit, item, ',');) {
+    lognames.push_back(item);
+  }
+  std::vector<TimeSeriesProperty<double> *> logs;
+  std::vector<size_t> moving_gonio_index;
+  for (const auto &name : lognames) {
+    auto *log = run.getTimeSeriesProperty<double>(name);
+    logs.push_back(log);
+    if ((log->maxValue() - log->minValue()) > 0.1) { // Assume gonio logs in degrees
+      moving_gonio_index.push_back(logs.size() - 1);
     }
-    double normfac =
-        run.hasProperty("NormalizationFactor")
-            ? (*dynamic_cast<Kernel::PropertyWithValue<double> *>(run.getProperty("NormalizationFactor")))()
-            : 1.0;
-    std::vector<std::string> lognames;
-    std::istringstream tosplit;
-    tosplit.str((*dynamic_cast<PropertyWithValue<std::string> *>(run.getProperty("useLogTimes")))());
-    for (std::string item; std::getline(tosplit, item, ',');) {
-      lognames.push_back(item);
+  }
+  const TimeSeriesProperty<double> *protonlog = run.getTimeSeriesProperty<double>(LOG_CHARGE_NAME);
+  std::vector<double> proton_charge = protonlog->valuesAsVector();
+  std::vector<Types::Core::DateAndTime> proton_times = protonlog->timesAsVector();
+  Geometry::Goniometer gonio(run.getGoniometer());
+  if (moving_gonio_index.size() == 1) {
+    // If we only have a single moving gonio, bin all its values to GONIOBINSTEP degree bins and
+    // run inner loop on each binned angle
+    const TimeROI &timeroi = run.getTimeROI();
+    std::vector<double> filteredVals = logs[moving_gonio_index[0]]->filteredValuesAsVector(&timeroi);
+    const auto &[min, max] = std::minmax_element(filteredVals.begin(), filteredVals.end());
+    std::vector<double> gonio_charge(static_cast<int>((*max - *min) / GONIOBINSTEP) + 1, 0.0);
+    for (size_t n = 0; n < proton_charge.size(); n++) {
+      double logval = logs[moving_gonio_index[0]]->getSingleValue(proton_times[n]);
+      if (std::isnan(logval) || logval > *max || logval < *min) {
+        continue;
+      }
+      auto idx = static_cast<size_t>(floor((logval - *min) / GONIOBINSTEP));
+      gonio_charge[idx] += proton_charge[n];
     }
-    std::vector<TimeSeriesProperty<double> *> logs;
-    std::vector<size_t> moving_gonio_index;
-    for (auto name : lognames) {
-      auto *log = run.getTimeSeriesProperty<double>(name);
-      logs.push_back(log);
-      if ((log->maxValue() - log->minValue()) > 0.1) { // Assume gonio logs in degrees
-        moving_gonio_index.push_back(logs.size() - 1);
+    m_accumulate = true;
+    const double pStep = 0.7 / static_cast<double>(gonio_charge.size());
+    for (size_t n = 0; n < gonio_charge.size(); n++) {
+      if (gonio_charge[n] < 0.01) {
+        continue;
       }
-    }
-    const TimeSeriesProperty<double> *protonlog = run.getTimeSeriesProperty<double>(LOG_CHARGE_NAME);
-    std::vector<double> proton_charge = protonlog->valuesAsVector();
-    std::vector<Types::Core::DateAndTime> proton_times = protonlog->timesAsVector();
-    Geometry::Goniometer gonio(run.getGoniometer());
-    if (moving_gonio_index.size() == 1) {
-      // If we only have a single moving gonio, bin all its values to GONIOBINSTEP degree bins and
-      // run inner loop on each binned angle
-      const TimeROI &timeroi = run.getTimeROI();
-      std::vector<double> filteredVals = logs[moving_gonio_index[0]]->filteredValuesAsVector(&timeroi);
-      auto minmax = std::minmax_element(filteredVals.begin(), filteredVals.end());
-      std::vector<double> gonio_charge(int((*minmax.second - *minmax.first) / GONIOBINSTEP) + 1, 0.0);
-      for (size_t n = 0; n < proton_charge.size(); n++) {
-        double logval = logs[moving_gonio_index[0]]->getSingleValue(proton_times[n]);
-        if (std::isnan(logval) || logval > *minmax.second || logval < *minmax.first) {
-          continue;
-        }
-        size_t idx = size_t(floor((logval - *minmax.first) / GONIOBINSTEP));
-        gonio_charge[idx] += proton_charge[n];
-      }
-      m_accumulate = true;
-      const double pStep = 0.7 / static_cast<double>(gonio_charge.size());
-      for (size_t n = 0; n < gonio_charge.size(); n++) {
-        if (gonio_charge[n] < 0.01) {
-          continue;
-        }
-        double nn = static_cast<double>(n);
-        gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + *minmax.first);
-        m_rubw = gonio.getR() * rubwValue;
-        m_rubw.Invert();
-        std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-        calculateNormInner(spectrumInfo, gonio_charge[n] / normfac, otherValues, affineTrans, progval);
-      }
-    } else {
-      // Otherwise run inner loop over small bins of proton charge in time
-      double charge_sum = 0.0;
-      size_t i0 = 0;
-      bool skip_iter = false;
-      const double pStep = 0.7 / static_cast<double>(proton_charge.size());
-      for (size_t n = 0; n < proton_charge.size(); n++) {
-        charge_sum += proton_charge[n];
-        if (charge_sum > CHARGEBINSIZE) {
-          size_t mid = int(floor(static_cast<double>(n - i0) / 2.));
-          skip_iter = false;
-          for (size_t gAx = 0; gAx < gonio.getNumberAxes(); gAx++) {
-            double logval = logs[gAx]->getSingleValue(proton_times[mid]);
-            if (std::isnan(logval)) {
-              skip_iter = true;
-              continue;
-            }
-            gonio.setRotationAngle(gAx, logval);
-          }
-          if (!skip_iter) {
-            double nn = static_cast<double>(n);
-            m_rubw = gonio.getR() * rubwValue;
-            m_rubw.Invert();
-            std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-            calculateNormInner(spectrumInfo, charge_sum / normfac, otherValues, affineTrans, progval);
-          }
-          charge_sum = 0;
-          i0 = n;
-        }
-      }
+      auto nn = static_cast<double>(n);
+      gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + *min);
+      m_rubw = gonio.getR() * rubwValue;
+      m_rubw.Invert();
+      m_progress->resetNumSteps(ndets, 0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
+      calculateNormInner(spectrumInfo, gonio_charge[n] / normfac, otherValues, affineTrans);
     }
   } else {
-    // Original workflow - each expInfo represents a fixed gonio orientation
-    m_rubw = currentExptInfo.run().getGoniometerMatrix() * rubwValue;
-    m_rubw.Invert();
-    const double protonCharge = currentExptInfo.run().getProtonCharge();
-
-    double progStep = 0.7 / m_numExptInfos;
-    std::pair<double, double> progval =
-        std::make_pair(0.3 + progStep * expInfoIndex, 0.3 + progStep * (expInfoIndex + 1.));
-    calculateNormInner(spectrumInfo, protonCharge, otherValues, affineTrans, progval);
+    // Otherwise run inner loop over small bins of proton charge in time
+    double charge_sum = 0.0;
+    size_t i0 = 0;
+    bool skip_iter = false;
+    const auto pStep = 0.7 / static_cast<double>(proton_charge.size());
+    for (size_t n = 0; n < proton_charge.size(); n++) {
+      charge_sum += proton_charge[n];
+      if (charge_sum > CHARGEBINSIZE) {
+        size_t mid = static_cast<int>(floor(static_cast<double>(n - i0) / 2.));
+        skip_iter = false;
+        for (size_t gAx = 0; gAx < gonio.getNumberAxes(); gAx++) {
+          double logval = logs[gAx]->getSingleValue(proton_times[mid]);
+          if (std::isnan(logval)) {
+            skip_iter = true;
+            continue;
+          }
+          gonio.setRotationAngle(gAx, logval);
+        }
+        if (!skip_iter) {
+          auto nn = static_cast<double>(n);
+          m_rubw = gonio.getR() * rubwValue;
+          m_rubw.Invert();
+          m_progress->resetNumSteps(ndets, 0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
+          calculateNormInner(spectrumInfo, charge_sum / normfac, otherValues, affineTrans);
+        }
+        charge_sum = 0;
+        i0 = n;
+      }
+    }
   }
 }
 
 void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, const double protonCharge,
                                         const std::vector<coord_t> &otherValues,
-                                        const Kernel::Matrix<coord_t> &affineTrans, std::pair<double, double> progval) {
+                                        const Kernel::Matrix<coord_t> &affineTrans) {
   constexpr double energyToK = 8.0 * M_PI * M_PI * PhysicalConstants::NeutronMass * PhysicalConstants::meV * 1e-20 /
                                (PhysicalConstants::h * PhysicalConstants::h);
   // Mapping
@@ -562,7 +580,6 @@ void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, c
   std::vector<std::atomic<signal_t>> signalArray(m_normWS->getNPoints());
   std::vector<std::array<double, 4>> intersections;
   std::vector<coord_t> pos, posNew;
-  auto prog = std::make_unique<API::Progress>(this, progval.first, progval.second, ndets);
 
   PRAGMA_OMP(parallel for private(intersections, pos, posNew))
   for (int64_t i = 0; i < ndets; i++) {
@@ -609,7 +626,7 @@ void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, c
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
       affineTrans.multiplyPoint(pos, posNew);
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
-      if (linIndex == size_t(-1))
+      if (linIndex == static_cast<size_t>(-1))
         continue;
 
       // signal = integral between two consecutive intersections *solid angle
@@ -617,7 +634,7 @@ void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, c
       double signal = solid * delta;
       Mantid::Kernel::AtomicOp(signalArray[linIndex], signal, std::plus<signal_t>());
     }
-    prog->report();
+    m_progress->report();
 
     PARALLEL_END_INTERRUPT_REGION
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -15,6 +15,7 @@
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/PhysicalConstants.h"
@@ -33,6 +34,9 @@ using namespace Mantid::Kernel;
 namespace {
 // function to  compare two intersections (h,k,l,Momentum) by Momentum
 bool compareMomentum(const std::array<double, 4> &v1, const std::array<double, 4> &v2) { return (v1[3] < v2[3]); }
+const std::string LOG_CHARGE_NAME("proton_charge");
+const double CHARGEBINSIZE = 1.0; // Proton charge bin size in uA.hr for useLogTimes normalization
+const double GONIOBINSTEP = 0.5;  // Bin size in angle in degrees for useLogTimes normalization
 } // namespace
 
 // Register the algorithm into the AlgorithmFactory
@@ -428,23 +432,115 @@ void MDNormDirectSC::cacheDimensionXValues() {
  */
 void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherValues,
                                             const Kernel::Matrix<coord_t> &affineTrans, uint16_t expInfoIndex) {
-  constexpr double energyToK = 8.0 * M_PI * M_PI * PhysicalConstants::NeutronMass * PhysicalConstants::meV * 1e-20 /
-                               (PhysicalConstants::h * PhysicalConstants::h);
-  const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
   using VectorDoubleProperty = Kernel::PropertyWithValue<std::vector<double>>;
+  using VectorStringProperty = Kernel::PropertyWithValue<std::vector<std::string>>;
+  const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
+  const auto &spectrumInfo = currentExptInfo.spectrumInfo();
   auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
   if (!rubwLog) {
     throw std::runtime_error("Wokspace does not contain a log entry for the RUBW matrix."
                              "Cannot continue.");
+  }
+  Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
+  if (currentExptInfo.run().hasProperty("useLogTimes")) {
+    // MDEventWS was created with the "useLogTimes" option: should be only a single expInfo, but
+    // gonios vary with time - we now coarse-bin it to compute the normalisation.
+    const Run &run = currentExptInfo.run();
+    if (!run.hasProperty(LOG_CHARGE_NAME)) {
+      throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
+    }
+    std::vector<std::string> lognames = (*dynamic_cast<VectorStringProperty *>(run.getProperty("useLogTimes")))();
+    std::vector<TimeSeriesProperty<double> *> logs;
+    std::vector<std::pair<double, double>> logminmax;
+    std::vector<size_t> moving_gonio_index;
+    for (auto name : lognames) {
+      auto *log = run.getTimeSeriesProperty<double>(name);
+      logs.push_back(log);
+      auto minmax = std::make_pair(log->minValue(), log->maxValue());
+      logminmax.push_back(minmax);
+      if ((minmax.second - minmax.first) > 0.1) { // Assume gonio logs in degrees
+        moving_gonio_index.push_back(logs.size() - 1);
+      }
+    }
+    const TimeSeriesProperty<double> *protonlog = run.getTimeSeriesProperty<double>(LOG_CHARGE_NAME);
+    std::vector<double> proton_charge = protonlog->valuesAsVector();
+    std::vector<Types::Core::DateAndTime> proton_times = protonlog->timesAsVector();
+    Geometry::Goniometer gonio(run.getGoniometer());
+    if (moving_gonio_index.size() == 1) {
+      // If we only have a single moving gonio, bin all its values to 0.5 degree bins and
+      // run inner loop on each binned angle
+      std::pair<double, double> minmax = logminmax[moving_gonio_index[0]];
+      std::vector<double> gonio_charge(int((minmax.second - minmax.first) / GONIOBINSTEP) + 1, 0.0);
+      for (size_t n = 0; n < proton_charge.size(); n++) {
+        double logval = logs[moving_gonio_index[0]]->getSingleValue(proton_times[n]);
+        if (std::isnan(logval)) {
+          continue;
+        }
+        size_t idx = size_t(floor((logval - minmax.first) / GONIOBINSTEP));
+        gonio_charge[idx] += proton_charge[n];
+      }
+      m_accumulate = true;
+      const double pStep = 0.7 / static_cast<double>(gonio_charge.size());
+      for (size_t n = 0; n < gonio_charge.size(); n++) {
+        if (gonio_charge[n] < 0.01) {
+          continue;
+        }
+        double nn = static_cast<double>(n);
+        gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + minmax.first);
+        m_rubw = gonio.getR() * rubwValue;
+        m_rubw.Invert();
+        std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
+        calculateNormInner(spectrumInfo, gonio_charge[n], otherValues, affineTrans, progval);
+      }
+    } else {
+      // Otherwise run inner loop over small bins of proton charge in time
+      double charge_sum = 0.0;
+      size_t i0 = 0;
+      bool skip_iter = false;
+      const double pStep = 0.7 / static_cast<double>(proton_charge.size());
+      for (size_t n = 0; n < proton_charge.size(); n++) {
+        charge_sum += proton_charge[n];
+        if (charge_sum > CHARGEBINSIZE) {
+          size_t mid = int(floor(static_cast<double>(n - i0) / 2.));
+          skip_iter = false;
+          for (size_t gAx = 0; gAx < gonio.getNumberAxes(); gAx++) {
+            double logval = logs[gAx]->getSingleValue(proton_times[mid]);
+            if (std::isnan(logval)) {
+              skip_iter = true;
+              continue;
+            }
+            gonio.setRotationAngle(gAx, logval);
+          }
+          if (!skip_iter) {
+            double nn = static_cast<double>(n);
+            m_rubw = gonio.getR() * rubwValue;
+            m_rubw.Invert();
+            std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
+            calculateNormInner(spectrumInfo, charge_sum, otherValues, affineTrans, progval);
+          }
+          charge_sum = 0;
+          i0 = n;
+        }
+      }
+    }
   } else {
-    Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
+    // Original workflow - each expInfo represents a fixed gonio orientation
     m_rubw = currentExptInfo.run().getGoniometerMatrix() * rubwValue;
     m_rubw.Invert();
+    const double protonCharge = currentExptInfo.run().getProtonCharge();
+
+    double progStep = 0.7 / m_numExptInfos;
+    std::pair<double, double> progval =
+        std::make_pair(0.3 + progStep * expInfoIndex, 0.3 + progStep * (expInfoIndex + 1.));
+    calculateNormInner(spectrumInfo, protonCharge, otherValues, affineTrans, progval);
   }
-  const double protonCharge = currentExptInfo.run().getProtonCharge();
+}
 
-  const auto &spectrumInfo = currentExptInfo.spectrumInfo();
-
+void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, const double protonCharge,
+                                        const std::vector<coord_t> &otherValues,
+                                        const Kernel::Matrix<coord_t> &affineTrans, std::pair<double, double> progval) {
+  constexpr double energyToK = 8.0 * M_PI * M_PI * PhysicalConstants::NeutronMass * PhysicalConstants::meV * 1e-20 /
+                               (PhysicalConstants::h * PhysicalConstants::h);
   // Mapping
   const auto ndets = static_cast<int64_t>(spectrumInfo.size());
   bool haveSA = false;
@@ -459,74 +555,72 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
   std::vector<std::atomic<signal_t>> signalArray(m_normWS->getNPoints());
   std::vector<std::array<double, 4>> intersections;
   std::vector<coord_t> pos, posNew;
-  double progStep = 0.7 / m_numExptInfos;
-  auto prog =
-      std::make_unique<API::Progress>(this, 0.3 + progStep * expInfoIndex, 0.3 + progStep * (expInfoIndex + 1.), ndets);
+  auto prog = std::make_unique<API::Progress>(this, progval.first, progval.second, ndets);
 
-PRAGMA_OMP(parallel for private(intersections, pos, posNew))
-for (int64_t i = 0; i < ndets; i++) {
-  PARALLEL_START_INTERRUPT_REGION
+  PRAGMA_OMP(parallel for private(intersections, pos, posNew))
+  for (int64_t i = 0; i < ndets; i++) {
+    PARALLEL_START_INTERRUPT_REGION
 
-  if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
-    continue;
-  }
-  const auto &detector = spectrumInfo.detector(i);
-  double theta = detector.getTwoTheta(m_samplePos, m_beamDir);
-  double phi = detector.getPhi();
-  // If the detector is a group, this should be the ID of the first detector
-  const auto detID = detector.getID();
+    if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
+      continue;
+    }
+    const auto &detector = spectrumInfo.detector(i);
+    double theta = detector.getTwoTheta(m_samplePos, m_beamDir);
+    double phi = detector.getPhi();
+    // If the detector is a group, this should be the ID of the first detector
+    const auto detID = detector.getID();
 
-  // Intersections
-  this->calculateIntersections(intersections, theta, phi);
-  if (intersections.empty())
-    continue;
-
-  // Get solid angle for this contribution
-  double solid = protonCharge;
-  if (haveSA) {
-    solid = solidAngleWS->y(solidAngDetToIdx.find(detID)->second)[0] * protonCharge;
-  }
-  // Compute final position in HKL
-  // pre-allocate for efficiency and copy non-hkl dim values into place
-  pos.resize(vmdDims + otherValues.size() + 1);
-  std::copy(otherValues.begin(), otherValues.end(), pos.begin() + vmdDims);
-  pos.emplace_back(1.f);
-  auto intersectionsBegin = intersections.begin();
-  for (auto it = intersectionsBegin + 1; it != intersections.end(); ++it) {
-    const auto &curIntSec = *it;
-    const auto &prevIntSec = *(it - 1);
-    // the full vector isn't used so compute only what is necessary
-    double delta = (curIntSec[3] * curIntSec[3] - prevIntSec[3] * prevIntSec[3]) / energyToK;
-    if (delta < 1e-10)
-      continue; // Assume zero contribution if difference is small
-
-    // Average between two intersections for final position
-    std::transform(curIntSec.data(), curIntSec.data() + vmdDims, prevIntSec.data(), pos.begin(),
-                   [](const double rhs, const double lhs) { return static_cast<coord_t>(0.5 * (rhs + lhs)); });
-
-    // transform kf to energy transfer
-    pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
-    affineTrans.multiplyPoint(pos, posNew);
-    size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
-    if (linIndex == size_t(-1))
+    // Intersections
+    this->calculateIntersections(intersections, theta, phi);
+    if (intersections.empty())
       continue;
 
-    // signal = integral between two consecutive intersections *solid angle
-    // *PC
-    double signal = solid * delta;
-    Mantid::Kernel::AtomicOp(signalArray[linIndex], signal, std::plus<signal_t>());
-  }
-  prog->report();
+    // Get solid angle for this contribution
+    double solid = protonCharge;
+    if (haveSA) {
+      solid = solidAngleWS->y(solidAngDetToIdx.find(detID)->second)[0] * protonCharge;
+    }
+    // Compute final position in HKL
+    // pre-allocate for efficiency and copy non-hkl dim values into place
+    pos.resize(vmdDims + otherValues.size() + 1);
+    std::copy(otherValues.begin(), otherValues.end(), pos.begin() + vmdDims);
+    pos.emplace_back(1.f);
+    auto intersectionsBegin = intersections.begin();
+    for (auto it = intersectionsBegin + 1; it != intersections.end(); ++it) {
+      const auto &curIntSec = *it;
+      const auto &prevIntSec = *(it - 1);
+      // the full vector isn't used so compute only what is necessary
+      double delta = (curIntSec[3] * curIntSec[3] - prevIntSec[3] * prevIntSec[3]) / energyToK;
+      if (delta < 1e-10)
+        continue; // Assume zero contribution if difference is small
 
-  PARALLEL_END_INTERRUPT_REGION
-}
-PARALLEL_CHECK_INTERRUPT_REGION
-if (m_accumulate) {
-  std::transform(signalArray.cbegin(), signalArray.cend(), m_normWS->getSignalArray(), m_normWS->mutableSignalArray(),
-                 [](const std::atomic<signal_t> &a, const signal_t &b) { return a + b; });
-} else {
-  std::copy(signalArray.cbegin(), signalArray.cend(), m_normWS->mutableSignalArray());
-}
+      // Average between two intersections for final position
+      std::transform(curIntSec.data(), curIntSec.data() + vmdDims, prevIntSec.data(), pos.begin(),
+                     [](const double rhs, const double lhs) { return static_cast<coord_t>(0.5 * (rhs + lhs)); });
+
+      // transform kf to energy transfer
+      pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
+      affineTrans.multiplyPoint(pos, posNew);
+      size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
+      if (linIndex == size_t(-1))
+        continue;
+
+      // signal = integral between two consecutive intersections *solid angle
+      // *PC
+      double signal = solid * delta;
+      Mantid::Kernel::AtomicOp(signalArray[linIndex], signal, std::plus<signal_t>());
+    }
+    prog->report();
+
+    PARALLEL_END_INTERRUPT_REGION
+  }
+  PARALLEL_CHECK_INTERRUPT_REGION
+  if (m_accumulate) {
+    std::transform(signalArray.cbegin(), signalArray.cend(), m_normWS->getSignalArray(), m_normWS->mutableSignalArray(),
+                   [](const std::atomic<signal_t> &a, const signal_t &b) { return a + b; });
+  } else {
+    std::copy(signalArray.cbegin(), signalArray.cend(), m_normWS->mutableSignalArray());
+  }
 }
 
 /**

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -89,7 +89,7 @@ void MDNormDirectSC::init() {
   solidAngleValidator->add<InstrumentValidator>();
   solidAngleValidator->add<CommonBinsValidator>();
 
-  m_progress = std::make_unique<API::Progress>();
+  m_progress = std::make_unique<API::Progress>(this, 0, 1, 1);
 
   declareProperty(std::make_unique<WorkspaceProperty<>>("SolidAngleWorkspace", "", Direction::Input,
                                                         PropertyMode::Optional, solidAngleValidator),
@@ -136,6 +136,7 @@ void MDNormDirectSC::exec() {
 
   m_numExptInfos = outputWS->getNumExperimentInfo();
   // loop over all experiment infos
+  m_progress->resetNumSteps(m_numExptInfos, 0.3, 1.0);
   for (uint16_t expInfoIndex = 0; expInfoIndex < m_numExptInfos; expInfoIndex++) {
     const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
     if (!currentExptInfo.run().hasProperty("RUBW_MATRIX")) {
@@ -161,6 +162,7 @@ void MDNormDirectSC::exec() {
     }
     // if more than one experiment info, keep accumulating
     m_accumulate = true;
+    m_progress->report();
   }
 
   // Set the display normalization based on the input workspace
@@ -447,14 +449,11 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
   const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
   const auto &spectrumInfo = currentExptInfo.spectrumInfo();
   auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
-  int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
   Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
   m_rubw = currentExptInfo.run().getGoniometerMatrix() * rubwValue;
   m_rubw.Invert();
   const double protonCharge = currentExptInfo.run().getProtonCharge();
 
-  double progStep = 0.7 / m_numExptInfos;
-  m_progress->resetNumSteps(ndets, 0.3 + progStep * expInfoIndex, 0.3 + progStep * (expInfoIndex + 1.));
   calculateNormInner(spectrumInfo, protonCharge, otherValues, affineTrans);
 }
 
@@ -470,94 +469,98 @@ void MDNormDirectSC::calculateNormContinuous(const std::vector<coord_t> &otherVa
   const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
   const auto &spectrumInfo = currentExptInfo.spectrumInfo();
   auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
-  int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
   Kernel::DblMatrix rubwValue((*rubwLog)()); // includes the 2*pi factor but not goniometer for now :)
+
   // MDEventWS was created with the "useLogTimes" option: should be only a single expInfo, but
   // gonios vary with time - we now coarse-bin it to compute the normalisation.
   const Run &run = currentExptInfo.run();
   if (!run.hasProperty(LOG_CHARGE_NAME)) {
     throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
   }
+
+  double progressStart = 0.3 + 0.7 * expInfoIndex / m_numExptInfos;
+  double progressEnd = 0.3 + 0.7 * (expInfoIndex + 1) / m_numExptInfos;
   double normfac = run.hasProperty("NormalizationFactor")
                        ? (*dynamic_cast<Kernel::PropertyWithValue<double> *>(run.getProperty("NormalizationFactor")))()
                        : 1.0;
-  std::vector<std::string> lognames;
   std::istringstream tosplit;
   tosplit.str((*dynamic_cast<PropertyWithValue<std::string> *>(run.getProperty("useLogTimes")))());
-  for (std::string item; std::getline(tosplit, item, ',');) {
-    lognames.push_back(item);
-  }
   std::vector<TimeSeriesProperty<double> *> logs;
-  std::vector<size_t> moving_gonio_index;
-  for (const auto &name : lognames) {
+  std::vector<size_t> movingGonioIndex;
+  const TimeSeriesProperty<double> *protonlog = run.getTimeSeriesProperty<double>(LOG_CHARGE_NAME);
+  std::vector<double> protonCharge = protonlog->valuesAsVector();
+  std::vector<Types::Core::DateAndTime> protonTimes = protonlog->timesAsVector();
+  Geometry::Goniometer gonio(run.getGoniometer());
+
+  for (std::string name; std::getline(tosplit, name, ',');) {
     auto *log = run.getTimeSeriesProperty<double>(name);
     logs.push_back(log);
-    if ((log->maxValue() - log->minValue()) > 0.1) { // Assume gonio logs in degrees
-      moving_gonio_index.push_back(logs.size() - 1);
+    if ((log->maxValue() - log->minValue()) > STATIONARYANGLIM) { // Assume gonio logs in degrees
+      movingGonioIndex.push_back(logs.size() - 1);
     }
   }
-  const TimeSeriesProperty<double> *protonlog = run.getTimeSeriesProperty<double>(LOG_CHARGE_NAME);
-  std::vector<double> proton_charge = protonlog->valuesAsVector();
-  std::vector<Types::Core::DateAndTime> proton_times = protonlog->timesAsVector();
-  Geometry::Goniometer gonio(run.getGoniometer());
-  if (moving_gonio_index.size() == 1) {
+
+  if (movingGonioIndex.size() == 1) {
     // If we only have a single moving gonio, bin all its values to GONIOBINSTEP degree bins and
     // run inner loop on each binned angle
     const TimeROI &timeroi = run.getTimeROI();
-    std::vector<double> filteredVals = logs[moving_gonio_index[0]]->filteredValuesAsVector(&timeroi);
+    const auto &gonioAxLog = logs[movingGonioIndex[0]];
+    std::vector<double> filteredVals = gonioAxLog->filteredValuesAsVector(&timeroi);
     const auto &[min, max] = std::minmax_element(filteredVals.begin(), filteredVals.end());
-    std::vector<double> gonio_charge(static_cast<int>((*max - *min) / GONIOBINSTEP) + 1, 0.0);
-    for (size_t n = 0; n < proton_charge.size(); n++) {
-      double logval = logs[moving_gonio_index[0]]->getSingleValue(proton_times[n]);
+    std::vector<double> gonioCharge(static_cast<int>((*max - *min) / GONIOBINSTEP) + 1, 0.0);
+    for (size_t n = 0; n < protonCharge.size(); n++) {
+      double logval = gonioAxLog->getSingleValue(protonTimes[n]);
       if (std::isnan(logval) || logval > *max || logval < *min) {
         continue;
       }
       auto idx = static_cast<size_t>(floor((logval - *min) / GONIOBINSTEP));
-      gonio_charge[idx] += proton_charge[n];
+      gonioCharge[idx] += protonCharge[n];
     }
     m_accumulate = true;
-    const double pStep = 0.7 / static_cast<double>(gonio_charge.size());
-    for (size_t n = 0; n < gonio_charge.size(); n++) {
-      if (gonio_charge[n] < 0.01) {
+    m_progress->resetNumSteps(static_cast<int64_t>(gonioCharge.size()), progressStart, progressEnd);
+    for (size_t n = 0; n < gonioCharge.size(); n++) {
+      if (gonioCharge[n] < MINPROTONCHARGE) {
         continue;
       }
       auto nn = static_cast<double>(n);
-      gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + *min);
+      gonio.setRotationAngle(movingGonioIndex[0], nn * GONIOBINSTEP + *min);
       m_rubw = gonio.getR() * rubwValue;
       m_rubw.Invert();
-      m_progress->resetNumSteps(ndets, 0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-      calculateNormInner(spectrumInfo, gonio_charge[n] / normfac, otherValues, affineTrans);
+      calculateNormInner(spectrumInfo, gonioCharge[n] / normfac, otherValues, affineTrans);
+      m_progress->report();
     }
   } else {
     // Otherwise run inner loop over small bins of proton charge in time
-    double charge_sum = 0.0;
+    double chargeSum = 0.0;
     size_t i0 = 0;
-    bool skip_iter = false;
-    const auto pStep = 0.7 / static_cast<double>(proton_charge.size());
-    for (size_t n = 0; n < proton_charge.size(); n++) {
-      charge_sum += proton_charge[n];
-      if (charge_sum > CHARGEBINSIZE) {
+    bool skipIter = false;
+    m_progress->resetNumSteps(static_cast<int64_t>(protonCharge.size()), progressStart, progressEnd);
+    for (size_t n = 0; n < protonCharge.size(); n++) {
+      chargeSum += protonCharge[n];
+      if (chargeSum > CHARGEBINSIZE) {
         size_t mid = static_cast<int>(floor(static_cast<double>(n - i0) / 2.));
-        skip_iter = false;
+        skipIter = false;
         for (size_t gAx = 0; gAx < gonio.getNumberAxes(); gAx++) {
-          double logval = logs[gAx]->getSingleValue(proton_times[mid]);
+          double logval = logs[gAx]->getSingleValue(protonTimes[mid]);
           if (std::isnan(logval)) {
-            skip_iter = true;
+            skipIter = true;
             continue;
           }
           gonio.setRotationAngle(gAx, logval);
         }
-        if (!skip_iter) {
-          auto nn = static_cast<double>(n);
+        if (!skipIter) {
           m_rubw = gonio.getR() * rubwValue;
           m_rubw.Invert();
-          m_progress->resetNumSteps(ndets, 0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-          calculateNormInner(spectrumInfo, charge_sum / normfac, otherValues, affineTrans);
+          calculateNormInner(spectrumInfo, chargeSum / normfac, otherValues, affineTrans);
         }
-        charge_sum = 0;
+        chargeSum = 0;
         i0 = n;
       }
+      m_progress->report();
     }
+  }
+  if (m_numExptInfos > 1) {
+    m_progress->resetNumSteps(m_numExptInfos - expInfoIndex, progressStart, 1.0);
   }
 }
 
@@ -634,8 +637,6 @@ void MDNormDirectSC::calculateNormInner(const API::SpectrumInfo &spectrumInfo, c
       double signal = solid * delta;
       Mantid::Kernel::AtomicOp(signalArray[linIndex], signal, std::plus<signal_t>());
     }
-    m_progress->report();
-
     PARALLEL_END_INTERRUPT_REGION
   }
   PARALLEL_CHECK_INTERRUPT_REGION

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -433,7 +433,6 @@ void MDNormDirectSC::cacheDimensionXValues() {
 void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherValues,
                                             const Kernel::Matrix<coord_t> &affineTrans, uint16_t expInfoIndex) {
   using VectorDoubleProperty = Kernel::PropertyWithValue<std::vector<double>>;
-  using VectorStringProperty = Kernel::PropertyWithValue<std::vector<std::string>>;
   const auto &currentExptInfo = *(m_inputWS->getExperimentInfo(expInfoIndex));
   const auto &spectrumInfo = currentExptInfo.spectrumInfo();
   auto *rubwLog = dynamic_cast<VectorDoubleProperty *>(currentExptInfo.getLog("RUBW_MATRIX"));
@@ -449,7 +448,12 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
     if (!run.hasProperty(LOG_CHARGE_NAME)) {
       throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
     }
-    std::vector<std::string> lognames = (*dynamic_cast<VectorStringProperty *>(run.getProperty("useLogTimes")))();
+    std::vector<std::string> lognames;
+    std::istringstream tosplit;
+    tosplit.str((*dynamic_cast<PropertyWithValue<std::string> *>(run.getProperty("useLogTimes")))());
+    for (std::string item; std::getline(tosplit, item, ',');) {
+      lognames.push_back(item);
+    }
     std::vector<TimeSeriesProperty<double> *> logs;
     std::vector<std::pair<double, double>> logminmax;
     std::vector<size_t> moving_gonio_index;

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -35,8 +35,6 @@ namespace {
 // function to  compare two intersections (h,k,l,Momentum) by Momentum
 bool compareMomentum(const std::array<double, 4> &v1, const std::array<double, 4> &v2) { return (v1[3] < v2[3]); }
 const std::string LOG_CHARGE_NAME("proton_charge");
-const double CHARGEBINSIZE = 1.0; // Proton charge bin size in uA.hr for useLogTimes normalization
-const double GONIOBINSTEP = 0.5;  // Bin size in angle in degrees for useLogTimes normalization
 } // namespace
 
 // Register the algorithm into the AlgorithmFactory
@@ -448,6 +446,10 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
     if (!run.hasProperty(LOG_CHARGE_NAME)) {
       throw std::runtime_error("Wokspace does not contain the proton charge log. Cannot continue.");
     }
+    double normfac =
+        run.hasProperty("NormalizationFactor")
+            ? (*dynamic_cast<Kernel::PropertyWithValue<double> *>(run.getProperty("NormalizationFactor")))()
+            : 1.0;
     std::vector<std::string> lognames;
     std::istringstream tosplit;
     tosplit.str((*dynamic_cast<PropertyWithValue<std::string> *>(run.getProperty("useLogTimes")))());
@@ -455,14 +457,11 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
       lognames.push_back(item);
     }
     std::vector<TimeSeriesProperty<double> *> logs;
-    std::vector<std::pair<double, double>> logminmax;
     std::vector<size_t> moving_gonio_index;
     for (auto name : lognames) {
       auto *log = run.getTimeSeriesProperty<double>(name);
       logs.push_back(log);
-      auto minmax = std::make_pair(log->minValue(), log->maxValue());
-      logminmax.push_back(minmax);
-      if ((minmax.second - minmax.first) > 0.1) { // Assume gonio logs in degrees
+      if ((log->maxValue() - log->minValue()) > 0.1) { // Assume gonio logs in degrees
         moving_gonio_index.push_back(logs.size() - 1);
       }
     }
@@ -471,16 +470,18 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
     std::vector<Types::Core::DateAndTime> proton_times = protonlog->timesAsVector();
     Geometry::Goniometer gonio(run.getGoniometer());
     if (moving_gonio_index.size() == 1) {
-      // If we only have a single moving gonio, bin all its values to 0.5 degree bins and
+      // If we only have a single moving gonio, bin all its values to GONIOBINSTEP degree bins and
       // run inner loop on each binned angle
-      std::pair<double, double> minmax = logminmax[moving_gonio_index[0]];
-      std::vector<double> gonio_charge(int((minmax.second - minmax.first) / GONIOBINSTEP) + 1, 0.0);
+      const TimeROI &timeroi = run.getTimeROI();
+      std::vector<double> filteredVals = logs[moving_gonio_index[0]]->filteredValuesAsVector(&timeroi);
+      auto minmax = std::minmax_element(filteredVals.begin(), filteredVals.end());
+      std::vector<double> gonio_charge(int((*minmax.second - *minmax.first) / GONIOBINSTEP) + 1, 0.0);
       for (size_t n = 0; n < proton_charge.size(); n++) {
         double logval = logs[moving_gonio_index[0]]->getSingleValue(proton_times[n]);
-        if (std::isnan(logval)) {
+        if (std::isnan(logval) || logval > *minmax.second || logval < *minmax.first) {
           continue;
         }
-        size_t idx = size_t(floor((logval - minmax.first) / GONIOBINSTEP));
+        size_t idx = size_t(floor((logval - *minmax.first) / GONIOBINSTEP));
         gonio_charge[idx] += proton_charge[n];
       }
       m_accumulate = true;
@@ -490,11 +491,11 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
           continue;
         }
         double nn = static_cast<double>(n);
-        gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + minmax.first);
+        gonio.setRotationAngle(moving_gonio_index[0], nn * GONIOBINSTEP + *minmax.first);
         m_rubw = gonio.getR() * rubwValue;
         m_rubw.Invert();
         std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-        calculateNormInner(spectrumInfo, gonio_charge[n], otherValues, affineTrans, progval);
+        calculateNormInner(spectrumInfo, gonio_charge[n] / normfac, otherValues, affineTrans, progval);
       }
     } else {
       // Otherwise run inner loop over small bins of proton charge in time
@@ -520,7 +521,7 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
             m_rubw = gonio.getR() * rubwValue;
             m_rubw.Invert();
             std::pair<double, double> progval = std::make_pair(0.3 + pStep * nn, 0.3 + pStep * (nn + 1.));
-            calculateNormInner(spectrumInfo, charge_sum, otherValues, affineTrans, progval);
+            calculateNormInner(spectrumInfo, charge_sum / normfac, otherValues, affineTrans, progval);
           }
           charge_sum = 0;
           i0 = n;

--- a/Framework/MDAlgorithms/test/MDNormDirectSCTest.h
+++ b/Framework/MDAlgorithms/test/MDNormDirectSCTest.h
@@ -9,7 +9,12 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/IMDHistoWorkspace.h"
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/UnitFactory.h"
+#include "MantidMDAlgorithms/ConvertToMD.h"
 #include "MantidMDAlgorithms/CreateMDWorkspace.h"
 #include "MantidMDAlgorithms/MDNormDirectSC.h"
 
@@ -22,6 +27,11 @@ public:
   // This means the constructor isn't called when running other tests
   static MDNormDirectSCTest *createSuite() { return new MDNormDirectSCTest(); }
   static void destroySuite(MDNormDirectSCTest *suite) { delete suite; }
+
+  std::vector<MatrixWorkspace_sptr> m_event_vec;
+  MatrixWorkspace_sptr m_event_ws;
+  int m_numAngles, m_numHist, m_numEvents, m_numEbins;
+  double m_Ei;
 
   void test_Init() {
     MDNormDirectSC alg;
@@ -44,6 +54,47 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputNormalizationWorkspace", "OutNormWSName"));
 
     AnalysisDataService::Instance().clear();
+  }
+
+  void test_compare_uselogtimes() {
+    // Tests that using a MDE with multiple ExpInfos (original workflow) and with a single
+    // ExpInfo and created using UseLogTimes=True are equivalent
+    m_numAngles = 5;
+    m_numHist = 5;
+    m_numEvents = 10000;
+    m_Ei = 100.;
+    createEventWorkspaces();
+    createMDEs();
+    MDNormDirectSC alg;
+    alg.initialize();
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim0", "Q1,-10,10,100"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim1", "Q2,-10,10,100"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim2", "Q3,-10,10,100"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("AlignedDim3", "DeltaE," + std::to_string(-m_Ei) + "," +
+                                                                     std::to_string(0.9 * m_Ei) + ",100"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "MDNorm"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputNormalizationWorkspace", "MDNorm_single"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "MDE_single"));
+    alg.execute();
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", "MDE_multiple"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputNormalizationWorkspace", "MDNorm_multiple"));
+    alg.execute();
+    IMDHistoWorkspace_sptr MDH_single =
+        std::dynamic_pointer_cast<IMDHistoWorkspace>(AnalysisDataService::Instance().retrieve("MDNorm_single"));
+    IMDHistoWorkspace_sptr MDH_multi =
+        std::dynamic_pointer_cast<IMDHistoWorkspace>(AnalysisDataService::Instance().retrieve("MDNorm_multiple"));
+    size_t np_single = MDH_single->getNPoints(), np_multi = MDH_multi->getNPoints();
+    TS_ASSERT_EQUALS(np_single, np_multi);
+    const auto sig_single = MDH_single->getSignalArray();
+    const auto sig_multi = MDH_multi->getSignalArray();
+    double diffsum = 0.0;
+    for (size_t i = 0; i < np_single; i++) {
+      diffsum += abs(sig_single[i] - sig_multi[i]);
+    }
+    TS_ASSERT_DELTA(diffsum, 0.0, 1e-3);
+    for (auto wsname : {"MDE_single", "MDE_multiple", "MDNorm_single", "MDNorm_multiple", "MDNorm"}) {
+      AnalysisDataService::Instance().remove(wsname);
+    }
   }
 
 private:
@@ -71,5 +122,81 @@ private:
   void createSolidAngleWorkspace(const std::string &wsName) {
     auto sa = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
     AnalysisDataService::Instance().addOrReplace(wsName, sa);
+  }
+
+  void createEventWorkspaces() {
+    Mantid::Geometry::Goniometer gonio;
+    gonio.pushAxis("Rot", 0., 1., 0., 0.);
+    // Creates a single workspace with m_numAngles
+    int nEv = m_numEvents * m_numAngles;
+    double binsize = 10000.0 / nEv; // To get range of 10000us
+    std::vector<Mantid::Types::Core::DateAndTime> pchargetimes(nEv), rottimes;
+    std::vector<double> pcharges(nEv, 0.1), rotvals;
+    Mantid::Types::Core::DateAndTime t0 = Mantid::Types::Core::DateAndTime("2010-01-01T00:00:00");
+    std::generate(pchargetimes.begin(), pchargetimes.end(), [t0, n = 0]() mutable { return t0 + double(n++); });
+    for (int i = 0; i < m_numAngles; i++) {
+      rotvals.push_back(i * MDNormDirectSC::GONIOBINSTEP);
+      rottimes.push_back(t0 + double(i * m_numEvents));
+    }
+    m_event_ws = std::dynamic_pointer_cast<MatrixWorkspace>(
+        WorkspaceCreationHelper::createEventWorkspace(m_numHist, nEv, nEv, 0.0, binsize, 3, 0));
+    m_event_ws->setInstrument(ComponentCreationHelper::createTestInstrumentCylindrical(m_numHist));
+    m_event_ws->getAxis(0)->unit() = Mantid::Kernel::UnitFactory::Instance().create("TOF");
+    m_event_ws->mutableRun().addProperty("Ei", m_Ei, "meV", true);
+    m_event_ws->mutableRun().addProperty("gd_prtn_chrg", 0.1 * nEv);
+    Mantid::Kernel::TimeSeriesProperty<double> *pchargelog =
+        new Mantid::Kernel::TimeSeriesProperty<double>("proton_charge");
+    pchargelog->addValues(pchargetimes, pcharges);
+    m_event_ws->mutableRun().addLogData(std::move(pchargelog));
+    Mantid::Kernel::TimeSeriesProperty<double> *rotlog = new Mantid::Kernel::TimeSeriesProperty<double>("Rot");
+    rotlog->addValues(rottimes, rotvals);
+    m_event_ws->mutableRun().addLogData(std::move(rotlog));
+    m_event_ws->mutableRun().setGoniometer(gonio, true);
+    // Creates a set of equivalent event workspaces at fixed angles
+    binsize = 10000.0 / m_numEvents; // So we get a range of 10000us
+    for (int i = 0; i < m_numAngles; i++) {
+      Mantid::Types::Core::DateAndTime t1 = t0 + double(i * m_numEvents);
+      MatrixWorkspace_sptr ws =
+          std::dynamic_pointer_cast<MatrixWorkspace>(WorkspaceCreationHelper::createEventWorkspaceWithStartTime(
+              m_numHist, m_numEvents, m_numEvents, 0.0, binsize, 3, 0, t1));
+      ws->setInstrument(ComponentCreationHelper::createTestInstrumentCylindrical(m_numHist));
+      ws->getAxis(0)->unit() = Mantid::Kernel::UnitFactory::Instance().create("TOF");
+      ws->mutableRun().addProperty("Ei", m_Ei, "meV", true);
+      ws->mutableRun().addProperty("gd_prtn_chrg", 0.1 * m_numEvents);
+      // pchargelog = new Mantid::Kernel::TimeSeriesProperty<double>("proton_charge");
+      // pchargelog->addValues(pchargetimes, pcharges);
+      // ws->mutableRun().addLogData(std::move(pchargelog));
+      rotlog = new Mantid::Kernel::TimeSeriesProperty<double>("Rot");
+      rotlog->addValues(std::vector<Mantid::Types::Core::DateAndTime>(1, t1),
+                        std::vector<double>(1, i * MDNormDirectSC::GONIOBINSTEP));
+      ws->mutableRun().addLogData(std::move(rotlog));
+      ws->mutableRun().setGoniometer(gonio, true);
+      m_event_vec.push_back(ws);
+    }
+  }
+
+  void createMDEs() {
+    Mantid::MDAlgorithms::ConvertToMD convMDAlg;
+    convMDAlg.initialize();
+    convMDAlg.setPropertyValue("QDimensions", "Q3D");
+    convMDAlg.setPropertyValue("dEAnalysisMode", "Direct");
+    std::string qm = std::to_string(2.35 * sqrt(m_Ei));
+    convMDAlg.setPropertyValue("MinValues", "-" + qm + ",-" + qm + ",-" + qm + "," + std::to_string(-m_Ei));
+    convMDAlg.setPropertyValue("MaxValues", qm + "," + qm + "," + qm + "," + std::to_string(m_Ei));
+    convMDAlg.setProperty("UseLogTimes", true);
+    AnalysisDataService::Instance().addOrReplace("EvWS", m_event_ws);
+    convMDAlg.setPropertyValue("InputWorkspace", "EvWS");
+    convMDAlg.setPropertyValue("OutputWorkspace", "MDE_single");
+    convMDAlg.execute();
+    // Now create an MDE from multiple workspaces
+    convMDAlg.setProperty("OverwriteExisting", false);
+    convMDAlg.setProperty("UseLogTimes", false);
+    for (auto ws : m_event_vec) {
+      AnalysisDataService::Instance().addOrReplace("EvWS", ws);
+      convMDAlg.setPropertyValue("InputWorkspace", "EvWS");
+      convMDAlg.setPropertyValue("OutputWorkspace", "MDE_multiple");
+      convMDAlg.execute();
+    }
+    AnalysisDataService::Instance().remove("EvWS");
   }
 };

--- a/docs/source/algorithms/MDNormDirectSC-v1.rst
+++ b/docs/source/algorithms/MDNormDirectSC-v1.rst
@@ -24,6 +24,10 @@ MDBox. A brief introduction to the multi-dimensional data normalization can be f
 
     As of :ref:`Release 4.0.0 <v4.0.0>`, the algorithm can handle merged MD workspaces. Make sure all original MDEvent workspaces have the same dimensions
 
+.. Note::
+    As of :ref:`Release 7.0.0 <v7.0.0>`, the algorithm can handle MDEvent workspaces created with the ``UseLogTimes=True`` option
+    (e.g. for continuous rotation scans). It does this by calculating trajectories at 0.25 degree intervals within the full logged angular range.
+
 Usage
 -----
 

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41802.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41802.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-MDNormDirectSC` can now handle MDEvent workspaces created by :ref:`algm-ConvertToMD` with the ``UseLogTimes`` property.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

As part of the [ConvertToMD Epic](https://github.com/orgs/mantidproject/projects/79/views/1) we need a binning algorithm which correctly handles event mode data - the original intention was to refactor `BinMD` but it was later found that `MDNorm` has the required [normalization calculations](https://docs.mantidproject.org/nightly/concepts/MDNorm.html#mdnorm) already implemented.

This PR modifies `MDNormDirectSC` to recognise `MDEventWorkspace`s created by `ConvertToMD` with `UseLogTimes=True` and to compute the normalization for the rebinning of these workspaces. It does this by using the usual `MDNorm` algorithm but at 0.25 degree steps ([hard coded](https://github.com/mantidproject/mantid/compare/converttomd_norm?expand=1#diff-ab928c8abd8be41f7911c93e555fad29f0b2fc3a63ceb7b9bdf8d63f05d80de9R30)). This is a quite compute intensive calculations and the current threading parallelisation algorithm is a bit inefficient and will be improved in another PR.

Closes #40804 <!-- One line per closed issue. -->
Closes #40805

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Uses the same data as for the ConvertToMD PR which can be found on this [OneDrive archive](https://stfc365-my.sharepoint.com/:u:/g/personal/duc_le_stfc_ac_uk/IQCeimTfms5hSpt3o3Cv5AIWATEMk0efsY2YzV6vYMgUskE) (if not from STFC, ask me for access). Use this modified script to test:

```python
############ User defined parameters ##############
rotation_block_name = 'Rot'
rotation_bin_size = 1.0             # In degrees (smaller needs more memory)
runno = 72410
wbvan = 71617
ei = 30      # Auto-ei currently doesn't work for live (streamed) data
lattice_pars = [4.446, 4.446, 4.446]
lattice_ang = [90, 90, 90]
uvector = '1,1,0'
vvector = '0,0,1'
rotation_zero_angle = 132.5           # psi0 in Horace notation
convert_with_logs = False
###################################################

import mantid, sys, os, importlib
from mantid.simpleapi import *
currdir = os.path.dirname(__file__)
sys.path.append(currdir)
import reduction_utils
output_dir = os.path.join(currdir, 'mno')
mantid.config.appendDataSearchDir(os.path.join(currdir, 'raw_data'))
mantid.config.appendDataSearchDir(os.path.join(currdir, 'instrument_files'))

wsname = runno if isinstance(runno, str) else f'MER{runno}'
ws = Load(wsname, OutputWorkspace=wsname) if wsname not in mtd else mtd[name]

if convert_with_logs:
    # Converts directly from events to MD without angular rebinning (needs PR code)
    output_ws = reduction_utils.iliad(runno=wsname, wbvan=wbvan, ei=ei, FixEi=True, hard_mask_file='mask_25_1.xml', inst='merlin',
        powder=False, powdermap='MERLIN_rings_251.xml', cs_single=True)
    SetGoniometer('single_md', Axis0='Rot,0,1,0,1', Axis1=f'{rotation_zero_angle},0,1,0,-1')
    a, b, c, alpha, beta, gamma = tuple(lattice_pars + lattice_ang)
    SetUB('single_md', a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma, u=uvector, v=vvector)
    mn, mx = ConvertToMDMinMaxLocal('single_md', QDimensions='Q3D', dEAnalysisMode='Direct', Q3DFrames='HKL')
    wsout = ConvertToMD('single_md', QDimensions='Q3D', dEAnalysisMode='Direct', Q3DFrames='HKL', QConversionScales='HKL', IgnoreZeroSignals=True, UseLogTimes=True,
        MinValues=mn, MaxValues=mx, PreprocDetectorsWS='-', OutputWorkspace='single_md_4d')
    #wsbin = BinMD(wsout, AlignedDim0=f'Q1,-4,2,100', AlignedDim1=f'Q2,-4,2,100', AlignedDim2=f'Q3,-5,2,100', AlignedDim3=f'DeltaE,-15,25,50')
    wsbin_norm = MDNormDirectSC(wsout, AlignedDim0=f'[H,0,0],-4,2,100', AlignedDim1=f'[0,K,0],-4,2,100', AlignedDim2=f'[0,0,L],-5,2,100', AlignedDim3=f'DeltaE,-15,25,50', OutputNormalizationWorkspace='wsnorm')
    wsbin_out = DivideMD('wsbin_norm', 'wsnorm')
    SaveMD(wsbin_out, Filename=os.path.join(output_dir, f'MER{runno}_{ei:g}meV_1to1_mdhisto_mdnorm.nxs'))
else:
    output_ws = reduction_utils.iliad(runno=wsname, wbvan=wbvan, ei=ei, FixEi=True, powder=False, ignore_zeros=True,
        Erange=[-0.5, 0.01, 0.85], cs_block=rotation_block_name, cs_bin_size=rotation_bin_size, cs_conv_to_md=True,
        cs_conv_pars={'lattice_pars':lattice_pars, 'lattice_ang':lattice_ang, 'u':uvector, 'v':vvector, 'psi0':rotation_zero_angle},
        hard_mask_file='mask_25_1.xml', inst='merlin', powdermap='MERLIN_rings_251.xml')
    wsout = RenameWorkspace('output_md', OutputWorkspace=f'MER{runno}_{ei:g}meV_1to1_md')
    wsbin = BinMD(wsout, AlignedDim0=f'[H,0,0],-4,2,100', AlignedDim1=f'[0,K,0],-4,2,100', AlignedDim2=f'[0,0,L],-5,2,100', AlignedDim3=f'DeltaE,-15,25,50')
    wsbin = CompactMD(wsbin)
    SaveMD(wsbin, Filename=os.path.join(output_dir, f'MER{runno}_{ei:g}meV_1to1_mdhisto_no0.nxs'))
```

The workspaces created by the two branches should look similar - unfortunately they are not numerically comparable (this should be investigated) but could be due to different angular bin sizes or MD bin sizes or other factors.

<img width="1671" height="722" alt="image" src="https://github.com/user-attachments/assets/c26aeed1-f406-4e16-9535-0f82d0f81426" />




<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
