### PR TITLE
Resolves a low impact covert warning in MDNorm

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -1321,7 +1321,6 @@ MDNorm::binMDEventWorkspace(const API::IMDEventWorkspace_sptr &ws, const std::st
     // set binning properties
     size_t qindex = 0;
     for (const auto &p : parameters) {
-      auto key = p.first;
       auto value = p.second;
       std::stringstream basisVector;
       std::vector<double> projection(ws->getNumDims(), 0.);
@@ -1338,7 +1337,7 @@ MDNorm::binMDEventWorkspace(const API::IMDEventWorkspace_sptr &ws, const std::st
         value = basisVector.str();
       }
 
-      binMD->setPropertyValue(key, value);
+      binMD->setPropertyValue(p.first, value);
       qindex++;
     }
     // execute algorithm


### PR DESCRIPTION
### Description of work

```
** CID 1664013:       Performance inefficiencies  (AUTO_CAUSES_COPY)
/home/docker/actions-runner/_work/mantid/mantid/Framework/MDAlgorithms/src/MDNorm.cpp: 1324           in Mantid::MDAlgorithms::MDNorm::binMDEventWorkspace(const std::shared_ptr<Mantid::API::IMDEventWorkspace> &, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const std::vector<Mantid::Geometry::SymmetryOperation, std::allocator<Mantid::Geometry::SymmetryOperation>> &, const std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>> &)()


_____________________________________________________________________________________________
*** CID 1664013:         Performance inefficiencies  (AUTO_CAUSES_COPY)
/home/docker/actions-runner/_work/mantid/mantid/Framework/MDAlgorithms/src/MDNorm.cpp: 1324             in Mantid::MDAlgorithms::MDNorm::binMDEventWorkspace(const std::shared_ptr<Mantid::API::IMDEventWorkspace> &, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const std::vector<Mantid::Geometry::SymmetryOperation, std::allocator<Mantid::Geometry::SymmetryOperation>> &, const std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>> &)()
1318         binMD->setProperty("TemporaryDataWorkspace", tempWS);
1319         binMD->setPropertyValue("NormalizeBasisVectors", "0");
1320         binMD->setPropertyValue("OutputWorkspace", getPropertyValue(outputWSPropertyName));
1321         // set binning properties
1322         size_t qindex = 0;
1323         for (const auto &p : parameters) {
>>>     CID 1664013:         Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "std::string".
1324           auto key = p.first;
1325           auto value = p.second;
1326           std::stringstream basisVector;
1327           std::vector<double> projection(ws->getNumDims(), 0.);
1328           // value is a string that can start with QDimension0, etc, but contain
1329           // other stuff. Do not use ==
```

### To test:

Compiles + CI

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
