### PR TITLE
Fix Crash when Copying only Material and Original Shape is destroyed

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GeometryHandler.h
@@ -74,6 +74,10 @@ public:
   GeometryHandler(const GeometryHandler &handler);
   GeometryHandler &operator=(GeometryHandler handler);
   std::shared_ptr<GeometryHandler> clone() const;
+  /// Clone the handler, rebinding it to render newOwner. The handler and its triangulator hold a
+  /// non-owning pointer to the CSGObject they render, so a copy taken for a new object must be
+  /// pointed at that object: the original may be destroyed while the copy is still in use.
+  std::shared_ptr<GeometryHandler> clone(CSGObject *newOwner) const;
   ~GeometryHandler();
   void render() const;     ///< Render Object or ObjComponent
   void initialize() const; ///< Prepare/Initialize Object/ObjComponent to be rendered

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -429,7 +429,9 @@ CSGObject &CSGObject::operator=(const CSGObject &A) {
     AABBzMin = A.AABBzMin;
     boolBounded = A.boolBounded;
     m_objNum = A.m_objNum;
-    m_handler = A.m_handler->clone();
+    // rebind the cloned handler to this object: it renders the object it points at, and A may be
+    // destroyed while this copy is still alive (e.g. cloneWithMaterial replacing a sample shape)
+    m_handler = A.m_handler->clone(this);
     bGeometryCaching = A.bGeometryCaching;
     vtkCacheReader = A.vtkCacheReader;
     vtkCacheWriter = A.vtkCacheWriter;

--- a/Framework/Geometry/src/Rendering/GeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryHandler.cpp
@@ -62,6 +62,14 @@ GeometryHandler::~GeometryHandler() = default;
 
 std::shared_ptr<GeometryHandler> GeometryHandler::clone() const { return std::make_shared<GeometryHandler>(*this); }
 
+std::shared_ptr<GeometryHandler> GeometryHandler::clone(CSGObject *newOwner) const {
+  auto cloned = std::make_shared<GeometryHandler>(*this);
+  cloned->m_csgObj = newOwner;
+  if (cloned->m_triangulator)
+    cloned->m_triangulator = std::make_unique<detail::GeometryTriangulator>(newOwner);
+  return cloned;
+}
+
 void GeometryHandler::render() const {
   if (m_shapeInfo)
     RenderingHelpers::renderShape(*m_shapeInfo);

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -132,9 +132,10 @@ public:
     TS_ASSERT(clone);
     original.reset();
 
-    TS_ASSERT_THROWS_NOTHING(clone->getGeometryHandler()->numberOfTriangles());
-    TS_ASSERT_EQUALS(3 * clone->numberOfVertices(), clone->getTriangleVertices().size());
-    TS_ASSERT_EQUALS(3 * clone->numberOfTriangles(), clone->getTriangleFaces().size());
+    auto handler = clone->getGeometryHandler();
+    TS_ASSERT_THROWS_NOTHING(handler->numberOfTriangles());
+    TS_ASSERT_EQUALS(3 * handler->numberOfPoints(), clone->getTriangleVertices().size());
+    TS_ASSERT_EQUALS(3 * handler->numberOfTriangles(), clone->getTriangleFaces().size());
   }
 
   void testIsOnSideCappedCylinder() {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -121,6 +121,22 @@ public:
     TSM_ASSERT_DELTA("Expected a number density of 45", 45.0, cloned_obj->material().numberDensity(), 1e-12);
   }
 
+  void testCloneOutlivesOriginal() {
+    using Mantid::Kernel::Material;
+    // Re-setting a sample material clones the shape and then drops the original (see
+    // SetSampleMaterial and CopySample), so the clone's handler and triangulator must render the
+    // clone. If they are left pointing at the original this reads freed memory.
+    auto original = createUnitCube();
+    std::shared_ptr<CSGObject> clone(dynamic_cast<CSGObject *>(
+        original->cloneWithMaterial(Material("arm", PhysicalConstants::getNeutronAtom(13), 45.0))));
+    TS_ASSERT(clone);
+    original.reset();
+
+    TS_ASSERT_THROWS_NOTHING(clone->getGeometryHandler()->numberOfTriangles());
+    TS_ASSERT_EQUALS(3 * clone->numberOfVertices(), clone->getTriangleVertices().size());
+    TS_ASSERT_EQUALS(3 * clone->numberOfTriangles(), clone->getTriangleFaces().size());
+  }
+
   void testIsOnSideCappedCylinder() {
     auto geom_obj = createCappedCylinder();
     // inside

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/41883.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/41883.rst
@@ -1,0 +1,1 @@
+- `:ref:algm-CopySample` no longer causes a crash when called with `CopyShape = False`, `CopyMaterial = True` and an input workspace that is subsequently overwritten.

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/41883.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/41883.rst
@@ -1,1 +1,1 @@
-- `:ref:algm-CopySample` no longer causes a crash when called with `CopyShape = False`, `CopyMaterial = True` and an input workspace that is subsequently overwritten.
+- :ref:`algm-CopySample` no longer causes a crash when called with ``CopyShape = False``, ``CopyMaterial = True`` and an input workspace that is subsequently overwritten.


### PR DESCRIPTION
### Description of work

Calling `CopySample` with `CopyShape = False` and `CopyMaterial = True` caused a crash because the geometry handler is passed from the original sample along with its pointer to the original shape, if the original shape goes out of scope it crashes.

To fix the geometry handler needs to be pointed to the new shape whenever the object is copied

### To test:

Hard to reproduce in just workbench, could verify the test fails on main, but I was seeing the crash on #40961 and this appears to have fixed it

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
