### PR TITLE
MD continuous rotation bugfix

### DIFF
--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -500,7 +500,7 @@ void MDNormDirectSC::calculateNormContinuous(const std::vector<coord_t> &otherVa
 
   // Convert from picoCoulomb to uA.hr for SNS data
   if (protonlog->units().find("picoCoulomb") != std::string::npos) {
-    const double pCTouA = 1.e-6 / 3600.;
+    constexpr double pCTouA = 1.e-6 / 3600.;
     std::transform(protonCharge.cbegin(), protonCharge.cend(), protonCharge.begin(),
                    [pCTouA](double v) { return v * pCTouA; });
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -500,9 +500,7 @@ void MDNormDirectSC::calculateNormContinuous(const std::vector<coord_t> &otherVa
 
   // Convert from picoCoulomb to uA.hr for SNS data
   if (protonlog->units().find("picoCoulomb") != std::string::npos) {
-    constexpr double pCTouA = 1.e-6 / 3600.;
-    std::transform(protonCharge.cbegin(), protonCharge.cend(), protonCharge.begin(),
-                   [pCTouA](double v) { return v * pCTouA; });
+    normfac *= 3600.e6;
   }
 
   if (movingGonioIndex.size() == 1) {

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -498,6 +498,13 @@ void MDNormDirectSC::calculateNormContinuous(const std::vector<coord_t> &otherVa
     }
   }
 
+  // Convert from picoCoulomb to uA.hr for SNS data
+  if (protonlog->units().find("picoCoulomb") != std::string::npos) {
+    const double pCTouA = 1.e-6 / 3600.;
+    std::transform(protonCharge.cbegin(), protonCharge.cend(), protonCharge.begin(),
+                   [pCTouA](double v) { return v * pCTouA; });
+  }
+
   if (movingGonioIndex.size() == 1) {
     // If we only have a single moving gonio, bin all its values to GONIOBINSTEP degree bins and
     // run inner loop on each binned angle

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -254,6 +254,7 @@ void MDTransfModQ::initialize(const MDWSDescription &ConvParams) {
   // get transformation matrix (needed for CrystalAsPoder mode)
   m_RotMat = ConvParams.getTransfMatrix();
   m_pEfixedArray = nullptr;
+  m_invertRot = false;
   if (!ConvParams.m_PreprDetTable)
     throw(std::runtime_error("The detectors have not been preprocessed but "
                              "they have to before running initialize"));

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -181,6 +181,7 @@ bool MDTransfQ3D::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
 void MDTransfQ3D::initialize(const MDWSDescription &ConvParams) {
   m_pEfixedArray = nullptr;
   m_pDetMasks = nullptr;
+  m_invertRot = false;
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   //********** Generic part of initialization, common for elastic and inelastic
   // modes:

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41924.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41924.rst
@@ -1,0 +1,1 @@
+- Ensure that :ref:`algm-ConvertToMD` and :ref:`algm-MDNormDirectSC` with the ``UseLogTimes`` property supports SNS data.

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41924.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/41924.rst
@@ -1,1 +1,0 @@
-- Ensure that :ref:`algm-ConvertToMD` and :ref:`algm-MDNormDirectSC` with the ``UseLogTimes`` property supports SNS data.


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
Fixes two bugs in the `ConvertToMD` + `MDNormDirectSC` workflow for continuous rotation scans (using the `useLogTimes` flag):

1. Running this sequence:
  a. `ConvertToMD` with `useLogTimes=False`
  b. `ConvertToMD` with `useLogTimes=True`
  c. `ADS.clear()`
  d. Again `ConvertToMD` with `useLogTimes=False`
gives results in step d which is inconsistent with step a - the transformation from scattering angle to Q is affected by the operations in b somehow when it should be independent.

2. Intensity output from `MDNormDirectSC` with `useLogTimes=True` is 10 orders of magnitude smaller than with `useLogTimes=False`.

The first bug is due to an internal flag not being (re)set on initialization of the `MDTransfQ3D` member class, whilst the second bug is due to a missing conversion from `picoCoulomb` to `micro-amp.hour`.

<!-- Closes #xxxx.  One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run this script with HYSPEC data from the system tests

[cont_rot.py](https://github.com/user-attachments/files/30487002/cont_rot.py)

And plot the 1D comparison plots (as shown in this file: [controt_hyspec_comparison.pdf](https://github.com/user-attachments/files/30487109/controt_hyspec_comparison.pdf)) - note that you'll need ~48GB of free memory to run it. If you have less than this comment out lines 90-116 for running the "nxspe-like" workflow.

Plot `merged` MDEventWorkspace. Run `ADS.clear()` and re-run lines 8-53 to regenerate the `merged` workspace. Check that it still looks the same as the original:

<img width="850" height="636" alt="image" src="https://github.com/user-attachments/assets/dd8ef1d5-5985-4772-8fc0-b1134522b453" />



<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
