### PR TITLE
Reject XMin >= XMax (and YMin >= YMax) in Muon GUIs plot range boxes

### DIFF
--- a/docs/source/release/v7.0.0/Muon/MA_FDA/Bugfixes/38657.rst
+++ b/docs/source/release/v7.0.0/Muon/MA_FDA/Bugfixes/38657.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the :ref:`Muon Analysis <Muon_Analysis-ref>` and :ref:`Frequency Domain Analysis <Frequency_Domain_Analysis-ref>` interfaces where entering an X (or Y) minimum value greater than or equal to the maximum in the plot range boxes flipped the axis. The invalid value is now rejected and the range reverted to its previous value.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/quick_edit/axis_changer/axis_changer_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/quick_edit/axis_changer/axis_changer_view.py
@@ -15,6 +15,7 @@ class AxisChangerView(QtWidgets.QWidget):
 
     def __init__(self, label, parent):
         super(AxisChangerView, self).__init__(parent)
+        self._previous_limits = None
         layout = QtWidgets.QHBoxLayout()
         self._label = QtWidgets.QLabel(label)
 
@@ -46,9 +47,17 @@ class AxisChangerView(QtWidgets.QWidget):
     def set_limits(self, limits):
         self.lower_bound.setText(str(limits[0]))
         self.upper_bound.setText(str(limits[1]))
+        self._previous_limits = list(limits)
 
     def _bound_changed(self):
-        self.sig_bound_changed.emit(self.get_limits())
+        limits = self.get_limits()
+        if limits[0] >= limits[1]:
+            # Reject an invalid min >= max range and restore the last valid values instead.
+            if self._previous_limits is not None:
+                self.set_limits(self._previous_limits)
+            return
+        self._previous_limits = limits
+        self.sig_bound_changed.emit(limits)
 
     def on_range_changed(self, slot):
         self.sig_bound_changed.connect(slot)

--- a/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
@@ -141,6 +141,7 @@ set(TEST_PY_FILES
     plotting_canvas/plotting_canvas_view_test.py
     plot_widget/frequency_analysis_plot_widget_test.py
     plot_widget/muon_analysis_plot_widget_test.py
+    quick_edit/axis_changer_view_test.py
     quick_edit/dual_quick_edit_test.py
     quick_edit/quick_edit_presenter_test.py
     raw_pane/raw_pane_model_test.py

--- a/qt/python/mantidqtinterfaces/test/Muon/quick_edit/axis_changer_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/quick_edit/axis_changer_view_test.py
@@ -1,0 +1,74 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from unittest import mock
+
+from mantidqtinterfaces.Muon.GUI.Common.plot_widget.quick_edit.axis_changer.axis_changer_view import AxisChangerView
+
+from mantidqt.utils.qt.testing import start_qapplication
+
+
+@start_qapplication
+class AxisChangerViewTest(unittest.TestCase):
+    def setUp(self):
+        self.view = AxisChangerView("X", None)
+        self.view.set_limits([0.0, 10.0])
+        self.slot = mock.Mock()
+        self.view.on_range_changed(self.slot)
+
+    def test_valid_range_is_emitted_and_stored(self):
+        self.view.lower_bound.setText("1.0")
+        self.view.upper_bound.setText("5.0")
+
+        self.view._bound_changed()
+
+        self.slot.assert_called_once_with([1.0, 5.0])
+        self.assertEqual(self.view.get_limits(), [1.0, 5.0])
+
+    def test_min_greater_than_max_is_rejected_and_reverted(self):
+        self.view.lower_bound.setText("30.0")
+        self.view.upper_bound.setText("10.0")
+
+        self.view._bound_changed()
+
+        self.slot.assert_not_called()
+        self.assertEqual(self.view.get_limits(), [0.0, 10.0])
+
+    def test_min_equal_to_max_is_rejected_and_reverted(self):
+        self.view.lower_bound.setText("5.0")
+        self.view.upper_bound.setText("5.0")
+
+        self.view._bound_changed()
+
+        self.slot.assert_not_called()
+        self.assertEqual(self.view.get_limits(), [0.0, 10.0])
+
+    def test_max_less_than_min_with_negative_values_is_rejected_and_reverted(self):
+        self.view.lower_bound.setText("-5.0")
+        self.view.upper_bound.setText("-10.0")
+
+        self.view._bound_changed()
+
+        self.slot.assert_not_called()
+        self.assertEqual(self.view.get_limits(), [0.0, 10.0])
+
+    def test_invalid_range_reverts_to_last_valid_range_not_initial_default(self):
+        self.view.lower_bound.setText("1.0")
+        self.view.upper_bound.setText("5.0")
+        self.view._bound_changed()
+
+        self.view.lower_bound.setText("30.0")
+        self.view.upper_bound.setText("10.0")
+        self.view._bound_changed()
+
+        self.slot.assert_called_once_with([1.0, 5.0])
+        self.assertEqual(self.view.get_limits(), [1.0, 5.0])
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
### Description of work
The X/Y min/max range boxes in the Muon Analysis and Frequency Domain Analysis plot windows accepted a minimum value greater than or equal to the maximum. This either silently flipped the axis or, when min == max, triggered a matplotlib "singular transformation; automatically expanding" warning.

The fix is in AxisChangerView._bound_changed, the single shared entry point both interfaces use for range-box input (via QuickEditView → AxisChangerWidget → AxisChangerView): if the entered range has min >= max, the change is now rejected, and the boxes are reverted to the last valid range instead of being emitted to the plot.


Closes #38657. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- New unit tests pass (python.MuonQt6.quick_edit.axis_changer_view_test)
- Manually test in Muon Analysis and Frequency Domain Analysis: entering XMin > XMax or XMin == XMax reverts to the previous range instead of flipping/warning; follow #38657 for test instructions.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
