### PR TITLE
deprecate DPDFreduction algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -12,6 +12,7 @@ import mantid.simpleapi as sapi
 import mantid.api as api
 import mantid.kernel as kapi
 from mantid import config
+from mantid.utils.deprecator import deprecated_algorithm
 from tempfile import mkstemp
 
 # conversion factor from energy (in meV) to vawevector (in inverse Angstroms)
@@ -20,6 +21,7 @@ ENERGY_TO_WAVEVECTOR = 2.072
 # pylint: disable=too-many-instance-attributes
 
 
+@deprecated_algorithm(None, "2026-07-24")
 class DPDFreduction(api.PythonAlgorithm):
     channelgroup = None
 

--- a/Framework/PythonInterface/test/python/mantid/utils/deprecatorTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/deprecatorTest.py
@@ -81,6 +81,10 @@ class DeprecatorTest(unittest.TestCase):
         log_file = self._exec_alg("log")
         self.assertTrue(' Algorithm "MyOldAlg" is deprecated' in log_file)
 
+    def test_deprecated_algorithm_adds_deprecated_category(self):
+        alg = MyOldAlg()
+        self.assertEqual("Inelastic\\Reduction;Deprecated", alg.category())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_PY_FILES
     CylinderPaalmanPingsCorrection2Test.py
     DakotaChiSquaredTest.py
     DeltaPDF3DTest.py
+    DPDFreductionTest.py
     DNSComputeDetEffCorrCoefsTest.py
     DNSMergeRunsTest.py
     DNSFlippingRatioCorrTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/DPDFreductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/DPDFreductionTest.py
@@ -1,0 +1,18 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from DPDFreduction import DPDFreduction
+
+
+class DPDFreductionTest(unittest.TestCase):
+    def test_category_includes_deprecated_category(self):
+        self.assertEqual("Inelastic\\Reduction;Deprecated", DPDFreduction().category())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Deprecated/41906.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Deprecated/41906.rst
@@ -1,0 +1,1 @@
+- The ``DPDFreduction`` algorithm has been deprecated and has no direct replacement.


### PR DESCRIPTION
### Description of work

Deprecates the `DPDFreduction` Python algorithm using Mantid’s `deprecated_algorithm` decorator so it is flagged as deprecated (and can optionally raise via `algorithms.deprecated`), with accompanying unit tests and a release note entry.

**Changes:**
- Mark `DPDFreduction` as deprecated (no replacement) with a deprecation date.
- Add/extend Python unit tests to verify deprecated algorithms gain the `;Deprecated` category.

Companion to #41907 
Implements [EWM 17169](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17169)

### To test:
In the workbench:

```python
from mantid.kernel import ConfigService
from mantid.simpleapi import DPDFreduction

config = ConfigService.Instance()
old_value = config["algorithms.deprecated"]

try:
    config["algorithms.deprecated"] = "Raise"
    DPDFreduction(RunNumbers="1", OutputWorkspace="__dpdf_deprecated_test")
finally:
    config["algorithms.deprecated"] = old_value
```

Expected output should contain:
```python
Configuration "algorithms.deprecated" set to raise upon use of any deprecated algorithm
  at line 76 in '/home/jbq/repositories/GitHub/mantidproject/mantid/Framework/PythonInterface/mantid/utils/deprecator.py'
```
<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
