### PR TITLE
Don't run delete pkg test on as many PRs

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -5,8 +5,6 @@ on:
       - .github/actions/setup-pixi/
       - .github/workflows/delete-old-nightlies.yml
       - .pixi-version
-      - pixi.lock
-      - pixi.toml
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Since it is not actually using packages from the pixi.toml, there is no need to test when that file changes. This will reduce build server usage.

This is originally part of #41852, but that is taking longer than expected to finish.

There is no associated issue. 

### To test:

Looking at the change in logic should be enough.

*This does not require release notes* because it is a CI change.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
