### PR TITLE
Add workflow to run grype for dependency CVE

### DIFF
--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -54,7 +54,7 @@ jobs:
           mkdir -p "$project_dir"
           cat > "$project_dir/pixi.toml" <<'EOF'
           [workspace]
-          channels = ["mantid/label/nightly", "mantid", "neutrons"]
+          channels = ["conda-forge", "mantid/label/nightly", "mantid", "neutrons"]
           platforms = ["linux-64"]
 
           [dependencies]

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -60,7 +60,7 @@ jobs:
           [dependencies]
           mantidworkbench = "*"
           mslice = "*"
-          pystog = "*"
+          pystog = ">=0.6.3"
           EOF
 
           echo "project_dir=$project_dir" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -1,0 +1,89 @@
+name: Grype Scan
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/grype.yml
+      - .grype.yaml
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run the install and scan but skip SARIF upload'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  scan-package:
+    if: ${{ github.repository_owner == 'mantidproject' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout workflow dependencies
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/workflows/grype.yml
+            .github/actions/setup-pixi/
+            .grype.yaml
+            .pixi-version
+          sparse-checkout-cone-mode: false
+
+      - name: Setup pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Create temporary pixi project
+        id: pixi-project
+        shell: bash
+        run: |
+          project_dir="${RUNNER_TEMP}/grype-scan"
+          mkdir -p "$project_dir"
+          cat > "$project_dir/pixi.toml" <<'EOF'
+          [workspace]
+          channels = ["mantid/label/nightly", "mantid", "neutrons"]
+          platforms = ["linux-64"]
+
+          [dependencies]
+          mantidworkbench = "*"
+          mslice = "*"
+          pystog = "*"
+          EOF
+
+          echo "project_dir=$project_dir" >> "$GITHUB_OUTPUT"
+          echo "environment_dir=$project_dir/.pixi/envs/default" >> "$GITHUB_OUTPUT"
+
+      - name: Log temporary pixi project
+        shell: bash
+        run: cat "${{ steps.pixi-project.outputs.project_dir }}/pixi.toml"
+
+      - name: Install scan environment
+        shell: bash
+        run: pixi install --manifest-path "${{ steps.pixi-project.outputs.project_dir }}/pixi.toml"
+
+      - name: Scan with Grype
+        id: scan
+        uses: anchore/scan-action@v7
+        with:
+          path: ${{ steps.pixi-project.outputs.environment_dir }}
+          fail-build: false
+          only-fixed: true
+
+      - name: Upload vulnerability report
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,4 @@
+ignore:
+  - package:
+      name: python
+      type: binary


### PR DESCRIPTION
This will scan the linux nightly package once per day using [grype](https://github.com/anchore/grype). It has been written so it can be expanded to matrix across other OS with small change.

grype sees both conda packages and binary python packages. To avoid double reporting, the binary python packages are ignored.

Most of the issues reported can be fixed by moving from python 3.12 to python 3.13 as planned in #41792. The individual security issues will be associated with that github issue.

Assisted-by: GPT-5.4 GitHub Copilot <copilot@github.com>

Refs #39497

### To test:

For people with admin permissions or higher, look at the [scanning results here](https://github.com/mantidproject/mantid/security/code-scanning?query=pr%3A41822+is%3Aopen).

*This does not require release notes* because it is a new CI workflow to do security checks to assist in project planning.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
