### PR TITLE
Install pixi for deleting old packages

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -48,6 +48,12 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - name: check out setup-pixi action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/actions/setup-pixi/
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
         with:
@@ -72,6 +78,12 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - name: check out setup-pixi action
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/actions/setup-pixi/
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
         with:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -48,6 +48,7 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
@@ -71,6 +72,7 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL }}

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-pixi/
+            .pixi-version
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
@@ -83,6 +84,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-pixi/
+            .pixi-version
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1


### PR DESCRIPTION
Since it was not possible to run the workflow until it got into the default branch, `main`, there is a bug in the workflow introduced in #41769. It was missing pixi for the action to use. This adds it back in.

Refs #41609 and part of [EWM16839](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16839)

### To test:
[Link to workflow run](https://github.com/mantidproject/mantid/actions/runs/29029100992) with `dryrun=true`.

*This does not require release notes* because it is a change to CI.