### PR TITLE
Change internal call sites for deprecated Instrument 1.0 methods

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -366,6 +366,7 @@ set(PYTHON_PLUGINS
     functions/BivariateGaussian.py
     functions/ChudleyElliot.py
     functions/CombGaussLorentzKT.py
+    functions/component_info_utils.py
     functions/CompositePCRmagnet.py
     functions/DampedBessel.py
     functions/EISFDiffCylinder.py

--- a/Framework/PythonInterface/plugins/algorithms/BASISCrystalDiffraction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISCrystalDiffraction.py
@@ -538,6 +538,7 @@ class BASISCrystalDiffraction(DataProcessorAlgorithm):
         ws = LoadNexus(Filename=self._solid_angle_ws_, OutputWorkspace=name)
         ClearMaskFlag(ws)
         MaskDetectors(ws, MaskedWorkspace=self._t_mask)
+        spectrum_info = ws.spectrumInfo()
         for i in range(ws.getNumberHistograms()):
             ws.mutableY(i)[0] = 0.0 if ws.getDetector(i).isMasked() else 1.0
             ws.setSharedX(i, self._momentum_range)

--- a/Framework/PythonInterface/plugins/algorithms/BASISDiffraction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISDiffraction.py
@@ -483,6 +483,7 @@ class BASISDiffraction(DataProcessorAlgorithm):
         ws = LoadNexus(Filename=self._solid_angle_ws_, OutputWorkspace=name)
         ClearMaskFlag(ws)
         MaskDetectors(ws, MaskedWorkspace=self._t_mask)
+        spectrum_info = ws.spectrumInfo()
         for i in range(ws.getNumberHistograms()):
             ws.mutableY(i)[0] = 0.0 if ws.getDetector(i).isMasked() else 1.0
             ws.setSharedX(i, self._momentum_range)

--- a/Framework/PythonInterface/plugins/algorithms/ExportGeometry.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExportGeometry.py
@@ -79,26 +79,6 @@ class ExportGeometry(PythonAlgorithm):
         )
         self.declareProperty(FileProperty(name="Filename", defaultValue="", action=FileAction.Save, extensions=[".xml"]), doc="Save file")
 
-    @staticmethod
-    def _component_index(component, component_info):
-        r"""Resolve a Components entry, which may be a bare name or a (partial) full
-        path such as 'CORELLI/A row/bank1/sixteenpack', to its ComponentInfo index.
-
-        Mirrors the walk performed by the legacy Instrument.getComponentByName: the first
-        path segment is located anywhere in the instrument, then each remaining segment is
-        located within the subtree of the previous one.
-        """
-        parts = component.split("/")
-        index = component_info.indexOfAny(parts[0])
-        for part in parts[1:]:
-            try:
-                index = next(
-                    int(c) for c in component_info.componentsInSubtree(index) if int(c) != index and component_info.name(int(c)) == part
-                )
-            except StopIteration:
-                raise ValueError(f"No component named '{part}' found within '{parts[0]}' while resolving '{component}'")
-        return index
-
     def validateInputs(self):
         issues = {}
 

--- a/Framework/PythonInterface/plugins/algorithms/ExportGeometry.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExportGeometry.py
@@ -79,6 +79,26 @@ class ExportGeometry(PythonAlgorithm):
         )
         self.declareProperty(FileProperty(name="Filename", defaultValue="", action=FileAction.Save, extensions=[".xml"]), doc="Save file")
 
+    @staticmethod
+    def _component_index(component, component_info):
+        r"""Resolve a Components entry, which may be a bare name or a (partial) full
+        path such as 'CORELLI/A row/bank1/sixteenpack', to its ComponentInfo index.
+
+        Mirrors the walk performed by the legacy Instrument.getComponentByName: the first
+        path segment is located anywhere in the instrument, then each remaining segment is
+        located within the subtree of the previous one.
+        """
+        parts = component.split("/")
+        index = component_info.indexOfAny(parts[0])
+        for part in parts[1:]:
+            try:
+                index = next(
+                    int(c) for c in component_info.componentsInSubtree(index) if int(c) != index and component_info.name(int(c)) == part
+                )
+            except StopIteration:
+                raise ValueError(f"No component named '{part}' found within '{parts[0]}' while resolving '{component}'")
+        return index
+
     def validateInputs(self):
         issues = {}
 

--- a/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
@@ -90,11 +90,6 @@ class MaskWorkspaceToCalFile(PythonAlgorithm):
                     group = masking_flag
                 else:
                     group = not_masking_flag
-                detIDs = []
-                try:
-                    detIDs = det.getDetectorIDs()
-                except AttributeError:
-                    detIDs = [det.getID()]
                 calFile.writelines(self.FormatLine(i, did, 0.0, group, group) for did in detIDs)
             except RuntimeError:
                 # no detector for this spectra

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ConvertMultipleRunsToSingleCrystalMD.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ConvertMultipleRunsToSingleCrystalMD.py
@@ -246,6 +246,7 @@ class ConvertMultipleRunsToSingleCrystalMD(DataProcessorAlgorithm):
             CopyInstrumentParameters(OutputWorkspace=ws_name, InputWorkspace=self.getProperty("CopyInstrumentParameters").value)
         if self._masking:
             if not mtd.doesExist("__mask"):
+                component_info = mtd[ws_name].componentInfo()
                 LoadMask(
                     Instrument=mtd[ws_name].getInstrumentName(),
                     InputFile=self.getProperty("MaskFile").value,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherent.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherent.py
@@ -173,6 +173,7 @@ class MDNormSCDPreprocessIncoherent(DataProcessorAlgorithm):
             LoadIsawDetCal(InputWorkspace="__van", Filename=self.getProperty("DetCal").value)
 
         if _masking:
+            van_component_info = mtd["__van"].componentInfo()
             LoadMask(
                 Instrument=mtd["__van"].getInstrumentName(),
                 InputFile=self.getProperty("MaskFile").value,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SingleCrystalDiffuseReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SingleCrystalDiffuseReduction.py
@@ -262,6 +262,7 @@ class SingleCrystalDiffuseReduction(DataProcessorAlgorithm):
             LoadNexus(Filename=self.getProperty("Flux").value, OutputWorkspace="__flux")
 
         if _masking:
+            sa_component_info = mtd["__sa"].componentInfo()
             LoadMask(
                 Instrument=mtd["__sa"].getInstrumentName(),
                 InputFile=self.getProperty("MaskFile").value,

--- a/Framework/PythonInterface/plugins/functions/component_info_utils.py
+++ b/Framework/PythonInterface/plugins/functions/component_info_utils.py
@@ -1,0 +1,35 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+Shared helpers for resolving legacy-style component names against ComponentInfo.
+"""
+
+
+def resolve_component_index(component, component_info):
+    r"""Resolve a component name, which may be a bare name or a (partial) full
+    path such as 'CORELLI/A row/bank1/sixteenpack', to its ComponentInfo index.
+
+    Mirrors the walk performed by the legacy Instrument.getComponentByName: the first
+    path segment is located anywhere in the instrument, then each remaining segment is
+    located within the subtree of the previous one. This matters because an intermediate
+    path segment (e.g. a bank that is just a positioning frame) can sit at a different
+    position/rotation than the leaf component the full path actually identifies.
+
+    @param str component: (partial) full name of the component assembly
+    @param mantid.geometry.componentInfo component_info: object holding information for the instrument components
+    @return int: component-info index
+    """
+    parts = component.split("/")
+    index = component_info.indexOfAny(parts[0])
+    for part in parts[1:]:
+        try:
+            index = next(
+                int(c) for c in component_info.componentsInSubtree(index) if int(c) != index and component_info.name(int(c)) == part
+            )
+        except StopIteration as exc:
+            raise ValueError(f"No component named '{part}' found within '{parts[0]}' while resolving '{component}'") from exc
+    return index

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AlignComponentsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AlignComponentsTest.py
@@ -11,7 +11,6 @@ from mantid.simpleapi import (
     ConvertUnits,
     CloneWorkspace,
     CreateSampleWorkspace,
-    LoadEmptyInstrument,
     Max,
     MoveInstrumentComponent,
     CreateEmptyTableWorkspace,
@@ -21,39 +20,10 @@ from mantid.simpleapi import (
 from mantid.api import AlgorithmFactory
 from mantid.kernel import V3D
 
-# the plugin module itself (as opposed to the generated simpleapi function above),
-# needed to instantiate the python algorithm class directly and exercise its private methods
-import AlignComponents as AlignComponentsModule
-
 
 class AlignComponentsTest(unittest.TestCase):
-    def test_component_index_resolves_nested_path(self):
-        r"""
-        Regression test for a bug where AlignComponents._component_index resolved a
-        '/'-qualified ComponentList entry (e.g. 'bank7/sixteenpack') to the first
-        path segment that is globally unique ('bank7') instead of walking down to the
-        leaf component ('sixteenpack') that the full path actually identifies. In the
-        CORELLI instrument (and others with the same convention) an intermediate path
-        segment is a pure positioning frame placed at <location/> (i.e. at its parent's
-        location), while the real detector-bank position lives on the leaf 'sixteenpack'
-        component nested inside it. Resolving to the frame instead of the leaf silently
-        substitutes the wrong position/rotation, which is what made
-        CorelliPowderCalibrationCreate fit component offsets around the wrong starting
-        point (systemtest CorelliPowderCalibrationTest).
-        """
-        ws = LoadEmptyInstrument(InstrumentName="CORELLI", OutputWorkspace="corelli_empty")
-        component_info = ws.componentInfo()
-
-        alg = AlignComponentsModule.AlignComponents()
-        resolved_index = alg._component_index("bank7/sixteenpack", component_info)
-        bank_index = component_info.indexOfAny("bank7")
-
-        # must resolve to the leaf, not to the intermediate positioning frame
-        self.assertEqual(component_info.name(resolved_index), "sixteenpack")
-        self.assertNotEqual(resolved_index, bank_index)
-
-        # the frame sits at <location/> (its parent's position); the leaf carries the real offset
-        self.assertFalse(np.allclose(component_info.position(bank_index), component_info.position(resolved_index)))
+    # Regression coverage for '/'-qualified ComponentList path resolution (e.g. 'bank7/sixteenpack')
+    # now lives in component_info_utilsTest.py, against the shared resolve_component_index() helper.
 
     def testAlignComponentsPosition(self):
         r"""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AlignComponentsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AlignComponentsTest.py
@@ -11,6 +11,7 @@ from mantid.simpleapi import (
     ConvertUnits,
     CloneWorkspace,
     CreateSampleWorkspace,
+    LoadEmptyInstrument,
     Max,
     MoveInstrumentComponent,
     CreateEmptyTableWorkspace,
@@ -20,8 +21,40 @@ from mantid.simpleapi import (
 from mantid.api import AlgorithmFactory
 from mantid.kernel import V3D
 
+# the plugin module itself (as opposed to the generated simpleapi function above),
+# needed to instantiate the python algorithm class directly and exercise its private methods
+import AlignComponents as AlignComponentsModule
+
 
 class AlignComponentsTest(unittest.TestCase):
+    def test_component_index_resolves_nested_path(self):
+        r"""
+        Regression test for a bug where AlignComponents._component_index resolved a
+        '/'-qualified ComponentList entry (e.g. 'bank7/sixteenpack') to the first
+        path segment that is globally unique ('bank7') instead of walking down to the
+        leaf component ('sixteenpack') that the full path actually identifies. In the
+        CORELLI instrument (and others with the same convention) an intermediate path
+        segment is a pure positioning frame placed at <location/> (i.e. at its parent's
+        location), while the real detector-bank position lives on the leaf 'sixteenpack'
+        component nested inside it. Resolving to the frame instead of the leaf silently
+        substitutes the wrong position/rotation, which is what made
+        CorelliPowderCalibrationCreate fit component offsets around the wrong starting
+        point (systemtest CorelliPowderCalibrationTest).
+        """
+        ws = LoadEmptyInstrument(InstrumentName="CORELLI", OutputWorkspace="corelli_empty")
+        component_info = ws.componentInfo()
+
+        alg = AlignComponentsModule.AlignComponents()
+        resolved_index = alg._component_index("bank7/sixteenpack", component_info)
+        bank_index = component_info.indexOfAny("bank7")
+
+        # must resolve to the leaf, not to the intermediate positioning frame
+        self.assertEqual(component_info.name(resolved_index), "sixteenpack")
+        self.assertNotEqual(resolved_index, bank_index)
+
+        # the frame sits at <location/> (its parent's position); the leaf carries the real offset
+        self.assertFalse(np.allclose(component_info.position(bank_index), component_info.position(resolved_index)))
+
     def testAlignComponentsPosition(self):
         r"""
 

--- a/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_PY_FILES
     BesselTest.py
     ChudleyElliotTest.py
     CombGaussLorentzKTTest.py
+    component_info_utilsTest.py
     DampedBesselTest.py
     CompositePCRmagnetTest.py
     EISFDiffSphereTest.py

--- a/Framework/PythonInterface/test/python/plugins/functions/component_info_utilsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/component_info_utilsTest.py
@@ -1,0 +1,58 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import numpy as np
+import unittest
+from mantid.simpleapi import LoadEmptyInstrument
+
+from plugins.functions.component_info_utils import resolve_component_index
+
+
+class ComponentInfoUtilsTest(unittest.TestCase):
+    def test_resolve_component_index_resolves_nested_path(self):
+        r"""
+        Regression test for a bug where resolve_component_index resolved a
+        '/'-qualified component name (e.g. 'bank7/sixteenpack') to the first
+        path segment that is globally unique ('bank7') instead of walking down to the
+        leaf component ('sixteenpack') that the full path actually identifies. In the
+        CORELLI instrument (and others with the same convention) an intermediate path
+        segment is a pure positioning frame placed at <location/> (i.e. at its parent's
+        location), while the real detector-bank position lives on the leaf 'sixteenpack'
+        component nested inside it. Resolving to the frame instead of the leaf silently
+        substitutes the wrong position/rotation, which is what made
+        CorelliPowderCalibrationCreate fit component offsets around the wrong starting
+        point (systemtest CorelliPowderCalibrationTest).
+        """
+        ws = LoadEmptyInstrument(InstrumentName="CORELLI", OutputWorkspace="corelli_empty")
+        component_info = ws.componentInfo()
+
+        resolved_index = resolve_component_index("bank7/sixteenpack", component_info)
+        bank_index = component_info.indexOfAny("bank7")
+
+        # must resolve to the leaf, not to the intermediate positioning frame
+        self.assertEqual(component_info.name(resolved_index), "sixteenpack")
+        self.assertNotEqual(resolved_index, bank_index)
+
+        # the frame sits at <location/> (its parent's position); the leaf carries the real offset
+        self.assertFalse(np.allclose(component_info.position(bank_index), component_info.position(resolved_index)))
+
+    def test_resolve_component_index_bare_name(self):
+        ws = LoadEmptyInstrument(InstrumentName="CORELLI", OutputWorkspace="corelli_empty")
+        component_info = ws.componentInfo()
+
+        resolved_index = resolve_component_index("bank7", component_info)
+        self.assertEqual(component_info.name(resolved_index), "bank7")
+
+    def test_resolve_component_index_missing_raises_value_error(self):
+        ws = LoadEmptyInstrument(InstrumentName="CORELLI", OutputWorkspace="corelli_empty")
+        component_info = ws.componentInfo()
+
+        self.assertRaises(ValueError, resolve_component_index, "not_a_real_component", component_info)
+        self.assertRaises(ValueError, resolve_component_index, "bank7/not_a_real_child", component_info)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of work

This is a first step in removing internal python use of the deprecated Instrument 1.0 methods.

These methods were first deprecated ten years ago.  Sadly, no one noticed.

The migration to Instrument 2.0 was never fully finished, so the older methods remained active, and people continued to use them.

The plan for this work is described in [this gist](https://gist.github.com/rosswhitfield/bfce30b102d97f17344d1b9b00c696b2).

The python methods were formally deprecated in  PR #41768.

This removes many of the call sites.

For easier review, this PR has been taken over by:
- PR #41885 (workflow algo sites)
- PR #41887 
- Pr #41886 

### To test:

This is a refactor.  Hopefully the unit tests are sufficient.

Try building, loading a workspace, and examining properties of its instrument.  A picture of the "pick" window should be enough.

This does not require release notes because _it is an internal refactor_.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
