### PR TITLE
Skip Bilby SANS system test on Windows to avoid memory exception.

### DIFF
--- a/Testing/SystemTests/tests/framework/BilbySANSDataProcessorTest.py
+++ b/Testing/SystemTests/tests/framework/BilbySANSDataProcessorTest.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import sys
 import systemtesting
 from BilbyReductionScript import RunBilbyReduction
 
@@ -12,6 +13,9 @@ class BilbySANSDataProcessorTest(systemtesting.MantidSystemTest):
     def __init__(self):
         systemtesting.MantidSystemTest.__init__(self)
         self.tolerance = 1e-6
+
+    def skipTests(self):
+        return sys.platform.startswith("win")
 
     def runTest(self):
         run_bilby_reduction = RunBilbyReduction("mantid_reduction_settings_example.csv", "0", "0", "shift_assembled.csv", False)


### PR DESCRIPTION
### Description of work
The test has failed 4/5 times recently, which is preventing the nightly publishing. This is blocking people who want to test new features. It will still run on Linux and MacOS. There is [an issue](https://github.com/mantidproject/mantid/issues/41818) to resolve the problem on Windows. Once that is done the test can be reinstated.

### To test:
Review code.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
