### PR TITLE
Allow for `HistogramX` to be resizable

### DIFF
--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -135,9 +135,9 @@ public:
     TS_ASSERT_EQUALS(h.dataE()[12], 0.0);
   }
   void testsetgetXPointer() {
-    auto px = std::make_shared<HistogramX>(0);
-    h.setX(px);
-    TS_ASSERT_EQUALS(&(*h.ptrX()), &(*px));
+    auto px = std::make_shared<HistogramX>(nel);
+    h.setSharedX(px);
+    TS_ASSERT_EQUALS(&(*h.sharedX()), &(*px));
   }
   void testsetgetDataYPointer() {
     h.setCounts(pa);

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace Mantid {

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -111,15 +111,21 @@ protected:
   std::vector<double> &mutableRawData() { return m_data; }
 
 private:
-  template <class Other> void checkAssignmentSize(const Other &other) const {
-    if (size() != other.size())
-      throw std::logic_error("FixedLengthVector::operator=: size mismatch");
+  /** Throws if the assignment would change the length of a non-empty vector.
+
+    An empty vector is not constrained yet (e.g., the data of a spectrum that
+    is still being initialized), so it may grow by assignment; any data set
+    afterwards is validated against the new length by the Histogram setters. */
+  void checkAssignmentSize(size_t const otherSize) const {
+    if (!empty() && size() != otherSize) {
+      throw std::logic_error("FixedLengthVector: size mismatch (" + std::to_string(size()) +
+                             " != " + std::to_string(otherSize) +
+                             "); the data arrays of a non-empty histogram cannot be resized individually. Use the "
+                             "Histogram setters instead, e.g. setBinEdges, setPoints, setCounts, or setHistogram.");
+    }
   }
 
-  void checkAssignmentSize(const size_t &size) const {
-    if (this->size() != size)
-      throw std::logic_error("FixedLengthVector::assign: size mismatch");
-  }
+  template <class Other> void checkAssignmentSize(const Other &other) const { checkAssignmentSize(other.size()); }
 
   std::vector<double> m_data;
 

--- a/Framework/HistogramData/src/Histogram.cpp
+++ b/Framework/HistogramData/src/Histogram.cpp
@@ -123,10 +123,24 @@ FrequencyStandardDeviations Histogram::frequencyStandardDeviations() const {
 
 /** Sets the internal x-data pointer of the Histogram.
 
-  Throws if the size does not match the current size. */
+  The new x-data must be consistent with the stored y- and dx-data: for
+  XMode::BinEdges there must be one more edge than data points (unless both are
+  empty), for XMode::Points the sizes must be equal. Throws if this invariant
+  would be broken. If the Histogram holds no data points (e.g. during
+  construction, or for event data where counts are computed on demand) it is
+  not yet constrained and any size is accepted. */
 void Histogram::setSharedX(const Kernel::cow_ptr<HistogramX> &x) & {
-  if (m_x->size() != x->size())
+  size_t targetSize = x->size();
+  // 0 edges -> 0 points, otherwise points are 1 less than edges.
+  if (xMode() == XMode::BinEdges && targetSize > 0) {
+    --targetSize;
+  }
+  if (m_y && !m_y->empty() && m_y->size() != targetSize) {
     throw std::logic_error("Histogram::setSharedX: size mismatch\n");
+  }
+  if (m_dx && !m_dx->empty() && m_dx->size() != targetSize) {
+    throw std::logic_error("Histogram::setSharedX: size mismatch with Dx data\n");
+  }
   m_x = x;
 }
 

--- a/Framework/HistogramData/test/FixedLengthVectorTest.h
+++ b/Framework/HistogramData/test/FixedLengthVectorTest.h
@@ -212,6 +212,41 @@ public:
     TS_ASSERT_THROWS((values = {0.1, 0.2, 0.3}), const std::logic_error &);
   }
 
+  // An empty vector is not constrained yet, so assignment may grow it. This
+  // supports initializing spectra via, e.g., ws.mutableX(i) = vec; any
+  // subsequent size change of the non-empty vector still throws.
+  void test_assignment_into_empty_may_grow() {
+    FixedLengthVectorTester values(0);
+    TS_ASSERT_THROWS_NOTHING((values = {0.1, 0.2, 0.3}));
+    TS_ASSERT_EQUALS(values.size(), 3);
+    TS_ASSERT_EQUALS(values[2], 0.3);
+    TS_ASSERT_THROWS((values = {0.1, 0.2}), const std::logic_error &);
+  }
+
+  void test_vector_assignment_into_empty_may_grow() {
+    std::vector<double> const src{3.6, 9.7};
+    FixedLengthVectorTester values(0);
+    TS_ASSERT_THROWS_NOTHING(values = src);
+    TS_ASSERT_EQUALS(values.size(), 2);
+    TS_ASSERT_EQUALS(values[1], 9.7);
+  }
+
+  void test_copy_assignment_into_empty_may_grow() {
+    const FixedLengthVectorTester src(2, 0.1);
+    FixedLengthVectorTester dest(0);
+    TS_ASSERT_THROWS_NOTHING(dest = src);
+    TS_ASSERT_EQUALS(dest.size(), 2);
+    TS_ASSERT_EQUALS(dest[0], 0.1);
+  }
+
+  void test_range_assign_into_empty_may_grow() {
+    std::vector<double> const src{3.6, 9.7, 8.5};
+    FixedLengthVectorTester dest(0);
+    TS_ASSERT_THROWS_NOTHING(dest.assign(src.cbegin(), src.cend()));
+    TS_ASSERT_EQUALS(dest.size(), 3);
+    TS_ASSERT_EQUALS(dest[2], 8.5);
+  }
+
   void test_vector_constructor() {
     const std::vector<double> vector(2, 0.1);
     FixedLengthVectorTester values(vector);

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -765,16 +765,46 @@ public:
   }
 
   void test_setSharedX_size_mismatch() {
-    auto data1 = Mantid::Kernel::make_cow<HistogramX>(0);
+    Histogram hist{BinEdges{1.0, 2.0, 3.0}, Counts{4.0, 5.0}};
     auto tmp = {1.0, 2.0};
     auto data2 = Mantid::Kernel::make_cow<HistogramX>(tmp);
-    Histogram hist{BinEdges(data1)};
     TS_ASSERT_THROWS(hist.setSharedX(data2), const std::logic_error &);
+  }
+
+  void test_setSharedX_size_mismatch_with_dx() {
+    Histogram hist{BinEdges{1.0, 2.0, 3.0}};
+    hist.setPointStandardDeviations(PointStandardDeviations{0.1, 0.2});
+    auto tmp = {1.0, 2.0};
+    auto data2 = Mantid::Kernel::make_cow<HistogramX>(tmp);
+    TS_ASSERT_THROWS(hist.setSharedX(data2), const std::logic_error &);
+  }
+
+  void test_setSharedX_size_change_without_y_data() {
+    // With no Y or Dx data there is no invariant to break, so the X data may
+    // change size, e.g., when initializing a workspace or rebinning events.
+    Histogram hist(Histogram::XMode::BinEdges, Histogram::YMode::Counts);
+    auto tmp = {1.0, 2.0, 3.0};
+    auto data = Mantid::Kernel::make_cow<HistogramX>(tmp);
+    TS_ASSERT_THROWS_NOTHING(hist.setSharedX(data));
+    TS_ASSERT_EQUALS(hist.sharedX(), data);
+    TS_ASSERT_THROWS_NOTHING(hist.setCounts(Counts{4.0, 5.0}));
+  }
+
+  void test_setSharedX_size_change_with_empty_y_data() {
+    // A histogram holding zero data points is not yet constrained either;
+    // this is the state of the spectra during Workspace2D::init().
+    Histogram hist(Histogram::XMode::BinEdges, Histogram::YMode::Counts);
+    hist.setCounts(0);
+    auto tmp = {1.0, 2.0, 3.0};
+    auto data = Mantid::Kernel::make_cow<HistogramX>(tmp);
+    TS_ASSERT_THROWS_NOTHING(hist.setSharedX(data));
+    TS_ASSERT_EQUALS(hist.sharedX(), data);
+    TS_ASSERT_THROWS_NOTHING(hist.setCounts(Counts{4.0, 5.0}));
   }
 
   void test_setSharedX_catches_misuse() {
     BinEdges edges{1.0, 2.0};
-    Histogram hist(edges);
+    Histogram hist(edges, Counts{4.0});
     auto points = hist.points();
     TS_ASSERT_THROWS(hist.setSharedX(points.cowData()), const std::logic_error &);
   }


### PR DESCRIPTION
### Description of work

Following [the plan](https://gist.github.com/rosswhitfield/834539a14a860c0bef4d338feff4009c) to remove the old Histogram access methods.  Part of the plan requires swapping from `setX()` to `setSharedX()`, and also changing from `dataX()` to `mutableX()`.

PR #41801 deprecated the old methods in python, and exposed the new ones.  Pr #41841 exposed the `setSharedX()` methods.   PR #41756 changed all of the usages within the documentation.  And then PR #41845 was meant to migrate over the majority of usages within the codebase.

However, `HistogramX` inherits from `FixedLengthVector`, which does not allow for resizing in the ways `setX()` and `dataX()` were being used.

These changes make these work as intended, so that the migration can  continue.

### To test:

This is a refactor.  Verify all existing unit tests pass.

This does not require release notes because _it is a refactor that will not impact user experience_.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
