### PR TITLE
Add user docs build and doctest publishing

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -46,7 +46,7 @@ devsite:
  - '.github/filters.yaml'
  - '.github/actions/devsite-build/**'
  - '.github/workflows/devdocs-publish.yml'
-code_changes:
+code_changes: &files_code_changes
  - *files_cpp
  - *files_py
  - *files_config
@@ -57,6 +57,9 @@ code_changes:
  - 'qt/**'
  - 'scripts/**'
  - 'tools/**'
+user_docs:
+ - *files_code_changes
+ - 'docs/**'
 # files that specifically affect the cppcheck job
 cppcheck: &files_cppcheck_config
  - 'buildconfig/CMake/CppCheckSetup.cmake'

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -278,3 +278,93 @@ jobs:
           name: test_logs_${{ matrix.os }}
           if-no-files-found: ignore
           path: ${{ github.workspace }}/build/test_logs/*.log
+
+
+  user-docs-build-and-test:
+    needs: [cppcheck, doxygen]
+    permissions:
+      contents: read
+
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - Linux
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CMAKE_PRESET: linux-64-ci
+      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
+      ENABLE_BUILD_CODE: true
+      ENABLE_UNIT_TESTS: false
+      ENABLE_SYSTEM_TESTS: false
+      ENABLE_DOCS: true
+      ENABLE_DOC_TESTS: true
+      # Developer docs are built and published separately by devdocs-publish.yml
+      ENABLE_DEV_DOCS: false
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Needed to fetch the tags for versioningit
+          fetch-depth: 100
+          fetch-tags: true
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - name: Install pixi
+        uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+
+      - name: Clean build tree
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        # supplying --clean-build or CLEAN_BUILD=true should be added here
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+
+      - name: Build code and user docs
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          echo "::add-matcher::.github/matchers/gcc.json"
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS
+          echo "::remove-matcher owner=gcc-problem-matcher::"
+
+      - name: Run doctests
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        id: testdocs
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          # Not physical but logical cores, includes hyper threaded - different for darwin
+          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          # bool flags for this are
+          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false false $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
+
+      - name: Upload doctest results
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.testdocs.conclusion == 'failure' }}
+        with:
+          name: junit-doctest
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/docs/doctest/TEST-doctest.xml
+
+      - name: Upload event payload
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        with:
+          name: event-file-doctest
+          path: ${{ github.event_path }}
+
+      - name: Upload build and test log artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: user_docs_test_logs_Linux
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/test_logs/*.log

--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -58,3 +58,15 @@ jobs:
           check_run_annotations: skipped tests
           comment_mode: failures
           files: artifacts/junit-system/**/TEST-systemtests*.xml
+
+      - name: Publish doctest results (Linux)
+        if: hashFiles('artifacts/junit-doctest/TEST-doctest.xml') != ''
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        with:
+          check_name: "Doctest results (Linux)"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file-doctest/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          check_run_annotations: skipped tests
+          comment_mode: failures
+          files: artifacts/junit-doctest/TEST-doctest.xml


### PR DESCRIPTION
### Description of work

Migrate the Linux user-docs build and doctest run from Jenkins to GitHub Actions. Adds a new `user-docs-build-and-test` job to `PR Build and Test` that builds the code with `ENABLE_DOCS=ON` / `ENABLE_DOC_TESTS=ON` and runs the `docs-doctest` CMake target, gated by a new `user_docs` paths filter (C++, Python, build config, `docs/**`, `Framework/**`, `instrument/**`, `qt/**`, `scripts/**`, `tools/**`). On failure, it uploads the JUnit XML and the PR event payload; `publish_test_results.yml` then downloads them via `workflow_run` and posts a "Doctest results (Linux)" check with inline annotations, following the same pattern used for the unit and system test reports added in #41724.

### To test: 

1. Verify the doctest publisher works fine in my fork with an intentionally failing doctest (test PR: https://github.com/MohamedAlmaki/mantid/pull/10).
2. Check that all doctests are passing in this PR.


Closes #41098. <!-- One line per closed issue. -->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
