### PR TITLE
Add command line option to remove lockfile left by qsettings

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/New_features/41928.rst
+++ b/docs/source/release/v7.0.0/Workbench/New_features/41928.rst
@@ -1,1 +1,1 @@
-- new command line argument ``--qt-rm-lockfiles`` forceably removes lockfiles created by QSettings. This is not available on windows.
+- new command line argument ``--qt-rm-lockfiles`` forcibly removes lockfiles created by QSettings. This is not available on Windows.

--- a/docs/source/release/v7.0.0/Workbench/New_features/41928.rst
+++ b/docs/source/release/v7.0.0/Workbench/New_features/41928.rst
@@ -1,0 +1,1 @@
+- new command line argument ``--qt-rm-lockfiles`` forceably removes lockfiles created by QSettings. This is not available on windows.

--- a/qt/applications/workbench/workbench/app/main.py
+++ b/qt/applications/workbench/workbench/app/main.py
@@ -23,7 +23,7 @@ def main(args=None):
         parser.add_argument(
             "--qt-rm-lockfiles",
             action="store_true",
-            help="Remove lockfiles for qt configuration. This should not be necessary under normal operation.",
+            help="Forceably remove lockfiles for qt configuration. This should not be necessary under normal operation.",
         )
     parser.add_argument("--profile", action="store", help="Run workbench with execution profiling. Specify a path for the output file.")
     parser.add_argument("--yappi", action="store_true", help="Profile using Yappi instead of cProfile to capture multi-threaded execution.")
@@ -61,7 +61,7 @@ def main(args=None):
         warnings.simplefilter("error")  # Change the filter in this process
         os.environ["PYTHONWARNINGS"] = "error"  # Also affect subprocesses
 
-    if options.qt_rm_lockfiles:
+    if getattr(options, "qt_rm_lockfiles", False):
         _remove_lock_files()
 
     if options.profile:

--- a/qt/applications/workbench/workbench/app/main.py
+++ b/qt/applications/workbench/workbench/app/main.py
@@ -19,6 +19,12 @@ def main(args=None):
     parser.add_argument("--version", action="version", version=mtd_version)
     parser.add_argument("-x", "--execute", action="store_true", help="execute the script file given as argument")
     parser.add_argument("-q", "--quit", action="store_true", help="execute the script file with '-x' given as argument and then exit")
+    if os.name == "posix":  # don't add argument to windows
+        parser.add_argument(
+            "--qt-rm-lockfiles",
+            action="store_true",
+            help="Remove lockfiles for qt configuration. This should not be necessary under normal operation.",
+        )
     parser.add_argument("--profile", action="store", help="Run workbench with execution profiling. Specify a path for the output file.")
     parser.add_argument("--yappi", action="store_true", help="Profile using Yappi instead of cProfile to capture multi-threaded execution.")
     parser.add_argument("--error-on-warning", action="store_true", help="Convert python warnings to exceptions")
@@ -55,6 +61,9 @@ def main(args=None):
         warnings.simplefilter("error")  # Change the filter in this process
         os.environ["PYTHONWARNINGS"] = "error"  # Also affect subprocesses
 
+    if options.qt_rm_lockfiles:
+        _remove_lock_files()
+
     if options.profile:
         output_path = os.path.abspath(os.path.expanduser(options.profile))
         if not os.path.exists(os.path.dirname(output_path)):
@@ -87,6 +96,12 @@ def _enable_cprofile_profiling(output_path, options):
     import cProfile
 
     cProfile.runctx("start(options)", globals(), locals(), filename=output_path)
+
+
+def _remove_lock_files():
+    from workbench.config.user import remove_lock_files
+
+    remove_lock_files()
 
 
 def start(options):

--- a/qt/applications/workbench/workbench/app/main.py
+++ b/qt/applications/workbench/workbench/app/main.py
@@ -23,7 +23,8 @@ def main(args=None):
         parser.add_argument(
             "--qt-rm-lockfiles",
             action="store_true",
-            help="Forceably remove lockfiles for qt configuration. This should not be necessary under normal operation.",
+            help="Forceably remove lockfiles for Qt configuration. This should not be necessary under normal operation. "
+            "Close all instances of mantidworkbench before restarting with this option.",
         )
     parser.add_argument("--profile", action="store", help="Run workbench with execution profiling. Specify a path for the output file.")
     parser.add_argument("--yappi", action="store_true", help="Profile using Yappi instead of cProfile to capture multi-threaded execution.")

--- a/qt/applications/workbench/workbench/config/test/test_user.py
+++ b/qt/applications/workbench/workbench/config/test/test_user.py
@@ -8,9 +8,12 @@
 #
 #
 import os
-from unittest import TestCase, main
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main, skipUnless
+from unittest.mock import patch
 
-from workbench.config.user import UserConfig
+from workbench.config.user import UserConfig, remove_lock_files
 
 
 class ConfigUserManager(object):
@@ -145,6 +148,48 @@ class ConfigUserTest(TestCase):
 
     def test_set_raises_when_key_is_not_str_and_second_is_none(self):
         self.assertRaises(TypeError, self.cfg.set, 123, None)
+
+
+class RemoveLockFilesTest(TestCase):
+    @patch("workbench.config.user.sleep")
+    def test_remove_default_lockfiles_including_nested_rmlock_variants_and_preserve_settings(self, _):
+        with TemporaryDirectory() as temp_dir:
+            settings_dir = Path(temp_dir)
+            settings_files = [
+                settings_dir / "mantidproject" / "mantidworkbench.ini",
+                settings_dir / "QtProject.conf",
+            ]
+            lock_suffixes = [".lock", ".lock.rmlock", ".lock.rmlock.rmlock"]
+
+            for settings_file in settings_files:
+                settings_file.parent.mkdir(parents=True, exist_ok=True)
+                settings_file.touch()
+                for suffix in lock_suffixes:
+                    settings_file.with_name(settings_file.name + suffix).touch()
+
+            with patch("workbench.config.user._get_settings_dir", return_value=settings_dir):
+                remove_lock_files()
+
+            for settings_file in settings_files:
+                self.assertTrue(settings_file.exists())
+                for suffix in lock_suffixes:
+                    self.assertFalse(settings_file.with_name(settings_file.name + suffix).exists())
+
+    def test_missing_target_is_ignored(self):
+        with TemporaryDirectory() as temp_dir:
+            with patch("workbench.config.user._get_settings_dir", return_value=Path(temp_dir)):
+                remove_lock_files(["missing.conf"])
+
+    @skipUnless(os.name == "posix", "--qt-rm-lockfiles is only available on POSIX")
+    @patch("workbench.app.main.start")
+    @patch("workbench.app.main._remove_lock_files")
+    def test_qt_rm_lockfiles_cli_option_removes_lockfiles(self, remove_lock_files_mock, start_mock):
+        from workbench.app.main import main as workbench_main
+
+        workbench_main(["--qt-rm-lockfiles"])
+
+        remove_lock_files_mock.assert_called_once_with()
+        start_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -7,8 +7,10 @@
 #  This file is part of the mantid workbench.
 #
 #
+from pathlib import Path
 from posixpath import join as joinsettings
-from qtpy.QtCore import QSettings
+from qtpy.QtCore import QSettings, QStandardPaths
+from time import sleep
 
 
 class UserConfig(object):
@@ -155,3 +157,41 @@ class UserConfig(object):
             # If a setting does not exist, we want to raise a KeyError
             raise KeyError(f"Unknown config item requested: '{option}'")
         return self.qsettings.value(full_option, type=type)
+
+
+def _get_settings_dir() -> Path:
+    # get directories to look in
+    options = QStandardPaths.standardLocations(QStandardPaths.ConfigLocation)
+    if len(options) < 1:
+        raise RuntimeError("Failed to find QStandardPaths.ConfigLocation")
+    # we only care about those in the home area
+    home_dir = Path.home().expanduser()
+    for candidate in options:
+        # return first one in home directory, likely ~/.config
+        if home_dir in Path(candidate).parents:
+            return Path(candidate)
+    raise RuntimeError("Failed to find QStandardPaths.ConfigLocation in home area")
+
+
+def remove_lock_files(filenames: list[str] = ["mantidproject/mantidworkbench.ini", "QtProject.conf"]) -> None:
+    GLOB_LOCK = ".lock*"
+
+    settings_dir = _get_settings_dir()
+    for filename in filenames:
+        filepath = settings_dir / filename
+        if not filepath.exists():
+            continue  # no need to remove lockfile
+
+        # longest pathname first e.g. .lock.rmlock.rmlock
+        lockfiles = sorted(filepath.parent.glob(filepath.name + GLOB_LOCK), reverse=True)
+        if not lockfiles:
+            continue  # no lockfiles exist
+
+        for lockfile in lockfiles:
+            # wait for the file to get removed properly
+            sleep(0.1)  # seconds
+
+            # remove if it still exists
+            if lockfile.exists():
+                print("Removing lockfile", lockfile)
+                lockfile.unlink(missing_ok=True)

--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -173,8 +173,11 @@ def _get_settings_dir() -> Path:
     raise RuntimeError("Failed to find QStandardPaths.ConfigLocation in home area")
 
 
-def remove_lock_files(filenames: list[str] = ["mantidproject/mantidworkbench.ini", "QtProject.conf"]) -> None:
+def remove_lock_files(filenames: list[str] | None = None) -> None:
     GLOB_LOCK = ".lock*"
+
+    if filenames is None or not filenames:
+        filenames = ["mantidproject/mantidworkbench.ini", "QtProject.conf"]
 
     settings_dir = _get_settings_dir()
     for filename in filenames:


### PR DESCRIPTION
On some systems with network mounted home directories, QSettings can create a lockfile that does not get cleaned up on exit. This forceably removes the orphaned files during startup.

Fixes #41904
[EWM17167](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=17167)

### To test:

On linux:
It is preferred that your configuration gets lock files on its own, but otherwise you can create them
```sh
touch ~/.config/QtProject.conf.lock
touch ~/.config/QtProject.conf.lock.rmlock
touch ~/.config/mantidproject/mantidworkbench.ini.lock
touch ~/.config/mantidproject/mantidworkbench.ini.lock.rmlock
```
Note: Manually created doesn't seem to stop mantidworkbench from starting.

Then start
```sh
mantidworkbench --qt-rm-lockfiles
```
and see the messages go by that the files are being removed.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
