### PR TITLE
Add Sum Runs checkbox to Diagnostic and Transmission tabs of Indirect Reduction Interface

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -22,6 +22,7 @@ from mantid.simpleapi import (
     Integration,
     Load,
     Transpose,
+    CloneWorkspace,
 )
 
 from IndirectCommon import check_hist_zero
@@ -154,23 +155,30 @@ class TimeSlice(PythonAlgorithm):
         workflow_prog = Progress(self, start=0.0, end=0.96, nreports=len(self._raw_files) * 3)
         for index, filename in enumerate(self._raw_files):
             workflow_prog.report("Reading file: " + str(i))
-
-            raw_file = self._read_raw_file(filename) if self._do_load else filename
+            if self._do_load:
+                raw_file = self._read_raw_file(filename)
+                run = mtd[raw_file].getRun().getLogData("run_number").value
+                inst = mtd[raw_file].getInstrumentName()
+                sliced_ws_name = inst.lower() + run + self._output_ws_name_suffix
+            else:
+                raw_file = "__" + filename
+                CloneWorkspace(InputWorkspace=filename, OutputWorkspace=raw_file)
+                # we just use workspace name if we haven't loaded a raw file
+                sliced_ws_name = raw_file.lstrip("__") + self._output_ws_name_suffix
 
             # Only need to process the calib file once
             if index == 0 and self._calib_ws is not None:
                 self._process_calib(raw_file)
 
             workflow_prog.report("Transposing Workspace: " + str(i))
-            slice_file = self._process_raw_file(raw_file)
-            Transpose(InputWorkspace=slice_file, OutputWorkspace=slice_file)
-            unit = mtd[slice_file].getAxis(0).setUnit("Label")
+            self._process_raw_file(raw_file, sliced_ws_name)
+            Transpose(InputWorkspace=sliced_ws_name, OutputWorkspace=sliced_ws_name)
+            unit = mtd[sliced_ws_name].getAxis(0).setUnit("Label")
             unit.setLabel("Spectrum Number", "")
 
             workflow_prog.report("Deleting Workspace")
-            out_ws_list.append(slice_file)
-            if self._do_load:
-                DeleteWorkspace(raw_file)
+            out_ws_list.append(sliced_ws_name)
+            DeleteWorkspace(raw_file)
 
         all_workspaces = ",".join(out_ws_list)
         final_prog = Progress(self, start=0.96, end=1.0, nreports=2)
@@ -246,39 +254,31 @@ class TimeSlice(PythonAlgorithm):
             EndWorkspaceIndex=calib_spec_max,
         )
 
-    def _process_raw_file(self, raw_file):
+    def _process_raw_file(self, curr_name, sliced_ws_name):
         """
         Process a raw sample file.
 
-        @param raw_file Name of file to process
+        @param curr_name Name of loaded raw file/ws to process
         """
         # Crop the raw file to use the desired number of spectra
         # less one because CropWorkspace is zero based
         CropWorkspace(
-            InputWorkspace=raw_file,
-            OutputWorkspace=raw_file,
+            InputWorkspace=curr_name,
+            OutputWorkspace=curr_name,
             StartWorkspaceIndex=int(self._spectra_range[0]) - 1,
             EndWorkspaceIndex=int(self._spectra_range[1]) - 1,
         )
 
-        num_hist = check_hist_zero(raw_file)[0]
+        num_hist = check_hist_zero(curr_name)[0]
 
         # Use calibration file if desired
         if self._calib_ws is not None:
-            Divide(LHSWorkspace=raw_file, RHSWorkspace=self._calib_ws, OutputWorkspace=raw_file)
-
-        # Construct output workspace name
-        slice_file = raw_file + self._output_ws_name_suffix  # we just use workspace name if we haven't loaded a raw file
-        if self._do_load:
-            run = mtd[raw_file].getRun().getLogData("run_number").value
-            inst = mtd[raw_file].getInstrumentName()
-            slice_file = inst.lower() + run + self._output_ws_name_suffix
-
+            Divide(LHSWorkspace=curr_name, RHSWorkspace=self._calib_ws, OutputWorkspace=curr_name)
 
         if self._background_range is None:
             Integration(
-                InputWorkspace=raw_file,
-                OutputWorkspace=slice_file,
+                InputWorkspace=curr_name,
+                OutputWorkspace=sliced_ws_name,
                 RangeLower=self._peak_range[0],
                 RangeUpper=self._peak_range[1],
                 StartWorkspaceIndex=0,
@@ -286,22 +286,20 @@ class TimeSlice(PythonAlgorithm):
             )
         else:
             CalculateFlatBackground(
-                InputWorkspace=raw_file,
-                OutputWorkspace=slice_file,
+                InputWorkspace=curr_name,
+                OutputWorkspace=sliced_ws_name,
                 StartX=self._background_range[0],
                 EndX=self._background_range[1],
                 Mode="Mean",
             )
             Integration(
-                InputWorkspace=slice_file,
-                OutputWorkspace=slice_file,
+                InputWorkspace=sliced_ws_name,
+                OutputWorkspace=sliced_ws_name,
                 RangeLower=self._peak_range[0],
                 RangeUpper=self._peak_range[1],
                 StartWorkspaceIndex=0,
                 EndWorkspaceIndex=num_hist - 1,
             )
-
-        return slice_file
 
 
 AlgorithmFactory.subscribe(TimeSlice)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -74,6 +74,7 @@ class TimeSlice(PythonAlgorithm):
     _background_range = None
     _calib_ws = None
     _out_ws_group = None
+    _do_load = True
 
     def category(self):
         return "Inelastic\\Utility"
@@ -85,7 +86,12 @@ class TimeSlice(PythonAlgorithm):
         return ["Integration"]
 
     def PyInit(self):
-        self.declareProperty(StringArrayProperty(name="InputFiles"), doc="Comma separated list of input files")
+        self.declareProperty(StringArrayProperty(name="InputFiles", values=[]), doc="Comma separated list of input files")
+
+        self.declareProperty(
+            WorkspaceProperty(name="SampleWorkspace", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional),
+            doc="Optional sample workspace that can be provided instead of Input Files, only uses the workspace if Input Files is empty",
+        )
 
         self.declareProperty(
             WorkspaceProperty(name="CalibrationWorkspace", defaultValue="", direction=Direction.Input, optional=PropertyMode.Optional),
@@ -127,6 +133,11 @@ class TimeSlice(PythonAlgorithm):
     def validateInputs(self):
         issues = dict()
 
+        if self.getProperty("InputFiles").isDefault and self.getProperty("SampleWorkspace").value is None:
+            msg = "Must supply either 'InputFiles' or 'SampleWorkspace'."
+            issues["InputFiles"] = msg
+            issues["SampleWorkspace"] = msg
+
         issues["SpectraRange"] = self._validate_range("SpectraRange")
         issues["PeakRange"] = self._validate_range("PeakRange")
 
@@ -143,7 +154,8 @@ class TimeSlice(PythonAlgorithm):
         workflow_prog = Progress(self, start=0.0, end=0.96, nreports=len(self._raw_files) * 3)
         for index, filename in enumerate(self._raw_files):
             workflow_prog.report("Reading file: " + str(i))
-            raw_file = self._read_raw_file(filename)
+
+            raw_file = self._read_raw_file(filename) if self._do_load else filename
 
             # Only need to process the calib file once
             if index == 0 and self._calib_ws is not None:
@@ -157,7 +169,8 @@ class TimeSlice(PythonAlgorithm):
 
             workflow_prog.report("Deleting Workspace")
             out_ws_list.append(slice_file)
-            DeleteWorkspace(raw_file)
+            if self._do_load:
+                DeleteWorkspace(raw_file)
 
         all_workspaces = ",".join(out_ws_list)
         final_prog = Progress(self, start=0.96, end=1.0, nreports=2)
@@ -170,8 +183,9 @@ class TimeSlice(PythonAlgorithm):
         """
         Gets properties.
         """
+        self._do_load = not self.getProperty("InputFiles").isDefault
+        self._raw_files = self.getProperty("InputFiles").value if self._do_load else [self.getPropertyValue("SampleWorkspace")]
 
-        self._raw_files = self.getProperty("InputFiles").value
         self._spectra_range = self.getProperty("SpectraRange").value
         self._peak_range = self.getProperty("PeakRange").value
         self._output_ws_name_suffix = self.getPropertyValue("OutputNameSuffix")
@@ -254,9 +268,12 @@ class TimeSlice(PythonAlgorithm):
             Divide(LHSWorkspace=raw_file, RHSWorkspace=self._calib_ws, OutputWorkspace=raw_file)
 
         # Construct output workspace name
-        run = mtd[raw_file].getRun().getLogData("run_number").value
-        inst = mtd[raw_file].getInstrumentName()
-        slice_file = inst.lower() + run + self._output_ws_name_suffix
+        slice_file = raw_file + self._output_ws_name_suffix  # we just use workspace name if we haven't loaded a raw file
+        if self._do_load:
+            run = mtd[raw_file].getRun().getLogData("run_number").value
+            inst = mtd[raw_file].getInstrumentName()
+            slice_file = inst.lower() + run + self._output_ws_name_suffix
+
 
         if self._background_range is None:
             Integration(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
@@ -57,6 +57,23 @@ class TimeSliceTest(unittest.TestCase):
         )
         self.assertTrue(mtd.doesExist("TestWs_graphite002_slice"))
 
+    def test_sample_workspace_property_does_not_alter_input_ws(self):
+        """
+        Test to check optional SampleWorkspace input property
+        """
+        ws = Load("IRS26173.raw", OutputWorkspace="TestWs")
+        no_hist = ws.getNumberHistograms()
+        TimeSlice(
+            SampleWorkspace="TestWs",
+            SpectraRange=[3, 53],
+            PeakRange=[62500, 65000],
+            BackgroundRange=[59000, 61500],
+            OutputNameSuffix="_graphite002_slice",
+            OutputWorkspace="SliceTestOut",
+        )
+        self.assertEqual(no_hist, mtd["TestWs"].getNumberHistograms())
+        self.assertTrue(mtd.doesExist("TestWs_graphite002_slice"))
+
     def test_validation_input_files_empty(self):
         """
         Tests to ensure that a valid input is selected

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.api import mtd
-from mantid.simpleapi import TimeSlice
+from mantid.simpleapi import TimeSlice, Load
 
 
 class TimeSliceTest(unittest.TestCase):
@@ -41,6 +41,37 @@ class TimeSliceTest(unittest.TestCase):
         )
 
         self.assertTrue(mtd.doesExist("iris26173_graphite002_slice"))
+
+    def test_sample_workspace_property(self):
+        """
+        Test to check optional SampleWorkspace input property
+        """
+        Load("IRS26173.raw", OutputWorkspace="TestWs")
+        TimeSlice(
+            SampleWorkspace="TestWs",
+            SpectraRange=[3, 53],
+            PeakRange=[62500, 65000],
+            BackgroundRange=[59000, 61500],
+            OutputNameSuffix="_graphite002_slice",
+            OutputWorkspace="SliceTestOut",
+        )
+        self.assertTrue(mtd.doesExist("TestWs_graphite002_slice"))
+
+    def test_validation_input_files_empty(self):
+        """
+        Tests to ensure that a valid input is selected
+        """
+
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must supply either 'InputFiles' or 'SampleWorkspace'",
+            TimeSlice,
+            SpectraRange=[3, 53],
+            PeakRange=[62500, 65000],
+            BackgroundRange=[59000, 61500],
+            OutputNameSuffix="_graphite002_slice",
+            OutputWorkspace="SliceTestOut",
+        )
 
     def test_validation_peak_range_order(self):
         """

--- a/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
+++ b/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
@@ -1,0 +1,2 @@
+- `ISISCalibration` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of input runs.
+- `Transmission` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of sample or can runs.

--- a/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
+++ b/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
@@ -1,2 +1,2 @@
-- `ISISDiagnostics` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of input runs.
-- `Transmission` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of sample or can runs.
+- `ISISDiagnostics` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `Sum Files` checkbox to average a comma separate list of input runs.
+- `Transmission` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `Sum Files` checkbox to average a comma separate list of sample or can runs.

--- a/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
+++ b/docs/source/release/v7.0.0/Indirect/New_features/40960.rst
@@ -1,2 +1,2 @@
-- `ISISCalibration` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of input runs.
+- `ISISDiagnostics` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of input runs.
 - `Transmission` tab of the :ref:`Data Reduction <interface-indirect-data-reduction>` interface now has a `SumFiles` checkbox to average a comma separate list of sample or can runs.

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -36,6 +36,7 @@ public:
   virtual QMap<QString, QString> getInstrumentDetails() = 0;
 
   virtual void showAnalyserAndReflectionOptions(bool visible) = 0;
+  virtual const std::string &ipfFileName() const = 0;
 };
 
 /**
@@ -84,6 +85,8 @@ public:
   QMap<QString, QString> getInstrumentDetails() override;
 
   void showAnalyserAndReflectionOptions(bool visible) override;
+
+  const std::string &ipfFileName() const override { return m_ipfFilename; }
 
 signals:
   /// Emitted when the instrument setup is changed

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -69,6 +69,8 @@ QString DataReductionTab::getInstrumentDetail(QMap<QString, QString> const &inst
   return instrumentDetails[key];
 }
 
+std::string DataReductionTab::getIpfFilename() const { return m_idrUI->ipfFileName(); }
+
 void DataReductionTab::validateInstrumentDetail(QString const &key) const {
   auto const instrumentName = getInstrumentName().toStdString();
 

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -77,6 +77,7 @@ protected:
   QString getInstrumentName() const;
   QString getAnalyserName() const;
   QString getReflectionName() const;
+  std::string getIpfFilename() const;
 
   std::map<std::string, double> getRangesFromInstrument(QString instName = "", QString analyser = "",
                                                         QString reflection = "");

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -5,14 +5,17 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ISISDiagnostics.h"
+
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
+#include "ReductionAlgorithmUtils.h"
 
 #include <MantidAPI/FileFinder.h>
+#include <MantidQtWidgets/Common/ParseKeyValueString.h>
 #include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 #include <QFileInfo>
 
@@ -132,7 +135,6 @@ ISISDiagnostics::~ISISDiagnostics() {
 
 void ISISDiagnostics::handleRun() {
   QString suffix = "_" + getAnalyserName() + getReflectionName() + "_slice";
-  QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
 
   std::vector<int> spectraRange;
   spectraRange.emplace_back(static_cast<int>(m_dblManager->value(m_properties["SpecMin"])));
@@ -145,7 +147,12 @@ void ISISDiagnostics::handleRun() {
   IAlgorithm_sptr sliceAlg = AlgorithmManager::Instance().create("TimeSlice");
   sliceAlg->initialize();
 
-  sliceAlg->setProperty("InputFiles", filenames.toStdString());
+  if (m_isSumFiles) {
+    sliceAlg->setProperty("SampleWorkspace", m_sampleName.toStdString());
+  } else {
+    sliceAlg->setProperty("InputFiles", m_sampleName.toStdString());
+  }
+
   sliceAlg->setProperty("SpectraRange", spectraRange);
   sliceAlg->setProperty("PeakRange", peakRange);
   sliceAlg->setProperty("OutputNameSuffix", suffix.toStdString());
@@ -254,20 +261,26 @@ void ISISDiagnostics::handleNewFile() {
   if (!m_uiForm.dsInputFiles->isValid())
     return;
 
-  QString filename = m_uiForm.dsInputFiles->getFirstFilename();
-
-  QFileInfo fi(filename);
-  QString wsname = fi.baseName();
+  QString wsname;
+  if (!m_uiForm.ckSumFiles->isChecked()) {
+    QFileInfo fi(m_uiForm.dsInputFiles->getFirstFilename());
+    wsname = fi.baseName();
+    if (!loadFile(m_uiForm.dsInputFiles->getFirstFilename().toStdString(), wsname.toStdString())) {
+      emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                          "and matches the selected instrument in the "
+                          "EnergyTransfer tab.");
+      return;
+    }
+    m_sampleName = m_uiForm.dsInputFiles->getFilenames().join(",");
+    m_isSumFiles = false;
+  } else {
+    wsname = QString::fromStdString(loadFilesWithSum(
+        MantidWidgets::qStringListToStdVector(m_uiForm.dsInputFiles->getFilenames()), getIpfFilename()));
+    m_sampleName = wsname;
+    m_isSumFiles = true;
+  }
 
   int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
-  int specMax = static_cast<int>(m_dblManager->value(m_properties["SpecMax"]));
-
-  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax, SettingsHelper::loadHistory())) {
-    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
-                        "and matches the selected instrument in the "
-                        "EnergyTransfer tab.");
-    return;
-  }
 
   auto const inputWorkspace = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsname.toStdString());
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -111,6 +111,7 @@ ISISDiagnostics::ISISDiagnostics(IDataReduction *idrUI, QWidget *parent) : DataR
   connect(m_uiForm.ckUseCalibration, &QCheckBox::toggled, this, &ISISDiagnostics::sliceCalib);
   // Plot slice miniplot when file has finished loading
   connect(m_uiForm.dsInputFiles, &FileFinderWidget::filesFoundChanged, this, &ISISDiagnostics::handleNewFile);
+  connect(m_uiForm.ckSumFiles, &QCheckBox::stateChanged, this, &ISISDiagnostics::handleNewFile);
   // Shows message on run button when Mantid is finding the file for a given run
   // number
   connect(m_uiForm.dsInputFiles, &FileFinderWidget::findingFiles, this, &ISISDiagnostics::pbRunFinding);
@@ -257,28 +258,40 @@ void ISISDiagnostics::setDefaultInstDetails(QMap<QString, QString> const &instru
   m_dblManager->setValue(m_properties["PreviewSpec"], spectraMin);
 }
 
+QString ISISDiagnostics::loadFiles(const QStringList &fileNames) {
+  if (fileNames.empty()) {
+    return "";
+  }
+
+  QString wsname;
+  bool loadError = false;
+  if (!m_uiForm.ckSumFiles->isChecked()) {
+    const QString fileName = fileNames.at(0);
+    const QFileInfo fi(fileName);
+    wsname = fi.baseName();
+    loadError = !loadFile(fileName.toStdString(), wsname.toStdString());
+  } else {
+    wsname =
+        QString::fromStdString(loadFilesWithSum(MantidWidgets::qStringListToStdVector(fileNames), getIpfFilename()));
+    loadError = wsname.isEmpty();
+  }
+
+  if (loadError) {
+    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                        "and matches the selected instrument in the "
+                        "EnergyTransfer tab.");
+    wsname.clear();
+  }
+  return wsname;
+}
+
 void ISISDiagnostics::handleNewFile() {
   if (!m_uiForm.dsInputFiles->isValid())
     return;
 
-  QString wsname;
-  if (!m_uiForm.ckSumFiles->isChecked()) {
-    QFileInfo fi(m_uiForm.dsInputFiles->getFirstFilename());
-    wsname = fi.baseName();
-    if (!loadFile(m_uiForm.dsInputFiles->getFirstFilename().toStdString(), wsname.toStdString())) {
-      emit showMessageBox("Unable to load file.\nCheck whether your file exists "
-                          "and matches the selected instrument in the "
-                          "EnergyTransfer tab.");
-      return;
-    }
-    m_sampleName = m_uiForm.dsInputFiles->getFilenames().join(",");
-    m_isSumFiles = false;
-  } else {
-    wsname = QString::fromStdString(loadFilesWithSum(
-        MantidWidgets::qStringListToStdVector(m_uiForm.dsInputFiles->getFilenames()), getIpfFilename()));
-    m_sampleName = wsname;
-    m_isSumFiles = true;
-  }
+  const auto wsname = loadFiles(m_uiForm.dsInputFiles->getFilenames());
+  m_sampleName = wsname;
+  m_isSumFiles = m_uiForm.ckSumFiles->isChecked();
 
   int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -111,7 +111,7 @@ ISISDiagnostics::ISISDiagnostics(IDataReduction *idrUI, QWidget *parent) : DataR
   connect(m_uiForm.ckUseCalibration, &QCheckBox::toggled, this, &ISISDiagnostics::sliceCalib);
   // Plot slice miniplot when file has finished loading
   connect(m_uiForm.dsInputFiles, &FileFinderWidget::filesFoundChanged, this, &ISISDiagnostics::handleNewFile);
-  connect(m_uiForm.ckSumFiles, &QCheckBox::stateChanged, this, &ISISDiagnostics::handleNewFile);
+  connect(m_uiForm.ckSumFiles, &QCheckBox::checkStateChanged, this, &ISISDiagnostics::handleNewFile);
   // Shows message on run button when Mantid is finding the file for a given run
   // number
   connect(m_uiForm.dsInputFiles, &FileFinderWidget::findingFiles, this, &ISISDiagnostics::pbRunFinding);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -83,6 +83,8 @@ private:
   void setBackgroundRange(double minimum, double maximum);
 
   Ui::ISISDiagnostics m_uiForm;
+  QString m_sampleName;
+  bool m_isSumFiles;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -81,6 +81,7 @@ private:
                       QString const &minPropertyName, QString const &maxPropertyName);
   void setPeakRange(double minimum, double maximum);
   void setBackgroundRange(double minimum, double maximum);
+  QString loadFiles(const QStringList &fileNames);
 
   Ui::ISISDiagnostics m_uiForm;
   QString m_sampleName;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
@@ -52,6 +52,19 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="ckSumFiles">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>SumFiles</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
@@ -61,7 +61,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>SumFiles</string>
+           <string>Sum Files</string>
           </property>
          </widget>
         </item>

--- a/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
@@ -52,7 +52,7 @@ std::string workspaceNameFromFilename(const std::string &filename) {
 }
 
 void loadFile(const std::string &filename, const std::string &ipfFilename, bool loadLogFiles, SumFilesData &sumData) {
-  const auto workspaceName = workspaceNameFromFilename(filename);
+  const auto workspaceName = "__" + workspaceNameFromFilename(filename);
 
   const auto loader = createAlgorithm("Load");
   loader->setPropertyValue("Filename", filename);
@@ -184,19 +184,25 @@ MantidQt::API::IConfiguredAlgorithm_sptr groupDetectorsConfiguredAlg(std::string
 
 std::string loadFilesWithSum(const std::vector<std::string> &filenames, const std::string &ipfFilename,
                              bool loadLogFiles, bool deleteMonitors) {
+  std::string outName;
+  try {
+    auto sumData = SumFilesData(filenames.size());
+    for (const auto &filename : filenames) {
+      loadFile(filename, ipfFilename, loadLogFiles, sumData);
+    }
 
-  auto sumData = SumFilesData(filenames.size());
-  for (const auto &filename : filenames) {
-    loadFile(filename, ipfFilename, loadLogFiles, sumData);
+    if (filenames.size() == 1) {
+      outName = filenames.at(0);
+    } else {
+      sumRegularRuns(sumData.wsNames, false);
+      outName = renameOutputWorkspace(sumData);
+      removeWorkspacesFromADS(sumData.wsNames, deleteMonitors);
+    }
+
+  } catch (const std::exception &e) {
+    // We are rethrowing all algorithm calls
+    outName.clear();
   }
-
-  if (filenames.size() == 1) {
-    return filenames.at(0);
-  }
-  sumRegularRuns(sumData.wsNames, false);
-  const auto outName = renameOutputWorkspace(sumData);
-  removeWorkspacesFromADS(sumData.wsNames, deleteMonitors);
-
   return outName;
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
@@ -9,13 +9,137 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AlgorithmProperties.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidQtWidgets/Common/ConfiguredAlgorithm.h"
+
+#include <filesystem>
+
+namespace {
+struct SumFilesData {
+  std::string instrumentName;
+  std::vector<std::string> wsNames;
+  std::vector<int> runNo;
+
+  explicit SumFilesData(const size_t vectorSize) {
+    wsNames.reserve(vectorSize);
+    runNo.reserve(vectorSize);
+  }
+};
+
+void removeWorkspacesFromADS(const std::vector<std::string> &workspaceNames, bool deleteMonitors) {
+  auto &ads = Mantid::API::AnalysisDataService::Instance();
+  for (size_t index = 0; index < workspaceNames.size(); index++) {
+    const auto &wsName = workspaceNames[index];
+    if (ads.doesExist(wsName)) {
+      ads.remove(wsName);
+    }
+    if (const auto &monitorName = wsName + "_mon"; ads.doesExist(monitorName) && deleteMonitors) {
+      ads.remove(monitorName);
+    }
+  }
+}
+
+Mantid::API::IAlgorithm_sptr createAlgorithm(const std::string &name) {
+  auto algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged(name);
+  algorithm->initialize();
+  algorithm->setRethrows(true);
+  return algorithm;
+}
+
+std::string workspaceNameFromFilename(const std::string &filename) {
+  return std::filesystem::path(filename).stem().string();
+}
+
+void loadFile(const std::string &filename, const std::string &ipfFilename, bool loadLogFiles, SumFilesData &sumData) {
+  const auto workspaceName = workspaceNameFromFilename(filename);
+
+  const auto loader = createAlgorithm("Load");
+  loader->setPropertyValue("Filename", filename);
+  loader->setPropertyValue("OutputWorkspace", workspaceName);
+
+  if (loader->existsProperty("LoadLogFiles"))
+    loader->setProperty("LoadLogFiles", loadLogFiles);
+
+  loader->execute();
+
+  const auto workspace =
+      Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName);
+
+  const auto loadParameters = createAlgorithm("LoadParameterFile");
+  loadParameters->setProperty("Workspace", workspaceName);
+  loadParameters->setPropertyValue("Filename", ipfFilename);
+  loadParameters->execute();
+
+  const auto inst = workspace->getInstrument();
+
+  if (sumData.instrumentName.empty()) {
+    sumData.instrumentName = inst->getName();
+  }
+  sumData.wsNames.emplace_back(workspaceName);
+  sumData.runNo.emplace_back(workspace->getRunNumber());
+}
+
+void mergeRuns(std::vector<std::string> const &inputNames, const std::string &outputName) {
+  const auto mergeAlg = createAlgorithm("MergeRuns");
+  mergeAlg->setProperty("InputWorkspaces", inputNames);
+  mergeAlg->setPropertyValue("OutputWorkspace", outputName);
+  mergeAlg->execute();
+}
+
+void scaleWorkspace(const std::string &workspaceName, double factor) {
+  const auto scaleAlg = createAlgorithm("Scale");
+  scaleAlg->setPropertyValue("InputWorkspace", workspaceName);
+  scaleAlg->setPropertyValue("OutputWorkspace", workspaceName);
+  scaleAlg->setProperty("Factor", factor);
+  scaleAlg->setPropertyValue("Operation", "Multiply");
+  scaleAlg->execute();
+}
+
+void sumRegularRuns(std::vector<std::string> workspaceNames, bool isMonitor) {
+  auto outputName = workspaceNames.front();
+  const auto scaleFactor = 1.0 / static_cast<double>(workspaceNames.size());
+
+  if (isMonitor) {
+    outputName += "_mon";
+    for (size_t i = 0; i < workspaceNames.size(); i++) {
+      workspaceNames.at(i) += "_mon";
+    }
+  }
+  mergeRuns(workspaceNames, outputName);
+  scaleWorkspace(outputName, scaleFactor);
+}
+
+std::string renameOutputWorkspace(const SumFilesData &sumData) {
+  const auto currName = sumData.wsNames.front();
+  auto inst = sumData.instrumentName;
+  if (inst == "TOSCA") {
+    inst = "TSC";
+  } else if (inst == "TFXA") {
+    inst = "TFX";
+  }
+
+  std::string runstr = std::to_string(sumData.runNo.at(0));
+  if (sumData.runNo.size() > 1) {
+    const auto &[minRun, maxRun] = std::minmax_element(sumData.runNo.cbegin(), sumData.runNo.cend());
+    runstr = std::to_string(*minRun) + "-" + std::to_string(*maxRun);
+  }
+  const auto wsName = inst + runstr + "_summed";
+  const auto rename = createAlgorithm("RenameWorkspace");
+  rename->setPropertyValue("InputWorkspace", currName);
+  rename->setPropertyValue("OutputWorkspace", wsName);
+  rename->execute();
+
+  return wsName;
+}
+
+} // namespace
 
 namespace MantidQt::CustomInterfaces {
 
 using namespace Mantid::API;
 
-MantidQt::API::IConfiguredAlgorithm_sptr configureAlgorithm(std::string const &algorithmName,
+MantidQt::API::IConfiguredAlgorithm_sptr configureAlgorithm(const std::string &algorithmName,
                                                             std::unique_ptr<IAlgorithmRuntimeProps> properties,
                                                             bool const validatePropsPreExec = true) {
   return std::make_unique<MantidQt::API::ConfiguredAlgorithm>(AlgorithmManager::Instance().create(algorithmName),
@@ -56,6 +180,20 @@ MantidQt::API::IConfiguredAlgorithm_sptr groupDetectorsConfiguredAlg(std::string
   AlgorithmProperties::update("DetectorList", detectorList, *properties, false);
   AlgorithmProperties::update("OutputWorkspace", outputWorkspace, *properties);
   return configureAlgorithm("GroupDetectors", std::move(properties));
+}
+
+std::string loadFilesWithSum(const std::vector<std::string> &filenames, const std::string &ipfFilename,
+                             bool loadLogFiles, bool deleteMonitors) {
+
+  auto sumData = SumFilesData(filenames.size());
+  for (const auto &filename : filenames) {
+    loadFile(filename, ipfFilename, loadLogFiles, sumData);
+  }
+  sumRegularRuns(sumData.wsNames, false);
+  const auto outName = renameOutputWorkspace(sumData);
+  removeWorkspacesFromADS(sumData.wsNames, deleteMonitors);
+
+  return outName;
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
@@ -120,11 +120,13 @@ std::string renameOutputWorkspace(const SumFilesData &sumData) {
   }
 
   std::string runstr = std::to_string(sumData.runNo.at(0));
+  std::string summedSuffix;
   if (sumData.runNo.size() > 1) {
     const auto &[minRun, maxRun] = std::minmax_element(sumData.runNo.cbegin(), sumData.runNo.cend());
     runstr = std::to_string(*minRun) + "-" + std::to_string(*maxRun);
+    summedSuffix = "_summed";
   }
-  const auto wsName = inst + runstr + "_summed";
+  const auto wsName = inst + runstr + summedSuffix;
   const auto rename = createAlgorithm("RenameWorkspace");
   rename->setPropertyValue("InputWorkspace", currName);
   rename->setPropertyValue("OutputWorkspace", wsName);
@@ -192,14 +194,14 @@ std::string loadFilesWithSum(const std::vector<std::string> &filenames, const st
     }
 
     if (filenames.size() == 1) {
-      outName = filenames.at(0);
+      outName = renameOutputWorkspace(sumData);
     } else {
       sumRegularRuns(sumData.wsNames, false);
       outName = renameOutputWorkspace(sumData);
       removeWorkspacesFromADS(sumData.wsNames, deleteMonitors);
     }
 
-  } catch (const std::exception &e) {
+  } catch (const std::exception &) {
     // We are rethrowing all algorithm calls
     outName.clear();
   }

--- a/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.cpp
@@ -189,6 +189,10 @@ std::string loadFilesWithSum(const std::vector<std::string> &filenames, const st
   for (const auto &filename : filenames) {
     loadFile(filename, ipfFilename, loadLogFiles, sumData);
   }
+
+  if (filenames.size() == 1) {
+    return filenames.at(0);
+  }
   sumRegularRuns(sumData.wsNames, false);
   const auto outName = renameOutputWorkspace(sumData);
   removeWorkspacesFromADS(sumData.wsNames, deleteMonitors);

--- a/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ReductionAlgorithmUtils.h
@@ -26,4 +26,8 @@ MANTIDQT_INDIRECT_DLL MantidQt::API::IConfiguredAlgorithm_sptr
 groupDetectorsConfiguredAlg(std::string const &inputWorkspace, std::vector<int> const &detectorList,
                             std::string const &outputWorkspace);
 
+MANTIDQT_INDIRECT_DLL std::string loadFilesWithSum(const std::vector<std::string> &filenames,
+                                                   const std::string &ipfFilename, bool loadLogFiles = false,
+                                                   bool deleteMonitors = true);
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -5,8 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "Transmission.h"
-#include "MantidAPI/WorkspaceGroup.h"
 
+#include "MantidAPI/WorkspaceGroup.h"
+#include "ReductionAlgorithmUtils.h"
+
+#include <MantidQtWidgets/Common/ParseKeyValueString.h>
 #include <QFileInfo>
 
 using namespace Mantid::API;
@@ -37,31 +40,53 @@ Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReducti
   connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Transmission::transAlgDone);
 
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &Transmission::saveClicked);
+  connect(m_uiForm.dsSampleInput, &FileFinderWidget::filesFoundChanged, this, &Transmission::handleNewInputData);
+  connect(m_uiForm.dsCanInput, &FileFinderWidget::filesFoundChanged, this, &Transmission::handleNewInputData);
 
   m_uiForm.ppPlot->setCanvasColour(QColor(240, 240, 240));
-
-  m_uiForm.dsSampleInput->setTypeSelectorVisible(false);
-  m_uiForm.dsCanInput->setTypeSelectorVisible(false);
 }
 
 Transmission::~Transmission() = default;
 
-void Transmission::handleRun() {
-  QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-  QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
-  QString outWsName = sampleWsName.toLower() + "_transmission_group";
+void Transmission::handleNewInputData() {
+  const auto *finder = qobject_cast<MantidQt::API::FileFinderWidget *>(sender());
+  const auto fileNames = finder->getFilenames();
 
-  IAlgorithm_sptr transAlg = AlgorithmManager::Instance().create("IndirectTransmissionMonitor", -1);
+  QString wsname;
+  if (!m_uiForm.ckSumFiles->isChecked() || fileNames.size() == 1) {
+    QFileInfo fi(finder->getFirstFilename());
+    wsname = fi.baseName();
+    if (!loadFile(finder->getFirstFilename().toStdString(), wsname.toStdString())) {
+      emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                          "and matches the selected instrument in the "
+                          "EnergyTransfer tab.");
+      return;
+    }
+  } else {
+    wsname =
+        QString::fromStdString(loadFilesWithSum(MantidWidgets::qStringListToStdVector(fileNames), getIpfFilename()));
+  }
+
+  if (finder != m_uiForm.dsCanInput) {
+    m_sampleName = wsname;
+  } else {
+    m_canName = wsname;
+  }
+}
+
+void Transmission::handleRun() {
+  const auto outWsName = m_sampleName.toLower().toStdString() + "_transmission_group";
+  const auto transAlg = AlgorithmManager::Instance().create("IndirectTransmissionMonitor", -1);
   transAlg->initialize();
 
-  transAlg->setProperty("SampleWorkspace", sampleWsName.toStdString());
-  transAlg->setProperty("CanWorkspace", canWsName.toStdString());
-  transAlg->setProperty("OutputWorkspace", outWsName.toStdString());
+  transAlg->setProperty("SampleWorkspace", m_sampleName.toStdString());
+  transAlg->setProperty("CanWorkspace", m_canName.toStdString());
+  transAlg->setProperty("OutputWorkspace", outWsName);
 
   m_batchAlgoRunner->addAlgorithm(transAlg);
   m_batchAlgoRunner->executeBatchAsync();
 
-  m_pythonExportWsName = outWsName.toStdString();
+  m_pythonExportWsName = outWsName;
 }
 
 void Transmission::handleValidation(IUserInputValidator *validator) const {
@@ -70,13 +95,8 @@ void Transmission::handleValidation(IUserInputValidator *validator) const {
   if (currentInst != "IRIS" && currentInst != "OSIRIS")
     validator->addErrorMessage("The selected instrument must be IRIS or OSIRIS");
 
-  // Check for an invalid sample input
-  if (!m_uiForm.dsSampleInput->isValid())
-    validator->addErrorMessage("Sample: " + m_uiForm.dsSampleInput->getProblem().toStdString());
-
-  // Check for an invalid can input
-  if (!m_uiForm.dsCanInput->isValid())
-    validator->addErrorMessage("Resolution: " + m_uiForm.dsCanInput->getProblem().toStdString());
+  validator->checkFileFinderWidgetIsValid("Sample", m_uiForm.dsSampleInput);
+  validator->checkFileFinderWidgetIsValid("Can", m_uiForm.dsCanInput);
 }
 
 void Transmission::transAlgDone(bool error) {
@@ -85,7 +105,7 @@ void Transmission::transAlgDone(bool error) {
   if (error)
     return;
 
-  auto const sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
+  auto const sampleWsName = m_sampleName;
   auto const transmissionName = sampleWsName.toLower().toStdString() + "_transmission";
   conjoinSpectra(sampleWsName.toStdString() + "_Can," + sampleWsName.toStdString() + "_Sam," +
                      sampleWsName.toStdString() + "_Trans",
@@ -124,10 +144,5 @@ void Transmission::saveClicked() {
 }
 
 void Transmission::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
-
-void Transmission::setLoadHistory(bool doLoadHistory) {
-  m_uiForm.dsSampleInput->setLoadProperty("LoadHistory", doLoadHistory);
-  m_uiForm.dsCanInput->setLoadProperty("LoadHistory", doLoadHistory);
-};
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -40,37 +40,64 @@ Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReducti
   connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Transmission::transAlgDone);
 
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &Transmission::saveClicked);
-  connect(m_uiForm.dsSampleInput, &FileFinderWidget::filesFoundChanged, this, &Transmission::handleNewInputData);
-  connect(m_uiForm.dsCanInput, &FileFinderWidget::filesFoundChanged, this, &Transmission::handleNewInputData);
+  connect(m_uiForm.dsSampleInput, &FileFinderWidget::filesFoundChanged, this,
+          [this]() { Transmission::handleNewInputData(SenderType::sampleInput); });
+  connect(m_uiForm.dsCanInput, &FileFinderWidget::filesFoundChanged, this,
+          [this]() { Transmission::handleNewInputData(SenderType::canInput); });
+  connect(m_uiForm.ckSumFiles, &QCheckBox::stateChanged, this,
+          [this]() { Transmission::handleNewInputData(SenderType::sumCheckbox); });
 
   m_uiForm.ppPlot->setCanvasColour(QColor(240, 240, 240));
 }
 
 Transmission::~Transmission() = default;
 
-void Transmission::handleNewInputData() {
-  const auto *finder = qobject_cast<MantidQt::API::FileFinderWidget *>(sender());
-  const auto fileNames = finder->getFilenames();
+QString Transmission::loadFiles(const QStringList &fileNames) {
+  if (fileNames.empty()) {
+    return "";
+  }
 
   QString wsname;
+  bool loadError = false;
   if (!m_uiForm.ckSumFiles->isChecked() || fileNames.size() == 1) {
-    QFileInfo fi(finder->getFirstFilename());
+    const QString fileName = fileNames.at(0);
+    const QFileInfo fi(fileName);
     wsname = fi.baseName();
-    if (!loadFile(finder->getFirstFilename().toStdString(), wsname.toStdString())) {
-      emit showMessageBox("Unable to load file.\nCheck whether your file exists "
-                          "and matches the selected instrument in the "
-                          "EnergyTransfer tab.");
-      return;
-    }
+    loadError = !loadFile(fileName.toStdString(), wsname.toStdString());
   } else {
     wsname =
         QString::fromStdString(loadFilesWithSum(MantidWidgets::qStringListToStdVector(fileNames), getIpfFilename()));
+    loadError = wsname.isEmpty();
   }
 
-  if (finder != m_uiForm.dsCanInput) {
-    m_sampleName = wsname;
-  } else {
-    m_canName = wsname;
+  if (loadError) {
+    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                        "and matches the selected instrument in the "
+                        "EnergyTransfer tab.");
+    wsname = "";
+  }
+  return wsname;
+}
+
+void Transmission::handleNewInputData(const SenderType &senderType) {
+  switch (senderType) {
+  case SenderType::sampleInput: {
+    const auto sampleName = loadFiles(m_uiForm.dsSampleInput->getFilenames());
+    m_sampleName = sampleName;
+    break;
+  }
+  case SenderType::canInput: {
+    const auto canName = loadFiles(m_uiForm.dsCanInput->getFilenames());
+    m_canName = canName;
+    break;
+  }
+  case SenderType::sumCheckbox: {
+    const auto canName = loadFiles(m_uiForm.dsCanInput->getFilenames());
+    const auto sampleName = loadFiles(m_uiForm.dsSampleInput->getFilenames());
+    m_sampleName = sampleName;
+    m_canName = canName;
+    break;
+  }
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -44,7 +44,7 @@ Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReducti
           [this]() { Transmission::handleNewInputData(SenderType::sampleInput); });
   connect(m_uiForm.dsCanInput, &FileFinderWidget::filesFoundChanged, this,
           [this]() { Transmission::handleNewInputData(SenderType::canInput); });
-  connect(m_uiForm.ckSumFiles, &QCheckBox::stateChanged, this,
+  connect(m_uiForm.ckSumFiles, &QCheckBox::checkStateChanged, this,
           [this]() { Transmission::handleNewInputData(SenderType::sumCheckbox); });
 
   m_uiForm.ppPlot->setCanvasColour(QColor(240, 240, 240));

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -12,6 +12,8 @@
 #include "MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h"
 #include "ui_Transmission.h"
 
+enum class SenderType { sumCheckbox, sampleInput, canInput };
+
 namespace MantidQt {
 namespace CustomInterfaces {
 class IDataReduction;
@@ -29,15 +31,14 @@ public:
 
 private slots:
   void transAlgDone(bool error);
-  void handleNewInputData();
-
   void saveClicked();
-
   void setSaveEnabled(bool enabled);
 
 private:
+  void handleNewInputData(const SenderType &senderType);
   void setInstrument(QString const &instrumentName);
   void updateInstrumentConfiguration() override;
+  QString loadFiles(const QStringList &fileNames);
 
   Ui::Transmission m_uiForm;
   QString m_sampleName;

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -29,17 +29,19 @@ public:
 
 private slots:
   void transAlgDone(bool error);
+  void handleNewInputData();
 
   void saveClicked();
 
   void setSaveEnabled(bool enabled);
 
 private:
-  void setLoadHistory(bool doLoadHistory) override;
   void setInstrument(QString const &instrumentName);
   void updateInstrumentConfiguration() override;
 
   Ui::Transmission m_uiForm;
+  QString m_sampleName;
+  QString m_canName;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
@@ -25,72 +25,43 @@
      <property name="title">
       <string>Input</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="loadLabelText" stdset="0">
-         <string/>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist/>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>.raw</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="lbSample">
-        <property name="text">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="MantidQt::API::FileFinderWidget" name="dsSampleInput" native="true">
+        <property name="label" stdset="0">
          <string>Sample:</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCanInput" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+        <property name="fileExtensions" stdset="0">
+         <string>.RAW</string>
         </property>
-        <property name="autoLoad" stdset="0">
+        <property name="multipleFiles" stdset="0">
          <bool>true</bool>
         </property>
-        <property name="loadLabelText" stdset="0">
-         <string/>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist/>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>.raw</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
+        <property name="findRunFiles" stdset="0">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lbBackground">
+      <item>
+       <widget class="MantidQt::API::FileFinderWidget" name="dsCanInput" native="true">
+        <property name="label" stdset="0">
+         <string>Can:</string>
+        </property>
+        <property name="findRunFiles" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="multipleFiles" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="fileExtensions" stdset="0">
+         <string>.RAW</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="ckSumFiles">
         <property name="text">
-         <string>Background:</string>
+         <string>SumFiles</string>
         </property>
        </widget>
       </item>
@@ -174,11 +145,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsView.h</header>
@@ -188,6 +154,12 @@
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
@@ -61,7 +61,7 @@
       <item>
        <widget class="QCheckBox" name="ckSumFiles">
         <property name="text">
-         <string>SumFiles</string>
+         <string>Sum Files</string>
         </property>
        </widget>
       </item>

--- a/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
@@ -33,6 +33,7 @@ public:
   MOCK_METHOD0(getInstrumentDetails, QMap<QString, QString>());
 
   MOCK_METHOD1(showAnalyserAndReflectionOptions, void(bool visible));
+  MOCK_CONST_METHOD0(ipfFileName, const std::string &());
 };
 
 class MockIETModel : public IIETModel {

--- a/qt/scientific_interfaces/Indirect/test/Reduction/ReductionAlgorithmUtilsTest.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/ReductionAlgorithmUtilsTest.h
@@ -115,8 +115,6 @@ public:
     auto const outName1 = std::filesystem::path(run1).stem().string();
     auto const outName2 = std::filesystem::path(run2).stem().string();
 
-    TS_ASSERT_EQUALS(outputName, outputName);
-
     auto &ads = Mantid::API::AnalysisDataService::Instance();
     Mantid::API::MatrixWorkspace_sptr outputWorkspace;
 

--- a/qt/scientific_interfaces/Indirect/test/Reduction/ReductionAlgorithmUtilsTest.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/ReductionAlgorithmUtilsTest.h
@@ -5,8 +5,14 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidFrameworkTestHelpers/ScopedFileHelper.h"
+#include "MantidKernel/OptionalBool.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
 #include "Reduction/ReductionAlgorithmUtils.h"
+#include <filesystem>
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -25,6 +31,16 @@ public:
     m_startX = 1.1;
     m_endX = 2.2;
     m_outputWorkspace = "OutputName";
+  }
+
+  void tearDown() override {
+    Mantid::API::AnalysisDataService::Instance().clear();
+
+    for (auto const &filename : m_testFiles)
+      std::filesystem::remove(filename);
+
+    m_testWorkspaceNames.clear();
+    m_testFiles.clear();
   }
 
   void test_loadConfiguredAlg_returns_the_expected_properties_for_TOSCA() {
@@ -87,11 +103,105 @@ public:
     TS_ASSERT_EQUALS(outputWorkspace, m_outputWorkspace);
   }
 
+  void test_loadFilesWithSum_loads_and_averages_two_regular_runs() {
+    auto const parameterFile = createTestParameterFile();
+
+    auto const run1 = createTestRun("run1", std::vector<double>{2.0, 4.0, 6.0, 8.0});
+    auto const run2 = createTestRun("run2", std::vector<double>{4.0, 8.0, 12.0, 16.0});
+
+    std::string outputName;
+    TS_ASSERT_THROWS_NOTHING(outputName = loadFilesWithSum({run1, run2}, parameterFile.getFileName(), false));
+
+    auto const outName1 = std::filesystem::path(run1).stem().string();
+    auto const outName2 = std::filesystem::path(run2).stem().string();
+
+    TS_ASSERT_EQUALS(outputName, outputName);
+
+    auto &ads = Mantid::API::AnalysisDataService::Instance();
+    Mantid::API::MatrixWorkspace_sptr outputWorkspace;
+
+    TS_ASSERT_THROWS_NOTHING(outputWorkspace = ads.retrieveWS<Mantid::API::MatrixWorkspace>(outputName));
+
+    TS_ASSERT_EQUALS(outputWorkspace->getNumberHistograms(), 4);
+
+    // loadFilesWithSum averages the merged runs.
+    TS_ASSERT_DELTA(outputWorkspace->y(0)[0], 3.0, 1e-12);
+    TS_ASSERT_DELTA(outputWorkspace->y(1)[0], 6.0, 1e-12);
+    TS_ASSERT_DELTA(outputWorkspace->y(2)[0], 9.0, 1e-12);
+    TS_ASSERT_DELTA(outputWorkspace->y(3)[0], 12.0, 1e-12);
+
+    // The secondary detector workspace should be removed
+    TS_ASSERT(!ads.doesExist(run2));
+  }
+
 private:
+  Mantid::API::IAlgorithm_sptr createTestAlgorithm(std::string const &name) {
+    auto algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged(name);
+    algorithm->initialize();
+    algorithm->setRethrows(true);
+    return algorithm;
+  }
+
+  std::string createTestRun(std::string const &fileName, std::vector<double> const &yValues) {
+    constexpr int numberOfSpectra = 4;
+
+    auto const wsName = "__" + fileName;
+    m_testWorkspaceNames.emplace_back(wsName);
+
+    auto const createWorkspace = createTestAlgorithm("CreateWorkspace");
+    createWorkspace->setProperty("DataX", std::vector<double>{0.0, 1.0});
+    createWorkspace->setProperty("DataY", yValues);
+    createWorkspace->setProperty("DataE", std::vector<double>(yValues.size(), 0.0));
+    createWorkspace->setProperty("NSpec", numberOfSpectra);
+    createWorkspace->setPropertyValue("UnitX", "TOF");
+    createWorkspace->setPropertyValue("OutputWorkspace", wsName);
+    createWorkspace->execute();
+
+    // DUM unit testing instrument
+    auto const loadInstrument = createTestAlgorithm("LoadInstrument");
+    loadInstrument->setPropertyValue("Filename", "unit_testing/DUM_Definition.xml");
+    loadInstrument->setPropertyValue("Workspace", wsName);
+    loadInstrument->setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(true));
+    loadInstrument->execute();
+
+    auto const filename =
+        (std::filesystem::path(Mantid::Kernel::ConfigService::Instance().getTempDir()) / (fileName + ".nxs")).string();
+
+    std::filesystem::remove(filename);
+    m_testFiles.emplace_back(filename);
+
+    auto saveWorkspace = createTestAlgorithm("SaveNexusProcessed");
+    saveWorkspace->setPropertyValue("InputWorkspace", wsName);
+    saveWorkspace->setPropertyValue("Filename", filename);
+    saveWorkspace->execute();
+
+    return saveWorkspace->getPropertyValue("Filename");
+  }
+
+  ScopedFileHelper::ScopedFile createTestParameterFile() {
+    static std::string const contents = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<parameter-file instrument="DUM" valid-from="1900-01-01T00:00:00">
+  <component-link name="DUM">
+    <parameter name="Workflow.Monitor1-SpectrumNumber">
+      <value val="0"/>
+    </parameter>
+    <parameter name="Workflow.ChopDataIfGreaterThan">
+      <value val="100"/>
+    </parameter>
+
+  </component-link>
+</parameter-file>
+)xml";
+
+    return ScopedFileHelper::ScopedFile(contents, "test_ParamFile.xml");
+  }
+
   std::string m_filename;
   std::string m_inputWorkspace;
   std::vector<int> m_detectorList;
   double m_startX;
   double m_endX;
   std::string m_outputWorkspace;
+  std::vector<std::string> m_testFiles;
+  std::vector<std::string> m_testWorkspaceNames;
 };


### PR DESCRIPTION
### Description of work
This was a bit more tricky than just enablling a sum files checkbox on the tabs, because the `SumFiles` is an option of the `ISISIndirectEnergyTransfer` algorithm, which is not used by `Transmission` or `ISISDiagnostics` tabs. 
I've been checking the history of the interface, it does not look like it was ever possible to sum files at was claimed by the user in #40960 , and furthermore, the method to do that is a bit specific with respect to what it does  (is not loading raw files and averaging them, although it end up being only that for the modified tabs), so I have constructed a simplified version of it in the helper file `ReductionAlgorithmUtils` that loads, merges, scales and average some runs (besides is a python helper method). 

Additionally, the `ISISDiagnostic` tab calls the algorithm `TimeSlice` under the hood, which is only prepared to handle loading raw files through run numbers, so I've had to modify it to also accept an optional workpsace input (it does so without breaking the current algorithm). 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40960. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- You can test using the Manual testing instructions for the tabs: https://developer.mantidproject.org/Testing/Indirect/DataReductionTests.html#isis-diagnostics:~:text=location-,ISIS,plot,-previous
- When checking with the `SumFiles` checkbox enabled, you can input runs `26173, 26176` from IRIS instrument, that are available in testing data sets. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
