### PR TITLE
Support Adjustment to Calibration DIFC due to sample partially intersecting illumination volume

### DIFF
--- a/docs/source/release/v7.0.0/Diffraction/Engineering/New_features/41819.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Engineering/New_features/41819.rst
@@ -1,0 +1,1 @@
+- In ``Engineering.EnggUtils``, focusing using the ``focus_run`` method will now adjust the calibration DIFCs per detector pixel to account for an offset in the scattering volume centre-of-mass (due to sample partially illuminated within the gauge volume). This is only done when both a Sample Shape and Gauge Volume are present on the Workspace.

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -772,7 +772,7 @@ def _correct_full_calib_for_offset_scattering_com(ws: MatrixWorkspace, full_cali
 
     If this assumption is not true L1, L2 and most importantly (read: biggest error) sin(theta) will be wrong.
 
-    Additionally this formualtion assumes that L2 can be calculated using this C.O.M and the as-defined detector positions
+    Additionally this formulation assumes that L2 can be calculated using this C.O.M and the as-defined detector positions
     in the IDF. The calibration is however done to correct for these deviations, so we need to find a way to correct
     the calibration DIFCs solely for the COM offset.
 

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -421,7 +421,7 @@ def create_output_files(calibration_dir: str, calibration: "CalibrationInfo", ws
             filepath, ext = path.splitext(prm_filepath_bank)
             nxs_filepath_bank = filepath + ".nxs"
             copy2(nxs_filepath, nxs_filepath_bank)
-    logger.notice(f'\n\nCalibration files saved to: "{calibration_dir}"\n\n')
+    logger.information(f'\n\nCalibration files saved to: "{calibration_dir}"\n\n')
 
     return prm_filepath  # if both banks, do not pass individual banks (prm_filepath_bank) to GSAS II tab
 
@@ -662,7 +662,7 @@ def _apply_vanadium_norm(sample_ws_foc: MatrixWorkspace, van_ws_foc: MatrixWorks
     return sample_ws_foc
 
 
-def _apply_vanadium_norm_histogram(sample_ws_foc, van_ws_foc, xmin=0.45):
+def _apply_vanadium_norm_histogram(sample_ws_foc: MatrixWorkspace, van_ws_foc: MatrixWorkspace, xmin: float = 0.45) -> MatrixWorkspace:
     # if Histogram data want to ragged crop to avoid zeroing out of scope bins which will affect fitting
     sample_ws_foc = mantid.CropWorkspaceRagged(
         InputWorkspace=sample_ws_foc, OutputWorkspace=sample_ws_foc.name(), XMin=xmin, XMax=float("inf")
@@ -680,7 +680,7 @@ def _apply_vanadium_norm_histogram(sample_ws_foc, van_ws_foc, xmin=0.45):
     return sample_ws_foc
 
 
-def _apply_vanadium_norm_event(sample_ws_foc, van_ws_foc, xmin=0.45):
+def _apply_vanadium_norm_event(sample_ws_foc: MatrixWorkspace, van_ws_foc: MatrixWorkspace, xmin: float = 0.45) -> MatrixWorkspace:
     sample_ws_foc = mantid.CropWorkspace(InputWorkspace=sample_ws_foc, OutputWorkspace=sample_ws_foc.name(), XMin=xmin, XMax=float("inf"))
     # alter the bins attached to the event workspace (used for histogram conversion) to remove any bins before the crop
     nspec = sample_ws_foc.getNumberHistograms()
@@ -701,7 +701,9 @@ def _apply_vanadium_norm_event(sample_ws_foc, van_ws_foc, xmin=0.45):
     return sample_ws_foc
 
 
-def _save_output_files(focus_dirs, sample_ws_foc, calibration, van_run, rb_num=None):
+def _save_output_files(
+    focus_dirs: List[str], sample_ws_foc: MatrixWorkspace, calibration: "CalibrationInfo", van_run: str, rb_num: str | None = None
+) -> Tuple[List[str], List[str], List[str]]:
     # set bankid for use in fit tab
     foc_suffix = calibration.get_foc_ws_suffix()
     xunit = sample_ws_foc.getDimension(0).name
@@ -748,11 +750,11 @@ def _save_output_files(focus_dirs, sample_ws_foc, calibration, van_run, rb_num=N
     return nxs_paths, gss_paths, combined_paths  # from last focus_dir only
 
 
-def _generate_output_file_name(inst, sample_run_no, van_run_no, suffix, xunit, ext=""):
+def _generate_output_file_name(inst: str, sample_run_no: str, van_run_no: str, suffix: str, xunit: str, ext: str = "") -> str:
     return "_".join([inst, sample_run_no, van_run_no, suffix, xunit]) + ext
 
 
-def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
+def _correct_full_calib_for_offset_scattering_com(ws: MatrixWorkspace, full_calib: TableWorkspace) -> TableWorkspace:
     """
     Adjusts the DIFC in the full calibration to account for an offset scattering volume centre of mass.
 
@@ -798,7 +800,10 @@ def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
     This means DIFC_t = DIFC_cal * DIFC_1/DIFC_0
     """
 
-    com = mantid.EstimateScatteringVolumeCentreOfMass(ws)
+    # gauge volume is expected to be present (see _can_calculate_scattering_com)
+    # engineering instrument gauge volumes are on the order of a few mm so this should be an
+    # appropriate level of detail
+    com = mantid.EstimateScatteringVolumeCentreOfMass(ws, ElementUnits="mm", ElementSize=0.1)
 
     # per-detector ratio of DIFC1(at com) / DIFC(at (0,0,0))
     difc0 = mantid.CalculateDIFC(InputWorkspace=ws, OutputWorkspace="__difc0", StoreInADS=False)
@@ -808,7 +813,7 @@ def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
     orig, name = sample.getPos(), sample.getFullName()
 
     # move the nominal sample location to the scattering COM and calculate the DIFCs from here
-    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=com.X(), Y=com.Y(), Z=com.Z(), RelativePosition=False)
+    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=com[0], Y=com[1], Z=com[2], RelativePosition=False)
     difc1 = mantid.CalculateDIFC(InputWorkspace=ws, OutputWorkspace="__difc1", StoreInADS=False)
 
     # move the sample back to avoid any issues down the line
@@ -823,11 +828,10 @@ def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
     return cal
 
 
-def _can_calculate_scattering_com(ws):
-    run = ws.getRun()
-    do_com_calc = run.hasProperty("GaugeVolume") and run.sample().getShape().hasValidShape()
+def _can_calculate_scattering_com(ws: MatrixWorkspace) -> bool:
+    do_com_calc = ws.getRun().hasProperty("GaugeVolume") and ws.sample().getShape().hasValidShape()
     if do_com_calc:
-        logger.notice(
+        logger.information(
             f"Workspace {ws.name()} has a Gauge Volume and Sample Shape defined - Calibration DIFCs will "
             f"be adjusted to account for any offset in the scattering volume centre of mass"
         )

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -774,13 +774,13 @@ def _correct_full_calib_for_offset_scattering_com(ws: MatrixWorkspace, full_cali
 
     Additionally this formualtion assumes that L2 can be calculated using this C.O.M and the as-defined detector positions
     in the IDF. The calibration is however done to correct for these deviations, so we need to find a way to correct
-    the calibartion DIFCs solely for the COM offset.
+    the calibration DIFCs solely for the COM offset.
 
 
     Broadly this means: DIFC_t = k.G(r, e) where G is a function of the scattering C.O.M, r, and the detector position
     errors e.
 
-    To correct this we that, to a first order approximation G(r,e) = H(r)F(e)
+    To correct this we can say, to a first order approximation, G(r,e) = H(r)F(e)
 
     This gives DIFC_t = k.H(r).F(e)
 

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -810,14 +810,15 @@ def _correct_full_calib_for_offset_scattering_com(ws: MatrixWorkspace, full_cali
 
     # extract sample information
     sample = ws.getInstrument().getSample()
-    orig, name = sample.getPos(), sample.getFullName()
+    name = sample.getFullName()
 
     # move the nominal sample location to the scattering COM and calculate the DIFCs from here
-    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=com[0], Y=com[1], Z=com[2], RelativePosition=False)
-    difc1 = mantid.CalculateDIFC(InputWorkspace=ws, OutputWorkspace="__difc1", StoreInADS=False)
-
-    # move the sample back to avoid any issues down the line
-    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=orig.X(), Y=orig.Y(), Z=orig.Z(), RelativePosition=False)
+    # (do this on a small copy of the ws to make sure data workspace state is never corrupted)
+    tmp_ws = mantid.ExtractSpectra(
+        InputWorkspace=ws, StartWorkspaceIndex=0, EndWorkspaceIndex=0, OutputWorkspace="__tmp_copy", StoreInADS=False
+    )
+    mantid.MoveInstrumentComponent(Workspace=tmp_ws, ComponentName=name, X=com[0], Y=com[1], Z=com[2], RelativePosition=False)
+    difc1 = mantid.CalculateDIFC(InputWorkspace=tmp_ws, OutputWorkspace="__difc1", StoreInADS=False)
 
     # scale DIFC column only, per detector; leave DIFA/TZERO untouched
     cal = mantid.CloneWorkspace(InputWorkspace=full_calib, OutputWorkspace="__full_calib_com")

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -616,8 +616,11 @@ def _load_run_and_convert_to_dSpacing(filepath: str, instrument: str, full_calib
         logger.warning(f"Run {ws.name()} has invalid proton charge.")
         mantid.DeleteWorkspace(ws)
         return None
-    mantid.ApplyDiffCal(InstrumentWorkspace=ws, CalibrationWorkspace=full_calib)
+    cal = _correct_full_calib_for_offset_scattering_com(ws, full_calib) if _can_calculate_scattering_com(ws) else full_calib
+    mantid.ApplyDiffCal(InstrumentWorkspace=ws, CalibrationWorkspace=cal)
     ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws.name(), Target="dSpacing")
+    if cal is not full_calib:
+        mantid.DeleteWorkspace(cal)
     return ws
 
 
@@ -747,6 +750,49 @@ def _save_output_files(focus_dirs, sample_ws_foc, calibration, van_run, rb_num=N
 
 def _generate_output_file_name(inst, sample_run_no, van_run_no, suffix, xunit, ext=""):
     return "_".join([inst, sample_run_no, van_run_no, suffix, xunit]) + ext
+
+
+def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
+    com = mantid.EstimateScatteringVolumeCentreOfMass(ws)
+
+    # per-detector ratio of DIFC1(at com) / DIFC(at (0,0,0))
+    difc0 = mantid.CalculateDIFC(InputWorkspace=ws, OutputWorkspace="__difc0", StoreInADS=False)
+
+    # extract sample information
+    sample = ws.getInstrument().getSample()
+    orig, name = sample.getPos(), sample.getFullName()
+
+    # move the nominal sample location to the scattering COM and calculate the DIFCs from here
+    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=com.X(), Y=com.Y(), Z=com.Z(), RelativePosition=False)
+    difc1 = mantid.CalculateDIFC(InputWorkspace=ws, OutputWorkspace="__difc1", StoreInADS=False)
+
+    # move the sample back to avoid any issues down the line
+    mantid.MoveInstrumentComponent(Workspace=ws, ComponentName=name, X=orig.X(), Y=orig.Y(), Z=orig.Z(), RelativePosition=False)
+
+    # scale DIFC column only, per detector; leave DIFA/TZERO untouched
+    cal = mantid.CloneWorkspace(InputWorkspace=full_calib, OutputWorkspace="__full_calib_com")
+    difc_col, detid_col = cal.column("difc"), cal.column("detid")
+    for irow, detid in enumerate(detid_col):
+        cal.setCell("difc", irow, difc_col[irow] * difc1.getValue(detid) / difc0.getValue(detid))
+
+    return cal
+
+
+def _can_calculate_scattering_com(ws):
+    run = ws.getRun()
+    do_com_calc = run.hasProperty("GaugeVolume") and run.sample().getShape().hasValidShape()
+    if do_com_calc:
+        logger.notice(
+            f"Workspace {ws.name()} has a Gauge Volume and Sample Shape defined - Calibration DIFCs will "
+            f"be adjusted to account for any offset in the scattering volume centre of mass"
+        )
+    else:
+        logger.notice(
+            f"Workspace {ws.name()} does not have a Gauge Volume and Sample Shape defined - use of calibration DIFCs "
+            f"assume the gauge volume is fully within the sample. "
+            f"If this is not correct, please define sample shape and gauge volume."
+        )
+    return do_com_calc
 
 
 # DEPRECATED FUNCTIONS BELOW

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -753,6 +753,51 @@ def _generate_output_file_name(inst, sample_run_no, van_run_no, suffix, xunit, e
 
 
 def _correct_full_calib_for_offset_scattering_com(ws, full_calib):
+    """
+    Adjusts the DIFC in the full calibration to account for an offset scattering volume centre of mass.
+
+    The reason for this is as follows:
+
+    Assuming the true DIFC for the experiment is DIFC_t = k.(L1+L2).sin(theta)
+
+    where k is a physical constant and L1 and L2 are the primary and secondary flight paths
+    and theta is the scattering angle - all of these L1, L2 and theta quantities are the averaged values across the
+    neutrons collected in each detector.
+
+    By default these values are taken assuming the average scattering position of the neutron is the same as
+    the sample position, i.e. the scattering volume (volume of the sample from which scattering occurs) has a
+    centre of mass which is the same as the sample position.
+
+    If this assumption is not true L1, L2 and most importantly (read: biggest error) sin(theta) will be wrong.
+
+    Additionally this formualtion assumes that L2 can be calculated using this C.O.M and the as-defined detector positions
+    in the IDF. The calibration is however done to correct for these deviations, so we need to find a way to correct
+    the calibartion DIFCs solely for the COM offset.
+
+
+    Broadly this means: DIFC_t = k.G(r, e) where G is a function of the scattering C.O.M, r, and the detector position
+    errors e.
+
+    To correct this we that, to a first order approximation G(r,e) = H(r)F(e)
+
+    This gives DIFC_t = k.H(r).F(e)
+
+    We can observe that we have calibrated DIFC for calibration sample (ceria) centred at the origin
+
+    So DIFC_cal = k.H(r0).F(e), where r0 is position of the sample origin
+
+    We can see that DIFC_t = DIFC_cal*H(r)/H(r0)
+    (assuming F(e) is constant - i.e the detector position errors haven't changed since ceria sample collection)
+
+    As we can calculate DIFC for the generic IDF geometry (i.e. calculate without F(e)) we can get
+
+    DIFC_1 = k.H(r) and DIFC_0 = k.H(r0)
+
+    DIFC_1/DIFC_0 = H(r)/H(r0)
+
+    This means DIFC_t = DIFC_cal * DIFC_1/DIFC_0
+    """
+
     com = mantid.EstimateScatteringVolumeCentreOfMass(ws)
 
     # per-detector ratio of DIFC1(at com) / DIFC(at (0,0,0))

--- a/scripts/test/Engineering/test_EnggUtils.py
+++ b/scripts/test/Engineering/test_EnggUtils.py
@@ -255,14 +255,14 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
     @patch(enggutils_path + ".mantid.CloneWorkspace")
     @patch(enggutils_path + ".mantid.MoveInstrumentComponent")
     @patch(enggutils_path + ".mantid.CalculateDIFC")
+    @patch(enggutils_path + ".mantid.ExtractSpectra")
     @patch(enggutils_path + ".mantid.EstimateScatteringVolumeCentreOfMass")
-    def test_correct_full_calib_for_offset_scattering_com_scales_difc_per_detector(self, mock_com, mock_calc_difc, mock_move, mock_clone):
+    def test_correct_full_calib_for_offset_scattering_com_scales_difc_per_detector(
+        self, mock_com, mock_extract, mock_calc_difc, mock_move, mock_clone
+    ):
         ws = MagicMock()
         # nominal sample position and component name
         sample = ws.getInstrument().getSample.return_value
-        orig = MagicMock()
-        orig.X.return_value, orig.Y.return_value, orig.Z.return_value = 0.0, 0.0, 0.0
-        sample.getPos.return_value = orig
         sample.getFullName.return_value = "sample-comp"
         # scattering centre of mass offset from the origin
         mock_com.return_value = (0.001, 0.002, 0.003)
@@ -274,9 +274,15 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
         # cloned calibration table to be corrected in place
         cal = MagicMock()
         cal.column.side_effect = lambda name: {"difc": [100.0, 200.0], "detid": [1, 2]}[name]
+        copy_ws = MagicMock()
+        mock_extract.return_value = copy_ws
         mock_clone.return_value = cal
 
         result = _correct_full_calib_for_offset_scattering_com(ws, "full_calib")
+
+        mock_extract.assert_called_once_with(
+            InputWorkspace=ws, StartWorkspaceIndex=0, EndWorkspaceIndex=0, OutputWorkspace="__tmp_copy", StoreInADS=False
+        )
 
         # returns the cloned (corrected) table, cloned from the supplied full calibration
         self.assertIs(result, cal)
@@ -287,11 +293,10 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
         # sample is moved to the com and then restored to its original position
         mock_move.assert_has_calls(
             [
-                call(Workspace=ws, ComponentName="sample-comp", X=0.001, Y=0.002, Z=0.003, RelativePosition=False),
-                call(Workspace=ws, ComponentName="sample-comp", X=0.0, Y=0.0, Z=0.0, RelativePosition=False),
+                call(Workspace=copy_ws, ComponentName="sample-comp", X=0.001, Y=0.002, Z=0.003, RelativePosition=False),
             ]
         )
-        self.assertEqual(mock_move.call_count, 2)
+        self.assertEqual(mock_move.call_count, 1)
         # only the DIFC column is scaled (by difc1/difc0 = 1.1), DIFA/TZERO are untouched
         cal.setCell.assert_has_calls(
             [

--- a/scripts/test/Engineering/test_EnggUtils.py
+++ b/scripts/test/Engineering/test_EnggUtils.py
@@ -10,6 +10,8 @@ from Engineering.EnggUtils import (
     create_output_files,
     _save_output_files,
     _load_run_and_convert_to_dSpacing,
+    _correct_full_calib_for_offset_scattering_com,
+    _can_calculate_scattering_com,
     process_vanadium,
     focus_run,
     convert_TOFerror_to_derror,
@@ -249,6 +251,132 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
         mock_log.warning.assert_called_once()
         mock_norm.assert_not_called()  # throws error if zero charge
         mock_del.assert_called_once()
+
+    @patch(enggutils_path + ".mantid.CloneWorkspace")
+    @patch(enggutils_path + ".mantid.MoveInstrumentComponent")
+    @patch(enggutils_path + ".mantid.CalculateDIFC")
+    @patch(enggutils_path + ".mantid.EstimateScatteringVolumeCentreOfMass")
+    def test_correct_full_calib_for_offset_scattering_com_scales_difc_per_detector(self, mock_com, mock_calc_difc, mock_move, mock_clone):
+        ws = MagicMock()
+        # nominal sample position and component name
+        sample = ws.getInstrument().getSample.return_value
+        orig = MagicMock()
+        orig.X.return_value, orig.Y.return_value, orig.Z.return_value = 0.0, 0.0, 0.0
+        sample.getPos.return_value = orig
+        sample.getFullName.return_value = "sample-comp"
+        # scattering centre of mass offset from the origin
+        mock_com.return_value = (0.001, 0.002, 0.003)
+        # per-detector geometric DIFCs -> ratio of 1.1 for both detectors
+        difc0, difc1 = MagicMock(), MagicMock()
+        difc0.getValue.side_effect = lambda detid: {1: 10.0, 2: 20.0}[detid]
+        difc1.getValue.side_effect = lambda detid: {1: 11.0, 2: 22.0}[detid]
+        mock_calc_difc.side_effect = [difc0, difc1]
+        # cloned calibration table to be corrected in place
+        cal = MagicMock()
+        cal.column.side_effect = lambda name: {"difc": [100.0, 200.0], "detid": [1, 2]}[name]
+        mock_clone.return_value = cal
+
+        result = _correct_full_calib_for_offset_scattering_com(ws, "full_calib")
+
+        # returns the cloned (corrected) table, cloned from the supplied full calibration
+        self.assertIs(result, cal)
+        mock_clone.assert_called_once_with(InputWorkspace="full_calib", OutputWorkspace="__full_calib_com")
+        # DIFC computed once at the nominal position and once at the com
+        mock_com.assert_called_once()
+        self.assertEqual(mock_calc_difc.call_count, 2)
+        # sample is moved to the com and then restored to its original position
+        mock_move.assert_has_calls(
+            [
+                call(Workspace=ws, ComponentName="sample-comp", X=0.001, Y=0.002, Z=0.003, RelativePosition=False),
+                call(Workspace=ws, ComponentName="sample-comp", X=0.0, Y=0.0, Z=0.0, RelativePosition=False),
+            ]
+        )
+        self.assertEqual(mock_move.call_count, 2)
+        # only the DIFC column is scaled (by difc1/difc0 = 1.1), DIFA/TZERO are untouched
+        cal.setCell.assert_has_calls(
+            [
+                call("difc", 0, 100.0 * 11.0 / 10.0),
+                call("difc", 1, 200.0 * 22.0 / 20.0),
+            ]
+        )
+        self.assertEqual(cal.setCell.call_count, 2)
+
+    @patch(enggutils_path + ".logger")
+    def test_can_calculate_scattering_com_true_when_gauge_volume_and_valid_shape(self, mock_logger):
+        ws = MagicMock()
+        ws.getRun().hasProperty.return_value = True
+        ws.sample().getShape().hasValidShape.return_value = True
+
+        self.assertTrue(_can_calculate_scattering_com(ws))
+        ws.getRun().hasProperty.assert_called_with("GaugeVolume")
+        mock_logger.information.assert_called_once()
+
+    @patch(enggutils_path + ".logger")
+    def test_can_calculate_scattering_com_false_when_no_gauge_volume(self, mock_logger):
+        ws = MagicMock()
+        ws.getRun().hasProperty.return_value = False
+        ws.sample().getShape().hasValidShape.return_value = True
+
+        self.assertFalse(_can_calculate_scattering_com(ws))
+
+    @patch(enggutils_path + ".logger")
+    def test_can_calculate_scattering_com_false_when_invalid_shape(self, mock_logger):
+        ws = MagicMock()
+        ws.getRun().hasProperty.return_value = True
+        ws.sample().getShape().hasValidShape.return_value = False
+
+        self.assertFalse(_can_calculate_scattering_com(ws))
+
+    @patch(enggutils_path + ".mantid.DeleteWorkspace")
+    @patch(enggutils_path + ".mantid.ConvertUnits")
+    @patch(enggutils_path + ".mantid.ApplyDiffCal")
+    @patch(enggutils_path + "._correct_full_calib_for_offset_scattering_com")
+    @patch(enggutils_path + "._can_calculate_scattering_com")
+    @patch(enggutils_path + ".mantid.NormaliseByCurrent")
+    @patch(enggutils_path + ".path_handling.get_run_number_from_path")
+    @patch(enggutils_path + ".mantid.Load")
+    def test_load_run_applies_com_corrected_calib_when_possible(
+        self, mock_load, mock_runno, mock_norm, mock_can, mock_correct, mock_apply, mock_conv, mock_del
+    ):
+        ws = MagicMock()
+        ws.getRun().getProtonCharge.return_value = 1.0
+        mock_load.return_value = ws
+        mock_norm.return_value = ws
+        mock_conv.return_value = "ws_dSpacing"
+        mock_can.return_value = True
+        mock_correct.return_value = "corrected_cal"
+
+        result = _load_run_and_convert_to_dSpacing("fpath", "ENGINX", "full_calib")
+
+        mock_correct.assert_called_once_with(ws, "full_calib")
+        mock_apply.assert_called_once_with(InstrumentWorkspace=ws, CalibrationWorkspace="corrected_cal")
+        mock_del.assert_called_once_with("corrected_cal")  # temporary corrected table is cleaned up
+        self.assertEqual(result, "ws_dSpacing")
+
+    @patch(enggutils_path + ".mantid.DeleteWorkspace")
+    @patch(enggutils_path + ".mantid.ConvertUnits")
+    @patch(enggutils_path + ".mantid.ApplyDiffCal")
+    @patch(enggutils_path + "._correct_full_calib_for_offset_scattering_com")
+    @patch(enggutils_path + "._can_calculate_scattering_com")
+    @patch(enggutils_path + ".mantid.NormaliseByCurrent")
+    @patch(enggutils_path + ".path_handling.get_run_number_from_path")
+    @patch(enggutils_path + ".mantid.Load")
+    def test_load_run_uses_uncorrected_calib_when_com_not_possible(
+        self, mock_load, mock_runno, mock_norm, mock_can, mock_correct, mock_apply, mock_conv, mock_del
+    ):
+        ws = MagicMock()
+        ws.getRun().getProtonCharge.return_value = 1.0
+        mock_load.return_value = ws
+        mock_norm.return_value = ws
+        mock_conv.return_value = "ws_dSpacing"
+        mock_can.return_value = False
+
+        result = _load_run_and_convert_to_dSpacing("fpath", "ENGINX", "full_calib")
+
+        mock_correct.assert_not_called()
+        mock_apply.assert_called_once_with(InstrumentWorkspace=ws, CalibrationWorkspace="full_calib")
+        mock_del.assert_not_called()  # full_calib is reused, nothing temporary to delete
+        self.assertEqual(result, "ws_dSpacing")
 
     @patch(enggutils_path + ".path.exists")
     @patch(enggutils_path + ".mantid.SaveFocusedXYE")


### PR DESCRIPTION
### Description of work

Adjusts the DIFC in the full calibration to account for an offset scattering volume centre of mass.

The reason for this is as follows:

Assuming the true DIFC for the experiment is DIFC_t = k.(L1+L2).sin(theta)

where k is a physical constant and L1 and L2 are the primary and secondary flight paths
and theta is the scattering angle - all of these L1, L2 and theta quantities are the averaged values across the
neutrons collected in each detector.

By default these values are taken assuming the average scattering position of the neutron is the same as
the sample position, i.e. the scattering volume (volume of the sample from which scattering occurs) has a
centre of mass which is the same as the sample position.

If this assumption is not true (see below) L1, L2 and most importantly (read: biggest error) sin(theta) will be wrong.

<img width="1024" height="614" alt="image" src="https://github.com/user-attachments/assets/4a6096d6-bf42-4665-9474-ba769b1f9bd5" />

Additionally this formualtion assumes that L2 can be calculated using this C.O.M and the as-defined detector positions
in the IDF. The calibration is however done to correct for these deviations, so we need to find a way to correct
the calibration DIFCs solely for the COM offset.


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

I have tried to validate the results by comparing with some more explicit approaches. 

As you will see from the fairly extensive comment in the code https://github.com/mantidproject/mantid/pull/41819/changes#diff-c98250bb42a79e8fd8c49b644fe4e676dbcb71d9db828fbcaf52173f41259e77R761-R800, the implemented correction is a first order approximation as it assumes the contributions to DIFC can be linearly separable to changes in L2 and 2Theta. 

Instead of making this assumption, you can make another assumption: that the error in the IDF detector positions within banks are all the result of the same rigid body transformation.

If you make this assumption it is possible to calculate a best-fit transformation (minimise the residuals of the observed CeO2 DIFC to the expected DIFC for a transformation), use this to adjust the detector IDF positions, calculate DIFC with these corrected positions and an offset scattering centre, calculate an overall DIFC correction.

I have done this with both with some real CeO2 calibration and with some simulated DIFC data (where a known rigid transform has been used to calculate the DIFCs) . The simulated DIFC the rigid fit found the transformation exactly, so there is some confidence that the result for the CeO2 is reliable.

If we compute the fractional error of the ratio of the "true" correction DIFC(corrected detector geometry, COM-adjusted)/ DIFC(corrected detector geometry, sample at origin) to that of first order approximation result: DIFC(IDF geometry, COM-adjusted)/ DIFC(IDF geometry, sample at origin), we see that the first order approximation is well within 10^-5 of the detector adjustment (both for the actual data and the synthetic data).

<img width="910" height="520" alt="validation_rel_diff" src="https://github.com/user-attachments/assets/9c6aa67a-3f7e-451a-b3a3-829a51ca936b" />
 
Even with the methodology to do the rigid transformation, I still favour the approximation method, both for simplicity and I prefer the assumption that the higher order effects will be small (as shown by this validation) to the assumption that the misalignment is purely a rigid-body transform. 
 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
