### PR TITLE
Fix incorrect run labeling in ISISCalibration tab

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -148,7 +148,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
         )
 
         workflow_prog.report("Masking detectors")
-        number_historgrams = mtd[calib_ws_name].getNumberHistograms()
+        number_histograms = mtd[calib_ws_name].getNumberHistograms()
         ws_mask, num_zero_spectra = FindDetectorsOutsideLimits(InputWorkspace=calib_ws_name, OutputWorkspace="__temp_ws_mask")
         DeleteWorkspace(ws_mask)
 
@@ -163,13 +163,14 @@ class IndirectCalibration(DataProcessorAlgorithm):
         DeleteWorkspace(temp_sum)
 
         if self._intensity_scale is None:
-            self._intensity_scale = 1 / (total / (number_historgrams - num_zero_spectra))
+            self._intensity_scale = 1 / (total / (number_histograms - num_zero_spectra))
 
         workflow_prog.report("Scaling calibration")
         Scale(InputWorkspace=calib_ws_name, OutputWorkspace=self._out_ws, Factor=self._intensity_scale, Operation="Multiply")
 
         # Remove old workspaces
         if len(runs) > 1:
+            DeleteWorkspace(Workspace=calib_ws_name)
             for run in runs:
                 DeleteWorkspace(Workspace=run)
                 workflow_prog.report("Deleting workspaces")

--- a/docs/source/release/v7.0.0/Indirect/Bugfixes/41506.rst
+++ b/docs/source/release/v7.0.0/Indirect/Bugfixes/41506.rst
@@ -1,0 +1,1 @@
+- The output workspace name for summed runs in the  ``ISISCalibration`` tab of the :ref:`Indirect Data Reduction<interface-indirect-data-reduction>` is formatted correctly.

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -309,7 +309,6 @@ void ISISCalibration::handleRun() {
 
   if (m_outputNamePrefix.isEmpty()) {
     m_outputNamePrefix = outputWorkspaceName().toLower();
-    ;
   }
   m_outputCalibrationName = m_outputNamePrefix + "_calib";
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -24,6 +24,8 @@ using namespace MantidQt::MantidWidgets;
 namespace {
 Mantid::Kernel::Logger g_log("ISISCalibration");
 const static std::string CALIBRATION_OUTPUT = "__IndirectCalibration_reduction";
+constexpr double PEAK_QUARTILE = 0.25;
+constexpr double BCKGRND_PERCENTILE = 0.125;
 
 template <typename Map, typename Key, typename Value>
 Value getValueOr(const Map &map, const Key &key, const Value &defaultValue) {
@@ -304,11 +306,12 @@ void ISISCalibration::algorithmComplete(bool error) {
 
 void ISISCalibration::handleRun() {
   const auto filenames = m_uiForm.leRunNo->getFilenames().join(",");
-  const auto outputWorkspaceNameStem = outputWorkspaceName().toLower();
 
-  m_outputCalibrationName =
-      m_outputNamePrefix.empty() ? outputWorkspaceNameStem : QString::fromStdString(m_outputNamePrefix);
-  m_outputCalibrationName += "_calib";
+  if (m_outputNamePrefix.isEmpty()) {
+    m_outputNamePrefix = outputWorkspaceName().toLower();
+    ;
+  }
+  m_outputCalibrationName = m_outputNamePrefix + "_calib";
 
   try {
     m_batchAlgoRunner->addAlgorithm(calibrationAlgorithm(filenames));
@@ -321,9 +324,7 @@ void ISISCalibration::handleRun() {
   m_pythonExportWsName = m_outputCalibrationName.toStdString();
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    m_outputResolutionName =
-        m_outputNamePrefix.empty() ? outputWorkspaceNameStem : QString::fromStdString(m_outputNamePrefix);
-    m_outputResolutionName += "_res";
+    m_outputResolutionName = m_outputNamePrefix + "_res";
     m_batchAlgoRunner->addAlgorithm(resolutionAlgorithm(filenames));
 
     if (m_uiForm.ckSmoothResolution->isChecked())
@@ -423,8 +424,11 @@ void ISISCalibration::calPlotRaw(const std::string &inputName) {
   disconnectRangeSelectors();
   if (dataX.back() <= getValueOr(ranges, "peak-end-tof", 0.0) ||
       dataX.front() >= getValueOr(ranges, "peak-start-tof", 0.0)) {
-    setPeakRange((3.0 * dataX.front() + dataX.back()) / 4.0, (dataX.front() + 3.0 * dataX.back()) / 4.0);
-    setBackgroundRange(dataX.front(), (7.0 * dataX.front() + dataX.back()) / 8.0);
+    // Sets peak beginning/end within start/end 25% of the dataX range and background range within the first 12.5% of
+    // dataX range.
+    setPeakRange(dataX.front() + (dataX.back() - dataX.front()) * PEAK_QUARTILE,
+                 (dataX.back() - (dataX.back() - dataX.front()) * PEAK_QUARTILE));
+    setBackgroundRange(dataX.front(), dataX.front() + (dataX.back() - dataX.front()) * BCKGRND_PERCENTILE);
   } else {
     setPeakRange(getValueOr(ranges, "peak-start-tof", 0.0), getValueOr(ranges, "peak-end-tof", 0.0));
     setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0), getValueOr(ranges, "back-end-tof", 0.0));
@@ -471,7 +475,7 @@ void ISISCalibration::calPlotEnergy() {
   const auto &wsName = energyWs->getName();
   const auto prefix_pos = wsName.find("_red");
   if (prefix_pos != std::string::npos) {
-    m_outputNamePrefix = wsName.substr(0, prefix_pos);
+    m_outputNamePrefix = QString::fromStdString(wsName.substr(0, prefix_pos)).toLower();
   }
 
   const auto &dataX = energyWs->x(0);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -23,6 +23,7 @@ using namespace MantidQt::MantidWidgets;
 
 namespace {
 Mantid::Kernel::Logger g_log("ISISCalibration");
+const static std::string CALIBRATION_OUTPUT = "__IndirectCalibration_reduction";
 
 template <typename Map, typename Key, typename Value>
 Value getValueOr(const Map &map, const Key &key, const Value &defaultValue) {
@@ -42,8 +43,7 @@ namespace MantidQt::CustomInterfaces {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
-    : DataReductionTab(idrUI, parent), m_lastCalPlotFilename("") {
+ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent) : DataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin);
@@ -135,7 +135,7 @@ ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
   // Update range selector positions when a value in the double manager changes
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ISISCalibration::calUpdateRS);
   // Plot miniplots after a file has loaded
-  connect(m_uiForm.leRunNo, &FileFinderWidget::filesFound, this, &ISISCalibration::calPlotRaw);
+  connect(m_uiForm.leRunNo, &FileFinderWidget::filesFoundChanged, this, &ISISCalibration::handleLoadFiles);
   // Toggle RES file options when user toggles Create RES File checkbox
   connect(m_uiForm.ckCreateResolution, &QCheckBox::toggled, this, &ISISCalibration::resCheck);
   // Shows message on run button when Mantid is finding the file for a given run
@@ -298,6 +298,7 @@ void ISISCalibration::algorithmComplete(bool error) {
     setOutputPlotOptionsWorkspaces(outputWorkspaces);
 
     m_uiForm.pbSave->setEnabled(true);
+    WorkspaceUtils::removeADSWorkspace(CALIBRATION_OUTPUT);
   }
 }
 
@@ -305,7 +306,9 @@ void ISISCalibration::handleRun() {
   const auto filenames = m_uiForm.leRunNo->getFilenames().join(",");
   const auto outputWorkspaceNameStem = outputWorkspaceName().toLower();
 
-  m_outputCalibrationName = outputWorkspaceNameStem + "_calib";
+  m_outputCalibrationName =
+      m_outputNamePrefix.empty() ? outputWorkspaceNameStem : QString::fromStdString(m_outputNamePrefix);
+  m_outputCalibrationName += "_calib";
 
   try {
     m_batchAlgoRunner->addAlgorithm(calibrationAlgorithm(filenames));
@@ -318,7 +321,9 @@ void ISISCalibration::handleRun() {
   m_pythonExportWsName = m_outputCalibrationName.toStdString();
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    m_outputResolutionName = outputWorkspaceNameStem + "_res";
+    m_outputResolutionName =
+        m_outputNamePrefix.empty() ? outputWorkspaceNameStem : QString::fromStdString(m_outputNamePrefix);
+    m_outputResolutionName += "_res";
     m_batchAlgoRunner->addAlgorithm(resolutionAlgorithm(filenames));
 
     if (m_uiForm.ckSmoothResolution->isChecked())
@@ -374,21 +379,45 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
 
   // Set spectra range
   setResolutionSpectraRange(spectraMin, spectraMax);
+}
+
+void ISISCalibration::handleLoadFiles() {
+  if (!m_uiForm.leRunNo->isValid()) {
+    return;
+  }
+  int const specMin = hasInstrumentDetail("spectra-min") ? getInstrumentDetail("spectra-min").toInt() : -1;
+  int const specMax = hasInstrumentDetail("spectra-max") ? getInstrumentDetail("spectra-max").toInt() : -1;
+
+  const QString filename = m_uiForm.leRunNo->getFirstFilename();
+  const QFileInfo fi(filename);
+  const std::string wsname = fi.baseName().toStdString();
+
+  if (!loadFile(filename.toStdString(), wsname, specMin, specMax)) {
+    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                        "and matches the selected instrument in the Energy "
+                        "Transfer tab.");
+    return;
+  }
+
+  calPlotRaw(wsname);
+  calPlotEnergy();
+}
+
+/**
+ * Replots the raw data mini plot and the energy mini plot
+ */
+void ISISCalibration::calPlotRaw(const std::string &inputName) {
+  const auto input = std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(inputName));
+  m_uiForm.ppCalibration->clear();
+  m_uiForm.ppCalibration->addSpectrum("Raw", input, 0);
+  m_uiForm.ppCalibration->resizeX();
+
+  const auto &dataX = input->x(0);
+  setPeakRangeLimits(dataX.front(), dataX.back());
+  setBackgroundRangeLimits(dataX.front(), dataX.back());
 
   // Set peak and background ranges
   const auto ranges = getRangesFromInstrument();
-
-  QString filename = m_uiForm.leRunNo->getFirstFilename();
-  if (filename.isEmpty())
-    return;
-  QFileInfo fi(filename);
-  QString wsname = fi.baseName();
-  if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsname.toStdString())) {
-    loadFile(filename.toStdString(), wsname.toStdString(), spectraMin, spectraMax);
-  }
-  const auto input =
-      std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
-  const auto &dataX = input->x(0);
 
   disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ISISCalibration::calUpdateRS);
   disconnectRangeSelectors();
@@ -401,59 +430,15 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
     setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0), getValueOr(ranges, "back-end-tof", 0.0));
   }
 
-  auto const hasResolution = hasInstrumentDetail(instrumentDetails, "resolution");
+  m_uiForm.ppCalibration->replot();
+
+  auto const hasResolution = hasInstrumentDetail(getInstrumentDetails(), "resolution");
   m_uiForm.ckCreateResolution->setEnabled(hasResolution);
   if (!hasResolution)
     m_uiForm.ckCreateResolution->setChecked(false);
 
   connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ISISCalibration::calUpdateRS);
   connectRangeSelectors();
-  // plot energy to correctly set the res plot
-  calPlotEnergy();
-}
-
-/**
- * Replots the raw data mini plot and the energy mini plot
- */
-void ISISCalibration::calPlotRaw() {
-  QString filename = m_uiForm.leRunNo->getFirstFilename();
-
-  // Don't do anything if the file we would plot has not changed
-  if (filename.isEmpty() || filename == m_lastCalPlotFilename)
-    return;
-
-  m_lastCalPlotFilename = filename;
-
-  QFileInfo fi(filename);
-  QString wsname = fi.baseName();
-
-  int const specMin = hasInstrumentDetail("spectra-min") ? getInstrumentDetail("spectra-min").toInt() : -1;
-  int const specMax = hasInstrumentDetail("spectra-max") ? getInstrumentDetail("spectra-max").toInt() : -1;
-
-  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax)) {
-    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
-                        "and matches the selected instrument in the Energy "
-                        "Transfer tab.");
-    return;
-  }
-
-  const auto input =
-      std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
-
-  m_uiForm.ppCalibration->clear();
-  m_uiForm.ppCalibration->addSpectrum("Raw", input, 0);
-  m_uiForm.ppCalibration->resizeX();
-
-  const auto &dataX = input->x(0);
-  setPeakRangeLimits(dataX.front(), dataX.back());
-  setBackgroundRangeLimits(dataX.front(), dataX.back());
-
-  updateInstrumentConfiguration();
-
-  m_uiForm.ppCalibration->replot();
-
-  // Also replot the energy
-  calPlotEnergy();
 }
 
 /**
@@ -471,7 +456,7 @@ void ISISCalibration::calPlotEnergy() {
   }
 
   WorkspaceGroup_sptr reductionOutputGroup =
-      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("__IndirectCalibration_reduction");
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(CALIBRATION_OUTPUT);
   if (reductionOutputGroup->isEmpty()) {
     g_log.warning("No result workspaces, cannot plot energy preview.");
     return;
@@ -481,6 +466,12 @@ void ISISCalibration::calPlotEnergy() {
   if (!energyWs) {
     g_log.warning("No result workspaces, cannot plot energy preview.");
     return;
+  }
+
+  const auto &wsName = energyWs->getName();
+  const auto prefix_pos = wsName.find("_red");
+  if (prefix_pos != std::string::npos) {
+    m_outputNamePrefix = wsName.substr(0, prefix_pos);
   }
 
   const auto &dataX = energyWs->x(0);
@@ -742,7 +733,7 @@ IAlgorithm_sptr ISISCalibration::energyTransferReductionAlgorithm(const QString 
   reductionAlg->setProperty("Reflection", getReflectionName().toStdString());
   reductionAlg->setProperty("InputFiles", inputFiles.toStdString());
   reductionAlg->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
-  reductionAlg->setProperty("OutputWorkspace", "__IndirectCalibration_reduction");
+  reductionAlg->setProperty("OutputWorkspace", CALIBRATION_OUTPUT);
   reductionAlg->setProperty("SpectraRange", resolutionDetectorRangeString().toStdString());
   reductionAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
   return reductionAlg;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
@@ -87,7 +87,7 @@ private:
 
   QString m_outputCalibrationName;
   QString m_outputResolutionName;
-  std::string m_outputNamePrefix;
+  QString m_outputNamePrefix;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
@@ -52,9 +52,8 @@ public:
   const std::string getSubscriberName() const override { return "ISISCalibration"; }
 
 private slots:
+  void handleLoadFiles();
   void algorithmComplete(bool error);
-  void calPlotRaw();
-  void calPlotEnergy();
   void calMinChanged(double /*val*/);
   void calMaxChanged(double /*val*/);
   void calUpdateRS(QtProperty * /*prop*/, double /*val*/);
@@ -70,6 +69,8 @@ private slots:
   void setSaveEnabled(bool enabled);
 
 private:
+  void calPlotRaw(const std::string &inputName);
+  void calPlotEnergy();
   void updateInstrumentConfiguration() override;
 
   void setDefaultInstDetails(QMap<QString, QString> const &instrumentDetails);
@@ -83,10 +84,10 @@ private:
   Mantid::API::IAlgorithm_sptr energyTransferReductionAlgorithm(const QString &inputFiles) const;
 
   Ui::ISISCalibration m_uiForm;
-  QString m_lastCalPlotFilename;
 
   QString m_outputCalibrationName;
   QString m_outputResolutionName;
+  std::string m_outputNamePrefix;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
@@ -53,6 +53,8 @@ getADSWorkspace(std::string const &workspaceName);
 template EXPORT_OPT_MANTIDQT_COMMON std::shared_ptr<Mantid::API::ITableWorkspace_sptr>
 getADSWorkspace(std::string const &workspaceName);
 
+EXPORT_OPT_MANTIDQT_COMMON void removeADSWorkspace(std::string const &workspaceName);
+
 template <typename Iterator, typename Functor>
 std::vector<std::string> transformElements(Iterator const fromIter, Iterator const toIter, Functor const &functor) {
   std::vector<std::string> newVector;

--- a/qt/widgets/common/src/WorkspaceUtils.cpp
+++ b/qt/widgets/common/src/WorkspaceUtils.cpp
@@ -221,6 +221,12 @@ bool doAllWsExistInADS(std::vector<std::string> const &workspaceNames) {
   return AnalysisDataService::Instance().doAllWsExist(workspaceNames);
 }
 
+void removeADSWorkspace(std::string const &workspaceName) {
+  if (doesExistInADS(workspaceName)) {
+    AnalysisDataService::Instance().remove(workspaceName);
+  }
+}
+
 std::vector<std::string> attachPrefix(std::vector<std::string> const &strings, std::string const &prefix) {
   return transformElements(strings.begin(), strings.end(), [&prefix](std::string const &str) { return prefix + str; });
 }


### PR DESCRIPTION
### Description of work

The original issue describes what is the problem. As the ISISCalibration tab calls ISISIndirectEnergyTransfer algorithm, the latest parses the run numbers, so the output of the calibration workspace is extracted from the the output name of the energy transfer algorithm. 
I've also refactored a bit the load files signal management to make it more stable and similar to how other tabs load files.
Also fix the bug that was creating unneeded calibration workspaces with the name `calibration` on the ads.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41506. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Test that the reported #41506 is not happening, run numbers are parsed corectly,  and the manual testing instructions are correct: https://developer.mantidproject.org/Testing/Indirect/DataReductionTests.html#isis-calibration:~:text=Data-,ISIS,002

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
