### PR TITLE
Addresss Qt6 deprecated calls and other updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,10 +174,8 @@ if(ENABLE_WORKBENCH OR BUILD_MANTIDQT)
     # Only the legacy sip<=v4 PyQt5 path consumes these flags
     separate_arguments(PYQT5_SIP_FLAGS)
   endif()
-  # Disable use of C++ API deprecated before the given version. Use the same 5.15 baseline for both builds: under Qt6
-  # this keeps APIs deprecated in 6.x (e.g. QMouseEvent::pos(), QVariant::Type) available, so the migration can defer
-  # cleaning those up - only APIs actually *removed* in Qt6 must be fixed.
-  add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
+  # Disable use of C++ API deprecated before Qt 6.11.
+  add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060B00)
 endif()
 
 # Now add in all the components

--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -178,7 +178,6 @@ function(mtd_add_qt_target)
   endif()
   set_target_properties(${_target} PROPERTIES CXX_CLANG_TIDY "")
   _disable_suggest_override(${PARSED_QT_VERSION} ${_target})
-  _disable_deprecation_warnings(${PARSED_QT_VERSION} ${_target})
   # Use public headers to populate the INTERFACE_INCLUDE_DIRECTORIES target property
   target_include_directories(${_target} PUBLIC ${_ui_dir} ${_other_ui_dirs} ${PARSED_INCLUDE_DIRS})
   if(PARSED_SYSTEM_INCLUDE_DIRS)
@@ -303,7 +302,6 @@ function(mtd_add_qt_test_executable)
 
   # Warning suppression
   _disable_suggest_override(${PARSED_QT_VERSION} ${_target_name})
-  _disable_deprecation_warnings(${PARSED_QT_VERSION} ${_target_name})
 
   # libraries
   set(_link_libs ${PARSED_LINK_LIBS} ${_mtd_qt_libs})
@@ -406,16 +404,6 @@ function(_internal_qt_wrap_cpp qtversion moc_generated)
       ${${moc_generated}}
       PARENT_SCOPE
   )
-endfunction()
-
-# Silences -Wdeprecated-declarations for Qt6 GUI targets. The Qt5->Qt6 migration surfaces many warnings from Qt APIs
-# that were deprecated in Qt6 (QMouseEvent::x()/y(), QLocale::country(), QVariant::type(), ...). We suppress them only
-# for the Qt6 build so that Qt5 builds still report deprecations and Mantid's own deprecation markers are unaffected.
-# Note: the global -Wno-deprecated does not cover -Wdeprecated-declarations; they are independent gcc/clang flags.
-function(_disable_deprecation_warnings _qt_version _target)
-  if(_qt_version EQUAL 6 AND (CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
-    target_compile_options(${_target} PRIVATE -Wno-deprecated-declarations)
-  endif()
 endfunction()
 
 # Disables suggest override for versions of Qt < 5.6.2 as Q_OBJECT produces them and the cannot be avoided.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -57,7 +57,7 @@ QVariant Encoder::extractFromEncoding(const QVariant &vMap, const std::vector<st
   QVariantMap map;
   QVariant extract = vMap;
   for (auto &key : jsonKey) {
-    if (extract.type() == 8 && extract.canConvert(8)) { // 8 = map - is there an enum?
+    if (extract.typeId() == QMetaType::QVariantMap && extract.canConvert<QVariantMap>()) {
       map = extract.toMap();
       auto qKey = QString::fromStdString(key);
       if (map.contains(qKey)) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -57,7 +57,7 @@ QVariant Encoder::extractFromEncoding(const QVariant &vMap, const std::vector<st
   QVariantMap map;
   QVariant extract = vMap;
   for (auto &key : jsonKey) {
-    if (extract.typeId() == QMetaType::QVariantMap && extract.canConvert<QVariantMap>()) {
+    if (extract.typeId() == QMetaType::QVariantMap) {
       map = extract.toMap();
       auto qKey = QString::fromStdString(key);
       if (map.contains(qKey)) {

--- a/qt/scientific_interfaces/Indirect/Common/DetectorGroupingOptions.cpp
+++ b/qt/scientific_interfaces/Indirect/Common/DetectorGroupingOptions.cpp
@@ -25,7 +25,7 @@ static std::unordered_map<std::string, GroupingMethod> GROUPING_METHODS = {{"Ind
 DetectorGroupingOptions::DetectorGroupingOptions(QWidget *parent) : QWidget(parent) {
   m_uiForm.setupUi(parent);
 
-  connect(m_uiForm.cbGroupingOptions, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbGroupingOptions, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->handleGroupingMethodChanged(m_uiForm.cbGroupingOptions->itemText(index)); });
   connect(m_uiForm.pbSaveCustomGrouping, &QPushButton::clicked, this, &DetectorGroupingOptions::emitSaveCustomGrouping);
   QRegularExpression re("([0-9]+[-:+]?[0-9]*([+]?[0-9]*)*,[ ]?)*[0-9]+[-:+]?[0-9]*([+]?[0-9]*)*");

--- a/qt/scientific_interfaces/Indirect/Common/InstrumentConfig.cpp
+++ b/qt/scientific_interfaces/Indirect/Common/InstrumentConfig.cpp
@@ -316,7 +316,7 @@ void InstrumentConfig::updateReflectionsList(int index) {
   m_uiForm.cbReflection->clear();
 
   QVariant currentData = m_uiForm.cbAnalyser->itemData(index);
-  bool valid = currentData != QVariant::Invalid;
+  bool valid = currentData.isValid();
   m_uiForm.cbReflection->setEnabled(valid);
 
   if (valid) {

--- a/qt/scientific_interfaces/Indirect/Common/InstrumentConfig.cpp
+++ b/qt/scientific_interfaces/Indirect/Common/InstrumentConfig.cpp
@@ -35,9 +35,9 @@ InstrumentConfig::InstrumentConfig(QWidget *parent)
           &InstrumentConfig::filterDisabledInstruments);
   connect(m_instrumentSelector, &InstrumentSelector::instrumentSelectionChanged, this,
           &InstrumentConfig::updateInstrumentConfigurations);
-  connect(m_uiForm.cbAnalyser, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbAnalyser, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &InstrumentConfig::updateReflectionsList);
-  connect(m_uiForm.cbReflection, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbReflection, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &InstrumentConfig::newInstrumentConfiguration);
   m_instrumentSelector->fillWithInstrumentsFromFacility();
 }

--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -78,8 +78,8 @@ void DiffractionReduction::initLayout() {
   connectRunButtonValidation(m_uiForm.rfCanFiles);
   connectRunButtonValidation(m_uiForm.rfCalFile);
 
-  connect(m_uiForm.ckUseVanadium, &QCheckBox::stateChanged, this, &DiffractionReduction::useVanadiumStateChanged);
-  connect(m_uiForm.ckUseCalib, &QCheckBox::stateChanged, this, &DiffractionReduction::useCalibStateChanged);
+  connect(m_uiForm.ckUseVanadium, &QCheckBox::checkStateChanged, this, &DiffractionReduction::useVanadiumStateChanged);
+  connect(m_uiForm.ckUseCalib, &QCheckBox::checkStateChanged, this, &DiffractionReduction::useCalibStateChanged);
   m_valDbl = new QDoubleValidator(this);
 
   m_uiForm.leRebinStart->setValidator(m_valDbl);

--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -69,9 +69,9 @@ void DiffractionReduction::initLayout() {
   connect(m_uiForm.iicInstrumentConfiguration, &MantidWidgets::InstrumentConfig::instrumentConfigurationUpdated, this,
           &DiffractionReduction::instrumentSelected);
 
-  connect(m_uiForm.spSpecMin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spSpecMin, qOverload<int>(&QSpinBox::valueChanged), this,
           &DiffractionReduction::validateSpectrumMin);
-  connect(m_uiForm.spSpecMax, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spSpecMax, qOverload<int>(&QSpinBox::valueChanged), this,
           &DiffractionReduction::validateSpectrumMax);
   // Update run button based on state of raw files field
   connectRunButtonValidation(m_uiForm.rfSampleFiles);

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -146,7 +146,7 @@ private:
             SLOT(showMessageBox(const std::string &)));
 
     // Add to the cache
-    m_tabs[name] = qMakePair(tabWidget, tabIDRContent);
+    m_tabs[name] = std::make_pair(tabWidget, tabIDRContent);
 
     // Add all tabs to UI initially
     m_uiForm.twIDRTabs->addTab(tabWidget, QString::fromStdString(name));
@@ -186,7 +186,7 @@ private:
             SLOT(showMessageBox(const std::string &)));
 
     // Add to the cache
-    m_tabs[name] = qMakePair(tabWidget, presenter.get());
+    m_tabs[name] = std::make_pair(tabWidget, presenter.get());
     m_presenters[name] = std::move(presenter);
 
     // Add all tabs to UI initially
@@ -200,7 +200,7 @@ private:
   QString m_settingsGroup;
 
   // All indirect tabs - this should be removed when the interface is in MVP
-  QMap<std::string, QPair<QWidget *, DataReductionTab *>> m_tabs;
+  QMap<std::string, std::pair<QWidget *, DataReductionTab *>> m_tabs;
   /// A map to hold the presenter corresponding to each tab
   std::unordered_map<std::string, std::unique_ptr<DataReductionTab>> m_presenters;
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -123,8 +123,8 @@ bool IETView::showRebinWidthPrompt() const {
   const char *text = "The Binning width is currently negative, this suggests "
                      "you wish to use logarithmic binning.\n"
                      " Do you want to use Logarithmic Binning?";
-  int result = QMessageBox::question(nullptr, tr("Logarithmic Binning"), tr(text), QMessageBox::Yes, QMessageBox::No,
-                                     QMessageBox::NoButton);
+  int result = QMessageBox::question(nullptr, tr("Logarithmic Binning"), tr(text), QMessageBox::Yes | QMessageBox::No,
+                                     QMessageBox::Yes);
 
   return result == QMessageBox::Yes;
 }

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
@@ -24,7 +24,7 @@ MolDyn::MolDyn(QWidget *parent) : SimulationTab(parent) {
 
   connect(m_uiForm.ckCropEnergy, &QCheckBox::toggled, m_uiForm.dspMaxEnergy, &QDoubleSpinBox::setEnabled);
   connect(m_uiForm.ckResolution, &QCheckBox::toggled, m_uiForm.dsResolution, &DataSelector::setEnabled);
-  connect(m_uiForm.cbVersion, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbVersion, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->versionSelected(m_uiForm.cbVersion->itemText(index)); });
 
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &MolDyn::saveClicked);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
@@ -69,9 +69,9 @@ QuasiView::QuasiView(QWidget *parent)
   connect(m_uiForm.dsResolution, &DataSelector::dataReady, this, &QuasiView::notifyResolutionInputReady);
   connect(m_uiForm.dsResolution, &DataSelector::filesAutoLoaded, this, &QuasiView::notifyFileAutoLoaded);
 
-  connect(m_uiForm.cbProgram, static_cast<void (QComboBox::*)(int const)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbProgram, qOverload<int const>(&QComboBox::currentIndexChanged), this,
           &QuasiView::handleProgramChange);
-  connect(m_uiForm.spPreviewSpectrum, static_cast<void (QSpinBox::*)(int const)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPreviewSpectrum, qOverload<int const>(&QSpinBox::valueChanged), this,
           &QuasiView::notifyPreviewSpectrumChanged);
 
   connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &QuasiView::notifyPlotCurrentPreview);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/QuasiView.cpp
@@ -257,8 +257,8 @@ bool QuasiView::displaySaveDirectoryMessage() const {
                             " If run, the algorithm will default to saving files "
                             "to the current working directory."
                             " Would you still like to run the algorithm?";
-  return QMessageBox::question(nullptr, "Save Directory", textMessage, QMessageBox::Yes, QMessageBox::No,
-                               QMessageBox::NoButton) == QMessageBox::No;
+  return QMessageBox::question(nullptr, "Save Directory", textMessage, QMessageBox::Yes | QMessageBox::No,
+                               QMessageBox::Yes) == QMessageBox::No;
 }
 
 void QuasiView::setFileExtensionsByName(bool const filter) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormView.cpp
@@ -62,7 +62,7 @@ void ResNormView::setup() {
   connect(m_uiForm.dsResolution, &DataSelector::dataReady, this, &ResNormView::notifyResolutionInputReady);
 
   // Connect the preview spectrum selector
-  connect(m_uiForm.spPreviewSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPreviewSpectrum, qOverload<int>(&QSpinBox::valueChanged), this,
           &ResNormView::notifyPreviewSpecChanged);
   // Post Plot and Save
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ResNormView::notifySaveClicked);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
@@ -51,8 +51,7 @@ StretchView::StretchView(QWidget *parent)
 
   connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &StretchView::handleSampleInputReady);
 
-  connect(m_uiForm.spPreviewSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-          &StretchView::previewSpecChanged);
+  connect(m_uiForm.spPreviewSpectrum, qOverload<int>(&QSpinBox::valueChanged), this, &StretchView::previewSpecChanged);
   m_uiForm.spPreviewSpectrum->setMaximum(0);
 
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &StretchView::saveWorkspacesClicked);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/StretchView.cpp
@@ -273,8 +273,8 @@ bool StretchView::displaySaveDirectoryMessage() {
                             " If run, the algorithm will default to saving files "
                             "to the current working directory."
                             " Would you still like to run the algorithm?";
-  auto const response = QMessageBox::question(nullptr, tr("Save Directory"), tr(textMessage), QMessageBox::Yes,
-                                              QMessageBox::No, QMessageBox::NoButton);
+  auto const response = QMessageBox::question(nullptr, tr("Save Directory"), tr(textMessage),
+                                              QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   return response == QMessageBox::No;
 }
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -123,8 +123,8 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   // Change of input
 
   connect(m_uiForm.dsSampleInput, &DataSelector::dataReady, this,
-          static_cast<void (AbsorptionCorrections::*)(const QString &)>(&AbsorptionCorrections::getParameterDefaults));
-  connect(m_uiForm.cbShape, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          qOverload<const QString &>(&AbsorptionCorrections::getParameterDefaults));
+  connect(m_uiForm.cbShape, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &AbsorptionCorrections::handlePresetShapeChanges);
   // Handle algorithm completion
   connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
@@ -133,21 +133,21 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &AbsorptionCorrections::saveClicked);
   // Handle density units
 
-  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbSampleDensity, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->setSampleDensityUnit(m_uiForm.cbSampleDensity->itemText(index)); });
-  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbCanDensity, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->setCanDensityUnit(m_uiForm.cbCanDensity->itemText(index)); });
-  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbSampleDensity, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->setSampleDensityValue(m_uiForm.cbSampleDensity->itemText(index)); });
-  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbCanDensity, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->setCanDensityValue(m_uiForm.cbCanDensity->itemText(index)); });
-  connect(m_uiForm.cbSampleMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbSampleMaterialMethod, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &AbsorptionCorrections::changeSampleMaterialOptions);
-  connect(m_uiForm.cbCanMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbCanMaterialMethod, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &AbsorptionCorrections::changeCanMaterialOptions);
-  connect(m_uiForm.spSampleDensity, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spSampleDensity, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &AbsorptionCorrections::setSampleDensity);
-  connect(m_uiForm.spCanDensity, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spCanDensity, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &AbsorptionCorrections::setCanDensity);
 
   // Allows empty workspace selector when initially selected

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -40,11 +40,11 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
 
   connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newSample);
   connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newContainer);
-  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPreviewSpec, qOverload<int>(&QSpinBox::valueChanged), this,
           &ApplyAbsorptionCorrections::plotPreview);
-  connect(m_uiForm.spCanScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spCanScale, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &ApplyAbsorptionCorrections::updateContainer);
-  connect(m_uiForm.spCanShift, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spCanShift, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &ApplyAbsorptionCorrections::updateContainer);
   connect(m_uiForm.ckShiftCan, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);
   connect(m_uiForm.ckScaleCan, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -249,8 +249,8 @@ void ApplyAbsorptionCorrections::handleRun() {
       const char *text = "Binning on sample and container does not match."
                          "Would you like to enable rebinning of the container?";
 
-      int result = QMessageBox::question(nullptr, tr("Rebin sample?"), tr(text), QMessageBox::Yes, QMessageBox::No,
-                                         QMessageBox::NoButton);
+      int result = QMessageBox::question(nullptr, tr("Rebin sample?"), tr(text), QMessageBox::Yes | QMessageBox::No,
+                                         QMessageBox::Yes);
 
       if (result == QMessageBox::Yes) {
         m_uiForm.ckRebinContainer->setChecked(true);
@@ -295,8 +295,9 @@ void ApplyAbsorptionCorrections::handleRun() {
                            "Would you like to interpolate this workspace to "
                            "match the sample?";
 
-        result = QMessageBox::question(nullptr, tr("Interpolate corrections?"), tr(text.c_str()), QMessageBox::YesToAll,
-                                       QMessageBox::Yes, QMessageBox::No);
+        result =
+            QMessageBox::question(nullptr, tr("Interpolate corrections?"), tr(text.c_str()),
+                                  QMessageBox::YesToAll | QMessageBox::Yes | QMessageBox::No, QMessageBox::YesToAll);
       }
 
       switch (result) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionView.cpp
@@ -21,13 +21,13 @@ ContainerSubtractionView::ContainerSubtractionView(QWidget *parent) : QWidget(pa
 
   connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ContainerSubtractionView::notifySampleDataReady);
   connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ContainerSubtractionView::notifyCanDataReady);
-  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPreviewSpec, qOverload<int>(&QSpinBox::valueChanged), this,
           &ContainerSubtractionView::notifySpectraIncreaseClicked);
   connect(m_uiForm.ckShiftCan, &QCheckBox::toggled, m_uiForm.spShift, &QDoubleSpinBox::setEnabled);
   connect(m_uiForm.ckScaleCan, &QCheckBox::toggled, m_uiForm.spCanScale, &QDoubleSpinBox::setEnabled);
-  connect(m_uiForm.spCanScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spCanScale, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &ContainerSubtractionView::notifyUpdateCan);
-  connect(m_uiForm.spShift, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spShift, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &ContainerSubtractionView::notifyUpdateCan);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ContainerSubtractionView::notifySaveClicked);
   connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &ContainerSubtractionView::notifyPreviewClicked);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtractionView.cpp
@@ -117,8 +117,8 @@ bool ContainerSubtractionView::requestRebinToSample() {
   const char *text = "Binning on sample and container does not match."
                      "Would you like to rebin the container to match the sample?";
 
-  const int result = QMessageBox::question(this, tr("Rebin container?"), tr(text), QMessageBox::Yes, QMessageBox::No,
-                                           QMessageBox::NoButton);
+  const int result = QMessageBox::question(this, tr("Rebin container?"), tr(text), QMessageBox::Yes | QMessageBox::No,
+                                           QMessageBox::Yes);
 
   return result == QMessageBox::Yes;
 }

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -113,7 +113,7 @@ void ElwinView::setup() {
   connect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
           &ElwinView::notifySelectedSpectrumChanged);
 
-  connect(m_uiForm.ckCollapse, &QCheckBox::stateChanged, this, &ElwinView::notifyRowModeChanged);
+  connect(m_uiForm.ckCollapse, &QCheckBox::checkStateChanged, this, &ElwinView::notifyRowModeChanged);
 
   // Handle plot and save
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ElwinView::notifySaveClicked);

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -95,7 +95,7 @@ void ElwinView::setup() {
   backgroundRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
   connect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
-          static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
+          qOverload<double, double>(&RangeSelector::setRange));
   connect(backgroundRangeSelector, &RangeSelector::minValueChanged, this, &ElwinView::notifyMinChanged);
   connect(backgroundRangeSelector, &RangeSelector::maxValueChanged, this, &ElwinView::notifyMaxChanged);
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ElwinView::notifyDoubleValueChanged);
@@ -106,11 +106,11 @@ void ElwinView::setup() {
   connect(m_uiForm.wkspRemove, &QPushButton::clicked, this, &ElwinView::notifyRemoveDataClicked);
   connect(m_uiForm.pbSelAll, &QPushButton::clicked, this, &ElwinView::notifySelectAllClicked);
 
-  connect(m_uiForm.cbPreviewFile, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbPreviewFile, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &ElwinView::notifyPreviewIndexChanged);
-  connect(m_uiForm.spPlotSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPlotSpectrum, qOverload<int>(&QSpinBox::valueChanged), this,
           &ElwinView::notifySelectedSpectrumChanged);
-  connect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbPlotSpectrum, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &ElwinView::notifySelectedSpectrumChanged);
 
   connect(m_uiForm.ckCollapse, &QCheckBox::checkStateChanged, this, &ElwinView::notifyRowModeChanged);
@@ -272,11 +272,11 @@ void ElwinView::notifyCheckboxValueChanged(QtProperty *prop, bool enabled) {
     m_properties["BackgroundEnd"]->setEnabled(enabled);
 
     disconnect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
-               static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
+               qOverload<double, double>(&RangeSelector::setRange));
     if (!enabled) {
       backgroundRangeSelector->setRange(integrationRangeSelector->getRange());
       connect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
-              static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
+              qOverload<double, double>(&RangeSelector::setRange));
     }
   }
 }
@@ -427,7 +427,7 @@ void ElwinView::setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maxim
 
 void ElwinView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
                                     const std::vector<WorkspaceIndex>::const_iterator &to) {
-  disconnect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  disconnect(m_uiForm.cbPlotSpectrum, qOverload<int>(&QComboBox::currentIndexChanged), this,
              &ElwinView::notifySelectedSpectrumChanged);
   m_uiForm.elwinPreviewSpec->setCurrentIndex(1);
   m_uiForm.cbPlotSpectrum->clear();
@@ -437,7 +437,7 @@ void ElwinView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_ite
 
   m_uiForm.cbPlotSpectrum->setCurrentIndex(0);
 
-  connect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_uiForm.cbPlotSpectrum, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &ElwinView::notifySelectedSpectrumChanged);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -9,7 +9,6 @@
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
-#include <QPair>
 #include <QStringList>
 
 #include <memory>

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -144,14 +144,13 @@ void IqtView::setup() {
   // signals / slots & validators
   connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &IqtView::notifySampDataReady);
   connect(m_uiForm.dsResolution, &DataSelector::dataReady, this, &IqtView::notifyResDataReady);
-  connect(m_uiForm.spIterations, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-          &IqtView::notifyIterationsChanged);
+  connect(m_uiForm.spIterations, qOverload<int>(&QSpinBox::valueChanged), this, &IqtView::notifyIterationsChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &IqtView::notifySaveClicked);
   connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &IqtView::notifyPlotCurrentPreview);
   connect(m_uiForm.cbCalculateErrors, &QCheckBox::checkStateChanged, this, &IqtView::notifyErrorsClicked);
   connect(m_uiForm.enEnforceNormalization, &QCheckBox::checkStateChanged, this,
           &IqtView::notifyEnableNormalizationClicked);
-  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_uiForm.spPreviewSpec, qOverload<int>(&QSpinBox::valueChanged), this,
           &IqtView::notifyPreviewSpectrumChanged);
   connect(m_uiForm.ckSymmetricEnergy, &QCheckBox::checkStateChanged, this, &IqtView::notifyUpdateEnergyRange);
   connect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -148,11 +148,12 @@ void IqtView::setup() {
           &IqtView::notifyIterationsChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &IqtView::notifySaveClicked);
   connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &IqtView::notifyPlotCurrentPreview);
-  connect(m_uiForm.cbCalculateErrors, &QCheckBox::stateChanged, this, &IqtView::notifyErrorsClicked);
-  connect(m_uiForm.enEnforceNormalization, &QCheckBox::stateChanged, this, &IqtView::notifyEnableNormalizationClicked);
+  connect(m_uiForm.cbCalculateErrors, &QCheckBox::checkStateChanged, this, &IqtView::notifyErrorsClicked);
+  connect(m_uiForm.enEnforceNormalization, &QCheckBox::checkStateChanged, this,
+          &IqtView::notifyEnableNormalizationClicked);
   connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
           &IqtView::notifyPreviewSpectrumChanged);
-  connect(m_uiForm.ckSymmetricEnergy, &QCheckBox::stateChanged, this, &IqtView::notifyUpdateEnergyRange);
+  connect(m_uiForm.ckSymmetricEnergy, &QCheckBox::checkStateChanged, this, &IqtView::notifyUpdateEnergyRange);
   connect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyValueChanged);

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -36,7 +36,7 @@ MomentsView::MomentsView(QWidget *parent) : QWidget(parent), m_presenter() {
 
   connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &MomentsView::notifyDataReady);
   connect(m_uiForm.ckScale, &QCheckBox::checkStateChanged, this, &MomentsView::notifyScaleChanged);
-  connect(m_uiForm.spScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+  connect(m_uiForm.spScale, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           &MomentsView::notifyScaleValueChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &MomentsView::notifySaveClicked);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -35,7 +35,7 @@ MomentsView::MomentsView(QWidget *parent) : QWidget(parent), m_presenter() {
   MantidWidgets::RangeSelector *xRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("XRange");
 
   connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &MomentsView::notifyDataReady);
-  connect(m_uiForm.ckScale, &QCheckBox::stateChanged, this, &MomentsView::notifyScaleChanged);
+  connect(m_uiForm.ckScale, &QCheckBox::checkStateChanged, this, &MomentsView::notifyScaleChanged);
   connect(m_uiForm.spScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
           &MomentsView::notifyScaleValueChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &MomentsView::notifySaveClicked);

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -39,18 +39,12 @@ SqwView::SqwView(QWidget *parent) : QWidget(parent), m_presenter() {
   m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
 
   connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &SqwView::notifyDataReady);
-  connect(m_uiForm.spQLow, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyQLowChanged);
-  connect(m_uiForm.spQWidth, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyQWidthChanged);
-  connect(m_uiForm.spQHigh, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyQHighChanged);
-  connect(m_uiForm.spELow, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyELowChanged);
-  connect(m_uiForm.spEWidth, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyEWidthChanged);
-  connect(m_uiForm.spEHigh, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
-          &SqwView::notifyEHighChanged);
+  connect(m_uiForm.spQLow, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyQLowChanged);
+  connect(m_uiForm.spQWidth, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyQWidthChanged);
+  connect(m_uiForm.spQHigh, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyQHighChanged);
+  connect(m_uiForm.spELow, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyELowChanged);
+  connect(m_uiForm.spEWidth, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyEWidthChanged);
+  connect(m_uiForm.spEHigh, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SqwView::notifyEHighChanged);
   connect(m_uiForm.ckRebinInEnergy, &QCheckBox::checkStateChanged, this, &SqwView::notifyRebinEChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &SqwView::notifySaveClicked);
   // Allows empty workspace selector when initially selected

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -51,7 +51,7 @@ SqwView::SqwView(QWidget *parent) : QWidget(parent), m_presenter() {
           &SqwView::notifyEWidthChanged);
   connect(m_uiForm.spEHigh, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
           &SqwView::notifyEHighChanged);
-  connect(m_uiForm.ckRebinInEnergy, &QCheckBox::stateChanged, this, &SqwView::notifyRebinEChanged);
+  connect(m_uiForm.ckRebinInEnergy, &QCheckBox::checkStateChanged, this, &SqwView::notifyRebinEChanged);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &SqwView::notifySaveClicked);
   // Allows empty workspace selector when initially selected
   m_uiForm.dsInput->isOptional(true);

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -224,14 +224,14 @@ void SymmetriseView::resetEDefaults(bool isPositive, std::pair<double, double> r
   auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
 
   // Set Selector range boundaries
-  auto rangeReflect = isPositive ? qMakePair(0.0, range.second) : qMakePair(range.first, 0.0);
+  auto rangeReflect = isPositive ? std::make_pair(0.0, range.second) : std::make_pair(range.first, 0.0);
   rangeESelector->setBounds(rangeReflect.first, rangeReflect.second);
   m_dblManager->setRange(m_properties["Ehigh"], rangeReflect.first, rangeReflect.second);
   m_dblManager->setRange(m_properties["Elow"], rangeReflect.first, rangeReflect.second);
 
   // Set Initial selector range values
-  auto rangeInitial =
-      isPositive ? qMakePair(0.1 * range.second, 0.9 * range.second) : qMakePair(0.9 * range.first, 0.1 * range.first);
+  auto rangeInitial = isPositive ? std::make_pair(0.1 * range.second, 0.9 * range.second)
+                                 : std::make_pair(0.9 * range.first, 0.1 * range.first);
   rangeESelector->setRange(rangeInitial.first, rangeInitial.second);
   m_dblManager->setValue(m_properties["Ehigh"], rangeInitial.second);
   m_dblManager->setValue(m_properties["Elow"], rangeInitial.first);
@@ -247,7 +247,7 @@ void SymmetriseView::resetEDefaults(bool isPositive, std::pair<double, double> r
 bool SymmetriseView::verifyERange(std::string const &workspaceName) {
   MatrixWorkspace_sptr sampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
   auto axisRange = getXRangeFromWorkspace(sampleWS);
-  auto Erange = qMakePair(getElow(), getEhigh());
+  auto Erange = std::make_pair(getElow(), getEhigh());
 
   bool const reflectType = m_enumManager->value(m_properties["ReflectType"]);
   if ((reflectType == 0) && (Erange.first > abs(axisRange.first))) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
@@ -29,7 +29,7 @@ ConvolutionAddWorkspaceDialog::ConvolutionAddWorkspaceDialog(QWidget *parent) : 
   setAllSpectraSelectionEnabled(false);
 
   connect(m_uiForm.dsWorkspace, &DataSelector::dataReady, this, &ConvolutionAddWorkspaceDialog::workspaceChanged);
-  connect(m_uiForm.ckAllSpectra, &QCheckBox::stateChanged, this, &ConvolutionAddWorkspaceDialog::selectAllSpectra);
+  connect(m_uiForm.ckAllSpectra, &QCheckBox::checkStateChanged, this, &ConvolutionAddWorkspaceDialog::selectAllSpectra);
   connect(m_uiForm.pbAdd, &QPushButton::clicked, this, &ConvolutionAddWorkspaceDialog::emitAddData);
   connect(m_uiForm.pbClose, &QPushButton::clicked, this, &ConvolutionAddWorkspaceDialog::close);
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
@@ -17,7 +17,7 @@ FitOutputOptionsView::FitOutputOptionsView(QWidget *parent)
       m_presenter() {
   m_outputOptions->setupUi(this);
 
-  connect(m_outputOptions->cbGroupWorkspace, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_outputOptions->cbGroupWorkspace, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->notifyGroupWorkspaceChanged(m_outputOptions->cbGroupWorkspace->itemText(index)); });
   connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
   connect(m_outputOptions->pbSave, &QPushButton::clicked, this, &FitOutputOptionsView::notifySaveClicked);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
@@ -41,7 +41,7 @@ FitPlotView::FitPlotView(QWidget *parent)
           &FitPlotView::notifyDelayedPlotSpectrumChanged);
   connect(m_plotForm->cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           [=](int index) { this->notifyPlotSpectrumChanged(m_plotForm->cbPlotSpectrum->itemText(index)); });
-  connect(m_plotForm->ckPlotGuess, &QCheckBox::stateChanged, this, &FitPlotView::notifyPlotGuessChanged);
+  connect(m_plotForm->ckPlotGuess, &QCheckBox::checkStateChanged, this, &FitPlotView::notifyPlotGuessChanged);
   connect(m_plotForm->pbPlotPreview, &QPushButton::clicked, this, &FitPlotView::notifyPlotCurrentPreview);
   connect(m_plotForm->pbFitSingle, &QPushButton::clicked, this, &FitPlotView::notifyFitSelectedSpectrum);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
@@ -35,11 +35,11 @@ FitPlotView::FitPlotView(QWidget *parent)
     : API::MantidWidget(parent), m_plotForm(new Ui::FitPreviewPlot), m_presenter() {
   m_plotForm->setupUi(this);
 
-  connect(m_plotForm->cbDataSelection, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_plotForm->cbDataSelection, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &FitPlotView::notifySelectedFitDataChanged);
-  connect(m_plotForm->spPlotSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_plotForm->spPlotSpectrum, qOverload<int>(&QSpinBox::valueChanged), this,
           &FitPlotView::notifyDelayedPlotSpectrumChanged);
-  connect(m_plotForm->cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_plotForm->cbPlotSpectrum, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->notifyPlotSpectrumChanged(m_plotForm->cbPlotSpectrum->itemText(index)); });
   connect(m_plotForm->ckPlotGuess, &QCheckBox::checkStateChanged, this, &FitPlotView::notifyPlotGuessChanged);
   connect(m_plotForm->pbPlotPreview, &QPushButton::clicked, this, &FitPlotView::notifyPlotCurrentPreview);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.h
@@ -20,7 +20,6 @@
 
 #include <QList>
 #include <QMap>
-#include <QPair>
 #include <QString>
 #include <QWidget>
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
@@ -21,7 +21,7 @@ FunctionQAddWorkspaceDialog::FunctionQAddWorkspaceDialog(QWidget *parent) : QDia
           &FunctionQAddWorkspaceDialog::emitWorkspaceChanged);
   connect(m_uiForm.dsWorkspace, &MantidWidgets::DataSelector::filesAutoLoaded, this,
           &FunctionQAddWorkspaceDialog::handleAutoLoaded);
-  connect(m_uiForm.cbParameterType, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+  connect(m_uiForm.cbParameterType, qOverload<int>(&QComboBox::currentIndexChanged),
           [=](int index) { this->emitParameterTypeChanged(m_uiForm.cbParameterType->itemText(index)); });
   connect(m_uiForm.pbAdd, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::emitAddData);
   connect(m_uiForm.pbClose, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::close);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.h
@@ -19,7 +19,6 @@
 
 #include <QDockWidget>
 #include <QList>
-#include <QPair>
 #include <QString>
 
 #include <optional>

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -278,7 +278,7 @@ const char *WidgetAutoSaver::changedSignal(QWidget *widget) {
  * @param enabled :: Whether auto-saving should be enabled or disabled
  */
 void WidgetAutoSaver::setAutoSaveEnabled(bool enabled) {
-  foreach (QWidget *w, m_registeredWidgets) {
+  for (QWidget *w : m_registeredWidgets) {
     setAutoSaveEnabled(w, enabled);
   }
 }
@@ -353,7 +353,7 @@ void WidgetAutoSaver::loadWidgetValue(QWidget *widget) {
  * Load the auto-saved (or default) value of all the registered widgets.
  */
 void WidgetAutoSaver::loadWidgetValues() {
-  foreach (QWidget *w, m_registeredWidgets) {
+  for (QWidget *w : m_registeredWidgets) {
     loadWidgetValue(w);
   }
 }

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
@@ -16,8 +16,8 @@
 
 #include <QDoubleValidator>
 #include <QLineEdit>
+#include <QList>
 #include <QSettings>
-#include <QVector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -171,7 +171,7 @@ private:
   const char *changedSignal(QWidget *widget);
 
   /// A list of all the registered widgets
-  QVector<QWidget *> m_registeredWidgets;
+  QList<QWidget *> m_registeredWidgets;
 
   /// Names of registered widgets
   QMap<QWidget *, QString> m_widgetNames;

--- a/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
+++ b/qt/scientific_interfaces/Muon/MuonSequentialFitDialog.cpp
@@ -278,7 +278,7 @@ void MuonSequentialFitDialog::updateInputEnabled(DialogState newState) {
   m_ui.runs->setEnabled(enabled);
   m_ui.labelInput->setEnabled(enabled);
 
-  foreach (QAbstractButton *button, m_ui.paramTypeGroup->buttons())
+  for (QAbstractButton *button : m_ui.paramTypeGroup->buttons())
     button->setEnabled(enabled);
 }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
@@ -312,10 +312,10 @@ protected:
   QStringList m_noValidation;
 
   /// Store a list of the names of input workspace boxes
-  QVector<QWidget *> m_inputws_opts;
+  QList<QWidget *> m_inputws_opts;
 
   /// Store a list of output workspace text edits
-  QVector<QLineEdit *> m_outputws_fields;
+  QList<QLineEdit *> m_outputws_fields;
 
   /// A map to keep track of replace workspace button presses
   QHash<QPushButton *, int> m_wsbtn_tracker;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmInputHistory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmInputHistory.h
@@ -30,7 +30,7 @@ public:
 
   /// Update the old values that are stored here. Only valid
   /// values are stored here
-  void storeNewValue(const QString &algName, const QPair<QString, QString> &property);
+  void storeNewValue(const QString &algName, const std::pair<QString, QString> &property);
 
   /// Clear values for a particular algorithm
   void clearAlgorithmInput(const QString &algName);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -184,7 +184,7 @@ public:
   /// Get the excluded range for the fit
   std::string getExcludeRange() const;
   /// Get the X limits of the workspace
-  QVector<double> getXRange();
+  QList<double> getXRange();
 
   /// Get the function as a string
   std::string getFunctionString() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionBrowser.h
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <QList>
-#include <QPair>
 #include <QString>
 
 namespace MantidQt {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionModel.h
@@ -13,7 +13,6 @@
 #include "MantidAPI/ITableWorkspace_fwd.h"
 
 #include <QList>
-#include <QPair>
 #include <QString>
 #include <QStringList>
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InputController.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InputController.h
@@ -41,7 +41,9 @@ public:
   ~InputController() override = default;
 
   virtual void mousePressEvent(QMouseEvent * /*unused*/) {}
-  virtual void mouseMoveEvent(QMouseEvent *event) { emit touchPointAt(event->x(), event->y()); }
+  virtual void mouseMoveEvent(QMouseEvent *event) {
+    emit touchPointAt(event->position().toPoint().x(), event->position().toPoint().y());
+  }
   virtual void mouseReleaseEvent(QMouseEvent * /*unused*/) {}
   virtual void wheelEvent(QWheelEvent * /*unused*/) {}
   virtual void keyPressEvent(QKeyEvent * /*unused*/) {}

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
@@ -46,7 +46,7 @@ std::string EXPORT_OPT_MANTIDQT_COMMON optionsToString(std::map<std::string, std
 QStringList EXPORT_OPT_MANTIDQT_COMMON stdVectorToQStringList(std::vector<std::string> const &vec);
 std::vector<std::string> EXPORT_OPT_MANTIDQT_COMMON qStringListToStdVector(QStringList const &qList);
 std::vector<std::string> EXPORT_OPT_MANTIDQT_COMMON qListToStdVector(QList<std::string> const &qList);
-QVector<QString> EXPORT_OPT_MANTIDQT_COMMON convertStdStringVector(const std::vector<std::string> &stringVec);
+QList<QString> EXPORT_OPT_MANTIDQT_COMMON convertStdStringVector(const std::vector<std::string> &stringVec);
 
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyWidget.h
@@ -156,7 +156,7 @@ protected:
   QPushButton *m_replaceWSButton;
 
   /// All contained widgets
-  QVector<QWidget *> m_widgets;
+  QList<QWidget *> m_widgets;
 
   /// Last modified value
   QString m_lastValue;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
@@ -34,15 +34,8 @@ template <typename T> T *extract(const Object &obj) {
   sipapi->api_transfer_to(obj.ptr(), 0);
   // reinterpret to sipWrapper
   auto wrapper = reinterpret_cast<sipSimpleWrapper *>(obj.ptr());
-// PyQt6's sip.h does not define SIP_API_MAJOR_NR, but its sip ABI (>=13) provides
-// api_get_address, so select that path for Qt6 explicitly.
-#if (SIP_API_MAJOR_NR == 8 && SIP_API_MINOR_NR >= 1) || SIP_API_MAJOR_NR > 8 || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  // PyQt6's sip ABI (>=13) provides api_get_address.
   return static_cast<T *>(sipapi->api_get_address(wrapper));
-#elif SIP_API_MAJOR_NR == 8
-  return static_cast<T *>(wrapper->data);
-#else
-  return static_cast<T *>(wrapper->u.cppPtr);
-#endif
 }
 
 /**

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QStringUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QStringUtils.h
@@ -20,8 +20,8 @@ namespace API {
  */
 inline QString toQStringInternal(const wchar_t *str) {
   return sizeof(wchar_t) == sizeof(QChar)
-             ? QString::fromUtf16(reinterpret_cast<const ushort *>(str), static_cast<int>(wcslen(str)))
-             : QString::fromUcs4(reinterpret_cast<const uint *>(str), static_cast<int>(wcslen(str)));
+             ? QString::fromUtf16(reinterpret_cast<const char16_t *>(str), static_cast<int>(wcslen(str)))
+             : QString::fromUcs4(reinterpret_cast<const char32_t *>(str), static_cast<int>(wcslen(str)));
 }
 
 /**
@@ -33,8 +33,8 @@ inline QString toQStringInternal(const wchar_t *str) {
  */
 inline QString toQStringInternal(const std::wstring &str) {
   return sizeof(wchar_t) == sizeof(QChar)
-             ? QString::fromUtf16(reinterpret_cast<const ushort *>(str.data()), static_cast<int>(str.size()))
-             : QString::fromUcs4(reinterpret_cast<const uint *>(str.data()), static_cast<int>(str.size()));
+             ? QString::fromUtf16(reinterpret_cast<const char16_t *>(str.data()), static_cast<int>(str.size()))
+             : QString::fromUcs4(reinterpret_cast<const char32_t *>(str.data()), static_cast<int>(str.size()));
 }
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtvariantproperty.h
@@ -282,7 +282,7 @@ public:
   QMap<int, QtAbstractPropertyManager *> m_typeToPropertyManager;
   QMap<int, QMap<QString, int>> m_typeToAttributeToAttributeType;
 
-  QMap<const QtProperty *, QPair<QtVariantProperty *, int>> m_propertyToType;
+  QMap<const QtProperty *, std::pair<QtVariantProperty *, int>> m_propertyToType;
 
   QMap<int, int> m_typeToValueType;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
@@ -92,7 +92,7 @@ template <typename TYPE> void UserSubWindowFactoryImpl::subscribe() {
   // Make a record of each interface's categories.
   const QStringList interfaceCategories = TYPE::categoryInfo().split(";", Qt::SkipEmptyParts);
   QSet<QString> result;
-  foreach (const QString &category, interfaceCategories) {
+  for (const QString &category : interfaceCategories) {
     result.insert(category.trimmed());
   }
   m_categoryLookup[QString::fromStdString(realName)] = result;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -244,12 +244,7 @@ private:
   /// Keep a map of renamed workspaces between updates
   QHash<QString, QString> m_renameMap;
   /// A mutex to lock m_renameMap and m_selectedNames for reading/writing
-  /// QMutex::Recursive was removed in Qt6 in favour of the dedicated QRecursiveMutex
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   mutable QRecursiveMutex m_mutex;
-#else
-  mutable QMutex m_mutex;
-#endif
 
 private slots:
   void handleUpdateTree(const TopLevelItems & /*items*/);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
@@ -10,9 +10,9 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "QPair"
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -165,7 +165,7 @@ void AlgorithmDialog::saveInput() {
       QString pName = *pitr;
       // normalize default (or default-derived) values to empty string.
       QString value = p->isDefault() || p->isDynamicDefault() ? "" : m_propertyValueMap.value(pName);
-      AlgorithmInputHistory::Instance().storeNewValue(m_algName, QPair<QString, QString>(pName, value));
+      AlgorithmInputHistory::Instance().storeNewValue(m_algName, std::pair<QString, QString>(pName, value));
     }
   }
 }

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -27,6 +27,7 @@
 #include <QMessageBox>
 #include <QTemporaryFile>
 #include <QTextStream>
+#include <QTimeZone>
 
 #include <cstdio>
 #include <fstream>
@@ -72,7 +73,7 @@ AlgExecSummaryGrpBox::AlgExecSummaryGrpBox(const QString &title, QWidget *w)
   if (m_execDurationlabel)
     m_execDurationlabel->setBuddy(m_execDurationEdit);
 
-  QDateTime datetime(QDate(0, 0, 0), QTime(0, 0, 0), Qt::LocalTime);
+  QDateTime datetime(QDate(0, 0, 0), QTime(0, 0, 0), QTimeZone(QTimeZone::LocalTime));
   m_execDateTimeEdit = new QLineEdit("", this);
   if (m_execDateTimeEdit)
     m_execDateTimeEdit->setReadOnly(true);
@@ -118,7 +119,7 @@ void AlgExecSummaryGrpBox::setData(const double execDuration, const Mantid::Type
   std::tm t = execDate.to_localtime_tm();
   QTime qt(t.tm_hour, t.tm_min, t.tm_sec);
   QDate qd(t.tm_year + 1900, t.tm_mon + 1, t.tm_mday);
-  QDateTime datetime(qd, qt, Qt::LocalTime);
+  QDateTime datetime(qd, qt, QTimeZone(QTimeZone::LocalTime));
 
   QString str("");
   str = datetime.toString("dd/MM/yyyy hh:mm:ss");

--- a/qt/widgets/common/src/AlgorithmInputHistory.cpp
+++ b/qt/widgets/common/src/AlgorithmInputHistory.cpp
@@ -45,7 +45,7 @@ AbstractAlgorithmInputHistory::~AbstractAlgorithmInputHistory() {
  * @param algName :: The name of the algorithm
  * @param property :: A pair containing <name,value> of a property
  */
-void AbstractAlgorithmInputHistory::storeNewValue(const QString &algName, const QPair<QString, QString> &property) {
+void AbstractAlgorithmInputHistory::storeNewValue(const QString &algName, const std::pair<QString, QString> &property) {
   m_lastInput[algName][property.first] = property.second;
 }
 

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -460,7 +460,7 @@ void AlgorithmPropertiesWidget::saveInput() {
       QString value = (prop->isDefault() || prop->isDynamicDefault() ? "" : widget->getValue());
 
       // save the value
-      m_inputHistory->storeNewValue(m_algoName, QPair<QString, QString>(propName, value));
+      m_inputHistory->storeNewValue(m_algoName, std::pair<QString, QString>(propName, value));
     }
   }
 }

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -677,19 +677,19 @@ QString FileFinderWidget::createFileFilter() {
     // The list may contain upper and lower cased versions, ensure these are on
     // the same line
     // I want this ordered
-    QList<QPair<QString, QStringList>> finalIndex;
+    QList<std::pair<QString, QStringList>> finalIndex;
     QStringListIterator sitr(fileExts);
     QString ext = sitr.next();
-    finalIndex.append(qMakePair(ext.toUpper(), QStringList(ext)));
+    finalIndex.append(std::make_pair(ext.toUpper(), QStringList(ext)));
     while (sitr.hasNext()) {
       ext = sitr.next();
       QString key = ext.toUpper();
       const auto it = std::find_if(finalIndex.begin(), finalIndex.end(),
-                                   [&key](const QPair<QString, QStringList> &pair) { return pair.first == key; });
+                                   [&key](const std::pair<QString, QStringList> &pair) { return pair.first == key; });
       if (it != finalIndex.end()) {
         it->second.append(ext);
       } else {
-        finalIndex.append(qMakePair(key, QStringList(ext)));
+        finalIndex.append(std::make_pair(key, QStringList(ext)));
       }
     }
 
@@ -700,7 +700,7 @@ QString FileFinderWidget::createFileFilter() {
     QString individualFiles("");
 
     if (extsAsSingleOption()) {
-      QListIterator<QPair<QString, QStringList>> itr(finalIndex);
+      QListIterator<std::pair<QString, QStringList>> itr(finalIndex);
       while (itr.hasNext()) {
         const QStringList values = itr.next().second;
 
@@ -712,7 +712,7 @@ QString FileFinderWidget::createFileFilter() {
       dataFiles.chop(1); // Remove last space
       dataFiles += ");;";
     } else {
-      QListIterator<QPair<QString, QStringList>> itr(finalIndex);
+      QListIterator<std::pair<QString, QStringList>> itr(finalIndex);
       while (itr.hasNext()) {
         const QStringList values = itr.next().second;
         dataFiles += "*" + values.join(" *") + ";;";

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -352,7 +352,7 @@ void FitOptionsBrowser::updateMinimizer() {
 
   // Remove properties of the old minimizer
   auto subProperties = m_minimizerGroup->subProperties();
-  foreach (QtProperty *prop, subProperties) {
+  for (QtProperty *prop : subProperties) {
     if (prop != m_minimizer) {
       m_minimizerGroup->removeSubProperty(prop);
       removeProperty(prop->propertyName());
@@ -388,10 +388,10 @@ void FitOptionsBrowser::switchFitType() {
  * Show normal Fit properties and hide the others.
  */
 void FitOptionsBrowser::displayNormalFitProperties() {
-  foreach (QtProperty *prop, m_simultaneousProperties) {
+  for (QtProperty *prop : m_simultaneousProperties) {
     m_browser->addProperty(prop);
   }
-  foreach (QtProperty *prop, m_sequentialProperties) {
+  for (QtProperty *prop : m_sequentialProperties) {
     m_browser->removeProperty(prop);
   }
   emit changedToSimultaneousFitting();
@@ -502,7 +502,7 @@ QString FitOptionsBrowser::getMinimizer(QtProperty * /*unused*/) const {
 
   auto subProperties = m_minimizerGroup->subProperties();
   if (subProperties.size() > 1) {
-    foreach (const QtProperty *prop, subProperties) {
+    for (const QtProperty *prop : subProperties) {
       if (prop == m_minimizer)
         continue;
       if (prop->propertyManager() == m_stringManager) {
@@ -524,7 +524,7 @@ QString FitOptionsBrowser::getMinimizer(QtProperty * /*unused*/) const {
                                    prop->propertyName().toStdString());
         }
       }
-    } // foreach
+    } // for
   }
   return minimStr;
 }
@@ -802,10 +802,10 @@ bool FitOptionsBrowser::addPropertyToBlacklist(const QString &name) {
  * Show sequential fit (PlotPeakByLogValue) properties and hide the others.
  */
 void FitOptionsBrowser::displaySequentialFitProperties() {
-  foreach (QtProperty *prop, m_sequentialProperties) {
+  for (QtProperty *prop : m_sequentialProperties) {
     m_browser->addProperty(prop);
   }
-  foreach (QtProperty *prop, m_simultaneousProperties) {
+  for (QtProperty *prop : m_simultaneousProperties) {
     m_browser->removeProperty(prop);
   }
   emit changedToSequentialFitting();

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1946,11 +1946,11 @@ void FitPropertyBrowser::setXRange(double start, double end) {
   connect(m_doubleManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(doubleChanged(QtProperty *)));
 }
 
-QVector<double> FitPropertyBrowser::getXRange() {
+QList<double> FitPropertyBrowser::getXRange() {
   auto ws = getWorkspace();
   auto tbl = std::dynamic_pointer_cast<ITableWorkspace>(ws);
   auto mws = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
-  QVector<double> range;
+  QList<double> range;
   if (tbl) {
     auto xColumnIndex = m_columnManager->value(m_xColumn);
     std::vector<double> xColumnData;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1149,7 +1149,7 @@ std::string FitPropertyBrowser::minimizer(bool withProperties) const {
   QString minimStr = m_minimizers[i];
   // append minimizer properties as name=value pairs
   if (withProperties) {
-    foreach (const QtProperty *const prop, m_minimizerProperties) {
+    for (const QtProperty *const prop : m_minimizerProperties) {
       if (prop->propertyManager() == m_stringManager) {
         QString value = m_stringManager->value(prop);
         if (!value.isEmpty()) {
@@ -2094,7 +2094,7 @@ void FitPropertyBrowser::clear() {
 
 void FitPropertyBrowser::clearBrowser() {
   QList<QtProperty *> props = m_functionsGroup->property()->subProperties();
-  foreach (QtProperty *prop, props) {
+  for (QtProperty *prop : props) {
     m_functionsGroup->property()->removeSubProperty(prop);
   }
 }
@@ -2676,7 +2676,7 @@ void FitPropertyBrowser::addAutoBackground() {
     return;
   if (!m_autoBgAttributes.isEmpty()) { // set attributes
     QStringList attList = m_autoBgAttributes.split(' ');
-    foreach (const QString &att, attList) {
+    for (const QString &att : attList) {
       QStringList name_value = att.split('=');
       if (name_value.size() == 2) {
         QString name = name_value[0].trimmed();
@@ -2793,7 +2793,7 @@ void FitPropertyBrowser::updateDecimals() {
     m_decimals = settings.value("decimals", 6).toInt();
   }
   QSet<QtProperty *> props = m_doubleManager->properties();
-  foreach (QtProperty *prop, props) {
+  for (QtProperty *prop : props) {
     m_doubleManager->setDecimals(prop, m_decimals);
   }
 }
@@ -2905,7 +2905,7 @@ void FitPropertyBrowser::processMultiBGResults() {
   // other colomns - the parameters
   Mantid::API::ITableWorkspace_sptr table = Mantid::API::WorkspaceFactory::Instance().createTable("TableWorkspace");
   table->addColumn("int", "Index");
-  foreach (const QString &par, parNames) {
+  for (const QString &par : parNames) {
     table->addColumn("double", par.toStdString());
   }
   // Create WorkspaceGroup with the fit results
@@ -3116,7 +3116,7 @@ void FitPropertyBrowser::columnChanged(QtProperty *prop) {
  */
 void FitPropertyBrowser::minimizerChanged() {
   // delete old minimizer properties
-  foreach (QtProperty *prop, m_minimizerProperties) {
+  for (QtProperty *prop : m_minimizerProperties) {
     m_settingsGroup->property()->removeSubProperty(prop);
   }
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2570,10 +2570,11 @@ void FitPropertyBrowser::saveFunction(const QString &fnName) {
   QSettings settings;
   settings.beginGroup("Mantid/FitBrowser/SavedFunctions");
   QStringList names = settings.childKeys();
-  if (names.contains(fnName) && QMessageBox::question(this, "Mantid - Question",
-                                                      "Function with this name already exists.\n"
-                                                      "Would you like to replace it?",
-                                                      QMessageBox::Yes) != QMessageBox::Yes) {
+  if (names.contains(fnName) &&
+      QMessageBox::question(this, "Mantid - Question",
+                            "Function with this name already exists.\n"
+                            "Would you like to replace it?",
+                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
     return;
   }
   settings.setValue(fnName, QString::fromStdString(theFunction()->asString()));

--- a/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp
@@ -159,7 +159,7 @@ QPersistentModelIndex FitScriptGeneratorDataTable::hoveredRowIndex(QEvent *event
   auto index = m_lastHoveredIndex;
   auto const eventType = event->type();
   if (eventType == QEvent::HoverMove)
-    index = QPersistentModelIndex(this->indexAt(static_cast<QHoverEvent *>(event)->pos()));
+    index = QPersistentModelIndex(this->indexAt(static_cast<QHoverEvent *>(event)->position().toPoint()));
   else if (eventType == QEvent::Leave)
     index = QPersistentModelIndex(QModelIndex());
 

--- a/qt/widgets/common/src/FlowLayout.cpp
+++ b/qt/widgets/common/src/FlowLayout.cpp
@@ -104,7 +104,7 @@ QSize FlowLayout::sizeHint() const { return minimumSize(); }
 
 QSize FlowLayout::minimumSize() const {
   QSize size;
-  foreach (QLayoutItem *item, itemList)
+  for (QLayoutItem *item : itemList)
     size = size.expandedTo(item->minimumSize());
 
   const QMargins margins = contentsMargins();

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -332,7 +332,7 @@ void FunctionTreeView::removeProperty(QtProperty *prop) {
 
   // remove references to the children
   auto children = prop->subProperties();
-  foreach (QtProperty *child, children) {
+  for (QtProperty *child : children) {
     removeProperty(child);
   }
   m_properties.erase(p);
@@ -428,7 +428,7 @@ FunctionTreeView::AProperty FunctionTreeView::addParameterProperty(QtProperty *p
  */
 void FunctionTreeView::setFunction(QtProperty *prop, const Mantid::API::IFunction_sptr &fun) {
   auto children = prop->subProperties();
-  foreach (QtProperty *child, children) {
+  for (QtProperty *child : children) {
     removeProperty(child);
   }
   // m_localParameterValues.clear();
@@ -808,7 +808,7 @@ void FunctionTreeView::updateFunctionIndices(QtProperty *prop, std::string const
   }
   auto children = prop->subProperties();
   size_t i = 0;
-  foreach (QtProperty *child, children) {
+  for (QtProperty *child : children) {
     if (isFunction(child)) {
       updateFunctionIndices(child, index + "f" + std::to_string(i) + ".");
       ++i;
@@ -1355,7 +1355,7 @@ Mantid::API::IFunction_sptr FunctionTreeView::getFunction(QtProperty *prop, bool
   auto cf = std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);
   if (cf) {
     auto children = prop->subProperties();
-    foreach (QtProperty *child, children) {
+    for (QtProperty *child : children) {
       if (isFunction(child)) {
         auto f = getFunction(child);
         // if f is null ignore that function
@@ -1369,7 +1369,7 @@ Mantid::API::IFunction_sptr FunctionTreeView::getFunction(QtProperty *prop, bool
   } else {
     // loop over the children properties and set parameters and attributes
     auto children = prop->subProperties();
-    foreach (QtProperty *child, children) {
+    for (QtProperty *child : children) {
       if (isAttribute(child)) {
         setAttributeToFunction(*fun, child);
       } else if (!attributesOnly && isParameter(child)) {
@@ -1399,7 +1399,7 @@ Mantid::API::IFunction_sptr FunctionTreeView::getFunction(QtProperty *prop, bool
       }
     }
     // remove failed ties from the browser
-    foreach (QtProperty *p, failedTies) {
+    for (QtProperty *p : failedTies) {
       removeProperty(p);
     }
   }
@@ -1806,7 +1806,7 @@ void FunctionTreeView::addConstraints50() {
 
 void FunctionTreeView::removeConstraintsQuiet(QtProperty *prop) {
   auto props = prop->subProperties();
-  foreach (QtProperty *p, props) {
+  for (QtProperty *p : props) {
     if (isConstraint(p)) {
       removeProperty(p);
     }

--- a/qt/widgets/common/src/InputController.cpp
+++ b/qt/widgets/common/src/InputController.cpp
@@ -372,7 +372,7 @@ void InputControllerSelection::drawCursor(QPixmap *cursor) {
   auto size = cursorSize();
 
   auto pen = QPen(Qt::DashLine);
-  QVector<qreal> dashPattern;
+  QList<qreal> dashPattern;
   dashPattern << 4 << 4;
   pen.setDashPattern(dashPattern);
   pen.setColor(QColor(0, 0, 0));
@@ -435,7 +435,7 @@ void InputControllerDrawAndErase::drawCursor(QPixmap *cursor) {
   auto poly = m_rect.translated(-bRect.topLeft());
 
   auto pen = QPen(Qt::DashLine);
-  QVector<qreal> dashPattern;
+  QList<qreal> dashPattern;
   qreal dashLength = cursorSize() < 10 ? 1 : 2;
   dashPattern << dashLength << dashLength;
   pen.setDashPattern(dashPattern);

--- a/qt/widgets/common/src/InputController.cpp
+++ b/qt/widgets/common/src/InputController.cpp
@@ -36,13 +36,13 @@ InputController3DMove::InputController3DMove(QObject *parent)
  */
 void InputController3DMove::mousePressEvent(QMouseEvent *event) {
   if (event->buttons() & Qt::MiddleButton) {
-    emit initZoom(event->x(), event->y());
+    emit initZoom(event->position().toPoint().x(), event->position().toPoint().y());
     m_isButtonPressed = true;
   } else if ((event->buttons() & Qt::LeftButton) && !m_isRotationFrozen) {
-    emit initRotation(event->x(), event->y());
+    emit initRotation(event->position().toPoint().x(), event->position().toPoint().y());
     m_isButtonPressed = true;
   } else if ((event->buttons() & Qt::RightButton) || ((event->buttons() & Qt::LeftButton) && m_isRotationFrozen)) {
-    emit initTranslation(event->x(), event->y());
+    emit initTranslation(event->position().toPoint().x(), event->position().toPoint().y());
     m_isButtonPressed = true;
   }
 }
@@ -53,11 +53,11 @@ void InputController3DMove::mousePressEvent(QMouseEvent *event) {
  */
 void InputController3DMove::mouseMoveEvent(QMouseEvent *event) {
   if ((event->buttons() & Qt::LeftButton) && !m_isRotationFrozen) {
-    emit rotate(event->x(), event->y());
+    emit rotate(event->position().toPoint().x(), event->position().toPoint().y());
   } else if ((event->buttons() & Qt::RightButton) || ((event->buttons() & Qt::LeftButton) && m_isRotationFrozen)) {
-    emit translate(event->x(), event->y());
+    emit translate(event->position().toPoint().x(), event->position().toPoint().y());
   } else if (event->buttons() & Qt::MiddleButton) {
-    emit zoom(event->x(), event->y());
+    emit zoom(event->position().toPoint().x(), event->position().toPoint().y());
   }
   InputController::mouseMoveEvent(event);
 }
@@ -96,8 +96,8 @@ InputControllerPick::InputControllerPick(QObject *parent) : InputController(pare
 void InputControllerPick::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton) {
     m_isButtonPressed = true;
-    m_rect.setRect(event->x(), event->y(), 1, 1);
-    emit pickPointAt(event->x(), event->y());
+    m_rect.setRect(event->position().toPoint().x(), event->position().toPoint().y(), 1, 1);
+    emit pickPointAt(event->position().toPoint().x(), event->position().toPoint().y());
   }
 }
 
@@ -106,10 +106,10 @@ void InputControllerPick::mousePressEvent(QMouseEvent *event) {
  */
 void InputControllerPick::mouseMoveEvent(QMouseEvent *event) {
   if (m_isButtonPressed) {
-    m_rect.setBottomRight(QPoint(event->x(), event->y()));
+    m_rect.setBottomRight(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
     emit setSelection(m_rect);
   } else {
-    emit touchPointAt(event->x(), event->y());
+    emit touchPointAt(event->position().toPoint().x(), event->position().toPoint().y());
   }
 }
 
@@ -136,15 +136,16 @@ void InputControllerDrawShape::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton) {
     m_isButtonPressed = true;
     if (m_creating && !m_shapeType.isEmpty()) {
-      emit addShape(m_shapeType, event->x(), event->y(), m_borderColor, m_fillColor);
+      emit addShape(m_shapeType, event->position().toPoint().x(), event->position().toPoint().y(), m_borderColor,
+                    m_fillColor);
     } else if (event->modifiers() & Qt::ControlModifier) {
-      emit selectCtrlAt(event->x(), event->y());
+      emit selectCtrlAt(event->position().toPoint().x(), event->position().toPoint().y());
     } else {
-      emit selectAt(event->x(), event->y());
+      emit selectAt(event->position().toPoint().x(), event->position().toPoint().y());
     }
-    m_x = event->x();
-    m_y = event->y();
-    m_rect.setRect(event->x(), event->y(), 1, 1);
+    m_x = event->position().toPoint().x();
+    m_y = event->position().toPoint().y();
+    m_rect.setRect(event->position().toPoint().x(), event->position().toPoint().y(), 1, 1);
   }
 }
 
@@ -155,16 +156,16 @@ void InputControllerDrawShape::mousePressEvent(QMouseEvent *event) {
 void InputControllerDrawShape::mouseMoveEvent(QMouseEvent *event) {
   if (m_isButtonPressed) {
     if (m_creating) {
-      emit moveRightBottomTo(event->x(), event->y());
+      emit moveRightBottomTo(event->position().toPoint().x(), event->position().toPoint().y());
     } else {
-      emit moveBy(event->x() - m_x, event->y() - m_y);
-      m_rect.setBottomRight(QPoint(event->x(), event->y()));
-      m_x = event->x();
-      m_y = event->y();
+      emit moveBy(event->position().toPoint().x() - m_x, event->position().toPoint().y() - m_y);
+      m_rect.setBottomRight(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
+      m_x = event->position().toPoint().x();
+      m_y = event->position().toPoint().y();
       emit setSelection(m_rect);
     }
   } else {
-    emit touchPointAt(event->x(), event->y());
+    emit touchPointAt(event->position().toPoint().x(), event->position().toPoint().y());
   }
 }
 
@@ -237,7 +238,7 @@ InputControllerMoveUnwrapped::InputControllerMoveUnwrapped(QObject *parent)
 void InputControllerMoveUnwrapped::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton || event->button() == Qt::RightButton) {
     m_isButtonPressed = true;
-    m_rect.setTopLeft(QPoint(event->x(), event->y()));
+    m_rect.setTopLeft(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
   }
 }
 
@@ -246,7 +247,7 @@ void InputControllerMoveUnwrapped::mousePressEvent(QMouseEvent *event) {
  */
 void InputControllerMoveUnwrapped::mouseMoveEvent(QMouseEvent *event) {
   if (m_isButtonPressed) {
-    m_rect.setBottomRight(QPoint(event->x(), event->y()));
+    m_rect.setBottomRight(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
     emit setSelectionRect(m_rect);
   }
   InputController::mouseMoveEvent(event);
@@ -285,7 +286,7 @@ InputControllerDraw::~InputControllerDraw() { delete m_cursor; }
  */
 void InputControllerDraw::mousePressEvent(QMouseEvent *event) {
   m_isActive = true;
-  setPosition(QPoint(event->x(), event->y()));
+  setPosition(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
   if (event->button() == Qt::LeftButton) {
     m_isLeftButtonPressed = true;
     signalLeftClick();
@@ -300,7 +301,7 @@ void InputControllerDraw::mousePressEvent(QMouseEvent *event) {
  */
 void InputControllerDraw::mouseMoveEvent(QMouseEvent *event) {
   m_isActive = true;
-  setPosition(QPoint(event->x(), event->y()));
+  setPosition(QPoint(event->position().toPoint().x(), event->position().toPoint().y()));
   if (m_isLeftButtonPressed) {
     signalLeftClick();
   } else if (m_isRightButtonPressed) {

--- a/qt/widgets/common/src/MantidTreeWidget.cpp
+++ b/qt/widgets/common/src/MantidTreeWidget.cpp
@@ -147,7 +147,7 @@ void MantidTreeWidget::mouseDoubleClickEvent(QMouseEvent *e) {
 QStringList MantidTreeWidget::getSelectedWorkspaceNames() const {
   QStringList names;
 
-  foreach (const auto selectedItem, this->selectedItems()) {
+  for (const auto selectedItem : this->selectedItems()) {
     if (selectedItem)
       names.append(selectedItem->text(0));
   }
@@ -168,7 +168,7 @@ QList<MatrixWorkspace_const_sptr> MantidTreeWidget::getSelectedMatrixWorkspaces(
   // We preserve the order, but use a set to avoid adding duplicate workspaces.
   std::set<QString> selectedWsNameSet;
   std::vector<QString> selectedWsNameList;
-  foreach (const QString &wsName, this->getSelectedWorkspaceNames()) {
+  for (const QString &wsName : this->getSelectedWorkspaceNames()) {
     const auto groupWs = std::dynamic_pointer_cast<const WorkspaceGroup>(m_ads.retrieve(wsName.toStdString()));
     if (groupWs) {
       const auto childWsNames = groupWs->getNames();
@@ -215,7 +215,7 @@ MantidWSIndexWidget::UserInput MantidTreeWidget::chooseSpectrumFromSelected(bool
                                                                             bool showTiledOpt, bool isAdvanced) const {
   auto selectedMatrixWsList = getSelectedMatrixWorkspaces();
   QList<QString> selectedMatrixWsNameList;
-  foreach (const auto matrixWs, selectedMatrixWsList) {
+  for (const auto &matrixWs : selectedMatrixWsList) {
     selectedMatrixWsNameList.append(QString::fromStdString(matrixWs->getName()));
   }
 
@@ -233,7 +233,7 @@ MantidWSIndexWidget::UserInput MantidTreeWidget::chooseSpectrumFromSelected(bool
   if (plotImmediately) {
     const std::set<int> SINGLE_SPECTRUM = {0};
     QMultiMap<QString, std::set<int>> spectrumToPlot;
-    foreach (const auto selectedMatrixWs, selectedMatrixWsList) {
+    for (const auto &selectedMatrixWs : selectedMatrixWsList) {
       spectrumToPlot.insert(QString::fromStdString(selectedMatrixWs->getName()), SINGLE_SPECTRUM);
     }
     // and get simple 1D plot done

--- a/qt/widgets/common/src/MantidTreeWidget.cpp
+++ b/qt/widgets/common/src/MantidTreeWidget.cpp
@@ -187,7 +187,7 @@ QList<MatrixWorkspace_const_sptr> MantidTreeWidget::getSelectedMatrixWorkspaces(
   // Get the names of, and pointers to, the MatrixWorkspaces only.
   QList<MatrixWorkspace_const_sptr> selectedMatrixWsList;
   QList<QString> selectedMatrixWsNameList;
-  foreach (const auto &selectedWsName, selectedWsNameList) {
+  for (const auto &selectedWsName : selectedWsNameList) {
     const auto matrixWs =
         std::dynamic_pointer_cast<const MatrixWorkspace>(m_ads.retrieve(selectedWsName.toStdString()));
     if (matrixWs) {

--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -303,8 +303,8 @@ std::vector<std::string> qListToStdVector(QList<std::string> const &qList) {
  * @param stringVec The standard vector of standard strings to convert.
  * @return          A QVector of QStrings.
  */
-QVector<QString> convertStdStringVector(const std::vector<std::string> &stringVec) {
-  QVector<QString> resultVec;
+QList<QString> convertStdStringVector(const std::vector<std::string> &stringVec) {
+  QList<QString> resultVec;
   resultVec.reserve(boost::numeric_cast<int>(stringVec.size()));
   std::transform(stringVec.cbegin(), stringVec.cend(), std::back_inserter(resultVec),
                  [](const auto &str) { return QString::fromStdString(str); });

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -890,7 +890,10 @@ void PropertyHandler::setAttribute(QString const &attName, AttributeType const &
     try {
       m_fun->setAttribute(attName.toStdString(), Mantid::API::IFunction::Attribute(attValue));
       m_browser->compositeFunction()->checkFunction();
-      foreach (const QtProperty *prop, m_attributes) {
+      // Iterate over a copy: initAttributes()/initParameters() rebuild m_attributes,
+      // which would invalidate iteration over the member list directly.
+      const auto attributes = m_attributes;
+      for (const QtProperty *prop : attributes) {
         if (prop->propertyName() == attName) {
           // re-insert the attribute and parameter properties as they may
           // depend on the value of the attribute being set
@@ -921,7 +924,7 @@ void PropertyHandler::setAttribute(const QString &attName, const QString &attVal
     att.fromString(attValue.toStdString());
     m_fun->setAttribute(name, att);
     m_browser->compositeFunction()->checkFunction();
-    foreach (QtProperty *prop, m_attributes) {
+    for (QtProperty *prop : m_attributes) {
       if (prop->propertyName() == attName) {
         SetAttributeProperty tmp(m_browser, prop);
         att.apply(tmp);
@@ -939,7 +942,7 @@ void PropertyHandler::setAttribute(const QString &attName, const QString &attVal
  * @param prop :: A property for a member of a vector attribute.
  */
 void PropertyHandler::setVectorAttribute(QtProperty *prop) {
-  foreach (QtProperty *att, m_attributes) {
+  for (QtProperty *att : m_attributes) {
     QList<QtProperty *> subProps = att->subProperties();
     if (subProps.contains(prop)) {
       bool resetProperties = m_vectorSizes.contains(prop);
@@ -1070,7 +1073,7 @@ Mantid::API::IFunction_sptr PropertyHandler::changeType(QtProperty *prop) {
     }
 
     QList<QtProperty *> subs = m_item->property()->subProperties();
-    foreach (QtProperty *sub, subs) {
+    for (QtProperty *sub : subs) {
       m_item->property()->removeSubProperty(sub);
     }
 
@@ -1615,7 +1618,7 @@ void PropertyHandler::updateWorkspaces(const QStringList &oldWorkspaces) {
       wsName = oldWorkspaces[index];
     }
     QStringList names("All");
-    foreach (const QString &name, m_browser->m_workspaceNames) {
+    for (const QString &name : m_browser->m_workspaceNames) {
       names.append(name);
     }
     m_browser->m_enumManager->setEnumNames(m_workspace, names);

--- a/qt/widgets/common/src/PropertyWidget.cpp
+++ b/qt/widgets/common/src/PropertyWidget.cpp
@@ -213,13 +213,13 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent, 
   // `addLayout` sets parent of `infoWidget` correctly
   m_gridLayout->addWidget(infoWidget, m_row, 4);
 
-  QMap<Info, QPair<QString, QString>> pathsAndToolTips;
+  QMap<Info, std::pair<QString, QString>> pathsAndToolTips;
   pathsAndToolTips[RESTORE] =
-      QPair<QString, QString>(":/history.png", "This property had a previously-entered value.  Click "
-                                               "to toggle it off and on.");
-  pathsAndToolTips[REPLACE] =
-      QPair<QString, QString>(":/replace.png", "A workspace with this name already exists and so will be overwritten.");
-  pathsAndToolTips[INVALID] = QPair<QString, QString>(":/invalid.png", "");
+      std::pair<QString, QString>(":/history.png", "This property had a previously-entered value.  Click "
+                                                   "to toggle it off and on.");
+  pathsAndToolTips[REPLACE] = std::pair<QString, QString>(
+      ":/replace.png", "A workspace with this name already exists and so will be overwritten.");
+  pathsAndToolTips[INVALID] = std::pair<QString, QString>(":/invalid.png", "");
 
   std::vector<Info> labelOrder = {RESTORE, REPLACE, INVALID};
 

--- a/qt/widgets/common/src/Python/Sip.cpp
+++ b/qt/widgets/common/src/Python/Sip.cpp
@@ -18,11 +18,7 @@ const sipAPIDef *sipAPI() {
     return sip_API;
 
   // Some configs have a private sip module inside PyQt. Try this first
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  sip_API = static_cast<const sipAPIDef *>(PyCapsule_Import("PyQt5.sip._C_API", 0));
-#else
   sip_API = static_cast<const sipAPIDef *>(PyCapsule_Import("PyQt6.sip._C_API", 0));
-#endif
   // Try plain sip module
   if (!sip_API) {
     PyErr_Clear();

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -80,7 +80,7 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
 
 std::string outputJsonToString(QVariant &v) {
   QJsonDocument doc;
-  if (v.typeId() == QMetaType::QVariantMap && v.canConvert<QVariantMap>()) {
+  if (v.typeId() == QMetaType::QVariantMap) {
     QVariantMap map = v.toMap();
     doc = QJsonDocument{QJsonObject::fromVariantMap(map)};
   } else if (v.canConvert<QString>()) {

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -80,7 +80,7 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
 
 std::string outputJsonToString(QVariant &v) {
   QJsonDocument doc;
-  if (v.type() == 8 && v.canConvert(8)) { // 8 = map - is there an enum?
+  if (v.typeId() == QMetaType::QVariantMap && v.canConvert<QVariantMap>()) {
     QVariantMap map = v.toMap();
     doc = QJsonDocument{QJsonObject::fromVariantMap(map)};
   } else if (v.canConvert<QString>()) {

--- a/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/ParameterPropertyManager.cpp
@@ -115,7 +115,7 @@ void ParameterPropertyManager::clearErrors() {
 void ParameterPropertyManager::setErrorsEnabled(bool enabled) {
   m_errorsEnabled = enabled;
   cleanUpErrors();
-  foreach (QtProperty *prop, m_errors.keys()) {
+  for (QtProperty *prop : m_errors.keys()) {
     // updateTooltip(prop) emits propertyChanged(prop)
     updateTooltip(prop);
   }

--- a/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp
@@ -1246,7 +1246,7 @@ void QtCharEdit::handleKeyEvent(QKeyEvent *e) {
   }
 
   const QString text = e->text();
-  if (text.count() != 1)
+  if (text.size() != 1)
     return;
 
   const QChar c = text.at(0);

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
@@ -340,10 +340,10 @@ void QtKeySequenceEdit::handleKeyEvent(QKeyEvent *e) {
     return;
 
   nextKey |= translateModifiers(e->modifiers(), e->text());
-  int k0 = m_keySequence[0];
-  int k1 = m_keySequence[1];
-  int k2 = m_keySequence[2];
-  int k3 = m_keySequence[3];
+  int k0 = m_keySequence[0].toCombined();
+  int k1 = m_keySequence[1].toCombined();
+  int k2 = m_keySequence[2].toCombined();
+  int k3 = m_keySequence[3].toCombined();
   switch (m_num) {
   case 0:
     k0 = nextKey;

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -4926,11 +4926,7 @@ void QtFontPropertyManager::setValue(QtProperty *property, const QFont &val) {
     return;
 
   const QFont oldVal = it.value();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   if (oldVal == val && oldVal.resolveMask() == val.resolveMask())
-#else
-  if (oldVal == val && oldVal.resolve() == val.resolve())
-#endif
     return;
 
   it.value() = val;

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -149,7 +149,7 @@ static QList<QLocale::Country> sortCountries(const QList<QLocale::Country> &coun
   QListIterator<QLocale::Country> itCountry(countries);
   while (itCountry.hasNext()) {
     QLocale::Country country = itCountry.next();
-    nameToCountry.insert(QLocale::countryToString(country), country);
+    nameToCountry.insert(QLocale::territoryToString(country), country);
   }
   return nameToCountry.values();
 }
@@ -171,9 +171,13 @@ void QtMetaEnumProvider::initLocale() {
   QListIterator<QLocale::Language> itLang(languages);
   for (const auto language : languages) {
     QList<QLocale::Country> countries;
-    countries = QLocale::countriesForLanguage(language);
+    const auto localesForLanguage = QLocale::matchingLocales(language, QLocale::AnyScript, QLocale::AnyTerritory);
+    for (const QLocale &locale : localesForLanguage) {
+      if (!countries.contains(locale.territory()))
+        countries << locale.territory();
+    }
     if (countries.isEmpty() && language == system.language())
-      countries << system.country();
+      countries << system.territory();
 
     if (!countries.isEmpty() && !m_languageToIndex.contains(language)) {
       countries = sortCountries(countries);
@@ -185,7 +189,7 @@ void QtMetaEnumProvider::initLocale() {
       int countryIdx = 0;
       while (it.hasNext()) {
         QLocale::Country country = it.next();
-        countryNames << QLocale::countryToString(country);
+        countryNames << QLocale::territoryToString(country);
         m_indexToCountry[langIdx][countryIdx] = country;
         m_countryToIndex[language][country] = countryIdx;
         ++countryIdx;
@@ -1802,14 +1806,14 @@ void QtLocalePropertyManagerPrivate::slotEnumChanged(const QtProperty *property,
   if (QtProperty *prop = m_languageToProperty.value(property, 0)) {
     const QLocale loc = m_values[prop];
     QLocale::Language newLanguage = loc.language();
-    QLocale::Country newCountry = loc.country();
+    QLocale::Country newCountry = loc.territory();
     metaEnumProvider()->indexToLocale(value, 0, &newLanguage, nullptr);
     QLocale newLoc(newLanguage, newCountry);
     q_ptr->setValue(prop, newLoc);
   } else if (QtProperty *prop = m_countryToProperty.value(property, 0)) {
     const QLocale loc = m_values[prop];
     QLocale::Language newLanguage = loc.language();
-    QLocale::Country newCountry = loc.country();
+    QLocale::Country newCountry = loc.territory();
     metaEnumProvider()->indexToLocale(m_enumPropertyManager->value(m_propertyToLanguage.value(prop)), value,
                                       &newLanguage, &newCountry);
     QLocale newLoc(newLanguage, newCountry);
@@ -1919,7 +1923,7 @@ QString QtLocalePropertyManager::valueText(const QtProperty *property) const {
 
   int langIdx = 0;
   int countryIdx = 0;
-  metaEnumProvider()->localeToIndex(loc.language(), loc.country(), &langIdx, &countryIdx);
+  metaEnumProvider()->localeToIndex(loc.language(), loc.territory(), &langIdx, &countryIdx);
   QString str = tr("%1, %2")
                     .arg(metaEnumProvider()->languageEnumNames().at(langIdx))
                     .arg(metaEnumProvider()->countryEnumNames(loc.language()).at(countryIdx));
@@ -1948,7 +1952,7 @@ void QtLocalePropertyManager::setValue(QtProperty *property, const QLocale &val)
 
   int langIdx = 0;
   int countryIdx = 0;
-  metaEnumProvider()->localeToIndex(val.language(), val.country(), &langIdx, &countryIdx);
+  metaEnumProvider()->localeToIndex(val.language(), val.territory(), &langIdx, &countryIdx);
   if (loc.language() != val.language()) {
     d_ptr->m_enumPropertyManager->setValue(d_ptr->m_propertyToLanguage.value(property), langIdx);
     d_ptr->m_enumPropertyManager->setEnumNames(d_ptr->m_propertyToCountry.value(property),
@@ -1969,7 +1973,7 @@ void QtLocalePropertyManager::initializeProperty(QtProperty *property) {
 
   int langIdx = 0;
   int countryIdx = 0;
-  metaEnumProvider()->localeToIndex(val.language(), val.country(), &langIdx, &countryIdx);
+  metaEnumProvider()->localeToIndex(val.language(), val.territory(), &langIdx, &countryIdx);
 
   QtProperty *languageProp = d_ptr->m_enumPropertyManager->addProperty();
   languageProp->setPropertyName(tr("Language"));
@@ -4660,8 +4664,6 @@ void QtSizePolicyPropertyManager::uninitializeProperty(QtProperty *property) {
 // enumeration manager to re-set its strings and index values
 // for each property.
 
-Q_GLOBAL_STATIC(QFontDatabase, fontDatabase)
-
 QtFontPropertyManagerPrivate::QtFontPropertyManagerPrivate()
     : m_settingValue(false), m_fontDatabaseChangeTimer(nullptr) {}
 
@@ -4751,7 +4753,7 @@ void QtFontPropertyManagerPrivate::slotFontDatabaseDelayedChange() {
   using PropertyPropertyMap = QMap<const QtProperty *, QtProperty *>;
   // rescan available font names
   const QStringList oldFamilies = m_familyNames;
-  m_familyNames = fontDatabase()->families();
+  m_familyNames = QFontDatabase::families();
 
   // Adapt all existing properties
   if (!m_propertyToFamily.empty()) {
@@ -4961,7 +4963,7 @@ void QtFontPropertyManager::initializeProperty(QtProperty *property) {
   QtProperty *familyProp = d_ptr->m_enumPropertyManager->addProperty();
   familyProp->setPropertyName(tr("Family"));
   if (d_ptr->m_familyNames.empty())
-    d_ptr->m_familyNames = fontDatabase()->families();
+    d_ptr->m_familyNames = QFontDatabase::families();
   d_ptr->m_enumPropertyManager->setEnumNames(familyProp, d_ptr->m_familyNames);
   int idx = static_cast<int>(d_ptr->m_familyNames.indexOf(val.family()));
   if (idx == -1)

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -394,7 +394,7 @@ void QtTreePropertyBrowserPrivate::init(QWidget *parent, const QStringList &opti
   labels.append(translateUtf8Encoded("QtTreePropertyBrowser", "Property", nullptr));
   labels.append(QApplication::translate("QtTreePropertyBrowser", "Value", nullptr));
   // add optional columns
-  foreach (const auto &opt, m_options) {
+  for (const auto &opt : m_options) {
     labels.append(QApplication::translate("QtTreePropertyBrowser", opt.toStdString().c_str(), nullptr));
   }
   m_treeWidget->setHeaderLabels(labels);

--- a/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
@@ -1111,7 +1111,7 @@ QtVariantPropertyManager::~QtVariantPropertyManager() {
     \sa createProperty()
 */
 QtVariantProperty *QtVariantPropertyManager::variantProperty(const QtProperty *property) const {
-  const QMap<const QtProperty *, QPair<QtVariantProperty *, int>>::const_iterator it =
+  const QMap<const QtProperty *, std::pair<QtVariantProperty *, int>>::const_iterator it =
       d_ptr->m_propertyToType.constFind(property);
   if (it == d_ptr->m_propertyToType.constEnd())
     return nullptr;
@@ -1252,7 +1252,7 @@ int QtVariantPropertyManager::valueType(int propertyType) const {
     \sa valueType()
 */
 int QtVariantPropertyManager::propertyType(const QtProperty *property) const {
-  const QMap<const QtProperty *, QPair<QtVariantProperty *, int>>::const_iterator it =
+  const QMap<const QtProperty *, std::pair<QtVariantProperty *, int>>::const_iterator it =
       d_ptr->m_propertyToType.constFind(property);
   if (it == d_ptr->m_propertyToType.constEnd())
     return 0;
@@ -1649,7 +1649,7 @@ void QtVariantPropertyManager::initializeProperty(QtProperty *property) {
     \reimp
 */
 void QtVariantPropertyManager::uninitializeProperty(QtProperty *property) {
-  const QMap<const QtProperty *, QPair<QtVariantProperty *, int>>::iterator type_it =
+  const QMap<const QtProperty *, std::pair<QtVariantProperty *, int>>::iterator type_it =
       d_ptr->m_propertyToType.find(property);
   if (type_it == d_ptr->m_propertyToType.end())
     return;
@@ -1676,7 +1676,7 @@ QtProperty *QtVariantPropertyManager::createProperty() {
     return nullptr;
 
   auto *property = new QtVariantProperty(this);
-  d_ptr->m_propertyToType.insert(property, qMakePair(property, d_ptr->m_propertyType));
+  d_ptr->m_propertyToType.insert(property, std::make_pair(property, d_ptr->m_propertyType));
 
   return property;
 }

--- a/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp
@@ -301,13 +301,13 @@ int QtVariantPropertyManagerPrivate::internalPropertyToType(const QtProperty *pr
   int type = 0;
   QtAbstractPropertyManager *internPropertyManager = property->propertyManager();
   if (qobject_cast<QtIntPropertyManager *>(internPropertyManager))
-    type = QVariant::Int;
+    type = QMetaType::Int;
   else if (qobject_cast<QtEnumPropertyManager *>(internPropertyManager))
     type = QtVariantPropertyManager::enumTypeId();
   else if (qobject_cast<QtBoolPropertyManager *>(internPropertyManager))
-    type = QVariant::Bool;
+    type = QMetaType::Bool;
   else if (qobject_cast<QtDoublePropertyManager *>(internPropertyManager))
-    type = QVariant::Double;
+    type = QMetaType::Double;
   return type;
 }
 
@@ -810,11 +810,11 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
 
   // IntPropertyManager
   auto *intPropertyManager = new QtIntPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Int] = intPropertyManager;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Int][d_ptr->m_minimumAttribute] = QVariant::Int;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Int][d_ptr->m_maximumAttribute] = QVariant::Int;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Int][d_ptr->m_singleStepAttribute] = QVariant::Int;
-  d_ptr->m_typeToValueType[QVariant::Int] = QVariant::Int;
+  d_ptr->m_typeToPropertyManager[QMetaType::Int] = intPropertyManager;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Int][d_ptr->m_minimumAttribute] = QMetaType::Int;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Int][d_ptr->m_maximumAttribute] = QMetaType::Int;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Int][d_ptr->m_singleStepAttribute] = QMetaType::Int;
+  d_ptr->m_typeToValueType[QMetaType::Int] = QMetaType::Int;
   connect(intPropertyManager, SIGNAL(valueChanged(QtProperty *, int)), this,
           SLOT(slotValueChanged(const QtProperty *, int)));
   connect(intPropertyManager, SIGNAL(rangeChanged(QtProperty *, int, int)), this,
@@ -823,12 +823,12 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotSingleStepChanged(const QtProperty *, int)));
   // DoublePropertyManager
   auto *doublePropertyManager = new QtDoublePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Double] = doublePropertyManager;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Double][d_ptr->m_minimumAttribute] = QVariant::Double;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Double][d_ptr->m_maximumAttribute] = QVariant::Double;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Double][d_ptr->m_singleStepAttribute] = QVariant::Double;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Double][d_ptr->m_decimalsAttribute] = QVariant::Int;
-  d_ptr->m_typeToValueType[QVariant::Double] = QVariant::Double;
+  d_ptr->m_typeToPropertyManager[QMetaType::Double] = doublePropertyManager;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Double][d_ptr->m_minimumAttribute] = QMetaType::Double;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Double][d_ptr->m_maximumAttribute] = QMetaType::Double;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Double][d_ptr->m_singleStepAttribute] = QMetaType::Double;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::Double][d_ptr->m_decimalsAttribute] = QMetaType::Int;
+  d_ptr->m_typeToValueType[QMetaType::Double] = QMetaType::Double;
   connect(doublePropertyManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(slotValueChanged(const QtProperty *, double)));
   connect(doublePropertyManager, SIGNAL(rangeChanged(QtProperty *, double, double)), this,
@@ -839,57 +839,57 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotDecimalsChanged(const QtProperty *, int)));
   // BoolPropertyManager
   auto *boolPropertyManager = new QtBoolPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Bool] = boolPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Bool] = QVariant::Bool;
+  d_ptr->m_typeToPropertyManager[QMetaType::Bool] = boolPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::Bool] = QMetaType::Bool;
   connect(boolPropertyManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
           SLOT(slotValueChanged(const QtProperty *, bool)));
   // StringPropertyManager
   auto *stringPropertyManager = new QtStringPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::String] = stringPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::String] = QVariant::String;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::String][d_ptr->m_regExpAttribute] = QVariant::RegularExpression;
+  d_ptr->m_typeToPropertyManager[QMetaType::QString] = stringPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QString] = QMetaType::QString;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QString][d_ptr->m_regExpAttribute] = QMetaType::QRegularExpression;
   connect(stringPropertyManager, SIGNAL(valueChanged(QtProperty *, const QString &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QString &)));
   connect(stringPropertyManager, SIGNAL(regExpChanged(QtProperty *, const QRegularExpression &)), this,
           SLOT(slotRegExpChanged(const QtProperty *, const QRegularExpression &)));
   // DatePropertyManager
   auto *datePropertyManager = new QtDatePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Date] = datePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Date] = QVariant::Date;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Date][d_ptr->m_minimumAttribute] = QVariant::Date;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Date][d_ptr->m_maximumAttribute] = QVariant::Date;
+  d_ptr->m_typeToPropertyManager[QMetaType::QDate] = datePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QDate] = QMetaType::QDate;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QDate][d_ptr->m_minimumAttribute] = QMetaType::QDate;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QDate][d_ptr->m_maximumAttribute] = QMetaType::QDate;
   connect(datePropertyManager, SIGNAL(valueChanged(QtProperty *, const QDate &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QDate &)));
   connect(datePropertyManager, SIGNAL(rangeChanged(QtProperty *, const QDate &, const QDate &)), this,
           SLOT(slotRangeChanged(const QtProperty *, const QDate &, const QDate &)));
   // TimePropertyManager
   auto *timePropertyManager = new QtTimePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Time] = timePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Time] = QVariant::Time;
+  d_ptr->m_typeToPropertyManager[QMetaType::QTime] = timePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QTime] = QMetaType::QTime;
   connect(timePropertyManager, SIGNAL(valueChanged(QtProperty *, const QTime &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QTime &)));
   // DateTimePropertyManager
   auto *dateTimePropertyManager = new QtDateTimePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::DateTime] = dateTimePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::DateTime] = QVariant::DateTime;
+  d_ptr->m_typeToPropertyManager[QMetaType::QDateTime] = dateTimePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QDateTime] = QMetaType::QDateTime;
   connect(dateTimePropertyManager, SIGNAL(valueChanged(QtProperty *, const QDateTime &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QDateTime &)));
   // KeySequencePropertyManager
   auto *keySequencePropertyManager = new QtKeySequencePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::KeySequence] = keySequencePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::KeySequence] = QVariant::KeySequence;
+  d_ptr->m_typeToPropertyManager[QMetaType::QKeySequence] = keySequencePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QKeySequence] = QMetaType::QKeySequence;
   connect(keySequencePropertyManager, SIGNAL(valueChanged(QtProperty *, const QKeySequence &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QKeySequence &)));
   // CharPropertyManager
   auto *charPropertyManager = new QtCharPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Char] = charPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Char] = QVariant::Char;
+  d_ptr->m_typeToPropertyManager[QMetaType::QChar] = charPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QChar] = QMetaType::QChar;
   connect(charPropertyManager, SIGNAL(valueChanged(QtProperty *, const QChar &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QChar &)));
   // LocalePropertyManager
   auto *localePropertyManager = new QtLocalePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Locale] = localePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Locale] = QVariant::Locale;
+  d_ptr->m_typeToPropertyManager[QMetaType::QLocale] = localePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QLocale] = QMetaType::QLocale;
   connect(localePropertyManager, SIGNAL(valueChanged(QtProperty *, const QLocale &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QLocale &)));
   connect(localePropertyManager->subEnumPropertyManager(), SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -900,8 +900,8 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // PointPropertyManager
   auto *pointPropertyManager = new QtPointPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Point] = pointPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Point] = QVariant::Point;
+  d_ptr->m_typeToPropertyManager[QMetaType::QPoint] = pointPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QPoint] = QMetaType::QPoint;
   connect(pointPropertyManager, SIGNAL(valueChanged(QtProperty *, const QPoint &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QPoint &)));
   connect(pointPropertyManager->subIntPropertyManager(), SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -912,9 +912,9 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // PointFPropertyManager
   auto *pointFPropertyManager = new QtPointFPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::PointF] = pointFPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::PointF] = QVariant::PointF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::PointF][d_ptr->m_decimalsAttribute] = QVariant::Int;
+  d_ptr->m_typeToPropertyManager[QMetaType::QPointF] = pointFPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QPointF] = QMetaType::QPointF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QPointF][d_ptr->m_decimalsAttribute] = QMetaType::Int;
   connect(pointFPropertyManager, SIGNAL(valueChanged(QtProperty *, const QPointF &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QPointF &)));
   connect(pointFPropertyManager, SIGNAL(decimalsChanged(QtProperty *, int)), this,
@@ -927,10 +927,10 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // SizePropertyManager
   auto *sizePropertyManager = new QtSizePropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Size] = sizePropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Size] = QVariant::Size;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Size][d_ptr->m_minimumAttribute] = QVariant::Size;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Size][d_ptr->m_maximumAttribute] = QVariant::Size;
+  d_ptr->m_typeToPropertyManager[QMetaType::QSize] = sizePropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QSize] = QMetaType::QSize;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QSize][d_ptr->m_minimumAttribute] = QMetaType::QSize;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QSize][d_ptr->m_maximumAttribute] = QMetaType::QSize;
   connect(sizePropertyManager, SIGNAL(valueChanged(QtProperty *, const QSize &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QSize &)));
   connect(sizePropertyManager, SIGNAL(rangeChanged(QtProperty *, const QSize &, const QSize &)), this,
@@ -945,11 +945,11 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // SizeFPropertyManager
   auto *sizeFPropertyManager = new QtSizeFPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::SizeF] = sizeFPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::SizeF] = QVariant::SizeF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::SizeF][d_ptr->m_minimumAttribute] = QVariant::SizeF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::SizeF][d_ptr->m_maximumAttribute] = QVariant::SizeF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::SizeF][d_ptr->m_decimalsAttribute] = QVariant::Int;
+  d_ptr->m_typeToPropertyManager[QMetaType::QSizeF] = sizeFPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QSizeF] = QMetaType::QSizeF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QSizeF][d_ptr->m_minimumAttribute] = QMetaType::QSizeF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QSizeF][d_ptr->m_maximumAttribute] = QMetaType::QSizeF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QSizeF][d_ptr->m_decimalsAttribute] = QMetaType::Int;
   connect(sizeFPropertyManager, SIGNAL(valueChanged(QtProperty *, const QSizeF &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QSizeF &)));
   connect(sizeFPropertyManager, SIGNAL(rangeChanged(QtProperty *, const QSizeF &, const QSizeF &)), this,
@@ -966,9 +966,9 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // RectPropertyManager
   auto *rectPropertyManager = new QtRectPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Rect] = rectPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Rect] = QVariant::Rect;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::Rect][d_ptr->m_constraintAttribute] = QVariant::Rect;
+  d_ptr->m_typeToPropertyManager[QMetaType::QRect] = rectPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QRect] = QMetaType::QRect;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QRect][d_ptr->m_constraintAttribute] = QMetaType::QRect;
   connect(rectPropertyManager, SIGNAL(valueChanged(QtProperty *, const QRect &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QRect &)));
   connect(rectPropertyManager, SIGNAL(constraintChanged(QtProperty *, const QRect &)), this,
@@ -983,10 +983,10 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // RectFPropertyManager
   auto *rectFPropertyManager = new QtRectFPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::RectF] = rectFPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::RectF] = QVariant::RectF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::RectF][d_ptr->m_constraintAttribute] = QVariant::RectF;
-  d_ptr->m_typeToAttributeToAttributeType[QVariant::RectF][d_ptr->m_decimalsAttribute] = QVariant::Int;
+  d_ptr->m_typeToPropertyManager[QMetaType::QRectF] = rectFPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QRectF] = QMetaType::QRectF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QRectF][d_ptr->m_constraintAttribute] = QMetaType::QRectF;
+  d_ptr->m_typeToAttributeToAttributeType[QMetaType::QRectF][d_ptr->m_decimalsAttribute] = QMetaType::Int;
   connect(rectFPropertyManager, SIGNAL(valueChanged(QtProperty *, const QRectF &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QRectF &)));
   connect(rectFPropertyManager, SIGNAL(constraintChanged(QtProperty *, const QRectF &)), this,
@@ -1003,8 +1003,8 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // ColorPropertyManager
   auto *colorPropertyManager = new QtColorPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Color] = colorPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Color] = QVariant::Color;
+  d_ptr->m_typeToPropertyManager[QMetaType::QColor] = colorPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QColor] = QMetaType::QColor;
   connect(colorPropertyManager, SIGNAL(valueChanged(QtProperty *, const QColor &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QColor &)));
   connect(colorPropertyManager->subIntPropertyManager(), SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -1017,8 +1017,8 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
   int enumId = enumTypeId();
   auto *enumPropertyManager = new QtEnumPropertyManager(this);
   d_ptr->m_typeToPropertyManager[enumId] = enumPropertyManager;
-  d_ptr->m_typeToValueType[enumId] = QVariant::Int;
-  d_ptr->m_typeToAttributeToAttributeType[enumId][d_ptr->m_enumNamesAttribute] = QVariant::StringList;
+  d_ptr->m_typeToValueType[enumId] = QMetaType::Int;
+  d_ptr->m_typeToAttributeToAttributeType[enumId][d_ptr->m_enumNamesAttribute] = QMetaType::QStringList;
   d_ptr->m_typeToAttributeToAttributeType[enumId][d_ptr->m_enumIconsAttribute] = iconMapTypeId();
   connect(enumPropertyManager, SIGNAL(valueChanged(QtProperty *, int)), this,
           SLOT(slotValueChanged(const QtProperty *, int)));
@@ -1028,8 +1028,8 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotEnumIconsChanged(const QtProperty *, const QMap<int, QIcon> &)));
   // SizePolicyPropertyManager
   auto *sizePolicyPropertyManager = new QtSizePolicyPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::SizePolicy] = sizePolicyPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::SizePolicy] = QVariant::SizePolicy;
+  d_ptr->m_typeToPropertyManager[QMetaType::QSizePolicy] = sizePolicyPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QSizePolicy] = QMetaType::QSizePolicy;
   connect(sizePolicyPropertyManager, SIGNAL(valueChanged(QtProperty *, const QSizePolicy &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QSizePolicy &)));
   connect(sizePolicyPropertyManager->subIntPropertyManager(), SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -1047,8 +1047,8 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // FontPropertyManager
   auto *fontPropertyManager = new QtFontPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Font] = fontPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Font] = QVariant::Font;
+  d_ptr->m_typeToPropertyManager[QMetaType::QFont] = fontPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QFont] = QMetaType::QFont;
   connect(fontPropertyManager, SIGNAL(valueChanged(QtProperty *, const QFont &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QFont &)));
   connect(fontPropertyManager->subIntPropertyManager(), SIGNAL(valueChanged(QtProperty *, int)), this,
@@ -1067,16 +1067,16 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
           SLOT(slotPropertyRemoved(const QtProperty *, QtProperty *)));
   // CursorPropertyManager
   auto *cursorPropertyManager = new QtCursorPropertyManager(this);
-  d_ptr->m_typeToPropertyManager[QVariant::Cursor] = cursorPropertyManager;
-  d_ptr->m_typeToValueType[QVariant::Cursor] = QVariant::Cursor;
+  d_ptr->m_typeToPropertyManager[QMetaType::QCursor] = cursorPropertyManager;
+  d_ptr->m_typeToValueType[QMetaType::QCursor] = QMetaType::QCursor;
   connect(cursorPropertyManager, SIGNAL(valueChanged(QtProperty *, const QCursor &)), this,
           SLOT(slotValueChanged(const QtProperty *, const QCursor &)));
   // FlagPropertyManager
   int flagId = flagTypeId();
   auto *flagPropertyManager = new QtFlagPropertyManager(this);
   d_ptr->m_typeToPropertyManager[flagId] = flagPropertyManager;
-  d_ptr->m_typeToValueType[flagId] = QVariant::Int;
-  d_ptr->m_typeToAttributeToAttributeType[flagId][d_ptr->m_flagNamesAttribute] = QVariant::StringList;
+  d_ptr->m_typeToValueType[flagId] = QMetaType::Int;
+  d_ptr->m_typeToAttributeToAttributeType[flagId][d_ptr->m_flagNamesAttribute] = QMetaType::QStringList;
   connect(flagPropertyManager, SIGNAL(valueChanged(QtProperty *, int)), this,
           SLOT(slotValueChanged(const QtProperty *, int)));
   connect(flagPropertyManager, SIGNAL(flagNamesChanged(QtProperty *, const QStringList &)), this,
@@ -1091,7 +1091,7 @@ QtVariantPropertyManager::QtVariantPropertyManager(QObject *parent) : QtAbstract
   int groupId = groupTypeId();
   auto *groupPropertyManager = new QtGroupPropertyManager(this);
   d_ptr->m_typeToPropertyManager[groupId] = groupPropertyManager;
-  d_ptr->m_typeToValueType[groupId] = QVariant::Invalid;
+  d_ptr->m_typeToValueType[groupId] = QMetaType::UnknownType;
 }
 
 /**
@@ -1415,7 +1415,7 @@ void QtVariantPropertyManager::setValue(QtProperty *property, const QVariant &va
 
   int valType = valueType(property);
 
-  if (propType != valType && !val.canConvert(static_cast<QVariant::Type>(valType)))
+  if (propType != valType && !val.canConvert(QMetaType(valType)))
     return;
 
   QtProperty *internProp = propertyToWrappedProperty()->value(property, 0);
@@ -1514,7 +1514,7 @@ void QtVariantPropertyManager::setAttribute(QtProperty *property, const QString 
   if (!attrType)
     return;
 
-  if (attrType != attributeType(propertyType(property), attribute) && !value.canConvert((QVariant::Type)attrType))
+  if (attrType != attributeType(propertyType(property), attribute) && !value.canConvert(QMetaType(attrType)))
     return;
 
   QtProperty *internProp = propertyToWrappedProperty()->value(property, 0);
@@ -1771,52 +1771,52 @@ QtVariantEditorFactory::QtVariantEditorFactory(QObject *parent)
   d_ptr->q_ptr = this;
 
   d_ptr->m_spinBoxFactory = new QtSpinBoxFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_spinBoxFactory] = QVariant::Int;
-  d_ptr->m_typeToFactory[QVariant::Int] = d_ptr->m_spinBoxFactory;
+  d_ptr->m_factoryToType[d_ptr->m_spinBoxFactory] = QMetaType::Int;
+  d_ptr->m_typeToFactory[QMetaType::Int] = d_ptr->m_spinBoxFactory;
 
   d_ptr->m_doubleSpinBoxFactory = new QtDoubleSpinBoxFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_doubleSpinBoxFactory] = QVariant::Double;
-  d_ptr->m_typeToFactory[QVariant::Double] = d_ptr->m_doubleSpinBoxFactory;
+  d_ptr->m_factoryToType[d_ptr->m_doubleSpinBoxFactory] = QMetaType::Double;
+  d_ptr->m_typeToFactory[QMetaType::Double] = d_ptr->m_doubleSpinBoxFactory;
 
   d_ptr->m_checkBoxFactory = new QtCheckBoxFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_checkBoxFactory] = QVariant::Bool;
-  d_ptr->m_typeToFactory[QVariant::Bool] = d_ptr->m_checkBoxFactory;
+  d_ptr->m_factoryToType[d_ptr->m_checkBoxFactory] = QMetaType::Bool;
+  d_ptr->m_typeToFactory[QMetaType::Bool] = d_ptr->m_checkBoxFactory;
 
   d_ptr->m_lineEditFactory = new QtLineEditFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_lineEditFactory] = QVariant::String;
-  d_ptr->m_typeToFactory[QVariant::String] = d_ptr->m_lineEditFactory;
+  d_ptr->m_factoryToType[d_ptr->m_lineEditFactory] = QMetaType::QString;
+  d_ptr->m_typeToFactory[QMetaType::QString] = d_ptr->m_lineEditFactory;
 
   d_ptr->m_dateEditFactory = new QtDateEditFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_dateEditFactory] = QVariant::Date;
-  d_ptr->m_typeToFactory[QVariant::Date] = d_ptr->m_dateEditFactory;
+  d_ptr->m_factoryToType[d_ptr->m_dateEditFactory] = QMetaType::QDate;
+  d_ptr->m_typeToFactory[QMetaType::QDate] = d_ptr->m_dateEditFactory;
 
   d_ptr->m_timeEditFactory = new QtTimeEditFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_timeEditFactory] = QVariant::Time;
-  d_ptr->m_typeToFactory[QVariant::Time] = d_ptr->m_timeEditFactory;
+  d_ptr->m_factoryToType[d_ptr->m_timeEditFactory] = QMetaType::QTime;
+  d_ptr->m_typeToFactory[QMetaType::QTime] = d_ptr->m_timeEditFactory;
 
   d_ptr->m_dateTimeEditFactory = new QtDateTimeEditFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_dateTimeEditFactory] = QVariant::DateTime;
-  d_ptr->m_typeToFactory[QVariant::DateTime] = d_ptr->m_dateTimeEditFactory;
+  d_ptr->m_factoryToType[d_ptr->m_dateTimeEditFactory] = QMetaType::QDateTime;
+  d_ptr->m_typeToFactory[QMetaType::QDateTime] = d_ptr->m_dateTimeEditFactory;
 
   d_ptr->m_keySequenceEditorFactory = new QtKeySequenceEditorFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_keySequenceEditorFactory] = QVariant::KeySequence;
-  d_ptr->m_typeToFactory[QVariant::KeySequence] = d_ptr->m_keySequenceEditorFactory;
+  d_ptr->m_factoryToType[d_ptr->m_keySequenceEditorFactory] = QMetaType::QKeySequence;
+  d_ptr->m_typeToFactory[QMetaType::QKeySequence] = d_ptr->m_keySequenceEditorFactory;
 
   d_ptr->m_charEditorFactory = new QtCharEditorFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_charEditorFactory] = QVariant::Char;
-  d_ptr->m_typeToFactory[QVariant::Char] = d_ptr->m_charEditorFactory;
+  d_ptr->m_factoryToType[d_ptr->m_charEditorFactory] = QMetaType::QChar;
+  d_ptr->m_typeToFactory[QMetaType::QChar] = d_ptr->m_charEditorFactory;
 
   d_ptr->m_cursorEditorFactory = new QtCursorEditorFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_cursorEditorFactory] = QVariant::Cursor;
-  d_ptr->m_typeToFactory[QVariant::Cursor] = d_ptr->m_cursorEditorFactory;
+  d_ptr->m_factoryToType[d_ptr->m_cursorEditorFactory] = QMetaType::QCursor;
+  d_ptr->m_typeToFactory[QMetaType::QCursor] = d_ptr->m_cursorEditorFactory;
 
   d_ptr->m_colorEditorFactory = new QtColorEditorFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_colorEditorFactory] = QVariant::Color;
-  d_ptr->m_typeToFactory[QVariant::Color] = d_ptr->m_colorEditorFactory;
+  d_ptr->m_factoryToType[d_ptr->m_colorEditorFactory] = QMetaType::QColor;
+  d_ptr->m_typeToFactory[QMetaType::QColor] = d_ptr->m_colorEditorFactory;
 
   d_ptr->m_fontEditorFactory = new QtFontEditorFactory(this);
-  d_ptr->m_factoryToType[d_ptr->m_fontEditorFactory] = QVariant::Font;
-  d_ptr->m_typeToFactory[QVariant::Font] = d_ptr->m_fontEditorFactory;
+  d_ptr->m_factoryToType[d_ptr->m_fontEditorFactory] = QMetaType::QFont;
+  d_ptr->m_typeToFactory[QMetaType::QFont] = d_ptr->m_fontEditorFactory;
 
   d_ptr->m_comboBoxFactory = new QtEnumEditorFactory(this);
   const int enumId = QtVariantPropertyManager::enumTypeId();

--- a/qt/widgets/common/src/ScriptEditor.cpp
+++ b/qt/widgets/common/src/ScriptEditor.cpp
@@ -327,7 +327,7 @@ void ScriptEditor::wheelEvent(QWheelEvent *e) {
  *  @param keyCombination :: QString of the key combination e.g. "Ctrl+/".
  */
 void ScriptEditor::clearKeyBinding(const QString &keyCombination) {
-  int keyIdentifier = QKeySequence(keyCombination)[0];
+  int keyIdentifier = QKeySequence(keyCombination)[0].toCombined();
   if (QsciCommand::validKey(keyIdentifier)) {
     QsciCommand *cmd = standardCommands()->boundTo(keyIdentifier);
     if (cmd) { /// if key identifier bound to a command

--- a/qt/widgets/common/src/SelectWorkspacesDialog.cpp
+++ b/qt/widgets/common/src/SelectWorkspacesDialog.cpp
@@ -102,7 +102,7 @@ SelectWorkspacesDialog::SelectWorkspacesDialog(QWidget *parent, const std::strin
 QStringList SelectWorkspacesDialog::getSelectedNames() const {
   QList<QListWidgetItem *> items = m_wsList->selectedItems();
   QStringList res;
-  foreach (QListWidgetItem *item, items) {
+  for (QListWidgetItem *item : items) {
     res << item->text();
   }
   return res;

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -92,7 +92,7 @@ bool SequentialFitDialog::addWorkspaces(const QStringList &wsNames) {
   ui.tWorkspaces->model()->insertRows(row, static_cast<int>(wsNames.size()));
   int wi = m_fitBrowser->workspaceIndex();
   QAbstractItemModel *model = ui.tWorkspaces->model();
-  foreach (QString wsName, wsNames) {
+  for (const QString &wsName : wsNames) {
     model->setData(model->index(row, 0, QModelIndex()), wsName);
 
     if (row == 0) {
@@ -157,7 +157,7 @@ void SequentialFitDialog::addFile() {
     ui.tWorkspaces->model()->insertRows(row, static_cast<int>(fileNames.size()));
     // int wi = m_fitBrowser->workspaceIndex();
     QAbstractItemModel *model = ui.tWorkspaces->model();
-    foreach (QString fileName, fileNames) {
+    for (const QString &fileName : fileNames) {
       model->setData(model->index(row, 0, QModelIndex()), fileName); // file name
       model->setData(model->index(row, 1, QModelIndex()),
                      ui.sbPeriod->value()); // period
@@ -216,7 +216,7 @@ bool SequentialFitDialog::validateLogs(const QString &wsName) {
           namesToRemove << logName;
         }
       }
-      foreach (QString logName, namesToRemove) {
+      for (const QString &logName : namesToRemove) {
         int i = ui.cbLogValue->findText(logName);
         if (i >= 0) {
           ui.cbLogValue->removeItem(i);

--- a/qt/widgets/common/src/UserFunctionDialog.cpp
+++ b/qt/widgets/common/src/UserFunctionDialog.cpp
@@ -108,7 +108,7 @@ void UserFunctionDialog::updateCategories() {
   QString currentCategory = getCurrentCategory();
   m_uiForm.lstCategory->clear();
   QSet<QString> cats = categoryNames();
-  foreach (QString cat, cats) {
+  for (const QString &cat : cats) {
     m_uiForm.lstCategory->addItem(cat);
   }
   // try to restore current item selection
@@ -125,7 +125,7 @@ void UserFunctionDialog::updateCategories() {
 void UserFunctionDialog::selectCategory(const QString &cat) {
   QSet<QString> funs = functionNames(cat);
   m_uiForm.lstFunction->clear();
-  foreach (QString fun, funs) {
+  for (const QString &fun : funs) {
     QString value = getFunction(cat, fun);
     if (!value.isEmpty()) {
       m_uiForm.lstFunction->addItem(fun);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -851,7 +851,7 @@ void WorkspaceTreeWidget::populateTopLevel(const TopLevelItems &topLevelItems, c
     // collect names of selected workspaces
     QList<QTreeWidgetItem *> selected = m_tree->selectedItems();
     m_selectedNames.clear(); // just in case
-    foreach (QTreeWidgetItem *item, selected) {
+    for (QTreeWidgetItem *item : selected) {
       m_selectedNames << item->text(0);
     }
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -127,12 +127,7 @@ namespace MantidQt::MantidWidgets {
 WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb, bool viewOnly, QWidget *parent)
     : QWidget(parent), m_mantidDisplayModel(mdb), m_viewOnly(viewOnly), m_updateCount(0), m_treeUpdating(false),
       m_promptDelete(false), m_saveFileType(SaveFileType::Nexus), m_sortCriteria(SortCriteria::ByName),
-      m_sortDirection(SortDirection::Ascending)
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-      ,
-      m_mutex(QMutex::Recursive) // Qt6 uses QRecursiveMutex, default-constructed
-#endif
-{
+      m_sortDirection(SortDirection::Ascending) {
   setObjectName("exploreMantid"); // this is needed for QMainWindow::restoreState()
   m_saveMenu = new QMenu(this);
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLDisplay.h
@@ -9,12 +9,10 @@
 #include "IGLDisplay.h"
 #include "MantidGeometry/IComponent.h"
 
+#include <QEnterEvent>
 #include <QString>
 
 #include <memory>
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <QEnterEvent>
-#endif
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -54,11 +52,7 @@ protected:
   void wheelEvent(QWheelEvent * /*unused*/) override;
   void keyPressEvent(QKeyEvent * /*unused*/) override;
   void keyReleaseEvent(QKeyEvent * /*unused*/) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   void enterEvent(QEnterEvent * /*unused*/) override;
-#else
-  void enterEvent(QEvent * /*unused*/) override;
-#endif
   void leaveEvent(QEvent * /*unused*/) override;
   void draw();
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtDisplay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtDisplay.h
@@ -8,12 +8,10 @@
 
 #include "IQtDisplay.h"
 
+#include <QEnterEvent>
 #include <QString>
 #include <QWidget>
 #include <memory>
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <QEnterEvent>
-#endif
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -47,11 +45,7 @@ protected:
   void mouseReleaseEvent(QMouseEvent * /*event*/) override;
   void wheelEvent(QWheelEvent * /*event*/) override;
   void keyPressEvent(QKeyEvent * /*event*/) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   void enterEvent(QEnterEvent * /*event*/) override;
-#else
-  void enterEvent(QEvent * /*event*/) override;
-#endif
   void leaveEvent(QEvent * /*event*/) override;
   ///< The projection surface
   std::shared_ptr<ProjectionSurface> m_surface;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtMetaObject.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/QtMetaObject.h
@@ -12,19 +12,13 @@
 
 namespace MantidQt::MantidWidgets {
 
-// Q_ARG / Q_RETURN_ARG produce QGenericArgument/QGenericReturnArgument in Qt5 but
-// QMetaMethodArgument/QMetaMethodReturnArgument in Qt6. Alias to the right type so
-// the wrapper (and its mock) match what the macros generate.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+// Q_ARG / Q_RETURN_ARG produce QMetaMethodArgument/QMetaMethodReturnArgument. Alias to
+// the right type so the wrapper (and its mock) match what the macros generate.
 using QtInvokeArgument = QMetaMethodArgument;
 using QtInvokeReturnArgument = QMetaMethodReturnArgument;
 
 namespace detail {
-// In Qt5 QMetaObject::invokeMethod accepted a fixed list of arguments terminated
-// by the first default-constructed (null) QGenericArgument, so the wrapper below
-// could always forward all ten slots and let Qt ignore the trailing padding.
-//
-// In Qt6 invokeMethod is variadic and counts its arguments at compile time; it has
+// QMetaObject::invokeMethod is variadic and counts its arguments at compile time; it has
 // no notion of a null terminator. Forwarding the padding would make Qt believe the
 // slot takes ten parameters, the method lookup fails, and Qt crashes while trying to
 // report the missing method (printMethodNotFoundWarning). So only forward the leading,
@@ -64,10 +58,6 @@ inline bool forwardInvoke(QObject *obj, const char *member, Qt::ConnectionType t
   }
 }
 } // namespace detail
-#else
-using QtInvokeArgument = QGenericArgument;
-using QtInvokeReturnArgument = QGenericReturnArgument;
-#endif
 
 struct QtMetaObject {
   virtual ~QtMetaObject() = default;
@@ -79,17 +69,12 @@ struct QtMetaObject {
                             QtInvokeArgument val6 = QtInvokeArgument(), QtInvokeArgument val7 = QtInvokeArgument(),
                             QtInvokeArgument val8 = QtInvokeArgument(),
                             QtInvokeArgument val9 = QtInvokeArgument()) const {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // Qt6's variadic invokeMethod only accepts a typed QTemplatedMetaMethodReturnArgument,
+    // The variadic invokeMethod only accepts a typed QTemplatedMetaMethodReturnArgument,
     // which cannot be reconstructed from the type-erased base passed here. Nothing in the
-    // instrument view captures a return value, so the return argument is unused under Qt6.
+    // instrument view captures a return value, so the return argument is unused.
     (void)ret;
     const QtInvokeArgument args[10] = {val0, val1, val2, val3, val4, val5, val6, val7, val8, val9};
     return detail::forwardInvoke(obj, member, type, args);
-#else
-    return QMetaObject::invokeMethod(obj, member, type, ret, val0, val1, val2, val3, val4, val5, val6, val7, val8,
-                                     val9);
-#endif
   }
 
   virtual bool invokeMethod(QObject *obj, const char *member, QtInvokeReturnArgument ret,
@@ -99,14 +84,10 @@ struct QtMetaObject {
                             QtInvokeArgument val6 = QtInvokeArgument(), QtInvokeArgument val7 = QtInvokeArgument(),
                             QtInvokeArgument val8 = QtInvokeArgument(),
                             QtInvokeArgument val9 = QtInvokeArgument()) const {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // See the note above: the type-erased return argument is unused under Qt6.
+    // See the note above: the type-erased return argument is unused.
     (void)ret;
     const QtInvokeArgument args[10] = {val0, val1, val2, val3, val4, val5, val6, val7, val8, val9};
     return detail::forwardInvoke(obj, member, Qt::AutoConnection, args);
-#else
-    return QMetaObject::invokeMethod(obj, member, ret, val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
-#endif
   }
 
   virtual bool invokeMethod(QObject *obj, const char *member, Qt::ConnectionType type,
@@ -116,12 +97,8 @@ struct QtMetaObject {
                             QtInvokeArgument val6 = QtInvokeArgument(), QtInvokeArgument val7 = QtInvokeArgument(),
                             QtInvokeArgument val8 = QtInvokeArgument(),
                             QtInvokeArgument val9 = QtInvokeArgument()) const {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const QtInvokeArgument args[10] = {val0, val1, val2, val3, val4, val5, val6, val7, val8, val9};
     return detail::forwardInvoke(obj, member, type, args);
-#else
-    return QMetaObject::invokeMethod(obj, member, type, val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
-#endif
   }
 
   virtual bool invokeMethod(QObject *obj, const char *member, QtInvokeArgument val0 = QtInvokeArgument(),
@@ -130,12 +107,8 @@ struct QtMetaObject {
                             QtInvokeArgument val5 = QtInvokeArgument(), QtInvokeArgument val6 = QtInvokeArgument(),
                             QtInvokeArgument val7 = QtInvokeArgument(), QtInvokeArgument val8 = QtInvokeArgument(),
                             QtInvokeArgument val9 = QtInvokeArgument()) const {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const QtInvokeArgument args[10] = {val0, val1, val2, val3, val4, val5, val6, val7, val8, val9};
     return detail::forwardInvoke(obj, member, Qt::AutoConnection, args);
-#else
-    return QMetaObject::invokeMethod(obj, member, val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
-#endif
   }
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/GLDisplay.cpp
+++ b/qt/widgets/instrumentview/src/GLDisplay.cpp
@@ -274,11 +274,7 @@ void GLDisplay::updateDetectors() {
   }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void GLDisplay::enterEvent(QEnterEvent *ev) {
-#else
-void GLDisplay::enterEvent(QEvent *ev) {
-#endif
   if (m_surface) {
     m_surface->enterEvent(ev);
   }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -788,7 +788,7 @@ void InstrumentWidgetMaskTab::saveInvertedMaskToCalFile() { saveMaskingToCalFile
 void InstrumentWidgetMaskTab::saveMaskToTable() { saveMaskingToTableWorkspace(false); }
 
 void InstrumentWidgetMaskTab::showMessageBox(const QString &message) {
-  QMessageBox::information(this, "GroupDetectors Error", message, "OK");
+  QMessageBox::information(this, "GroupDetectors Error", message);
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -964,7 +964,7 @@ void InstrumentWidgetPickTab::onRunRebin() {
                          m_instrWidget->getWorkspaceNameStdString());
     }
   } catch (const std::exception &ex) {
-    QMessageBox::information(this, "Rebin Error", ex.what(), "OK");
+    QMessageBox::information(this, "Rebin Error", ex.what());
   }
 }
 

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -199,7 +199,7 @@ void PanelsSurface::processStructured(size_t rootIndex) {
   info->endDetectorIndex = lastRow.back();
 
   // set the outline
-  QVector<QPointF> verts;
+  QList<QPointF> verts;
   for (auto &corner : corners) {
     auto pos = corner - ref;
     info->rotation.rotate(pos);
@@ -308,7 +308,7 @@ std::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
              m_yaxis.scalar_prod(pos0));
   QPointF p1(m_zaxis.scalar_prod(pos1) > 0 ? -m_xaxis.scalar_prod(pos1) : m_xaxis.scalar_prod(pos1),
              m_yaxis.scalar_prod(pos1));
-  QVector<QPointF> vert;
+  QList<QPointF> vert;
   vert << p0 << p1;
   info->polygon = QPolygonF(vert);
 
@@ -327,7 +327,7 @@ std::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
     //      assumption is made here that any two adjacent tubes in an assembly's
     //      children's list
     //      are close to each other
-    QVector<QPointF> vertQuad;
+    QList<QPointF> vertQuad;
     vertQuad << p0 << p1 << p3 << p2;
     info->polygon = info->polygon.united(QPolygonF(vertQuad));
     p0 = p2;
@@ -401,7 +401,7 @@ void PanelsSurface::processUnstructured(size_t rootIndex, std::vector<bool> &vis
     pos1 += pos0;
     QPointF p0(m_xaxis.scalar_prod(pos0), m_yaxis.scalar_prod(pos0));
     QPointF p1(m_xaxis.scalar_prod(pos1), m_yaxis.scalar_prod(pos1));
-    QVector<QPointF> vert;
+    QList<QPointF> vert;
     vert << p1 << p0;
     info->polygon = QPolygonF(vert);
     // initialise bank polygon with sensible bounding box points

--- a/qt/widgets/instrumentview/src/QtDisplay.cpp
+++ b/qt/widgets/instrumentview/src/QtDisplay.cpp
@@ -132,11 +132,7 @@ void QtDisplay::keyPressEvent(QKeyEvent *event) {
   update();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void QtDisplay::enterEvent(QEnterEvent *event) {
-#else
-void QtDisplay::enterEvent(QEvent *event) {
-#endif
   if (m_surface) {
     m_surface->enterEvent(event);
   }

--- a/qt/widgets/instrumentview/src/XIntegrationControl.cpp
+++ b/qt/widgets/instrumentview/src/XIntegrationControl.cpp
@@ -97,7 +97,7 @@ bool XIntegrationScrollBar::eventFilter(QObject *object, QEvent *e) {
 
   case QEvent::MouseButtonPress: {
     auto *me = static_cast<QMouseEvent *>(e);
-    m_x = me->x();
+    m_x = me->position().toPoint().x();
     m_width = m_slider->width();
     if (m_x < m_resizeMargin) {
       m_resizingLeft = true;
@@ -130,7 +130,7 @@ bool XIntegrationScrollBar::manageEventContinuous(QEvent *e) {
   switch (e->type()) {
   case QEvent::MouseMove: {
     auto *me = static_cast<QMouseEvent *>(e);
-    int x = me->x();
+    int x = me->position().toPoint().x();
     int w = m_slider->width();
     if (x < m_resizeMargin || x > w - m_resizeMargin) {
       if (!QApplication::overrideCursor()) {
@@ -307,7 +307,7 @@ bool XIntegrationScrollBar::manageEventDiscrete(QEvent *e) {
 
   case QEvent::MouseMove: {
     auto *me = static_cast<QMouseEvent *>(e);
-    int x = me->x();
+    int x = me->position().toPoint().x();
     int w = m_slider->width();
     if (x < m_resizeMargin || x > w - m_resizeMargin) {
       if (!QApplication::overrideCursor()) {

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/BackendQt.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/BackendQt.h
@@ -8,21 +8,10 @@
 
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/MplCpp/DllConfig.h"
-#include <QtGlobal>
 
 /*
  * Defines constants relating to the matplotlib backend
  */
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-
-/// Define PyQt version that matches the matplotlib backend
-constexpr static const char *PYQT_MODULE = "PyQt5";
-
-/// Define matplotlib backend that will be used to draw the canvas
-constexpr static const char *MPL_QT_BACKEND = "matplotlib.backends.backend_qt5agg";
-
-#elif QT_VERSION < QT_VERSION_CHECK(7, 0, 0)
 
 /// Define PyQt version that matches the matplotlib backend
 constexpr static const char *PYQT_MODULE = "PyQt6";
@@ -30,10 +19,6 @@ constexpr static const char *PYQT_MODULE = "PyQt6";
 /// Define matplotlib backend that will be used to draw the canvas. backend_qtagg
 /// is the binding-agnostic Qt backend (matplotlib >= 3.5) and uses QT_API=pyqt6.
 constexpr static const char *MPL_QT_BACKEND = "matplotlib.backends.backend_qtagg";
-
-#else
-#error "Unknown Qt version. Cannot determine matplotlib backend."
-#endif
 
 namespace MantidQt {
 namespace Widgets {

--- a/qt/widgets/mplcpp/src/PanZoomTool.cpp
+++ b/qt/widgets/mplcpp/src/PanZoomTool.cpp
@@ -33,7 +33,7 @@ constexpr auto TOOLBAR_PAN_METHOD = "pan";
 
 /// Return the matplotlib NavigationToolbar type appropriate
 /// for our backend. It is returned hidden
-Python::Object mplNavigationToolbar(FigureCanvasQt *canvas) {
+Python::Object mplNavigationToolbar(const FigureCanvasQt *canvas) {
   const auto backend = backendModule();
   bool showCoordinates(false);
   auto obj = Python::Object(backend.attr(TOOLBAR_CLS)(canvas->pyobj(), canvas->pyobj(), showCoordinates));

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -17,7 +17,6 @@
 #include "MantidQtWidgets/Plotting/SingleSelector.h"
 
 #include <QHash>
-#include <QPair>
 #include <QVariant>
 #include <QWidget>
 #include <list>

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -505,7 +505,7 @@ void PreviewPlot::showContextMenu(QMouseEvent *evt) {
   contextMenu.addSeparator();
   contextMenu.addAction(m_contextLegend);
 
-  contextMenu.exec(evt->globalPos());
+  contextMenu.exec(evt->globalPosition().toPoint());
 }
 
 /**

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/PeriodicTableWidget.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/PeriodicTableWidget.h
@@ -8,7 +8,7 @@
 
 #include "MantidQtWidgets/Common/DllOption.h"
 #include "ui_PeriodicTableWidget.h"
-#include <QVector>
+#include <QList>
 #include <QWidget>
 
 /**
@@ -25,31 +25,31 @@ public:
   /// Destructor
   ~PeriodicTableWidget() override {};
   /// Vectors to Hold the QPushButtons of Elements in corresponding Groups
-  QVector<QPushButton *> OtherNonMetals;
-  QVector<QPushButton *> AlkaliMetals;
-  QVector<QPushButton *> AlkalineEarthMetals;
-  QVector<QPushButton *> TransitionMetals;
-  QVector<QPushButton *> Actinides;
-  QVector<QPushButton *> Lanthanides;
-  QVector<QPushButton *> UnknownProperties;
-  QVector<QPushButton *> PostTransitionMetals;
-  QVector<QPushButton *> Metalloids;
-  QVector<QPushButton *> Halogens;
-  QVector<QPushButton *> NobleGases;
+  QList<QPushButton *> OtherNonMetals;
+  QList<QPushButton *> AlkaliMetals;
+  QList<QPushButton *> AlkalineEarthMetals;
+  QList<QPushButton *> TransitionMetals;
+  QList<QPushButton *> Actinides;
+  QList<QPushButton *> Lanthanides;
+  QList<QPushButton *> UnknownProperties;
+  QList<QPushButton *> PostTransitionMetals;
+  QList<QPushButton *> Metalloids;
+  QList<QPushButton *> Halogens;
+  QList<QPushButton *> NobleGases;
 
   /// Vector to hold all group vectors for access to All Buttons at once
-  QVector<QVector<QPushButton *>> AllElementButtons;
+  QList<QList<QPushButton *>> AllElementButtons;
 
   /// @return Comma-separated string of all the element buttons for one group
   /// that are currently checked
-  QString elementsSelectedToString(const QVector<QPushButton *> &elementsSelected);
+  QString elementsSelectedToString(const QList<QPushButton *> &elementsSelected);
 
   /// @return Comma-separated string of all element buttons that are checked in
   /// the whole PeriodicTableWidget
   QString getAllCheckedElementsStr();
 
   /// Disables all buttons associated with a group.
-  void disableButtons(QVector<QPushButton *> buttons);
+  void disableButtons(QList<QPushButton *> buttons);
 
   /// Disables All buttons in periodicTableWidget.
   void disableAllElementButtons();
@@ -70,17 +70,17 @@ private:
   /// The Form containing the PeriodicTableWidget
   Ui::PeriodicTable ui;
   /// Methods to colour element buttons by periodic group
-  void ColourNonMetals(const QVector<QPushButton *> &nonMetals);
-  void ColourAlkaliMetals(const QVector<QPushButton *> &alkaliMetals);
-  void ColourAlkalineEarthMetals(const QVector<QPushButton *> &alkalineEarthMetals);
-  void ColourTransitionMetals(const QVector<QPushButton *> &transMetals);
-  void ColourActinides(const QVector<QPushButton *> &actinides);
-  void ColourLanthanides(const QVector<QPushButton *> &lanthanides);
-  void ColourPostTransitionMetals(const QVector<QPushButton *> &postTransMetals);
-  void ColourUnknownProperties(const QVector<QPushButton *> &unknownProperties);
-  void ColourMetalloids(const QVector<QPushButton *> &metalloids);
-  void ColourHalogens(const QVector<QPushButton *> &halogens);
-  void ColourNobleGases(const QVector<QPushButton *> &nobleGases);
+  void ColourNonMetals(const QList<QPushButton *> &nonMetals);
+  void ColourAlkaliMetals(const QList<QPushButton *> &alkaliMetals);
+  void ColourAlkalineEarthMetals(const QList<QPushButton *> &alkalineEarthMetals);
+  void ColourTransitionMetals(const QList<QPushButton *> &transMetals);
+  void ColourActinides(const QList<QPushButton *> &actinides);
+  void ColourLanthanides(const QList<QPushButton *> &lanthanides);
+  void ColourPostTransitionMetals(const QList<QPushButton *> &postTransMetals);
+  void ColourUnknownProperties(const QList<QPushButton *> &unknownProperties);
+  void ColourMetalloids(const QList<QPushButton *> &metalloids);
+  void ColourHalogens(const QList<QPushButton *> &halogens);
+  void ColourNobleGases(const QList<QPushButton *> &nobleGases);
 
   /// Methods to colour single element button by setting styleSheet
   void ColourButton(QPushButton *elementButton, const QString &colour);

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -334,7 +334,7 @@ void FitDialog::parseInput() {
     // Cannot set any other properties until Function is set
     return;
   }
-  foreach (QWidget *t, m_tabs) {
+  for (QWidget *t : m_tabs) {
     auto iww = dynamic_cast<InputWorkspaceWidget *>(t);
     if (iww) {
       iww->setProperties();
@@ -408,7 +408,7 @@ void FitDialog::domainTypeChanged() {
 void FitDialog::createInputWorkspaceWidgets() {
   m_form.tabWidget->clear();
   QStringList wsNames;
-  foreach (QWidget *t, m_tabs) {
+  for (QWidget *t : m_tabs) {
     const auto *tab = dynamic_cast<InputWorkspaceWidget *>(t);
     if (tab) {
       wsNames << tab->getWorkspaceName();

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -188,7 +188,7 @@ void LoadDialog::saveInput() {
   m_form.fileWidget->saveSettings("Mantid/Algorithms/Load");
   AlgorithmDialog::saveInput();
   // Ensure the filename is store as the full file
-  API::AlgorithmInputHistory::Instance().storeNewValue("Load", QPair<QString, QString>("Filename", m_currentFiles));
+  API::AlgorithmInputHistory::Instance().storeNewValue("Load", std::pair<QString, QString>("Filename", m_currentFiles));
 }
 
 /**

--- a/qt/widgets/plugins/algorithm_dialogs/src/PeriodicTableWidget.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/PeriodicTableWidget.cpp
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Plugins/AlgorithmDialogs/PeriodicTableWidget.h"
-#include <QVector>
+#include <QList>
 
 /**
  * Default constructor
@@ -42,77 +42,77 @@ void PeriodicTableWidget::ColourElements() {
   ColourTransitionMetals(TransitionMetals);
   ColourUnknownProperties(UnknownProperties);
 }
-void PeriodicTableWidget::ColourActinides(const QVector<QPushButton *> &actinides) {
+void PeriodicTableWidget::ColourActinides(const QList<QPushButton *> &actinides) {
   QString buttonColourStr = "background-color: rgb(255, 85, 127, 255)";
   for (auto actinide : actinides) {
     ColourButton(actinide, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourAlkaliMetals(const QVector<QPushButton *> &alkaliMetals) {
+void PeriodicTableWidget::ColourAlkaliMetals(const QList<QPushButton *> &alkaliMetals) {
   QString buttonColourStr = "background-color: rgb(255, 255, 0, 255)";
   for (auto alkaliMetal : alkaliMetals) {
     ColourButton(alkaliMetal, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourAlkalineEarthMetals(const QVector<QPushButton *> &alkalineEarthMetals) {
+void PeriodicTableWidget::ColourAlkalineEarthMetals(const QList<QPushButton *> &alkalineEarthMetals) {
   QString buttonColourStr = "background-color: rgb(170, 170, 127, 255)";
   for (auto alkalineEarthMetal : alkalineEarthMetals) {
     ColourButton(alkalineEarthMetal, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourHalogens(const QVector<QPushButton *> &halogens) {
+void PeriodicTableWidget::ColourHalogens(const QList<QPushButton *> &halogens) {
   QString buttonColourStr = "background-color: rgb(0, 255, 255, 255)";
   for (auto halogen : halogens) {
     ColourButton(halogen, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourLanthanides(const QVector<QPushButton *> &lanthanides) {
+void PeriodicTableWidget::ColourLanthanides(const QList<QPushButton *> &lanthanides) {
   QString buttonColourStr = "background-color: rgb(170, 85, 255, 255)";
   for (auto lanthanide : lanthanides) {
     ColourButton(lanthanide, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourMetalloids(const QVector<QPushButton *> &metalloids) {
+void PeriodicTableWidget::ColourMetalloids(const QList<QPushButton *> &metalloids) {
   QString buttonColourStr = "background-color: rgb(255, 170, 255, 255)";
   for (auto metalloid : metalloids) {
     ColourButton(metalloid, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourNobleGases(const QVector<QPushButton *> &nobleGases) {
+void PeriodicTableWidget::ColourNobleGases(const QList<QPushButton *> &nobleGases) {
   QString buttonColourStr = "background-color: rgb(255, 170, 0, 255)";
   for (auto nobleGas : nobleGases) {
     ColourButton(nobleGas, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourNonMetals(const QVector<QPushButton *> &nonMetals) {
+void PeriodicTableWidget::ColourNonMetals(const QList<QPushButton *> &nonMetals) {
   QString buttonColourStr = "background-color: rgb(0, 170, 255, 255)";
   for (auto nonMetal : nonMetals) {
     ColourButton(nonMetal, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourPostTransitionMetals(const QVector<QPushButton *> &postTransMetals) {
+void PeriodicTableWidget::ColourPostTransitionMetals(const QList<QPushButton *> &postTransMetals) {
   QString buttonColourStr = "background-color: rgb(116, 116, 116, 255)";
   for (auto postTransMetal : postTransMetals) {
     ColourButton(postTransMetal, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourTransitionMetals(const QVector<QPushButton *> &transMetals) {
+void PeriodicTableWidget::ColourTransitionMetals(const QList<QPushButton *> &transMetals) {
   QString buttonColourStr = "background-color: rgb(0, 255, 127, 255)";
   for (auto transMetal : transMetals) {
     ColourButton(transMetal, buttonColourStr);
     update();
   }
 }
-void PeriodicTableWidget::ColourUnknownProperties(const QVector<QPushButton *> &UnknownProperties) {
+void PeriodicTableWidget::ColourUnknownProperties(const QList<QPushButton *> &UnknownProperties) {
   QString buttonColourStr = "background-color: rgb(255, 0, 0, 255)";
   for (auto unknownProperty : UnknownProperties) {
     ColourButton(unknownProperty, buttonColourStr);
@@ -153,7 +153,7 @@ void PeriodicTableWidget::ColourButton(QPushButton *element, const QString &colo
                          "QPushButton:!enabled{background-color: rgb(204,204,204);" + "}");
 }
 
-QString PeriodicTableWidget::elementsSelectedToString(const QVector<QPushButton *> &elements) {
+QString PeriodicTableWidget::elementsSelectedToString(const QList<QPushButton *> &elements) {
   QString selectedElements = "";
   /* Loop through QPushButtons and if they are checked
    * then retrieve the text on the button i.e the
@@ -192,7 +192,7 @@ QString PeriodicTableWidget::getAllCheckedElementsStr() {
 
 QString PeriodicTableWidget::getValue() { return getAllCheckedElementsStr(); }
 
-void PeriodicTableWidget::disableButtons(QVector<QPushButton *> buttonsToDisable) {
+void PeriodicTableWidget::disableButtons(QList<QPushButton *> buttonsToDisable) {
   for (auto &button : buttonsToDisable) {
     button->setDisabled(true);
   }

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
@@ -27,7 +27,6 @@
 
 #include <QDoubleValidator>
 #include <QMap>
-#include <QPair>
 
 #include <algorithm>
 #include <map>

--- a/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsView.cpp
+++ b/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsView.cpp
@@ -81,10 +81,9 @@ void OutputPlotOptionsView::setupView() {
           &OutputPlotOptionsView::notifySelectedUnitChanged);
 
   connect(m_plotOptions->leIndices, &QLineEdit::editingFinished, this,
-          static_cast<void (OutputPlotOptionsView::*)()>(&OutputPlotOptionsView::notifySelectedIndicesChanged));
+          qOverload<>(&OutputPlotOptionsView::notifySelectedIndicesChanged));
   connect(m_plotOptions->leIndices, &QLineEdit::textEdited, this,
-          static_cast<void (OutputPlotOptionsView::*)(QString const &)>(
-              &OutputPlotOptionsView::notifySelectedIndicesChanged));
+          qOverload<QString const &>(&OutputPlotOptionsView::notifySelectedIndicesChanged));
 
   connect(m_plotOptions->pbPlotSpectra, &QPushButton::clicked, this, &OutputPlotOptionsView::notifyPlotSpectraClicked);
   setIndicesErrorLabelVisibleImpl(false);

--- a/qt/widgets/spectroscopy/test/InterfaceUtilsTest.h
+++ b/qt/widgets/spectroscopy/test/InterfaceUtilsTest.h
@@ -11,7 +11,6 @@
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
 
-#include <QPair>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;


### PR DESCRIPTION
### Description of work

Since we have now moved to Qt6 everywhere we can address the deprecation that are now in Qt6. Once this is merged we would be effectively dropping support for Qt5 since it will no longer compile against it.

This updates the `QT_DISABLE_DEPRECATED_BEFORE` to prevent use of any deprecated Qt6 calls in 6.11.

Other modernisations:
 * Drop the `#if QT_VERSION` statements since we don't need to support both Qt5 and Qt6.
 * Replaced `QPair` with `std::pair` since in Qt6 `QPair` is now just a alias to `std::pair`.
 * Replaced `QVector` with `QList` since in Qt6 `QVector` is now just a alias to `QList`
 * Replaced `foreach` with `for` as recommend if using at least c++11
 * Make use of `qOverload` to simply some code. `qOverload` was actually introduced in Qt 5.8 so could have used this before.

There should also fixed all the qt related deprecation warnings.

This doesn't remove the Qt5 stuff from the cmake files which can be done later since I focused only on the c++ code changes for this PR.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Doesn't need release notes since this is an internal change only, not visible to users.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

Ref #38415

### To test:

Code review. If CI passes we should be good.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
