### PR TITLE
Python binding for the `setSharedXYZ` family of methods -- `ornl-next`

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -10,9 +10,13 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidHistogramData/HistogramDx.h"
+#include "MantidHistogramData/HistogramE.h"
+#include "MantidHistogramData/HistogramX.h"
 #include "MantidHistogramData/HistogramY.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidKernel/make_cow.h"
 
 #include "MantidPythonInterface/api/CloneMatrixWorkspace.h"
 #include "MantidPythonInterface/api/RegisterWorkspacePtrToPython.h"
@@ -312,6 +316,114 @@ void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::
  */
 void setDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataDx, wsIndex, values);
+}
+
+/**
+ * Adds a deprecation warning to the setX call to warn about using setSharedX instead
+ * @param self A reference to the calling object
+ * @param wsIndex The workspace index for the spectrum to set
+ * @param values A numpy array. The length must match the size of the spectrum
+ */
+void setXDeprecated(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.setX()` is deprecated in Mantid 7.0, use `MatrixWorkspace.setSharedX()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  setXFromPyObject(self, wsIndex, values);
+}
+
+/**
+ * Adds a deprecation warning to the setY call to warn about using setSharedY instead
+ * @param self A reference to the calling object
+ * @param wsIndex The workspace index for the spectrum to set
+ * @param values A numpy array. The length must match the size of the spectrum
+ */
+void setYDeprecated(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.setY()` is deprecated in Mantid 7.0, use `MatrixWorkspace.setSharedY()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  setYFromPyObject(self, wsIndex, values);
+}
+
+/**
+ * Adds a deprecation warning to the setE call to warn about using setSharedE instead
+ * @param self A reference to the calling object
+ * @param wsIndex The workspace index for the spectrum to set
+ * @param values A numpy array. The length must match the size of the spectrum
+ */
+void setEDeprecated(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.setE()` is deprecated in Mantid 7.0, use `MatrixWorkspace.setSharedE()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  setEFromPyObject(self, wsIndex, values);
+}
+
+/**
+ * Adds a deprecation warning to the setDx call to warn about using setSharedDx instead
+ * @param self A reference to the calling object
+ * @param wsIndex The workspace index for the spectrum to set
+ * @param values A numpy array. The length must match the size of the spectrum
+ */
+void setDxDeprecated(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "`MatrixWorkspace.setDx()` is deprecated in Mantid 7.0, use `MatrixWorkspace.setSharedDx()` instead. "
+             "For more information, see the Histogram data concept page: "
+             "https://docs.mantidproject.org/nightly/concepts/HistogramData.html");
+  setDxFromPyObject(self, wsIndex, values);
+}
+
+/**
+ * Converts a python array-style object into a vector of doubles
+ * @param values :: A numpy array or python sequence
+ * @returns The extracted data as a std::vector<double>
+ */
+std::vector<double> extractVectorFromPyObject(const boost::python::object &values) {
+  if (NDArray::check(values)) {
+    return NDArrayToVector<double>(values)();
+  }
+  return PySequenceToVector<double>(values)();
+}
+
+/**
+ * Set the X values by sharing a new copy-on-write array built from a python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the spectrum.
+ */
+void setSharedXFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  self.setSharedX(wsIndex, make_cow<Mantid::HistogramData::HistogramX>(extractVectorFromPyObject(values)));
+}
+
+/**
+ * Set the Y values by sharing a new copy-on-write array built from a python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the spectrum.
+ */
+void setSharedYFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  self.setSharedY(wsIndex, make_cow<Mantid::HistogramData::HistogramY>(extractVectorFromPyObject(values)));
+}
+
+/**
+ * Set the E values by sharing a new copy-on-write array built from a python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the spectrum.
+ */
+void setSharedEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  self.setSharedE(wsIndex, make_cow<Mantid::HistogramData::HistogramE>(extractVectorFromPyObject(values)));
+}
+
+/**
+ * Set the Dx values by sharing a new copy-on-write array built from a python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the spectrum.
+ */
+void setSharedDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
+  self.setSharedDx(wsIndex, make_cow<Mantid::HistogramData::HistogramDx>(extractVectorFromPyObject(values)));
 }
 
 std::vector<double> getIntegratedCountsForWorkspaceIndices(MatrixWorkspace &self,
@@ -662,18 +774,34 @@ void export_MatrixWorkspace() {
            "Creates a writable numpy wrapper around the original Dx data at "
            "the given index (deprecated, use "
            ":class:`~mantid.api.MatrixWorkspace.mutableDx` instead)")
-      .def("setX", &setXFromPyObject, args("self", "workspaceIndex", "x"),
+      .def("setX", &setXDeprecated, args("self", "workspaceIndex", "x"),
            "Set X values from a python list or numpy array. It performs a "
-           "simple copy into the array.")
-      .def("setY", &setYFromPyObject, args("self", "workspaceIndex", "y"),
+           "simple copy into the array (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.setSharedX` instead)")
+      .def("setY", &setYDeprecated, args("self", "workspaceIndex", "y"),
            "Set Y values from a python list or numpy array. It performs a "
-           "simple copy into the array.")
-      .def("setE", &setEFromPyObject, args("self", "workspaceIndex", "e"),
+           "simple copy into the array (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.setSharedY` instead)")
+      .def("setE", &setEDeprecated, args("self", "workspaceIndex", "e"),
            "Set E values from a python list or numpy array. It performs a "
-           "simple copy into the array.")
-      .def("setDx", &setDxFromPyObject, args("self", "workspaceIndex", "dX"),
+           "simple copy into the array (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.setSharedE` instead)")
+      .def("setDx", &setDxDeprecated, args("self", "workspaceIndex", "dX"),
            "Set Dx values from a python list or numpy array. It performs a "
-           "simple copy into the array.")
+           "simple copy into the array (deprecated, use "
+           ":class:`~mantid.api.MatrixWorkspace.setSharedDx` instead)")
+      .def("setSharedX", &setSharedXFromPyObject, args("self", "workspaceIndex", "x"),
+           "Set the X data at the given index by building a new copy-on-write array "
+           "from a python list or numpy array and sharing it into the workspace.")
+      .def("setSharedY", &setSharedYFromPyObject, args("self", "workspaceIndex", "y"),
+           "Set the Y data at the given index by building a new copy-on-write array "
+           "from a python list or numpy array and sharing it into the workspace.")
+      .def("setSharedE", &setSharedEFromPyObject, args("self", "workspaceIndex", "e"),
+           "Set the E data at the given index by building a new copy-on-write array "
+           "from a python list or numpy array and sharing it into the workspace.")
+      .def("setSharedDx", &setSharedDxFromPyObject, args("self", "workspaceIndex", "dX"),
+           "Set the Dx data at the given index by building a new copy-on-write array "
+           "from a python list or numpy array and sharing it into the workspace.")
 
       // --------------------------------------- Extract data
       // ------------------------------

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -159,6 +159,99 @@ class MatrixWorkspaceTest(unittest.TestCase):
         for attr in [x, y, e, dx]:
             do_numpy_test(attr)
 
+    def test_x_y_e_dx_give_readonly_numpy_array(self):
+        def do_numpy_test(arr):
+            self.assertEqual(type(arr), np.ndarray)
+            self.assertFalse(arr.flags.writeable)
+
+        x = self._test_ws.x(0)
+        y = self._test_ws.y(0)
+        e = self._test_ws.e(0)
+        dx = self._test_ws.dx(0)
+
+        for attr in [x, y, e, dx]:
+            do_numpy_test(attr)
+
+        self.assertTrue(np.array_equal(x, self._test_ws.readX(0)))
+        self.assertTrue(np.array_equal(y, self._test_ws.readY(0)))
+        self.assertTrue(np.array_equal(e, self._test_ws.readE(0)))
+        self.assertTrue(np.array_equal(dx, self._test_ws.readDx(0)))
+
+    def test_mutable_data_members_give_writable_numpy_array(self):
+        def do_numpy_test(arr):
+            self.assertEqual(type(arr), np.ndarray)
+            self.assertTrue(arr.flags.writeable)
+
+        x = self._test_ws.mutableX(0)
+        y = self._test_ws.mutableY(0)
+        e = self._test_ws.mutableE(0)
+        dx = self._test_ws.mutableDx(0)
+
+        for attr in [x, y, e, dx]:
+            do_numpy_test(attr)
+
+        self._do_numpy_comparison(self._test_ws, x, y, e, 0)
+
+        # Can we change something
+        ynow = y[0]
+        ynow *= 2.5
+        y[0] = ynow
+        self.assertEqual(self._test_ws.y(0)[0], ynow)
+
+    def test_set_shared_x_y_e_dx_sets_expected_values(self):
+        nvectors = 2
+        xlength = 11
+        ylength = 10
+
+        test_ws = WorkspaceFactory.create("Workspace2D", nvectors, xlength, ylength)
+        ws_index = 1
+
+        xvalues = np.linspace(0, 1, xlength)
+        test_ws.setSharedX(ws_index, xvalues)
+        self.assertTrue(np.array_equal(xvalues, test_ws.x(ws_index)))
+
+        yvalues = np.ones(ylength)
+        test_ws.setSharedY(ws_index, yvalues)
+        self.assertTrue(np.array_equal(yvalues, test_ws.y(ws_index)))
+
+        evalues = np.sqrt(yvalues)
+        test_ws.setSharedE(ws_index, evalues)
+        self.assertTrue(np.array_equal(evalues, test_ws.e(ws_index)))
+
+        dxvalues = np.full(ylength, 0.1)
+        test_ws.setSharedDx(ws_index, dxvalues)
+        self.assertTrue(np.array_equal(dxvalues, test_ws.dx(ws_index)))
+
+    def test_set_shared_x_y_e_dx_raise_on_size_mismatch(self):
+        nvectors = 1
+        xlength = 11
+        ylength = 10
+
+        test_ws = WorkspaceFactory.create("Workspace2D", nvectors, xlength, ylength)
+
+        wrong_length_xvalues = np.ones(xlength - 1)
+        self.assertRaises(RuntimeError, test_ws.setSharedX, 0, wrong_length_xvalues)
+
+        wrong_length_values = np.ones(ylength - 1)
+        self.assertRaises(RuntimeError, test_ws.setSharedY, 0, wrong_length_values)
+        self.assertRaises(RuntimeError, test_ws.setSharedE, 0, wrong_length_values)
+        self.assertRaises(RuntimeError, test_ws.setSharedDx, 0, wrong_length_values)
+
+    def test_set_x_y_e_dx_are_deprecated_in_favour_of_set_shared_x_y_e_dx(self):
+        nvectors = 1
+        xlength = 11
+        ylength = 10
+        test_ws = WorkspaceFactory.create("Workspace2D", nvectors, xlength, ylength)
+
+        xvalues = np.linspace(0, 1, xlength)
+        with self.assertWarns(DeprecationWarning):
+            test_ws.setX(0, xvalues)
+
+        values = np.ones(ylength)
+        for method_name in ("setY", "setE", "setDx"):
+            with self.assertWarns(DeprecationWarning):
+                getattr(test_ws, method_name)(0, values)
+
     def test_setting_spectra_from_array_of_incorrect_length_raises_error(self):
         nvectors = 2
         xlength = 11


### PR DESCRIPTION
Sister to PR #41841 