### PR TITLE
Coverity Defect: Sample.cpp

### DIFF
--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -413,7 +413,7 @@ int Sample::loadNexus(Nexus::File *file, const std::string &group) {
     // Only replace the default shape if the file actually defines one; otherwise
     // keep the valid (empty) shape so callers never observe a null m_shape.
     if (IObject_sptr loadedShape = loadShapeFromFile(file))
-      m_shape = loadedShape;
+      m_shape = std::move(loadedShape);
 
     // sample environment
     if (file->hasAttr("env_name")) {


### PR DESCRIPTION
### Description of work

Move shared pointer rather than having copy invoked

```
*** CID 1663858:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/home/docker/actions-runner/_work/mantid/mantid/Framework/API/src/Sample.cpp: 416             in Mantid::API::Sample::loadNexus(Mantid::Nexus::File *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &)()
410           }
411         }
412     
413         // Only replace the default shape if the file actually defines one; otherwise
414         // keep the valid (empty) shape so callers never observe a null m_shape.
415         if (IObject_sptr loadedShape = loadShapeFromFile(file))
>>>     CID 1663858:         Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
>>>     "loadedShape" is copied in call to copy assignment for class "Mantid::Geometry::IObject_sptr", when it could be moved instead.
416           m_shape = loadedShape;
417     
418         // sample environment
419         if (file->hasAttr("env_name")) {
420           std::string env_name;
421           file->getAttr("env_name", env_name);
```

### To test:

passes CI

*This does not require release notes* because no user facing change

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
