### PR TITLE
Add SaveMDToAscii algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -185,6 +185,7 @@ set(PYTHON_PLUGINS
     algorithms/SaveINS.py
     algorithms/SaveISISReflectometryORSO.py
     algorithms/SaveMDHistoToVTK.py
+    algorithms/SaveMDToAscii.py
     algorithms/SaveNexusPD.py
     algorithms/SaveP2D.py
     algorithms/SavePlot1DAsJson.py

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -146,8 +146,7 @@ class SaveMDToAscii(PythonAlgorithm):
         header_lines = []
         extra_header = self.getPropertyValue("ExtraHeader")
         if extra_header:  # in case `\n` was interpreted as a literal string
-            header_lines.append(extra_header.replace("\\n", "\n"))
-            header_lines.append(extra_header.replace("\\t", "\t"))
+            header_lines.append(extra_header.replace("\\n", "\n").replace("\\t", "\t"))
         header_lines.append(separator.join([*(d.name for d in dims), "Intensity", "Error"]))
         header_lines.append("shape: " + "x".join(str(d.getNBins()) for d in dims))
         header = "\n".join(header_lines)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -1,0 +1,158 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import numpy as np
+from mantid.api import AlgorithmFactory, FileAction, FileProperty, IMDHistoWorkspaceProperty, MDNormalization, PropertyMode, PythonAlgorithm
+from mantid.kernel import Direction, EnabledWhenProperty, IntBoundedValidator, Property, PropertyCriterion, StringListValidator
+
+_SEPARATORS = {"CSV": ",", "Tab": "\t", "Space": " ", "Colon": ":", "SemiColon": ";"}
+_DEFAULT_PRECISION = 6
+
+
+def _dim2array(d):
+    """Bin-centre coordinates along dimension d, as a 1D numpy array of length d.getNBins()."""
+    dmin = d.getMinimum()
+    dmax = d.getMaximum()
+    dstep = d.getX(1) - d.getX(0)
+    return np.arange(dmin + dstep / 2, dmax, dstep)
+
+
+class SaveMDToAscii(PythonAlgorithm):
+    def category(self):
+        return "MDAlgorithms\\DataHandling"
+
+    def summary(self):
+        return (
+            "Save an MDHistoWorkspace to a plain ASCII file, one row per bin, "
+            "with dimension coordinate columns followed by intensity and error."
+        )
+
+    def seeAlso(self):
+        return ["SaveAscii", "SaveMD", "SaveMDHistoToVTK"]
+
+    def PyInit(self):
+        self.declareProperty(
+            IMDHistoWorkspaceProperty("InputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Input),
+            doc="Input MDHistoWorkspace to save.",
+        )
+        self.declareProperty(
+            FileProperty("Filename", "", action=FileAction.Save, extensions=[".dat", ".txt"], direction=Direction.Input),
+            doc="Output filename.",
+        )
+        self.declareProperty(
+            name="ExcludeIntegratedDimensions",
+            defaultValue=True,
+            direction=Direction.Input,
+            doc="If True (default), integrated dimensions (those with a single bin) are excluded from the "
+            "output columns. If False, all dimensions are written as columns.",
+        )
+        self.declareProperty(
+            name="Normalization",
+            defaultValue="FromWorkspace",
+            validator=StringListValidator(["FromWorkspace", "NoNormalization", "VolumeNormalization", "NumEventsNormalization"]),
+            direction=Direction.Input,
+            doc="Normalization to apply to the signal and error before writing. 'FromWorkspace' (default) uses "
+            "the workspace's own displayNormalizationHisto() setting. The other choices force that "
+            "normalization regardless of what the workspace reports.",
+        )
+        self.declareProperty(
+            name="Separator",
+            defaultValue="Space",
+            validator=StringListValidator(["CSV", "Tab", "Space", "Colon", "SemiColon", "UserDefined"]),
+            direction=Direction.Input,
+            doc="Column delimiter to use in the output file. 'UserDefined' requires CustomSeparator to be set.",
+        )
+        self.declareProperty(
+            name="CustomSeparator",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="Used as the column delimiter when Separator is set to 'UserDefined'.",
+        )
+        self.setPropertySettings("CustomSeparator", EnabledWhenProperty("Separator", PropertyCriterion.IsEqualTo, "UserDefined"))
+        self.declareProperty(
+            name="Precision",
+            defaultValue=Property.EMPTY_INT,
+            validator=IntBoundedValidator(lower=1),
+            direction=Direction.Input,
+            doc="Number of significant digits for the numeric columns. If not set, a default of 6 is used.",
+        )
+
+    def validateInputs(self):
+        issues = dict()
+
+        separator = self.getPropertyValue("Separator")
+        custom_separator = self.getPropertyValue("CustomSeparator")
+        if separator == "UserDefined" and not custom_separator:
+            issues["CustomSeparator"] = "CustomSeparator must be set when Separator is 'UserDefined'."
+
+        ws = self.getProperty("InputWorkspace").value
+        if ws is not None and self.getProperty("ExcludeIntegratedDimensions").value:
+            if len(ws.getNonIntegratedDimensions()) == 0:
+                issues["ExcludeIntegratedDimensions"] = "All dimensions of the workspace are integrated; there are no columns to write."
+
+        return issues
+
+    def PyExec(self):
+        ws = self.getProperty("InputWorkspace").value
+        filename = self.getPropertyValue("Filename")
+        exclude_integrated = self.getProperty("ExcludeIntegratedDimensions").value
+
+        if exclude_integrated:
+            dims = ws.getNonIntegratedDimensions()
+        else:
+            dims = [ws.getDimension(i) for i in range(ws.getNumDims())]
+
+        dim_arrays = [_dim2array(d) for d in dims]
+        if len(dim_arrays) > 1:
+            broadcast_arrays = np.meshgrid(*dim_arrays, indexing="ij")
+        else:
+            broadcast_arrays = dim_arrays
+
+        signal = ws.getSignalArray() * 1.0
+        err2 = ws.getErrorSquaredArray() * 1.0
+
+        normalization = self._resolve_normalization(ws)
+        if normalization == MDNormalization.NumEventsNormalization:
+            nev = ws.getNumEventsArray()
+            signal = signal / nev
+            err2 = err2 / (nev * nev)
+        error = np.sqrt(err2)
+
+        if signal.ndim != len(dims):
+            signal = np.squeeze(signal)
+            error = np.squeeze(error)
+
+        columns = [d.flatten() for d in broadcast_arrays] + [signal.flatten(), error.flatten()]
+        data_to_write = np.column_stack(columns)
+
+        header = " ".join(d.name for d in dims) + " Intensity Error"
+        header += "\nshape: " + "x".join(str(d.getNBins()) for d in dims)
+
+        separator = self._resolve_separator()
+        precision = self.getProperty("Precision").value
+        if precision == Property.EMPTY_INT:
+            precision = _DEFAULT_PRECISION
+        fmt = f"%.{precision}e"
+
+        np.savetxt(filename, data_to_write, fmt=fmt, delimiter=separator, header=header)
+
+    def _resolve_normalization(self, ws):
+        """Resolve the MDNormalization to apply. Mirrors the override pattern of
+        get_md_normalization/get_md_data (mantid.plots.datafunctions) without importing that module,
+        which pulls in matplotlib and is inappropriate for a headless Save algorithm."""
+        choice = self.getPropertyValue("Normalization")
+        if choice == "FromWorkspace":
+            return ws.displayNormalizationHisto()
+        return getattr(MDNormalization, choice)
+
+    def _resolve_separator(self):
+        choice = self.getPropertyValue("Separator")
+        if choice == "UserDefined":
+            return self.getPropertyValue("CustomSeparator")
+        return _SEPARATORS[choice]
+
+
+AlgorithmFactory.subscribe(SaveMDToAscii)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -145,8 +145,8 @@ class SaveMDToAscii(PythonAlgorithm):
 
         header_lines = []
         extra_header = self.getPropertyValue("ExtraHeader")
-        if extra_header:
-            header_lines.append(extra_header)
+        if extra_header:  # in case `\n` was interpreted as a literal string
+            header_lines.append(extra_header.replace("\\n", "\n"))
         header_lines.append(separator.join([*(d.name for d in dims), "Intensity", "Error"]))
         header_lines.append("shape: " + "x".join(str(d.getNBins()) for d in dims))
         header = "\n".join(header_lines)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -143,15 +143,16 @@ class SaveMDToAscii(PythonAlgorithm):
         columns = [d.flatten() for d in broadcast_arrays] + [signal.flatten(), error.flatten()]
         data_to_write = np.column_stack(columns)
 
+        separator = self._resolve_separator()
+
         header_lines = []
         extra_header = self.getPropertyValue("ExtraHeader")
         if extra_header:
             header_lines.append(extra_header)
-        header_lines.append(" ".join(d.name for d in dims) + " Intensity Error")
+        header_lines.append(separator.join([*(d.name for d in dims), "Intensity", "Error"]))
         header_lines.append("shape: " + "x".join(str(d.getNBins()) for d in dims))
         header = "\n".join(header_lines)
 
-        separator = self._resolve_separator()
         precision = self.getProperty("Precision").value
         if precision == Property.EMPTY_INT:
             precision = _DEFAULT_PRECISION

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -147,6 +147,7 @@ class SaveMDToAscii(PythonAlgorithm):
         extra_header = self.getPropertyValue("ExtraHeader")
         if extra_header:  # in case `\n` was interpreted as a literal string
             header_lines.append(extra_header.replace("\\n", "\n"))
+            header_lines.append(extra_header.replace("\\t", "\t"))
         header_lines.append(separator.join([*(d.name for d in dims), "Intensity", "Error"]))
         header_lines.append("shape: " + "x".join(str(d.getNBins()) for d in dims))
         header = "\n".join(header_lines)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -138,7 +138,7 @@ class SaveMDToAscii(PythonAlgorithm):
             signal = np.squeeze(signal)
             error = np.squeeze(error)
 
-        columns = [d.flatten() for d in broadcast_arrays] + [signal.flatten(), error.flatten()]
+        columns = [d.ravel() for d in broadcast_arrays] + [signal.ravel(), error.ravel()]
         data_to_write = np.column_stack(columns)
 
         separator = self._resolve_separator()

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -87,7 +87,8 @@ class SaveMDToAscii(PythonAlgorithm):
             defaultValue=Property.EMPTY_INT,
             validator=IntBoundedValidator(lower=1),
             direction=Direction.Input,
-            doc="Number of significant digits for the numeric columns. If not set, a default of 6 is used.",
+            doc="Number of digits after the decimal point in scientific notation for the numeric columns. "
+            "If not set, a default of 6 is used.",
         )
 
     def validateInputs(self):

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -64,7 +64,9 @@ class SaveMDToAscii(PythonAlgorithm):
             direction=Direction.Input,
             doc="Normalization to apply to the signal and error before writing. 'FromWorkspace' (default) uses "
             "the workspace's own displayNormalizationHisto() setting. The other choices force that "
-            "normalization regardless of what the workspace reports.",
+            "normalization regardless of what the workspace reports: 'NumEventsNormalization' divides by the "
+            "number of events in each bin, and 'VolumeNormalization' multiplies by the workspace's inverse "
+            "bin volume.",
         )
         self.declareProperty(
             name="Separator",
@@ -127,6 +129,10 @@ class SaveMDToAscii(PythonAlgorithm):
             nev = ws.getNumEventsArray()
             signal = signal / nev
             err2 = err2 / (nev * nev)
+        elif normalization == MDNormalization.VolumeNormalization:
+            inverse_volume = ws.getInverseVolume()
+            signal = signal * inverse_volume
+            err2 = err2 * (inverse_volume * inverse_volume)
         error = np.sqrt(err2)
 
         if signal.ndim != len(dims):

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -43,6 +43,14 @@ class SaveMDToAscii(PythonAlgorithm):
             doc="Output filename.",
         )
         self.declareProperty(
+            name="ExtraHeader",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="If not empty, this text is written at the top of the file's header, above the column names "
+            "and shape lines. Each line is prefixed with '#', the same as the rest of the header; if this "
+            "text spans multiple lines, every one of them is prefixed individually.",
+        )
+        self.declareProperty(
             name="ExcludeIntegratedDimensions",
             defaultValue=True,
             direction=Direction.Input,
@@ -128,8 +136,13 @@ class SaveMDToAscii(PythonAlgorithm):
         columns = [d.flatten() for d in broadcast_arrays] + [signal.flatten(), error.flatten()]
         data_to_write = np.column_stack(columns)
 
-        header = " ".join(d.name for d in dims) + " Intensity Error"
-        header += "\nshape: " + "x".join(str(d.getNBins()) for d in dims)
+        header_lines = []
+        extra_header = self.getPropertyValue("ExtraHeader")
+        if extra_header:
+            header_lines.append(extra_header)
+        header_lines.append(" ".join(d.name for d in dims) + " Intensity Error")
+        header_lines.append("shape: " + "x".join(str(d.getNBins()) for d in dims))
+        header = "\n".join(header_lines)
 
         separator = self._resolve_separator()
         precision = self.getProperty("Precision").value

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDToAscii.py
@@ -14,10 +14,8 @@ _DEFAULT_PRECISION = 6
 
 def _dim2array(d):
     """Bin-centre coordinates along dimension d, as a 1D numpy array of length d.getNBins()."""
-    dmin = d.getMinimum()
-    dmax = d.getMaximum()
-    dstep = d.getX(1) - d.getX(0)
-    return np.arange(dmin + dstep / 2, dmax, dstep)
+    boundaries = np.array([d.getX(i) for i in range(d.getNBins() + 1)])
+    return 0.5 * (boundaries[:-1] + boundaries[1:])
 
 
 class SaveMDToAscii(PythonAlgorithm):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -129,6 +129,7 @@ set(TEST_PY_FILES
     SaveGEMMAUDParamFileTest.py
     SaveNexusPDTest.py
     SaveMDHistoToVTKTest.py
+    SaveMDToAsciiTest.py
     SaveGSSCWTest.py
     SaveHKLCWTest.py
     SaveINSTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -129,6 +129,27 @@ class SaveMDToAsciiTest(unittest.TestCase):
         self.assertEqual(header_lines[1].strip(), "# Run: 12345")
         self.assertIn("A Intensity Error", header_lines[2])
 
+    def test_extra_header_literal_backslash_n_treated_as_newline(self):
+        # A literal backslash-n (as opposed to an embedded newline character) is what a user
+        # typing into a single-line text field would produce; it should be treated the same way.
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, ExtraHeader=r"test1\ntest2")
+
+        with open(self.tmp_file.name) as f:
+            header_lines = [line for line in f if line.startswith("#")]
+        self.assertEqual(len(header_lines), 4)
+        self.assertEqual(header_lines[0].strip(), "# test1")
+        self.assertEqual(header_lines[1].strip(), "# test2")
+        self.assertIn("A Intensity Error", header_lines[2])
+
     def test_exclude_integrated_dimensions_true_by_default(self):
         ws = CreateMDHistoWorkspace(
             Dimensionality=3,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -1,0 +1,247 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+
+import numpy as np
+from mantid.api import MDNormalization
+from mantid.simpleapi import CreateMDHistoWorkspace, CreateSampleWorkspace, SaveMDToAscii
+
+
+class SaveMDToAsciiTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_file = tempfile.NamedTemporaryFile(suffix=".dat", delete=False)
+        self.tmp_file.close()
+
+    def tearDown(self) -> None:
+        os.remove(self.tmp_file.name)
+
+    def _read_data_lines(self):
+        with open(self.tmp_file.name) as f:
+            return [line for line in f if not line.startswith("#")]
+
+    def test_column_order_and_values(self):
+        # SignalInput/ErrorInput fill the underlying array with dimension 0 varying fastest,
+        # so for a 2x2 workspace bin (A=0,B=0)->1, (A=1,B=0)->2, (A=0,B=1)->3, (A=1,B=1)->4.
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents="0,2,0,2",
+            SignalInput=[1, 2, 3, 4],
+            ErrorInput=[1, 1, 1, 1],
+            NumberOfBins="2,2",
+            Names="A,B",
+            Units="U,V",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+
+        data = np.loadtxt(self.tmp_file.name)
+        expected = np.array(
+            [
+                [0.5, 0.5, 1, 1],
+                [0.5, 1.5, 3, 1],
+                [1.5, 0.5, 2, 1],
+                [1.5, 1.5, 4, 1],
+            ]
+        )
+        np.testing.assert_allclose(data, expected)
+
+    def test_exclude_integrated_dimensions_true_by_default(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="0,2,0,2,10,20",
+            SignalInput=[1, 2, 3, 4],
+            ErrorInput=[1, 1, 1, 1],
+            NumberOfBins="2,2,1",
+            Names="A,B,C",
+            Units="U,V,W",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+
+        data = np.loadtxt(self.tmp_file.name)
+        # dimension C is integrated (1 bin) and excluded by default: same shape as the 2D case
+        expected = np.array(
+            [
+                [0.5, 0.5, 1, 1],
+                [0.5, 1.5, 3, 1],
+                [1.5, 0.5, 2, 1],
+                [1.5, 1.5, 4, 1],
+            ]
+        )
+        np.testing.assert_allclose(data, expected)
+
+    def test_exclude_integrated_dimensions_false(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="0,2,0,2,10,20",
+            SignalInput=[1, 2, 3, 4],
+            ErrorInput=[1, 1, 1, 1],
+            NumberOfBins="2,2,1",
+            Names="A,B,C",
+            Units="U,V,W",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, ExcludeIntegratedDimensions=False)
+
+        data = np.loadtxt(self.tmp_file.name)
+        expected = np.array(
+            [
+                [0.5, 0.5, 15.0, 1, 1],
+                [0.5, 1.5, 15.0, 3, 1],
+                [1.5, 0.5, 15.0, 2, 1],
+                [1.5, 1.5, 15.0, 4, 1],
+            ]
+        )
+        np.testing.assert_allclose(data, expected)
+
+    def test_all_dimensions_integrated_raises(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents="0,2,0,2",
+            SignalInput=[1],
+            ErrorInput=[1],
+            NumberOfBins="1,1",
+            Names="A,B",
+            Units="U,V",
+        )
+
+        self.assertRaises(RuntimeError, SaveMDToAscii, InputWorkspace=ws, Filename=self.tmp_file.name)
+
+    def test_normalization_from_workspace_uses_num_events(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents="0,2,0,2",
+            SignalInput=[2, 4, 6, 8],
+            ErrorInput=[2, 2, 2, 2],
+            NumberOfEvents=[2, 2, 2, 2],
+            NumberOfBins="2,2",
+            Names="A,B",
+            Units="U,V",
+        )
+        ws.setDisplayNormalization(MDNormalization.NumEventsNormalization)
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+
+        data = np.loadtxt(self.tmp_file.name)
+        np.testing.assert_allclose(data[:, 2], [1, 3, 2, 4])
+        np.testing.assert_allclose(data[:, 3], [1, 1, 1, 1])
+
+    def test_normalization_override_no_normalization(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents="0,2,0,2",
+            SignalInput=[2, 4, 6, 8],
+            ErrorInput=[2, 2, 2, 2],
+            NumberOfEvents=[2, 2, 2, 2],
+            NumberOfBins="2,2",
+            Names="A,B",
+            Units="U,V",
+        )
+        ws.setDisplayNormalization(MDNormalization.NumEventsNormalization)
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Normalization="NoNormalization")
+
+        data = np.loadtxt(self.tmp_file.name)
+        np.testing.assert_allclose(data[:, 2], [2, 6, 4, 8])
+        np.testing.assert_allclose(data[:, 3], [2, 2, 2, 2])
+
+    def test_normalization_volume_normalization_does_not_divide_by_events(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=2,
+            Extents="0,2,0,2",
+            SignalInput=[2, 4, 6, 8],
+            ErrorInput=[2, 2, 2, 2],
+            NumberOfEvents=[2, 2, 2, 2],
+            NumberOfBins="2,2",
+            Names="A,B",
+            Units="U,V",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Normalization="VolumeNormalization")
+
+        data = np.loadtxt(self.tmp_file.name)
+        np.testing.assert_allclose(data[:, 2], [2, 6, 4, 8])
+        np.testing.assert_allclose(data[:, 3], [2, 2, 2, 2])
+
+    def test_separator_choices(self):
+        separators = {"CSV": ",", "Tab": "\t", "Space": " ", "Colon": ":", "SemiColon": ";"}
+        for name, char in separators.items():
+            with self.subTest(separator=name):
+                ws = CreateMDHistoWorkspace(
+                    Dimensionality=1,
+                    Extents="0,2",
+                    SignalInput=[1, 2],
+                    ErrorInput=[1, 1],
+                    NumberOfBins="2",
+                    Names="A",
+                    Units="U",
+                )
+                SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Separator=name)
+
+                data_lines = self._read_data_lines()
+                self.assertEqual(len(data_lines), 2)
+                fields = data_lines[0].strip().split(char)
+                self.assertEqual(len(fields), 3)
+
+    def test_separator_userdefined_with_custom(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Separator="UserDefined", CustomSeparator="|")
+
+        data_lines = self._read_data_lines()
+        fields = data_lines[0].strip().split("|")
+        self.assertEqual(len(fields), 3)
+
+    def test_separator_userdefined_without_custom_raises(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        self.assertRaises(RuntimeError, SaveMDToAscii, InputWorkspace=ws, Filename=self.tmp_file.name, Separator="UserDefined")
+
+    def test_precision(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Precision=2)
+        data_lines = self._read_data_lines()
+        for value in data_lines[0].split():
+            self.assertRegex(value, r"^\d\.\d{2}e[+-]\d+$")
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+        data_lines = self._read_data_lines()
+        for value in data_lines[0].split():
+            self.assertRegex(value, r"^\d\.\d{6}e[+-]\d+$")
+
+    def test_wrong_workspace_type_raises(self):
+        ws = CreateSampleWorkspace()
+        self.assertRaises(ValueError, SaveMDToAscii, InputWorkspace=ws, Filename=self.tmp_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -51,6 +51,60 @@ class SaveMDToAsciiTest(unittest.TestCase):
         )
         np.testing.assert_allclose(data, expected)
 
+    def test_extra_header_default_empty_adds_nothing(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+
+        with open(self.tmp_file.name) as f:
+            header_lines = [line for line in f if line.startswith("#")]
+        self.assertEqual(len(header_lines), 2)
+        self.assertIn("A Intensity Error", header_lines[0])
+
+    def test_extra_header_written_as_first_header_line(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, ExtraHeader="Collected on 2026-07-17, run 12345")
+
+        with open(self.tmp_file.name) as f:
+            header_lines = [line for line in f if line.startswith("#")]
+        self.assertEqual(len(header_lines), 3)
+        self.assertIn("Collected on 2026-07-17, run 12345", header_lines[0])
+        self.assertIn("A Intensity Error", header_lines[1])
+
+    def test_extra_header_multiline_each_line_prefixed(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, ExtraHeader="Sample: NaCl powder\nRun: 12345")
+
+        with open(self.tmp_file.name) as f:
+            header_lines = [line for line in f if line.startswith("#")]
+        self.assertEqual(len(header_lines), 4)
+        self.assertEqual(header_lines[0].strip(), "# Sample: NaCl powder")
+        self.assertEqual(header_lines[1].strip(), "# Run: 12345")
+        self.assertIn("A Intensity Error", header_lines[2])
+
     def test_exclude_integrated_dimensions_true_by_default(self):
         ws = CreateMDHistoWorkspace(
             Dimensionality=3,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -51,6 +51,30 @@ class SaveMDToAsciiTest(unittest.TestCase):
         )
         np.testing.assert_allclose(data, expected)
 
+    def test_bin_centres_correct_for_bin_count_prone_to_float_drift(self):
+        # 7 bins over a 0-1 extent gives a step (1/7) that is not exactly representable
+        # in binary floating point; np.arange(start, stop, step) can drop or add an
+        # extra element here due to accumulated rounding, producing the wrong number
+        # of bin centres (see _dim2array).
+        nbins = 7
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,1",
+            SignalInput=list(range(nbins)),
+            ErrorInput=[1] * nbins,
+            NumberOfBins=str(nbins),
+            Names="A",
+            Units="U",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name)
+
+        data = np.loadtxt(self.tmp_file.name)
+        self.assertEqual(data.shape[0], nbins)
+        halfstep = 0.5 / nbins
+        np.testing.assert_allclose(data[0, 0], halfstep)
+        np.testing.assert_allclose(data[-1, 0], 1 - halfstep)
+
     def test_extra_header_default_empty_adds_nothing(self):
         ws = CreateMDHistoWorkspace(
             Dimensionality=1,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -205,7 +205,10 @@ class SaveMDToAsciiTest(unittest.TestCase):
         np.testing.assert_allclose(data[:, 2], [2, 6, 4, 8])
         np.testing.assert_allclose(data[:, 3], [2, 2, 2, 2])
 
-    def test_normalization_volume_normalization_does_not_divide_by_events(self):
+    def test_normalization_volume_normalization_divides_by_bin_volume(self):
+        # 2x2 bins over a 2x2 extent: each bin is 1x1, so inverse volume is 1 and this
+        # normalization is a no-op here; see test_normalization_volume_normalization_scales_by_inverse_volume
+        # for a case where the bin volume is not 1.
         ws = CreateMDHistoWorkspace(
             Dimensionality=2,
             Extents="0,2,0,2",
@@ -222,6 +225,24 @@ class SaveMDToAsciiTest(unittest.TestCase):
         data = np.loadtxt(self.tmp_file.name)
         np.testing.assert_allclose(data[:, 2], [2, 6, 4, 8])
         np.testing.assert_allclose(data[:, 3], [2, 2, 2, 2])
+
+    def test_normalization_volume_normalization_scales_by_inverse_volume(self):
+        # 2 bins over a 4-wide extent: each bin has volume 2, so inverse volume is 0.5.
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,4",
+            SignalInput=[2, 4],
+            ErrorInput=[2, 4],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Normalization="VolumeNormalization")
+
+        data = np.loadtxt(self.tmp_file.name)
+        np.testing.assert_allclose(data[:, 1], [1, 2])
+        np.testing.assert_allclose(data[:, 2], [1, 2])
 
     def test_separator_choices(self):
         separators = {"CSV": ",", "Tab": "\t", "Space": " ", "Colon": ":", "SemiColon": ";"}

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDToAsciiTest.py
@@ -264,6 +264,43 @@ class SaveMDToAsciiTest(unittest.TestCase):
                 fields = data_lines[0].strip().split(char)
                 self.assertEqual(len(fields), 3)
 
+    def test_header_column_names_use_configured_separator(self):
+        separators = {"CSV": ",", "Tab": "\t", "Space": " ", "Colon": ":", "SemiColon": ";"}
+        for name, char in separators.items():
+            with self.subTest(separator=name):
+                ws = CreateMDHistoWorkspace(
+                    Dimensionality=1,
+                    Extents="0,2",
+                    SignalInput=[1, 2],
+                    ErrorInput=[1, 1],
+                    NumberOfBins="2",
+                    Names="A",
+                    Units="U",
+                )
+                SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Separator=name)
+
+                with open(self.tmp_file.name) as f:
+                    header_lines = [line for line in f if line.startswith("#")]
+                column_header = header_lines[0].lstrip("#").strip()
+                self.assertEqual(column_header.split(char), ["A", "Intensity", "Error"])
+
+    def test_header_column_names_use_custom_separator(self):
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=1,
+            Extents="0,2",
+            SignalInput=[1, 2],
+            ErrorInput=[1, 1],
+            NumberOfBins="2",
+            Names="A",
+            Units="U",
+        )
+        SaveMDToAscii(InputWorkspace=ws, Filename=self.tmp_file.name, Separator="UserDefined", CustomSeparator="|")
+
+        with open(self.tmp_file.name) as f:
+            header_lines = [line for line in f if line.startswith("#")]
+        column_header = header_lines[0].lstrip("#").strip()
+        self.assertEqual(column_header.split("|"), ["A", "Intensity", "Error"])
+
     def test_separator_userdefined_with_custom(self):
         ws = CreateMDHistoWorkspace(
             Dimensionality=1,

--- a/docs/source/algorithms/SaveMDToAscii-v1.rst
+++ b/docs/source/algorithms/SaveMDToAscii-v1.rst
@@ -27,8 +27,8 @@ Normalization defaults to whatever the workspace itself declares via its display
 ``VolumeNormalization`` multiplies Intensity and Error by the workspace's inverse bin volume.
 
 ``Separator`` and ``CustomSeparator`` control the column delimiter used in the output file.
-``Precision`` controls the number of significant digits used for the numeric columns (Intensity, Error, and
-the dimension coordinates).
+``Precision`` controls the number of digits after the decimal point in scientific notation used for the
+numeric columns (Intensity, Error, and the dimension coordinates).
 
 If ``ExtraHeader`` is set to a non-empty string, it is written at the top of the file's header, above the
 column names and shape lines. Every line is prefixed with ``#``, the same as the rest of the header; if

--- a/docs/source/algorithms/SaveMDToAscii-v1.rst
+++ b/docs/source/algorithms/SaveMDToAscii-v1.rst
@@ -22,9 +22,9 @@ there would be no dimension columns left to write.
 
 Normalization defaults to whatever the workspace itself declares via its display normalization
 (:py:obj:`MDNormalization <mantid.api.MDNormalization>`, as set for example by :ref:`algm-BinMD` or
-:ref:`algm-ConvertToMD`); only ``NumEventsNormalization`` changes what is written, dividing Intensity and
-Error by the number of events in each bin. Set ``Normalization`` explicitly to override the workspace's own
-setting.
+:ref:`algm-ConvertToMD`). Set ``Normalization`` explicitly to override the workspace's own setting:
+``NumEventsNormalization`` divides Intensity and Error by the number of events in each bin, and
+``VolumeNormalization`` multiplies Intensity and Error by the workspace's inverse bin volume.
 
 ``Separator`` and ``CustomSeparator`` control the column delimiter used in the output file.
 ``Precision`` controls the number of significant digits used for the numeric columns (Intensity, Error, and

--- a/docs/source/algorithms/SaveMDToAscii-v1.rst
+++ b/docs/source/algorithms/SaveMDToAscii-v1.rst
@@ -1,0 +1,60 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm saves an :py:obj:`MDHistoWorkspace <mantid.dataobjects.MDHistoWorkspace>` to a plain ASCII
+text file, with one row per bin. Each row contains, in order, the bin-centre coordinate for every
+dimension written out, followed by the Intensity and the Error for that bin.
+
+An integrated dimension is one with exactly one bin (``getNBins() == 1``). By default such dimensions are
+excluded from the output columns, since their coordinate is constant across the whole workspace; set
+``ExcludeIntegratedDimensions`` to ``False`` to include them instead, as constant-value columns. If every
+dimension is integrated and ``ExcludeIntegratedDimensions`` is left as ``True``, the algorithm fails since
+there would be no dimension columns left to write.
+
+Normalization defaults to whatever the workspace itself declares via its display normalization
+(:py:obj:`MDNormalization <mantid.api.MDNormalization>`, as set for example by :ref:`algm-BinMD` or
+:ref:`algm-ConvertToMD`); only ``NumEventsNormalization`` changes what is written, dividing Intensity and
+Error by the number of events in each bin. Set ``Normalization`` explicitly to override the workspace's own
+setting.
+
+``Separator`` and ``CustomSeparator`` control the column delimiter used in the output file.
+``Precision`` controls the number of significant digits used for the numeric columns (Intensity, Error, and
+the dimension coordinates).
+
+Usage
+-----
+
+.. testcode:: SaveMDToAscii
+
+    import os
+    signalInput = [i for i in range(1, 10)]
+    errorInput = [1 for i in range(1, 10)]
+
+    ws = CreateMDHistoWorkspace(SignalInput=signalInput, ErrorInput=errorInput, Dimensionality='2',
+                                Extents='-1,1,-1,1', NumberOfBins='3,3', Names='A,B', Units='U,V')
+
+    savefile = os.path.join(config["defaultsave.directory"], "mdws_ascii.dat")
+    SaveMDToAscii(InputWorkspace=ws, Filename=savefile, Separator='Space', Precision=3)
+
+    print("File created: {}".format(os.path.exists(savefile)))
+
+.. testoutput:: SaveMDToAscii
+
+    File created: True
+
+.. testcleanup:: SaveMDToAscii
+
+    os.remove(savefile)
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/SaveMDToAscii-v1.rst
+++ b/docs/source/algorithms/SaveMDToAscii-v1.rst
@@ -30,6 +30,10 @@ setting.
 ``Precision`` controls the number of significant digits used for the numeric columns (Intensity, Error, and
 the dimension coordinates).
 
+If ``ExtraHeader`` is set to a non-empty string, it is written at the top of the file's header, above the
+column names and shape lines. Every line is prefixed with ``#``, the same as the rest of the header; if
+``ExtraHeader`` itself spans multiple lines, each one is prefixed individually.
+
 Usage
 -----
 

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41853.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41853.rst
@@ -1,0 +1,1 @@
+- A new algorithm :ref:`algm-SaveMDToAscii` has been added to save an :py:obj:`MDHistoWorkspace <mantid.dataobjects.MDHistoWorkspace>` to a plain ASCII file, with configurable exclusion of integrated dimensions, normalization, column separator and numeric precision.


### PR DESCRIPTION
### Description of work

New Mantid Python Algorithm, `SaveMDToAscii`, to export `MDHistoWorkspace` data to a plain ASCII table (dimension coordinates first, then intensity/error), with configurable normalization, delimiter, precision, and integrated-dimension handling.

**Changes:**
- Added `SaveMDToAscii` Python plugin algorithm with normalization auto-detection (and override), separator/precision controls, and optional header text.
- Added Python unit tests covering column order, integrated-dimension inclusion/exclusion, normalization modes, delimiter options, precision, and failure cases.
- Added algorithm documentation and a release note.

Companion to #41854 
Implements EWM [14692](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14692)

### To test:
Run the following script in the workbench:

```python
import os
import re
import tempfile

import numpy as np
from mantid.api import MDNormalization
from mantid.simpleapi import CreateMDHistoWorkspace, CreateSampleWorkspace, SaveMDToAscii

results = []

def check(name, condition):
    status = "PASS" if condition else "FAIL"
    results.append((name, status))
    print(f"[{status}] {name}")

tmp_dir = tempfile.mkdtemp(prefix="SaveMDToAscii_review_")

def tmp_path(name):
    return os.path.join(tmp_dir, name)

# 1. Basic 2D save: dims-first column order, default Space separator, default Precision (6)
ws = CreateMDHistoWorkspace(
    Dimensionality=2,
    Extents="0,2,0,2",
    SignalInput=[1, 2, 3, 4],
    ErrorInput=[1, 1, 1, 1],
    NumberOfBins="2,2",
    Names="A,B",
    Units="U,V",
)
f1 = tmp_path("basic_2d.dat")
SaveMDToAscii(InputWorkspace=ws, Filename=f1)
data = np.loadtxt(f1)
check("basic 2D: 4 rows x 4 columns (A, B, Intensity, Error)", data.shape == (4, 4))
check("basic 2D: dim columns hold the expected bin centres (0.5/1.5)", np.allclose(sorted(data[:, 0]), [0.5, 0.5, 1.5, 1.5]))
check("basic 2D: Intensity column has the expected values {1,2,3,4}", sorted(data[:, 2].tolist()) == [1, 2, 3, 4])

print("\n--- basic_2d.dat contents ---")
print(open(f1).read())
print("-----------------------------\n")

# 2. Integrated dimension exclusion
ws3d = CreateMDHistoWorkspace(
    Dimensionality=3,
    Extents="0,2,0,2,10,20",
    SignalInput=[1, 2, 3, 4],
    ErrorInput=[1, 1, 1, 1],
    NumberOfBins="2,2,1",  # C is integrated (1 bin)
    Names="A,B,C",
    Units="U,V,W",
)
f2a = tmp_path("exclude_integrated_true.dat")
SaveMDToAscii(InputWorkspace=ws3d, Filename=f2a)  # default ExcludeIntegratedDimensions=True
check("ExcludeIntegratedDimensions=True drops the integrated dim (4 cols)", np.loadtxt(f2a).shape[1] == 4)

f2b = tmp_path("exclude_integrated_false.dat")
SaveMDToAscii(InputWorkspace=ws3d, Filename=f2b, ExcludeIntegratedDimensions=False)
data_incl = np.loadtxt(f2b)
check("ExcludeIntegratedDimensions=False keeps it (5 cols)", data_incl.shape[1] == 5)
check("...and C's column is constant at its bin centre (15.0)", np.allclose(data_incl[:, 2], 15.0))

# 3. Normalization: auto-detect from workspace vs explicit override
ws_norm = CreateMDHistoWorkspace(
    Dimensionality=2,
    Extents="0,2,0,2",
    SignalInput=[2, 4, 6, 8],
    ErrorInput=[2, 2, 2, 2],
    NumberOfEvents=[2, 2, 2, 2],
    NumberOfBins="2,2",
    Names="A,B",
    Units="U,V",
)
ws_norm.setDisplayNormalization(MDNormalization.NumEventsNormalization)

f3a = tmp_path("normalization_auto.dat")
SaveMDToAscii(InputWorkspace=ws_norm, Filename=f3a)  # Normalization="FromWorkspace" (default)
check("Normalization=FromWorkspace divides by NumberOfEvents (max intensity 4)", np.isclose(np.loadtxt(f3a)[:, 2].max(), 4.0))

f3b = tmp_path("normalization_override.dat")
SaveMDToAscii(InputWorkspace=ws_norm, Filename=f3b, Normalization="NoNormalization")
check(
    "Normalization=NoNormalization override ignores the workspace flag (max intensity 8)",
    np.isclose(np.loadtxt(f3b)[:, 2].max(), 8.0),
)

# 4. Separator choices
ws1d = CreateMDHistoWorkspace(
    Dimensionality=1, Extents="0,2", SignalInput=[1, 2], ErrorInput=[1, 1], NumberOfBins="2", Names="A", Units="U"
)
for sep_name, sep_char in [("CSV", ","), ("Tab", "\t"), ("Space", " "), ("Colon", ":"), ("SemiColon", ";")]:
    f = tmp_path(f"separator_{sep_name}.dat")
    SaveMDToAscii(InputWorkspace=ws1d, Filename=f, Separator=sep_name)
    with open(f) as fh:
        data_line = next(line for line in fh if not line.startswith("#"))
    check(f"Separator={sep_name} uses {sep_char!r} as the delimiter", sep_char in data_line)

f_custom = tmp_path("separator_custom.dat")
SaveMDToAscii(InputWorkspace=ws1d, Filename=f_custom, Separator="UserDefined", CustomSeparator="|")
with open(f_custom) as fh:
    custom_line = next(line for line in fh if not line.startswith("#"))
check("Separator=UserDefined with CustomSeparator='|' uses '|'", "|" in custom_line)

# 5. Precision
f_prec = tmp_path("precision_2.dat")
SaveMDToAscii(InputWorkspace=ws1d, Filename=f_prec, Precision=2)
with open(f_prec) as fh:
    prec_line = next(line for line in fh if not line.startswith("#"))
check("Precision=2 yields exactly 2 digits after the decimal point", bool(re.search(r"\d\.\d{2}e[+-]\d+", prec_line)))

# 6. Error handling: all dims integrated + ExcludeIntegratedDimensions=True should fail cleanly
ws_all_integrated = CreateMDHistoWorkspace(
    Dimensionality=2, Extents="0,2,0,2", SignalInput=[1], ErrorInput=[1], NumberOfBins="1,1", Names="A,B", Units="U,V"
)
try:
    SaveMDToAscii(InputWorkspace=ws_all_integrated, Filename=tmp_path("should_not_exist.dat"))
    check("All-integrated workspace raises a clear error", False)
except RuntimeError:
    check("All-integrated workspace raises a clear error", True)

# 7. Error handling: wrong workspace type
ws_matrix = CreateSampleWorkspace()
try:
    SaveMDToAscii(InputWorkspace=ws_matrix, Filename=tmp_path("should_not_exist2.dat"))
    check("Non-MDHistoWorkspace input is rejected", False)
except ValueError:
    check("Non-MDHistoWorkspace input is rejected", True)

# Summary
print("\n=== SUMMARY ===")
n_pass = sum(1 for _, s in results if s == "PASS")
print(f"{n_pass}/{len(results)} checks passed")
for name, status in results:
    if status != "PASS":
        print(f"  -> FAILED: {name}")

print(f"\nOutput files written to: {tmp_dir}")
print("(left in place for inspection; workspaces ws, ws3d, ws_norm, ws1d, ws_all_integrated, ws_matrix are in the ADS too)")

```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
