### PR TITLE
Change workflow algorithm call sites for deprecated Instrument 1.0 python methods

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
@@ -130,19 +130,19 @@ class PowderILLDetectorScan(DataProcessorAlgorithm):
 
         self.declareProperty(name="AlignTubes", defaultValue=False, doc="Align the tubes vertically and horizontally according to IPF.")
 
-    def _generate_mask(self, n_pix, instrument):
+    def _generate_mask(self, n_pix, component_info):
         """
         Generates the DetectorList input for MaskDetectors
         Masks the bottom and top n_pix pixels in each tube, for D2B only
         @param n_pix : Number of pixels to mask from top and bottom of each tube
-        @param instrument : Instrument
+        @param component_info : ComponentInfo of the workspace whose detectors are to be masked
         @return the DetectorList string
         """
         mask = ""
-        det = instrument.getComponentByName("detectors")
-        tube = instrument.getComponentByName("tube_1")
-        n_tubes = det.nelements()
-        n_pixels = tube.nelements()
+        det_index = component_info.indexOfAny("detectors")
+        tube_index = component_info.indexOfAny("tube_1")
+        n_tubes = len(component_info.children(det_index))
+        n_pixels = len(component_info.children(tube_index))
         for tube in range(n_tubes):
             start_bottom = tube * n_pixels + 1
             end_bottom = start_bottom + n_pix - 1

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
@@ -461,9 +461,13 @@ class PowderILLEfficiency(PythonAlgorithm):
         Configures the calibration with GlobalSummedReference2D method (D2B)
         @param : first raw ws name in the list
         """
-        inst = mtd[raw_ws].getInstrument()
-        self._n_tubes = inst.getComponentByName("detectors").nelements()
-        self._n_pixels_per_tube = inst.getComponentByName("detectors/tube_1").nelements()
+        component_info = mtd[raw_ws].componentInfo()
+        det_index = component_info.indexOfAny("detectors")
+        tube_index = next(
+            int(c) for c in component_info.componentsInSubtree(det_index) if int(c) != det_index and component_info.name(int(c)) == "tube_1"
+        )
+        self._n_tubes = len(component_info.children(det_index))
+        self._n_pixels_per_tube = len(component_info.children(tube_index))
         # self._n_scans_per_file = mtd[raw_ws].getRun().getLogData('ScanSteps').value
         self._n_scans_per_file = 25  # TODO: In v2 this should be freely variable
         self._scan_points = self._n_scans_per_file * self._n_scan_files

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
@@ -464,8 +464,15 @@ class PowderILLEfficiency(PythonAlgorithm):
         component_info = mtd[raw_ws].componentInfo()
         det_index = component_info.indexOfAny("detectors")
         tube_index = next(
-            int(c) for c in component_info.componentsInSubtree(det_index) if int(c) != det_index and component_info.name(int(c)) == "tube_1"
+            (
+                int(c)
+                for c in component_info.componentsInSubtree(det_index)
+                if int(c) != det_index and component_info.name(int(c)) == "tube_1"
+            ),
+            None,
         )
+        if tube_index is None:
+            raise RuntimeError("Could not find component 'tube_1' in the detectors subtree.")
         self._n_tubes = len(component_info.children(det_index))
         self._n_pixels_per_tube = len(component_info.children(tube_index))
         # self._n_scans_per_file = mtd[raw_ws].getRun().getLogData('ScanSteps').value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -795,9 +795,10 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
             components = instrument.getStringParameter("detector_panels")
             if components:
                 components = components[0].split(",")
+                component_info = mtd[ws].componentInfo()
                 for c in components:
                     if c in ws:
-                        distance = instrument.getComponentByName(c).getPos()[2]
+                        distance = component_info.position(component_info.indexOfAny(c))[2]
                         break
             if not distance:
                 distance = float(logs[DISTANCE_LOG])

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2.py
@@ -485,8 +485,9 @@ class SANSILLReduction(DataProcessorAlgorithm):
         l2_main = mtd[ws].getRun()["L2"].value
         if instrument.hasParameter("detector_panels"):
             panel_names = instrument.getStringParameter("detector_panels")[0].split(",")
+            component_info = mtd[ws].componentInfo()
             for panel in panel_names:
-                l2_panel = instrument.getComponentByName(panel).getPos()[2]
+                l2_panel = component_info.position(component_info.indexOfAny(panel))[2]
                 MoveInstrumentComponent(Workspace=ws, X=-beam_x * l2_panel / l2_main, Y=-beam_y * l2_panel / l2_main, ComponentName=panel)
         else:
             MoveInstrumentComponent(Workspace=ws, X=-beam_x, Y=-beam_y, ComponentName="detector")
@@ -1087,10 +1088,11 @@ class SANSILLReduction(DataProcessorAlgorithm):
         TODO: It is not good to repeat the logic of the LoadILLSANS, the only way to avoid this would be to create a small separate C++
         algorithm that does the placement, and it can be called both from within the loader, and here if needed; that is, for events.
         """
-        instr = mtd[ws].getInstrument()
         run = mtd[ws].getRun()
-        if mtd[ws].getInstrumentName() == "D22B":
-            back_pos = instr.getComponentByName("detector_back").getPos()
+        component_info = mtd[ws].componentInfo()
+        instrument_name = mtd[ws].getInstrumentName()
+        if instrument_name == "D22B":
+            back_pos = component_info.position(component_info.indexOfAny("detector_back"))
             distance = run["Detector 1.det1_calc"].value
             MoveInstrumentComponent(
                 Workspace=ws,
@@ -1100,7 +1102,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
                 Y=back_pos[1],
                 Z=distance,
             )
-            front_pos = instr.getComponentByName("detector_front").getPos()
+            front_pos = component_info.position(component_info.indexOfAny("detector_front"))
             MoveInstrumentComponent(
                 Workspace=ws,
                 ComponentName="detector_front",
@@ -1119,9 +1121,9 @@ class SANSILLReduction(DataProcessorAlgorithm):
                 Z=0,
             )
             AddSampleLog(Workspace=ws, LogName="L2", LogText=str(distance), LogType="Number")
-        if mtd[ws].getInstrumentName() == "D11B":
-            back_pos = instr.getComponentByName("detector_center").getPos()
-            det_pos = instr.getComponentByName("detector").getPos()
+        if instrument_name == "D11B":
+            back_pos = component_info.position(component_info.indexOfAny("detector_center"))
+            det_pos = component_info.position(component_info.indexOfAny("detector"))
             distance = run["Detector 1.det_calc"].value - back_pos[2]
             MoveInstrumentComponent(Workspace=ws, ComponentName="detector", RelativePosition=False, X=det_pos[0], Y=det_pos[1], Z=distance)
             AddSampleLog(Workspace=ws, LogName="L2", LogText=str(distance), LogType="Number")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
@@ -33,8 +33,7 @@ class MDNormSCDPreprocessIncoherentTest(unittest.TestCase):
         # Baseline the value the masking branch is expected to derive, and preserve the original
         # regression assertion that it matches the loaded vanadium workspace's instrument name.
         van = Load(Filename="CNCS_7860", OutputWorkspace="__van_probe")
-        component_info = van.componentInfo()
-        expected_instrument = component_info.name(component_info.root())
+        expected_instrument = van.getInstrumentName()
         self.assertEqual(expected_instrument, van.getInstrument().getName())
 
         captured = {}

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
@@ -6,10 +6,28 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
-from mantid.simpleapi import MDNormSCDPreprocessIncoherent
+from mantid.simpleapi import Load, MDNormSCDPreprocessIncoherent
 
 
 class MDNormSCDPreprocessIncoherentTest(unittest.TestCase):
+    def testMaskingBranchUsesMatchingInstrumentName(self):
+        r"""
+        Regression coverage for the masking branch's instrument-name lookup: LoadMask is given
+        Instrument=componentInfo().name(componentInfo().root()) rather than the deprecated
+        getInstrument().getName(). This asserts the two produce an identical string for the
+        exact vanadium workspace the algorithm loads, i.e. the conversion is behaviour-preserving.
+
+        Coverage does not extend to actually running LoadMask/MaskDetectors end-to-end here: doing
+        so exposed a pre-existing, unrelated environment issue - the historical CNCS_7860 file's
+        geometry has 51203 detectors, while LoadMask(Instrument="CNCS", ...) builds its reference
+        workspace from the environment's bundled (newer) CNCS IDF, which has 51204 - so
+        MaskDetectors always raises "Instrument's detector numbers mismatch" regardless of which
+        detector IDs are masked or which API produced the instrument name string.
+        """
+        van = Load(Filename="CNCS_7860", OutputWorkspace="__van")
+        component_info = van.componentInfo()
+        self.assertEqual(component_info.name(component_info.root()), van.getInstrument().getName())
+
     def testCNCS(self):
         # CNCS_7860 is not an incoherent scatterer but for this test
         # it doesn't matter

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherentTest.py
@@ -4,29 +4,69 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
 import unittest
+from unittest import mock
+
 import numpy as np
 from mantid.simpleapi import Load, MDNormSCDPreprocessIncoherent
 
 
 class MDNormSCDPreprocessIncoherentTest(unittest.TestCase):
-    def testMaskingBranchUsesMatchingInstrumentName(self):
+    def testMaskingBranchPassesRootComponentInstrumentName(self):
         r"""
-        Regression coverage for the masking branch's instrument-name lookup: LoadMask is given
-        Instrument=componentInfo().name(componentInfo().root()) rather than the deprecated
-        getInstrument().getName(). This asserts the two produce an identical string for the
-        exact vanadium workspace the algorithm loads, i.e. the conversion is behaviour-preserving.
+        Regression coverage for the masking branch's instrument-name lookup: the algorithm must
+        call LoadMask with Instrument=componentInfo().name(componentInfo().root()) rather than the
+        deprecated getInstrument().getName(). Instead of only comparing the two APIs on a bare
+        workspace, this drives MDNormSCDPreprocessIncoherent with a MaskFile so the masking branch
+        actually executes, spies on the LoadMask call it issues, and asserts the Instrument value
+        it received.
 
-        Coverage does not extend to actually running LoadMask/MaskDetectors end-to-end here: doing
-        so exposed a pre-existing, unrelated environment issue - the historical CNCS_7860 file's
-        geometry has 51203 detectors, while LoadMask(Instrument="CNCS", ...) builds its reference
-        workspace from the environment's bundled (newer) CNCS IDF, which has 51204 - so
-        MaskDetectors always raises "Instrument's detector numbers mismatch" regardless of which
-        detector IDs are masked or which API produced the instrument name string.
+        The end-to-end mask cannot be applied here: the historical CNCS_7860 file's geometry has
+        51203 detectors, while LoadMask(Instrument="CNCS", ...) builds its reference workspace from
+        the environment's bundled (newer) CNCS IDF, which has 51204 - so MaskDetectors always
+        raises "Instrument's detector numbers mismatch" independent of the instrument-name API.
+        The spy therefore intercepts LoadMask, records the Instrument argument, and aborts the run
+        before MaskDetectors, which is exactly the branch behaviour under test.
         """
-        van = Load(Filename="CNCS_7860", OutputWorkspace="__van")
+        # Baseline the value the masking branch is expected to derive, and preserve the original
+        # regression assertion that it matches the loaded vanadium workspace's instrument name.
+        van = Load(Filename="CNCS_7860", OutputWorkspace="__van_probe")
         component_info = van.componentInfo()
-        self.assertEqual(component_info.name(component_info.root()), van.getInstrument().getName())
+        expected_instrument = component_info.name(component_info.root())
+        self.assertEqual(expected_instrument, van.getInstrument().getName())
+
+        captured = {}
+
+        def spy_load_mask(*args, **kwargs):
+            captured.update(kwargs)
+            # Abort the algorithm here: the following MaskDetectors call would fail on the
+            # unrelated 51203/51204 detector-count mismatch described above.
+            raise RuntimeError("stop after LoadMask")
+
+        mask_handle, mask_path = tempfile.mkstemp(suffix=".xml")
+        with os.fdopen(mask_handle, "w") as mask_file:
+            mask_file.write("<?xml version='1.0'?>\n<detector-masking>\n<group>\n<detids>1</detids>\n</group>\n</detector-masking>\n")
+
+        try:
+            with mock.patch("MDNormSCDPreprocessIncoherent.LoadMask", side_effect=spy_load_mask):
+                # The masking branch runs, calls the spied LoadMask, and the algorithm then fails.
+                with self.assertRaises(RuntimeError):
+                    MDNormSCDPreprocessIncoherent(
+                        Filename="CNCS_7860",
+                        MomentumMin=1,
+                        MomentumMax=1.5,
+                        MaskFile=mask_path,
+                        SolidAngleOutputWorkspace="__SA",
+                        FluxOutputWorkspace="__Flux",
+                    )
+        finally:
+            os.remove(mask_path)
+
+        # LoadMask was reached, and the Instrument it received is the root component's name
+        # (the behaviour-preserving replacement for the deprecated getInstrument().getName()).
+        self.assertEqual(captured.get("Instrument"), expected_instrument)
 
     def testCNCS(self):
         # CNCS_7860 is not an incoherent scatterer but for this test


### PR DESCRIPTION
### Description of work

To try to make PR #41869 more reviewable, this has moved instances within the `WorkflowAlgorithms` into this separate PR.

The plan for this work is described in [this gist](https://gist.github.com/rosswhitfield/bfce30b102d97f17344d1b9b00c696b2).

The python methods were formally deprecated in  PR #41768.

[EWM 16817](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16817)

### To test:

This is a refactor.  Hopefully the unit tests are sufficient.

Try building, loading a workspace, and examining properties of its instrument.  A picture of the "pick" window should be enough.

This does not require release notes because _it is an internal refactor_.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
