### PR TITLE
Performance improvements for new IV

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/InstrumentViewer/Bugfixes/41807.rst
+++ b/docs/source/release/v7.0.0/Workbench/InstrumentViewer/Bugfixes/41807.rst
@@ -1,0 +1,1 @@
+- In new Instrument View, sped up initial opening and building of the detector mesh

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -124,7 +124,7 @@ class FullInstrumentViewPresenter:
         )
         self._view.hide_status_box()
         self._select_bank_tube = self._view.is_select_bank_tube_checked()
-        self.update_plotter()
+        self.update_plotter(False)
 
         if self._model.workspace_base_unit in self._UNIT_OPTIONS:
             self._view.set_unit_combo_box_index(self._UNIT_OPTIONS.index(self._model.workspace_base_unit))

--- a/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
+++ b/qt/python/instrumentview/instrumentview/renderers/shape_renderer.py
@@ -411,15 +411,17 @@ class ShapeRenderer(InstrumentRenderer):
                 projection_scales = per_detector_scales[group_indices][:, np.newaxis, np.newaxis]
                 tiled = tiled * projection_scales
 
+                # Rotate only the detectors flagged for rotation; leave others axis-aligned.
                 rotate_mask = per_detector_rotate[group_indices]
+                group_rots = rotations[group_indices[rotate_mask]]
+                tiled[rotate_mask] = tiled[rotate_mask] @ group_rots.transpose(0, 2, 1)
                 group_pos = detector_positions[group_indices][:, np.newaxis, :]  # (n_group, 1, 3)
             else:
-                rotate_mask = np.ones(n_group).astype(bool)
+                # All detectors are rotated — apply directly without boolean masking.
+                group_rots = rotations[group_indices]
+                tiled = tiled @ group_rots.transpose(0, 2, 1)
                 group_pos = self._all_positions_3d[detector_indices[group_indices]][:, np.newaxis, :]
 
-            # Rotate
-            group_rots = rotations[group_indices[rotate_mask]]
-            tiled[rotate_mask] = np.einsum("nij,nvj->nvi", group_rots, tiled[rotate_mask])
             # Translate
             tiled = tiled + group_pos
 

--- a/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
+++ b/qt/python/instrumentview/instrumentview/renderers/test/test_renderers.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pyvista as pv
+from scipy.spatial.transform import Rotation
 
 from instrumentview.renderers.base_renderer import InstrumentRenderer
 from instrumentview.renderers.point_cloud_renderer import PointCloudRenderer
@@ -782,6 +783,82 @@ class TestShapeRenderer(unittest.TestCase):
         observer_fn = self.renderer.get_callback_tied_to_detector_index(plotter, callback, hover=True)
         observer_fn(None, None)
         callback.assert_not_called()
+
+    def test_assemble_mesh_rotation_applied_correctly_via_matmul(self):
+        """_assemble_mesh applies per-detector rotation via batched matmul (@ operator).
+
+        A 90° rotation about Z maps (1, 0, 0) -> (0, 1, 0).  Verify the
+        assembled mesh vertices reflect this exactly.
+        """
+        self._refresh_render_with_mock_workspace(n_detectors=1)
+
+        template_verts = np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.0, 0.1, 0.0]], dtype=np.float64)
+        template_faces = np.array([[0, 1, 2]], dtype=np.int64)
+        shape_key = 777
+        self.renderer._shape_cache = {shape_key: (template_verts, template_faces, 3)}
+        self.renderer._det_shape_keys = np.array([shape_key], dtype=np.int64)
+
+        rot_90z = Rotation.from_euler("z", 90, degrees=True).as_matrix()
+        self.renderer._det_rotations = rot_90z[np.newaxis]  # (1, 3, 3)
+        self.renderer._det_scales = np.ones((1, 3))
+        self.renderer._all_positions_3d = np.array([[0.0, 0.0, 0.0]])
+
+        mesh, _, _ = self.renderer._assemble_mesh(
+            detector_indices=np.array([0]),
+            detector_positions=np.array([[0.0, 0.0, 0.0]]),
+            projection=None,
+        )
+
+        expected = (rot_90z @ template_verts.T).T  # (3, 3): rotate each row-vertex
+        np.testing.assert_allclose(mesh.points, expected, atol=1e-10)
+
+    def test_assemble_mesh_all_detectors_in_group_rotated_without_boolean_mask(self):
+        """In the non-SIDE_BY_SIDE path every detector is rotated via a single
+        batched matmul — no per-detector boolean mask is applied.
+
+        Two detectors share the same template shape but carry different
+        rotations (identity and 90° about Z).  Both must produce independently
+        correct vertices, confirming the vectorised path applies each detector's
+        own rotation matrix without skipping any entry.
+        """
+        self._refresh_render_with_mock_workspace(n_detectors=2)
+
+        template_verts = np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.0, 0.1, 0.0]], dtype=np.float64)
+        template_faces = np.array([[0, 1, 2]], dtype=np.int64)
+        shape_key = 888
+        self.renderer._shape_cache = {shape_key: (template_verts, template_faces, 3)}
+        self.renderer._det_shape_keys = np.array([shape_key, shape_key], dtype=np.int64)
+
+        rot_90z = Rotation.from_euler("z", 90, degrees=True).as_matrix()
+        self.renderer._det_rotations = np.stack([np.eye(3), rot_90z])  # (2, 3, 3)
+        self.renderer._det_scales = np.ones((2, 3))
+        self.renderer._all_positions_3d = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+
+        mesh, _, _ = self.renderer._assemble_mesh(
+            detector_indices=np.array([0, 1]),
+            detector_positions=np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+            projection=None,
+        )
+
+        # Both detectors share shape_key=888, so they are processed in a single
+        # group.  Vertex layout: detector 0 occupies rows 0-2, detector 1 rows 3-5.
+
+        # Detector 0: identity rotation, no translation offset
+        np.testing.assert_allclose(
+            mesh.points[:3],
+            template_verts,
+            atol=1e-10,
+            err_msg="Identity-rotation detector must preserve template vertices",
+        )
+
+        # Detector 1: 90° Z rotation then translated to [2, 0, 0]
+        expected_det1 = (template_verts @ rot_90z.T) + np.array([2.0, 0.0, 0.0])
+        np.testing.assert_allclose(
+            mesh.points[3:],
+            expected_det1,
+            atol=1e-10,
+            err_msg="90°-Z-rotation detector must have rotated and translated vertices",
+        )
 
     # ------------------------------------------------------------------
     # Helper methods to create mock objects

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -32,6 +32,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._mock_view._RENDER_MODE_SHAPES_FAST = "Approximated Shapes (Fast)"
         self._mock_view._RENDER_MODE_RAW_SHAPES = "Raw Shapes (Slowest)"
         self._mock_view.is_select_bank_tube_checked.return_value = False
+        self._mock_view.get_contour_limits.return_value = (0.0, 1.0)
         self._mock_view.selected_peaks_workspaces.return_value = []
         self._ws = CreateSampleWorkspace(OutputWorkspace="TestFullInstrumentViewPresenter", EnableLogging=False)
         self._model = FullInstrumentViewModel(self._ws)
@@ -60,6 +61,15 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.update_plotter()
         self.assertEqual(self._model.projection_type, ProjectionType.CYLINDRICAL_Y)
         self._mock_view.clear_main_plotter.assert_called()
+
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.on_integration_limits_reset_clicked")
+    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.on_contour_limits_updated")
+    def test_update_plotter_false_preserves_contour_limits(self, mock_on_contour_limits_updated, mock_on_integration_limits_reset):
+        """Test that update_plotter(False) preserves contour limits by calling on_contour_limits_updated
+        instead of resetting them via on_integration_limits_reset_clicked."""
+        self._presenter.update_plotter(False)
+        mock_on_contour_limits_updated.assert_called_once()
+        mock_on_integration_limits_reset.assert_not_called()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.on_contour_range_reset_clicked")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.update_integration_range")


### PR DESCRIPTION
Two performance improvements for the new Instrument View:

- Don't do a full recalculation of the contour limits on initial setup in the presenter, since these have just been calculated. The limits are still refreshed.
- Use a matrix multiplication instead of `einsum`, since the matrix multiplication will use BLAS in `numpy`, should be faster.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Check contour limits, projections

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
