### PR TITLE
Convert report to SARIF and archive

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -88,6 +88,20 @@ jobs:
             exit 1
           fi
 
+      - name: Convert report to SARIF
+        run: |
+          ls -lah ${COVERITY_DIR}
+          ${COVERITY_DIR}/SARIF/cov-format-sarif-for-github.js --inputFile ${REPORT_FILE} --outputFile ${GITHUB_WORKSPACE}/build/coverity.sarif
+
+      - name: Upload cppcheck SARIF report
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && hashFiles('build/coverity.sarif') != '' }}
+        with:
+          name: coverity_sarif_report
+          if-no-files-found: warn
+          path: ${GITHUB_WORKSPACE}/build/coverity.sarif
+
+
       - name: Upload result
         # only run on schedule or workflow_dispatch when the secret is available
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
I discovered in #41783 that SARIF is a moderately universal format for sharing static analsysis and that [coverity can convert its reports](https://sig-synopsys.my.site.com/community/s/article/How-can-I-export-analysis-results-to-SARIF-format) to that format. When the coverity workflow is run, this converts the reports and attaches it to the build so people can download it later.

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
