### PR TITLE
Added a catch to guard against a crash caused by a TypeError in listdir_fullpath

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/41748.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/41748.rst
@@ -1,0 +1,1 @@
+- The :ref:`Project Recovery <Project Recovery>` feature is now guarded against a ``TypeError`` emanating from the ``listdir_fullpath`` method.

--- a/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
@@ -184,7 +184,7 @@ class ProjectRecovery(object):
         """
         try:
             return [os.path.join(directory, item) for item in os.listdir(directory)]
-        except OSError:
+        except (OSError, TypeError):
             return []
 
     def remove_current_pid_folder(self, ignore_errors=False):

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -164,6 +164,12 @@ class ProjectRecoveryTest(unittest.TestCase):
         # There is no concern for list order in this equality assertion
         self.assertCountEqual([one, two], self.pr.listdir_fullpath(self.working_directory))
 
+    @mock.patch("workbench.projectrecovery.projectrecovery.os.listdir", side_effect=[[None], OSError])
+    def test_list_dir_full_path_with_error(self, mock):
+        self.assertEqual([], self.pr.listdir_fullpath("dir"))
+        self.assertEqual([], self.pr.listdir_fullpath("dir"))
+        self.assertEqual(2, mock.call_count)
+
     def test_recovery_save_when_nothing_is_present(self):
         self.pr.saver._spin_off_another_time_thread = mock.MagicMock()
         self.assertIsNone(self.pr.recovery_save())


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41748. <!-- One line per closed issue. -->
Added a catch for a `TypeError` to prevent a crash.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
The user did not provide information about how to recreate the crash. Verify that the test added passes.
1) Build the code using `pixi run ctest --build .`. Should not have any build errors.
2) Build the tests using `pixi run cmake --build . --target AllTests`. Should not have any build errors.
3) Run the test using `pixi run ctest -R workbench.test_projectrecovery.test_projectrecovery` and verify that it passes.
<img width="654" height="127" alt="image" src="https://github.com/user-attachments/assets/99b67eab-ed71-42b6-843f-319be8b076be" />


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
