### PR TITLE
Updated FlowLayout classes in C++ and python to prevent style jumping when resizing the Workspaces and Plots widgets on Mac

### DIFF
--- a/qt/python/mantidqt/mantidqt/utils/flowlayout.py
+++ b/qt/python/mantidqt/mantidqt/utils/flowlayout.py
@@ -38,7 +38,7 @@
 ##
 #############################################################################
 
-
+import mantid.kernel.environment as mtd_env
 from qtpy.QtCore import QPoint, QRect, QSize, Qt
 from qtpy.QtWidgets import QLayout, QSizePolicy
 
@@ -118,17 +118,20 @@ class FlowLayout(QLayout):
             wid = item.widget()
             spaceX = self.spacing() + wid.style().layoutSpacing(QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Horizontal)
             spaceY = self.spacing() + wid.style().layoutSpacing(QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Vertical)
-            nextX = x + item.sizeHint().width() + spaceX
-            if nextX - spaceX > rect.right() and lineHeight > 0:
+            size = item.sizeHint()
+            if mtd_env.is_mac() and size.height() <= 28:
+                size.setHeight(28)
+            lineHeight = size.height() // 2
+
+            nextX = x + size.width() + spaceX
+            if nextX - spaceX > rect.right():
                 x = rect.x()
                 y = y + lineHeight + spaceY
-                nextX = x + item.sizeHint().width() + spaceX
-                lineHeight = 0
+                nextX = x + size.width() + spaceX
 
             if not testOnly:
-                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
+                item.setGeometry(QRect(QPoint(x, y), size))
 
             x = nextX
-            lineHeight = max(lineHeight, item.sizeHint().height())
 
         return y + lineHeight - rect.y()

--- a/qt/python/mantidqt/mantidqt/utils/flowlayout.py
+++ b/qt/python/mantidqt/mantidqt/utils/flowlayout.py
@@ -121,8 +121,9 @@ class FlowLayout(QLayout):
             size = item.sizeHint()
             if mtd_env.is_mac() and size.height() <= 28:
                 size.setHeight(28)
-            lineHeight = size.height() // 2
-
+                lineHeight = size.height() // 2
+            else:
+                lineHeight = max(lineHeight, size.height())
             nextX = x + size.width() + spaceX
             if nextX - spaceX > rect.right():
                 x = rect.x()
@@ -133,5 +134,4 @@ class FlowLayout(QLayout):
                 item.setGeometry(QRect(QPoint(x, y), size))
 
             x = nextX
-
         return y + lineHeight - rect.y()

--- a/qt/widgets/common/src/FlowLayout.cpp
+++ b/qt/widgets/common/src/FlowLayout.cpp
@@ -132,8 +132,10 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const {
 #ifdef Q_OS_MACOS
     if (size.height() <= 28)
       size.setHeight(28);
-#endif
     lineHeight = size.height() / 2;
+#else
+    lineHeight = qMax(lineHeight, size.height());
+#endif
     int nextX = x + size.width() + spaceX;
     if (nextX - spaceX > effectiveRect.right()) {
       x = effectiveRect.x();

--- a/qt/widgets/common/src/FlowLayout.cpp
+++ b/qt/widgets/common/src/FlowLayout.cpp
@@ -128,19 +128,23 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const {
     int spaceY = verticalSpacing();
     if (spaceY == -1)
       spaceY = wid->style()->layoutSpacing(QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
-    int nextX = x + item->sizeHint().width() + spaceX;
-    if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
+    QSize size = item->sizeHint();
+#ifdef Q_OS_MACOS
+    if (size.height() <= 28)
+      size.setHeight(28);
+#endif
+    lineHeight = size.height() / 2;
+    int nextX = x + size.width() + spaceX;
+    if (nextX - spaceX > effectiveRect.right()) {
       x = effectiveRect.x();
       y = y + lineHeight + spaceY;
-      nextX = x + item->sizeHint().width() + spaceX;
-      lineHeight = 0;
+      nextX = x + size.width() + spaceX;
     }
 
     if (!testOnly)
-      item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+      item->setGeometry(QRect(QPoint(x, y), size));
 
     x = nextX;
-    lineHeight = qMax(lineHeight, item->sizeHint().height());
   }
   return y + lineHeight - rect.y() + bottom;
 }


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41952. <!-- One line per closed issue. -->
Fixes the style jumps on the buttons on Mac.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
1) `pixi run cmake --build .`
2) `pixi run workbench`
3) Resize the widgets and verify that the buttons have the same styles as they jump from row 2 to row 1 and vice versa.

**Note -** Does not need a release note.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
