### PR TITLE
Fix remove nightly packages from anaconda

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -1,5 +1,12 @@
 name: 'Delete old nightly artifacts'
 on:
+  pull_request:
+    paths:
+      - .github/actions/setup-pixi/
+      - .github/workflows/delete-old-nightlies.yml
+      - .pixi-version
+      - pixi.lock
+      - pixi.toml
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
@@ -54,6 +61,8 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-pixi/
             .pixi-version
+            pixi.lock
+            pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
@@ -63,7 +72,7 @@ jobs:
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
-          dry_run: ${{ github.event.inputs.dry_run || 'false' }}
+          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
 
   delete-old-nightly-anaconda-packages-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -85,6 +94,8 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-pixi/
             .pixi-version
+            pixi.lock
+            pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
@@ -94,4 +105,4 @@ jobs:
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
-          dry_run: ${{ github.event.inputs.dry_run || 'false' }}
+          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}


### PR DESCRIPTION
[This run](https://github.com/mantidproject/mantid/actions/runs/29226641722) failed to delete `mantidmpi` packages from both the `mantid` and `mantid-ornl` conda channels. All of the other packages "succeeded" because they had nothing to remove yet. It appears to be that the proper fix is to add a `pixi.toml` so pixi will know where to put it's environment. This adds the `pixi.toml` and `pixi.lock` to the sparse checkout.

To make it easier to verify, this adds that the workflow will (dry)run on PRs.

### To test:

*This does not require release notes* because it is a change to CI.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
