### PR TITLE
Change IPeak python export to be shared_ptr instead of raw pointer

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -59,7 +59,7 @@ void export_IPeak() {
   // return_value_policy for read-only numpy array
   using return_copy_to_numpy = return_value_policy<Policies::MatrixToNumpy>;
 
-  register_ptr_to_python<IPeak *>();
+  register_ptr_to_python<std::shared_ptr<IPeak>>();
 
   class_<IPeak, boost::noncopyable>("IPeak", no_init)
       .def("getRunNumber", &IPeak::getRunNumber, arg("self"), "Return the run number this peak was measured at")

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -11,11 +11,14 @@
 #include "MantidPythonInterface/api/RegisterWorkspacePtrToPython.h"
 #include "MantidPythonInterface/core/Converters/PyObjectToV3D.h"
 #include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
+#include "MantidPythonInterface/core/ExtractSharedPtr.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include <boost/none.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/iterator.hpp>
 #include <boost/python/manage_new_object.hpp>
+#include <boost/python/object.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/return_internal_reference.hpp>
 #include <optional>
 #include <utility>
@@ -232,34 +235,53 @@ void setCell(IPeaksWorkspace &self, const object &col_or_row, const int row_or_c
   tableMap.setProperty(columnName, rowIndex, value);
 }
 
+/// Extract the calling workspace as a shared_ptr so peaks handed out to Python
+/// can share ownership of it.
+IPeaksWorkspace_sptr extractWorkspace(const object &self) {
+  return std::dynamic_pointer_cast<IPeaksWorkspace>(Mantid::PythonInterface::ExtractSharedPtr<Workspace>(self)());
+}
+
+/**
+ * Return the peak at the given index as a shared_ptr that shares ownership with
+ * the owning workspace.
+ */
+std::shared_ptr<IPeak> makePeakHandle(const IPeaksWorkspace_sptr &workspace, const int index) {
+  return std::shared_ptr<IPeak>(workspace, workspace->getPeakPtr(index));
+}
+
+/// getPeak binding: return a peak that keeps its workspace alive
+std::shared_ptr<IPeak> getPeak(const object &self, const int index) {
+  return makePeakHandle(extractWorkspace(self), index);
+}
+
 /// Internal helper to support iteration on PeaksWorkspace in Python
 struct IPeaksWorkspaceIterator {
-  explicit IPeaksWorkspaceIterator(IPeaksWorkspace *const workspace)
+  explicit IPeaksWorkspaceIterator(const IPeaksWorkspace_sptr &workspace)
       : m_workspace{workspace}, m_numPeaks{workspace->getNumberPeaks()}, m_rowIndex{-1} {
     assert(workspace);
   }
-  IPeak *next() {
+  std::shared_ptr<IPeak> next() {
     ++m_rowIndex;
     if (m_rowIndex >= m_numPeaks) {
       objects::stop_iteration_error();
     }
-    return m_workspace->getPeakPtr(m_rowIndex);
+    return makePeakHandle(m_workspace, m_rowIndex);
   }
 
 private:
-  IPeaksWorkspace *const m_workspace;
+  IPeaksWorkspace_sptr m_workspace;
   const int m_numPeaks;
   int m_rowIndex;
 };
 
 // Create an iterator from the given workspace
-IPeaksWorkspaceIterator makePyIterator(IPeaksWorkspace &self) { return IPeaksWorkspaceIterator(&self); }
+IPeaksWorkspaceIterator makePyIterator(const object &self) { return IPeaksWorkspaceIterator(extractWorkspace(self)); }
 
 } // namespace
 
 void export_IPeaksWorkspaceIterator() {
   class_<IPeaksWorkspaceIterator>("IPeaksWorkspaceIterator", no_init)
-      .def("__next__", &IPeaksWorkspaceIterator::next, return_value_policy<reference_existing_object>())
+      .def("__next__", &IPeaksWorkspaceIterator::next)
       .def("__iter__", objects::identity_function());
 }
 
@@ -272,8 +294,7 @@ void export_IPeaksWorkspace() {
       .def("addPeak", addPeak2, (arg("self"), arg("data"), arg("coord_system")), "Add a peak to the workspace")
       .def("removePeak", removePeak, (arg("self"), arg("peak_num")), "Remove a peak from the workspace")
       .def("removePeaks", removePeaks, (arg("self"), arg("peak_num")), "Remove specified peaks from the workspace")
-      .def("getPeak", &IPeaksWorkspace::getPeakPtr, (arg("self"), arg("peak_num")), return_internal_reference<>(),
-           "Returns a peak at the given index")
+      .def("getPeak", &getPeak, (arg("self"), arg("peak_num")), "Returns a peak at the given index")
       .def("createPeak", createPeakQLab, (arg("self"), arg("data")), return_value_policy<manage_new_object>(),
            "Create a Peak and return it from its coordinates in the QLab frame")
       .def("createPeak", createPeakQLabWithDistance, (arg("self"), arg("data"), arg("detector_distance")),

--- a/Framework/PythonInterface/test/python/mantid/api/IPeaksWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/IPeaksWorkspaceTest.py
@@ -8,6 +8,7 @@ import unittest
 from testhelpers import WorkspaceCreationHelper
 from mantid.kernel import SpecialCoordinateSystem, V3D
 from mantid.api import IPeaksWorkspace, IPeak
+from mantid.simpleapi import CreatePeaksWorkspace, DeleteWorkspace
 
 import math
 
@@ -168,6 +169,35 @@ class IPeaksWorkspaceTest(unittest.TestCase):
         pws = WorkspaceCreationHelper.createPeaksWorkspace(5)
         pws.removePeaks([2, 3, 4])
         self.assertEqual(pws.getNumberPeaks(), 2)
+
+    def test_getPeak_modifications_are_reflected_in_workspace(self):
+        """A peak returned by getPeak references the peak stored in the workspace,
+        so modifications must be visible when the peak is fetched again."""
+        pws = CreatePeaksWorkspace(NumberOfPeaks=2, OutputType="LeanElasticPeak")
+        pws.getPeak(1).setIntensity(123.0)
+        self.assertEqual(pws.getPeak(1).getIntensity(), 123.0)
+
+    def test_peak_keeps_workspace_alive_after_deletion(self):
+        """A peak handed out by getPeak co-owns its workspace, so accessing it
+        after the workspace is deleted must remain safe rather than segfault."""
+        pws = CreatePeaksWorkspace(NumberOfPeaks=1, OutputType="LeanElasticPeak")
+        peak = pws.getPeak(0)
+        self.assertTrue(isinstance(peak, IPeak))
+
+        DeleteWorkspace(pws)
+        # The peak still owns the workspace data, so this must not crash.
+        self.assertEqual(peak.getScattering(), 0)
+
+    def test_iterator_peak_keeps_workspace_alive_after_deletion(self):
+        """Peaks obtained by iterating a workspace must also keep the workspace
+        alive once it is deleted."""
+        pws = CreatePeaksWorkspace(NumberOfPeaks=2, OutputType="LeanElasticPeak")
+        peaks = list(pws)
+        self.assertEqual(len(peaks), 2)
+
+        DeleteWorkspace(pws)
+        for peak in peaks:
+            self.assertEqual(peak.getScattering(), 0)
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v7.0.0/Framework/Python/Bugfixes/41876.rst
+++ b/docs/source/release/v7.0.0/Framework/Python/Bugfixes/41876.rst
@@ -1,0 +1,1 @@
+- Fixed a crash where a ``Peak`` retrieved from a ``PeaksWorkspace`` in Python could reference deleted memory after the owning workspace is deleted. Peaks now share ownership of their workspace, keeping it alive for as long as the peak is in use.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Fix segfault when accessing Peak from python after PeaksWorkspace has been deleted. This bug has existed in Mantid since at least Mantid 3.10.

By changing `IPeak` to be a `shared_ptr` the peaks workspace will exist as long a the python `Peak`'s continue to exist. So this will fixes the segfault.

Closes #31345

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

This causes a segfault that should now be fixed

```python
import time
from mantid.simpleapi import CreatePeaksWorkspace, DeleteWorkspace
peaks=CreatePeaksWorkspace(OutputType="LeanElasticPeak")
p=peaks.getPeak(0)
print(p.getScattering())
DeleteWorkspace(peaks)
time.sleep(1)
print(p.getScattering())
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
