### PR TITLE
Fix slow systems test from parallelising ConvertToMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWS.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWS.h
@@ -63,17 +63,17 @@ private:
   unsigned int m_NMatrixDimensions{0};
 
   // Private method to update rotation matrix for a single event from log values
-  template <class T> bool setGoniometersFromLogs(const T &ev, Geometry::Goniometer &gonio, MDTransf_sptr QConv) {
+  template <class T> bool setGoniometersFromLogs(const T &ev) {
     if (!m_useLogTimes || m_GonioIndex.empty())
       return true;
     for (size_t axIdx = 0; axIdx < m_GonioIndex.size(); axIdx++) {
       double logval = m_Logs[axIdx]->getSingleValue(ev->pulseTime());
       if (std::isnan(logval))
         return false;
-      gonio.setRotationAngle(m_GonioIndex[axIdx], logval);
+      m_Goniometer.setRotationAngle(m_GonioIndex[axIdx], logval);
     }
-    Kernel::DblMatrix tmpR = gonio.getR() * m_Wtransf;
-    QConv->updateRotMat(tmpR.getVector());
+    m_tmpRot = m_Goniometer.getR() * m_Wtransf;
+    m_QConverter->updateRotMat(m_tmpRot.getVector());
     return true;
   }
 };

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDEventWSWrapper.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDEventWSWrapper.h
@@ -35,7 +35,7 @@ class MDEventWSWrapper;
 using fpVoidMethod = void (MDEventWSWrapper::*)();
 /// signature for the internal templated function pointer to add data to an
 /// existing workspace
-using fpAddData = void (MDEventWSWrapper::*)(const float *, const uint16_t, const uint16_t, const uint32_t *,
+using fpAddData = void (MDEventWSWrapper::*)(const float *, const uint16_t *, const uint16_t *, const uint32_t *,
                                              const coord_t *, size_t) const;
 /// signature for the internal templated function pointer to create workspace
 using fpCreateWS = void (MDEventWSWrapper::*)(const MDWSDescription &);
@@ -56,8 +56,9 @@ public:
   API::IMDEventWorkspace_sptr createEmptyMDWS(const MDWSDescription &WSD);
   /// add the data to the internal workspace. The workspace has to exist and be
   /// initiated
-  void addMDData(std::vector<float> &sigErr, uint16_t expInfoIndex, uint16_t goniometerIndex,
-                 std::vector<uint32_t> &detId, std::vector<coord_t> &Coord, size_t dataSize) const;
+  void addMDData(std::vector<float> &sigErr, std::vector<uint16_t> &expInfoIndex,
+                 std::vector<uint16_t> &goniometerIndex, std::vector<uint32_t> &detId, std::vector<coord_t> &Coord,
+                 size_t dataSize) const;
   /// releases the shared pointer to the MD workspace, stored by the class and
   /// makes the class instance undefined;
   void releaseWorkspace();
@@ -103,7 +104,7 @@ private:
   // internal function tempates to generate as function of dimensions and
   // assign to function pointers
   template <size_t nd>
-  void addMDDataND(const float *sigErr, const uint16_t expInfoIndex, const uint16_t goniometerIndex,
+  void addMDDataND(const float *sigErr, const uint16_t *expInfoIndex, const uint16_t *goniometerIndex,
                    const uint32_t *detId, const coord_t *Coord, size_t dataSize) const;
   template <size_t nd>
   void addAndTraceMDDataND(float *sig_err, uint16_t *expInfoIndex, uint16_t *goniometerIndex, uint32_t *det_id,

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -42,6 +42,7 @@ template <class T> size_t ConvToMDEventsWS::convertEventList(size_t workspaceInd
   UnitsConversionHelper localUnitConv(m_UnitConversion);
 
   uint32_t detID = m_detID[workspaceIndex];
+  uint16_t expInfoIndexLoc = m_ExpInfoIndex;
 
   std::vector<coord_t> locCoord(m_Coord);
   // set up unit conversion and calculate up all coordinates, which depend on
@@ -53,82 +54,45 @@ template <class T> size_t ConvToMDEventsWS::convertEventList(size_t workspaceInd
   // allocate temporary buffers for MD Events data
   // MD events coordinates buffer
   std::vector<coord_t> allCoord;
-  std::vector<float> sig_err; // array for signal and error.
+  std::vector<float> sig_err;             // array for signal and error.
+  std::vector<uint16_t> expInfoIndex;     // Buffer for associated experiment-info index for each event
+  std::vector<uint16_t> goniometer_index; // Buffer for goniometer index for each event
+  std::vector<uint32_t> det_ids;          // Buffer of det Id-s for each event
 
   allCoord.reserve(this->m_NDims * numEvents);
   sig_err.reserve(2 * numEvents);
+  expInfoIndex.reserve(numEvents);
+  goniometer_index.reserve(numEvents);
+  det_ids.reserve(numEvents);
 
   // This little dance makes the getting vector of events more general (since
   // you can't overload by return type).
   typename std::vector<T> const *events_ptr;
   getEventsFrom(el, events_ptr);
   const typename std::vector<T> &events = *events_ptr;
+  // Iterators to start/end
+  for (auto it = events.cbegin(); it != events.cend(); it++) {
+    double val = localUnitConv.convertUnits(it->tof());
+    double signal = it->weight();
+    double errorSq = it->errorSquared();
+    if (!setGoniometersFromLogs(it))
+      continue; // skip if log value is NaN
+    if (!setGenericVariableFromLogs(it->pulseTime(), locCoord))
+      continue; // skip if log value is NaN or out of bounds
+    if (!m_QConverter->calcMatrixCoord(val, locCoord, signal, errorSq))
+      continue; // skip ND outside the range
 
-  int nThreads = m_NumThreads < 0 ? PARALLEL_GET_MAX_THREADS : std::max(1, m_NumThreads);
-  int nEvents = static_cast<int>(events.size());
-  if (nEvents < (nThreads * 1000)) {
-    nThreads = 1;
+    sig_err.emplace_back(static_cast<float>(signal));
+    sig_err.emplace_back(static_cast<float>(errorSq));
+    expInfoIndex.emplace_back(expInfoIndexLoc);
+    goniometer_index.emplace_back(0); // default value
+    det_ids.emplace_back(detID);
+    allCoord.insert(allCoord.end(), locCoord.begin(), locCoord.end());
   }
-
-  if (nThreads > 1) {
-    // Parallelise loops by workers, each worker needs a clone of QConverter and Goniometer
-    int nBatch = static_cast<int>(ceil(nEvents / nThreads));
-    std::vector<std::vector<float>> sigErrs(nThreads, sig_err);
-    std::vector<std::vector<coord_t>> allCoords(nThreads, allCoord);
-
-    PRAGMA_OMP(parallel for)
-    for (int i = 0; i < nThreads; i++) {
-      MDTransf_sptr t_QConverter(m_QConverter->clone());
-      std::vector<coord_t> locCoord_(m_Coord);
-      Geometry::Goniometer t_gonio(m_Goniometer);
-      auto iStart = events.begin() + (nBatch * i);
-      auto iEnd = (i == (nThreads - 1)) ? events.end() : events.begin() + (nBatch * (i + 1));
-      // Iterators to start/end
-      for (auto it = iStart; it != iEnd; it++) {
-        double val = localUnitConv.convertUnits(it->tof());
-        double signal = it->weight();
-        double errorSq = it->errorSquared();
-        if (!setGoniometersFromLogs(it, t_gonio, t_QConverter))
-          continue; // skip if log value is NaN
-        if (!setGenericVariableFromLogs(it->pulseTime(), locCoord_))
-          continue; // skip if log value is NaN or out of bounds
-        if (!t_QConverter->calcMatrixCoord(val, locCoord_, signal, errorSq))
-          continue; // skip ND outside the range
-
-        sigErrs[i].emplace_back(static_cast<float>(signal));
-        sigErrs[i].emplace_back(static_cast<float>(errorSq));
-        allCoords[i].insert(allCoords[i].end(), locCoord_.begin(), locCoord_.end());
-      }
-    }
-    for (int i = 0; i < nThreads; i++) {
-      // The order of the events is important for some tests
-      sig_err.insert(sig_err.end(), sigErrs[i].begin(), sigErrs[i].end());
-      allCoord.insert(allCoord.end(), allCoords[i].begin(), allCoords[i].end());
-    }
-
-  } else {
-    // Non-parallelised version, avoids OpenMP overhead
-    for (auto it = events.cbegin(); it != events.cend(); it++) {
-      if (!setGoniometersFromLogs(it, m_Goniometer, m_QConverter))
-        continue; // skip if log value is NaN
-      if (!setGenericVariableFromLogs(it->pulseTime(), locCoord))
-        continue; // skip if log value is NaN or out of bounds
-      double val = localUnitConv.convertUnits(it->tof());
-      double signal = it->weight();
-      double errorSq = it->errorSquared();
-      if (!m_QConverter->calcMatrixCoord(val, locCoord, signal, errorSq))
-        continue; // skip ND outside the range
-      sig_err.emplace_back(static_cast<float>(signal));
-      sig_err.emplace_back(static_cast<float>(errorSq));
-      allCoord.insert(allCoord.end(), locCoord.begin(), locCoord.end());
-    }
-  }
-
-  size_t n_added_events = sig_err.size() / 2;
-  std::vector<uint32_t> det_ids(n_added_events, detID);
 
   // Add them to the MDEW
-  m_OutWSWrapper->addMDData(sig_err, m_ExpInfoIndex, 0, det_ids, allCoord, n_added_events);
+  size_t n_added_events = expInfoIndex.size();
+  m_OutWSWrapper->addMDData(sig_err, expInfoIndex, goniometer_index, det_ids, allCoord, n_added_events);
   return n_added_events;
 }
 

--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -64,42 +64,66 @@ template <class T> size_t ConvToMDEventsWS::convertEventList(size_t workspaceInd
   getEventsFrom(el, events_ptr);
   const typename std::vector<T> &events = *events_ptr;
 
-  // Parallelise loops by workers, each worker needs a clone of QConverter and Goniometer
-  int numthreads = m_NumThreads < 0 ? PARALLEL_GET_MAX_THREADS : std::max(1, m_NumThreads);
-  std::vector<MDTransf_sptr> qConverters;
-  std::vector<Geometry::Goniometer> gonios;
-  std::vector<std::vector<coord_t>> allCoords;
-  std::vector<std::vector<float>> sig_errs;
-  for (int i = 0; i < numthreads; i++) {
-    qConverters.emplace_back(m_QConverter->clone());
-    allCoords.push_back(allCoord);
-    sig_errs.push_back(sig_err);
-    gonios.emplace_back(m_Goniometer);
+  int nThreads = m_NumThreads < 0 ? PARALLEL_GET_MAX_THREADS : std::max(1, m_NumThreads);
+  int nEvents = static_cast<int>(events.size());
+  if (nEvents < (nThreads * 1000)) {
+    nThreads = 1;
   }
-  // Iterators to start/end
-  PRAGMA_OMP(parallel for)
-  for (int i = 0; i < static_cast<int>(events.size()); i++) {
-    MDTransf_sptr p_QConverter = qConverters[PARALLEL_THREAD_NUMBER];
-    double val = localUnitConv.convertUnits(events[i].tof());
-    double signal = events[i].weight();
-    double errorSq = events[i].errorSquared();
-    if (!setGoniometersFromLogs(&events[i], gonios[PARALLEL_THREAD_NUMBER], p_QConverter))
-      continue; // skip if log value is NaN
-    std::vector<coord_t> locCoord_(m_Coord);
-    if (!setGenericVariableFromLogs(events[i].pulseTime(), locCoord_))
-      continue; // skip if log value is NaN or out of bounds
-    if (!p_QConverter->calcMatrixCoord(val, locCoord_, signal, errorSq))
-      continue; // skip ND outside the range
 
-    sig_errs[PARALLEL_THREAD_NUMBER].emplace_back(static_cast<float>(signal));
-    sig_errs[PARALLEL_THREAD_NUMBER].emplace_back(static_cast<float>(errorSq));
-    allCoords[PARALLEL_THREAD_NUMBER].insert(allCoords[PARALLEL_THREAD_NUMBER].end(), locCoord_.begin(),
-                                             locCoord_.end());
+  if (nThreads > 1) {
+    // Parallelise loops by workers, each worker needs a clone of QConverter and Goniometer
+    int nBatch = static_cast<int>(ceil(nEvents / nThreads));
+    std::vector<std::vector<float>> sigErrs(nThreads, sig_err);
+    std::vector<std::vector<coord_t>> allCoords(nThreads, allCoord);
+
+    PRAGMA_OMP(parallel for)
+    for (int i = 0; i < nThreads; i++) {
+      MDTransf_sptr t_QConverter(m_QConverter->clone());
+      std::vector<coord_t> locCoord_(m_Coord);
+      Geometry::Goniometer t_gonio(m_Goniometer);
+      auto iStart = events.begin() + (nBatch * i);
+      auto iEnd = (i == (nThreads - 1)) ? events.end() : events.begin() + (nBatch * (i + 1));
+      // Iterators to start/end
+      for (auto it = iStart; it != iEnd; it++) {
+        double val = localUnitConv.convertUnits(it->tof());
+        double signal = it->weight();
+        double errorSq = it->errorSquared();
+        if (!setGoniometersFromLogs(it, t_gonio, t_QConverter))
+          continue; // skip if log value is NaN
+        if (!setGenericVariableFromLogs(it->pulseTime(), locCoord_))
+          continue; // skip if log value is NaN or out of bounds
+        if (!t_QConverter->calcMatrixCoord(val, locCoord_, signal, errorSq))
+          continue; // skip ND outside the range
+
+        sigErrs[i].emplace_back(static_cast<float>(signal));
+        sigErrs[i].emplace_back(static_cast<float>(errorSq));
+        allCoords[i].insert(allCoords[i].end(), locCoord_.begin(), locCoord_.end());
+      }
+    }
+    for (int i = 0; i < nThreads; i++) {
+      // The order of the events is important for some tests
+      sig_err.insert(sig_err.end(), sigErrs[i].begin(), sigErrs[i].end());
+      allCoord.insert(allCoord.end(), allCoords[i].begin(), allCoords[i].end());
+    }
+
+  } else {
+    // Non-parallelised version, avoids OpenMP overhead
+    for (auto it = events.cbegin(); it != events.cend(); it++) {
+      if (!setGoniometersFromLogs(it, m_Goniometer, m_QConverter))
+        continue; // skip if log value is NaN
+      if (!setGenericVariableFromLogs(it->pulseTime(), locCoord))
+        continue; // skip if log value is NaN or out of bounds
+      double val = localUnitConv.convertUnits(it->tof());
+      double signal = it->weight();
+      double errorSq = it->errorSquared();
+      if (!m_QConverter->calcMatrixCoord(val, locCoord, signal, errorSq))
+        continue; // skip ND outside the range
+      sig_err.emplace_back(static_cast<float>(signal));
+      sig_err.emplace_back(static_cast<float>(errorSq));
+      allCoord.insert(allCoord.end(), locCoord.begin(), locCoord.end());
+    }
   }
-  for (int i = 0; i < numthreads; i++) {
-    sig_err.insert(sig_err.end(), sig_errs[i].begin(), sig_errs[i].end());
-    allCoord.insert(allCoord.end(), allCoords[i].begin(), allCoords[i].end());
-  }
+
   size_t n_added_events = sig_err.size() / 2;
   std::vector<uint32_t> det_ids(n_added_events, detID);
 

--- a/Framework/MDAlgorithms/src/ConvToMDHistoWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDHistoWS.cpp
@@ -63,8 +63,10 @@ size_t ConvToMDHistoWS::conversionChunk(size_t startSpectra) {
   std::vector<coord_t> locCoord(m_Coord);
 
   // allocate temporary buffer for MD Events data
-  std::vector<float> sig_err(2 * m_bufferSize); // array for signal and error.
-  std::vector<uint32_t> det_ids(m_bufferSize);  // Buffer of det Id-s for each event
+  std::vector<float> sig_err(2 * m_bufferSize);         // array for signal and error.
+  std::vector<uint16_t> expInfoIndex(m_bufferSize);     // Buffer associated experiment-info index for each event
+  std::vector<uint16_t> goniometer_index(m_bufferSize); // Buffer goniometer index for each event
+  std::vector<uint32_t> det_ids(m_bufferSize);          // Buffer of det Id-s for each event
 
   std::vector<coord_t> allCoord(m_NDims * m_bufferSize); // MD events coordinates buffer
   size_t n_coordinates = 0;
@@ -124,6 +126,8 @@ size_t ConvToMDHistoWS::conversionChunk(size_t startSpectra) {
       // coppy all data into data buffer for future transformation into events;
       sig_err[2 * nBufEvents + 0] = float(signal);
       sig_err[2 * nBufEvents + 1] = float(errorSq);
+      expInfoIndex[nBufEvents] = m_ExpInfoIndex;
+      goniometer_index[nBufEvents] = 0; // default value
       det_ids[nBufEvents] = det_id;
 
       for (size_t ii = 0; ii < m_NDims; ii++)
@@ -132,7 +136,7 @@ size_t ConvToMDHistoWS::conversionChunk(size_t startSpectra) {
       // calculate number of events
       nBufEvents++;
       if (nBufEvents >= m_bufferSize) {
-        m_OutWSWrapper->addMDData(sig_err, m_ExpInfoIndex, 0 /*goniometer_index*/, det_ids, allCoord, nBufEvents);
+        m_OutWSWrapper->addMDData(sig_err, expInfoIndex, goniometer_index, det_ids, allCoord, nBufEvents);
         nAddedEvents += nBufEvents;
         // reset buffer counts
         n_coordinates = 0;
@@ -142,7 +146,7 @@ size_t ConvToMDHistoWS::conversionChunk(size_t startSpectra) {
   } // end detectors loop;
 
   if (nBufEvents > 0) {
-    m_OutWSWrapper->addMDData(sig_err, m_ExpInfoIndex, 0 /*goniometer_index*/, det_ids, allCoord, nBufEvents);
+    m_OutWSWrapper->addMDData(sig_err, expInfoIndex, goniometer_index, det_ids, allCoord, nBufEvents);
     nAddedEvents += nBufEvents;
     nBufEvents = 0;
   }

--- a/Framework/MDAlgorithms/src/MDEventWSWrapper.cpp
+++ b/Framework/MDAlgorithms/src/MDEventWSWrapper.cpp
@@ -82,14 +82,14 @@ coordinates of nd-dimensional events
 *@param dataSize -- the length of the vector of MD events
 */
 template <size_t nd>
-void MDEventWSWrapper::addMDDataND(const float *sigErr, const uint16_t expInfoIndex, const uint16_t goniometerIndex,
+void MDEventWSWrapper::addMDDataND(const float *sigErr, const uint16_t *expInfoIndex, const uint16_t *goniometerIndex,
                                    const uint32_t *detId, const coord_t *Coord, size_t dataSize) const {
 
   auto *const pWs = dynamic_cast<DataObjects::MDEventWorkspace<DataObjects::MDEvent<nd>, nd> *>(m_Workspace.get());
   if (pWs) {
     for (size_t i = 0; i < dataSize; i++) {
-      pWs->addEvent(DataObjects::MDEvent<nd>(*(sigErr + 2 * i), *(sigErr + 2 * i + 1), expInfoIndex, goniometerIndex,
-                                             *(detId + i), (Coord + i * nd)));
+      pWs->addEvent(DataObjects::MDEvent<nd>(*(sigErr + 2 * i), *(sigErr + 2 * i + 1), *(expInfoIndex + i),
+                                             *(goniometerIndex + i), *(detId + i), (Coord + i * nd)));
     }
   } else {
     auto *const pLWs =
@@ -109,9 +109,9 @@ void MDEventWSWrapper::addMDDataND(const float *sigErr, const uint16_t expInfoIn
 /// the function used in template metaloop termination on 0 dimensions and to
 /// throw the error in attempt to add data to 0-dimension workspace
 template <>
-void MDEventWSWrapper::addMDDataND<0>(const float * /*unused*/, const uint16_t /*unused*/, const uint16_t /*unused*/,
-                                      const uint32_t * /*unused*/, const coord_t * /*unused*/,
-                                      size_t /*unused*/) const {
+void MDEventWSWrapper::addMDDataND<0>(const float * /*unused*/, const uint16_t * /*unused*/,
+                                      const uint16_t * /*unused*/, const uint32_t * /*unused*/,
+                                      const coord_t * /*unused*/, size_t /*unused*/) const {
   throw(std::invalid_argument(" class has not been initiated, can not add data "
                               "to 0-dimensional workspace"));
 }
@@ -201,13 +201,15 @@ void MDEventWSWrapper::setMDWS(API::IMDEventWorkspace_sptr spWS) {
  *coordinates od nd-dimensional events
  *@param dataSize -- the length of the vector of MD events
  */
-void MDEventWSWrapper::addMDData(std::vector<float> &sigErr, uint16_t expInfoIndex, uint16_t goniometerIndex,
-                                 std::vector<uint32_t> &detId, std::vector<coord_t> &Coord, size_t dataSize) const {
+void MDEventWSWrapper::addMDData(std::vector<float> &sigErr, std::vector<uint16_t> &expInfoIndex,
+                                 std::vector<uint16_t> &goniometerIndex, std::vector<uint32_t> &detId,
+                                 std::vector<coord_t> &Coord, size_t dataSize) const {
 
   if (dataSize == 0)
     return;
   // perform the actual dimension-dependent addition
-  (this->*(mdEvAddAndForget[m_NDimensions]))(&sigErr[0], expInfoIndex, goniometerIndex, &detId[0], &Coord[0], dataSize);
+  (this->*(mdEvAddAndForget[m_NDimensions]))(&sigErr[0], &expInfoIndex[0], &goniometerIndex[0], &detId[0], &Coord[0],
+                                             dataSize);
 }
 
 /** method should be called at the end of the algorithm, to let the workspace

--- a/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
+++ b/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
@@ -70,8 +70,8 @@ public:
     allCoord[0] = -0.5;
 
     std::vector<float> sig_err(2 * n_MDev, 2);
-    uint16_t expInfoIndex = 2;
-    uint16_t goniometer_index = 42;
+    std::vector<uint16_t> expInfoIndex(n_MDev, 2);
+    std::vector<uint16_t> goniometer_index(n_MDev, 42);
     std::vector<uint32_t> det_ids(n_MDev, 5);
 
     TSM_ASSERT_THROWS_NOTHING("should be fine",


### PR DESCRIPTION
### Description of work

The `ConvertToMD` parallelisation implementation in #41892 assumed (incorrectly) that `ConvertToMD` for event workspaces is called for large workspaces (with >1000 events per spectrum), but in the case of the TOPAZ system test, each spectrum has ~200 events which mean that there was a large overhead in the parallelisation.

One option (implemented here) is to add a branch which for small number of events will not use OpenMP but will run in serial.

A better option might be to parallel at the [loop over spectra](https://github.com/mantidproject/mantid/blob/main/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp#L230) rather than the inner loop over events but this will require more care to ensure thread private data/properties.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41943. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
