### PR TITLE
Fix test race condition

### DIFF
--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -662,7 +662,7 @@ public:
   }
 
   void setUp() override {
-    std::string resFileName = "ResolutionTestResolution.res";
+    std::string resFileName = "ResolutionTestResolution_fit.res";
     std::ofstream fil(resFileName.c_str());
 
     double N = 117;
@@ -685,7 +685,7 @@ public:
   }
 
   void tearDown() override {
-    std::string resFileName = "ResolutionTestResolution.res";
+    std::string resFileName = "ResolutionTestResolution_fit.res";
     std::filesystem::path phandle(resFileName);
     if (std::filesystem::exists(phandle)) {
       std::filesystem::remove(phandle);
@@ -734,7 +734,7 @@ public:
 
     fit.setPropertyValue("Function", "composite=Convolution,"
                                      "FixResolution=true,NumDeriv=true;name=Resolution,FileName="
-                                     "\"ResolutionTestResolution.res\","
+                                     "\"ResolutionTestResolution_fit.res\","
                                      "WorkspaceIndex=0;name=ResolutionTest_Gauss,c=5,h=2,s=1");
     fit.setPropertyValue("InputWorkspace", "ResolutionTest_WS");
     fit.setPropertyValue("WorkspaceIndex", "0");

--- a/Framework/CurveFitting/test/Functions/ResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/ResolutionTest.h
@@ -85,7 +85,7 @@ public:
 
   ResolutionTest()
       : resH(3), resS(acos(0.)), N(117), DX(10), X0(-DX / 2), dX(DX / (N - 1)), yErr(0),
-        resFileName("ResolutionTestResolution.res") {}
+        resFileName("ResolutionTestResolution_res.res") {}
 
   void setUp() override {
     std::ofstream fil(resFileName.c_str());


### PR DESCRIPTION
### Description of work

Two tests write to a file with the same name, and both tests delete the file when done.

When tests are run in parallel, this can produce a race condition that can cause unit test failures.

The change in this PR to make their names vary should be enough to prevent the error.

### To test:

It would be hard to simulate the race condition.

Just make sure the impacted unit tests pass with this refactor.

this does not require release notes because: it is only changing a file name in a unit test, and does not impact users.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
