### PR TITLE
Make some SCD system test less resource heavy

### DIFF
--- a/Framework/MDAlgorithms/src/BaseConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/BaseConvertToDiffractionMDWorkspace.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidMDAlgorithms/BaseConvertToDiffractionMDWorkspace.h"
 
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 
 #include "MantidDataObjects/EventWorkspace.h"
@@ -130,6 +131,16 @@ void BaseConvertToDiffractionMDWorkspace::convertFramePropertyNames(const std::s
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.   */
 void BaseConvertToDiffractionMDWorkspace::exec() {
+  const std::string preprocDetectorsWSName{"PreprocDetectorsWS"};
+  struct PreprocDetectorsWSCleanup final {
+    std::string workspaceName;
+    ~PreprocDetectorsWSCleanup() {
+      auto &ads = AnalysisDataService::Instance();
+      if (ads.doesExist(workspaceName)) {
+        ads.remove(workspaceName);
+      }
+    }
+  } cleanup{preprocDetectorsWSName};
 
   Mantid::API::Algorithm_sptr Convert = createChildAlgorithm("ConvertToMD", 0., 1.);
   Convert->initialize();
@@ -157,7 +168,7 @@ void BaseConvertToDiffractionMDWorkspace::exec() {
   Convert->setProperty("QConversionScales", Scaling);
 
   Convert->setProperty("OtherDimensions", "");
-  Convert->setProperty("PreprocDetectorsWS", "-");
+  Convert->setProperty("PreprocDetectorsWS", preprocDetectorsWSName);
 
   bool lorCorr = this->getProperty("LorentzCorrection");
   Convert->setProperty("LorentzCorrection", lorCorr);
@@ -182,6 +193,7 @@ void BaseConvertToDiffractionMDWorkspace::exec() {
 
   Convert->executeAsChildAlg();
 
+  // write out the output
   IMDEventWorkspace_sptr iOut = Convert->getProperty("OutputWorkspace");
   this->setProperty("OutputWorkspace", iOut);
 }

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace3.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace3.cpp
@@ -96,6 +96,7 @@ void ConvertToDiffractionMDWorkspace3::calculateExtentsFromData(std::vector<doub
   convertFramePropertyNames(getPropertyValue("OutputDimensions"), TargetFrame, Scaling);
   alg->setProperty("Q3DFrames", TargetFrame);
   alg->setProperty("QConversionScales", Scaling);
+  alg->setProperty("PreprocDetectorsWS", "PreprocDetectorsWS");
 
   alg->execute();
 

--- a/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace2Test.h
+++ b/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace2Test.h
@@ -114,6 +114,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "test_md3");
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted())
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("PreprocDetectorsWS"))
 
     MDEventWorkspace3::sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>("test_md3"));
@@ -138,6 +139,7 @@ public:
       alg.setPropertyValue("OutputWorkspace", "test_md3");
       TS_ASSERT_THROWS_NOTHING(alg.execute();)
       TS_ASSERT(alg.isExecuted())
+      TS_ASSERT(!AnalysisDataService::Instance().doesExist("PreprocDetectorsWS"))
 
       TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>("test_md3"));
       TS_ASSERT(ws);

--- a/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace3Test.h
+++ b/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspace3Test.h
@@ -114,6 +114,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "test_md3");
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted())
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("PreprocDetectorsWS"))
 
     MDEventWorkspace3::sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>("test_md3"));
@@ -138,6 +139,7 @@ public:
       alg.setPropertyValue("OutputWorkspace", "test_md3");
       TS_ASSERT_THROWS_NOTHING(alg.execute();)
       TS_ASSERT(alg.isExecuted())
+      TS_ASSERT(!AnalysisDataService::Instance().doesExist("PreprocDetectorsWS"))
 
       TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>("test_md3"));
       TS_ASSERT(ws);
@@ -189,6 +191,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "test_md3");
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted())
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("PreprocDetectorsWS"))
 
     MDEventWorkspace3::sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<MDEventWorkspace3>("test_md3"));

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -1486,88 +1486,88 @@ def testThreadsLoopImpl(
         test_sub_directory = None
         # Empty test list
         local_test_list = None
+        # Data files locked for the selected test module
+        locked_files = ()
         # Get the lock to inspect the global list of tests
-        lock.acquire()
-        # Run through the list of test modules, starting from the ith
-        # element where i is the process number.
-        for i in range(process_number, len(tests_lock)):
-            # If the lock for this particular module is 0, it means
-            # this module has not yet been run and it will be chosen
-            # for this particular loop
-            if tests_lock[i] == 0:
-                # Check for the lock status of the required files for this test module
-                modname = tests_dict[str(i)][1][0]._modname
-                no_files_are_locked = True
-                for f in required_files_dict[modname]:
-                    if locked_files_dict[f]:
-                        no_files_are_locked = False
+        with lock:
+            # Run through the list of test modules, starting from the ith
+            # element where i is the process number.
+            for i in range(process_number, len(tests_lock)):
+                # If the lock for this particular module is 0, it means
+                # this module has not yet been run and it will be chosen
+                # for this particular loop
+                if tests_lock[i] == 0:
+                    # Check for the lock status of the required files for this test module
+                    modname = tests_dict[str(i)][1][0]._modname
+                    required_files = tuple(required_files_dict[modname])
+                    no_files_are_locked = True
+                    for f in required_files:
+                        if locked_files_dict[f]:
+                            no_files_are_locked = False
+                            break
+                    # If all files are available, we can proceed with this module
+                    if no_files_are_locked:
+                        # Lock the data files for this test module
+                        for f in required_files:
+                            locked_files_dict[f] = True
+                        locked_files = required_files
+                        # Set the current test list to the chosen module
+                        test_sub_directory, local_test_list = tests_dict[str(i)]
+                        tests_lock[i] = 1
+                        imodule = i
+                        tests_left.value -= 1
                         break
-                # If all files are available, we can proceed with this module
-                if no_files_are_locked:
-                    # Lock the data files for this test module
-                    for f in required_files_dict[modname]:
-                        locked_files_dict[f] = True
-                    # Set the current test list to the chosen module
-                    test_sub_directory, local_test_list = tests_dict[str(i)]
-                    tests_lock[i] = 1
-                    imodule = i
-                    tests_left.value -= 1
-                    break
-        # Release the lock
-        lock.release()
 
         # Check if local_test_list exists: if all data was locked,
         # then there is no test list
         if local_test_list and test_sub_directory:
-            if not options.quiet:
-                print(
-                    "##### Thread %2i will execute module: [%3i] %s (%i tests)" % (process_number, imodule, modname, len(local_test_list))
-                )
-                sys.stdout.flush()
-
-            test_directory = os.path.abspath(os.path.join(mtdconf.testDir, test_sub_directory))
-            if os.path.isdir(test_directory):
-                sys.path.insert(0, test_directory)
-            else:
-                raise RuntimeError("Expected a tests directory at {0}.".format(test_directory))
-
-            runner.setTestDir(test_directory)
-
-            # Create a TestManager, giving it a pre-compiled list_of_tests
-            mgr = TestManager(
-                mantid_config=mtdconf,
-                runner=runner,
-                output=[reporter],
-                quiet=options.quiet,
-                testsInclude=options.testsInclude,
-                testsExclude=options.testsExclude,
-                exclude_in_pr_builds=options.exclude_in_pr_builds,
-                showSkipped=options.showskipped,
-                output_on_failure=options.output_on_failure,
-                clean=options.clean,
-                list_of_tests=local_test_list,
-            )
-
             try:
-                mgr.executeTests(tests_done)
-            except KeyboardInterrupt:
-                mgr.markSkipped("KeyboardInterrupt", tests_done.value)
+                if not options.quiet:
+                    print(
+                        "##### Thread %2i will execute module: [%3i] %s (%i tests)"
+                        % (process_number, imodule, modname, len(local_test_list))
+                    )
+                    sys.stdout.flush()
 
-            # Update the test results in the array shared across cores
-            res_array[process_number] += mgr._skippedTests
-            res_array[process_number + options.ncores] += mgr._failedTests
-            res_array[process_number + 2 * options.ncores] = min(
-                int(reporter.reportStatus()), res_array[process_number + 2 * options.ncores]
-            )
+                test_directory = os.path.abspath(os.path.join(mtdconf.testDir, test_sub_directory))
+                if os.path.isdir(test_directory):
+                    sys.path.insert(0, test_directory)
+                else:
+                    raise RuntimeError("Expected a tests directory at {0}.".format(test_directory))
 
-            # Delete the TestManager
-            del mgr
+                runner.setTestDir(test_directory)
 
-            # Unlock the data files
-            lock.acquire()
-            for f in required_files_dict[modname]:
-                locked_files_dict[f] = False
-            lock.release()
+                # Create a TestManager, giving it a pre-compiled list_of_tests
+                mgr = TestManager(
+                    mantid_config=mtdconf,
+                    runner=runner,
+                    output=[reporter],
+                    quiet=options.quiet,
+                    testsInclude=options.testsInclude,
+                    testsExclude=options.testsExclude,
+                    exclude_in_pr_builds=options.exclude_in_pr_builds,
+                    showSkipped=options.showskipped,
+                    output_on_failure=options.output_on_failure,
+                    clean=options.clean,
+                    list_of_tests=local_test_list,
+                )
+
+                try:
+                    mgr.executeTests(tests_done)
+                except KeyboardInterrupt:
+                    mgr.markSkipped("KeyboardInterrupt", tests_done.value)
+
+                # Update the test results in the array shared across cores
+                res_array[process_number] += mgr._skippedTests
+                res_array[process_number + options.ncores] += mgr._failedTests
+                res_array[process_number + 2 * options.ncores] = min(
+                    int(reporter.reportStatus()), res_array[process_number + 2 * options.ncores]
+                )
+            finally:
+                # Unlock the data files even if the test module raises
+                with lock:
+                    for f in locked_files:
+                        locked_files_dict[f] = False
 
     # Report the errors
     local_dict = dict()

--- a/Testing/SystemTests/tests/framework/Diffraction_Workflow_Test.py
+++ b/Testing/SystemTests/tests/framework/Diffraction_Workflow_Test.py
@@ -21,6 +21,7 @@ from mantid.simpleapi import (
     CentroidPeaksMD,
     CopySample,
     ConvertToDiffractionMDWorkspace,
+    DeleteWorkspace,
     FindPeaksMD,
     FindUBUsingFFT,
     FindUBUsingLatticeParameters,
@@ -47,8 +48,8 @@ class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
         return True
 
     def requiredMemoryMB(self):
-        """Require about 4GB free"""
-        return 4000
+        """Require about 4.5GB free"""
+        return 4500
 
     def runTest(self):
         # raise tolerance to 1e-4
@@ -147,6 +148,7 @@ class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
             PeaksWorkspace=ws + "_peaksFFT",
             OutputWorkspace=ws + "_peaksFFT",
         )
+        DeleteWorkspace(ws + "_MD2")
         # Save for SHELX
         SaveHKL(InputWorkspace=ws + "_peaksFFT", Filename=savedir + "/" + ws + "FFT.hkl")
 
@@ -178,6 +180,7 @@ class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
             AlignedDim2="[0,0,L], -10, 10,  800",
             OutputWorkspace=ws + "_binned",
         )
+        DeleteWorkspace(ws + "_HKL")
 
         originalUB = numpy.array(mtd["TOPAZ_3132"].sample().getOrientedLattice().getUB())
         w = mtd["TOPAZ_3132"]
@@ -212,6 +215,7 @@ class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
             OutputBins="60,1,1",
             OutputWorkspace="TOPAZ_3132_HKL_line",
         )
+        DeleteWorkspace("TOPAZ_3132_HKL")
 
         # Now check the integrated bin and the peaks
         w = mtd["TOPAZ_3132_HKL_line"]
@@ -231,6 +235,7 @@ class Diffraction_Workflow_Test(systemtesting.MantidSystemTest):
             SplitThreshold="150",
         )
         FindPeaksMD(InputWorkspace="TOPAZ_3132_QSample", PeakDistanceThreshold="0.12", MaxPeaks="200", OutputWorkspace="peaks_QSample")
+        DeleteWorkspace("TOPAZ_3132_QSample")
         FindUBUsingFFT(PeaksWorkspace="peaks_QSample", MinD="2", MaxD="16")
         CopySample(
             InputWorkspace="peaks_QSample", OutputWorkspace="TOPAZ_3132", CopyName="0", CopyMaterial="0", CopyEnvironment="0", CopyShape="0"

--- a/Testing/SystemTests/tests/framework/ReduceOneSCD_Run.py
+++ b/Testing/SystemTests/tests/framework/ReduceOneSCD_Run.py
@@ -24,11 +24,12 @@ import platform
 import systemtesting
 
 import os
-from mantid.api import mtd, AnalysisDataService
+from mantid.api import mtd
 from mantid.simpleapi import (
     ConvertToDiffractionMDWorkspace,
     ConvertToMD,
     CreateSingleValuedWorkspace,
+    DeleteWorkspace,
     FindPeaksMD,
     FindUBUsingFFT,
     IndexPeaks,
@@ -64,8 +65,8 @@ class ReduceOneSCD_Run(systemtesting.MantidSystemTest):
         config["Q.convention"] = "Crystallography"
 
     def requiredMemoryMB(self):
-        """Require about 12GB free"""
-        return 6000
+        """Require about 3GB free"""
+        return 3000
 
     def runTest(self):
         start_time = time.time()
@@ -167,7 +168,8 @@ class ReduceOneSCD_Run(systemtesting.MantidSystemTest):
         distance_threshold = 0.9 * 6.28 / float(max_d)
         peaks_ws = FindPeaksMD(MDEW, MaxPeaks=num_peaks_to_find, PeakDistanceThreshold=distance_threshold)
 
-        AnalysisDataService.remove(MDEW.name())
+        DeleteWorkspace(MDEW)
+        del MDEW
         #      SaveIsawPeaks( InputWorkspace=peaks_ws, AppendFile=False,
         #               Filename='A'+run_niggli_integrate_file )
         #
@@ -233,6 +235,8 @@ class ReduceOneSCD_Run(systemtesting.MantidSystemTest):
                 PeaksWorkspace=peaks_ws,
                 IntegrateIfOnEdge=integrate_if_edge_peak,
             )
+            DeleteWorkspace(MDEW)
+            del MDEW
 
         elif use_fit_peaks_integration:
             event_ws = Rebin(InputWorkspace=event_ws, Params=rebin_params, PreserveEvents=preserve_events)

--- a/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
+++ b/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
@@ -168,10 +168,9 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
         if indexed < 199:
             raise Exception("Expected at least 199 of 200 peaks to be indexed. Only indexed %d!" % indexed)
 
-        # get new UB matrix and OrientedLattice so the EventWorkspace can be deleted
+        # get new UB matrix and OrientedLattice
         newUB = numpy.array(mtd["topaz_3132"].sample().getOrientedLattice().getUB())
         ol = mtd["topaz_3132"].sample().getOrientedLattice()
-        DeleteWorkspace("topaz_3132")  # no longer needed
 
         # Check the UB matrix
         self.assertDelta(ol.a(), unitcell_exp.a(), 0.01, "Correct lattice a value not found.")
@@ -182,7 +181,6 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
         self.assertDelta(ol.gamma(), unitcell_exp.gamma(), 0.4, "Correct lattice angle gamma value not found.")
 
         # Compare new and old UBs
-        newUB = numpy.array(mtd["topaz_3132"].sample().getOrientedLattice().getUB())
         # UB Matrices are not necessarily the same, some of the H,K and/or L sign can be reversed
         diff = abs(newUB) - abs(originalUB) < 0.001
         for c in range(3):
@@ -191,6 +189,7 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
                 raise Exception(
                     "More than 0.001 difference between UB matrices: Q (lab frame):\n%s\nQ (sample frame):\n%s" % (originalUB, newUB)
                 )
+        DeleteWorkspace("topaz_3132")  # no longer needed
 
     def doValidation(self):
         # If we reach here, no validation failed

--- a/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
+++ b/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
@@ -14,15 +14,24 @@ them.
 import systemtesting
 import numpy
 from mantid.api import mtd
-from mantid.simpleapi import BinMD, ConvertToDiffractionMDWorkspace, CopySample, FindPeaksMD, FindUBUsingFFT, IndexPeaks, LoadEventNexus
+from mantid.simpleapi import (
+    BinMD,
+    ConvertToDiffractionMDWorkspace,
+    CopySample,
+    DeleteWorkspace,
+    FindPeaksMD,
+    FindUBUsingFFT,
+    IndexPeaks,
+    LoadEventNexus,
+)
 from mantid.dataobjects import PeaksWorkspace, LeanElasticPeaksWorkspace
 from mantid.geometry import UnitCell
 
 
 class TOPAZPeakFinding(systemtesting.MantidSystemTest):
     def requiredMemoryMB(self):
-        """Require about 2GB free"""
-        return 2000
+        """Require about 3.5GB free"""
+        return 3500
 
     def runTest(self):
         unitcell_exp = UnitCell(4.714, 6.06, 10.40)  # orthorhombic
@@ -41,6 +50,7 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
         # Find peaks and UB matrix
         FindPeaksMD(InputWorkspace="topaz_3132_MD", PeakDistanceThreshold="0.12", MaxPeaks="200", OutputWorkspace="peaks")
         FindUBUsingFFT(PeaksWorkspace="peaks", MinD="2", MaxD="16")
+        DeleteWorkspace("topaz_3132_MD")  # no longer needed
 
         # Index the peaks and check
         results = IndexPeaks(PeaksWorkspace="peaks")
@@ -83,6 +93,7 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
             OutputBins="60,1,1",
             OutputWorkspace="topaz_3132_HKL_line",
         )
+        DeleteWorkspace("topaz_3132_HKL")  # no longer needed
 
         # Now check the integrated bin and the peaks
         w = mtd["topaz_3132_HKL_line"]
@@ -144,6 +155,7 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
             OutputWorkspace="peaks_QSample",
             OutputType="LeanElasticPeak",
         )
+        DeleteWorkspace("topaz_3132_QSample")  # no longer needed
         self.assertTrue(isinstance(mtd["peaks_QSample"], LeanElasticPeaksWorkspace))
         FindUBUsingFFT(PeaksWorkspace="peaks_QSample", MinD="2", MaxD="16")
         CopySample(
@@ -156,10 +168,12 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
         if indexed < 199:
             raise Exception("Expected at least 199 of 200 peaks to be indexed. Only indexed %d!" % indexed)
 
+        # get new UB matrix and OrientedLattice so the EventWorkspace can be deleted
+        newUB = numpy.array(mtd["topaz_3132"].sample().getOrientedLattice().getUB())
+        ol = mtd["topaz_3132"].sample().getOrientedLattice()
+        DeleteWorkspace("topaz_3132")  # no longer needed
+
         # Check the UB matrix
-        w = mtd["topaz_3132"]
-        s = w.sample()
-        ol = s.getOrientedLattice()
         self.assertDelta(ol.a(), unitcell_exp.a(), 0.01, "Correct lattice a value not found.")
         self.assertDelta(ol.b(), unitcell_exp.b(), 0.01, "Correct lattice b value not found.")
         self.assertDelta(ol.c(), unitcell_exp.c(), 0.01, "Correct lattice c value not found.")

--- a/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
+++ b/Testing/SystemTests/tests/framework/TOPAZPeakFinding.py
@@ -37,7 +37,7 @@ class TOPAZPeakFinding(systemtesting.MantidSystemTest):
         unitcell_exp = UnitCell(4.714, 6.06, 10.40)  # orthorhombic
 
         # Load then convert to Q in the lab frame
-        LoadEventNexus(Filename=r"TOPAZ_3132_event.nxs", OutputWorkspace="topaz_3132")
+        LoadEventNexus(Filename=r"TOPAZ_3132_event.nxs", OutputWorkspace="topaz_3132", BlockList="frequency")
         ConvertToDiffractionMDWorkspace(
             InputWorkspace="topaz_3132",
             OutputWorkspace="topaz_3132_MD",

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -192,7 +192,6 @@ class BaseSX(ABC):
         )
         BaseSX._normalise_by_bin_width_in_k(ws, undo=True)  # normalise by bin-width in K = 2pi/lambda
         mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws, Target=xunit, EnableLogging=False)
-        mantid.DeleteWorkspace("PreprocessedDetectorsWS")
         return wsMD
 
     @default_apply_to_all_runs


### PR DESCRIPTION
This has a couple of features:
1. Move lockfile deletion in `systesmtests.py` to a `finally` clause. This makes sure that even when an exception happens, the lockfiles blocking work are removed.
1. Reuse the `PreprocessedToDetectorsToMD` output between the two child algorithms. Also, delete the detector table at the end of the algorithm rather than leaving it in the ADS when it was never published as an output workspace. This does not change the behavior because it was originally created in a mode that ignores pre-existing tables.
2. Delete workspaces after they are no longer used in `Diffraction_Workflow_Test`, `ReduceOneSCD_Run`, and `TOPAZPeakFinding`. This helps because it finds peaks using 3 different methods and 3 different MD workspaces. As a side note, increase the minimum memory used based on what was observed.

Discovered while using mantidprofiler on the `TOPAZPeakFinding` systemtest. It saves ~1s per call and not a ton of memory, but every`little bit helps.

There is no associated issue.

### To test:

My original testing was done by running `TOPAZPeakFinding` through mantidprofiler before and after the changes. That shows clearly 3s faster and ~.5GB less peak memory. You're specific method can vary.

*This does not require release notes* because it is a non-functional change to make the code run a tiny bit faster, and the system test to take a bit less memory.

Assisted-by: GPT-5.4 GitHub Copilot <copilot@github.com>
Assisted-by: GPT-5.6 Codex <noreply@openai.com>

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
