### PR TITLE
Bugfix delete nightly anaconda packages

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -24,6 +24,10 @@ on:
         default: false
         type: boolean
 
+env:
+  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN || 'unset_token' }}
+  ANACONDA_TOKEN_MANTIDORNL: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL || 'unset_token' }}
+
 jobs:
   releases:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'github-releases') }}
@@ -65,7 +69,7 @@ jobs:
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
         with:
-          anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
+          anaconda_token: ${{ env.ANACONDA_TOKEN }}
           organization: mantid
           package_name: ${{ matrix.package_name }}
           label: nightly
@@ -98,7 +102,7 @@ jobs:
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
         with:
-          anaconda_token: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL }}
+          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl
           package_name: ${{ matrix.package_name }}
           label: nightly

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
 
 jobs:
-  delete-old-nightly-releases:
+  releases:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'github-releases') }}
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  delete-old-nightly-anaconda-packages-mantid:
+  anaconda-mantid:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
     runs-on: ubuntu-latest
     strategy:
@@ -72,7 +72,7 @@ jobs:
           keep: '3'
           dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
 
-  delete-old-nightly-anaconda-packages-mantid-ornl:
+  anaconda-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -67,14 +67,14 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
+      - uses: neutrons/gh-actions/pkg-remove@ae14e70c9a8cbbd84437711b4ee5cda8d2b50298 # test version
         with:
           anaconda_token: ${{ env.ANACONDA_TOKEN }}
           organization: mantid
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
-          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
+          dry_run: false
 
   anaconda-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -100,7 +100,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
+      - uses: neutrons/gh-actions/pkg-remove@ae14e70c9a8cbbd84437711b4ee5cda8d2b50298 # test version
         with:
           anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -63,7 +63,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@225d73f1a9e96b7dfff4f64ca1eddc8fb2e01cb3 # test version
+      - uses: neutrons/gh-actions/pkg-remove@0e90b67c2f71113d1aa022f7e3dd057369e9c572 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
           organization: mantid
@@ -96,7 +96,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@225d73f1a9e96b7dfff4f64ca1eddc8fb2e01cb3 # test version
+      - uses: neutrons/gh-actions/pkg-remove@0e90b67c2f71113d1aa022f7e3dd057369e9c572 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -18,7 +18,7 @@ on:
           - all
           - github-releases
           - anaconda-packages
-      dry_run:
+      dry-run:
         description: 'Print Anaconda packages that would be removed without deleting them'
         required: false
         default: false
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package_name:
+        package-name:
           - mantid
           - mantid-developer
           - mantidmpi
@@ -79,14 +79,14 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@ae14e70c9a8cbbd84437711b4ee5cda8d2b50298 # test version
+      - uses: neutrons/gh-actions/pkg-remove@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
-          anaconda_token: ${{ env.ANACONDA_TOKEN }}
+          anaconda-token: ${{ env.ANACONDA_TOKEN }}
           organization: mantid
-          package_name: ${{ matrix.package_name }}
+          package-name: ${{ matrix.package-name }}
           label: nightly
           keep: '3'
-          dry_run: false
+          dry-run: ${{ github.event.inputs.dry-run || github.event_name != 'schedule' }}
 
   anaconda-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package_name:
+        package-name:
           - mantid
           - mantid-developer
           - mantidmpi
@@ -117,11 +117,11 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@ae14e70c9a8cbbd84437711b4ee5cda8d2b50298 # test version
+      - uses: neutrons/gh-actions/pkg-remove@eb7a7c6fcfd0cda1a7b238329afc0afd09a4f4af # v2
         with:
-          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
+          anaconda-token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl
-          package_name: ${{ matrix.package_name }}
+          package-name: ${{ matrix.package-name }}
           label: nightly
           keep: '3'
-          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
+          dry-run: ${{ github.event.inputs.dry-run || github.event_name != 'schedule' }}

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -67,14 +67,15 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
+      - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
         with:
-          anaconda_token: ${{ env.ANACONDA_TOKEN }}
           organization: mantid
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
           dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
+        secrets:
+          anaconda_token: ${{ env.ANACONDA_TOKEN }}
 
   anaconda-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -100,11 +101,12 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
+      - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
         with:
-          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
           dry_run: false
+        secrets:
+          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -69,13 +69,12 @@ jobs:
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
         with:
+          anaconda_token: ${{ env.ANACONDA_TOKEN }}
           organization: mantid
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
           dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
-        secrets:
-          anaconda_token: ${{ env.ANACONDA_TOKEN }}
 
   anaconda-mantid-ornl:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -103,10 +102,9 @@ jobs:
       - uses: ./.github/actions/setup-pixi
       - uses: neutrons/gh-actions/pkg-remove@619696bee3525e7bdb8383e3f57ce4bba602d771 # test version
         with:
+          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
           dry_run: false
-        secrets:
-          anaconda_token: ${{ env.ANACONDA_TOKEN_MANTIDORNL }}

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -103,4 +103,4 @@ jobs:
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
-          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}
+          dry_run: false

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -63,7 +63,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@0e90b67c2f71113d1aa022f7e3dd057369e9c572 # test version
+      - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
           organization: mantid
@@ -96,7 +96,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@0e90b67c2f71113d1aa022f7e3dd057369e9c572 # test version
+      - uses: neutrons/gh-actions/pkg-remove@61a36cc23945ebd0d0cfbbac47bf126d5af6e3a6 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -107,4 +107,4 @@ jobs:
           package_name: ${{ matrix.package_name }}
           label: nightly
           keep: '3'
-          dry_run: false
+          dry_run: ${{ github.event.inputs.dry_run || github.event_name != 'schedule' }}

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -25,6 +25,8 @@ on:
         type: boolean
 
 env:
+  # the secrets are only available on branches in the main repository
+  RELEASES_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN || 'unset_token' }}
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN || 'unset_token' }}
   ANACONDA_TOKEN_MANTIDORNL: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL || 'unset_token' }}
 
@@ -33,6 +35,11 @@ jobs:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'github-releases') }}
     runs-on: ubuntu-latest
     steps:
+      - name: fail if GITHUB_TOKEN is unavailable
+        if: ${{ env.RELEASES_GITHUB_TOKEN == 'unset_token' }}
+        run: |
+          echo "RELEASES_GITHUB_TOKEN is unset_token. The GITHUB_TOKEN secret is not available in this workflow context."
+          exit 1
       - uses: thomashampson/delete-older-releases@main
         with:
           keep_latest: 3
@@ -41,7 +48,7 @@ jobs:
           prerelease_only: true
           delete_tags: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.RELEASES_GITHUB_TOKEN }}
 
   anaconda-mantid:
     if: ${{ github.repository_owner == 'mantidproject' && (github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'anaconda-packages') }}
@@ -57,6 +64,11 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - name: fail if ANACONDA_TOKEN is unavailable
+        if: ${{ env.ANACONDA_TOKEN == 'unset_token' }}
+        run: |
+          echo "ANACONDA_TOKEN is unset_token. The ANACONDA_TOKEN secret is not available in this workflow context."
+          exit 1
       - name: check out setup-pixi action
         uses: actions/checkout@v7
         with:
@@ -90,6 +102,11 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
+      - name: fail if ANACONDA_TOKEN_MANTIDORNL is unavailable
+        if: ${{ env.ANACONDA_TOKEN_MANTIDORNL == 'unset_token' }}
+        run: |
+          echo "ANACONDA_TOKEN_MANTIDORNL is unset_token. The ANACONDA_TOKEN_MANTIDORNL secret is not available in this workflow context."
+          exit 1
       - name: check out setup-pixi action
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -5,8 +5,6 @@ on:
       - .github/actions/setup-pixi/
       - .github/workflows/delete-old-nightlies.yml
       - .pixi-version
-      - pixi.lock
-      - pixi.toml
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
@@ -65,7 +63,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+      - uses: neutrons/gh-actions/pkg-remove@225d73f1a9e96b7dfff4f64ca1eddc8fb2e01cb3 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
           organization: mantid
@@ -98,7 +96,7 @@ jobs:
             pixi.toml
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-pixi
-      - uses: neutrons/gh-actions/pkg-remove@a1e1c8b4123ced6c66fe57b9a60a56a6e4bf6861 # v1
+      - uses: neutrons/gh-actions/pkg-remove@225d73f1a9e96b7dfff4f64ca1eddc8fb2e01cb3 # test version
         with:
           anaconda_token: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL }}
           organization: mantid-ornl


### PR DESCRIPTION
1. Bugfix actually removing the packages (permission issue with secrets)
2. Remove that changing pixi configuration runs the workflow
3. Shorten job names

This replaces #41851

Refs #39497 and [EWM16839](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16839)

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
