### PR TITLE
Fix bug in Remember me checkbox from Error Reporter

### DIFF
--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
@@ -49,7 +49,7 @@ Error Reporter test
 
 - Cause a crash by running the ``Segfault`` algorithm, Workbench should close
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The private contact details from Test 1 should **NOT** be displayed and the ``Remember Me`` checkbox should **NOT** be ticked
+- The private contact details from Test 1 should be displayed as the ``Remember Me`` checkbox was ticked when closing the reporter
 - In the ``Name`` box enter ``Public`` and in the ``Email`` box enter ``public@public.com``
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
 - Tick the ``Remember Me`` checkbox
@@ -79,7 +79,7 @@ Error Reporter test
 - Load the file ``Training_Exercise3a_SNS.nxs``
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The shared contact details from test 2 should be displayed and the ``Remember Me`` checkbox ticked
+- The shared contact details from test 3 should be displayed and the ``Remember Me`` checkbox ticked
 - Click the ``Show More Details`` button to open the Show More Details dialog. This should show user details such as OS.
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
 - Leave the ``Name`` box EMPTY and in the ``Email`` box enter ``public2@public.com``
@@ -87,7 +87,7 @@ Error Reporter test
 - Make sure the ``Continue`` radio button is checked
 - Click the ``Yes, share information`` button
 - You should be returned to the main Mantid window
-- Check with the database admin that an error report was sent **WITH** a name, email, stacktrace and a textbox.
+- Check with the database admin that an error report was sent **WITH** the name as ``Not provided``, but the correct email, stacktrace and textbox.
 
 ---------------
 
@@ -97,7 +97,7 @@ Error Reporter test
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
 - Only the ``public2@public.com`` email from test 4 should be displayed in the email box and the ``Remember Me`` checkbox ticked.
-- In the `Name` box enter ``Public3`` and in the ``Email`` box enter ``public3@public.com``
+- In the ``Name`` box enter ``Public3`` and in the ``Email`` box enter ``public3@public.com``
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
 - Tick the ``Remember Me`` checkbox
 - Make sure the ``Terminate`` radio button is checked
@@ -113,11 +113,21 @@ Error Reporter test
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
 - The shared contact details from test 5 should be displayed and the ``Remember Me`` checkbox ticked
-- Close the error reporter and MantidWorkbench
+- Make sure the ``Continue`` radio button is checked
+- Untick the ``Remember Me`` checkbox and click the ``Dont' share any information`` button
+- MantidWorkbench should still be opened
+- Run the ``NormaliseToMonitor`` algorithm again
+- This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
+- The ``Name`` and ``Email`` boxes should be empty and the ``Remember Me`` checkbox unticked
+- Click the ``Don't share any information`` button
 
 --------------
 
 7. Open your ``Mantid.user.properties`` file
+
+.. note::
+   To quickly locate the path to the user properties file you can type: ``ConfigService.getUserFilename()`` on the ``IPython`` terminal session
+   running on the testing instance of ``MantidWorkbench``
 
 - Add the incorrect rooturl ``errorreports.rooturl = https://fake.mantidproject.org`` anywhere in the file (correct url is ``https://errorreports.mantidproject.org``)
 - This will cause the error reporter to fail to send the report

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
@@ -1,0 +1,2 @@
+- The Error Reporter Dialog now does not erase the local contact information of the user after clicking ``Don't share any information``. This information is never shared if the button
+  ``Don't share any information`` is clicked.

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -49,19 +49,19 @@ class ErrorReporterPresenter(object):
             except OSError:
                 pass
 
-    def do_not_share(self, continue_working=True, remember_checkbox=False, name="", email=""):
+    def do_not_share(self, continue_working=True, remember_contact_info=False, name="", email=""):
         self.error_log.notice("No information shared")
-        self._manage_remember_me_setting(remember_checkbox, name, email)
+        self._manage_remember_me_setting(remember_contact_info, name, email)
         self._handle_exit(continue_working)
         return -1
 
-    def _manage_remember_me_setting(self, remember_checkbox=False, name: str = "", email: str = "") -> None:
+    def _manage_remember_me_setting(self, remember_contact_info=False, name: str = "", email: str = "") -> None:
         """
         Stores locally the name and email set by the user on the error reporter form if they choose to do so
         when clicking on the `Remember Me` checkbox. This information is never shared if the button
         `Don't share any information` is clicked.
         """
-        if not remember_checkbox:
+        if not remember_contact_info:
             name = email = ""
         settings = QSettings()
         settings.beginGroup(self._view.CONTACT_INFO)
@@ -69,22 +69,22 @@ class ErrorReporterPresenter(object):
         settings.setValue(self._view.EMAIL, email)
         settings.endGroup()
 
-    def share_all_information(self, continue_working, remember_checkbox, new_name, new_email, text_box):
+    def share_all_information(self, continue_working, remember_contact_info, new_name, new_email, text_box):
         uptime = UsageService.getUpTime()
         status = self._send_report_to_server(share_identifiable=True, uptime=uptime, name=new_name, email=new_email, text_box=text_box)
         self.error_log.notice("Sent full information")
         # Remember name and email in QSettings
-        self._manage_remember_me_setting(remember_checkbox, new_name, new_email)
+        self._manage_remember_me_setting(remember_contact_info, new_name, new_email)
 
         self._handle_exit(continue_working)
 
         return status
 
-    def error_handler(self, continue_working, remember_checkbox, share, name, email, text_box):
+    def error_handler(self, continue_working, remember_contact_info, share, name, email, text_box):
         if share:
-            status = self.share_all_information(continue_working, remember_checkbox, name, email, text_box)
+            status = self.share_all_information(continue_working, remember_contact_info, name, email, text_box)
         else:
-            status = self.do_not_share(continue_working, remember_checkbox, name, email)
+            status = self.do_not_share(continue_working, remember_contact_info, name, email)
 
         self._view.close_reporter(status)
 

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -49,19 +49,19 @@ class ErrorReporterPresenter(object):
             except OSError:
                 pass
 
-    def do_not_share(self, continue_working=True, name="", email=""):
+    def do_not_share(self, continue_working=True, remember_checkbox=False, name="", email=""):
         self.error_log.notice("No information shared")
-        self._manage_remember_me_checkbox(name, email)
+        self._manage_remember_me_setting(remember_checkbox, name, email)
         self._handle_exit(continue_working)
         return -1
 
-    def _manage_remember_me_checkbox(self, name: str = "", email: str = "") -> None:
+    def _manage_remember_me_setting(self, remember_checkbox=False, name: str = "", email: str = "") -> None:
         """
         Stores locally the name and email set by the user on the error reporter form if they choose to do so
         when clicking on the `Remember Me` checkbox. This information is never shared if the button
         `Don't share any information` is clicked.
         """
-        if not self._view.rememberContactInfoCheckbox.isChecked():
+        if not remember_checkbox:
             name = email = ""
         settings = QSettings()
         settings.beginGroup(self._view.CONTACT_INFO)
@@ -69,22 +69,22 @@ class ErrorReporterPresenter(object):
         settings.setValue(self._view.EMAIL, email)
         settings.endGroup()
 
-    def share_all_information(self, continue_working, new_name, new_email, text_box):
+    def share_all_information(self, continue_working, remember_checkbox, new_name, new_email, text_box):
         uptime = UsageService.getUpTime()
         status = self._send_report_to_server(share_identifiable=True, uptime=uptime, name=new_name, email=new_email, text_box=text_box)
         self.error_log.notice("Sent full information")
         # Remember name and email in QSettings
-        self._manage_remember_me_checkbox(new_name, new_email)
+        self._manage_remember_me_setting(remember_checkbox, new_name, new_email)
 
         self._handle_exit(continue_working)
 
         return status
 
-    def error_handler(self, continue_working, share, name, email, text_box):
+    def error_handler(self, continue_working, remember_checkbox, share, name, email, text_box):
         if share:
-            status = self.share_all_information(continue_working, name, email, text_box)
+            status = self.share_all_information(continue_working, remember_checkbox, name, email, text_box)
         else:
-            status = self.do_not_share(continue_working, name, email)
+            status = self.do_not_share(continue_working, remember_checkbox, name, email)
 
         self._view.close_reporter(status)
 

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -49,42 +49,42 @@ class ErrorReporterPresenter(object):
             except OSError:
                 pass
 
-    def forget_contact_info(self):
+    def do_not_share(self, continue_working=True, name="", email=""):
+        self.error_log.notice("No information shared")
+        self._manage_remember_me_checkbox(name, email)
+        self._handle_exit(continue_working)
+        return -1
+
+    def _manage_remember_me_checkbox(self, name: str = "", email: str = "") -> None:
+        """
+        Stores locally the name and email set by the user on the error reporter form if they choose to do so
+        when clicking on the `Remember Me` checkbox. This information is never shared if the button
+        `Don't share any information` is clicked.
+        """
+        if not self._view.rememberContactInfoCheckbox.isChecked():
+            name = email = ""
         settings = QSettings()
         settings.beginGroup(self._view.CONTACT_INFO)
-        settings.setValue(self._view.NAME, "")
-        settings.setValue(self._view.EMAIL, "")
+        settings.setValue(self._view.NAME, name)
+        settings.setValue(self._view.EMAIL, email)
         settings.endGroup()
-
-    def do_not_share(self, continue_working=True):
-        self.error_log.notice("No information shared")
-        self._handle_exit(continue_working)
-        if not self._view.rememberContactInfoCheckbox.isChecked():
-            self.forget_contact_info()
-        return -1
 
     def share_all_information(self, continue_working, new_name, new_email, text_box):
         uptime = UsageService.getUpTime()
         status = self._send_report_to_server(share_identifiable=True, uptime=uptime, name=new_name, email=new_email, text_box=text_box)
         self.error_log.notice("Sent full information")
+        # Remember name and email in QSettings
+        self._manage_remember_me_checkbox(new_name, new_email)
+
         self._handle_exit(continue_working)
 
-        # Remember name and email in QSettings
-        if self._view.rememberContactInfoCheckbox.isChecked():
-            settings = QSettings()
-            settings.beginGroup(self._view.CONTACT_INFO)
-            settings.setValue(self._view.NAME, new_name)
-            settings.setValue(self._view.EMAIL, new_email)
-            settings.endGroup()
-        else:
-            self.forget_contact_info()
         return status
 
     def error_handler(self, continue_working, share, name, email, text_box):
         if share:
             status = self.share_all_information(continue_working, name, email, text_box)
         else:
-            status = self.do_not_share(continue_working)
+            status = self.do_not_share(continue_working, name, email)
 
         self._view.close_reporter(status)
 

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -32,7 +32,7 @@ ErrorReportUIBase, ErrorReportUI = load_ui(__file__, "errorreport.ui")
 
 
 class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
-    action = Signal(bool, int, str, str, str)
+    action = Signal(bool, bool, int, str, str, str)
     quit_signal = Signal()
     free_text_edited = False
     interface_manager = InterfaceManager()
@@ -127,10 +127,10 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.quit_signal.emit()
 
     def fullShare(self):
-        self.action.emit(self.continue_working, True, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, self.get_remember_checkbox, True, self.input_name, self.input_email, self.input_text)
 
     def noShare(self):
-        self.action.emit(self.continue_working, False, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, self.get_remember_checkbox, False, self.input_name, self.input_email, self.input_text)
 
     def close_reporter(self, status):
         if status == 201 or status == -1:
@@ -217,3 +217,7 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
     @property
     def continue_working(self):
         return self.radioButtonContinue.isChecked()
+
+    @property
+    def get_remember_checkbox(self):
+        return self.rememberContactInfoCheckbox.isChecked()

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -127,10 +127,10 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.quit_signal.emit()
 
     def fullShare(self):
-        self.action.emit(self.continue_working, self.get_remember_checkbox, True, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, self.remember_contact_info, True, self.input_name, self.input_email, self.input_text)
 
     def noShare(self):
-        self.action.emit(self.continue_working, self.get_remember_checkbox, False, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, self.remember_contact_info, False, self.input_name, self.input_email, self.input_text)
 
     def close_reporter(self, status):
         if status == 201 or status == -1:
@@ -219,5 +219,5 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         return self.radioButtonContinue.isChecked()
 
     @property
-    def get_remember_checkbox(self):
+    def remember_contact_info(self):
         return self.rememberContactInfoCheckbox.isChecked()

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -61,9 +61,7 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.quit.call_count, 1)
 
     def test_remember_me_ticked_stores_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
-        self.view.rememberContactInfoCheckbox.isChecked.return_value = True
-
-        self.error_report_presenter.do_not_share(False, "MantidUser", "MantidUser@mail.com")
+        self.error_report_presenter.do_not_share(False, True, "MantidUser", "MantidUser@mail.com")
 
         self.q_settings_mock_instance.beginGroup.assert_called_once()
         self.q_settings_mock_instance.endGroup.assert_called_once()
@@ -72,9 +70,8 @@ class ErrorReportPresenterTest(unittest.TestCase):
         )
 
     def test_remember_me_unticked_does_not_store_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
-        self.view.rememberContactInfoCheckbox.isChecked.return_value = False
+        self.error_report_presenter.do_not_share(False, False, "MantidUser", "MantidUser@mail.com")
 
-        self.error_report_presenter.do_not_share(False, "MantidUser", "MantidUser@mail.com")
         self.q_settings_mock_instance.beginGroup.assert_called_once()
         self.q_settings_mock_instance.endGroup.assert_called_once()
         self.q_settings_mock_instance.setValue.assert_has_calls([mock.call(self.view.NAME, ""), mock.call(self.view.EMAIL, "")])
@@ -110,11 +107,12 @@ class ErrorReportPresenterTest(unittest.TestCase):
         email = "john.smith@example.com"
         text_box = "Details about error"
         continue_working = False
+        remember_checkbox = False
         share = True
         self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
         self.error_report_presenter._handle_exit = mock.MagicMock()
 
-        self.error_report_presenter.error_handler(continue_working, share, name, email, text_box)
+        self.error_report_presenter.error_handler(continue_working, remember_checkbox, share, name, email, text_box)
 
         self.error_report_presenter._send_report_to_server.assert_called_once_with(
             share_identifiable=True, name=name, email=email, uptime=mock.ANY, text_box=text_box
@@ -126,11 +124,12 @@ class ErrorReportPresenterTest(unittest.TestCase):
         email = "john.smith@example.com"
         text_box = "Details about error"
         continue_working = True
+        remember_checkbox = False
         share = False
         self.error_report_presenter._send_report_to_server = mock.MagicMock()
         self.error_report_presenter._handle_exit = mock.MagicMock()
 
-        self.error_report_presenter.error_handler(continue_working, share, name, email, text_box)
+        self.error_report_presenter.error_handler(continue_working, remember_checkbox, share, name, email, text_box)
 
         self.assertEqual(self.error_report_presenter._send_report_to_server.call_count, 0)
         self.error_report_presenter._handle_exit.assert_called_once_with(True)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -27,6 +27,12 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.errorreport_mock = errorreport_patcher.start()
         self.errorreport_mock.return_value = self.errorreport_mock_instance
 
+        self.q_settings_mock_instance = mock.MagicMock()
+        q_settings_patcher = mock.patch(f"{self.PRESENTER_CLS_PATH}.QSettings")
+        self.addCleanup(q_settings_patcher.stop)
+        self.q_settings_mock = q_settings_patcher.start()
+        self.q_settings_mock.return_value = self.q_settings_mock_instance
+
         self.view = mock.MagicMock()
         self.exit_code = 255
         self.app_name = "ErrorReportPresenterTest"
@@ -53,6 +59,25 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.logger_mock_instance.notice.assert_called_once_with("No information shared")
         self.logger_mock_instance.error.assert_called_once_with("Terminated by user.")
         self.assertEqual(self.view.quit.call_count, 1)
+
+    def test_remember_me_ticked_stores_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
+        self.view.rememberContactInfoCheckbox.isChecked.return_value = True
+
+        self.error_report_presenter.do_not_share(False, "MantidUser", "MantidUser@mail.com")
+
+        self.q_settings_mock_instance.beginGroup.assert_called_once()
+        self.q_settings_mock_instance.endGroup.assert_called_once()
+        self.q_settings_mock_instance.setValue.assert_has_calls(
+            [mock.call(self.view.NAME, "MantidUser"), mock.call(self.view.EMAIL, "MantidUser@mail.com")]
+        )
+
+    def test_remember_me_unticked_does_not_store_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
+        self.view.rememberContactInfoCheckbox.isChecked.return_value = False
+
+        self.error_report_presenter.do_not_share(False, "MantidUser", "MantidUser@mail.com")
+        self.q_settings_mock_instance.beginGroup.assert_called_once()
+        self.q_settings_mock_instance.endGroup.assert_called_once()
+        self.q_settings_mock_instance.setValue.assert_has_calls([mock.call(self.view.NAME, ""), mock.call(self.view.EMAIL, "")])
 
     def test_send_error_report_to_server_calls_ErrorReport_correctly(self):
         name = "John Smith"


### PR DESCRIPTION
### Description of work
Closes #40759 

The ``Remember me`` checkbox is a quality-of-life feature of the Error Reporter dialog whose function is to store locally (Qsettings ini file) the typed name and email fields so that these are filled in automatically the next time error reporter is needed. 
Its function is independent of whether the name and mail contact info is sent to Mantid server but in its current implementation it does not work like this when the ``Don't share any information`` button is clicked. Even if the ``Remember me`` checkbox is ticked, the local contact information is erased. This is also slightly confusing in the Error Reporter manual testing instructions, and it seems the behaviour of the ``Remember me`` checkbox is different depending on the test. 
This PR fixes that and makes the ``Remember me`` checkbox behaviour consistent with its preteneded use and tooltip description. 
The Error Reporter Manual testing instructions have been updated accordingly.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

<!-- One line per closed issue. -->

* Added release notes*

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Build `dev-docs-html` and follow the new Error Reporter Manual Testing instructions on this branch. Everything should work as described.
_You may need to remove `--single-process` flag for error reporter to work if testing from a debug configuration_

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
