### PR TITLE
Protect against calls to `fileno` during init

### DIFF
--- a/qt/python/mantidqt/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/mantidqt/utils/writetosignal.py
@@ -58,3 +58,8 @@ class WriteToSignal(QObject):
                 pass
         # always write to the message log
         self.sig_write_received.emit(txt)
+
+    def fileno(self):
+        if self._original_out is not None and hasattr(self._original_out, "fileno"):
+            return self._original_out.fileno()
+        raise UnsupportedOperation("fileno not available for WriteToSignal object")


### PR DESCRIPTION
When the new Instrument View is opened, `BackgroundPlotter` is created. During initialisation, some code path in `pyvistaqt` calls sys.stdout.fileno() or sys.stderr.fileno(). In the package build on Linux, sys.stdout/sys.stderr have already been replaced with `WriteToSignal` objects (done in `LogMessageDisplay.__init__`), so the call fails.

This is broken since `pyvistaqt` moved to 0.12, versions 0.11.* are fine.

The problem manifested itself by the new Instrument View not opening on multiple versions of Mantid on Ada (including 6.15, 6.16, and the nightly). 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Test this package on Linux: [![Build Status](https://builds.mantidproject.org/job/build_branch/1663/badge/icon)](https://builds.mantidproject.org/job/build_branch/1663/)

For `conda` it's under `mantid-test/label/writetosignal`

Open the new Instrument View, there should be no error message, e.g. see what happens in the current nightly.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
