### PR TITLE
Fix CylinderAbsorptionCW Sabine calculation for large μR

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import numpy as np
-from scipy.special import modstruve, iv, gamma
+from scipy.special import modstruve, i0, i1, gamma
 
 from mantid.api import AlgorithmFactory, PythonAlgorithm, WorkspaceProperty
 from mantid.kernel import Direction, Property, StringListValidator, FloatBoundedValidator, FloatMandatoryValidator, CompositeValidator
@@ -248,13 +248,13 @@ def bilinear_interpolate(x, y, x_grid, y_grid, Z):
 )
 
 
-def asymptotic_diff(n, z, N_terms=6):
+def asymptotic_diff(n, z, n_terms=6):
     """
     Computes the asymptotic expansion of I_n(z) - L_n(z) to N_terms.
     """
     total = 0.0
 
-    for k in range(N_terms):
+    for k in range(n_terms):
         num = gamma(k + 0.5)
         den = gamma(n + 0.5 - k)
         power = (z / 2.0) ** (2 * k - n + 1)
@@ -263,14 +263,24 @@ def asymptotic_diff(n, z, N_terms=6):
     return total / np.pi
 
 
-def get_diff(n, z):
+def get_diff0(z, cutoff):
     """
-    Computes I_n(z) - L_n(z) using the asymptotic expansion for large z.
+    Computes I_0(z) - L_0(z) using the asymptotic expansion for large z.
     """
-    if z > 12:
-        return asymptotic_diff(n, z)
+    if z > cutoff:
+        return asymptotic_diff(0, z)
     else:
-        return iv(n, z) - modstruve(n, z)
+        return i0(z) - modstruve(0, z)
+
+
+def get_diff1(z, cutoff):
+    """
+    Computes I_1(z) - L_1(z) using the asymptotic expansion for large z.
+    """
+    if z > cutoff:
+        return asymptotic_diff(1, z)
+    else:
+        return i1(z) - modstruve(1, z)
 
 
 class CylinderAbsorptionCW(PythonAlgorithm):
@@ -465,8 +475,10 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             if z == 0:
                 A = np.ones_like(thetas, dtype=float)
             else:
-                A_L = 2 * (get_diff(0, z) - get_diff(1, z) / z)
-                A_B = get_diff(1, 2 * z) / z
+                # Use different cutoffs for the asymptotic expansion based on the Sabine paper recommendations.
+                # Use asymptotic expansions for A_L when z > 24 and for A_B when z > 16.
+                A_L = 2 * (get_diff0(z, cutoff=24) - get_diff1(z, cutoff=24) / z)
+                A_B = get_diff1(2 * z, cutoff=32) / z  # cutoff=32 because input is 2z for A_B, so z > 16
                 A = A_L * np.cos(thetas) ** 2 + A_B * np.sin(thetas) ** 2
 
         # Create output absorption correction workspace

--- a/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import numpy as np
-from scipy.special import modstruve, i0, i1
+from scipy.special import modstruve, iv, gamma
 
 from mantid.api import AlgorithmFactory, PythonAlgorithm, WorkspaceProperty
 from mantid.kernel import Direction, Property, StringListValidator, FloatBoundedValidator, FloatMandatoryValidator, CompositeValidator
@@ -248,6 +248,31 @@ def bilinear_interpolate(x, y, x_grid, y_grid, Z):
 )
 
 
+def asymptotic_diff(n, z, N_terms=6):
+    """
+    Computes the asymptotic expansion of I_n(z) - L_n(z) to N_terms.
+    """
+    total = 0.0
+
+    for k in range(N_terms):
+        num = gamma(k + 0.5)
+        den = gamma(n + 0.5 - k)
+        power = (z / 2.0) ** (2 * k - n + 1)
+        total += num / (den * power)
+
+    return total / np.pi
+
+
+def get_diff(n, z):
+    """
+    Computes I_n(z) - L_n(z) using the asymptotic expansion for large z.
+    """
+    if z > 12:
+        return asymptotic_diff(n, z)
+    else:
+        return iv(n, z) - modstruve(n, z)
+
+
 class CylinderAbsorptionCW(PythonAlgorithm):
     def category(self):
         return "CorrectionFunctions\\AbsorptionCorrection"
@@ -440,8 +465,8 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             if z == 0:
                 A = np.ones_like(thetas, dtype=float)
             else:
-                A_L = 2 * (i0(z) - modstruve(0, z) - (i1(z) - modstruve(1, z)) / z)
-                A_B = (i1(2 * z) - modstruve(1, 2 * z)) / z
+                A_L = 2 * (get_diff(0, z) - get_diff(1, z) / z)
+                A_B = get_diff(1, 2 * z) / z
                 A = A_L * np.cos(thetas) ** 2 + A_B * np.sin(thetas) ** 2
 
         # Create output absorption correction workspace

--- a/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
@@ -251,11 +251,17 @@ def bilinear_interpolate(x, y, x_grid, y_grid, Z):
 def asymptotic_diff(n, z, n_terms=6):
     """
     Computes the asymptotic expansion of I_n(z) - L_n(z) to N_terms.
+
+    Uses Eq. (6) in Sabine et al. (1998), doi:10.1107/S0021889897006961.
+    That equation is written for L_n(z) - I_{-n}(z); for integer n, I_{-n}=I_n,
+    so I_n(z) - L_n(z) uses the same series with an overall sign flip.
     """
     total = 0.0
 
+    # n_terms=6 was chosen empirically: it balances runtime and accuracy for
+    # the z cutoffs used below in the Sabine correction path.
     for k in range(n_terms):
-        num = gamma(k + 0.5)
+        num = ((-1) ** k) * gamma(k + 0.5)
         den = gamma(n + 0.5 - k)
         power = (z / 2.0) ** (2 * k - n + 1)
         total += num / (den * power)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
@@ -128,6 +128,28 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
         # Check multiple scattering, should be 0 since we set MultipleScattering=False
         self.assertEqual(result.MultipleScatteringWorkspace.extractY()[0][0], 0)
 
+    def testSabineLargeZ(self):
+        """When z is large, the algorithm should use the asymptotic expansion of I_n(z) - L_n(z) to avoid numerical overflow."""
+        ws = self.createWorkspace()
+
+        # Run the algorithm with Sabine method using large attenuation cross-section to produce large z values
+        result = CylinderAbsorptionCW(
+            InputWorkspace=ws,
+            Radius=2,  # cm
+            Height=10,  # cm
+            Wavelength=1.7982,  # Å
+            AttenuationXSection=100,  # barn at 1.798 Å
+            ScatteringXSection=5.1,  # barn
+            SampleNumberDensity=0.0723,  # atoms/Å^3
+            AbsorptionCorrectionMethod="Sabine",
+            AbsorptionWorkspace="Absorption",
+            MultipleScatteringWorkspace="MultipleScattering",
+            MultipleScattering=False,
+        )
+
+        # Check absorption
+        np.testing.assert_allclose(result.AbsorptionWorkspace.extractY()[:, 0], [0.00299123, 0.01043025, 0.01786926, 0.01043025], rtol=1e-6)
+
     def testMissingProperties(self):
         ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=1)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
+from scipy.special import i0, i1, modstruve
 from mantid.simpleapi import CylinderAbsorptionCW, CreateSampleWorkspace, EditInstrumentGeometry, SetSample
 
 
@@ -148,7 +149,42 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
         )
 
         # Check absorption
-        np.testing.assert_allclose(result.AbsorptionWorkspace.extractY()[:, 0], [0.00299123, 0.01043025, 0.01786926, 0.01043025], rtol=1e-6)
+        np.testing.assert_allclose(result.AbsorptionWorkspace.extractY()[:, 0], [0.00314441, 0.01051528, 0.01788615, 0.01051528], rtol=1e-5)
+
+    def testSabineAsymptoticAgreesWithDirectNearCutoff(self):
+        """Near asymptotic cutoffs, asymptotic and direct Sabine evaluations should agree."""
+        ws = self.createWorkspace()
+
+        # Choose parameters that gives z = 17 so A_B (2z > 32) uses the asymptotic branch to compare to direct evaluation.
+        radius = 2.0  # cm
+        attenuation_xs = 80  # barn at 1.7982 A
+        scattering_xs = 5  # barn
+        number_density = 0.05  # atoms/A^3
+
+        result = CylinderAbsorptionCW(
+            InputWorkspace=ws,
+            Radius=radius,
+            Height=10.0,  # cm
+            Wavelength=1.7982,  # A
+            AttenuationXSection=attenuation_xs,
+            ScatteringXSection=scattering_xs,
+            SampleNumberDensity=number_density,
+            AbsorptionCorrectionMethod="Sabine",
+            AbsorptionWorkspace="Absorption",
+            MultipleScatteringWorkspace="MultipleScattering",
+            MultipleScattering=False,
+        )
+
+        spectrum_info = ws.spectrumInfo()
+        thetas = np.array([spectrum_info.twoTheta(i) for i in range(spectrum_info.size())]) / 2.0
+
+        z = 2.0 * number_density * (attenuation_xs + scattering_xs) * radius  # equals 17
+
+        a_l_direct = 2.0 * ((i0(z) - modstruve(0, z)) - (i1(z) - modstruve(1, z)) / z)
+        a_b_direct = (i1(2.0 * z) - modstruve(1, 2.0 * z)) / z
+        expected = a_l_direct * np.cos(thetas) ** 2 + a_b_direct * np.sin(thetas) ** 2
+
+        np.testing.assert_allclose(result.AbsorptionWorkspace.extractY()[:, 0], expected, rtol=0.01)
 
     def testMissingProperties(self):
         ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=1)

--- a/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41855.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41855.rst
@@ -1,1 +1,1 @@
-- Fix :ref:`CylinderAbsorptionCW <algm-CylinderAbsorptionCW>` Sabine calculation for large μR
+- Fixed :ref:`CylinderAbsorptionCW <algm-CylinderAbsorptionCW>` Sabine calculation for large μR

--- a/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41855.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/41855.rst
@@ -1,0 +1,1 @@
+- Fix :ref:`CylinderAbsorptionCW <algm-CylinderAbsorptionCW>` Sabine calculation for large μR


### PR DESCRIPTION
### Description of work

Fix for algorithm added in #41278

This is a problem with the Sabine calculation when `z` ($$z=2 \mu R$$) gets large, when calculating the difference `i0(z) - modstruve(0, z)` both modified Struve functions $L_n(z)$ and the modified Bessel functions $I_n(z)$ grow exponentially $$I_n(z) \sim \frac{e^z}{\sqrt{2\pi z}}, \quad L_n(z) \sim \frac{e^z}{\sqrt{2\pi z}}$$ so you end up with large numerical inaccuracy when calculating the difference. This replaces the calculation with a asymptotic expansion of $I_n(z) - L_n(z)$ for large (>12) z.

Sabine paper https://doi.org/10.1107/S0021889897006961

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->


<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

```python
ws = LoadEmptyInstrument(InstrumentName="WAND")

# Using Sears
CylinderAbsorptionCW(
            InputWorkspace=ws,
            Radius=2,
            Height=4,
            Wavelength=1.7982,
            AttenuationXSection=200,
            ScatteringXSection=5.1,
            SampleNumberDensity=0.0723,
            AbsorptionCorrectionMethod="Sabine",
            AbsorptionWorkspace="Absorption",
            MultipleScatteringWorkspace="MultipleScattering"
        )
        
print(mtd["Absorption"].y(0))
```

Before this fix it would get crazy numbers like `-1.24071353e+31` now you get correct values like `0.00010718`

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
