### PR TITLE
Improve interface behaviour with new IV

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/41948.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/41948.rst
@@ -1,0 +1,3 @@
+- In the ISIS Reflectometry interface, fixed a bug where the (new) Instrument View would not fill the available space in the dock when first opened. The view now correctly fills the dock area upon initial display.
+- In the ALF View interface, fixed bug where the "Add ROI" button was not working. The button now correctly adds a new ROI to the view when clicked.
+- In the ALF View interface, fixed an error on opening the interface.

--- a/qt/python/instrumentview/CMakeLists.txt
+++ b/qt/python/instrumentview/CMakeLists.txt
@@ -27,6 +27,8 @@ set(PYTHON_TEST_FILES
     instrumentview/renderers/test/test_side_by_side_shape_renderer.py
     instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
     instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_view.py
+    instrumentview/alfview/test/test_alf_instrument_view_presenter.py
+    instrumentview/alfview/test/test_alf_instrument_view_view.py
 )
 
 # Tests

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -715,16 +715,21 @@ class FullInstrumentViewModel:
     def add_new_detector_key(self, new_value: list[bool], kind: CurrentTab):
         if kind is CurrentTab.Masking:
             new_key = f"Mask {len(self._cached_masks_map) + 1} (unsaved)"
-            mask_to_save = self._is_masked_in_ws.copy()
-            mask_to_save[self.is_pickable] = new_value
-            self._cached_masks_map[new_key] = mask_to_save
-            return new_key
         else:
             new_key = f"Pick Selection {len(self._cached_rois_map) + 1} (unsaved)"
+        return self.set_detector_key(new_key, new_value, kind)
+
+    def set_detector_key(self, key: str, new_value: list[bool], kind: CurrentTab) -> str:
+        """Store new_value (one entry per pickable detector) under key, replacing any existing entry."""
+        if kind is CurrentTab.Masking:
+            mask_to_save = self._is_masked_in_ws.copy()
+            mask_to_save[self.is_pickable] = new_value
+            self._cached_masks_map[key] = mask_to_save
+        else:
             selection_to_save = np.zeros_like(self._workspace_indices, dtype=bool)
             selection_to_save[self.is_pickable] = new_value
-            self._cached_rois_map[new_key] = selection_to_save
-            return new_key
+            self._cached_rois_map[key] = selection_to_save
+        return key
 
     def _get_boolean_masks_from_workspaces_in_ads(self, selected_keys: list[str], kind: CurrentTab):
         ws_in_ads = (

--- a/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewPresenter.py
@@ -11,7 +11,9 @@ from instrumentview.alfview.ALFInstrumentViewView import ALFInstrumentViewView
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 from instrumentview.FullInstrumentViewPresenter import FullInstrumentViewPresenter
 from instrumentview.ComponentSelectionUtils import detector_component_indices_in_subtrees
+from instrumentview.Globals import CurrentTab
 
+import numpy as np
 from mantid.simpleapi import CreateSampleWorkspace, Rebin
 from qtpy.QtCore import QObject, QMetaObject, Q_ARG
 
@@ -22,6 +24,8 @@ class ALFInstrumentViewPresenter(FullInstrumentViewPresenter):
     This keeps the import and construction path lightweight so the C++ side can
     always acquire a Qt widget from the `view` attribute.
     """
+
+    _ROI_SELECTION_KEY = "Rectangle ROI"
 
     def __init__(self, view=None):
         _placeholder_ws = CreateSampleWorkspace(InstrumentName="ALF", StoreInADS=False, OutputWorkspace="test_alfview")
@@ -51,6 +55,27 @@ class ALFInstrumentViewPresenter(FullInstrumentViewPresenter):
     def update_picked_detectors_on_view(self) -> None:
         super().update_picked_detectors_on_view()
         self.notify_cpp_callback("notify_whole_tube_selected")
+
+    def on_roi_shape_changed(self) -> None:
+        """Re-derive the selection from the rectangle overlaid on the projection.
+
+        Called on the Qt thread when the rectangle is added, and again by the shape overlay
+        manager each time it is dragged, resized or rotated, so that the ALF tube selection
+        always follows the rectangle.
+        """
+        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        # Projection uses VTK, so must be done on the Qt thread before queueing the rest
+        self._view.project_and_cache_detector_points(centres)
+        self._callback_queue.put((self._on_roi_shape_changed, (centres,)))
+
+    def _on_roi_shape_changed(self, centres: np.ndarray) -> None:
+        mask = self._view.get_shape_mask(centres)
+        if self._select_bank_tube:
+            mask = self._model.expand_pickable_mask_to_parent_subtrees(mask)
+        # A single stored key so that moving the rectangle replaces the selection rather than adding to it
+        self._model.set_detector_key(self._ROI_SELECTION_KEY, mask.tolist(), CurrentTab.Grouping)
+        self._model.apply_detector_items([self._ROI_SELECTION_KEY], CurrentTab.Grouping)
+        self.update_picked_detectors_on_view()
 
     def rebin_button_clicked(self, params: str) -> None:
         # Rewrites the active workspace in the model

--- a/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewView.py
+++ b/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewView.py
@@ -58,6 +58,44 @@ class ALFInstrumentViewView(FullInstrumentViewView):
         self._presenter.rebin_button_clicked(params)
 
     @override
+    def setup_connections_to_presenter(self):
+        super().setup_connections_to_presenter()
+        # ALF has no shape selector, so "Add ROI" is the rectangle control itself rather than the
+        # base class button that commits an already drawn shape to the (hidden) ROI list.
+        self._add_selection.clicked.disconnect()
+        self._add_selection.setCheckable(True)
+        self._add_selection.setEnabled(True)
+        self._add_selection.setToolTip("Overlay a rectangle on the projection to select a region of detectors.")
+        self._add_selection.toggled.connect(self._on_add_roi_toggled)
+
+    def _on_add_roi_toggled(self, checked: bool):
+        if not checked:
+            self.delete_current_overlaid_shape()
+            return
+        self.add_rectangular_widget()
+        if self._shape_overlay_manager is None:
+            return
+        self._shape_overlay_manager.set_on_shape_changed(self._presenter.on_roi_shape_changed)
+        # Select whatever the rectangle covers where it is first drawn
+        self._presenter.on_roi_shape_changed()
+
+    # NOTE: "Add ROI" creates the rectangle rather than acting on an existing one, so unlike in the
+    # full view it must stay enabled when no shape is overlaid.
+    @override
+    def set_add_selection_and_mask_buttons_enabled(self, enabled: bool):
+        return
+
+    @override
+    def set_overlaid_shape_controls_enabled(self, enabled: bool):
+        if not enabled:
+            self._add_selection.setChecked(False)
+        self._add_selection.setEnabled(enabled)
+
+    @override
+    def set_overlaid_shape_controls_checked(self, checked: bool):
+        self._add_selection.setChecked(checked)
+
+    @override
     def set_selected_detector_info(self, detector_infos):
         return
 
@@ -75,7 +113,6 @@ class ALFInstrumentViewView(FullInstrumentViewView):
         parent_layout = QHBoxLayout(self)
         options_widget = QWidget()
         options_layout = QVBoxLayout(options_widget)
-        options_layout.addWidget(self._add_rectangle)
         options_layout.addWidget(self._add_selection)
         options_layout.addWidget(self._hover_pick)
         options_layout.addWidget(self.rebin_btn)

--- a/qt/python/instrumentview/instrumentview/alfview/test/__init__.py
+++ b/qt/python/instrumentview/instrumentview/alfview/test/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_presenter.py
@@ -1,0 +1,131 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from instrumentview.alfview.ALFInstrumentViewPresenter import ALFInstrumentViewPresenter
+from instrumentview.Globals import CurrentTab
+from instrumentview.Projections.ProjectionType import ProjectionType
+
+
+class TestALFInstrumentViewPresenter(unittest.TestCase):
+    def setUp(self):
+        self._mock_view = MagicMock()
+        self._mock_view.current_selected_projection.return_value = ProjectionType.CYLINDRICAL_Y
+        self._mock_view.get_render_mode_option.return_value = "Points"
+        self._mock_view._RENDER_MODE_POINTS = "Points (Fastest)"
+        self._mock_view._RENDER_MODE_SHAPES_FAST = "Approximated Shapes (Fast)"
+        self._mock_view._RENDER_MODE_RAW_SHAPES = "Raw Shapes (Slowest)"
+        self._mock_view.is_hover_pick_mode_checked.return_value = False
+        self._mock_view.is_select_bank_tube_checked.return_value = True
+        self._mock_view.get_contour_limits.return_value = (0.0, 1.0)
+        self._mock_view.selected_peaks_workspaces.return_value = []
+
+        with (
+            mock.patch("instrumentview.alfview.ALFInstrumentViewPresenter.ALFInstrumentViewView", return_value=self._mock_view),
+            mock.patch("instrumentview.FullInstrumentViewPresenter.InstrumentViewADSObserver"),
+        ):
+            self._presenter = ALFInstrumentViewPresenter()
+        self._model = self._presenter._model
+        self._mock_view.reset_mock()
+        self._n_pickable = len(self._model.detector_positions)
+
+    def tearDown(self):
+        self._presenter.handle_close()
+
+    def _mask_for_first_n_pickable_detectors(self, n: int) -> np.ndarray:
+        mask = np.zeros(self._n_pickable, dtype=bool)
+        mask[:n] = True
+        return mask
+
+    def test_on_roi_shape_changed_projects_points_before_queueing_the_update(self):
+        self._presenter._callback_queue = MagicMock()
+
+        self._presenter.on_roi_shape_changed()
+
+        self._mock_view.project_and_cache_detector_points.assert_called_once()
+        queued_function, queued_args = self._presenter._callback_queue.put.call_args.args[0]
+        self.assertEqual(queued_function, self._presenter._on_roi_shape_changed)
+        np.testing.assert_allclose(queued_args[0], self._mock_view.project_and_cache_detector_points.call_args.args[0])
+
+    def test_on_roi_shape_changed_picks_the_detectors_inside_the_shape(self):
+        mask = self._mask_for_first_n_pickable_detectors(5)
+        self._mock_view.get_shape_mask.return_value = mask
+        self._presenter._select_bank_tube = False
+
+        with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        np.testing.assert_array_equal(self._model._detector_is_picked[self._model.is_pickable], mask)
+
+    def test_on_roi_shape_changed_expands_the_selection_to_whole_tubes(self):
+        expanded_mask = self._mask_for_first_n_pickable_detectors(64)
+        self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(5)
+        self._presenter._select_bank_tube = True
+        self._model.expand_pickable_mask_to_parent_subtrees = MagicMock(return_value=expanded_mask)
+
+        with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        self._model.expand_pickable_mask_to_parent_subtrees.assert_called_once()
+        np.testing.assert_array_equal(self._model._detector_is_picked[self._model.is_pickable], expanded_mask)
+
+    def test_moving_the_shape_replaces_the_previous_selection(self):
+        first_mask = self._mask_for_first_n_pickable_detectors(10)
+        second_mask = np.zeros(self._n_pickable, dtype=bool)
+        second_mask[20:30] = True
+        self._presenter._select_bank_tube = False
+
+        with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
+            self._mock_view.get_shape_mask.return_value = first_mask
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+            self._mock_view.get_shape_mask.return_value = second_mask
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        np.testing.assert_array_equal(self._model._detector_is_picked[self._model.is_pickable], second_mask)
+        self.assertEqual(self._model.cached_pick_selections_keys, [ALFInstrumentViewPresenter._ROI_SELECTION_KEY])
+
+    def test_empty_shape_clears_the_selection(self):
+        self._presenter._select_bank_tube = False
+
+        with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
+            self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(10)
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+            self._mock_view.get_shape_mask.return_value = np.zeros(self._n_pickable, dtype=bool)
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        self.assertFalse(np.any(self._model._detector_is_picked))
+
+    def test_on_roi_shape_changed_stores_the_selection_as_a_grouping_item(self):
+        mask = self._mask_for_first_n_pickable_detectors(5)
+        self._mock_view.get_shape_mask.return_value = mask
+        self._presenter._select_bank_tube = False
+        self._model.set_detector_key = MagicMock(return_value=ALFInstrumentViewPresenter._ROI_SELECTION_KEY)
+
+        with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
+            self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        self._model.set_detector_key.assert_called_once_with(
+            ALFInstrumentViewPresenter._ROI_SELECTION_KEY, mask.tolist(), CurrentTab.Grouping
+        )
+
+    def test_on_roi_shape_changed_updates_the_view_and_notifies_alf(self):
+        self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(5)
+        self._presenter._select_bank_tube = False
+
+        with mock.patch.object(self._presenter, "notify_cpp_callback") as mock_notify:
+            with mock.patch.object(ALFInstrumentViewPresenter.__bases__[0], "update_picked_detectors_on_view"):
+                self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
+
+        mock_notify.assert_called_once_with("notify_whole_tube_selected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_view.py
+++ b/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_view.py
@@ -1,0 +1,81 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from mantidqt.utils.qt.testing import start_qapplication
+from instrumentview.alfview.ALFInstrumentViewView import ALFInstrumentViewView
+from instrumentview.ShapeWidgets import RectangleSelectionShape
+
+
+@start_qapplication
+class TestALFInstrumentViewView(unittest.TestCase):
+    # Figure is mocked so that the line plot does not need the "mantid" matplotlib projection
+    @mock.patch("instrumentview.FullInstrumentViewWindow.Figure")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.FigureCanvas")
+    @mock.patch("qtpy.QtWidgets.QHBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QVBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
+    def setUp(self, mock_plotter, mock_splitter_add_widget, mock_v_add_widget, mock_h_add_widget, mock_figure_canvas, mock_figure) -> None:
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            self._view = ALFInstrumentViewView()
+        self._view._presenter = MagicMock()
+        self._view.setup_connections_to_presenter()
+
+    def test_add_roi_button_is_a_checkable_and_enabled_shape_control(self):
+        self.assertEqual(self._view._add_selection.text(), "Add ROI")
+        self.assertTrue(self._view._add_selection.isCheckable())
+        self.assertTrue(self._view._add_selection.isEnabled())
+        self.assertFalse(self._view._add_selection.isChecked())
+
+    def test_checking_add_roi_overlays_a_rectangle(self):
+        self._view._add_selection.setChecked(True)
+        self.assertIsNotNone(self._view._shape_overlay_manager)
+        self.assertIsInstance(self._view._shape_overlay_manager.current_shape, RectangleSelectionShape)
+
+    def test_checking_add_roi_registers_shape_changed_callback(self):
+        self._view._add_selection.setChecked(True)
+        self.assertEqual(self._view._shape_overlay_manager._on_shape_changed, self._view._presenter.on_roi_shape_changed)
+
+    def test_checking_add_roi_selects_the_region_under_the_new_rectangle(self):
+        self._view._add_selection.setChecked(True)
+        self._view._presenter.on_roi_shape_changed.assert_called_once()
+
+    def test_unchecking_add_roi_removes_the_rectangle(self):
+        self._view._add_selection.setChecked(True)
+        self._view._add_selection.setChecked(False)
+        self.assertIsNone(self._view._shape_overlay_manager)
+
+    def test_add_roi_stays_enabled_when_no_shape_is_overlaid(self):
+        self._view.set_add_selection_and_mask_buttons_enabled(False)
+        self.assertTrue(self._view._add_selection.isEnabled())
+
+    def test_disabling_shape_controls_unchecks_and_disables_add_roi(self):
+        self._view._add_selection.setChecked(True)
+        self._view.set_overlaid_shape_controls_enabled(False)
+        self.assertFalse(self._view._add_selection.isChecked())
+        self.assertFalse(self._view._add_selection.isEnabled())
+        self.assertIsNone(self._view._shape_overlay_manager)
+
+    def test_enabling_shape_controls_enables_add_roi(self):
+        self._view.set_overlaid_shape_controls_enabled(False)
+        self._view.set_overlaid_shape_controls_enabled(True)
+        self.assertTrue(self._view._add_selection.isEnabled())
+
+    def test_set_overlaid_shape_controls_checked_drives_add_roi(self):
+        self._view.set_overlaid_shape_controls_checked(True)
+        self.assertTrue(self._view._add_selection.isChecked())
+        self.assertIsNotNone(self._view._shape_overlay_manager)
+        self._view.set_overlaid_shape_controls_checked(False)
+        self.assertFalse(self._view._add_selection.isChecked())
+        self.assertIsNone(self._view._shape_overlay_manager)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
@@ -8,6 +8,7 @@
 from instrumentview.FullInstrumentViewModel import FullInstrumentViewModel
 from instrumentview.isisreflectometry.ReflectometryInstrumentViewView import ReflectometryInstrumentViewView
 from instrumentview.renderers.shape_renderer import ShapeRenderer
+from instrumentview.InteractorStyles import InteractorStyles
 from instrumentview.Projections.ProjectionType import ProjectionType
 from qtpy.QtCore import QObject, QMetaObject, Qt
 import numpy as np
@@ -29,6 +30,7 @@ class ReflectometryInstrumentViewPresenter:
     def __init__(self, view: Optional[ReflectometryInstrumentViewView] = None):
         self.view = view or ReflectometryInstrumentViewView()
         self._model: Optional[FullInstrumentViewModel] = None
+        self._interactor_styles: Optional[InteractorStyles] = None
         self._transform: Optional[np.ndarray] = None
         self._original_mesh_bounds: Optional[tuple] = None
         self._rect_selected_detector_ids: list[int] = []
@@ -53,6 +55,7 @@ class ReflectometryInstrumentViewPresenter:
         self._original_mesh_bounds = None
         self._rect_selected_detector_ids = []
         self._model = None
+        self._interactor_styles = None
 
     def plot(self):
         """Re-render the current instrument."""
@@ -62,9 +65,7 @@ class ReflectometryInstrumentViewPresenter:
     def set_zoom_mode(self):
         """Set the plotter interaction to zoom/pan mode."""
         self.view.remove_shape()
-        plotter = self.view.main_plotter
-        if plotter is not None and self._model is not None:
-            self._renderer.set_interactive_style(plotter, self._model.is_2d_projection)
+        self._apply_interactor_style()
 
     def set_select_rect_mode(self):
         """Set the plotter interaction to rectangle selection mode."""
@@ -117,20 +118,50 @@ class ReflectometryInstrumentViewPresenter:
         self._original_mesh_bounds = self._detector_mesh.bounds
         self._transform = np.eye(4)
 
-        self._renderer.set_parallel_view(plotter)
+        plotter.view_xy()
+        plotter.enable_parallel_projection()
         plotter.reset_camera()
-        self._renderer.set_interactive_style(plotter, self._model.is_2d_projection)
 
-        # Schedule the fill transform via resizeEvent so it runs after Qt/VTK
-        # have applied the correct dock dimensions to the VTK render window.
+        # Recreate the styles after the camera reset so that their cached
+        # "default" camera state (used for right-click reset) is the full view.
+        self._interactor_styles = None
+        self._apply_interactor_style()
+
+        # Keep the mesh filling the viewport on every subsequent resize.
         self.view.set_on_resize_callback(self._apply_fill_transform)
+
+        # Fill now rather than waiting for a resize event: Qt emits none when
+        # plotting into an already-sized widget, so the mesh would otherwise
+        # keep its unfilled aspect ratio until the user resized the window.
+        self._apply_fill_transform()
+
+        # ...and again once Qt has finished laying the plotter out.  On the
+        # very first plot the render window is still at PyVista's default size
+        # (BackgroundPlotter sets it in its constructor) and only shrinks to
+        # the widget when QVTKRenderWindowInteractor handles the resize event
+        # Qt posts after this call returns.  Rendering before that happens
+        # crops the image, which reads as being slightly zoomed in.
+        self.view.schedule_refresh()
+
+    def _apply_interactor_style(self) -> None:
+        """Set the plotter's interactor style to cursor-centred scroll zoom.
+
+        This view is always a 2D projection (see ``update_workspace``), so the
+        trackball/rotation style is never needed.  Picking is disabled because
+        detector selection here is done via the rectangle overlay.
+        """
+        plotter = self.view.main_plotter
+        if plotter is None or self._model is None:
+            return
+        if self._interactor_styles is None:
+            self._interactor_styles = InteractorStyles(plotter, picking_callback=lambda *_: None, hover_callback=lambda *_: None)
+        plotter.iren.style = self._interactor_styles.SCROLL_ZOOM_NO_PICKING
 
     def _apply_fill_transform(self):
         """Stretch the detector mesh to fill the viewport.
 
-        Called from the view's resizeEvent (deferred by one event-loop cycle so
-        QVTKRenderWindowInteractor.resizeEvent has already updated the VTK
-        render window dimensions via vtkRenderWindow.SetSize).
+        Called at the end of ``_render`` and again from the view's resizeEvent
+        (the latter deferred by the view's debounce timer).
         """
         if self._detector_mesh is None or self._original_mesh_bounds is None:
             return
@@ -138,7 +169,7 @@ class ReflectometryInstrumentViewPresenter:
         if plotter is None:
             return
 
-        w, h = plotter.ren_win.GetSize()
+        w, h = self._viewport_size(plotter)
         if w <= 0 or h <= 0:
             return
 
@@ -186,6 +217,22 @@ class ReflectometryInstrumentViewPresenter:
         style = plotter.iren.style
         if hasattr(style, "update_default_camera_state"):
             style.update_default_camera_state()
+
+    def _viewport_size(self, plotter) -> tuple[int, int]:
+        """Return the (width, height) of the render area.
+
+        Taken from the Qt widget rather than ``vtkRenderWindow.GetSize()``:
+        VTK's render window is only resized to the widget when
+        QVTKRenderWindowInteractor first handles a resize event, so on the
+        first plot it still reports PyVista's default size.  Filling against
+        that gives the wrong aspect ratio, which is why the view only looked
+        right once the user had resized the window.  Only the ratio matters
+        here, so Qt's logical pixels serve as well as VTK's physical ones.
+        """
+        w, h = self.view.render_area_size()
+        if w > 0 and h > 0:
+            return w, h
+        return plotter.ren_win.GetSize()
 
     @staticmethod
     def _scale_matrix_relative_to_centre(centre, scale_x=1.0, scale_y=1.0) -> np.ndarray:

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewView.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewView.py
@@ -62,6 +62,50 @@ class ReflectometryInstrumentViewView(QWidget):
         """Set a callable invoked (deferred) on every resize, or None to clear."""
         self._on_resize_callback = callback
 
+    def schedule_refresh(self) -> None:
+        """Run the deferred resize callback without waiting for a resize event.
+
+        Qt emits no resizeEvent when something is drawn into an already-sized
+        widget, so after the first plot the fill transform would not run until
+        the user happened to resize the window.  Starting the same debounce
+        timer applies it once Qt/VTK have settled at the current size.
+        """
+        if self.main_plotter is None:
+            return
+        self._resize_timer.start()
+
+    def render_area_size(self) -> tuple[int, int]:
+        """Size, in logical pixels, of the area the plotter renders into.
+
+        BackgroundPlotter *is* the interactor widget, nested inside its own
+        app_window and frame, so its size is inset from this widget's by those
+        layout margins.  Measuring the interactor rather than this widget is
+        what makes the aspect ratio exact.
+
+        Qt has this right as soon as the widget is laid out, whereas
+        ``vtkRenderWindow.GetSize()`` reports PyVista's default window size
+        until QVTKRenderWindowInteractor has handled its first resize event.
+        """
+        width, height = self.width(), self.height()
+        if self.main_plotter is not None:
+            size = self.main_plotter.size()
+            # The plotter is nested inside this widget, so it can never be
+            # larger than us.  When it is, Qt has not laid it out yet — it is
+            # still at the default window size BackgroundPlotter's constructor
+            # applied — and our own geometry is the trustworthy one.
+            if 0 < size.width() <= width and 0 < size.height() <= height:
+                return size.width(), size.height()
+        return width, height
+
+    def showEvent(self, event):
+        """Re-run the deferred resize callback when the widget becomes visible.
+
+        The VTK render window only takes its true size once the widget is
+        shown, so anything plotted while hidden needs re-filling here.
+        """
+        super().showEvent(event)
+        self.schedule_refresh()
+
     def resizeEvent(self, event):
         """Start (or restart) the debounce timer on every resize event.
 

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
@@ -20,6 +20,12 @@ def _make_presenter():
     mock_view = MagicMock()
     mock_view.main_plotter = MagicMock()
     mock_view.shape_overlay_manager = None
+    # _render() runs the real fill transform, so the plotter needs numeric
+    # geometry rather than mocks — the arithmetic would otherwise produce
+    # MagicMocks that NumPy cannot build a transform matrix from.
+    mock_view.render_area_size.return_value = (400, 300)
+    mock_view.main_plotter.ren_win.GetSize.return_value = (400, 300)
+    mock_view.main_plotter.camera.parallel_scale = 0.75
     return ReflectometryInstrumentViewPresenter(view=mock_view), mock_view
 
 
@@ -48,9 +54,10 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
             mock_view_cls.assert_called_once()
             self.assertIs(presenter.view, mock_view_cls.return_value)
 
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.ShapeRenderer")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.FullInstrumentViewModel")
-    def test_update_workspace_calls_view_initialise(self, mock_model_cls, mock_renderer_cls):
+    def test_update_workspace_calls_view_initialise(self, mock_model_cls, mock_renderer_cls, _mock_styles_cls):
         mock_ws = MagicMock()
         mock_model_cls.return_value.detector_positions = np.zeros((10, 3))
         mock_model_cls.return_value.flip_z = False
@@ -60,9 +67,10 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         self._presenter.update_workspace(mock_ws)
         self._mock_view.initialise.assert_called_once()
 
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.ShapeRenderer")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.FullInstrumentViewModel")
-    def test_update_workspace_sets_model(self, mock_model_cls, mock_renderer_cls):
+    def test_update_workspace_sets_model(self, mock_model_cls, mock_renderer_cls, _mock_styles_cls):
         mock_ws = MagicMock()
         mock_model_cls.return_value.detector_positions = np.zeros((10, 3))
         mock_model_cls.return_value.flip_z = False
@@ -73,9 +81,10 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         mock_model_cls.assert_called_once_with(mock_ws)
         self.assertIsNotNone(self._presenter._model)
 
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.ShapeRenderer")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.FullInstrumentViewModel")
-    def test_update_workspace_sets_cylindrical_projection(self, mock_model_cls, mock_renderer_cls):
+    def test_update_workspace_sets_cylindrical_projection(self, mock_model_cls, mock_renderer_cls, _mock_styles_cls):
         mock_ws = MagicMock()
         mock_model_cls.return_value.detector_positions = np.zeros((10, 3))
         mock_model_cls.return_value.flip_z = False
@@ -106,31 +115,36 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         self._presenter.plot()
         self._presenter._render.assert_not_called()
 
-    def test_set_zoom_mode_removes_shape(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_set_zoom_mode_removes_shape(self, _mock_styles_cls):
         self._presenter._model = MagicMock()
-        self._presenter._model.is_2d_projection = True
         self._presenter._renderer = MagicMock()
         self._presenter.set_zoom_mode()
         self._mock_view.remove_shape.assert_called_once()
 
-    def test_set_zoom_mode_calls_set_interactive_style(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_set_zoom_mode_sets_scroll_zoom_style(self, mock_styles_cls):
+        """This view is always a 2D projection, so the scroll-zoom style is always used."""
         self._presenter._model = MagicMock()
-        self._presenter._model.is_2d_projection = True
         self._presenter._renderer = MagicMock()
         self._presenter.set_zoom_mode()
-        self._presenter._renderer.set_interactive_style.assert_called_once_with(self._mock_view.main_plotter, True)
+        mock_styles_cls.assert_called_once()
+        self.assertIs(mock_styles_cls.call_args[0][0], self._mock_view.main_plotter)
+        self.assertIs(self._mock_view.main_plotter.iren.style, mock_styles_cls.return_value.SCROLL_ZOOM_NO_PICKING)
 
-    def test_set_zoom_mode_no_op_when_no_plotter(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_set_zoom_mode_no_op_when_no_plotter(self, mock_styles_cls):
         self._mock_view.main_plotter = None
         self._presenter._model = MagicMock()
         self._presenter._renderer = MagicMock()
         self._presenter.set_zoom_mode()
-        self._presenter._renderer.set_interactive_style.assert_not_called()
+        mock_styles_cls.assert_not_called()
 
-    def test_set_zoom_mode_no_op_when_no_model(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_set_zoom_mode_no_op_when_no_model(self, mock_styles_cls):
         self._presenter._renderer = MagicMock()
         self._presenter.set_zoom_mode()
-        self._presenter._renderer.set_interactive_style.assert_not_called()
+        mock_styles_cls.assert_not_called()
 
     def test_set_select_rect_mode_calls_overlay_rectangle(self):
         self._presenter.set_select_rect_mode()
@@ -233,13 +247,67 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         np.testing.assert_allclose(called_coords[0, :3], [1.0, 2.0, 0.0])
         self.assertEqual(self._presenter._rect_selected_detector_ids, [55])
 
-    def test_render_registers_fill_transform_callback(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_registers_fill_transform_callback(self, _mock_styles_cls):
         """After _render, the view's resize callback is set to _apply_fill_transform."""
         self._presenter._model = MagicMock()
         self._presenter._renderer = MagicMock()
         self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
         self._presenter._render()
         self._mock_view.set_on_resize_callback.assert_called_once_with(self._presenter._apply_fill_transform)
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_fills_viewport_without_waiting_for_a_resize_event(self, _mock_styles_cls):
+        """The fill transform must run on first load, not only after a user resize."""
+        self._presenter._model = MagicMock()
+        self._presenter._renderer = MagicMock()
+        self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+        self._presenter._apply_fill_transform = MagicMock()
+        self._presenter._render()
+        self._presenter._apply_fill_transform.assert_called_once()
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_also_refreshes_once_the_layout_has_settled(self, _mock_styles_cls):
+        """The first render happens before VTK's window shrinks to the widget, so re-fill after."""
+        self._presenter._model = MagicMock()
+        self._presenter._renderer = MagicMock()
+        self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+        self._presenter._render()
+        self._mock_view.schedule_refresh.assert_called_once()
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_fills_after_the_camera_has_been_reset(self, _mock_styles_cls):
+        """The fill reads camera.parallel_scale, so reset_camera must come first."""
+        self._presenter._model = MagicMock()
+        self._presenter._renderer = MagicMock()
+        self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+        call_order = []
+        self._mock_view.main_plotter.reset_camera.side_effect = lambda: call_order.append("reset_camera")
+        self._presenter._apply_fill_transform = MagicMock(side_effect=lambda: call_order.append("fill"))
+        self._presenter._render()
+        self.assertEqual(call_order, ["reset_camera", "fill"])
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_enables_parallel_projection_on_plotter(self, _mock_styles_cls):
+        """The parallel (2D) camera must be set up via the plotter itself."""
+        self._presenter._model = MagicMock()
+        self._presenter._renderer = MagicMock()
+        self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+        self._presenter._render()
+        self._mock_view.main_plotter.view_xy.assert_called_once()
+        self._mock_view.main_plotter.enable_parallel_projection.assert_called_once()
+        self._mock_view.main_plotter.reset_camera.assert_called_once()
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_recreates_interactor_styles_after_camera_reset(self, mock_styles_cls):
+        """Styles are rebuilt on every render so their cached default camera is the full view."""
+        self._presenter._model = MagicMock()
+        self._presenter._renderer = MagicMock()
+        self._presenter._renderer.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+        self._presenter._interactor_styles = MagicMock()
+        self._presenter._render()
+        mock_styles_cls.assert_called_once()
+        self.assertIs(self._presenter._interactor_styles, mock_styles_cls.return_value)
 
     def test_apply_fill_transform_scales_mesh_to_fill_viewport(self):
         """Fill transform should scale mesh so both dimensions fill the viewport."""
@@ -325,6 +393,60 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         # Should not raise
         self._presenter._apply_fill_transform()
 
+    def test_apply_fill_transform_uses_widget_size_not_stale_render_window_size(self):
+        """On the first plot VTK still reports its default size — the widget is authoritative.
+
+        Regression test: filling against the stale VTK size gave the wrong
+        aspect ratio until the user happened to resize the window.
+        """
+        mesh = MagicMock()
+        self._presenter._detector_mesh = mesh
+        self._presenter._original_mesh_bounds = (0, 2, 0, 1, 0, 0)
+        self._presenter._transform = np.eye(4)
+        # VTK has not been resized yet; Qt has laid the widget out at 400x300.
+        self._mock_view.main_plotter.ren_win.GetSize.return_value = (1024, 768)
+        self._mock_view.render_area_size.return_value = (400, 300)
+        self._mock_view.main_plotter.camera.parallel_scale = 0.75
+
+        self._presenter._apply_fill_transform()
+
+        transform = mesh.transform.call_args[0][0]
+        # Widget aspect 400/300 → visible_width 2.0, so scale_x = 2.0/2 = 1.0.
+        # The stale 1024/768 would have given visible_width 2.0*... = 1.0 → scale_x 0.5.
+        np.testing.assert_allclose(transform[0, 0], 1.0, atol=1e-6)
+        np.testing.assert_allclose(transform[1, 1], 1.5, atol=1e-6)
+
+    def test_apply_fill_transform_falls_back_to_render_window_size(self):
+        """With no usable widget size, VTK's render window is the only source left."""
+        mesh = MagicMock()
+        self._presenter._detector_mesh = mesh
+        self._presenter._original_mesh_bounds = (0, 2, 0, 1, 0, 0)
+        self._presenter._transform = np.eye(4)
+        self._mock_view.render_area_size.return_value = (0, 0)
+        self._mock_view.main_plotter.ren_win.GetSize.return_value = (400, 300)
+        self._mock_view.main_plotter.camera.parallel_scale = 0.75
+
+        self._presenter._apply_fill_transform()
+
+        transform = mesh.transform.call_args[0][0]
+        np.testing.assert_allclose(transform[0, 0], 1.0, atol=1e-6)
+        np.testing.assert_allclose(transform[1, 1], 1.5, atol=1e-6)
+
+    def test_apply_fill_transform_unaffected_by_dpi_scaling(self):
+        """Only the ratio matters, so logical vs physical pixels make no difference."""
+        mesh = MagicMock()
+        self._presenter._detector_mesh = mesh
+        self._presenter._original_mesh_bounds = (0, 2, 0, 1, 0, 0)
+        self._presenter._transform = np.eye(4)
+        self._mock_view.render_area_size.return_value = (800, 600)  # 2x the 400x300 case
+        self._mock_view.main_plotter.camera.parallel_scale = 0.75
+
+        self._presenter._apply_fill_transform()
+
+        transform = mesh.transform.call_args[0][0]
+        np.testing.assert_allclose(transform[0, 0], 1.0, atol=1e-6)
+        np.testing.assert_allclose(transform[1, 1], 1.5, atol=1e-6)
+
     def test_reset_clears_resize_callback(self):
         self._presenter._model = MagicMock()
         self._presenter.reset()
@@ -351,7 +473,8 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
         # Origin is 1 unit away from centre; after 2x scale it should be 2 units away
         np.testing.assert_allclose(result[:2], [-1.0, -1.0])
 
-    def test_render_does_not_raise(self):
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    def test_render_does_not_raise(self, _mock_styles_cls):
         """_render must complete without raising.
 
         The model mock is spec-restricted to only the attributes that

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_view.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_view.py
@@ -8,6 +8,8 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
+from qtpy.QtCore import QSize
+
 from mantidqt.utils.qt.testing import start_qapplication
 from instrumentview.isisreflectometry.ReflectometryInstrumentViewView import ReflectometryInstrumentViewView
 from instrumentview.ShapeWidgets import RectangleSelectionShape
@@ -194,6 +196,66 @@ class TestReflectometryInstrumentViewView(unittest.TestCase):
     def test_on_resize_finished_no_op_when_no_plotter(self):
         """_on_resize_finished should not raise if the plotter has not been created."""
         self._view._on_resize_finished()  # no exception expected
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_schedule_refresh_starts_debounce_timer(self, mock_bg_plotter_cls):
+        """schedule_refresh runs the resize callback path without a real resize event."""
+        self._view.initialise()
+        self._view._resize_timer = MagicMock()
+        self._view.schedule_refresh()
+        self._view._resize_timer.start.assert_called_once()
+
+    def test_schedule_refresh_no_op_when_no_plotter(self):
+        self._view._resize_timer = MagicMock()
+        self._view.schedule_refresh()
+        self._view._resize_timer.start.assert_not_called()
+
+    @mock.patch("qtpy.QtWidgets.QWidget.showEvent")
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_show_event_schedules_refresh(self, mock_bg_plotter_cls, _mock_super_show):
+        """Becoming visible is when VTK finally gets its true size, so re-fill."""
+        self._view.initialise()
+        self._view._resize_timer = MagicMock()
+        self._view.showEvent(MagicMock())
+        self._view._resize_timer.start.assert_called_once()
+
+    @mock.patch("qtpy.QtWidgets.QWidget.showEvent")
+    def test_show_event_no_op_when_no_plotter(self, _mock_super_show):
+        self._view._resize_timer = MagicMock()
+        self._view.showEvent(MagicMock())
+        self._view._resize_timer.start.assert_not_called()
+
+    def test_render_area_size_falls_back_to_widget_size(self):
+        """Before the plotter exists there is nothing else to measure."""
+        self._view.resize(640, 480)
+        self.assertEqual(self._view.render_area_size(), (640, 480))
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_render_area_size_prefers_the_interactor_widget(self, mock_bg_plotter_cls):
+        """The plotter is inset from this widget by its frame margins, so measure the plotter."""
+        self._view.initialise()
+        self._view.resize(640, 480)
+        self._view.main_plotter.size.return_value = QSize(622, 462)
+        self.assertEqual(self._view.render_area_size(), (622, 462))
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_render_area_size_ignores_unsized_interactor(self, mock_bg_plotter_cls):
+        self._view.initialise()
+        self._view.resize(640, 480)
+        self._view.main_plotter.size.return_value = QSize(0, 0)
+        self.assertEqual(self._view.render_area_size(), (640, 480))
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_render_area_size_ignores_interactor_larger_than_this_widget(self, mock_bg_plotter_cls):
+        """Before Qt lays it out the plotter still reports its default window size.
+
+        It is nested inside this widget, so a larger size can only mean stale
+        geometry — using it gives the mesh the wrong aspect ratio.
+        """
+        self._view.initialise()
+        self._view.resize(640, 480)
+        self._view.main_plotter.size.return_value = QSize(1024, 768)
+        self.assertEqual(self._view.render_area_size(), (640, 480))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes some problems in the nightly with the ALF View and the ISIS Reflectometry interfaces.

The ISIS Reflectometry interface was not rendering the instrument with the correct aspect ratio or interactor (the user could spin the projection around). There was a problem, possibly related to recent dependency updates, where the window size that the interface was getting is incorrect until a resize, this fixes that.

ALF View had a disabled "Add ROI" button, and didn't open due to a broken connection.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Test those two interfaces with the new Instrument View (option in the Workbench settings).

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
