### PR TITLE
Add and export `getInstrumentName()` as new `ExperimentInfo` method

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -159,6 +159,8 @@ public:
   const Geometry::ComponentInfo &componentInfo() const;
   Geometry::ComponentInfo &mutableComponentInfo();
 
+  std::string getInstrumentName() const;
+
   void invalidateSpectrumDefinition(const size_t index);
   void updateSpectrumDefinitionIfNecessary(const size_t index) const;
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -858,6 +858,13 @@ void ExperimentInfo::setSpectrumDefinitions(Kernel::cow_ptr<std::vector<Spectrum
   m_spectrumInfoWrapper = nullptr;
 }
 
+/** Return the name of the instrument from the ComponentInfo object */
+std::string ExperimentInfo::getInstrumentName() const {
+  populateIfNotLoaded();
+  Geometry::ComponentInfo const &compInfo = componentInfo();
+  return compInfo.name(compInfo.root());
+}
+
 /** Notifies the ExperimentInfo that a spectrum definition has changed.
  *
  * ExperimentInfo will rebuild its spectrum definitions before the next use. In

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -758,6 +758,23 @@ public:
     TS_ASSERT(fp.getFunction() == "Bk2BkExpConvPV" || fp.getFunction() == "IkedaCarpenterPV");
   }
 
+  void test_getInstrumentName_NoInstrument() {
+    ExperimentInfo expInfo;
+    auto inst = expInfo.getInstrument();
+    TS_ASSERT(inst->isEmptyInstrument());
+    TS_ASSERT(inst->getName().empty())
+    TS_ASSERT(expInfo.getInstrumentName().empty());
+  }
+
+  void test_getInstrumentName_WithInstrument() {
+    std::string instrName = "MyTestInst";
+    ExperimentInfo expInfo;
+    std::shared_ptr<Instrument> inst1 = std::make_shared<Instrument>();
+    inst1->setName(instrName);
+    expInfo.setInstrument(inst1);
+    TS_ASSERT_EQUALS(expInfo.getInstrumentName(), instrName);
+  }
+
 private:
   void addInstrumentWithParameter(ExperimentInfo &expt, const std::string &name, const std::string &value) {
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(1);

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -129,6 +129,8 @@ void export_ExperimentInfo() {
            "Return a const reference to the "
            ":class:`~mantid.geometry.ComponentInfo` "
            "object.")
+      .def("getInstrumentName", &ExperimentInfo::getInstrumentName, args("self"),
+           "Return the name of the instrument for this experiment.")
       .def("setSample", setSample, args("self", "sample"))
       .def("setRun", setRun, args("self", "run"))
       .def("populateInstrumentParameters", &ExperimentInfo::populateInstrumentParameters, (arg("self")),

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -63,7 +63,7 @@ def __get_instrument_name(wksp):
         ws = mtd[wksp]
     else:
         raise ValueError(f"{wksp} cannot be found")
-    return mantid.kernel.ConfigService.getInstrument(ws.getInstrument().getName()).shortName()
+    return mantid.kernel.ConfigService.getInstrument(ws.getInstrumentName()).shortName()
 
 
 def __get_cache_name(

--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -170,7 +170,7 @@ class MantidORSODataset:
         run = ws.getRun()
         experiment = Experiment(
             title=None,
-            instrument=ws.getInstrument().getName(),
+            instrument=ws.getInstrumentName(),
             start_date=self._get_exp_start_time(run),
             probe=self.PROBE_NEUTRON,
         )

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -183,7 +183,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         if run.getNumGoniometers() != number_of_runs:
             issues["InputWorkspace"] = "goniometers not set correctly, did you run SetGoniometer with Average=False"
 
-        instrument = experiment_info.getInstrument().getName()
+        instrument = experiment_info.getInstrumentName()
         if instrument in ("HB3A", "DEMAND"):
             for prop in ["monitor", "time"]:
                 if run.hasProperty(prop):
@@ -307,7 +307,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
 
         normaliseBy = self.getProperty("NormaliseBy").value
 
-        instrument_name = inWS.getExperimentInfo(0).getInstrument().getName()
+        instrument_name = inWS.getExperimentInfo(0).getInstrumentName()
         assert instrument_name in ["HB3A", "DEMAND", "HB2C", "WAND"], "Supported instruments are HB3A and HB2C"
 
         if normaliseBy == "Monitor":
@@ -404,7 +404,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             # so that the first two dimensions of inWS correspond to the extent of the individual detector pixels
             di = inWS.getExperimentInfo(0).detectorInfo()
             polar = np.array([di.twoTheta(i) for i in range(di.size()) if not di.isMonitor(i)])
-            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
+            if inWS.getExperimentInfo(0).getInstrumentName() == "HB3A":
                 polar = polar.reshape(512 * 3, 512).T.flatten()
 
         if inWS.getExperimentInfo(0).run().hasProperty("azimuthal"):
@@ -412,7 +412,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         else:
             di = inWS.getExperimentInfo(0).detectorInfo()
             azim = np.array([di.azimuthal(i) for i in range(di.size()) if not di.isMonitor(i)])
-            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
+            if inWS.getExperimentInfo(0).getInstrumentName() == "HB3A":
                 azim = azim.reshape(512 * 3, 512).T.flatten()
 
         # check convention to determine the sign

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -392,7 +392,7 @@ class DPDFreduction(api.PythonAlgorithm):
                 sapi.Plus(LHSWorkspace=data_name, RHSWorkspace=data_name + "_tmp", OutputWorkspace=data_name)
                 sapi.Plus(LHSWorkspace=monitor_name, RHSWorkspace=data_name + "_tmp_monitors", OutputWorkspace=monitor_name)
             sapi.DeleteWorkspace(data_name + "_tmp")
-        if sapi.mtd[data_name].getInstrument().getName() not in ("ARCS"):
+        if sapi.mtd[data_name].getInstrumentName() not in ("ARCS"):
             raise NotImplementedError("This algorithm works only for ARCS instrument")
 
     def _findGaps(self, workspace_name, min_i, max_i):

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -392,7 +392,7 @@ class DPDFreduction(api.PythonAlgorithm):
                 sapi.Plus(LHSWorkspace=data_name, RHSWorkspace=data_name + "_tmp", OutputWorkspace=data_name)
                 sapi.Plus(LHSWorkspace=monitor_name, RHSWorkspace=data_name + "_tmp_monitors", OutputWorkspace=monitor_name)
             sapi.DeleteWorkspace(data_name + "_tmp")
-        if sapi.mtd[data_name].getInstrumentName() not in ("ARCS"):
+        if sapi.mtd[data_name].getInstrumentName() != "ARCS":
             raise NotImplementedError("This algorithm works only for ARCS instrument")
 
     def _findGaps(self, workspace_name, min_i, max_i):

--- a/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
@@ -85,10 +85,10 @@ class GenerateGroupingSNSInelastic(mantid.api.PythonAlgorithm):
             else:
                 __w = mantid.simpleapi.LoadEmptyInstrument(Filename=IDF)
                 # checks the instrument from the loaded IDF belongs to the DGS/SNS suite.
-                if __w.getInstrument().getName() not in ["ARCS", "CNCS", "HYSPEC", "SEQUOIA"]:
+                if __w.getInstrumentName() not in ["ARCS", "CNCS", "HYSPEC", "SEQUOIA"]:
                     raise ValueError("Select the instrument definition file from only one of ARCS, SEQUOIA, CNCS, HYSPEC")
                 # set instrument to instrument name from the loaded IDF instead of drop down menu
-                instrument = __w.getInstrument().getName()
+                instrument = __w.getInstrumentName()
 
         i = 0
         spectrumInfo = __w.spectrumInfo()

--- a/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
+++ b/Framework/PythonInterface/plugins/algorithms/HFIRCalculateGoniometer.py
@@ -67,9 +67,9 @@ class HFIRCalculateGoniometer(PythonAlgorithm):
             flip_x = self.getProperty("FlipX").value
             inner = self.getProperty("InnerGoniometer").value
         else:
-            flip_x = peaks.getInstrument().getName() == "HB3A"
+            flip_x = peaks.getInstrumentName() == "HB3A"
 
-            if peaks.getInstrument().getName() == "HB3A":
+            if peaks.getInstrumentName() == "HB3A":
                 inner = math.isclose(peaks.run().getTimeAveragedStd("omega"), 0.0)
             else:
                 inner = False

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -255,7 +255,7 @@ class IntegratePeaks1DProfile(DataProcessorAlgorithm):
         ws = self.getProperty("InputWorkspace").value
         inst = ws.getInstrument()
         pk_ws = self.getProperty("PeaksWorkspace").value
-        if inst.getName() != pk_ws.getInstrument().getName():
+        if inst.getName() != pk_ws.getInstrumentName():
             issues["PeaksWorkspace"] = "PeaksWorkspace must have same instrument as the InputWorkspace."
         if pk_ws.getNumberPeaks() < 1:
             issues["PeaksWorkspace"] = "PeaksWorkspace must have at least 1 peak."

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -302,7 +302,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
         ws = self.getProperty("InputWorkspace").value
         inst = ws.getInstrument()
         pk_ws = self.getProperty("PeaksWorkspace").value
-        if inst.getName() != pk_ws.getInstrument().getName():
+        if inst.getName() != pk_ws.getInstrumentName():
             issues["PeaksWorkspace"] = "PeaksWorkspace must have same instrument as the InputWorkspace."
         if pk_ws.getNumberPeaks() < 1:
             issues["PeaksWorkspace"] = "PeaksWorkspace must have at least 1 peak."

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -683,7 +683,7 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
         ws = self.getProperty("InputWorkspace").value
         inst = ws.getInstrument()
         pk_ws = self.getProperty("PeaksWorkspace").value
-        if inst.getName() != pk_ws.getInstrument().getName():
+        if inst.getName() != pk_ws.getInstrumentName():
             issues["PeaksWorkspace"] = "PeaksWorkspace must have same instrument as the InputWorkspace."
         if pk_ws.getNumberPeaks() < 1:
             issues["PeaksWorkspace"] = "PeaksWorkspace must have at least 1 peak."

--- a/Framework/PythonInterface/plugins/algorithms/LoadPreNexusLive.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadPreNexusLive.py
@@ -97,7 +97,7 @@ class LoadPreNexusLive(DataProcessorAlgorithm):
 
         # let people know what was just loaded
         wksp = mtd[wkspName]
-        instrument = str(wksp.getInstrument().getName())
+        instrument = str(wksp.getInstrumentName())
         runNumber = int(wksp.run()["run_number"].value)
         startTime = str(wksp.run().startTime())
         self.log().information("Loaded %s live run %d - starttime=%s" % (instrument, runNumber, startTime))

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -157,7 +157,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             IDF = mantid.api.ExperimentInfo.getInstrumentFilename(self.instname)
             ws = mantid.simpleapi.LoadEmptyInstrument(Filename=IDF, OutputWorkspace=self.instname + "MaskBTP")
             deleteWS = True  # if there is going to be an issue with the instrument provided
-        self.instname = ws.getInstrument().getName()  # update the instrument name
+        self.instname = ws.getInstrumentName()  # update the instrument name
 
         # only check against valid instrument if components isn't set
         checkInstrument = self.getProperty("Components").isDefault

--- a/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
@@ -77,7 +77,7 @@ class MaskWorkspaceToCalFile(PythonAlgorithm):
 
         calFile = open(outputFileName, "w")
         # write a header
-        instrumentName = inputWorkspace.getInstrument().getName()
+        instrumentName = inputWorkspace.getInstrumentName()
         calFile.write("# " + instrumentName + " detector file\n")
         calFile.write("# Format: number      UDET       offset       select    group\n")
         # save the grouping

--- a/Framework/PythonInterface/plugins/algorithms/PDToGUDRUN.py
+++ b/Framework/PythonInterface/plugins/algorithms/PDToGUDRUN.py
@@ -168,7 +168,7 @@ class PDToGUDRUN(DataProcessorAlgorithm):
 
         groupingFile = self.getProperty("GroupingFile").value
         if len(groupingFile) > 0:
-            instrumentName = wksp.getInstrument().getName()
+            instrumentName = wksp.getInstrumentName()
             instrumentName = ConfigService.getInstrument(instrumentName).shortName()
             LoadDetectorsGroupingFile(InputFile=groupingFile, OutputWorkspace=instrumentName + "_group")
 

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -72,7 +72,7 @@ class ReflectometryDataset:
 
     @property
     def instrument_name(self) -> str:
-        return self._ws.getInstrument().getName()
+        return self._ws.getInstrumentName()
 
     @property
     def spin_state(self) -> str:

--- a/Framework/PythonInterface/plugins/algorithms/SaveP2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveP2D.py
@@ -100,7 +100,7 @@ class SaveP2D(PythonAlgorithm):
             print("Exporting: " + OutFile + "\n")
             # Create File header with additional information
             of.write("#Title: " + Data.getTitle() + "\n")
-            of.write("#Inst: " + Data.getInstrument().getName() + ".prm\n")
+            of.write("#Inst: " + Data.getInstrumentName() + ".prm\n")
             binning = form.format(Data.getDimension(0).getBinWidth()) + " " + form.format(Data.getDimension(1).getBinWidth()) + "\n"
             of.write("#Binning: ddperp" + binning)
             of.write("#Bank: 1\n")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CalculateMonteCarloAbsorption.py
@@ -713,7 +713,7 @@ class CalculateMonteCarloAbsorption(DataProcessorAlgorithm):
         """
         self._indirect_elastic = True
         self._q_values = workspace.getAxis(1).extractValues()
-        instrument_name = workspace.getInstrument().getName()
+        instrument_name = workspace.getInstrumentName()
         self._isis_instrument = instrument_name == "IRIS" or instrument_name == "OSIRIS"
 
         # ---------- Load Elastic Instrument Definition File ----------

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ConvertMultipleRunsToSingleCrystalMD.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ConvertMultipleRunsToSingleCrystalMD.py
@@ -247,7 +247,7 @@ class ConvertMultipleRunsToSingleCrystalMD(DataProcessorAlgorithm):
         if self._masking:
             if not mtd.doesExist("__mask"):
                 LoadMask(
-                    Instrument=mtd[ws_name].getInstrument().getName(),
+                    Instrument=mtd[ws_name].getInstrumentName(),
                     InputFile=self.getProperty("MaskFile").value,
                     OutputWorkspace="__mask",
                 )

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLAutoProcess.py
@@ -524,7 +524,7 @@ class DirectILLAutoProcess(DataProcessorAlgorithm):
             kwargs[common.PROP_CLEANUP_MODE] = "Cleanup OFF"
 
         DirectILLCollectData(Run=sample, OutputWorkspace=ws, IncidentEnergyWorkspace=self.incident_energy_ws, **kwargs)
-        instrument = mtd[ws].getInstrument().getName()
+        instrument = mtd[ws].getInstrumentName()
         if self.instrument and instrument != self.instrument:
             self.log().error(
                 "Sample data: {} comes from different instruments that the rest of the data: {} and {}".format(

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLReduction.py
@@ -557,7 +557,7 @@ class DirectILLReduction(DataProcessorAlgorithm):
         # out of range from the original ragged workspace in delta E.
         # The mask is later respected by the detector grouping
         # to get the normalisation right also in the non-overlapping regions.
-        if mainWS.getInstrument().getName() in ["IN5", "PANTHER", "SHARP"]:
+        if mainWS.getInstrumentName() in ["IN5", "PANTHER", "SHARP"]:
             rebinnedWS = MaskNonOverlappingBins(
                 InputWorkspace=rebinnedWS,
                 ComparisonWorkspace=mainWS,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILL_common.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILL_common.py
@@ -165,7 +165,7 @@ def get_grouping_pattern(ws, vertical_step, horizontal_step=1):
     vertical_step -- grouping step inside a tube
     horizontal_step -- grouping step between tubes
     """
-    instrument = ws.getInstrument().getName()
+    instrument = ws.getInstrumentName()
     n_pixels = ws.getNumberHistograms()
     if horizontal_step == 1:
         group_by = vertical_step

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
@@ -237,7 +237,7 @@ class IndirectDiffScan(DataProcessorAlgorithm):
             else:
                 raise RuntimeError("Could not find run number associated with workspace.")
 
-        instrument = mtd[ws_name].getInstrument().getName()
+        instrument = mtd[ws_name].getInstrumentName()
         if instrument != "":
             for facility in config.getFacilities():
                 try:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherent.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MDNormSCDPreprocessIncoherent.py
@@ -174,7 +174,9 @@ class MDNormSCDPreprocessIncoherent(DataProcessorAlgorithm):
 
         if _masking:
             LoadMask(
-                Instrument=mtd["__van"].getInstrument().getName(), InputFile=self.getProperty("MaskFile").value, OutputWorkspace="__mask"
+                Instrument=mtd["__van"].getInstrumentName(),
+                InputFile=self.getProperty("MaskFile").value,
+                OutputWorkspace="__mask",
             )
             MaskDetectors(Workspace="__van", MaskedWorkspace="__mask")
             DeleteWorkspace("__mask")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PaalmanPingsMonteCarloAbsorption.py
@@ -784,7 +784,7 @@ class PaalmanPingsMonteCarloAbsorption(DataProcessorAlgorithm):
         """
         self._indirect_elastic = True
         self._q_values = workspace.getAxis(1).extractValues()
-        instrument_name = workspace.getInstrument().getName()
+        instrument_name = workspace.getInstrumentName()
         self._isis_instrument = instrument_name == "IRIS" or instrument_name == "OSIRIS"
 
         # ---------- Load Elastic Instrument Definition File ----------

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PolDiffILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PolDiffILLReduction.py
@@ -616,7 +616,7 @@ class PolDiffILLReduction(PythonAlgorithm):
         masked_detectors = self.getProperty("MaskDetectors").value
         if len(masked_detectors) > 0:
             MaskDetectors(Workspace=ws, SpectraList=masked_detectors)
-        self._instrument = mtd[ws][0].getInstrument().getName()
+        self._instrument = mtd[ws][0].getInstrumentName()
         self._figure_out_measurement_method(ws)
         if measurement_technique == "SingleCrystal":
             progress.report(7, "Merging omega scan")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
@@ -237,7 +237,7 @@ class PowderILLDetectorScan(DataProcessorAlgorithm):
         input_group = GroupWorkspaces(InputWorkspaces=input_workspace)
 
         instrument = input_group[0].getInstrument()
-        instrument_name = instrument.getName()
+        instrument_name = input_group[0].getInstrumentName()
         self._validate_instrument(instrument_name)
 
         self._progress.report("Normalising to monitor")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
@@ -741,7 +741,7 @@ class PowderILLEfficiency(PythonAlgorithm):
             LoadILLDiffraction(Filename=numor, OutputWorkspace=ws_name)
             self._validate_scan(ws_name)
             if index == 0:
-                if mtd[ws_name].getInstrument().getName() != "D2B":
+                if mtd[ws_name].getInstrumentName() != "D2B":
                     raise RuntimeError("Global reference method is not supported for the instrument given")
                 self._configure_global(ws_name)
             if self._normalise_to == "Monitor":
@@ -910,7 +910,7 @@ class PowderILLEfficiency(PythonAlgorithm):
         if self._derivation_method == "SequentialSummedReference1D":  # D20
             self._input_files = self._input_files.replace(",", "+")
             LoadAndMerge(Filename=self._input_files, OutputWorkspace=raw_ws, LoaderName="LoadILLDiffraction")
-            if not mtd[raw_ws].getInstrument().getName().startswith("D20"):
+            if not mtd[raw_ws].getInstrumentName().startswith("D20"):
                 DeleteWorkspace(raw_ws)
                 raise RuntimeError("Sequential reference method is not supported for the instrument given")
             self._validate_scan(raw_ws)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
@@ -416,7 +416,7 @@ class ReflectometryILLPreprocess(DataProcessorAlgorithm):
 
         ws = self._input_ws()
 
-        self._instrument_name = ws.getInstrument().getName()
+        self._instrument_name = ws.getInstrumentName()
 
         ws, mon_ws = self._extract_monitors(ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
@@ -152,7 +152,7 @@ def instrument_name(ws: MatrixWorkspace) -> str:
     Keyword arguments:
     ws -- workspace object with defined instrument
     """
-    name = ws.getInstrument().getName()
+    name = ws.getInstrumentName()
     if name != "D17" and name != "FIGARO":
         raise RuntimeError("Unrecognized instrument {}. Only D17 and FIGARO are supported.".format(name))
     return name

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -253,7 +253,7 @@ class SANSSave(DataProcessorAlgorithm):
         additional_properties["SampleWidth"] = sample.getWidth()
         additional_properties["SampleThickness"] = sample.getThickness()
 
-        instrument = SANSInstrument_string_as_key_NoInstrument[workspace.getInstrument().getName()]
+        instrument = SANSInstrument_string_as_key_NoInstrument[workspace.getInstrumentName()]
         additional_properties["DetectorNames"] = ",".join(get_detector_names_from_instrument(instrument))
 
         maybe_geometry = convert_to_shape(sample.getGeometryFlag())

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeMerge.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeMerge.py
@@ -92,7 +92,7 @@ class SANSTubeMerge(DataProcessorAlgorithm):
     def _create_empty_calibrated_workspace(self, merged_calib_ws, calibrated_ws_name: str) -> None:
         """Copy the instrument parameters of a merged calibration workspace into a new workspace with no counts"""
 
-        inst_file_name = merged_calib_ws.getInstrumentFilename(merged_calib_ws.getInstrument().getName())
+        inst_file_name = merged_calib_ws.getInstrumentFilename(merged_calib_ws.getInstrumentName())
         load_inst_alg = self._create_child_alg("LoadEmptyInstrument", Filename=inst_file_name, OutputWorkspace=calibrated_ws_name)
         load_inst_alg.execute()
         calibrated_ws = load_inst_alg.getProperty("OutputWorkspace").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLCommon.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLCommon.py
@@ -318,7 +318,7 @@ def get_vertical_grouping_pattern(ws):
     TODO: These are static and can be turned to grouping files in instrument/Grouping folder
     :param ws: Empty beam workspace.
     """
-    inst_name = mtd[ws].getInstrument().getName()
+    inst_name = mtd[ws].getInstrumentName()
     min_id = 0
     if "D11" in inst_name:
         if "lr" in inst_name:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
@@ -251,7 +251,7 @@ class SANSILLIntegration(PythonAlgorithm):
         self._integrate(self._input_ws, self._output_ws)
         self.setProperty("OutputWorkspace", self._output_ws)
         panels_out_ws = self.getPropertyValue("PanelOutputWorkspaces")
-        if mtd[self._output_ws].getInstrument().getName() in ["D33", "D11B", "D22B"] and panels_out_ws:
+        if mtd[self._output_ws].getInstrumentName() in ["D33", "D11B", "D22B"] and panels_out_ws:
             panel_names = mtd[self._output_ws].getInstrument().getStringParameter("detector_panels")[0].split(",")
             panel_outputs = []
             for panel in panel_names:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction.py
@@ -101,7 +101,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
 
     @staticmethod
     def _make_solid_angle_name(ws):
-        return mtd[ws].getInstrument().getName() + "_" + str(round(mtd[ws].getRun().getLogData("L2").value)) + "m_SolidAngle"
+        return mtd[ws].getInstrumentName() + "_" + str(round(mtd[ws].getRun().getLogData("L2").value)) + "m_SolidAngle"
 
     @staticmethod
     def _check_distances_match(ws1, ws2):
@@ -370,7 +370,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
         Provides vertical grouping pattern and crops to the main detector panel where counts from the beam are measured.
         :param ws: Empty beam workspace.
         """
-        inst_name = mtd[ws].getInstrument().getName()
+        inst_name = mtd[ws].getInstrumentName()
         min_id = 0
         if "D11" in inst_name:
             if "lr" in inst_name:
@@ -872,7 +872,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
         if mtd[ws].blocksize() > 1:
             if mtd[ws].getAxis(0).getUnit().unitID() == "Wavelength":
                 self._mode = "TOF"
-            elif mtd[ws].getInstrument().getName() != "D16":
+            elif mtd[ws].getInstrumentName() != "D16":
                 self._mode = "Kinetic"
 
     def PyExec(self):
@@ -911,7 +911,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
             else:
                 raise RuntimeError("Only the sample can be in kinetic mode, the calibration measurements cannot be.")
 
-        self._instrument = mtd[ws].getInstrument().getName()
+        self._instrument = mtd[ws].getInstrumentName()
         self._normalise(ws)
         if process in ["Beam", "Transmission", "Container", "Sample"]:
             absorber_ws = self.getProperty("AbsorberInputWorkspace").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2.py
@@ -356,7 +356,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
     def setup(self, ws):
         """Performs a full setup, which can be done only after having loaded the sample data"""
         self.process = self.getPropertyValue("ProcessAs")
-        self.instrument = ws.getInstrument().getName()
+        self.instrument = ws.getInstrumentName()
         self.log().notice(f"Set the instrument name to {self.instrument}")
         unit = ws.getAxis(0).getUnit().unitID()
         self.n_frames = ws.blocksize()
@@ -1089,7 +1089,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
         """
         instr = mtd[ws].getInstrument()
         run = mtd[ws].getRun()
-        if instr.getName() == "D22B":
+        if mtd[ws].getInstrumentName() == "D22B":
             back_pos = instr.getComponentByName("detector_back").getPos()
             distance = run["Detector 1.det1_calc"].value
             MoveInstrumentComponent(
@@ -1119,7 +1119,7 @@ class SANSILLReduction(DataProcessorAlgorithm):
                 Z=0,
             )
             AddSampleLog(Workspace=ws, LogName="L2", LogText=str(distance), LogType="Number")
-        if instr.getName() == "D11B":
+        if mtd[ws].getInstrumentName() == "D11B":
             back_pos = instr.getComponentByName("detector_center").getPos()
             det_pos = instr.getComponentByName("detector").getPos()
             distance = run["Detector 1.det_calc"].value - back_pos[2]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SingleCrystalDiffuseReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SingleCrystalDiffuseReduction.py
@@ -263,7 +263,9 @@ class SingleCrystalDiffuseReduction(DataProcessorAlgorithm):
 
         if _masking:
             LoadMask(
-                Instrument=mtd["__sa"].getInstrument().getName(), InputFile=self.getProperty("MaskFile").value, OutputWorkspace="__mask"
+                Instrument=mtd["__sa"].getInstrumentName(),
+                InputFile=self.getProperty("MaskFile").value,
+                OutputWorkspace="__mask",
             )
             MaskDetectors(Workspace="__sa", MaskedWorkspace="__mask")
             DeleteWorkspace("__mask")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
@@ -485,7 +485,7 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
             else:
                 raise RuntimeError("Could not find run number associated with workspace.")
 
-        instrument = mtd[ws_name].getInstrument().getName()
+        instrument = mtd[ws_name].getInstrumentName()
         if instrument != "":
             for facility in config.getFacilities():
                 try:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -255,7 +255,7 @@ class TimeSlice(PythonAlgorithm):
 
         # Construct output workspace name
         run = mtd[raw_file].getRun().getLogData("run_number").value
-        inst = mtd[raw_file].getInstrument().getName()
+        inst = mtd[raw_file].getInstrumentName()
         slice_file = inst.lower() + run + self._output_ws_name_suffix
 
         if self._background_range is None:

--- a/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
@@ -13,6 +13,7 @@ import unittest
 from testhelpers import run_algorithm
 from mantid.geometry import Instrument
 from mantid.api import Sample, Run
+from mantid.simpleapi import LoadEmptyInstrument
 
 
 class ExperimentInfoTest(unittest.TestCase):
@@ -66,6 +67,15 @@ class ExperimentInfoTest(unittest.TestCase):
 
         self.assertNotEqual(id(held_run), id(run))
         self.assertTrue(held_run.hasProperty("run_property"))
+
+    def test_get_instrument_name_none(self):
+        inst_name = self._expt_ws.getInstrumentName()
+        self.assertEqual(inst_name, "")
+
+    def test_get_instrument_name_with_instrument(self):
+        ws = LoadEmptyInstrument(InstrumentName="SNAP")
+        inst_name = ws.getInstrumentName()
+        self.assertEqual(inst_name, "SNAP")
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -435,7 +435,7 @@ class MantidORSODatasetTest(unittest.TestCase):
             "    affiliation: null\n"
             "  experiment:\n"
             "    title: null\n"
-            f"    instrument: {ws.getInstrument().getName()}\n"
+            f"    instrument: {ws.getInstrumentName()}\n"
             "    start_date: 2010-01-01T00:00:00\n"
             "    probe: neutron\n"
             "  sample:\n"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GenerateGroupingSNSInelasticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GenerateGroupingSNSInelasticTest.py
@@ -103,7 +103,7 @@ class GenerateGroupingSNSInelasticTest(unittest.TestCase):
         IDF_name = alg_test.getProperty("InstrumentDefinitionFile").value
 
         __w = mantid.simpleapi.LoadEmptyInstrument(Filename=IDF_name)
-        instrument_name = __w.getInstrument().getName()
+        instrument_name = __w.getInstrumentName()
 
         self.assertTrue(alg_test.isExecuted())
         self.assertTrue(os.path.exists(outfilename))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadSANS1MLZTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadSANS1MLZTest.py
@@ -21,7 +21,7 @@ class LoadSANSMLZTest(unittest.TestCase):
 
         self.assertTrue(alg_test.isExecuted())
         ws = AnalysisDataService.retrieve(output_ws_name)
-        self.assertEqual("SANS-1_MLZ", ws.getInstrument().getName())
+        self.assertEqual("SANS-1_MLZ", ws.getInstrumentName())
         run_algorithm("DeleteWorkspace", Workspace=output_ws_name)
 
     def test_VerifyValues001(self):
@@ -91,7 +91,7 @@ class LoadSANSMLZTest(unittest.TestCase):
 
         # Verify some values
         ws = AnalysisDataService.retrieve(output_ws_name)
-        self.assertEqual("SANS-1_MLZ", ws.getInstrument().getName())
+        self.assertEqual("SANS-1_MLZ", ws.getInstrumentName())
         # dimensions
         self.assertEqual(16384, ws.getNumberHistograms())
         # data array
@@ -110,7 +110,7 @@ class LoadSANSMLZTest(unittest.TestCase):
         alg_test = run_algorithm("LoadSANS1MLZ", Filename=self.filename_incomplete, Wavelength=4.6, OutputWorkspace=output_ws_name)
 
         ws = AnalysisDataService.retrieve(output_ws_name)
-        self.assertEqual("SANS-1_MLZ", ws.getInstrument().getName())
+        self.assertEqual("SANS-1_MLZ", ws.getInstrumentName())
 
         self.assertTrue(alg_test.isExecuted())
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -37,7 +37,7 @@ class LoadWANDTest(unittest.TestCase):
         self.assertEqual(d2.getMaximum(), 2.5)
 
         self.assertEqual(LoadWANDTest_ws.getNumExperimentInfo(), 1)
-        self.assertEqual(LoadWANDTest_ws.getExperimentInfo(0).getInstrument().getName(), "WAND")
+        self.assertEqual(LoadWANDTest_ws.getExperimentInfo(0).getInstrumentName(), "WAND")
 
         run = LoadWANDTest_ws.getExperimentInfo(0).run()
         s1 = run.getProperty("HB2C:Mot:s1").value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -222,7 +222,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
 
     def test_instrument_was_set_on_output_workspace(self):
         workspace = self._run_algorithm_with_defaults()
-        self.assertEqual(workspace.getInstrument().getName(), self._instrument_name)
+        self.assertEqual(workspace.getInstrumentName(), self._instrument_name)
 
         load_inst_history = self._get_child_alg_history(workspace, "LoadInstrument")
         self.assertIsNotNone(load_inst_history)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
@@ -64,7 +64,7 @@ class TOFTOFMergeRunsTest(unittest.TestCase):
         self.assertEqual(wsoutput.getNumberHistograms(), self._input_ws_base.getNumberHistograms())
         self.assertEqual(wsoutput.blocksize(), self._input_ws_base.blocksize())
         # check instrument
-        self.assertEqual(wsoutput.getInstrument().getName(), "TOFTOF")
+        self.assertEqual(wsoutput.getInstrumentName(), "TOFTOF")
 
         AnalysisDataService.remove("output_ws")
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -2181,7 +2181,7 @@ class IDFOverrideTests(unittest.TestCase):
     def test_wand_uses_custom_idf(self):
         algo = _create_algo(Instrument="WAND^2", IDFFilename=self._idf)
         algo._load_WAND_Data("HB2C_7000.nxs.h5", "test_wand_custom_idf")
-        instrument_name = mtd["test_wand_custom_idf"].getInstrument().getName()
+        instrument_name = mtd["test_wand_custom_idf"].getInstrumentName()
         self.assertEqual(instrument_name, os.path.basename(self._idf))
 
     def test_midas_uses_custom_idf(self):
@@ -2193,7 +2193,7 @@ class IDFOverrideTests(unittest.TestCase):
 
         algo = _create_algo(Instrument="MIDAS", Wavelength=2.5, IDFFilename=self._idf)
         algo._loadMIDASData(midas_file, "test_midas_custom_idf")
-        instrument_name = mtd["test_midas_custom_idf"].getInstrument().getName()
+        instrument_name = mtd["test_midas_custom_idf"].getInstrumentName()
         self.assertEqual(instrument_name, os.path.basename(self._idf))
 
 

--- a/Testing/SystemTests/tests/framework/LoadAndCheckBase.py
+++ b/Testing/SystemTests/tests/framework/LoadAndCheckBase.py
@@ -56,8 +56,8 @@ class LoadAndCheckBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
 
     def do_check_instrument_applied(self, ws1, ws2):
         instrument_name = self.get_expected_instrument_name()
-        self.assertEqual(ws1.getInstrument().getName(), instrument_name)
-        self.assertEqual(ws2.getInstrument().getName(), instrument_name)
+        self.assertEqual(ws1.getInstrumentName(), instrument_name)
+        self.assertEqual(ws2.getInstrumentName(), instrument_name)
 
     def runTest(self):
         Load(Filename=self.get_nexus_workspace_filename(), OutputWorkspace="nexus")

--- a/Testing/SystemTests/tests/framework/SingleCrystalAbsorptionTest.py
+++ b/Testing/SystemTests/tests/framework/SingleCrystalAbsorptionTest.py
@@ -71,7 +71,7 @@ class SingleCrystalPeaksAbsorptionTest(systemtesting.MantidSystemTest):
             self.assertAlmostEqual(peak_lean.getSigmaIntensity(), peak_corr.getSigmaIntensity(), 3)
             self.assertAlmostEqual(peak_lean.getAbsorptionWeightedPathLength(), peak_corr.getAbsorptionWeightedPathLength(), 3)
 
-        self.assertEqual(peaks_lean.getInstrument().getName(), "TOPAZ")
+        self.assertEqual(peaks_lean.getInstrumentName(), "TOPAZ")
 
         # create lean peaks workspace without instrument
         AddAbsorptionWeightedPathLengths(InputWorkspace=peaks_lean_no_inst, ApplyCorrection=True)
@@ -81,4 +81,4 @@ class SingleCrystalPeaksAbsorptionTest(systemtesting.MantidSystemTest):
             self.assertAlmostEqual(peak_lean.getSigmaIntensity(), peak_lean_no_inst.getSigmaIntensity(), 3)
             self.assertAlmostEqual(peak_lean.getAbsorptionWeightedPathLength(), peak_lean_no_inst.getAbsorptionWeightedPathLength(), 3)
 
-        self.assertEqual(peaks_lean_no_inst.getInstrument().getName(), "")
+        self.assertEqual(peaks_lean_no_inst.getInstrumentName(), "")

--- a/docs/source/algorithms/CalculateMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/CalculateMonteCarloAbsorption-v1.rst
@@ -47,7 +47,7 @@ Usage
                                       BinWidth=0.01)
     # Efixed is generally defined as part of the IDF for real data.
     # Fake it here
-    inst_name = sample_ws.getInstrument().getName()
+    inst_name = sample_ws.getInstrumentName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 

--- a/docs/source/algorithms/LoadEmptyInstrument-v1.rst
+++ b/docs/source/algorithms/LoadEmptyInstrument-v1.rst
@@ -41,7 +41,7 @@ Output:
 
     ws = LoadEmptyInstrument(Filename="LOKI_Definition.hdf5")
     print("The workspace contains {} spectra".format(ws.getNumberHistograms()))
-    print("Instrument is {}".format(ws.getInstrument().getName()))
+    print("Instrument is {}".format(ws.getInstrumentName()))
 
 Output:
 

--- a/docs/source/algorithms/LoadMLZ-v1.rst
+++ b/docs/source/algorithms/LoadMLZ-v1.rst
@@ -29,7 +29,7 @@ Usage
 
    ws = LoadMLZ(Filename='TOFTOFTestdata.nxs')
 
-   print("Name of the instrument:  {}".format(ws.getInstrument().getName()))
+   print("Name of the instrument:  {}".format(ws.getInstrumentName()))
    print("Number of spectra:  {}".format(ws.getNumberHistograms()))
 
 

--- a/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsMonteCarloAbsorption-v1.rst
@@ -74,7 +74,7 @@ Usage
                                       BinWidth=0.01)
     # Efixed is generally defined as part of the IDF for real data.
     # Fake it here
-    inst_name = sample_ws.getInstrument().getName()
+    inst_name = sample_ws.getInstrumentName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
@@ -127,7 +127,7 @@ Usage
                                       BinWidth=0.01)
     # Efixed is generally defined as part of the IDF for real data.
     # Fake it here
-    inst_name = sample_ws.getInstrument().getName()
+    inst_name = sample_ws.getInstrumentName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
@@ -178,7 +178,7 @@ Usage
                                       BinWidth=0.01)
     # Efixed is generally defined as part of the IDF for real data.
     # Fake it here
-    inst_name = sample_ws.getInstrument().getName()
+    inst_name = sample_ws.getInstrumentName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 
@@ -231,7 +231,7 @@ Usage
                                       BinWidth=0.01)
     # Efixed is generally defined as part of the IDF for real data.
     # Fake it here
-    inst_name = sample_ws.getInstrument().getName()
+    inst_name = sample_ws.getInstrumentName()
     SetInstrumentParameter(sample_ws, ComponentName=inst_name,
         ParameterName='Efixed', ParameterType='Number', Value='4.1')
 

--- a/docs/source/release/v7.0.0/Framework/Data_Objects/New_features/41885.rst
+++ b/docs/source/release/v7.0.0/Framework/Data_Objects/New_features/41885.rst
@@ -1,0 +1,1 @@
+- `getInstrumentName()` can be used on workspaces or `ExperimentInfo` objects to get the name of the underlying instrument.  Use this instead of `getInstrument().getName()`.

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -285,7 +285,7 @@ class WorkspaceWidget(PluginWidget):
         """
         parent, flags = get_window_config()
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
-            if ws.getInstrument().getName():
+            if ws.getInstrumentName():
                 try:
                     presenter = InstrumentViewPresenter(ws, parent=parent, window_flags=flags)
                     presenter.show_view()
@@ -302,7 +302,7 @@ class WorkspaceWidget(PluginWidget):
         """
         parent, _ = get_window_config()
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
-            if ws.getInstrument().getName():
+            if ws.getInstrumentName():
                 try:
                     self._instrument_view_window = FullInstrumentViewWindow(parent=parent, off_screen=off_screen)
                     self._instrument_view_window.show()

--- a/qt/python/instrumentview/instrumentview/InstrumentView.py
+++ b/qt/python/instrumentview/instrumentview/InstrumentView.py
@@ -29,7 +29,7 @@ class InstrumentView:
 
         if (
             not ws.getInstrument()
-            or not ws.getInstrument().getName()
+            or not ws.getInstrumentName()
             or not ws.getAxis(1).isSpectra()
             or (ws.detectorInfo().detectorIDs().size == 0)
         ):

--- a/qt/python/instrumentview/instrumentview/NotebookUtils.py
+++ b/qt/python/instrumentview/instrumentview/NotebookUtils.py
@@ -13,12 +13,7 @@ import pyvista as pv
 
 def _load_file(file_path: Path) -> Workspace2D:
     ws = Load(str(file_path))
-    if (
-        not ws.getInstrument()
-        or not ws.getInstrument().getName()
-        or not ws.getAxis(1).isSpectra()
-        or (ws.detectorInfo().detectorIDs().size == 0)
-    ):
+    if not ws.getInstrument() or not ws.getInstrumentName() or not ws.getAxis(1).isSpectra() or (ws.detectorInfo().detectorIDs().size == 0):
         raise RuntimeError(f"Could not open instrument for {file_path}. Check that instrument and detectors are present in the workspace.")
     return ws
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/model.py
@@ -48,7 +48,7 @@ class BrowseFileWidgetModel(object):
                 failed_files += [(filename, error)]
                 continue
             if not psi_data:
-                instrument_from_workspace = ws["OutputWorkspace"][0].workspace.getInstrument().getName()
+                instrument_from_workspace = ws["OutputWorkspace"][0].workspace.getInstrumentName()
             else:
                 # Load another instrument first
                 instrument_from_workspace = "PSI"
@@ -85,7 +85,7 @@ class BrowseFileWidgetModel(object):
         return self._loaded_data_store.get_data(**kwargs)
 
     def get_instrument_from_latest_run(self):
-        instrument = self._loaded_data_store.get_latest_data()["workspace"]["OutputWorkspace"][0].workspace.getInstrument().getName()
+        instrument = self._loaded_data_store.get_latest_data()["workspace"]["OutputWorkspace"][0].workspace.getInstrumentName()
         if instrument:
             return instrument
         else:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
@@ -38,7 +38,7 @@ class LoadUtils(object):
         self.options = mantid.AnalysisDataService.getObjectNames()
         self.options = [item.replace(" ", "") for item in self.options]
         self.N_points = len(tmpWS.readX(0))
-        self.instrument = tmpWS.getInstrument().getName()
+        self.instrument = tmpWS.getInstrumentName()
 
         self.runName = self.instrument + str(tmpWS.getRunNumber()).zfill(8)
 
@@ -62,7 +62,7 @@ class LoadUtils(object):
     def hasDataChanged(self):
         exists, ws = self.MuonAnalysisExists()
         if exists:
-            current = ws.getInstrument().getName() + str(ws.getRunNumber()).zfill(8)
+            current = ws.getInstrumentName() + str(ws.getRunNumber()).zfill(8)
             if self.runName != current:
                 mantid.logger.error("Active workspace has changed. Reloading the data")
                 self.setUp(ws)

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -85,6 +85,7 @@ class LoadFileWidgetPresenterMultipleFileModeTest(unittest.TestCase):
         instrument_mock = mock.MagicMock()
         instrument_mock.getName.return_value = "EMU"
         workspace_mock.workspace.getInstrument.return_value = instrument_mock
+        workspace_mock.workspace.getInstrumentName.return_value = "EMU"
 
         return {"OutputWorkspace": [workspace_mock]}
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -84,6 +84,7 @@ class LoadFileWidgetPresenterTest(unittest.TestCase):
         instrument_mock = mock.MagicMock()
         instrument_mock.getName.return_value = "EMU"
         workspace_mock.workspace.getInstrument.return_value = instrument_mock
+        workspace_mock.workspace.getInstrumentName.return_value = "EMU"
 
         return {"OutputWorkspace": [workspace_mock]}
 

--- a/scripts/Calibration/tofpd/diagnostics.py
+++ b/scripts/Calibration/tofpd/diagnostics.py
@@ -234,7 +234,7 @@ def difc_plot2d(calib_new, calib_old=None, instr_ws=None, mask=None, vrange=(0, 
     ws_old = _get_difc_ws(calib_old, instr_ws)
     if ws_old is None:
         # If no second workspace is given, then load default instrument to compare against
-        instr_name = ws_new.getInstrument().getName()
+        instr_name = ws_new.getInstrumentName()
         ws_old = CalculateDIFC(InputWorkspace=ws_new, OutputWorkspace="__difc_{}".format(instr_name))
 
     delta = ws_new - ws_old

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -319,7 +319,7 @@ def pdcalibration_groups(
     # put the input data back into time-of-flight
     ConvertUnits(data_ws, Target="dSpacing", OutputWorkspace=data_ws)
 
-    instrument = data_ws.getInstrument().getName()
+    instrument = data_ws.getInstrumentName()
 
     if instrument == "POWGEN":
         pdcalib_for_powgen(

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -599,7 +599,7 @@ def _plot_focused_workspaces(ws_names: Sequence[str]) -> None:
 
     for ws_name in ws_names:
         ws_foc = ADS.retrieve(ws_name)
-        ws_label = "_".join([ws_foc.getInstrument().getName(), ws_foc.run().get("run_number").value])
+        ws_label = "_".join([ws_foc.getInstrumentName(), ws_foc.run().get("run_number").value])
         fig, ax = subplots(subplot_kw={"projection": "mantid"})
         for ispec in range(ws_foc.getNumberHistograms()):
             ax.plot(ws_foc, label=f"{ws_label} focused: spec {ispec + 1}", marker=".", wkspIndex=ispec)

--- a/scripts/Engineering/texture/TextureUtils/focus_utils.py
+++ b/scripts/Engineering/texture/TextureUtils/focus_utils.py
@@ -78,7 +78,7 @@ def _get_instrument_from_ws_list(wss: Sequence[str]) -> str | None:
             except:
                 logger.error(f"Could not find or load '{ws_str}'")
                 return None
-        instruments.add(ws.getInstrument().getName())
+        instruments.add(ws.getInstrumentName())
     instruments = list(instruments)
     if len(instruments) == 1:
         return instruments[0]

--- a/scripts/Engineering/texture/correction/correction_model.py
+++ b/scripts/Engineering/texture/correction/correction_model.py
@@ -307,7 +307,7 @@ class TextureCorrectionModel:
     def get_atten_table_name(ws_str: str, eval_val: float, unit: str) -> str:
         ws = ADS.retrieve(ws_str)
         run_num = str(ws.getRun().getProperty("run_number").value)
-        instr = ws.getInstrument().getName()
+        instr = ws.getInstrumentName()
         return f"{instr}_{run_num}_attenuation_coefficient_{eval_val}_{unit}"
 
     def write_atten_val_table(

--- a/scripts/Engineering/texture/polefigure/polefigure_model.py
+++ b/scripts/Engineering/texture/polefigure/polefigure_model.py
@@ -65,7 +65,7 @@ class TextureProjection:
         readout_column = readout_column.replace("/", "_over_")
         try:
             run_range = f"{fws.getRun().getLogData('run_number').value}-{lws.getRun().getLogData('run_number').value}"
-            instr = fws.getInstrument().getName()
+            instr = fws.getInstrumentName()
         except RuntimeError:
             instr = "UNKNOWN"
             run_range = "XXXXXX-XXXXXX"

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -527,7 +527,7 @@ def _retrieve_ws_object(ws: str | Workspace2D | TableWorkspace) -> Workspace2D |
 
 def generous_rebin(ws: str | Workspace2D, out_ws: str, StoreInADS: bool = True) -> Workspace2D:
     ws = _retrieve_ws_object(ws)
-    if ws.getInstrument().getName() not in ("ENGIN-X", "IMAT"):
+    if ws.getInstrumentName() not in ("ENGIN-X", "IMAT"):
         # the size and detector ranges for enginx and imat should not cause issues with this
         logger.warning("Rebinning generously - this may cause memory issues for workspaces with very different x binning")
     minX, maxX, diffX = np.inf, 0, np.inf

--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -53,7 +53,7 @@ def get_instrument_and_run(ws_name: str) -> Tuple[str, str]:
     """
     run_number = get_run_number(ws_name)
 
-    instrument = AnalysisDataService.retrieve(ws_name).getInstrument().getName()
+    instrument = AnalysisDataService.retrieve(ws_name).getInstrumentName()
     if instrument == "":
         return instrument, run_number
 

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -872,7 +872,7 @@ def create_detector_grouping_string(number_of_groups: int, spectra_min: int, spe
 
 
 def create_grouping_workspace(workspace: MatrixWorkspace, cal_file: str) -> GroupingWorkspace:
-    group_ws, _, _ = CreateGroupingWorkspace(InstrumentName=workspace.getInstrument().getName(), OldCalFilename=cal_file, StoreInADS=False)
+    group_ws, _, _ = CreateGroupingWorkspace(InstrumentName=workspace.getInstrumentName(), OldCalFilename=cal_file, StoreInADS=False)
     return group_ws
 
 

--- a/scripts/Reflectometry/isis_reflectometry/saveModule.py
+++ b/scripts/Reflectometry/isis_reflectometry/saveModule.py
@@ -83,7 +83,7 @@ def saveMFT(idx, fname, logs):
     sep = "\t"
     f = open(fname, "w")
     f.write("MFT\n")
-    f.write("Instrument: " + a1.getInstrument().getName() + "\n")
+    f.write("Instrument: " + a1.getInstrumentName() + "\n")
     f.write("User-local contact: \n")
     f.write("Title: \n")
     samp = a1.getRun()

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1581,7 +1581,7 @@ def _apply_polarization_component_adjustments(polarization_state, ws):
         component = ws.getInstrument().getComponentByName(idf_name)
         if component is None:
             raise AttributeError(
-                f'The name "{idf_name}" is not present in the Instrument Definition File for {ws.getInstrument().getName()}. '
+                f'The name "{idf_name}" is not present in the Instrument Definition File for {ws.getInstrumentName()}. '
                 f'Please ensure any "idf_component_name" fields in the User File match an existing entry in the IDF for the '
                 f"component you wish to override."
             )

--- a/scripts/reduction_gui/reduction/inelastic/dgs_reduction_script.py
+++ b/scripts/reduction_gui/reduction/inelastic/dgs_reduction_script.py
@@ -74,13 +74,13 @@ class DgsReductionScripter(BaseReductionScripter):
 
         filenames = self.filenameParser(data_list)
         if len(filenames) == 1:
-            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0].getInstrument().getName()"
+            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0].getInstrumentName()"
             script += "+str(DGS_output_data[0].getRunNumber())+'.nxs')\n"
             script += "SaveNexus(DGS_output_data[0],OutputFilename)\n"
         else:
             script += "for i in range(" + str(len(filenames)) + "):\n"
             script += DgsReductionScripter.WIDTH
-            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0][i].getInstrument().getName()"
+            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0][i].getInstrumentName()"
             script += "+str(DGS_output_data[0][i].getRunNumber())+'.nxs')\n"
             script += DgsReductionScripter.WIDTH + "SaveNexus(DGS_output_data[0][i],OutputFilename)\n"
 
@@ -169,7 +169,7 @@ class DgsReductionScripter(BaseReductionScripter):
                 out_dir_line = 'OutputDirectory="%s"\n' % output_dir
             script += out_dir_line
 
-            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0].getInstrument().getName()"
+            script += "OutputFilename=os.path.join(OutputDirectory,DGS_output_data[0].getInstrumentName()"
             script += "+str(DGS_output_data[0].getRunNumber())+'.nxs')\n"
             script += "SaveNexus(DGS_output_data[0],OutputFilename)\n"
 

--- a/scripts/test/Engineering/texture/TextureUtils/test_focus_utils.py
+++ b/scripts/test/Engineering/texture/TextureUtils/test_focus_utils.py
@@ -16,7 +16,7 @@ class TestGetInstrumentFromWsList(unittest.TestCase):
     @patch(f"{texture_utils_path}.ADS")
     def test_single_ws_in_ads_returns_instrument_name(self, mock_ads):
         mock_ws = MagicMock()
-        mock_ws.getInstrument().getName.return_value = "ENGINX"
+        mock_ws.getInstrumentName.return_value = "ENGINX"
         mock_ads.doesExist.return_value = True
         mock_ads.retrieve.return_value = mock_ws
 
@@ -29,7 +29,7 @@ class TestGetInstrumentFromWsList(unittest.TestCase):
     @patch(f"{texture_utils_path}.ADS")
     def test_multiple_ws_same_instrument_in_ads_returns_instrument_name(self, mock_ads):
         mock_ws = MagicMock()
-        mock_ws.getInstrument().getName.return_value = "ENGINX"
+        mock_ws.getInstrumentName.return_value = "ENGINX"
         mock_ads.doesExist.return_value = True
         mock_ads.retrieve.return_value = mock_ws
 
@@ -42,7 +42,7 @@ class TestGetInstrumentFromWsList(unittest.TestCase):
     @patch(f"{texture_utils_path}.ADS")
     def test_ws_not_in_ads_loads_from_file(self, mock_ads, mock_load):
         mock_ws = MagicMock()
-        mock_ws.getInstrument().getName.return_value = "IMAT"
+        mock_ws.getInstrumentName.return_value = "IMAT"
         mock_ads.doesExist.return_value = False
         mock_load.return_value = mock_ws
 
@@ -68,9 +68,9 @@ class TestGetInstrumentFromWsList(unittest.TestCase):
     @patch(f"{texture_utils_path}.ADS")
     def test_multiple_instruments_logs_error_and_returns_none(self, mock_ads, mock_logger):
         mock_ws1 = MagicMock()
-        mock_ws1.getInstrument().getName.return_value = "ENGINX"
+        mock_ws1.getInstrumentName.return_value = "ENGINX"
         mock_ws2 = MagicMock()
-        mock_ws2.getInstrument().getName.return_value = "IMAT"
+        mock_ws2.getInstrumentName.return_value = "IMAT"
         mock_ads.doesExist.return_value = True
         mock_ads.retrieve.side_effect = [mock_ws1, mock_ws2]
 
@@ -93,7 +93,7 @@ class TestGetInstrumentFromWsList(unittest.TestCase):
     def test_load_failure_stops_processing_remaining_ws(self, mock_ads, mock_load, mock_logger):
         # If the second ws fails to load, processing stops early and returns None.
         mock_ws1 = MagicMock()
-        mock_ws1.getInstrument().getName.return_value = "ENGINX"
+        mock_ws1.getInstrumentName.return_value = "ENGINX"
         mock_ads.doesExist.side_effect = [True, False]
         mock_ads.retrieve.return_value = mock_ws1
         mock_load.side_effect = RuntimeError("Cannot load")

--- a/scripts/test/Engineering/texture/correction/test_correction_model.py
+++ b/scripts/test/Engineering/texture/correction/test_correction_model.py
@@ -27,6 +27,7 @@ class TextureCorrectionModelTest(unittest.TestCase):
         # Mock instrument
         mock_inst = MagicMock()
         mock_inst.getName.return_value = "instrument"
+        instrument_name = "instrument"
 
         # Mock run_number log property
         mock_run_number = MagicMock()
@@ -51,6 +52,7 @@ class TextureCorrectionModelTest(unittest.TestCase):
         # Mock workspace
         self.mock_ws = MagicMock()
         self.mock_ws.getInstrument.return_value = mock_inst
+        self.mock_ws.getInstrumentName.return_value = instrument_name
         self.mock_ws.getRun.return_value = mock_run
         self.mock_ws.run.return_value = mock_run
         self.mock_ws.sample.return_value = mock_sample

--- a/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
+++ b/scripts/test/Engineering/texture/polefigure/test_polefigure_model.py
@@ -47,6 +47,7 @@ class TextureProjectionTest(unittest.TestCase):
         self.mock_ws.sample().hasCrystalStructure.return_value = True
         self.mock_ws.getRun.return_value = mock_run
         self.mock_ws.getInstrument.return_value = mock_inst
+        self.mock_ws.getInstrumentName.return_value = "instrument"
 
     @patch(correction_model_path + ".ADS")
     @patch(correction_model_path + ".TextureProjection._has_no_valid_shape")

--- a/scripts/test/Engineering/texture/test_texture_helper.py
+++ b/scripts/test/Engineering/texture/test_texture_helper.py
@@ -523,7 +523,7 @@ class TestGenerousRebin(unittest.TestCase):
         mock_ws = MagicMock()
         mock_ws.getNumberHistograms.return_value = len(x_arrays)
         mock_ws.readX.side_effect = lambda i: np.array(x_arrays[i])
-        mock_ws.getInstrument.return_value.getName.return_value = instrument_name
+        mock_ws.getInstrumentName.return_value = instrument_name
         return mock_ws
 
     @patch(texture_utils_path + ".Rebin")


### PR DESCRIPTION
### Description of work

As part of the Instrument 1.0 full deprecation, many places in python needed a way to get the name of a workspace's instrument as a string.  There was no Instrument 2.0 way to do this, except with

```python
compInfo = ws.getComponentInfo()
instrName = compInfo.name(compInfo.root())
```

Instead, this PR adds a new method to `ExperimentInfo` to perform this same step, at the C++ layer.  This is exposed to python, with additional tests for its behavior with and without an instrument.

Then, this replaces everywhere calling the pattern `ws.getInstrument().getName()` with `ws.getInstrumentName()`.

Part of [EWM 16817](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16817)

Developed out of PR #41885

### To test:

This is a refactor.  Make sure the existing unit tests pass.

The majority of changes are mechanical.  The five places for focused review:
- `ExperimentInfo.h`
- `ExperimentInfo.cpp` (the class source)
- `ExperimentInfo.cpp` (the API export)
- `ExperimentInfoTest.h` (CxxTests)
- `ExperimentInfoTest.py` (tests of the python binding)

This has release notes.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
