### PR TITLE
Added the model column to the search interface of the ISIS Reflectometry GUI

### DIFF
--- a/docs/source/release/v7.0.0/Reflectometry/Bugfixes/41523.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/Bugfixes/41523.rst
@@ -1,0 +1,1 @@
+- The Search table in the ``Runs`` tab of the :ref:`ISIS Reflectometry <ISISReflectometryInterface>` interface now has a **Model** column to add the model description of the run.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -434,7 +434,7 @@ Decoder::decodeSearchResult(const QMap<QString, QVariant> &map) {
       map[QString("runNumber")].toString().toStdString(), map[QString("title")].toString().toStdString(),
       map[QString("groupName")].toString().toStdString(), map[QString("theta")].toString().toStdString(),
       map[QString("error")].toString().toStdString(), map[QString("excludeReason")].toString().toStdString(),
-      map[QString("comment")].toString().toStdString());
+      map[QString("comment")].toString().toStdString(), map[QString("model")].toString().toStdString());
   return searchResult;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -242,6 +242,7 @@ QMap<QString, QVariant> Encoder::encodeSearchResult(const SearchResult &row) {
   searchResultMap.insert(QString("error"), QVariant(QString::fromStdString(row.error())));
   searchResultMap.insert(QString("excludeReason"), QVariant(QString::fromStdString(row.excludeReason())));
   searchResultMap.insert(QString("comment"), QVariant(QString::fromStdString(row.comment())));
+  searchResultMap.insert(QString("model"), QVariant(QString::fromStdString(row.model())));
   return searchResultMap;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
@@ -22,7 +22,7 @@ manipulate the view's model.
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL ISearchModel {
 public:
-  enum class Column { RUN, TITLE, EXCLUDE, COMMENT, NUM_COLUMNS };
+  enum class Column { RUN, TITLE, EXCLUDE, COMMENT, MODEL, NUM_COLUMNS };
 
   virtual void mergeNewResults(std::vector<SearchResult> const &source) = 0;
   virtual void replaceResults(std::vector<SearchResult> const &source) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -61,7 +61,7 @@ int QtSearchModel::rowCount(const QModelIndex &) const { return static_cast<int>
 /**
 @return the number of columns in the model.
 */
-int QtSearchModel::columnCount(const QModelIndex &) const { return 4; }
+int QtSearchModel::columnCount(const QModelIndex &) const { return static_cast<int>(Column::NUM_COLUMNS); }
 
 /**
 Overrident data method, allows consuming view to extract data for an index and
@@ -90,6 +90,8 @@ QVariant QtSearchModel::data(const QModelIndex &index, int role) const {
         return QString::fromStdString(std::string("Excluded by user: ") + run.excludeReason());
       else if (run.hasComment())
         return QString::fromStdString(std::string("User comment: ") + run.comment());
+      else if (run.hasModel())
+        return QString::fromStdString(std::string("Model: ") + run.model());
     } else if (role == Qt::BackgroundRole) {
       // setting the background colour for any unsuccessful transfers / excluded
       // runs
@@ -109,6 +111,8 @@ QVariant QtSearchModel::data(const QModelIndex &index, int role) const {
     return QString::fromStdString(run.excludeReason());
   if (column == Column::COMMENT)
     return QString::fromStdString(run.comment());
+  if (column == Column::MODEL)
+    return QString::fromStdString(run.model());
 
   return QVariant();
 }
@@ -129,6 +133,8 @@ bool QtSearchModel::setData(const QModelIndex &index, const QVariant &value, int
     run.addExcludeReason(value.toString().toStdString());
   else if (column == Column::COMMENT)
     run.addComment(value.toString().toStdString());
+  else if (column == Column::MODEL)
+    run.addModel(value.toString().toStdString());
   else
     return false;
 
@@ -157,6 +163,8 @@ QVariant QtSearchModel::headerData(int section, Qt::Orientation orientation, int
         return QString("Exclude");
       case Column::COMMENT:
         return QString("Comment");
+      case Column::MODEL:
+        return QString("Model");
       default:
         return "";
       }
@@ -175,6 +183,8 @@ QVariant QtSearchModel::headerData(int section, Qt::Orientation orientation, int
       case Column::COMMENT:
         return QString("User-specified annotation. Double-click to edit. Does "
                        "not affect the reduction.");
+      case Column::MODEL:
+        return QString("The model description of the run.");
       default:
         return "";
       }
@@ -192,7 +202,7 @@ Qt::ItemFlags QtSearchModel::flags(const QModelIndex &index) const {
   const auto column = static_cast<Column>(index.column());
   if (!index.isValid())
     return {};
-  else if (column == Column::EXCLUDE || column == Column::COMMENT)
+  else if (column == Column::EXCLUDE || column == Column::COMMENT || column == Column::MODEL)
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
   else
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
@@ -227,7 +237,8 @@ std::string QtSearchModel::makeSearchResultsCSV(SearchResults const &results) co
   }
   std::string csv = makeSearchResultsCSVHeaders();
   for (SearchResult const &result : results) {
-    csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "\n";
+    csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "," +
+           result.model() + "\n";
   }
   return csv;
 }
@@ -246,6 +257,10 @@ std::string QtSearchModel::makeSearchResultsCSVHeaders() const {
                 .toStdString() +
             ",";
   header += headerData(static_cast<int>(Column::COMMENT), Qt::Orientation::Horizontal, Qt::DisplayRole)
+                .toString()
+                .toStdString() +
+            ",";
+  header += headerData(static_cast<int>(Column::MODEL), Qt::Orientation::Horizontal, Qt::DisplayRole)
                 .toString()
                 .toStdString() +
             "\n";

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -17,10 +17,10 @@ SearchResult::SearchResult(const std::string &runNumber, std::string title) : m_
 }
 
 SearchResult::SearchResult(std::string runNumber, std::string title, std::string groupName, std::string theta,
-                           std::string error, std::string excludeReason, std::string comment)
+                           std::string error, std::string excludeReason, std::string comment, std::string model)
     : m_runNumber(std::move(runNumber)), m_title(std::move(title)), m_groupName(std::move(groupName)),
       m_theta(std::move(theta)), m_error(std::move(error)), m_excludeReason(std::move(excludeReason)),
-      m_comment(std::move(comment)) {}
+      m_comment(std::move(comment)), m_model(std::move(model)) {}
 
 void SearchResult::parseRun(std::string const &runNumber) {
   auto const maybeRunNumber = parseRunNumber(runNumber);
@@ -70,7 +70,11 @@ const std::string &SearchResult::excludeReason() const { return m_excludeReason;
 
 bool SearchResult::hasComment() const { return !m_comment.empty(); }
 
+bool SearchResult::hasModel() const { return !m_model.empty(); }
+
 const std::string &SearchResult::comment() const { return m_comment; }
+
+const std::string &SearchResult::model() const { return m_model; }
 
 void SearchResult::addError(std::string const &error) {
   if (m_error.empty())
@@ -82,6 +86,8 @@ void SearchResult::addError(std::string const &error) {
 void SearchResult::addExcludeReason(std::string const &excludeReason) { m_excludeReason = excludeReason; }
 
 void SearchResult::addComment(std::string const &comment) { m_comment = comment; }
+
+void SearchResult::addModel(std::string const &model) { m_model = model; }
 
 bool operator==(SearchResult const &lhs, SearchResult const &rhs) {
   // Ignore the error field in the comparison because this represents the

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -23,7 +23,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL SearchResult {
 public:
   SearchResult(const std::string &runNumber, std::string title);
   SearchResult(std::string runNumber, std::string title, std::string groupName, std::string theta, std::string error,
-               std::string excludeReason, std::string comment);
+               std::string excludeReason, std::string comment, std::string model);
 
   const std::string &runNumber() const;
   const std::string &title() const;
@@ -35,8 +35,11 @@ public:
   const std::string &excludeReason() const;
   void addExcludeReason(std::string const &error);
   bool hasComment() const;
+  bool hasModel() const;
   const std::string &comment() const;
-  void addComment(std::string const &error);
+  const std::string &model() const;
+  void addComment(std::string const &comment);
+  void addModel(std::string const &model);
 
 private:
   std::string m_runNumber;
@@ -46,6 +49,7 @@ private:
   std::string m_error;
   std::string m_excludeReason;
   std::string m_comment;
+  std::string m_model;
 
   void parseRun(std::string const &runNumber);
   void parseMetadataFromTitle();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -243,6 +243,7 @@ private:
     TS_ASSERT_EQUALS(searchResult.error(), map[QString("error")].toString().toStdString());
     TS_ASSERT_EQUALS(searchResult.excludeReason(), map[QString("excludeReason")].toString().toStdString());
     TS_ASSERT_EQUALS(searchResult.comment(), map[QString("comment")].toString().toStdString());
+    TS_ASSERT_EQUALS(searchResult.model(), map[QString("model")].toString().toStdString());
   }
 
   void testReductionWorkspaces(const ReductionWorkspaces &redWs, const QMap<QString, QVariant> &map) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -52,17 +52,17 @@ private:
   static SearchResults getTestSearchResults() {
     auto results = SearchResults();
     results.push_back(SearchResult("111111", "a title with a theta th=0.1", "a title with a theta", "0.1", "", "",
-                                   "this is a good one", "model one"));
+                                   "this is a good one", "air | Ni 100 | SiO2 0.5 | Si"));
     results.push_back(SearchResult("222222", "a title without a theta"));
     results.push_back(SearchResult("333333", "This one is purposely excluded th=0.2", "This one is purposely excluded",
-                                   "0.2", "", "it's bad", "something"));
+                                   "0.2", "", "it's bad", "something", ""));
 
     return results;
   }
 
   static std::string getTestCSV() {
     return "Run,Description,Exclude,Comment,Model\n"
-           "111111,a title with a theta th=0.1,,this is a good one,model one\n"
+           "111111,a title with a theta th=0.1,,this is a good one,air | Ni 100 | SiO2 0.5 | Si\n"
            "222222,a title without a theta,,,\n"
            "333333,This one is purposely excluded th=0.2,it's bad,something,\n";
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -52,7 +52,7 @@ private:
   static SearchResults getTestSearchResults() {
     auto results = SearchResults();
     results.push_back(SearchResult("111111", "a title with a theta th=0.1", "a title with a theta", "0.1", "", "",
-                                   "this is a good one"));
+                                   "this is a good one", "model one"));
     results.push_back(SearchResult("222222", "a title without a theta"));
     results.push_back(SearchResult("333333", "This one is purposely excluded th=0.2", "This one is purposely excluded",
                                    "0.2", "", "it's bad", "something"));
@@ -61,9 +61,9 @@ private:
   }
 
   static std::string getTestCSV() {
-    return "Run,Description,Exclude,Comment\n"
-           "111111,a title with a theta th=0.1,,this is a good one\n"
-           "222222,a title without a theta,,\n"
-           "333333,This one is purposely excluded th=0.2,it's bad,something\n";
+    return "Run,Description,Exclude,Comment,Model\n"
+           "111111,a title with a theta th=0.1,,this is a good one,model one\n"
+           "222222,a title without a theta,,,\n"
+           "333333,This one is purposely excluded th=0.2,it's bad,something,\n";
   }
 };


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41523 . <!-- One line per closed issue. -->
Adds an additional model column to the search table in the ISIS Reflectometry GUI to save the model description.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
1) Build mantid using `pixi run cmake --build .`
2) Launch mantid using `pixi run workbench`
3) Open the `ISIS Reflectometry` GUI.
4) Fill in the Investigation Id `1120015` and Cycle `11_3` and click `Search`. This search criteria comes from the [manual test](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#search-by-experiment).
5) Type something into the model column for example `air | Ni 100 | SiO2 0.5 | Si` and click enter.
6) Click the `Export` button.
7) Specify the name of the `csv` file.
8) Verify that the model description is saved into the file.
<img width="870" height="162" alt="image" src="https://github.com/user-attachments/assets/9f27e3de-5cc8-480b-9e5f-818828e5882d" />

**Note -** This is slightly different from the functionality that is requested in the issue because I couldn't find a way to export ORSO formatted files from the table. I have also left the functionality added to the Save tabs as it is.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
